### PR TITLE
Upload Brave QA builds to a new private repo

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -18,7 +18,7 @@ from lib.util import execute, parse_version, scoped_cwd, s3put
 from lib.github import GitHub
 
 
-ANTIMUON_REPO = "brave/brave"
+ANTIMUON_REPO = "brave/brave-browser-builds"
 
 DIST_NAME = get_zip_name(project_name(), get_antimuon_version())
 SYMBOLS_NAME = get_zip_name(project_name(), get_antimuon_version(), 'symbols')


### PR DESCRIPTION
We're ready to open source,
but not for public builds.
Internal QA needs to test,
so upload builds to a diff  private repo.

Fix https://github.com/brave/brave/issues/107