### PR TITLE
Forbes and Twitter site hacks

### DIFF
--- a/browser/net/brave_httpse_network_delegate_helper.cc
+++ b/browser/net/brave_httpse_network_delegate_helper.cc
@@ -19,7 +19,7 @@ namespace brave {
 void OnBeforeURLRequest_HttpseFileWork(
     net::URLRequest* request,
     GURL* new_url,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+    std::shared_ptr<BraveURLRequestContext> ctx) {
   base::AssertBlockingAllowed();
   DCHECK_CURRENTLY_ON(BrowserThread::FILE);
   DCHECK(ctx->request_identifier != 0);
@@ -31,7 +31,7 @@ void OnBeforeURLRequest_HttpsePostFileWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+    std::shared_ptr<BraveURLRequestContext> ctx) {
 
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
@@ -49,7 +49,7 @@ int OnBeforeURLRequest_HttpsePreFileWork(
   net::URLRequest* request,
   GURL* new_url,
   const ResponseCallback& next_callback,
-  std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+  std::shared_ptr<BraveURLRequestContext> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   GURL tab_origin = request->site_for_cookies().GetOrigin();

--- a/browser/net/brave_httpse_network_delegate_helper.cc
+++ b/browser/net/brave_httpse_network_delegate_helper.cc
@@ -19,7 +19,7 @@ namespace brave {
 void OnBeforeURLRequest_HttpseFileWork(
     net::URLRequest* request,
     GURL* new_url,
-    std::shared_ptr<BraveURLRequestContext> ctx) {
+    std::shared_ptr<BraveRequestInfo> ctx) {
   base::AssertBlockingAllowed();
   DCHECK_CURRENTLY_ON(BrowserThread::FILE);
   DCHECK(ctx->request_identifier != 0);
@@ -31,7 +31,7 @@ void OnBeforeURLRequest_HttpsePostFileWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx) {
+    std::shared_ptr<BraveRequestInfo> ctx) {
 
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
@@ -49,7 +49,7 @@ int OnBeforeURLRequest_HttpsePreFileWork(
   net::URLRequest* request,
   GURL* new_url,
   const ResponseCallback& next_callback,
-  std::shared_ptr<BraveURLRequestContext> ctx) {
+  std::shared_ptr<BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   GURL tab_origin = request->site_for_cookies().GetOrigin();

--- a/browser/net/brave_httpse_network_delegate_helper.h
+++ b/browser/net/brave_httpse_network_delegate_helper.h
@@ -8,7 +8,7 @@
 #include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
-struct OnBeforeURLRequestContext;
+struct BraveURLRequestContext;
 
 namespace net {
 class URLRequest;
@@ -20,7 +20,7 @@ int OnBeforeURLRequest_HttpsePreFileWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx);
+    std::shared_ptr<BraveURLRequestContext> ctx);
 
 }  // namespace brave
 

--- a/browser/net/brave_httpse_network_delegate_helper.h
+++ b/browser/net/brave_httpse_network_delegate_helper.h
@@ -8,7 +8,7 @@
 #include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
-struct BraveURLRequestContext;
+struct BraveRequestInfo;
 
 namespace net {
 class URLRequest;
@@ -20,7 +20,7 @@ int OnBeforeURLRequest_HttpsePreFileWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx);
+    std::shared_ptr<BraveRequestInfo> ctx);
 
 }  // namespace brave
 

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -28,8 +28,8 @@ int BraveNetworkDelegateBase::OnBeforeURLRequest(net::URLRequest* request,
   if (before_url_request_callbacks_.empty() || !request) {
     return ChromeNetworkDelegate::OnBeforeURLRequest(request, callback, new_url);
   }
-  std::shared_ptr<brave::BraveURLRequestContext> ctx(
-      new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo> ctx(
+      new brave::BraveRequestInfo());
   callbacks_[request->identifier()] = callback;
   ctx->request_identifier = request->identifier();
   ctx->event_type = brave::kOnBeforeRequest;
@@ -44,8 +44,8 @@ int BraveNetworkDelegateBase::OnBeforeStartTransaction(net::URLRequest* request,
     return ChromeNetworkDelegate::OnBeforeStartTransaction(request, callback,
                                                            headers);
   }
-  std::shared_ptr<brave::BraveURLRequestContext> ctx(
-      new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo> ctx(
+      new brave::BraveRequestInfo());
   callbacks_[request->identifier()] = callback;
   ctx->headers = headers;
   ctx->request_identifier = request->identifier();
@@ -57,7 +57,7 @@ int BraveNetworkDelegateBase::OnBeforeStartTransaction(net::URLRequest* request,
 void BraveNetworkDelegateBase::RunNextCallback(
     net::URLRequest* request,
     GURL* new_url,
-    std::shared_ptr<brave::BraveURLRequestContext> ctx) {
+    std::shared_ptr<brave::BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   if (!ContainsKey(callbacks_, ctx->request_identifier)) {

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -47,6 +47,7 @@ int BraveNetworkDelegateBase::OnBeforeStartTransaction(net::URLRequest* request,
   std::shared_ptr<brave::BraveURLRequestContext> ctx(
       new brave::BraveURLRequestContext());
   callbacks_[request->identifier()] = callback;
+  ctx->headers = headers;
   ctx->request_identifier = request->identifier();
   ctx->event_type = brave::kOnBeforeStartTransaction;
   RunNextCallback(request, nullptr, ctx);

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -13,12 +13,6 @@
 
 using content::BrowserThread;
 
-BraveNetworkDelegateBase::ResponseListenerInfo::ResponseListenerInfo() {
-}
-
-BraveNetworkDelegateBase::ResponseListenerInfo::~ResponseListenerInfo() {
-}
-
 BraveNetworkDelegateBase::BraveNetworkDelegateBase(
     extensions::EventRouterForwarder* event_router,
     BooleanPrefMember* enable_referrers) :
@@ -34,20 +28,35 @@ int BraveNetworkDelegateBase::OnBeforeURLRequest(net::URLRequest* request,
   if (before_url_request_callbacks_.empty() || !request) {
     return ChromeNetworkDelegate::OnBeforeURLRequest(request, callback, new_url);
   }
-
-  std::shared_ptr<brave::OnBeforeURLRequestContext> ctx(
-      new brave::OnBeforeURLRequestContext());
-
+  std::shared_ptr<brave::BraveURLRequestContext> ctx(
+      new brave::BraveURLRequestContext());
   callbacks_[request->identifier()] = callback;
   ctx->request_identifier = request->identifier();
+  ctx->event_type = brave::kOnBeforeRequest;
   RunNextCallback(request, new_url, ctx);
+  return net::ERR_IO_PENDING;
+}
+
+int BraveNetworkDelegateBase::OnBeforeStartTransaction(net::URLRequest* request,
+    const net::CompletionCallback& callback,
+    net::HttpRequestHeaders* headers) {
+  if (before_start_transaction_callbacks_.empty() || !request) {
+    return ChromeNetworkDelegate::OnBeforeStartTransaction(request, callback,
+                                                           headers);
+  }
+  std::shared_ptr<brave::BraveURLRequestContext> ctx(
+      new brave::BraveURLRequestContext());
+  callbacks_[request->identifier()] = callback;
+  ctx->request_identifier = request->identifier();
+  ctx->event_type = brave::kOnBeforeStartTransaction;
+  RunNextCallback(request, nullptr, ctx);
   return net::ERR_IO_PENDING;
 }
 
 void BraveNetworkDelegateBase::RunNextCallback(
     net::URLRequest* request,
-    GURL *new_url,
-    std::shared_ptr<brave::OnBeforeURLRequestContext> ctx) {
+    GURL* new_url,
+    std::shared_ptr<brave::BraveURLRequestContext> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   if (!ContainsKey(callbacks_, ctx->request_identifier)) {
@@ -56,18 +65,36 @@ void BraveNetworkDelegateBase::RunNextCallback(
 
   // Continue processing callbacks until we hit one that returns PENDING
   int rv = net::OK;
-  while(before_url_request_callbacks_.size() != ctx->next_url_request_index) {
-    brave::OnBeforeURLRequestCallback callback =
-        before_url_request_callbacks_[ctx->next_url_request_index++];
-    brave::ResponseCallback next_callback =
-        base::Bind(&BraveNetworkDelegateBase::RunNextCallback,
-            base::Unretained(this), request, new_url, ctx);
-    rv = callback.Run(request, new_url, next_callback, ctx);
-    if (rv == net::ERR_IO_PENDING) {
-      return;
+
+  if (ctx->event_type == brave::kOnBeforeRequest) {
+    while(before_url_request_callbacks_.size() != ctx->next_url_request_index) {
+      brave::OnBeforeURLRequestCallback callback =
+          before_url_request_callbacks_[ctx->next_url_request_index++];
+      brave::ResponseCallback next_callback =
+          base::Bind(&BraveNetworkDelegateBase::RunNextCallback,
+              base::Unretained(this), request, new_url, ctx);
+      rv = callback.Run(request, new_url, next_callback, ctx);
+      if (rv == net::ERR_IO_PENDING) {
+        return;
+      }
+      if (rv == net::ERR_ABORTED) {
+        break;
+      }
     }
-    if (rv == net::ERR_ABORTED) {
-      break;
+  } else if (ctx->event_type == brave::kOnBeforeStartTransaction) {
+    while(before_start_transaction_callbacks_.size() != ctx->next_url_request_index) {
+      brave::OnBeforeStartTransactionCallback callback =
+          before_start_transaction_callbacks_[ctx->next_url_request_index++];
+      brave::ResponseCallback next_callback =
+          base::Bind(&BraveNetworkDelegateBase::RunNextCallback,
+              base::Unretained(this), request, new_url, ctx);
+      rv = callback.Run(request, ctx->headers, next_callback, ctx);
+      if (rv == net::ERR_IO_PENDING) {
+        return;
+      }
+      if (rv == net::ERR_ABORTED) {
+        break;
+      }
     }
   }
 
@@ -78,17 +105,22 @@ void BraveNetworkDelegateBase::RunNextCallback(
     return;
   }
 
-  rv =
-    ChromeNetworkDelegate::OnBeforeURLRequest(request,
+  if (ctx->event_type == brave::kOnBeforeRequest) {
+    rv = ChromeNetworkDelegate::OnBeforeURLRequest(request,
         net_completion_callback, new_url);
+  } else if (ctx->event_type == brave::kOnBeforeStartTransaction) {
+    rv = ChromeNetworkDelegate::OnBeforeStartTransaction(request,
+        net_completion_callback, ctx->headers);
+  }
+
   if (rv != net::ERR_IO_PENDING) {
     net_completion_callback.Run(rv);
   }
 }
 
 void BraveNetworkDelegateBase::OnURLRequestDestroyed(net::URLRequest* request) {
-  if (!ContainsKey(callbacks_, request->identifier())) {
-    return;
+  if (ContainsKey(callbacks_, request->identifier())) {
+    callbacks_.erase(request->identifier());
   }
-  callbacks_.erase(request->identifier());
+  ChromeNetworkDelegate::OnURLRequestDestroyed(request);
 }

--- a/browser/net/brave_network_delegate_base.h
+++ b/browser/net/brave_network_delegate_base.h
@@ -49,7 +49,7 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
   void RunNextCallback(
     net::URLRequest* request,
     GURL *new_url,
-    std::shared_ptr<brave::BraveURLRequestContext> ctx);
+    std::shared_ptr<brave::BraveRequestInfo> ctx);
   std::vector<brave::OnBeforeURLRequestCallback>
       before_url_request_callbacks_;
   std::vector<brave::OnBeforeStartTransactionCallback>

--- a/browser/net/brave_network_delegate_base.h
+++ b/browser/net/brave_network_delegate_base.h
@@ -29,19 +29,6 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
   using ResponseListener = base::Callback<void(const base::DictionaryValue&,
                                                const ResponseCallback&)>;
 
-  enum ResponseEvent {
-    kOnBeforeRequest,
-    kOnBeforeSendHeaders,
-    kOnHeadersReceived,
-  };
-
-  struct ResponseListenerInfo {
-    ResponseListenerInfo();
-    ~ResponseListenerInfo();
-
-    ResponseListener listener_;
-  };
-
   // |enable_referrers| (and all of the other optional PrefMembers) should be
   // initialized on the UI thread (see below) beforehand. This object's owner is
   // responsible for cleaning them up at shutdown.
@@ -53,18 +40,22 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
   int OnBeforeURLRequest(net::URLRequest* request,
                          const net::CompletionCallback& callback,
                          GURL* new_url) override;
+  int OnBeforeStartTransaction(net::URLRequest* request,
+                               const net::CompletionCallback& callback,
+                               net::HttpRequestHeaders* headers) override;
   void OnURLRequestDestroyed(net::URLRequest* request) override;
 
  protected:
   void RunNextCallback(
     net::URLRequest* request,
     GURL *new_url,
-    std::shared_ptr<brave::OnBeforeURLRequestContext> ctx);
+    std::shared_ptr<brave::BraveURLRequestContext> ctx);
   std::vector<brave::OnBeforeURLRequestCallback>
       before_url_request_callbacks_;
+  std::vector<brave::OnBeforeStartTransactionCallback>
+      before_start_transaction_callbacks_;
 
  private:
-  std::map<ResponseEvent, ResponseListenerInfo> response_listeners_;
   std::map<uint64_t, net::CompletionCallback> callbacks_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveNetworkDelegateBase);

--- a/browser/net/brave_profile_network_delegate.cc
+++ b/browser/net/brave_profile_network_delegate.cc
@@ -21,6 +21,11 @@ BraveProfileNetworkDelegate::BraveProfileNetworkDelegate(
           brave::OnBeforeURLRequest_HttpsePreFileWork);
   before_url_request_callbacks_.push_back(callback);
 
+  brave::OnBeforeStartTransactionCallback start_transactions_callback =
+      base::Bind(
+          brave::OnBeforeStartTransaction_SiteHacksWork);
+  before_start_transaction_callbacks_.push_back(start_transactions_callback);
+
 }
 
 BraveProfileNetworkDelegate::~BraveProfileNetworkDelegate() {

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -85,7 +85,7 @@ int OnBeforeURLRequest_SiteHacksWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx) {
+    std::shared_ptr<BraveRequestInfo> ctx) {
   const GURL& url = request->url();
 
   if (IsEmptyDataURLRedirect(url)) {
@@ -134,7 +134,7 @@ bool IsBlockTwitterSiteHack(net::URLRequest* request,
 int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
         net::HttpRequestHeaders* headers,
         const ResponseCallback& next_callback,
-        std::shared_ptr<BraveURLRequestContext> ctx) {
+        std::shared_ptr<BraveRequestInfo> ctx) {
   CheckForCookieOverride(request->url(),
       URLPattern(URLPattern::SCHEME_ALL, kForbesPattern), headers,
       kForbesExtraCookies);

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -105,4 +105,26 @@ int OnBeforeURLRequest_SiteHacksWork(
   return net::OK;
 }
 
+void CheckForCookieOverride(const GURL& url, const URLPattern& pattern,
+    net::HttpRequestHeaders* headers, const std::string& extra_cookies) {
+  if (pattern.MatchesURL(url)) {
+    std::string cookies;
+    if (headers->GetHeader(kCookieHeader, &cookies)) {
+      cookies = "; ";
+    }
+    cookies += extra_cookies;
+    headers->SetHeader(kCookieHeader, cookies);
+  }
+}
+
+int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
+        net::HttpRequestHeaders* headers,
+        const ResponseCallback& next_callback,
+        std::shared_ptr<BraveURLRequestContext> ctx) {
+  CheckForCookieOverride(request->url(),
+      URLPattern(URLPattern::SCHEME_ALL, kForbesPattern), headers,
+      kForbesExtraCookies);
+  return net::OK;
+}
+
 }  // namespace brave

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -85,7 +85,7 @@ int OnBeforeURLRequest_SiteHacksWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+    std::shared_ptr<BraveURLRequestContext> ctx) {
   const GURL& url = request->url();
 
   if (IsEmptyDataURLRedirect(url)) {

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -21,6 +21,11 @@ int OnBeforeURLRequest_SiteHacksWork(
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveURLRequestContext> ctx);
 
+int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
+    net::HttpRequestHeaders* headers,
+    const ResponseCallback& next_callback,
+    std::shared_ptr<BraveURLRequestContext> ctx);
+
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_H_

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -7,7 +7,7 @@
 
 #include "brave/browser/net/url_context.h"
 
-struct OnBeforeURLRequestContext;
+struct BraveURLRequestContext;
 
 namespace net {
 class URLRequest;
@@ -19,7 +19,7 @@ int OnBeforeURLRequest_SiteHacksWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx);
+    std::shared_ptr<BraveURLRequestContext> ctx);
 
 }  // namespace brave
 

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -7,7 +7,7 @@
 
 #include "brave/browser/net/url_context.h"
 
-struct BraveURLRequestContext;
+struct BraveRequestInfo;
 
 namespace net {
 class URLRequest;
@@ -19,12 +19,12 @@ int OnBeforeURLRequest_SiteHacksWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx);
+    std::shared_ptr<BraveRequestInfo> ctx);
 
 int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
     net::HttpRequestHeaders* headers,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx);
+    std::shared_ptr<BraveRequestInfo> ctx);
 
 }  // namespace brave
 

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -34,8 +34,8 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoChangeURL) {
   std::unique_ptr<net::URLRequest> request =
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                                TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::OnBeforeURLRequestContext>
-      before_url_context(new brave::OnBeforeURLRequestContext());
+  std::shared_ptr<brave::BraveURLRequestContext>
+      before_url_context(new brave::BraveURLRequestContext());
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
@@ -56,8 +56,8 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, RedirectsToEmptyDataURLs) {
     std::unique_ptr<net::URLRequest> request =
         context()->CreateRequest(url, net::IDLE, &test_delegate,
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
-    std::shared_ptr<brave::OnBeforeURLRequestContext>
-        before_url_context(new brave::OnBeforeURLRequestContext());
+    std::shared_ptr<brave::BraveURLRequestContext>
+        before_url_context(new brave::BraveURLRequestContext());
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
@@ -79,8 +79,8 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, RedirectsToStubs) {
     std::unique_ptr<net::URLRequest> request =
         context()->CreateRequest(url, net::IDLE, &test_delegate,
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
-    std::shared_ptr<brave::OnBeforeURLRequestContext>
-        before_url_context(new brave::OnBeforeURLRequestContext());
+    std::shared_ptr<brave::BraveURLRequestContext>
+        before_url_context(new brave::BraveURLRequestContext());
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
@@ -102,8 +102,8 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, Blocking) {
     std::unique_ptr<net::URLRequest> request =
         context()->CreateRequest(url, net::IDLE, &test_delegate,
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
-    std::shared_ptr<brave::OnBeforeURLRequestContext>
-        before_url_context(new brave::OnBeforeURLRequestContext());
+    std::shared_ptr<brave::BraveURLRequestContext>
+        before_url_context(new brave::BraveURLRequestContext());
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -169,4 +169,53 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NotForbesNoCookieChange) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoScriptTwitterMobileRedirect) {
+  GURL url("https://mobile.twitter.com/i/nojs_router?path=%2F");
+  net::TestDelegate test_delegate;
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                               TRAFFIC_ANNOTATION_FOR_TESTS);
+  net::HttpRequestHeaders headers;
+  headers.SetHeader(kRefererHeader, "https://twitter.com/");
+  std::shared_ptr<brave::BraveURLRequestContext>
+      url_context(new brave::BraveURLRequestContext());
+  brave::ResponseCallback callback;
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+      callback, url_context);
+  EXPECT_EQ(ret, net::ERR_ABORTED);
+}
+
+TEST_F(BraveSiteHacksNetworkDelegateHelperTest, AllowTwitterMobileRedirectFromDiffSite) {
+  GURL url("https://mobile.twitter.com/i/nojs_router?path=%2F");
+  net::TestDelegate test_delegate;
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                               TRAFFIC_ANNOTATION_FOR_TESTS);
+  net::HttpRequestHeaders headers;
+  headers.SetHeader(kRefererHeader, "https://brianbondy.com/");
+  std::shared_ptr<brave::BraveURLRequestContext>
+      url_context(new brave::BraveURLRequestContext());
+  brave::ResponseCallback callback;
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+      callback, url_context);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveSiteHacksNetworkDelegateHelperTest, TwitterNoCancelWithReferer) {
+  GURL url("https://twitter.com/brianbondy");
+  net::TestDelegate test_delegate;
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                               TRAFFIC_ANNOTATION_FOR_TESTS);
+  net::HttpRequestHeaders headers;
+  headers.SetHeader(kRefererHeader, "https://twitter.com/");
+  std::shared_ptr<brave::BraveURLRequestContext>
+      url_context(new brave::BraveURLRequestContext());
+  brave::ResponseCallback callback;
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+      callback, url_context);
+  EXPECT_EQ(ret, net::OK);
+}
+
+
 }  // namespace

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -34,13 +34,13 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoChangeURL) {
   std::unique_ptr<net::URLRequest> request =
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                                TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
     OnBeforeURLRequest_SiteHacksWork(request.get(), &new_url, callback,
-        url_context);
+        brave_request_info);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);
 }
