### PR TITLE
Prompt user to close Chrome before importing from a Chrome profile

### DIFF
--- a/app/generated_resources.grd
+++ b/app/generated_resources.grd
@@ -15,6 +15,14 @@ If you update this file, be sure also to update google_chrome_strings.grd. -->
       <message name="IDS_SHOW_BRAVE_PAYMENTS" desc="The show brave payments menu in the app menu">
         Brave Payments
       </message>
+
+      <!-- Importer Lock Dialog -->
+      <message name="IDS_CHROME_IMPORTER_LOCK_TITLE" desc="Dialog title for Chrome importer lock dialog">
+	Close Chrome
+      </message>
+      <message name="IDS_CHROME_IMPORTER_LOCK_TEXT" desc="The message to be displayed in the Chrome importer lock dialog">
+	To finish importing, close all Chrome windows.
+      </message>
     </messages>
     <includes>
       <include name="IDR_BRAVE_TAG_SERVICES_POLYFILL" file="resources/js/tag_services_polyfill.js" type="BINDATA" />

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -18,10 +18,13 @@ source_set("browser_process") {
     "importer/brave_external_process_importer_client.h",
     "importer/brave_external_process_importer_host.cc",
     "importer/brave_external_process_importer_host.h",
+    "importer/brave_importer_lock_dialog.h",
     "importer/brave_in_process_importer_bridge.cc",
     "importer/brave_in_process_importer_bridge.h",
     "importer/brave_profile_writer.cc",
-    "importer/brave_profile_writer.h"
+    "importer/brave_profile_writer.h",
+    "importer/chrome_profile_lock.cc",
+    "importer/chrome_profile_lock.h",
   ]
 
   deps = [

--- a/browser/importer/brave_external_process_importer_host.cc
+++ b/browser/importer/brave_external_process_importer_host.cc
@@ -6,8 +6,42 @@
 #include "brave/browser/importer/brave_external_process_importer_host.h"
 #include "brave/browser/importer/brave_in_process_importer_bridge.h"
 
+#include "brave/browser/importer/brave_importer_lock_dialog.h"
+
 BraveExternalProcessImporterHost::BraveExternalProcessImporterHost()
-  : ExternalProcessImporterHost() {}
+  : ExternalProcessImporterHost(),
+    weak_ptr_factory_(this) {}
+
+BraveExternalProcessImporterHost::~BraveExternalProcessImporterHost() {}
+
+void BraveExternalProcessImporterHost::StartImportSettings(
+    const importer::SourceProfile& source_profile,
+    Profile* target_profile,
+    uint16_t items,
+    ProfileWriter* writer) {
+  // We really only support importing from one host at a time.
+  DCHECK(!profile_);
+  DCHECK(target_profile);
+
+  profile_ = target_profile;
+  writer_ = writer;
+  source_profile_ = source_profile;
+  items_ = items;
+
+  if (!ExternalProcessImporterHost::CheckForFirefoxLock(source_profile)) {
+    Cancel();
+    return;
+  }
+
+  if (!CheckForChromeLock(source_profile)) {
+    Cancel();
+    return;
+  }
+
+  ExternalProcessImporterHost::CheckForLoadedModels(items);
+
+  LaunchImportIfReady();
+}
 
 void BraveExternalProcessImporterHost::LaunchImportIfReady() {
   if (waiting_for_bookmarkbar_model_ || template_service_subscription_.get() ||
@@ -27,4 +61,53 @@ void BraveExternalProcessImporterHost::LaunchImportIfReady() {
   client_->Start();
 }
 
-BraveExternalProcessImporterHost::~BraveExternalProcessImporterHost() {}
+void BraveExternalProcessImporterHost::ShowWarningDialog() {
+  DCHECK(!headless_);
+  brave::importer::ShowImportLockDialog(
+      parent_window_,
+      base::Bind(&BraveExternalProcessImporterHost::OnImportLockDialogEnd,
+                 weak_ptr_factory_.GetWeakPtr()));
+}
+
+void BraveExternalProcessImporterHost::OnImportLockDialogEnd(bool is_continue) {
+  if (is_continue) {
+    // User chose to continue, then we check the lock again to make
+    // sure that Chrome has been closed. Try to import the settings
+    // if successful. Otherwise, show a warning dialog.
+    chrome_lock_->Lock();
+    if (chrome_lock_->HasAcquired()) {
+      is_source_readable_ = true;
+      LaunchImportIfReady();
+    } else {
+      ShowWarningDialog();
+    }
+  } else {
+    NotifyImportEnded();
+  }
+}
+
+bool BraveExternalProcessImporterHost::CheckForChromeLock(
+    const importer::SourceProfile& source_profile) {
+  if (source_profile.importer_type != importer::TYPE_CHROME)
+    return true;
+
+  // Extract the user data directory from the path of the profile to be
+  // imported, because we can only lock/unlock the entire user directory with
+  // ProcessSingleton.
+  base::FilePath user_data_dir = source_profile.source_path.DirName();
+
+  DCHECK(!chrome_lock_.get());
+  chrome_lock_.reset(new ChromeProfileLock(user_data_dir));
+  if (chrome_lock_->HasAcquired())
+    return true;
+
+  // If fail to acquire the lock, we set the source unreadable and
+  // show a warning dialog, unless running without UI (in which case the import
+  // must be aborted).
+  is_source_readable_ = false;
+  if (headless_)
+    return false;
+
+  ShowWarningDialog();
+  return true;
+}

--- a/browser/importer/brave_importer_lock_dialog.h
+++ b/browser/importer/brave_importer_lock_dialog.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_IMPORTER_BRAVE_IMPORTER_LOCK_DIALOG_H_
+#define BRAVE_BROWSER_IMPORTER_BRAVE_IMPORTER_LOCK_DIALOG_H_
+
+#include "base/callback_forward.h"
+#include "ui/gfx/native_widget_types.h"
+
+namespace brave {
+namespace importer {
+
+// This function is called by an ImporterHost, and presents the Chrome profile
+// warning dialog. After closing the dialog, the ImportHost receives a callback
+// with the message either to skip the import, or to continue the process.
+void ShowImportLockDialog(gfx::NativeWindow parent,
+                          const base::Callback<void(bool)>& callback);
+
+}  // namespace importer
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_IMPORTER_BRAVE_IMPORTER_LOCK_DIALOG_H_

--- a/browser/importer/chrome_profile_lock.cc
+++ b/browser/importer/chrome_profile_lock.cc
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/importer/chrome_profile_lock.h"
+
+#include "base/bind.h"
+#include "base/bind_helpers.h"
+
+ChromeProfileLock::ChromeProfileLock(
+    const base::FilePath& user_data_dir)
+    : lock_acquired_(false),
+      process_singleton_(user_data_dir,
+                         base::Bind(&ChromeProfileLock::NotificationCallback,
+				    base::Unretained(this))) {
+  Lock();
+}
+
+ChromeProfileLock::~ChromeProfileLock() {
+  Unlock();
+}
+
+void ChromeProfileLock::Lock() {
+  if (HasAcquired())
+    return;
+  lock_acquired_ = process_singleton_.Create();
+}
+
+void ChromeProfileLock::Unlock() {
+  if (!HasAcquired())
+    return;
+  process_singleton_.Cleanup();
+}
+
+bool ChromeProfileLock::HasAcquired() {
+  return lock_acquired_;
+}
+
+bool ChromeProfileLock::NotificationCallback(
+    const base::CommandLine& command_line,
+    const base::FilePath& current_directory) {
+  return false;
+}

--- a/browser/importer/chrome_profile_lock.h
+++ b/browser/importer/chrome_profile_lock.h
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_IMPORTER_CHROME_PROFILE_LOCK_H__
+#define BRAVE_BROWSER_IMPORTER_CHROME_PROFILE_LOCK_H__
+
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "chrome/browser/process_singleton.h"
+
+class ChromeProfileLock {
+ public:
+  explicit ChromeProfileLock(const base::FilePath& user_data_dir);
+  ~ChromeProfileLock();
+
+  // Locks and releases the profile.
+  void Lock();
+  void Unlock();
+
+  // Returns true if we lock the profile successfully.
+  bool HasAcquired();
+
+ private:
+  bool lock_acquired_;
+  ProcessSingleton process_singleton_;
+
+  bool NotificationCallback(const base::CommandLine& command_line,
+			    const base::FilePath& current_directory);
+
+  DISALLOW_COPY_AND_ASSIGN(ChromeProfileLock);
+};
+
+#endif  // BRAVE_BROWSER_IMPORTER_CHROME_PROFILE_LOCK_H__

--- a/browser/importer/chrome_profile_lock.h
+++ b/browser/importer/chrome_profile_lock.h
@@ -23,7 +23,8 @@ class ChromeProfileLock {
 
  private:
   bool lock_acquired_;
-  ProcessSingleton process_singleton_;
+  base::FilePath user_data_dir_;
+  std::unique_ptr<ProcessSingleton> process_singleton_;
 
   bool NotificationCallback(const base::CommandLine& command_line,
 			    const base::FilePath& current_directory);

--- a/browser/importer/chrome_profile_lock_unittest.cc
+++ b/browser/importer/chrome_profile_lock_unittest.cc
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/importer/chrome_profile_lock.h"
+
+#if defined(OS_POSIX)
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <memory>
+
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/strings/string_util.h"
+#include "base/test/test_simple_task_runner.h"
+#include "base/threading/thread_task_runner_handle.h"
+#include "build/build_config.h"
+#include "chrome/common/chrome_constants.h"
+#include "chrome/common/chrome_paths.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if defined(OS_WIN)
+const char kLockFile[] = "lockfile";
+#endif
+
+class ChromeProfileLockTest : public testing::Test {
+ public:
+   ChromeProfileLockTest ()
+    : task_runner_(base::MakeRefCounted<base::TestSimpleTaskRunner>()),
+      thread_task_runner_handle_override_(
+        base::ThreadTaskRunnerHandle::OverrideForTesting(task_runner_)) {}
+   ~ChromeProfileLockTest () override {
+     task_runner_->RunUntilIdle();
+   }
+ protected:
+  void SetUp() override {
+    testing::Test::SetUp();
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    user_data_path_ = temp_dir_.GetPath();
+#if defined(OS_POSIX)
+    lock_file_path_ =
+      user_data_path_.Append(chrome::kSingletonLockFilename);
+#elif defined(OS_WIN)
+    lock_file_path_ = user_data_path_.AppendASCII(kLockFile);
+#else
+#error unsupport platforms
+#endif
+  }
+
+  void LockFileExists(bool expect);
+
+  base::ScopedTempDir temp_dir_;
+  base::FilePath user_data_path_;
+  base::FilePath lock_file_path_;
+  scoped_refptr<base::TestSimpleTaskRunner> task_runner_;
+  base::ScopedClosureRunner thread_task_runner_handle_override_;
+};
+
+void ChromeProfileLockTest::LockFileExists(bool expect) {
+#if defined(OS_POSIX)
+  struct stat statbuf;
+  if (expect) {
+    ASSERT_EQ(0, lstat(lock_file_path_.value().c_str(), &statbuf));
+    ASSERT_TRUE(S_ISLNK(statbuf.st_mode));
+    char buf[PATH_MAX];
+    ssize_t len = readlink(lock_file_path_.value().c_str(), buf, PATH_MAX);
+    ASSERT_GT(len, 0);
+  } else {
+    ASSERT_GT(0, lstat(lock_file_path_.value().c_str(), &statbuf));
+  }
+#elif defined(OS_WIN)
+  if (expect)
+    EXPECT_TRUE(base::PathExists(lock_file_path_));
+  else
+    EXPECT_FALSE(base::PathExists(lock_file_path_));
+#endif
+}
+
+TEST_F(ChromeProfileLockTest, LockTest) {
+  ChromeProfileLock lock(user_data_path_);
+  ASSERT_TRUE(lock.HasAcquired());
+  lock.Unlock();
+  ASSERT_FALSE(lock.HasAcquired());
+  lock.Lock();
+  ASSERT_TRUE(lock.HasAcquired());
+}
+
+// Tests basic functionality and verifies that the lock file is deleted after
+// use.
+TEST_F(ChromeProfileLockTest, ProfileLock) {
+  std::unique_ptr<ChromeProfileLock> lock;
+  EXPECT_EQ(static_cast<ChromeProfileLock*>(NULL), lock.get());
+  LockFileExists(false);
+  lock.reset(new ChromeProfileLock(user_data_path_));
+  EXPECT_TRUE(lock->HasAcquired());
+  LockFileExists(true);
+  lock->Unlock();
+  EXPECT_FALSE(lock->HasAcquired());
+
+  lock->Lock();
+  EXPECT_TRUE(lock->HasAcquired());
+  LockFileExists(true);
+  lock->Lock();
+  EXPECT_TRUE(lock->HasAcquired());
+  lock->Unlock();
+  EXPECT_FALSE(lock->HasAcquired());
+}

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -8,6 +8,8 @@ source_set("ui") {
     "brave_pages.h",
     "toolbar/brave_app_menu_model.cc",
     "toolbar/brave_app_menu_model.h",
+    "views/importer/brave_import_lock_dialog_view.cc",
+    "views/importer/brave_import_lock_dialog_view.h",
     "webui/basic_ui.cc",
     "webui/basic_ui.h",
     "webui/brave_web_ui_controller_factory.cc",
@@ -15,6 +17,12 @@ source_set("ui") {
     "webui/new_tab_html_source.cc",
     "webui/new_tab_html_source.h",
   ]
+
+  if (is_mac) {
+    sources += [
+      "cocoa/importer/brave_import_lock_dialog_cocoa.mm",
+    ]
+  }
   public_deps = [
     "//content/public/browser",
   ]

--- a/browser/ui/cocoa/importer/brave_import_lock_dialog_cocoa.mm
+++ b/browser/ui/cocoa/importer/brave_import_lock_dialog_cocoa.mm
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import <Cocoa/Cocoa.h>
+
+#include "base/bind.h"
+#include "base/callback.h"
+#include "base/mac/scoped_nsobject.h"
+#include "base/metrics/user_metrics.h"
+#include "base/threading/thread_task_runner_handle.h"
+#include "brave/browser/importer/brave_importer_lock_dialog.h"
+#include "brave/browser/ui/views/importer/brave_import_lock_dialog_view.h"
+#include "brave/grit/generated_resources.h"
+#include "chrome/browser/ui/cocoa/browser_dialogs_views_mac.h"
+#include "chrome/grit/chromium_strings.h"
+#include "chrome/grit/generated_resources.h"
+#include "components/strings/grit/components_strings.h"
+#include "ui/base/l10n/l10n_util_mac.h"
+
+using base::UserMetricsAction;
+
+namespace brave {
+namespace importer {
+
+void ShowImportLockDialog(gfx::NativeWindow parent,
+                          const base::Callback<void(bool)>& callback) {
+  if (chrome::ShowAllDialogsWithViewsToolkit())
+    return ImportLockDialogView::Show(parent, callback);
+
+  base::scoped_nsobject<NSAlert> lock_alert([[NSAlert alloc] init]);
+  [lock_alert addButtonWithTitle:l10n_util::GetNSStringWithFixup(
+      IDS_IMPORTER_LOCK_OK)];
+  [lock_alert addButtonWithTitle:l10n_util::GetNSStringWithFixup(IDS_CANCEL)];
+  [lock_alert setInformativeText:l10n_util::GetNSStringWithFixup(
+      IDS_CHROME_IMPORTER_LOCK_TEXT)];
+  [lock_alert setMessageText:l10n_util::GetNSStringWithFixup(
+      IDS_CHROME_IMPORTER_LOCK_TITLE)];
+
+  base::ThreadTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE,
+      base::Bind(callback, [lock_alert runModal] == NSAlertFirstButtonReturn));
+  base::RecordAction(UserMetricsAction("ImportLockDialogCocoa_Shown"));
+}
+
+}  // namespace importer
+}  // namespace brave

--- a/browser/ui/views/importer/brave_import_lock_dialog_view.cc
+++ b/browser/ui/views/importer/brave_import_lock_dialog_view.cc
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/importer/brave_import_lock_dialog_view.h"
+
+#include "base/bind.h"
+#include "base/location.h"
+#include "base/metrics/user_metrics.h"
+#include "base/single_thread_task_runner.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/threading/thread_task_runner_handle.h"
+#include "brave/grit/generated_resources.h"
+#include "build/build_config.h"
+#include "chrome/browser/importer/importer_lock_dialog.h"
+#include "chrome/browser/ui/browser_dialogs.h"
+#include "chrome/browser/ui/views/harmony/chrome_layout_provider.h"
+#include "chrome/grit/chromium_strings.h"
+#include "chrome/grit/generated_resources.h"
+#include "chrome/grit/locale_settings.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/ui_features.h"
+#include "ui/views/border.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/layout/fill_layout.h"
+#include "ui/views/widget/widget.h"
+
+using base::UserMetricsAction;
+
+namespace brave {
+namespace importer {
+
+#if !defined(OS_MACOSX) || BUILDFLAG(MAC_VIEWS_BROWSER)
+void ShowImportLockDialog(gfx::NativeWindow parent,
+                          const base::Callback<void(bool)>& callback) {
+  ImportLockDialogView::Show(parent, callback);
+}
+#endif  // !OS_MACOSX || MAC_VIEWS_BROWSER
+
+}  // namespace importer
+
+// static
+void ImportLockDialogView::Show(gfx::NativeWindow parent,
+                                const base::Callback<void(bool)>& callback) {
+  views::DialogDelegate::CreateDialogWidget(
+      new ImportLockDialogView(callback), NULL, NULL)->Show();
+  base::RecordAction(UserMetricsAction("ImportLockDialogView_Shown"));
+}
+
+ImportLockDialogView::ImportLockDialogView(
+    const base::Callback<void(bool)>& callback)
+    : callback_(callback) {
+  SetLayoutManager(std::make_unique<views::FillLayout>());
+  views::Label* description_label =
+      new views::Label(l10n_util::GetStringUTF16(IDS_CHROME_IMPORTER_LOCK_TEXT));
+  description_label->SetBorder(views::CreateEmptyBorder(
+      ChromeLayoutProvider::Get()->GetDialogInsetsForContentType(views::TEXT,
+                                                                 views::TEXT)));
+  description_label->SetMultiLine(true);
+  description_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+  AddChildView(description_label);
+  chrome::RecordDialogCreation(chrome::DialogIdentifier::IMPORT_LOCK);
+}
+
+ImportLockDialogView::~ImportLockDialogView() {
+}
+
+gfx::Size ImportLockDialogView::CalculatePreferredSize() const {
+  const int width = ChromeLayoutProvider::Get()->GetDistanceMetric(
+      DISTANCE_MODAL_DIALOG_PREFERRED_WIDTH);
+  return gfx::Size(width, GetHeightForWidth(width));
+}
+
+base::string16 ImportLockDialogView::GetDialogButtonLabel(
+    ui::DialogButton button) const {
+  if (button == ui::DIALOG_BUTTON_OK)
+    return l10n_util::GetStringUTF16(IDS_IMPORTER_LOCK_OK);
+  return DialogDelegateView::GetDialogButtonLabel(button);
+}
+
+base::string16 ImportLockDialogView::GetWindowTitle() const {
+  return l10n_util::GetStringUTF16(IDS_CHROME_IMPORTER_LOCK_TITLE);
+}
+
+bool ImportLockDialogView::Accept() {
+  if (callback_) {
+    base::ThreadTaskRunnerHandle::Get()->PostTask(
+        FROM_HERE, base::BindOnce(callback_, true));
+  }
+  return true;
+}
+
+bool ImportLockDialogView::Cancel() {
+  if (callback_) {
+    base::ThreadTaskRunnerHandle::Get()->PostTask(
+        FROM_HERE, base::BindOnce(callback_, false));
+  }
+  return true;
+}
+
+bool ImportLockDialogView::ShouldShowCloseButton() const {
+  return false;
+}
+
+}  // namespace brave

--- a/browser/ui/views/importer/brave_import_lock_dialog_view.h
+++ b/browser/ui/views/importer/brave_import_lock_dialog_view.h
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_IMPORTER_BRAVE_IMPORT_LOCK_DIALOG_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_IMPORTER_BRAVE_IMPORT_LOCK_DIALOG_VIEW_H_
+
+#include "base/callback.h"
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "ui/views/window/dialog_delegate.h"
+
+namespace brave {
+
+// ImportLockDialogView asks the user to shut down Chrome before starting the
+// profile import.
+class ImportLockDialogView : public views::DialogDelegateView {
+ public:
+  static void Show(gfx::NativeWindow parent,
+                   const base::Callback<void(bool)>& callback);
+
+ private:
+  explicit ImportLockDialogView(const base::Callback<void(bool)>& callback);
+  ~ImportLockDialogView() override;
+
+  // views::View:
+  gfx::Size CalculatePreferredSize() const override;
+
+  // views::DialogDelegate:
+  base::string16 GetDialogButtonLabel(ui::DialogButton button) const override;
+  base::string16 GetWindowTitle() const override;
+  bool Accept() override;
+  bool Cancel() override;
+
+  // views::WidgetDelegate:
+  bool ShouldShowCloseButton() const override;
+
+ private:
+  // Called with the result of the dialog.
+  base::Callback<void(bool)> callback_;
+
+  DISALLOW_COPY_AND_ASSIGN(ImportLockDialogView);
+};
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_IMPORTER_BRAVE_IMPORT_LOCK_DIALOG_VIEW_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -33,6 +33,7 @@ test("brave_unit_tests") {
     "//brave/common/importer/brave_mock_importer_bridge.h",
     "//chrome/common/importer/mock_importer_bridge.cc",
     "//chrome/common/importer/mock_importer_bridge.h",
+    "../browser/importer/chrome_profile_lock_unittest.cc",
     "../utility/importer/chrome_importer_unittest.cc",
   ]
 


### PR DESCRIPTION
The UX and implementation are based on how Chrome's Firefox importer prompts the user to close Firefox before importing from a Firefox profile. ChromeProfileLock provides the same interface as FirefoxProfileLock, and the implementation is simpler because we are able to reuse Chromium's ProcessSingleton to check if Chrome is running at the time of import.

Resolves brave/brave-browser#103.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan

### Manual testing

1. You will need a Chrome profile with some profile data saved in it.
2. Start Chrome in the background.
3. `yarn start`
4. Open the main menu (e.g. **Brave** on macOS) and choose **Import Bookmarks and Settings...**
5. Choose your test Chrome profile from the dropdown menu of browser profiles and click **Import**.
6. You should see an alert with the title "Close Chrome," the text "To finish importing, close all Chrome windows," and two buttons: **Try again** and **Cancel**.
7. **Cancel** should return you to the Settings page without importing anything from the Chrome profile.
8. **Try again** should return you to the same alert repeatedly, until the background Chrome process is quit.
9. Quit the background Chrome process, then click **Try again**.
10. Your Chrome profile data should be successfully imported.

### Cross-platform testing

I have verified that this PR builds and passes the manual tests described above on macOS, Windows, and Linux.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
