### PR TITLE
modified output name to 'brave', fixed symbols for on linux build

### DIFF
--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -22,9 +22,18 @@ index 93a04ceb27d04671efddc245fc4e57ec388112da..683d6dce475462785fd365e373ca090d
          r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'):
        if path and os.path.exists(path):
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index cf36e40ee5426464cee670a11128a0e11ca49efd..1ddd819e9f7fc33515281035ce6488a0813b36a1 100644
+index cf36e40ee5426464cee670a11128a0e11ca49efd..94b5a52ee73e150c82bea889bd3d2b733558c68e 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
+@@ -52,7 +52,7 @@ if (is_win) {
+       "$root_out_dir/initialexe/chrome.exe",
+     ]
+     outputs = [
+-      "$root_out_dir/chrome.exe",
++      "$root_out_dir/brave.exe",
+     ]
+     if (symbol_level != 0) {
+       outputs += [ "$root_out_dir/chrome.exe.pdb" ]
 @@ -253,6 +253,8 @@ if (!is_android && !is_mac) {
            "app/chrome_main.cc",
            "app/chrome_main_delegate.cc",
@@ -34,6 +43,15 @@ index cf36e40ee5426464cee670a11128a0e11ca49efd..1ddd819e9f7fc33515281035ce6488a0
          ]
  
          deps += [
+@@ -325,7 +327,7 @@ if (!is_android && !is_mac) {
+     if (is_win) {
+       output_name = "initialexe/chrome"
+     } else {
+-      output_name = "chrome"
++      output_name = "brave"
+     }
+ 
+     sources = []
 @@ -375,6 +377,8 @@ if (is_win) {
        "app/chrome_main.cc",
        "app/chrome_main_delegate.cc",
@@ -106,6 +124,15 @@ index cf36e40ee5426464cee670a11128a0e11ca49efd..1ddd819e9f7fc33515281035ce6488a0
      ]
  
      include_dirs = [ android_ndk_include_dir ]
+@@ -1825,7 +1839,7 @@ if (is_linux) {
+       dump_syms_binary =
+           get_label_info(dump_syms_label, "root_out_dir") + "/" + "dump_syms"
+ 
+-      chrome_binary = "$root_out_dir/chrome"
++      chrome_binary = "$root_out_dir/brave"
+       if (current_cpu == "x86") {
+         # GYP used "ia32" so keep that naming for back-compat.
+         symbol_file = "$root_out_dir/chrome.breakpad.ia32"
 diff --git a/chrome/app/BUILD.gn b/chrome/app/BUILD.gn
 index f85f3d75cf76d8861a1f57ce9b799d60e830e878..0275be6c254d7cce443913ddc7f1fab14ff4dcc0 100644
 --- a/chrome/app/BUILD.gn


### PR DESCRIPTION
These are the changes for comments on https://github.com/brave/antimuon/pull/2 , branch 'build-linux-output-name2'. 
Created a new branch and PR because could not build and verify changes in 'build-linux-output-name'.
