### PR TITLE
Fix redirect output for commands without /c on Win

### DIFF
--- a/script/redirect-cc.py
+++ b/script/redirect-cc.py
@@ -11,10 +11,14 @@ def main():
 
 def replace_cc_arg(args):
     # Interested in -c <path>.cc
-    if sys.platform == 'win32':
-      index_c = args.index('/c')
-    else:
-      index_c = args.index('-c')
+    try:
+      if sys.platform == 'win32':
+        index_c = args.index('/c')
+      else:
+        index_c = args.index('-c')
+    except:
+      # no -c or /c so just skip
+      return
 
     if 0 == len(args) or index_c == len(args) - 1:
         # Something wrong, we have -c but have no path in the next arg


### PR DESCRIPTION
@AlexeyBarabash this is only hit on windows. I'm going to merge, but let me know if you want any follow ups changed.