### PR TITLE
Import passwords from Chrome

### DIFF
--- a/common/importer/chrome_importer_utils.cc
+++ b/common/importer/chrome_importer_utils.cc
@@ -63,11 +63,15 @@ bool ChromeImporterCanImport(const base::FilePath& profile,
     profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("Bookmarks")));
   base::FilePath history =
     profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("History")));
+  base::FilePath passwords =
+    profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("Login Data")));
 
   if (base::PathExists(bookmarks))
     *services_supported |= importer::FAVORITES;
   if (base::PathExists(history))
     *services_supported |= importer::HISTORY;
+  if (base::PathExists(passwords))
+    *services_supported |= importer::PASSWORDS;
 
   return *services_supported != importer::NONE;
 }

--- a/patches/chrome-utility-importer-profile_import_impl.cc.patch
+++ b/patches/chrome-utility-importer-profile_import_impl.cc.patch
@@ -1,0 +1,34 @@
+diff --git a/chrome/utility/importer/profile_import_impl.cc b/chrome/utility/importer/profile_import_impl.cc
+index 97fafc01166bbc7fbc94f6038f925ed4dedc3c2e..ae7daac3265bfc5abd16b768a99d32039a9618ad 100644
+--- a/chrome/utility/importer/profile_import_impl.cc
++++ b/chrome/utility/importer/profile_import_impl.cc
+@@ -5,10 +5,12 @@
+ #include "chrome/utility/importer/profile_import_impl.h"
+ 
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/location.h"
+ #include "base/memory/ptr_util.h"
+ #include "base/memory/ref_counted.h"
+ #include "base/single_thread_task_runner.h"
++#include "base/strings/utf_string_conversions.h"
+ #include "base/threading/thread.h"
+ #include "base/threading/thread_task_runner_handle.h"
+ #include "build/build_config.h"
+@@ -39,6 +41,16 @@ void ProfileImportImpl::StartImport(
+   }
+ 
+   items_to_import_ = items;
++  
++  // Signal change to OSCrypt password for importing from Chrome/Chromium
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++  if (base::StartsWith(base::UTF16ToUTF8(source_profile.importer_name),
++                       "Chrome", base::CompareCase::SENSITIVE)) {
++    command_line->AppendSwitch("import-chrome");
++  } else if (base::StartsWith(base::UTF16ToUTF8(source_profile.importer_name),
++                              "Chromium", base::CompareCase::SENSITIVE)) {
++    command_line->AppendSwitch("import-chromium");
++  }
+ 
+   // Create worker thread in which importer runs.
+   import_thread_.reset(new base::Thread("import_thread"));

--- a/patches/components-os_crypt-key_storage_keyring.cc.patch
+++ b/patches/components-os_crypt-key_storage_keyring.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/components/os_crypt/key_storage_keyring.cc b/components/os_crypt/key_storage_keyring.cc
-index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..59cd364e90bcab68eddf8936945730c6de3ba2f3 100644
+index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..4de119827b80cb8bbf83c26ef4937c6d8218e448 100644
 --- a/components/os_crypt/key_storage_keyring.cc
 +++ b/components/os_crypt/key_storage_keyring.cc