@@ -56,13 +56,13 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, RedirectsToEmptyDataURLs) {
     std::unique_ptr<net::URLRequest> request =
         context()->CreateRequest(url, net::IDLE, &test_delegate,
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
-    std::shared_ptr<brave::BraveURLRequestContext>
-        url_context(new brave::BraveURLRequestContext());
+    std::shared_ptr<brave::BraveRequestInfo>
+        brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
       OnBeforeURLRequest_SiteHacksWork(request.get(), &new_url, callback,
-          url_context);
+          brave_request_info);
     EXPECT_EQ(ret, net::OK);
     EXPECT_STREQ(new_url.spec().c_str(), kEmptyDataURI);
   }); }
@@ -78,13 +78,13 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, RedirectsToStubs) {
     std::unique_ptr<net::URLRequest> request =
         context()->CreateRequest(url, net::IDLE, &test_delegate,
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
-    std::shared_ptr<brave::BraveURLRequestContext>
-        url_context(new brave::BraveURLRequestContext());
+    std::shared_ptr<brave::BraveRequestInfo>
+        brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
       OnBeforeURLRequest_SiteHacksWork(request.get(), &new_url, callback,
-          url_context);
+          brave_request_info);
     EXPECT_EQ(ret, net::OK);
     EXPECT_TRUE(new_url.SchemeIs("data"));
   });
