### PR TITLE
Use Homebrew Git's hunk headers

### DIFF
--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -10,7 +10,7 @@ index 2b38db266f9aa1f4141c8649c021042ede4e5589..4b14f15e5091b251be53eff29139beaa
  #include "base/mac/mac_logging.h"
  #include "base/rand_util.h"
  #include "crypto/apple_keychain.h"
-@@ -54,11 +55,23 @@
+@@ -54,11 +55,23 @@ std::string AddRandomPasswordToKeychain(const AppleKeychain& keychain,
  const char KeychainPassword::service_name[] = "Chrome Safe Storage";
  const char KeychainPassword::account_name[] = "Chrome";
  #else


### PR DESCRIPTION
Apple's Git and Homebrew's Git sometimes disagree about hunk headers. Homebrew's Git is newer and closer to other platform's versions of Git, so we prefer it.

After installing Homebrew's Git, I ran `yarn run init` and `yarn run update_patches` (without having made any changes to the Chromium source). There is one file with a hunk header change, because I resolved a merge conflict that was created in `9f292d21` because @bbondy was using Homebrew's Git while I was using Apple's Git.

I will update the wiki to recommend developers using macOS install git from Homebrew.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. Make sure you're running a recent version of Git (e.g. 2.17.0). Don't use the version provided by Apple.
2. `yarn run init`
3. `yarn run update_patches`

There should be no bogus changes to the hunk headers in any of the patch files.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions