### PR TITLE
Brave vector icons

### DIFF
--- a/patches/components-vector_icons-aggregate_vector_icons.py.patch
+++ b/patches/components-vector_icons-aggregate_vector_icons.py.patch
@@ -1,0 +1,52 @@
+diff --git a/components/vector_icons/aggregate_vector_icons.py b/components/vector_icons/aggregate_vector_icons.py
+index 87aa1bea0f6a5159f241479f6bb52547e508fcb3..0a9d96d1c580bdbebc25b444b9eb54a9f61bedda 100644
+--- a/components/vector_icons/aggregate_vector_icons.py
++++ b/components/vector_icons/aggregate_vector_icons.py
+@@ -21,7 +21,7 @@ def CamelCase(name, suffix):
+   return 'k' + ''.join(words) + suffix
+ 
+ 
+-def AggregateVectorIcons(working_directory, file_list, output_cc, output_h):
++def AggregateVectorIcons(working_directory, file_list, output_cc, output_h, alt_working_directory):
+   """Compiles all .icon files in a directory into two C++ files.
+ 
+   Args:
+@@ -30,6 +30,8 @@ def AggregateVectorIcons(working_directory, file_list, output_cc, output_h):
+       file_list: A file containing the list of vector icon files to process.
+       output_cc: The path that should be used to write the .cc file.
+       output_h: The path that should be used to write the .h file.
++      alt_working_directory: The alternative path to the directory that holds
++          the .icon files
+   """
+ 
+   # For each file in |file_list|, place it in |path_map| if its extension is
+@@ -52,6 +54,11 @@ def AggregateVectorIcons(working_directory, file_list, output_cc, output_h):
+       Error("Only filenames " + icon_name + ".icon or " + icon_name +
+             ".1x.icon are allowed.")
+ 
++    # Check for alternative path
++    alt_icon_path = os.path.join(alt_working_directory, os.path.basename(icon_path))
++    if (os.path.exists(alt_icon_path)):
++      icon_path = alt_icon_path
++
+     if not scale_factor and icon_name not in path_map:
+       path_map[icon_name] = icon_path
+     elif scale_factor and icon_name not in path_map_1x:
+@@ -144,13 +151,16 @@ def main():
+                     help="The path to output the CC file to.")
+   parser.add_option("--output_h",
+                     help="The path to output the header file to.")
++  parser.add_option("--alt_working_directory",
++                    help="The directory to look for alternative icon files.")
+ 
+   (options, args) = parser.parse_args()
+ 
+   AggregateVectorIcons(options.working_directory,
+                        options.file_list,
+                        options.output_cc,
+-                       options.output_h)
++                       options.output_h,
++                       options.alt_working_directory)
+ 
+ 
+ if __name__ == "__main__":

--- a/patches/components-vector_icons-vector_icons.gni.patch
+++ b/patches/components-vector_icons-vector_icons.gni.patch
@@ -1,0 +1,30 @@
+diff --git a/components/vector_icons/vector_icons.gni b/components/vector_icons/vector_icons.gni
+index e1a364810743c236111bacfff50be5e26bcbe335..6f394b48c6633ce9739d46fb7aea36103ccab1d5 100644
+--- a/components/vector_icons/vector_icons.gni
++++ b/components/vector_icons/vector_icons.gni
+@@ -40,6 +40,10 @@ template("aggregate_vector_icons") {
+       "vector_icons.cc.template",
+       "vector_icons.h.template",
+     ]
++
++    alt_icons_dir = "//brave/vector_icons/"+ rebase_path(invoker.icon_directory, "//")
++    alt_icons_dir_rel = rebase_path(alt_icons_dir, root_build_dir)
++
+     inputs = rebase_path(templates + invoker.icons, ".", invoker.icon_directory)
+ 
+     outputs = [
+@@ -49,13 +53,13 @@ template("aggregate_vector_icons") {
+ 
+     response_file_contents =
+         rebase_path(invoker.icons, root_build_dir, invoker.icon_directory)
+-
+     args = [
+       "--working_directory=" +
+           rebase_path(invoker.icon_directory, root_build_dir),
+       "--file_list={{response_file_name}}",
+       "--output_cc=" + rebase_path(output_cc, root_build_dir),
+       "--output_h=" + rebase_path(output_h, root_build_dir),
++      "--alt_working_directory=" + alt_icons_dir_rel,
+     ]
+   }
+ }

--- a/vector_icons/chrome/app/vector_icons/navigate_home.1x.icon
+++ b/vector_icons/chrome/app/vector_icons/navigate_home.1x.icon
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 16,
+STROKE, 1.2,
+MOVE_TO, 5.33f, 15.65f,
+R_H_LINE_TO, 5.33f,
+V_LINE_TO, 8.66f,
+H_LINE_TO, 5.33f,
+CLOSE,
+MOVE_TO, 14.61f, 15.65f,
+H_LINE_TO, 1.37f,
+ARC_TO, 1.04f, 1.04f, 0, 0, 0.33f, 0.33f, 14.61f,
+V_LINE_TO, 5.66f,
+R_ARC_TO, 1.04f, 1.04f, 0, 0, 0.33f, 0.47f, -0.87f,
+LINE_TO, 7.43f, 0.5f,
+R_ARC_TO, 1.04f, 1.04f, 0, 0, 0.33f, 1.13f, 0,
+R_LINE_TO, 6.62f, 4.29f,
+ARC_TO, 1.04f, 1.04f, 0, 0, 0.33f, 15.65f, 5.66f,
+R_V_LINE_TO, 8.95f,
+ARC_TO, 1.04f, 1.04f, 0, 0, 0.33f, 14.61f, 15.65f,
+CLOSE,
+END

--- a/vector_icons/chrome/app/vector_icons/navigate_home.icon
+++ b/vector_icons/chrome/app/vector_icons/navigate_home.icon
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 32,
+STROKE, 1.2,
+MOVE_TO, 10.67f, 31.35f,
+R_H_LINE_TO, 10.67f,
+V_LINE_TO, 17.34f,
+H_LINE_TO, 10.67f,
+CLOSE,
+MOVE_TO, 29.27f, 31.35f,
+H_LINE_TO, 2.75f,
+ARC_TO, 2.08f, 2.08f, 0, 0, 0.67f, 0.67f, 29.27f,
+V_LINE_TO, 11.34f,
+R_ARC_TO, 2.07f, 2.07f, 0, 0, 0.67f, 0.95f, -1.74f,
+LINE_TO, 14.87f, 1,
+R_ARC_TO, 2.08f, 2.08f, 0, 0, 0.67f, 2.27f, 0,
+R_LINE_TO, 13.26f, 8.6f,
+ARC_TO, 2.07f, 2.07f, 0, 0, 0.67f, 31.35f, 11.34f,
+R_V_LINE_TO, 17.93f,
+ARC_TO, 2.08f, 2.08f, 0, 0, 0.67f, 29.27f, 31.35f,
+CLOSE,
+END

--- a/vector_icons/chrome/app/vector_icons/navigate_stop.1x.icon
+++ b/vector_icons/chrome/app/vector_icons/navigate_stop.1x.icon
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 16,
+STROKE, 1.2,
+MOVE_TO, 0, 0,
+R_LINE_TO, 15.98f, 15.98f,
+MOVE_TO, 15.98f, 0,
+LINE_TO, 0, 15.98f,
+END

--- a/vector_icons/chrome/app/vector_icons/navigate_stop.icon
+++ b/vector_icons/chrome/app/vector_icons/navigate_stop.icon
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 32,
+STROKE, 1.2,
+MOVE_TO, 0, 0,
+R_LINE_TO, 32.02f, 32.02f,
+MOVE_TO, 32.02f, 0,
+LINE_TO, 0, 32.02f,
+END

--- a/vector_icons/components/vector_icons/back_arrow.1x.icon
+++ b/vector_icons/components/vector_icons/back_arrow.1x.icon
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 16,
+STROKE, 1.2,
+MOVE_TO, 2.02f, 8.62f,
+R_LINE_TO, 11.44f, 6.92f,
+R_CUBIC_TO, 0.52f, 0.31f, 1.19f, -0.04f, 1.19f, -0.62f,
+V_LINE_TO, 1.07f,
+R_CUBIC_TO, 0, -0.58f, -0.67f, -0.94f, -1.19f, -0.62f,
+LINE_TO, 2.02f, 7.37f,
+R_ARC_TO, 0.72f, 0.72f, 0, 0, 0, 0, 1.25f,
+CLOSE,
+END

--- a/vector_icons/components/vector_icons/back_arrow.icon
+++ b/vector_icons/components/vector_icons/back_arrow.icon
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 32,
+STROKE, 1.2,
+MOVE_TO, 4.06f, 17.26f,
+R_LINE_TO, 22.91f, 13.86f,
+R_CUBIC_TO, 1.03f, 0.63f, 2.39f, -0.08f, 2.39f, -1.25f,
+V_LINE_TO, 2.15f,
+R_CUBIC_TO, 0, -1.17f, -1.35f, -1.87f, -2.39f, -1.25f,
+LINE_TO, 4.06f, 14.76f,
+R_ARC_TO, 1.44f, 1.44f, 0, 0, 0, 0, 2.5f,
+CLOSE,
+END

--- a/vector_icons/components/vector_icons/forward_arrow.1x.icon
+++ b/vector_icons/components/vector_icons/forward_arrow.1x.icon
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 16,
+STROKE, 1.2,
+MOVE_TO, 13.9f, 8.93f,
+R_LINE_TO, -10.42f, 6.39f,
+CUBIC_TO, 2.68f, 15.81f, 1.67f, 15.24f, 1.67f, 14.31f,
+V_LINE_TO, 1.52f,
+CUBIC_TO, 1.67f, 0.6f, 2.68f, 0.02f, 3.48f, 0.51f,
+R_LINE_TO, 10.42f, 6.39f,
+R_CUBIC_TO, 0.76f, 0.47f, 0.76f, 1.56f, 0, 2.03f,
+CLOSE,
+END