-@@ -16,7 +16,7 @@ namespace {
+@@ -6,6 +6,7 @@
+ 
+ #include "base/base64.h"
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/rand_util.h"
+ #include "base/single_thread_task_runner.h"
+ #include "base/strings/string_number_conversions.h"
+@@ -16,7 +17,7 @@ namespace {
  #if defined(GOOGLE_CHROME_BUILD)
  const char kApplicationName[] = "chrome";
  #else
@@ -11,3 +19,23 @@ index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..59cd364e90bcab68eddf8936945730c6
  #endif
  
  const GnomeKeyringPasswordSchema kSchema = {
+@@ -45,9 +46,18 @@ std::string KeyStorageKeyring::GetKeyImpl() {
+ 
+   std::string password;
+   gchar* password_c = nullptr;
++  const char* application_name;
++  base::CommandLine* command_line = base::CommandLine()::ForCurrentProcess();
++  if (command_line->HasSwitch("import-chrome")) {
++    application_name = "chrome";
++  } else if (command_line->HasSwitch("import-chromium")) {
++    application_name = "chromium";
++  } else {
++    application_name = kApplicationName;
++  }
+   GnomeKeyringResult result =
+       GnomeKeyringLoader::gnome_keyring_find_password_sync_ptr(
+-          &kSchema, &password_c, "application", kApplicationName, nullptr);
++          &kSchema, &password_c, "application", application_name, nullptr);
+   if (result == GNOME_KEYRING_RESULT_OK) {
+     password = password_c;
+     GnomeKeyringLoader::gnome_keyring_free_password_ptr(password_c);

--- a/patches/components-os_crypt-key_storage_kwallet.cc.patch
+++ b/patches/components-os_crypt-key_storage_kwallet.cc.patch
@@ -1,0 +1,58 @@
+diff --git a/components/os_crypt/key_storage_kwallet.cc b/components/os_crypt/key_storage_kwallet.cc
+index aa4b3d4a6b5c7b1f725d6446ea5e573094ec935b..3d53b65e81969d7bc88466e09623eab22f3088cd 100644
+--- a/components/os_crypt/key_storage_kwallet.cc
++++ b/components/os_crypt/key_storage_kwallet.cc
+@@ -7,6 +7,7 @@
+ #include <utility>
+ 
+ #include "base/base64.h"
++#include "base/command_line.h"
+ #include "base/rand_util.h"
+ #include "components/os_crypt/kwallet_dbus.h"
+ #include "dbus/bus.h"
+@@ -90,11 +91,24 @@ std::string KeyStorageKWallet::GetKeyImpl() {
+   if (!InitFolder())
+     return std::string();
+ 
++  const char *folder_name, *key;
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++  if (command_line->HasSwitch("import-chrome")) {
++    folder_name = "Chrome Keys";
++    key = "Chrome Safe Storage"
++  } else if (command_line->HasSwitch("import-chromium")) {
++    folder_name = "Chromium Keys";
++    key = "Chromium Safe Storage";
++  } else {
++    folder_name = KeyStorageLinux::kFolderName;
++    key = KeyStorageLinux::kKey;
++  }
++
+   // Read password
+   std::string password;
+   error =
+-      kwallet_dbus_->ReadPassword(handle_, KeyStorageLinux::kFolderName,
+-                                  KeyStorageLinux::kKey, app_name_, &password);
++      kwallet_dbus_->ReadPassword(handle_, folder_name,
++                                  key, app_name_, &password);
+   if (error)
+     return std::string();
+ 
+@@ -114,8 +128,17 @@ std::string KeyStorageKWallet::GetKeyImpl() {
+ 
+ bool KeyStorageKWallet::InitFolder() {
+   bool has_folder = false;
++  const char *folder_name;
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++  if (command_line->HasSwitch("import-chrome")) {
++    folder_name = "Chrome Keys";
++  } else if (command_line->HasSwitch("import-chromium")) {
++    folder_name = "Chromium Keys";
++  } else {
++    folder_name = KeyStorageLinux::kFolderName;
++  }
+   KWalletDBus::Error error = kwallet_dbus_->HasFolder(
+-      handle_, KeyStorageLinux::kFolderName, app_name_, &has_folder);
++      handle_, folder_name, app_name_, &has_folder);
+   if (error)
+     return false;
+ 

--- a/patches/components-os_crypt-key_storage_libsecret.cc.patch
+++ b/patches/components-os_crypt-key_storage_libsecret.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/components/os_crypt/key_storage_libsecret.cc b/components/os_crypt/key_storage_libsecret.cc
-index a1b5b975bc89c4891643adab17ce0b00ba2a8032..2f46d442e548e94e956b107b3333388fa49e145c 100644
+index a1b5b975bc89c4891643adab17ce0b00ba2a8032..9d4be365463d2555101a96006ca4c68a61b7e886 100644
 --- a/components/os_crypt/key_storage_libsecret.cc
 +++ b/components/os_crypt/key_storage_libsecret.cc
-@@ -14,7 +14,7 @@ namespace {
+@@ -5,6 +5,7 @@
+ #include "components/os_crypt/key_storage_libsecret.h"
+ 
+ #include "base/base64.h"
++#include "base/command_line.h"
+ #include "base/rand_util.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "components/os_crypt/libsecret_util_linux.h"
+@@ -14,7 +15,7 @@ namespace {
  #if defined(GOOGLE_CHROME_BUILD)
  const char kApplicationName[] = "chrome";
  #else
@@ -11,3 +19,21 @@ index a1b5b975bc89c4891643adab17ce0b00ba2a8032..2f46d442e548e94e956b107b3333388f
  #endif
  
  // Deprecated in M55 (crbug.com/639298)
+@@ -73,7 +74,16 @@ std::string KeyStorageLibsecret::AddRandomPasswordInLibsecret() {
+ 
+ std::string KeyStorageLibsecret::GetKeyImpl() {
+   LibsecretAttributesBuilder attrs;
+-  attrs.Append("application", kApplicationName);
++  const char* application_name;
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++  if (command_line->HasSwitch("import-chrome")) {
++    application_name = "chrome";
++  } else if (command_line->HasSwitch("import-chromium")) {
++    application_name = "chromium";
++  } else {
++    application_name = kApplicationName;
++  }
++  attrs.Append("application", application_name);
+ 
+   LibsecretLoader::SearchHelper helper;
+   helper.Search(&kKeystoreSchemaV2, attrs.Get(),

--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -1,8 +1,16 @@
 diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
-index 2b38db266f9aa1f4141c8649c021042ede4e5589..c2d65b751f19d8226cc867be124a3f6fd1d1c894 100644
+index 2b38db266f9aa1f4141c8649c021042ede4e5589..4b14f15e5091b251be53eff29139beaa59a93dbc 100644
 --- a/components/os_crypt/keychain_password_mac.mm
 +++ b/components/os_crypt/keychain_password_mac.mm
-@@ -54,8 +54,8 @@ std::string AddRandomPasswordToKeychain(const AppleKeychain& keychain,
+@@ -7,6 +7,7 @@
+ #import <Security/Security.h>
+ 
+ #include "base/base64.h"
++#include "base/command_line.h"
+ #include "base/mac/mac_logging.h"
+ #include "base/rand_util.h"
+ #include "crypto/apple_keychain.h"
+@@ -54,11 +55,23 @@
  const char KeychainPassword::service_name[] = "Chrome Safe Storage";
  const char KeychainPassword::account_name[] = "Chrome";
  #else
@@ -13,3 +21,18 @@ index 2b38db266f9aa1f4141c8649c021042ede4e5589..c2d65b751f19d8226cc867be124a3f6f
  #endif
  
  std::string KeychainPassword::GetPassword() const {
++  const char *service_name, *account_name;
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++  if (command_line->HasSwitch("import-chrome")) {
++    service_name = "Chrome Safe Storage";
++    account_name = "Chrome";
++  } else if (command_line->HasSwitch("import-chromium")) {
++    service_name = "Chromium Safe Storage";
++    account_name = "Chromium";
++  } else {
++    service_name = ::KeychainPassword::service_name;
++    account_name = ::KeychainPassword::account_name;
++  }
+   UInt32 password_length = 0;
+   void* password_data = NULL;
+   OSStatus error = keychain_.FindGenericPassword(

--- a/utility/importer/chrome_importer.cc
+++ b/utility/importer/chrome_importer.cc
@@ -58,6 +58,12 @@ void ChromeImporter::StartImport(const importer::SourceProfile& source_profile,
     bridge_->NotifyItemEnded(importer::FAVORITES);
   }
 
+  if ((items & importer::PASSWORDS) && !cancelled()) {
+    bridge_->NotifyItemStarted(importer::PASSWORDS);
+    ImportPasswords();
+    bridge_->NotifyItemEnded(importer::PASSWORDS);
+  }
+
   bridge_->NotifyEnded();
 }
 
@@ -264,4 +270,94 @@ void ChromeImporter::RecursiveReadBookmarksFolder(
 
 double ChromeImporter::chromeTimeToDouble(int64_t time) {
   return ((time * 10 - 0x19DB1DED53E8000) / 10000) / 1000;
+}
+
+void ChromeImporter::ImportPasswords() {
+  #if !defined(USE_X11)
+    base::FilePath passwords_path =
+      source_path_.Append(
+        base::FilePath::StringType(FILE_PATH_LITERAL("Login Data")));
+
+    password_manager::LoginDatabase database(passwords_path);
+    if (!database.Init()) {
+      LOG(ERROR) << "LoginDatabase Init() failed";
+      return;
+    }
+
+    std::vector<std::unique_ptr<autofill::PasswordForm>> forms;
+    bool success = database.GetAutofillableLogins(&forms);
+    if (success) {
+      for (size_t i = 0; i < forms.size(); ++i) {
+        bridge_->SetPasswordForm(*forms[i].get());
+      }
+    }
+    std::vector<std::unique_ptr<autofill::PasswordForm>> blacklist;
+    success = database.GetBlacklistLogins(&blacklist);
+    if (success) {
+      for (size_t i = 0; i < blacklist.size(); ++i) {
+        bridge_->SetPasswordForm(*blacklist[i].get());
+      }
+    }
+  #else
+    base::FilePath prefs_path =
+      source_path_.Append(
+        base::FilePath::StringType(FILE_PATH_LITERAL("Preferences")));
+    const base::Value *value;
+    scoped_refptr<JsonPrefStore> prefs = new JsonPrefStore(prefs_path);
+    int local_profile_id;
+    if (prefs->ReadPrefs() != PersistentPrefStore::PREF_READ_ERROR_NONE) {
+      return;
+    }
+    if (!prefs->GetValue(password_manager::prefs::kLocalProfileId, &value)) {
+      return;
+    }
+    if (!value->GetAsInteger(&local_profile_id)) {
+      return;
+    }
+
+    std::unique_ptr<PasswordStoreX::NativeBackend> backend;
+    base::nix::DesktopEnvironment desktop_env = GetDesktopEnvironment();
+
+    // WIP proper kEnableEncryptionSelection
+    os_crypt::SelectedLinuxBackend selected_backend =
+        os_crypt::SelectBackend(std::string(), true, desktop_env);
+    if (!backend &&
+        (selected_backend == os_crypt::SelectedLinuxBackend::KWALLET ||
+        selected_backend == os_crypt::SelectedLinuxBackend::KWALLET5)) {
+      base::nix::DesktopEnvironment used_desktop_env =
+          selected_backend == os_crypt::SelectedLinuxBackend::KWALLET
+              ? base::nix::DESKTOP_ENVIRONMENT_KDE4
+              : base::nix::DESKTOP_ENVIRONMENT_KDE5;
+      backend.reset(new NativeBackendKWallet(local_profile_id,
+                                             used_desktop_env));
+    } else if (selected_backend == os_crypt::SelectedLinuxBackend::GNOME_ANY ||
+               selected_backend ==
+                   os_crypt::SelectedLinuxBackend::GNOME_KEYRING ||
+               selected_backend ==
+                   os_crypt::SelectedLinuxBackend::GNOME_LIBSECRET) {
+  #if defined(USE_LIBSECRET)
+      if (!backend &&
+          (selected_backend == os_crypt::SelectedLinuxBackend::GNOME_ANY ||
+          selected_backend == os_crypt::SelectedLinuxBackend::GNOME_LIBSECRET)) {
+        backend.reset(new NativeBackendLibsecret(local_profile_id));
+      }
+  #endif
+    }
+    if (backend && backend->Init()) {
+      std::vector<std::unique_ptr<autofill::PasswordForm>> forms;
+      bool success = backend->GetAutofillableLogins(&forms);
+      if (success) {
+        for (size_t i = 0; i < forms.size(); ++i) {
+          bridge_->SetPasswordForm(*forms[i].get());
+        }
+      }
+      std::vector<std::unique_ptr<autofill::PasswordForm>> blacklist;
+      success = backend->GetBlacklistLogins(&blacklist);
+      if (success) {
+        for (size_t i = 0; i < blacklist.size(); ++i) {
+          bridge_->SetPasswordForm(*blacklist[i].get());
+        }
+      }
+    }
+  #endif
 }

--- a/utility/importer/chrome_importer.h
+++ b/utility/importer/chrome_importer.h
@@ -45,6 +45,7 @@ class ChromeImporter : public Importer {
 
   void ImportBookmarks();
   void ImportHistory();
+  void ImportPasswords();
 
   // Multiple URLs can share the same favicon; this is a map
   // of URLs -> IconIDs that we load as a temporary step before


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. Create a test Chrome profile.
2. Log in to any website and allow Chrome to save the password when prompted.
3. Open Brave
4. Go to Brave → Import Bookmarks and Settings...
5. Choose your test Chrome profile, make sure **Saved passwords** option is checked, click Import.
6. "Allow" any prompts for access to "Brave Safe Storage" or "Chrome Safe Storage."
6. Attempt to login to the website from earlier. The form fields should be autofilled (highlighted yellow) and a key icon should be visible in the address bar.

I spent some time working on automated tests for this branch, but they were complicated by the design of OSCrypt and interactions with the various system keychains. To keep momentum going, I'm posting this branch for review without tests. I think I may be able to get a reasonable unit test working in the near future, which could be included in this PR or a follow-up.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions