### PR TITLE
Fix brave_unit_tests LNK1120 error on Windows

### DIFF
--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -47,6 +47,7 @@ test("brave_unit_tests") {
     "//base/test:test_support",
     "//brave/browser",
     "//brave/common",
+    "//brave/components/content_settings/core/browser",
     "//brave/extensions",
     "//brave/renderer",
     "//brave/utility",


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/172.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

On a Windows dev machine:

1. `yarn test brave_unit_tests`

`brave_unit_tests` should successfully build and link, and all tests should pass.

Disclaimer: I can verify that this PR fixes the LNK1120 error I was experiencing, but I cannot confirm that this PR totally fixes `yarn test brave_unit_tests` on Windows because I am still running into LNK1318 errors even with this fix applied. It is possible that the LNK1318 errors are unique to my Windows dev VM (e.g. due to insufficient RAM). I am currently trying a clean build at @emerick's suggestion to see if that can resolve the LNK1318 errors. 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
