### PR TITLE
Disabling getBattery | bluetooth | credential.get/store | navigator.usb apis

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -110,6 +110,14 @@ bool BraveContentBrowserClient::AllowGetCookie(
   return allow;
 }
 
+content::ContentBrowserClient::AllowWebBluetoothResult
+BraveContentBrowserClient::AllowWebBluetooth(
+    content::BrowserContext* browser_context,
+    const url::Origin& requesting_origin,
+    const url::Origin& embedding_origin) {
+  return content::ContentBrowserClient::AllowWebBluetoothResult::BLOCK_GLOBALLY_DISABLED;
+}
+
 bool BraveContentBrowserClient::AllowSetCookie(
     const GURL& url,
     const GURL& first_party,

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -6,6 +6,7 @@
 #define BRAVE_BROWSER_BRAVE_CONTENT_BROWSER_CLIENT_H_
 
 #include "chrome/browser/chrome_content_browser_client.h"
+#include "content/public/browser/content_browser_client.h"
 
 class BraveContentBrowserClient : public ChromeContentBrowserClient {
  public:
@@ -29,6 +30,12 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
                       int render_process_id,
                       int render_frame_id,
                       const net::CookieOptions& options) override;
+
+  content::ContentBrowserClient::AllowWebBluetoothResult AllowWebBluetooth(
+      content::BrowserContext* browser_context,
+      const url::Origin& requesting_origin,
+      const url::Origin& embedding_origin) override;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(BraveContentBrowserClient);
 };

--- a/chromium_src/third_party/blink/renderer/modules/battery/navigator_battery.cc
+++ b/chromium_src/third_party/blink/renderer/modules/battery/navigator_battery.cc
@@ -1,0 +1,14 @@
+#include "third_party/blink/renderer/modules/battery/navigator_battery.h"
+
+#include "gin/converter.h"
+#include "third_party/blink/renderer/platform/bindings/v8_per_isolate_data.h"
+#include "net/proxy_resolution/proxy_resolver_v8.h"
+
+namespace blink {
+  ScriptPromise NavigatorBattery::getBattery(ScriptState* script_state,
+                                           Navigator& navigator) {
+    v8::Isolate* isolate = script_state->GetIsolate();
+    return blink::ScriptPromise::Reject(script_state,
+           v8::Exception::TypeError(gin::StringToV8(isolate, "This api has been disabled.")));
+  }
+} // namespace blink

--- a/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc
+++ b/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+
+const char kBatteryTest[] = "/battery.html";
+
+class NavigatorGetBatteryDisabledTest : public InProcessBrowserTest {
+  public:
+    void SetUpOnMainThread() override {
+      InProcessBrowserTest::SetUpOnMainThread();
+
+      content_client_.reset(new ChromeContentClient);
+      content::SetContentClient(content_client_.get());
+      browser_content_client_.reset(new BraveContentBrowserClient());
+      content::SetBrowserClientForTesting(browser_content_client_.get());
+      content::SetupCrossSiteRedirector(embedded_test_server());
+
+      brave::RegisterPathProvider();
+      base::FilePath test_data_dir;
+      PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+      embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+      ASSERT_TRUE(embedded_test_server()->Start());
+    }
+
+    void TearDown() override {
+      browser_content_client_.reset();
+      content_client_.reset();
+    }
+
+  private:
+    std::unique_ptr<ChromeContentClient> content_client_;
+    std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+    base::ScopedTempDir temp_user_data_dir_;
+};
+
+IN_PROC_BROWSER_TEST_F(NavigatorGetBatteryDisabledTest, IsDisabled) {
+  GURL url = embedded_test_server()->GetURL(kBatteryTest);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool getBatteryBlocked;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "window.domAutomationController.send(getBatteryBlocked())",
+      &getBatteryBlocked));
+  EXPECT_TRUE(getBatteryBlocked);
+}

--- a/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc
+++ b/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ #include "base/path_service.h"
+ #include "brave/browser/brave_content_browser_client.h"
+ #include "brave/common/brave_paths.h"
+ #include "chrome/browser/ui/browser.h"
+ #include "chrome/common/chrome_content_client.h"
+ #include "chrome/test/base/in_process_browser_test.h"
+ #include "chrome/test/base/ui_test_utils.h"
+ #include "content/public/test/browser_test_utils.h"
+
+const char kBluetoothTest[] = "/bluetooth.html";
+
+class NavigatorBluetoothDisabledTest : public InProcessBrowserTest {
+  public:
+    void SetUpOnMainThread() override {
+      InProcessBrowserTest::SetUpOnMainThread();
+
+      content_client_.reset(new ChromeContentClient);
+      content::SetContentClient(content_client_.get());
+      browser_content_client_.reset(new BraveContentBrowserClient());
+      content::SetBrowserClientForTesting(browser_content_client_.get());
+      content::SetupCrossSiteRedirector(embedded_test_server());
+
+      brave::RegisterPathProvider();
+      base::FilePath test_data_dir;
+      PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+      embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+      ASSERT_TRUE(embedded_test_server()->Start());
+    }
+
+    void TearDown() override {
+      browser_content_client_.reset();
+      content_client_.reset();
+    }
+
+  private:
+    std::unique_ptr<ChromeContentClient> content_client_;
+    std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+    base::ScopedTempDir temp_user_data_dir_;
+};
+
+IN_PROC_BROWSER_TEST_F(NavigatorBluetoothDisabledTest, IsDisabled) {
+  GURL url = embedded_test_server()->GetURL(kBluetoothTest);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool bluetoothBlocked;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "window.domAutomationController.send(bluetoothBlocked())",
+      &bluetoothBlocked));
+  EXPECT_TRUE(bluetoothBlocked);
+}

