### PR TITLE
linux package name is 'brave-browser' now

### DIFF
--- a/patches/chrome-installer-linux-common-installer.include.patch
+++ b/patches/chrome-installer-linux-common-installer.include.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/installer/linux/common/installer.include b/chrome/installer/linux/common/installer.include
-index 4c460fc0244e7c1066e1abc3f3cacbfc92b1ed48..a595365da8685462f1cddfa807b89f93c67c0169 100644
+index 4c460fc0244e7c1066e1abc3f3cacbfc92b1ed48..02625d909e1fcaf3a457f08e1295571611623e15 100644
 --- a/chrome/installer/linux/common/installer.include
 +++ b/chrome/installer/linux/common/installer.include
-@@ -153,6 +153,9 @@ stage_install_common() {
+@@ -75,6 +75,7 @@ process_template() (
+     -e "s#@@PACKAGE@@#${PACKAGE}#g" \
+     -e "s#@@PACKAGE_ORIG@@#${PACKAGE_ORIG}#g" \
+     -e "s#@@PACKAGE_FILENAME@@#${PACKAGE_FILENAME}#g" \
++    -e "s#@@PACKAGEANDCHANNEL@@#${PACKAGEANDCHANNEL}#g" \
+     -e "s#@@PROGNAME@@#${PROGNAME}#g" \
+     -e "s#@@CHANNEL@@#${CHANNEL}#g" \
+     -e "s#@@COMPANY_FULLNAME@@#${COMPANY_FULLNAME}#g" \
+@@ -153,6 +154,9 @@ stage_install_common() {
      install -m 644 "${BUILDDIR}/ui_resources_100_percent.pak" "${STAGEDIR}/${INSTALLDIR}/"
    fi
  
@@ -12,7 +20,7 @@ index 4c460fc0244e7c1066e1abc3f3cacbfc92b1ed48..a595365da8685462f1cddfa807b89f93
    # ICU data file; Necessary when the GN icu_use_data_file flag is true.
    install -m 644 "${BUILDDIR}/icudtl.dat" "${STAGEDIR}/${INSTALLDIR}/"
  
-@@ -359,7 +362,7 @@ stage_install_common() {
+@@ -359,7 +363,7 @@ stage_install_common() {
          exit 1
        fi
        local expected_perms=777

--- a/patches/chrome-installer-linux-debian-build.sh.patch
+++ b/patches/chrome-installer-linux-debian-build.sh.patch
@@ -1,0 +1,52 @@
+diff --git a/chrome/installer/linux/debian/build.sh b/chrome/installer/linux/debian/build.sh
+index a91c416cd20e251312c58ebfdaddf3c04e8f75de..d71333022bf838caacc40a60e71d973aa2e2a8e9 100755
+--- a/chrome/installer/linux/debian/build.sh
++++ b/chrome/installer/linux/debian/build.sh
+@@ -21,7 +21,7 @@ gen_changelog() {
+   process_template "${SCRIPTDIR}/changelog.template" "${DEB_CHANGELOG}"
+   debchange -a --nomultimaint -m --changelog "${DEB_CHANGELOG}" \
+     "Release Notes: ${RELEASENOTES}"
+-  GZLOG="${STAGEDIR}/usr/share/doc/${PACKAGE}-${CHANNEL}/changelog.gz"
++  GZLOG="${STAGEDIR}/usr/share/doc/${PACKAGEANDCHANNEL}/changelog.gz"
+   mkdir -p "$(dirname "${GZLOG}")"
+   gzip -9 -c "${DEB_CHANGELOG}" > "${GZLOG}"
+   chmod 644 "${GZLOG}"
+@@ -30,7 +30,7 @@ gen_changelog() {
+ # Create the Debian control file needed by dpkg-deb.
+ gen_control() {
+   dpkg-gencontrol -v"${VERSIONFULL}" -c"${DEB_CONTROL}" -l"${DEB_CHANGELOG}" \
+-  -f"${DEB_FILES}" -p"${PACKAGE}-${CHANNEL}" -P"${STAGEDIR}" \
++  -f"${DEB_FILES}" -p"${PACKAGEANDCHANNEL}" -P"${STAGEDIR}" \
+   -O > "${STAGEDIR}/DEBIAN/control"
+   rm -f "${DEB_CONTROL}"
+ }
+@@ -49,7 +49,7 @@ stage_install_debian() {
+   # Always use a different name for /usr/bin symlink depending on channel.
+   # First, to avoid file collisions. Second, to make it possible to
+   # use update-alternatives for /usr/bin/google-chrome.
+-  local USR_BIN_SYMLINK_NAME="${PACKAGE}-${CHANNEL}"
++  local USR_BIN_SYMLINK_NAME="${PACKAGEANDCHANNEL}"
+ 
+   local PACKAGE_ORIG="${PACKAGE}"
+   if [ "$CHANNEL" != "stable" ]; then
+@@ -92,7 +92,7 @@ verify_package() {
+   local EXPECTED_DEPENDS="${TMPFILEDIR}/expected_deb_depends"
+   local ACTUAL_DEPENDS="${TMPFILEDIR}/actual_deb_depends"
+   echo ${DEPENDS} | sed 's/, /\n/g' | LANG=C sort > "${EXPECTED_DEPENDS}"
+-  dpkg -I "${PACKAGE}-${CHANNEL}_${VERSIONFULL}_${ARCHITECTURE}.deb" | \
++  dpkg -I "${PACKAGEANDCHANNEL}_${VERSIONFULL}_${ARCHITECTURE}.deb" | \
+       grep '^ Depends: ' | sed 's/^ Depends: //' | sed 's/, /\n/g' | \
+       LANG=C sort > "${ACTUAL_DEPENDS}"
+   BAD_DIFF=0
+@@ -254,6 +254,11 @@ fi
+ eval $(sed -e "s/^\([^=]\+\)=\(.*\)$/export \1='\2'/" \
+   "${BUILDDIR}/installer/theme/BRANDING")
+ 
++PACKAGEANDCHANNEL="${PACKAGE}-${CHANNEL}"
++if [ "$CHANNEL" = "stable" ]; then
++  PACKAGEANDCHANNEL="${PACKAGE}"
++fi
++
+ verify_channel
+ 
+ # Some Debian packaging tools want these set.

--- a/patches/chrome-installer-linux-debian-changelog.template.patch
+++ b/patches/chrome-installer-linux-debian-changelog.template.patch
@@ -1,0 +1,10 @@
+diff --git a/chrome/installer/linux/debian/changelog.template b/chrome/installer/linux/debian/changelog.template
+index 290128804a9a724e9b04ea57be59ce34a0154b42..d46a8aaa55c519ba25a4fe487ae268932dff0699 100644
+--- a/chrome/installer/linux/debian/changelog.template
++++ b/chrome/installer/linux/debian/changelog.template
+@@ -1,4 +1,4 @@
+-@@PACKAGE@@-@@CHANNEL@@ (@@VERSIONFULL@@) @@CHANNEL@@; urgency=low
++@@PACKAGEANDCHANNEL@@ (@@VERSIONFULL@@) @@CHANNEL@@; urgency=low
+ 
+   * Build spec: https://chromium.googlesource.com/chromium/src.git/+/@@VERSION@@/
+ 

--- a/patches/chrome-installer-linux-debian-control.template.patch
+++ b/patches/chrome-installer-linux-debian-control.template.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/installer/linux/debian/control.template b/chrome/installer/linux/debian/control.template
+index 93c075c8822ff843cc44199669b59664a9cd2a8e..588bab340769807ac1c36da570d52dcf836fc0e6 100644
+--- a/chrome/installer/linux/debian/control.template
++++ b/chrome/installer/linux/debian/control.template
+@@ -1,11 +1,11 @@
+-Source: @@PACKAGE@@-@@CHANNEL@@
++Source: @@PACKAGEANDCHANNEL@@
+ Section: web
+ Priority: optional
+ Maintainer: @@MAINTNAME@@ <@@MAINTMAIL@@>
+ Build-Depends: dpkg-dev, devscripts, fakeroot, xz-utils
+ Standards-Version: 3.8.0
+ 
+-Package: @@PACKAGE@@-@@CHANNEL@@
++Package: @@PACKAGEANDCHANNEL@@
+ Provides: @@PROVIDES@@
+ Pre-Depends: @@PREDEPENDS@@
+ Depends: @@DEPENDS@@

--- a/patches/chrome-installer-linux-debian-postinst.patch
+++ b/patches/chrome-installer-linux-debian-postinst.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/installer/linux/debian/postinst b/chrome/installer/linux/debian/postinst
+index b284f042a0bdcc9964037ad636bd5e5fa49e7daa..8707a5b62c30508645dcea129d39597c2deef57c 100755
+--- a/chrome/installer/linux/debian/postinst
++++ b/chrome/installer/linux/debian/postinst
+@@ -49,8 +49,11 @@ update-alternatives --install /usr/bin/x-www-browser x-www-browser \
+ update-alternatives --install /usr/bin/gnome-www-browser gnome-www-browser \
+   /usr/bin/@@USR_BIN_SYMLINK_NAME@@ $PRIORITY
+ 
+-update-alternatives --install /usr/bin/@@PACKAGE_ORIG@@ @@PACKAGE_ORIG@@ \
+-  /usr/bin/@@USR_BIN_SYMLINK_NAME@@ $PRIORITY
++if [ '"@@PACKAGE_ORIG@@"' != '"@@USR_BIN_SYMLINK_NAME@@"' ]; then
++  update-alternatives --install /usr/bin/@@PACKAGE_ORIG@@ @@PACKAGE_ORIG@@ \
++    /usr/bin/@@USR_BIN_SYMLINK_NAME@@ $PRIORITY
++fi
++
+ 
+ @@include@@../common/apt.include
+ 

--- a/patches/chrome-installer-linux-rpm-build.sh.patch
+++ b/patches/chrome-installer-linux-rpm-build.sh.patch
@@ -1,0 +1,27 @@
+diff --git a/chrome/installer/linux/rpm/build.sh b/chrome/installer/linux/rpm/build.sh
+index d1397286e1b374d0722e85d7c10dc55b1a975138..e25dd633fd19e1131c8602dd6c5fcff86adf6d0d 100755
+--- a/chrome/installer/linux/rpm/build.sh
++++ b/chrome/installer/linux/rpm/build.sh
+@@ -15,8 +15,9 @@ gen_spec() {
+   # Different channels need to install to different locations so they
+   # don't conflict with each other.
+   local PACKAGE_ORIG="${PACKAGE}"
+-  local PACKAGE_FILENAME="${PACKAGE}-${CHANNEL}"
++  local PACKAGE_FILENAME="${PACKAGE}"
+   if [ "$CHANNEL" != "stable" ]; then
++    local PACKAGE_FILENAME="${PACKAGE}-${CHANNEL}"
+     local INSTALLDIR="${INSTALLDIR}-${CHANNEL}"
+     local PACKAGE="${PACKAGE}-${CHANNEL}"
+     local MENUNAME="${MENUNAME} (${CHANNEL})"
+@@ -107,7 +108,10 @@ do_package() {
+     --define "${COMPRESSION_OPT}" \
+     --define "__os_install_post  %{nil}" \
+     "${SPEC}"
+-  PKGNAME="${PACKAGE}-${CHANNEL}-${VERSION}-${PACKAGE_RELEASE}"
++  PKGNAME="${PACKAGE}-${VERSION}-${PACKAGE_RELEASE}"
++  if [ "$CHANNEL" != "stable" ]; then
++    PKGNAME="${PACKAGE}-${CHANNEL}-${VERSION}-${PACKAGE_RELEASE}"
++  fi
+   mv "$RPMBUILD_DIR/RPMS/$ARCHITECTURE/${PKGNAME}.${ARCHITECTURE}.rpm" \
+      "${OUTPUTDIR}"
+   # Make sure the package is world-readable, otherwise it causes problems when


### PR DESCRIPTION
Package name now is `brave-browser` instead of `brave-browser-stable`. Can be verified by  `apt list --installed` command. Packages for beta and unstable channels have old names `brave-browser-beta` and `brave-browser-unstable`, but these channels are not used.