@@ -101,13 +101,13 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, Blocking) {
     std::unique_ptr<net::URLRequest> request =
         context()->CreateRequest(url, net::IDLE, &test_delegate,
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
-    std::shared_ptr<brave::BraveURLRequestContext>
-        url_context(new brave::BraveURLRequestContext());
+    std::shared_ptr<brave::BraveRequestInfo>
+        brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
       OnBeforeURLRequest_SiteHacksWork(request.get(), &new_url, callback,
-          url_context);
+          brave_request_info);
     EXPECT_EQ(ret, net::ERR_ABORTED);
   });
 }
@@ -120,11 +120,11 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithCookieHeader) {
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   net::HttpRequestHeaders headers;
   headers.SetHeader(kCookieHeader, "name=value; name2=value2; name3=value3");
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
-      callback, url_context);
+      callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
   EXPECT_TRUE(cookies.find(std::string("; ") + kForbesExtraCookies) != std::string::npos);
@@ -138,11 +138,11 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithoutCookieHeader) {
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   net::HttpRequestHeaders headers;
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
-      callback, url_context);
+      callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
   EXPECT_TRUE(cookies.find(kForbesExtraCookies) != std::string::npos);
@@ -158,11 +158,11 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NotForbesNoCookieChange) {
   net::HttpRequestHeaders headers;
   std::string expected_cookies = "name=value; name2=value2; name3=value3";
   headers.SetHeader(kCookieHeader, "name=value; name2=value2; name3=value3");
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
-      callback, url_context);
+      callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
   EXPECT_STREQ(cookies.c_str(), expected_cookies.c_str());
@@ -177,11 +177,11 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoScriptTwitterMobileRedirect) {
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   net::HttpRequestHeaders headers;
   headers.SetHeader(kRefererHeader, "https://twitter.com/");
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
-      callback, url_context);
+      callback, brave_request_info);
   EXPECT_EQ(ret, net::ERR_ABORTED);
 }
 
@@ -193,11 +193,11 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, AllowTwitterMobileRedirectFromDi
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   net::HttpRequestHeaders headers;
   headers.SetHeader(kRefererHeader, "https://brianbondy.com/");
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
-      callback, url_context);
+      callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
 
@@ -209,11 +209,11 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, TwitterNoCancelWithReferer) {
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   net::HttpRequestHeaders headers;
   headers.SetHeader(kRefererHeader, "https://twitter.com/");
-  std::shared_ptr<brave::BraveURLRequestContext>
-      url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
-      callback, url_context);
+      callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
 

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -15,7 +15,7 @@ int OnBeforeURLRequest_StaticRedirectWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx) {
+    std::shared_ptr<BraveURLRequestContext> ctx) {
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   if (geo_pattern.MatchesURL(request->url())) {
     *new_url = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -15,7 +15,7 @@ int OnBeforeURLRequest_StaticRedirectWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx) {
+    std::shared_ptr<BraveRequestInfo> ctx) {
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   if (geo_pattern.MatchesURL(request->url())) {
     *new_url = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);

--- a/browser/net/brave_static_redirect_network_delegate_helper.h
+++ b/browser/net/brave_static_redirect_network_delegate_helper.h
@@ -8,7 +8,7 @@
 #include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
-struct BraveURLRequestContext;
+struct BraveRequestInfo;
 
 namespace net {
 class URLRequest;
@@ -20,7 +20,7 @@ int OnBeforeURLRequest_StaticRedirectWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<BraveURLRequestContext> ctx);
+    std::shared_ptr<BraveRequestInfo> ctx);
 
 }  // namespace brave
 