--- a/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_container.cc
+++ b/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_container.cc
@@ -1,0 +1,54 @@
+#include "third_party/blink/renderer/modules/credentialmanager/credentials_container.h"
+
+#include "gin/converter.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+#include "third_party/blink/renderer/platform/bindings/v8_per_isolate_data.h"
+#include "v8/include/v8.h"
+
+namespace blink {
+
+  CredentialsContainer::CredentialsContainer() = default;
+
+  ScriptPromise CredentialsContainer::get(
+    ScriptState* script_state,
+    const CredentialRequestOptions& options) {
+      ScriptPromiseResolver* resolver = ScriptPromiseResolver::Create(script_state);
+      ScriptPromise promise = resolver->Promise();
+      v8::Isolate* isolate = script_state->GetIsolate();
+      resolver->Resolve(v8::Null(isolate));
+      return promise;
+  }
+
+  ScriptPromise CredentialsContainer::store(ScriptState* script_state,
+                                          Credential* credential) {
+    ScriptPromiseResolver* resolver = ScriptPromiseResolver::Create(script_state);
+    ScriptPromise promise = resolver->Promise();
+    v8::Isolate* isolate = script_state->GetIsolate();
+    resolver->Resolve(v8::Null(isolate));
+    return promise;
+  }
+
+  ScriptPromise CredentialsContainer::preventSilentAccess(
+    ScriptState* script_state) {
+    ScriptPromiseResolver* resolver = ScriptPromiseResolver::Create(script_state);
+    ScriptPromise promise = resolver->Promise();
+    resolver->Resolve();
+    return promise;
+  }
+
+  CredentialsContainer* CredentialsContainer::Create() {
+    return new CredentialsContainer();
+  }
+
+  ScriptPromise CredentialsContainer::create(
+    ScriptState* script_state,
+    const CredentialCreationOptions& options,
+    ExceptionState& exception_state) {
+      ScriptPromiseResolver* resolver = ScriptPromiseResolver::Create(script_state);
+      ScriptPromise promise = resolver->Promise();
+      v8::Isolate* isolate = script_state->GetIsolate();
+      resolver->Resolve(v8::Null(isolate));
+      return promise;
+  }
+} // namespace blink

--- a/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_containertest.cc
+++ b/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_containertest.cc
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+
+const char kCredentialsGetTest[] = "/credentialsget.html";
+const char kCredentialsStoreTest[] = "/credentialsstore.html";
+const char kCredentialsPreventSilentAccessTest[] = "/credentialspreventsilentaccess.html";
+
+class CredentialsContainersTest : public InProcessBrowserTest {
+  public:
+    void SetUpOnMainThread() override {
+      InProcessBrowserTest::SetUpOnMainThread();
+
+      content_client_.reset(new ChromeContentClient);
+      content::SetContentClient(content_client_.get());
+      browser_content_client_.reset(new BraveContentBrowserClient());
+      content::SetBrowserClientForTesting(browser_content_client_.get());
+      content::SetupCrossSiteRedirector(embedded_test_server());
+
+      brave::RegisterPathProvider();
+      base::FilePath test_data_dir;
+      PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+      embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+      ASSERT_TRUE(embedded_test_server()->Start());
+    }
+
+    void TearDown() override {
+      browser_content_client_.reset();
+      content_client_.reset();
+    }
+
+  private:
+    std::unique_ptr<ChromeContentClient> content_client_;
+    std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+    base::ScopedTempDir temp_user_data_dir_;
+};
+
+IN_PROC_BROWSER_TEST_F(CredentialsContainersTest, GetDisabled) {
+  GURL url = embedded_test_server()->GetURL(kCredentialsGetTest);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool credentialsGetBlocked;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "window.domAutomationController.send(credentialsGetBlocked())",
+      &credentialsGetBlocked));
+  EXPECT_TRUE(credentialsGetBlocked);
+}
+
+IN_PROC_BROWSER_TEST_F(CredentialsContainersTest, StoreDisabled) {
+  GURL url = embedded_test_server()->GetURL(kCredentialsStoreTest);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool credentialsStoreBlocked;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "window.domAutomationController.send(credentialsStoreBlocked())",
+      &credentialsStoreBlocked));
+  EXPECT_TRUE(credentialsStoreBlocked);
+}
+
+IN_PROC_BROWSER_TEST_F(CredentialsContainersTest, PreventSilentAccessDisabled) {
+  GURL url = embedded_test_server()->GetURL(kCredentialsPreventSilentAccessTest);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool credentialsPreventSilentAccess;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "window.domAutomationController.send(credentialspreventSilentAccessBlocked())",
+      &credentialsPreventSilentAccess));
+  EXPECT_TRUE(credentialsPreventSilentAccess);
+}

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -3,8 +3,13 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/renderer/brave_content_renderer_client.h"
+#include "third_party/blink/public/platform/web_runtime_features.h"
 
 BraveContentRendererClient::BraveContentRendererClient()
     : ChromeContentRendererClient() {}
 
