### PR TITLE
fix for x86 linux ffmpeg issue

### DIFF
--- a/patches/third_party-ffmpeg-BUILD.gn.patch
+++ b/patches/third_party-ffmpeg-BUILD.gn.patch
@@ -1,0 +1,16 @@
+diff --git a/third_party/ffmpeg/BUILD.gn b/third_party/ffmpeg/BUILD.gn
+index 01535c488ba6e6a86b9e4d4cd0fd654f18d9701b..518c3e5e455795f07ac1e818b9bb29cafc4b93c3 100755
+--- a/third_party/ffmpeg/BUILD.gn
++++ b/third_party/ffmpeg/BUILD.gn
+@@ -247,11 +247,9 @@ target(link_target_type, "ffmpeg_internal") {
+     # On POSIX x86, sanitizers will fail to compiler the H264 CABAC code due to
+     # insufficient registers unless we disable EBP usage. crbug.com/786760
+     if (target_cpu == "x86") {
+-      if (using_sanitizer) {
+         defines += [ "HAVE_EBP_AVAILABLE=0" ]
+       } else {
+         defines += [ "HAVE_EBP_AVAILABLE=1" ]
+-      }
+     }
+ 
+     if (!is_clang) {


### PR DESCRIPTION
Fixes x86 linux build, ffmpeg issue.
Based on discussion https://groups.google.com/a/chromium.org/forum/#!msg/chromium-dev/VBlimAzVDbY/szIIrWhFAwAJ and patch https://bazaar.launchpad.net/~chromium-team/chromium-browser/bionic-stable/view/head:/debian/patches/fix-ffmpeg-ia32-build.patch .