### PR TITLE
Use Brave-specific labels for os_crypt key

### DIFF
--- a/patches/components-os_crypt-key_storage_keyring.cc.patch
+++ b/patches/components-os_crypt-key_storage_keyring.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/os_crypt/key_storage_keyring.cc b/components/os_crypt/key_storage_keyring.cc
+index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..59cd364e90bcab68eddf8936945730c6de3ba2f3 100644
+--- a/components/os_crypt/key_storage_keyring.cc
++++ b/components/os_crypt/key_storage_keyring.cc
+@@ -16,7 +16,7 @@ namespace {
+ #if defined(GOOGLE_CHROME_BUILD)
+ const char kApplicationName[] = "chrome";
+ #else
+-const char kApplicationName[] = "chromium";
++const char kApplicationName[] = "brave";
+ #endif
+ 
+ const GnomeKeyringPasswordSchema kSchema = {

--- a/patches/components-os_crypt-key_storage_keyring_unittest.cc.patch
+++ b/patches/components-os_crypt-key_storage_keyring_unittest.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/os_crypt/key_storage_keyring_unittest.cc b/components/os_crypt/key_storage_keyring_unittest.cc
+index f7d8067ab474bd416b099829097114dde7c346e1..52e3899bfcdef29ffee1226e2eb3d95b5580f665 100644
+--- a/components/os_crypt/key_storage_keyring_unittest.cc
++++ b/components/os_crypt/key_storage_keyring_unittest.cc
+@@ -16,7 +16,7 @@ namespace {
+ #if defined(GOOGLE_CHROME_BUILD)
+ const char kApplicationName[] = "chrome";
+ #else
+-const char kApplicationName[] = "chromium";
++const char kApplicationName[] = "brave";
+ #endif
+ 
+ // Replaces some of GnomeKeyringLoader's methods with mocked ones.

--- a/patches/components-os_crypt-key_storage_kwallet_unittest.cc.patch
+++ b/patches/components-os_crypt-key_storage_kwallet_unittest.cc.patch
@@ -1,0 +1,15 @@
+diff --git a/components/os_crypt/key_storage_kwallet_unittest.cc b/components/os_crypt/key_storage_kwallet_unittest.cc
+index 9f9b7da6d44b161934d6055828eefd7f50280a62..c75bd6a6e7ae5acf0e8d46beecaab3fd17200e7a 100644
+--- a/components/os_crypt/key_storage_kwallet_unittest.cc
++++ b/components/os_crypt/key_storage_kwallet_unittest.cc
+@@ -34,8 +34,8 @@ constexpr KWalletDBus::Error CANNOT_CONTACT =
+ const char kExpectedFolderName[] = "Chrome Keys";
+ const char kExpectedEntryName[] = "Chrome Safe Storage";
+ #else
+-const char kExpectedFolderName[] = "Chromium Keys";
+-const char kExpectedEntryName[] = "Chromium Safe Storage";
++const char kExpectedFolderName[] = "Brave Keys";
++const char kExpectedEntryName[] = "Brave Safe Storage";
+ #endif
+ 
+ // Environment-specific behavior is handled and tested with KWalletDBus, not

--- a/patches/components-os_crypt-key_storage_libsecret.cc.patch
+++ b/patches/components-os_crypt-key_storage_libsecret.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/os_crypt/key_storage_libsecret.cc b/components/os_crypt/key_storage_libsecret.cc
+index a1b5b975bc89c4891643adab17ce0b00ba2a8032..2f46d442e548e94e956b107b3333388fa49e145c 100644
+--- a/components/os_crypt/key_storage_libsecret.cc
++++ b/components/os_crypt/key_storage_libsecret.cc
+@@ -14,7 +14,7 @@ namespace {
+ #if defined(GOOGLE_CHROME_BUILD)
+ const char kApplicationName[] = "chrome";
+ #else
+-const char kApplicationName[] = "chromium";
++const char kApplicationName[] = "brave";
+ #endif
+ 
+ // Deprecated in M55 (crbug.com/639298)

--- a/patches/components-os_crypt-key_storage_linux.cc.patch
+++ b/patches/components-os_crypt-key_storage_linux.cc.patch
@@ -1,0 +1,15 @@
+diff --git a/components/os_crypt/key_storage_linux.cc b/components/os_crypt/key_storage_linux.cc
+index 9e6f0f27535fdf52a23b5a734c108196ae0b728c..e504eb223b66c0608b7d22411859bd69de091328 100644
+--- a/components/os_crypt/key_storage_linux.cc
++++ b/components/os_crypt/key_storage_linux.cc
+@@ -29,8 +29,8 @@
+ const char KeyStorageLinux::kFolderName[] = "Chrome Keys";
+ const char KeyStorageLinux::kKey[] = "Chrome Safe Storage";
+ #else
+-const char KeyStorageLinux::kFolderName[] = "Chromium Keys";
+-const char KeyStorageLinux::kKey[] = "Chromium Safe Storage";
++const char KeyStorageLinux::kFolderName[] = "Brave Keys";
++const char KeyStorageLinux::kKey[] = "Brave Safe Storage";
+ #endif
+ 
+ // static

--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -1,0 +1,15 @@
+diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
+index 2b38db266f9aa1f4141c8649c021042ede4e5589..c2d65b751f19d8226cc867be124a3f6fd1d1c894 100644
+--- a/components/os_crypt/keychain_password_mac.mm
++++ b/components/os_crypt/keychain_password_mac.mm
+@@ -54,8 +54,8 @@
+ const char KeychainPassword::service_name[] = "Chrome Safe Storage";
+ const char KeychainPassword::account_name[] = "Chrome";
+ #else
+-const char KeychainPassword::service_name[] = "Chromium Safe Storage";
+-const char KeychainPassword::account_name[] = "Chromium";
++const char KeychainPassword::service_name[] = "Brave Safe Storage";
++const char KeychainPassword::account_name[] = "Brave";
+ #endif
+ 
+ std::string KeychainPassword::GetPassword() const {


### PR DESCRIPTION
I used this [codesearch](https://cs.chromium.org/search/?q=%22%23if+defined(GOOGLE_CHROME_BUILD)%22+file:os_crypt/*&sq=package:chromium&type=cs) to find all apparent mentions of "(C|c)hrom(e|ium)" labels used by the os_crypt backend and replaced them with Brave-specific labels. Brave doesn't have a Chrome vs. Chromium-style branding divide, so I removed the corresponding preprocessor conditionals as necessary.

If there's a better way to accomplish this other than adding a bunch of small patches, please let me know!

Resolves https://github.com/brave/brave/issues/110.