### PR TITLE
Add switch for disable-brave-extension

### DIFF
--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -4,6 +4,8 @@
 
 #include "brave/browser/extensions/brave_component_loader.h"
 
+#include "base/command_line.h"
+#include "brave/common/brave_switches.h"
 #include "components/grit/brave_components_resources.h"
 
 namespace extensions {
@@ -22,10 +24,15 @@ BraveComponentLoader::~BraveComponentLoader() {
 void BraveComponentLoader::AddDefaultComponentExtensions(
     bool skip_session_components) {
   ComponentLoader::AddDefaultComponentExtensions(skip_session_components);
-  base::FilePath brave_extension_path(FILE_PATH_LITERAL(""));
-  brave_extension_path =
-      brave_extension_path.Append(FILE_PATH_LITERAL("brave_extension"));
-  Add(IDR_BRAVE_EXTENSON, brave_extension_path);
+
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  if (!command_line.HasSwitch(switches::kDisableBraveExtension)) {
+    base::FilePath brave_extension_path(FILE_PATH_LITERAL(""));
+    brave_extension_path =
+        brave_extension_path.Append(FILE_PATH_LITERAL("brave_extension"));
+    Add(IDR_BRAVE_EXTENSON, brave_extension_path);
+  }
 }
 
 }  // namespace extensions

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -2,6 +2,8 @@ source_set("common") {
   sources = [
     "brave_paths.cc",
     "brave_paths.h",
+    "brave_switches.cc",
+    "brave_switches.h",
     "common_message_generator.cc",
     "common_message_generator.h",
     "importer/chrome_importer_utils.cc",

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/common/brave_switches.h"
+
+namespace switches {
+
+// Allows disabling the Brave extension.
+// This is commonly used for loading the extension manually to debug things
+// in debug mode with auto-reloading.
+const char kDisableBraveExtension[] = "disable-brave-extension";
+
+}  // namespace switches

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMMON_BRAVE_SWITCHES_H_
+#define BRAVE_COMMON_BRAVE_SWITCHES_H_
+
+namespace switches {
+
+// All switches in alphabetical order. The switches should be documented
+// alongside the definition of their values in the .cc file.
+extern const char kDisableBraveExtension[];
+
+}  // namespace switches
+
+#endif  // BRAVE_COMMON_BRAVE_SWITCHES_H_
+


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/150
Related: https://github.com/brave/brave-browser/pull/151
Documented here: https://github.com/brave/brave-browser/wiki/Debugging-brave-extension

This disables loading the Brave extension, this is commonly done for loading the extension manually to debug the extension

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