--- a/vector_icons/components/vector_icons/forward_arrow.icon
+++ b/vector_icons/components/vector_icons/forward_arrow.icon
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 32,
+STROKE, 1.2,
+MOVE_TO, 27.83f, 17.89f,
+R_LINE_TO, -20.87f, 12.81f,
+CUBIC_TO, 5.38f, 31.67f, 3.34f, 30.53f, 3.34f, 28.67f,
+V_LINE_TO, 3.05f,
+CUBIC_TO, 3.34f, 1.19f, 5.38f, 0.05f, 6.97f, 1.02f,
+R_LINE_TO, 20.87f, 12.81f,
+R_CUBIC_TO, 1.52f, 0.93f, 1.52f, 3.13f, 0, 4.06f,
+CLOSE,
+END

--- a/vector_icons/components/vector_icons/reload.1x.icon
+++ b/vector_icons/components/vector_icons/reload.1x.icon
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 16,
+STROKE, 1.2,
+MOVE_TO, 11.15f, 13.41f,
+CUBIC_TO, 10.03f, 14.19f, 8.66f, 14.65f, 7.17f, 14.65f,
+R_H_LINE_TO, -0.01f,
+CUBIC_TO, 3.39f, 14.65f, 0.33f, 11.67f, 0.33f, 8,
+R_V_LINE_TO, -0.01f,
+CUBIC_TO, 0.33f, 4.31f, 3.39f, 1.33f, 7.16f, 1.33f,
+R_H_LINE_TO, 0.01f,
+R_CUBIC_TO, 2.59f, 0, 4.5f, 1.41f, 5.66f, 3.48f,
+LINE_TO, 13.65f, 6.86f,
+NEW_PATH,
+MOVE_TO, 15.98f, 7.33f,
+R_CUBIC_TO, 0, -1.1f, -0.9f, -2, -2, -2,
+R_CUBIC_TO, -1.1f, 0, -2, 0.9f, -2, 2,
+R_ARC_TO, 2, 2, 0, 0, 0, 4, 0,
+CLOSE,
+END

--- a/vector_icons/components/vector_icons/reload.1x.icon
+++ b/vector_icons/components/vector_icons/reload.1x.icon
@@ -18,5 +18,5 @@ MOVE_TO, 15.98f, 7.33f,
 R_CUBIC_TO, 0, -1.1f, -0.9f, -2, -2, -2,
 R_CUBIC_TO, -1.1f, 0, -2, 0.9f, -2, 2,
 R_ARC_TO, 2, 2, 0, 0, 0, 4, 0,
-CLOSE,
+CLOSE, 
 END

--- a/vector_icons/components/vector_icons/reload.icon
+++ b/vector_icons/components/vector_icons/reload.icon
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CANVAS_DIMENSIONS, 32,
+STROKE, 1.2,
+MOVE_TO, 22.33f, 26.85f,
+CUBIC_TO, 20.09f, 28.42f, 17.34f, 29.35f, 14.36f, 29.35f,
+R_H_LINE_TO, -0.02f,
+CUBIC_TO, 6.79f, 29.35f, 0.67f, 23.38f, 0.67f, 16.02f,
+R_V_LINE_TO, -0.02f,
+CUBIC_TO, 0.67f, 8.64f, 6.79f, 2.67f, 14.35f, 2.67f,
+R_H_LINE_TO, 0.02f,
+R_CUBIC_TO, 5.19f, 0, 9.01f, 2.82f, 11.33f, 6.98f,
+LINE_TO, 27.35f, 13.75f,
+NEW_PATH,
+MOVE_TO, 32.02f, 14.67f,
+R_CUBIC_TO, 0, -2.21f, -1.79f, -4, -4, -4,
+R_CUBIC_TO, -2.21f, 0, -4, 1.79f, -4, 4,
+R_ARC_TO, 4, 4, 0, 0, 0, 8, 0,
+CLOSE,
+END


### PR DESCRIPTION
This PR is for https://github.com/brave/brave-browser/issues/160 , "Add support of Brave-branded vector icons".

- Modified build script to use icon files from brave-core.
- Replaced toolbar icons:
 back / forward / home / reload / stop  
 with the icons from @alexwykoff .
- Created wiki article with instructions how to put new vector icons https://github.com/brave/brave-browser/wiki/Making-vector-icons .
- Checked on Linux, macOS, Windows platforms.

![image 1](https://user-images.githubusercontent.com/24739341/38623399-3fbae680-3dae-11e8-9915-23c12bb9e17b.png)
<img width="163" alt="screen shot 2018-04-11 at 11 40 36 am" src="https://user-images.githubusercontent.com/24739341/38623400-3fdbfc08-3dae-11e8-9814-2db10ea2d0ea.png">

Brave icon files are not specified in gn scripts, so ninja tool cannot detect they were changed. 
For now it is required to remove manually all `vector_icons.cc` inside of `brave-browser/src/out/Release/gen/` to make it do rebuild. 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues/160) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. Launch browser
2. Turn home button on in the settings
3. Ensure icons  back / forward / home / reload / stop  has been replaced

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