+void BraveContentRendererClient::SetRuntimeFeaturesDefaultsBeforeBlinkInitialization() {
+  blink::WebRuntimeFeatures::EnableWebUsb(false);
+  blink::WebRuntimeFeatures::EnableSharedArrayBuffer(false);
+}
 BraveContentRendererClient::~BraveContentRendererClient() = default;

--- a/renderer/brave_content_renderer_client.h
+++ b/renderer/brave_content_renderer_client.h
@@ -11,6 +11,7 @@ class BraveContentRendererClient : public ChromeContentRendererClient {
  public:
   BraveContentRendererClient();
   ~BraveContentRendererClient() override;
+  void SetRuntimeFeaturesDefaultsBeforeBlinkInitialization() override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(BraveContentRendererClient);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -133,6 +133,9 @@ static_library("browser_tests_runner") {
 
 test("brave_browser_tests") {
   sources = [
+    "//brave/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc",
+    "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",
+    "//brave/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_containertest.cc",
     "//brave/browser/brave_content_browser_client_browsertest.cc",
     "//brave/browser/brave_profile_prefs_browsertest.cc",
     "//brave/browser/brave_resources_browsertest.cc",

--- a/test/data/battery.html
+++ b/test/data/battery.html
@@ -1,0 +1,10 @@
+<script>
+  function getBatteryBlocked() {
+    try {
+      navigator.get_battery();
+    } catch (err) {
+      return true;
+    }
+    return false;
+  }
+</script>

--- a/test/data/bluetooth.html
+++ b/test/data/bluetooth.html
@@ -1,0 +1,15 @@
+<script>
+function bluetoothBlocked() {
+  let options = {
+    filters: [
+      {namePrefix: 'Prefix'}
+    ]
+  }
+  try {
+    navigator.bluetooth.requestDevice(options).resolve('Waiting');
+  } catch (e) {
+    return true;
+  }
+  return false;
+}
+</script>

--- a/test/data/credentialsget.html
+++ b/test/data/credentialsget.html
@@ -1,0 +1,10 @@
+<script>
+  var result = false;
+  navigator.credentials.get().then(function(data){
+    result = data;
+  });
+
+  function credentialsGetBlocked() {
+    return result == null;
+  }
+</script>

--- a/test/data/credentialspreventsilentaccess.html
+++ b/test/data/credentialspreventsilentaccess.html
@@ -1,0 +1,11 @@
+<script>
+  var result = false; 
+
+  navigator.credentials.preventSilentAccess().then(function(){
+    result = true;
+  })
+
+  function credentialspreventSilentAccessBlocked() {
+    return result;
+  }
+</script>

--- a/test/data/credentialsstore.html
+++ b/test/data/credentialsstore.html
@@ -1,0 +1,17 @@
+<script>
+  var result = false;
+
+  const credentials = new PasswordCredential({
+    id: 'test@test.com',
+    name: 'test',
+    password: 'test'
+  });
+ 
+  navigator.credentials.store(credentials).then(function (data) {
+    result = data;
+  });
+  
+  function credentialsStoreBlocked() {
+    return result == null;
+  }
+</script>


### PR DESCRIPTION
See here: https://github.com/brave/brave-browser/issues/13#issuecomment-376991976

## Test Instructions:

1. Open JS console ( Inspect > Console )
2. Try using the following apis:
 
```
>navigator.credentials.get()
Promise {<resolved>: null}

>const credentials = new PasswordCredential({
    id: 'test@test.com',
    name: 'test',
    password: 'test'
});
navigator.credentials.store(credentials);
Promise {<resolved>: null}

> navigator.credentials.preventSilentAccess().then(function(data){ console.log(arguments); });
Arguments [undefined, callee: ƒ, Symbol(Symbol.iterator): ƒ]
Promise {<resolved>: undefined}

>navigator.getBattery()
Promise {<rejected>: TypeError: This api has been disabled.
    at <anonymous>:1:11}

>let options = {
    filters: [
      {namePrefix: 'Prefix'}
    ]
  }
undefined
navigator.bluetooth.requestDevice(options);
Promise {<pending>}
Bluetooth permission has been blocked.
Uncaught (in promise) DOMException: Web Bluetooth API globally disabled.

>navigator.usb
undefined
```