### PR TITLE
Make shields settings have precedence over script/FP settings

### DIFF
--- a/components/content_settings/core/browser/brave_host_content_settings_map.cc
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.cc
@@ -17,6 +17,7 @@ BraveHostContentSettingsMap::BraveHostContentSettingsMap(
   InitializeFingerprintingContentSetting();
   InitializeReferrerContentSetting();
   InitializeCookieContentSetting();
+  InitializeBraveShieldsContentSetting();
 }
 
 BraveHostContentSettingsMap::~BraveHostContentSettingsMap() {
@@ -48,5 +49,14 @@ void BraveHostContentSettingsMap::InitializeCookieContentSetting() {
       ContentSettingsPattern::FromString("https://firstParty/*"),
       CONTENT_SETTINGS_TYPE_PLUGINS,
       brave_shields::kCookies,
+      CONTENT_SETTING_ALLOW);
+}
+
+void BraveHostContentSettingsMap::InitializeBraveShieldsContentSetting() {
+  SetContentSettingCustomScope(
+      ContentSettingsPattern::Wildcard(),
+      ContentSettingsPattern::Wildcard(),
+      CONTENT_SETTINGS_TYPE_PLUGINS,
+      brave_shields::kBraveShields,
       CONTENT_SETTING_ALLOW);
 }

--- a/components/content_settings/core/browser/brave_host_content_settings_map.h
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.h
@@ -17,6 +17,7 @@ class BraveHostContentSettingsMap : public HostContentSettingsMap {
    void InitializeFingerprintingContentSetting();
    void InitializeReferrerContentSetting();
    void InitializeCookieContentSetting();
+   void InitializeBraveShieldsContentSetting();
    ~BraveHostContentSettingsMap() override;
 };
 

--- a/renderer/brave_content_settings_observer.h
+++ b/renderer/brave_content_settings_observer.h
@@ -42,7 +42,11 @@ class BraveContentSettingsObserver
 
   ContentSetting GetContentSettingFromRules(
       const ContentSettingsForOneType& rules,
-      const blink::WebLocalFrame* frame,
+      const blink::WebFrame* frame,
+      const GURL& secondary_url);
+
+  bool IsBraveShieldsDown(
+      const blink::WebFrame* frame,
       const GURL& secondary_url);
 
   // RenderFrameObserver


### PR DESCRIPTION
Fix brave/brave-browser/issues/189
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Automated browser tests.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
