### PR TITLE
Fix errors in os_crypt patch files for Linux

### DIFF
--- a/patches/components-os_crypt-key_storage_keyring.cc.patch
+++ b/patches/components-os_crypt-key_storage_keyring.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/os_crypt/key_storage_keyring.cc b/components/os_crypt/key_storage_keyring.cc
-index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..4de119827b80cb8bbf83c26ef4937c6d8218e448 100644
+index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..9db6e47b35e6cac14168908a4385120fe44cb8d0 100644
 --- a/components/os_crypt/key_storage_keyring.cc
 +++ b/components/os_crypt/key_storage_keyring.cc
 @@ -6,6 +6,7 @@
@@ -24,7 +24,7 @@ index af2f64b34ddb8e49d72dd0dd22ffd2418a422efb..4de119827b80cb8bbf83c26ef4937c6d
    std::string password;
    gchar* password_c = nullptr;
 +  const char* application_name;
-+  base::CommandLine* command_line = base::CommandLine()::ForCurrentProcess();
++  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
 +  if (command_line->HasSwitch("import-chrome")) {
 +    application_name = "chrome";
 +  } else if (command_line->HasSwitch("import-chromium")) {

--- a/patches/components-os_crypt-key_storage_kwallet.cc.patch
+++ b/patches/components-os_crypt-key_storage_kwallet.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/os_crypt/key_storage_kwallet.cc b/components/os_crypt/key_storage_kwallet.cc
-index aa4b3d4a6b5c7b1f725d6446ea5e573094ec935b..3d53b65e81969d7bc88466e09623eab22f3088cd 100644
+index aa4b3d4a6b5c7b1f725d6446ea5e573094ec935b..4c4c7191a57afc7a42dfa87701578bd99d417d94 100644
 --- a/components/os_crypt/key_storage_kwallet.cc
 +++ b/components/os_crypt/key_storage_kwallet.cc
 @@ -7,6 +7,7 @@
@@ -18,7 +18,7 @@ index aa4b3d4a6b5c7b1f725d6446ea5e573094ec935b..3d53b65e81969d7bc88466e09623eab2
 +  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
 +  if (command_line->HasSwitch("import-chrome")) {
 +    folder_name = "Chrome Keys";
-+    key = "Chrome Safe Storage"
++    key = "Chrome Safe Storage";
 +  } else if (command_line->HasSwitch("import-chromium")) {
 +    folder_name = "Chromium Keys";
 +    key = "Chromium Safe Storage";


### PR DESCRIPTION
Fixes Linux compilation errors that were introduced in #77.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. Checkout this branch and run `yarn run sync --run_hooks` to apply the updated patches.
2. Build on Linux. The build should complete without errors.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions