### PR TITLE
Introduce BRAVE_CHROMIUM_BUILD define guard

### DIFF
--- a/brave_init_settings.gni
+++ b/brave_init_settings.gni
@@ -1,0 +1,3 @@
+declare_args() {
+  brave_chromium_build = true
+}

--- a/build/BUILD.gn
+++ b/build/BUILD.gn
@@ -6,3 +6,9 @@ brave_include_dirs_ = [
 config("brave_include_dirs") {
   include_dirs = brave_include_dirs_
 }
+
+config("feature_flags") {
+  if (brave_chromium_build) {
+    defines = [ "BRAVE_CHROMIUM_BUILD" ]
+  }
+}

--- a/patches/build-config-BUILDCONFIG.gn.patch
+++ b/patches/build-config-BUILDCONFIG.gn.patch
@@ -1,22 +1,24 @@
 diff --git a/build/config/BUILDCONFIG.gn b/build/config/BUILDCONFIG.gn
-index 853c8492ce95d1cfaab058c799546e20f9d52cb4..fabd1368273d08c588754fa6a0c85c83b1baf00f 100644
+index 853c8492ce95d1cfaab058c799546e20f9d52cb4..6e8bf892d1ccc0840cfb8ddb393dd8faee560475 100644
 --- a/build/config/BUILDCONFIG.gn
 +++ b/build/config/BUILDCONFIG.gn
-@@ -152,6 +152,7 @@ declare_args() {
-   host_toolchain = ""
+@@ -46,6 +46,8 @@
+ # When writing build files, to do something only for the host:
+ #   if (current_toolchain == host_toolchain) { ...
  
-   # DON'T ADD MORE FLAGS HERE. Read the comment above.
-+  brave_chromium_build = false
++import("//brave/brave_init_settings.gni")
++
+ if (target_os == "") {
+   target_os = host_os
  }
- 
- declare_args() {
-@@ -534,6 +535,13 @@ default_compiler_configs = [
+@@ -534,6 +536,14 @@ default_compiler_configs = [
    "//build/config/coverage:default_coverage",
    "//build/config/sanitizers:default_sanitizer_flags",
  ]
-+if (!brave_chromium_build) {
++if (brave_chromium_build) {
 +  default_compiler_configs -= [ "//build/config/compiler:default_include_dirs" ]
 +  default_compiler_configs += [
++    "//brave/build:feature_flags",
 +    "//brave/build:brave_include_dirs",
 +    "//build/config/compiler:default_include_dirs"
 +  ]

--- a/patches/chrome-browser-extensions-extension_service.cc.patch
+++ b/patches/chrome-browser-extensions-extension_service.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/extension_service.cc b/chrome/browser/extensions/extension_service.cc
-index 9410c6daeabccba17d72244f2395c150aa84283a..417180bfe370c611a591a768d5fb5076bd7955ad 100644
+index 9410c6daeabccba17d72244f2395c150aa84283a..8c9d8397e8101c5b6f053229185bddac9b610ec9 100644
 --- a/chrome/browser/extensions/extension_service.cc
 +++ b/chrome/browser/extensions/extension_service.cc
 @@ -28,6 +28,8 @@
@@ -24,7 +24,7 @@ index 9410c6daeabccba17d72244f2395c150aa84283a..417180bfe370c611a591a768d5fb5076
    }
  
    AddExtension(extension);
-+#if defined(CHROMIUM_BUILD)
++#if defined(BRAVE_CHROMIUM_BUILD)
 +  // ContentSettingsStore::RegisterExtension is only called for default components
 +  // on the first run with a fresh profile. All restarts of the browser after that do not call it.
 +  // This causes ContentSettingsStore's `entries_` to never insert the component ID

--- a/patches/chrome-browser-prefs-session_startup_pref.cc.patch
+++ b/patches/chrome-browser-prefs-session_startup_pref.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/prefs/session_startup_pref.cc b/chrome/browser/prefs/session_startup_pref.cc
-index 01328069d4ef68583ddfd1a54c627d860703df0e..bcacc9410cbe55dc152d3ac9df28e291a3164a5a 100644
+index 01328069d4ef68583ddfd1a54c627d860703df0e..16d8ceb2938edffae3271687dd5c5b6af797d8fb 100644
 --- a/chrome/browser/prefs/session_startup_pref.cc
 +++ b/chrome/browser/prefs/session_startup_pref.cc
 @@ -60,6 +60,8 @@ void SessionStartupPref::RegisterProfilePrefs(
  SessionStartupPref::Type SessionStartupPref::GetDefaultStartupType() {
  #if defined(OS_CHROMEOS)
    return SessionStartupPref::LAST;
-+#elif !defined(GOOGLE_CHROME_BUILD)
++#elif defined(BRAVE_CHROMIUM_BUILD)
 +  return SessionStartupPref::LAST;
  #else
    return SessionStartupPref::DEFAULT;


### PR DESCRIPTION
brave_init_settings.gni is introduced for top level gn setting.
Also, BRAVE_CHROMIUM_BUILD is used instead of CHROMIUM_BUILD/GOOGLE_CHROME_BUILD
in our patches.

Fixes https://github.com/brave/brave-browser/issues/143

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
