### PR TITLE
Add tests for static redirect helper

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/brave_static_redirect_network_delegate_helper.h"
+
+#include "brave/browser/net/url_context.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
+#include "net/url_request/url_request_test_util.h"
+
+
+namespace {
+
+class BraveStaticRedirectNetworkDelegateHelperTest: public testing::Test {
+ public:
+  BraveStaticRedirectNetworkDelegateHelperTest()
+      : thread_bundle_(content::TestBrowserThreadBundle::IO_MAINLOOP),
+        context_(new net::TestURLRequestContext(true)) {
+  }
+  ~BraveStaticRedirectNetworkDelegateHelperTest() override {}
+  void SetUp() override {}
+  net::TestURLRequestContext* context() { return context_.get(); }
+
+ private:
+  content::TestBrowserThreadBundle thread_bundle_;
+  std::unique_ptr<net::TestURLRequestContext> context_;
+};
+
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
+  net::TestDelegate test_delegate;
+  GURL url("https://bradhatesprimes.brave.com/composite_numbers_ftw");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::OnBeforeURLRequestContext>
+      before_url_context(new brave::OnBeforeURLRequestContext());
+  brave::ResponseCallback callback;
+  GURL new_url;
+  int ret =
+    OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
+        before_url_context);
+  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_EQ(ret, net::OK);
+}
+
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
+  net::TestDelegate test_delegate;
+  GURL url("https://www.googleapis.com/geolocation/v1/geolocate?key=2_3_5_7");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::OnBeforeURLRequestContext>
+      before_url_context(new brave::OnBeforeURLRequestContext());
+  brave::ResponseCallback callback;
+  GURL new_url;
+  GURL expected_url(GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY));
+  int ret =
+      OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
+                                            before_url_context);
+  EXPECT_EQ(new_url, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+
+}  // namespace

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -27,6 +27,7 @@ static_library("brave_test_support_unit") {
 
 test("brave_unit_tests") {
   sources = [
+    "//brave/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc",
     "//chrome/common/importer/mock_importer_bridge.cc",
     "//chrome/common/importer/mock_importer_bridge.h",
     "../utility/importer/chrome_importer_unittest.cc",
@@ -34,6 +35,10 @@ test("brave_unit_tests") {
 
   data = [
     "data/",
+  ]
+
+  configs += [
+    "//brave/build/geolocation",
   ]
 
   public_deps = [


### PR DESCRIPTION
This adds a couple tests to the static redirect helper, which is currently only used to rewrite geolocation api requests to our endpoint.

To test:
`./src/out/Release/brave_unit_tests`
