### PR TITLE
Fix Windows link error

### DIFF
--- a/utility/BUILD.gn
+++ b/utility/BUILD.gn
@@ -18,6 +18,7 @@ source_set("utility") {
   deps = [
     "//chrome/common",
     "//chrome/utility",
+    "//components/password_manager/core/browser",
   ]
 
   if (use_glib) {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/146.

It's unclear to me why this linker error should only appear on Windows, and not macOS or Linux. I noticed that the `static_library` target that contains the missing `password_manager::LoginDatabase` symbols is [split into multiple static libraries on Windows builds](https://cs.chromium.org/chromium/src/chrome/browser/BUILD.gn?l=62-70&rcl=dee45b30620a7ddafa8ceb735e54737bf5d86a7a), but I am not sure if that is the cause.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

On Windows:

1. Checkout this branch in your brave-core subrepo (e.g. `brave/src/brave`)
2. `yarn build` in your brave-browser repo

The build should complete successfully.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