--- a/browser/net/brave_static_redirect_network_delegate_helper.h
+++ b/browser/net/brave_static_redirect_network_delegate_helper.h
@@ -8,7 +8,7 @@
 #include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
-struct OnBeforeURLRequestContext;
+struct BraveURLRequestContext;
 
 namespace net {
 class URLRequest;
@@ -20,7 +20,7 @@ int OnBeforeURLRequest_StaticRedirectWork(
     net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
-    std::shared_ptr<OnBeforeURLRequestContext> ctx);
+    std::shared_ptr<BraveURLRequestContext> ctx);
 
 }  // namespace brave
 

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -34,8 +34,8 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
   std::unique_ptr<net::URLRequest> request =
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                              TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::OnBeforeURLRequestContext>
-      before_url_context(new brave::OnBeforeURLRequestContext());
+  std::shared_ptr<brave::BraveURLRequestContext>
+      before_url_context(new brave::BraveURLRequestContext());
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
@@ -52,8 +52,8 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   std::unique_ptr<net::URLRequest> request =
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                              TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::OnBeforeURLRequestContext>
-      before_url_context(new brave::OnBeforeURLRequestContext());
+  std::shared_ptr<brave::BraveURLRequestContext>
+      before_url_context(new brave::BraveURLRequestContext());
   brave::ResponseCallback callback;
   GURL new_url;
   GURL expected_url(GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY));

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -34,8 +34,8 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
   std::unique_ptr<net::URLRequest> request =
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                              TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveURLRequestContext>
-      before_url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
@@ -52,8 +52,8 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   std::unique_ptr<net::URLRequest> request =
       context()->CreateRequest(url, net::IDLE, &test_delegate,
                              TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveURLRequestContext>
-      before_url_context(new brave::BraveURLRequestContext());
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
   GURL new_url;
   GURL expected_url(GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY));

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -9,10 +9,10 @@
 
 namespace brave {
 
-OnBeforeURLRequestContext::OnBeforeURLRequestContext() {
+BraveURLRequestContext::BraveURLRequestContext() {
 }
 
-OnBeforeURLRequestContext::~OnBeforeURLRequestContext() {
+BraveURLRequestContext::~BraveURLRequestContext() {
 }
 
 }  // namespace brave

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -9,10 +9,10 @@
 
 namespace brave {
 
-BraveURLRequestContext::BraveURLRequestContext() {
+BraveRequestInfo::BraveRequestInfo() {
 }
 
-BraveURLRequestContext::~BraveURLRequestContext() {
+BraveRequestInfo::~BraveRequestInfo() {
 }
 
 }  // namespace brave

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -13,14 +13,22 @@
 
 namespace brave {
 
-struct OnBeforeURLRequestContext {
-  OnBeforeURLRequestContext();
-  ~OnBeforeURLRequestContext();
+enum BraveNetworkDelegateEventType {
+  kOnBeforeRequest,
+  kOnBeforeStartTransaction,
+  kUnknownEventType
+};
+
+struct BraveURLRequestContext {
+  BraveURLRequestContext();
+  ~BraveURLRequestContext();
   GURL request_url;
   std::string new_url_spec;
   uint64_t request_identifier = 0;
   size_t next_url_request_index = 0;
-  DISALLOW_COPY_AND_ASSIGN(OnBeforeURLRequestContext);
+  net::HttpRequestHeaders* headers = nullptr;
+  BraveNetworkDelegateEventType event_type = kUnknownEventType;
+  DISALLOW_COPY_AND_ASSIGN(BraveURLRequestContext);
 };
 
 using ResponseCallback = base::Callback<void()>;
@@ -30,8 +38,12 @@ using OnBeforeURLRequestCallback =
     base::Callback<int(net::URLRequest* request,
         GURL* new_url,
         const ResponseCallback& next_callback,
-        std::shared_ptr<OnBeforeURLRequestContext> ctx)>;
-
+        std::shared_ptr<BraveURLRequestContext> ctx)>;
+using OnBeforeStartTransactionCallback =
+    base::Callback<int(net::URLRequest* request,
+        net::HttpRequestHeaders* headers,
+        const ResponseCallback& next_callback,
+        std::shared_ptr<BraveURLRequestContext> ctx)>;
 }  // namespace brave
 
 

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -19,16 +19,16 @@ enum BraveNetworkDelegateEventType {
   kUnknownEventType
 };
 
-struct BraveURLRequestContext {
-  BraveURLRequestContext();
-  ~BraveURLRequestContext();
+struct BraveRequestInfo {
+  BraveRequestInfo();
+  ~BraveRequestInfo();
   GURL request_url;
   std::string new_url_spec;
   uint64_t request_identifier = 0;
   size_t next_url_request_index = 0;
   net::HttpRequestHeaders* headers = nullptr;
   BraveNetworkDelegateEventType event_type = kUnknownEventType;
-  DISALLOW_COPY_AND_ASSIGN(BraveURLRequestContext);
+  DISALLOW_COPY_AND_ASSIGN(BraveRequestInfo);
 };
 
 using ResponseCallback = base::Callback<void()>;
@@ -38,12 +38,12 @@ using OnBeforeURLRequestCallback =
     base::Callback<int(net::URLRequest* request,
         GURL* new_url,
         const ResponseCallback& next_callback,
-        std::shared_ptr<BraveURLRequestContext> ctx)>;
+        std::shared_ptr<BraveRequestInfo> ctx)>;
 using OnBeforeStartTransactionCallback =
     base::Callback<int(net::URLRequest* request,
         net::HttpRequestHeaders* headers,
         const ResponseCallback& next_callback,
-        std::shared_ptr<BraveURLRequestContext> ctx)>;
+        std::shared_ptr<BraveRequestInfo> ctx)>;
 }  // namespace brave
 
 

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -6,5 +6,10 @@ const char kGeoLocationsPattern[] = "https://www.googleapis.com/geolocation/v1/g
 const char kGoogleTagManagerPattern[] = "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] = "https://www.googletagservices.com/tag/js/gpt.js";
 const char kCookieHeader[] = "Cookie";
+// Intentional mispelling on referrer to match HTTP spec
+const char kRefererHeader[] = "Referer";
 const char kForbesPattern[] = "https://www.forbes.com/*";
 const char kForbesExtraCookies[] = "forbes_ab=true; welcomeAd=true; adblock_session=Off; dailyWelcomeCookie=true";
+const char kTwitterPattern[] = "https://*.twitter.com/*";
+const char kTwitterReferrer[] = "https://twitter.com/*";
+const char kTwitterRedirectURL[] = "https://mobile.twitter.com/i/nojs_router*";

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -5,3 +5,6 @@ const char kJSDataURLPrefix[] = "data:application/javascript;base64,";
 const char kGeoLocationsPattern[] = "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kGoogleTagManagerPattern[] = "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] = "https://www.googletagservices.com/tag/js/gpt.js";
+const char kCookieHeader[] = "Cookie";
+const char kForbesPattern[] = "https://www.forbes.com/*";
+const char kForbesExtraCookies[] = "forbes_ab=true; welcomeAd=true; adblock_session=Off; dailyWelcomeCookie=true";

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -7,8 +7,12 @@ extern const char kGeoLocationsPattern[];
 extern const char kGoogleTagManagerPattern[];
 extern const char kGoogleTagServicesPattern[];
 extern const char kCookieHeader[];
+extern const char kRefererHeader[];
 extern const char kForbesPattern[];
 extern const char kForbesExtraCookies[];
+extern const char kTwitterPattern[];
+extern const char kTwitterReferrer[];
+extern const char kTwitterRedirectURL[];
 
 #endif  // BRAVE_COMMON_NETWORK_CONSTANTS_H_
 

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -6,6 +6,9 @@ extern const char kJSDataURLPrefix[];
 extern const char kGeoLocationsPattern[];
 extern const char kGoogleTagManagerPattern[];
 extern const char kGoogleTagServicesPattern[];
+extern const char kCookieHeader[];
+extern const char kForbesPattern[];
+extern const char kForbesExtraCookies[];
 
 #endif  // BRAVE_COMMON_NETWORK_CONSTANTS_H_
 


### PR DESCRIPTION
This implements `OnBeforeStartTransaction` and adds 2 more site hacks:
- Avoid Twitter redirecting NoScript loads to the mobile site.
- Add extra cookies for Forbes to avoid the welcome page.


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
    - Intentionally not closing because it just resolves 2 of the sub-items.  But I linked them.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
    - History should be preserved, no useless commits.
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
