### PR TITLE
Ensure ContentSettingsStore::RegisterExtension is called for components

### DIFF
--- a/patches/chrome-browser-extensions-extension_service.cc.patch
+++ b/patches/chrome-browser-extensions-extension_service.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/extension_service.cc b/chrome/browser/extensions/extension_service.cc
-index ca649731ea800e0c7bd3e4c39ff6232f41af85db..b0b7bdec4fffebccd9e136ff51cffbb66e5b7359 100644
+index ca649731ea800e0c7bd3e4c39ff6232f41af85db..e390f76c5fbc62c79568cabc0373e68bbfaa42b7 100644
 --- a/chrome/browser/extensions/extension_service.cc
 +++ b/chrome/browser/extensions/extension_service.cc
 @@ -27,6 +27,7 @@
@@ -19,3 +19,23 @@ index ca649731ea800e0c7bd3e4c39ff6232f41af85db..b0b7bdec4fffebccd9e136ff51cffbb6
                                        profile->GetPrefs(),
                                        g_browser_process->local_state(),
                                        profile));
+@@ -1417,6 +1418,19 @@ void ExtensionService::AddComponentExtension(const Extension* extension) {
+   }
+ 
+   AddExtension(extension);
++#if defined(CHROMIUM_BUILD)
++  // ContentSettingsStore::RegisterExtension is only called for default components
++  // on the first run with a fresh profile. All restarts of the browser after that do not call it.
++  // This causes ContentSettingsStore's `entries_` to never insert the component ID
++  // and then  ContentSettingsStore::GetValueMap always returns nullptr.
++  // I don't think Chromium is affeced by this simply because they don't use content settings
++  // from default component extensions.
++  extension_prefs_->OnExtensionInstalled(extension, Extension::ENABLED,
++                                         syncer::StringOrdinal(),
++                                         extensions::kInstallFlagNone,
++                                         std::string(),
++                                         base::nullopt);
++#endif
+ }
+ 
+ void ExtensionService::CheckPermissionsIncrease(const Extension* extension,


### PR DESCRIPTION
Fix https://github.com/brave/brave/issues/81

Note for reviewing that the added call to `extension_prefs_->OnExtensionInstalled` is always called right away in `AddNewOrUpdatedExtension` but for `AddExtension` it is never called:

```
void ExtensionService::AddComponentExtension(const Extension* extension) {
  const std::string old_version_string(
      extension_prefs_->GetVersionString(extension->id()));
  const base::Version old_version(old_version_string);

  VLOG(1) << "AddComponentExtension " << extension->name();
  if (!old_version.IsValid() || old_version != *extension->version()) {
    VLOG(1) << "Component extension " << extension->name() << " ("
        << extension->id() << ") installing/upgrading from '"
        << old_version_string << "' to " << extension->version()->GetString();

    // TODO(crbug.com/696822): If needed, add support for Declarative Net
    // Request to component extensions and pass the ruleset checksum here.
    AddNewOrUpdatedExtension(
        extension, Extension::ENABLED, extensions::kInstallFlagNone,
        syncer::StringOrdinal(), std::string(), base::nullopt);
    return;
  }

  AddExtension(extension);
```

This seem to only be needed for `AddComponentExtension` and not extensions because the extensions are always loaded before the default components are added.

Let me know if you can think of a better way to fix this. I had trouble finding a cleaner way.