### PR TITLE
[WIP] Add codesigning to create_dist on osx

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -1,9 +1,44 @@
+import("//brave/build/config.gni")
+
 declare_args() {
   mac_signing_identifier = ""
+  mac_signing_keychain = "login"
 }
 
-action("create_dist_mac") {
-  output = "$root_out_dir/Brave.dmg"
+_packaging_dir = "$root_out_dir/$brave_product_name Packaging"
+keychain_db = getenv("HOME") + "/Library/Keychains/login.${mac_signing_keychain}-db"
+
+action("sign_app") {
+  brave_app = "$root_build_dir/Brave.app"
+
+  script = "//build/gn_run_binary.py"
+  shell_script = "//brave/build/mac/sign_app.sh"
+
+  inputs = [
+    shell_script,
+    brave_app,
+    "$_packaging_dir/sign_app.sh",
+    "$_packaging_dir/sign_versioned_dir.sh",
+  ]
+  outputs = [ "$root_out_dir/signing/Brave.app" ]
+  args = [
+    rebase_path(shell_script, root_out_dir),
+
+    # Use absolute paths needed by codesign
+    rebase_path(brave_app),
+    rebase_path("$root_out_dir/signing/Brave.app"),
+    rebase_path(_packaging_dir),
+    keychain_db,
+    mac_signing_identifier
+  ]
+  deps = [
+    "//brave:chrome_app",
+    "//chrome/installer/mac"
+  ]
+}
+
+action("create_dmg") {
+  output = "$root_out_dir/unsigned/Brave.dmg"
   script = "//build/gn_run_binary.py"
   shell_script = "//chrome/installer/mac/pkg-dmg"
   inputs = [
@@ -13,19 +48,45 @@ action("create_dist_mac") {
   outputs = [ output ]
   args = [
     rebase_path(shell_script, root_build_dir),
-    "--source",
-    "/var/empty",
-    "--target",
-    "Brave.dmg",
-    "--format",
-    "UDBZ",
-    "--verbosity",
-    "0",
-    "--volname",
-    "Brave",
-    "--copy",
-    "Brave.app",
-    "--tempdir",
-    "/tmp",
+    "--source", "/var/empty",
+    "--target", "Brave.dmg",
+    "--format", "UDBZ",
+    "--verbosity", "0",
+    "--volname", "Brave",
+    "--copy", rebase_path("$root_out_dir/signing/Brave.app", root_build_dir),
+    "--tempdir", "/tmp",
+    "--symlink", "/Applications",
+  ]
+
+  deps = [":sign_app"]
+}
+
+action("sign_dmg") {
+  script = "//build/gn_run_binary.py"
+  shell_script = "sign_dmg.sh"
+  inputs = [
+    script,
+    shell_script,
+    "$root_out_dir/unsigned/Brave.dmg",
+  ]
+  outputs = [ "${root_out_dir}/signing/Brave.dmg" ]
+  args = [
+    rebase_path(shell_script, root_build_dir),
+    rebase_path("$root_out_dir/unsigned/Brave.dmg"),
+    rebase_path("$root_out_dir/Brave.dmg"),
+    keychain_db,
+    mac_signing_identifier,
+    "-r=designated => identifier \"Brave\" and certificate leaf = H\"$mac_signing_identifier\"",
+  ]
+
+  deps = [":create_dmg"]
+}
+
+group("create_dist_mac") {
+  deps = [ ":create_dmg" ]
+
+  deps += [
+    ":sign_app",
+    ":sign_dmg",
   ]
 }

--- a/build/mac/sign_app.sh
+++ b/build/mac/sign_app.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt "4" ]]; then
+  echo "usage: $0 <source_app> <dest_app> <packaging_dir> <mac_signing_keychain> <mac_signing_identifier>"
+  exit 1
+fi
+
+SOURCE="${1}"
+DEST="${2}"
+PKG_DIR="${3}"
+MAC_SIGNING_KEYCHAIN="${4}"
+MAC_SIGNING_IDENTIFIER="${5}"
+
+app_name="$(basename $SOURCE)"
+
+set -v
+
+function check_exit() {
+    return=$?;
+    if [[ $return -eq 0 ]]; then
+  echo "[INFO] $0 succeded"
+    else
+  echo "[ERROR] $0 failed"
+    fi
+
+    exit $return
+}
+
+trap check_exit EXIT
+
+if [[ -d "$DEST" ]]; then
+  rm -rf "$DEST"
+fi
+
+mkdir -p "$(dirname $DEST)"
+
+cp -a "$SOURCE" "$DEST"
+
+"${PKG_DIR}/sign_versioned_dir.sh" "$DEST" "$MAC_SIGNING_KEYCHAIN" "$MAC_SIGNING_IDENTIFIER"
+
+"${PKG_DIR}/sign_app.sh" "$DEST" "$MAC_SIGNING_KEYCHAIN" "$MAC_SIGNING_IDENTIFIER"

--- a/build/mac/sign_dmg.sh
+++ b/build/mac/sign_dmg.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt "5" ]]; then
+  echo "usage: $0 <dmg_path>"
+  exit 1
+fi
+
+SOURCE="${1}"
+DEST="${2}"
+MAC_SIGNING_KEYCHAIN="${3}"
+MAC_SIGNING_IDENTIFIER="${4}"
+REQUIREMENTS="${5}"
+
+app_name="$(basename $SOURCE)"
+
+set -v
+
+function check_exit() {
+    return=$?;
+    if [[ $return -eq 0 ]]; then
+  echo "[INFO] $0 succeded"
+    else
+  echo "[ERROR] $0 failed"
+    fi
+
+    exit $return
+}
+
+trap check_exit EXIT
+
+if [[ -f $DEST ]]; then
+  rm -f "$DEST"
+fi
+
+cp "$SOURCE" "$DEST"
+
+set -v
+
+/usr/bin/codesign --force --sign "$MAC_SIGNING_IDENTIFIER" --keychain "$MAC_SIGNING_KEYCHAIN" "$DEST"  "$REQUIREMENTS"
+
+/usr/bin/codesign -vvvvd "$DEST"
+/usr/bin/codesign --verify --strict --deep -vvvv "$DEST"

--- a/patches/chrome-installer-mac-sign_app.sh.in.patch
+++ b/patches/chrome-installer-mac-sign_app.sh.in.patch
@@ -1,0 +1,36 @@
+diff --git a/chrome/installer/mac/sign_app.sh.in b/chrome/installer/mac/sign_app.sh.in
+index a2694af5cc7a66103ad4f88778c2bc25133c97b9..f0a70b137f10f971d4d81c5bd8be5311182bdcb3 100644
+--- a/chrome/installer/mac/sign_app.sh.in
++++ b/chrome/installer/mac/sign_app.sh.in
+@@ -40,10 +40,7 @@ if [[ ${#} == 4 && "${4}" == "--development" ]]; then
+ fi
+ 
+ script_dir="$(dirname "${0}")"
+-source "${script_dir}/variables.sh"
+-
+-# Use custom resource rules for the browser application.
+-browser_app_rules="${script_dir}/app_resource_rules.plist"
++codesign_id=$codesign_id source "${script_dir}/variables.sh"
+ 
+ versioned_dir="${app_path}/Contents/Versions/@VERSION@"
+ 
+@@ -57,10 +54,7 @@ app_mode_loader="${app_mode_loader_app}/Contents/MacOS/app_mode_loader"
+ 
+ requirement="\
+ designated => \
+-(identifier \"com.google.Chrome\" or \
+-identifier \"com.google.Chrome.beta\" or \
+-identifier \"com.google.Chrome.dev\" or \
+-identifier \"com.google.Chrome.canary\") \
++identifier \"org.brave.Brave\" \
+ ${requirement_suffix} \
+ "
+ 
+@@ -68,7 +62,6 @@ codesign_cmd=(
+   codesign --sign "${codesign_id}" --keychain "${codesign_keychain}"
+   "${browser_app}"
+   --options "${enforcement_flags_app}"
+-  --resource-rules "${browser_app_rules}"
+ )
+ if [[ -z "${is_development}" ]]; then
+   codesign_cmd+=( -r="${requirement}" )

--- a/patches/chrome-installer-mac-sign_versioned_dir.sh.in.patch
+++ b/patches/chrome-installer-mac-sign_versioned_dir.sh.in.patch
@@ -1,0 +1,48 @@
+diff --git a/chrome/installer/mac/sign_versioned_dir.sh.in b/chrome/installer/mac/sign_versioned_dir.sh.in
+index a9db32c8ec17629f745eff38a6c732124a21f63e..b2ac9db824bdf769474beb0477b2b06b49268d4f 100644
+--- a/chrome/installer/mac/sign_versioned_dir.sh.in
++++ b/chrome/installer/mac/sign_versioned_dir.sh.in
+@@ -24,7 +24,7 @@ ME="$(basename "${0}")"
+ readonly ME
+ 
+ script_dir="$(dirname "${0}")"
+-source "${script_dir}/variables.sh"
++codesign_id=$codesign_id source "${script_dir}/variables.sh"
+ 
+ codesign_display_and_verify() {
+   args=("${@}")
+@@ -86,6 +86,7 @@ versioned_dir="${app_path}/Contents/Versions/@VERSION@"
+ # https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG13
+ 
+ framework="${versioned_dir}/@MAC_PRODUCT_NAME@ Framework.framework"
++sparkle_framework="${framework}/Frameworks/Sparkle.framework"
+ notification_service="${framework}/XPCServices/AlertNotificationService.xpc"
+ crashpad_handler="${framework}/Helpers/crashpad_handler"
+ helper_app="${versioned_dir}/@MAC_PRODUCT_NAME@ Helper.app"
+@@ -126,12 +127,14 @@ if [[ -f "${widevine_plugin}" ]]; then
+   codesign_with_options "${widevine_plugin}" "" "widevinecdmadapter"
+ fi
+ 
++codesign_with_options "${sparkle_framework}" "" "org.sparkle-project.Sparkle"
++
+ # The framework is a dylib, so ${enforcement_flags_helpers} are meaningless.
+-codesign_with_options "${framework}" "" "com.google.Chrome.framework"
++codesign_with_options "${framework}" "" "org.brave.Brave.framework"
+ 
+ codesign_with_options "${helper_app}" \
+                       "${enforcement_flags_app}" \
+-                      "com.google.Chrome.helper"
++                      "org.brave.Brave.helper"
+ 
+ if [[ -f "${widevine_plugin}" ]]; then
+   codesign_display_and_verify "${widevine_plugin}"
+@@ -140,8 +143,6 @@ fi
+ codesign_display_and_verify "${crashpad_handler}" --deep
+ codesign_display_and_verify "${app_mode_loader}" --ignore-resources
+ codesign_display_and_verify "${notification_service}" --deep
+-# The framework contains KeystoneRegistration.framework, which uses
+-# custom resource rules, so use --no-strict to verify.
+-codesign_display_and_verify "${framework}" --deep --no-strict
++codesign_display_and_verify "${framework}" --deep
+ codesign_display_and_verify "${framework}" --strict
+ codesign_display_and_verify "${helper_app}" --deep

--- a/patches/chrome-installer-mac-variables.sh.patch
+++ b/patches/chrome-installer-mac-variables.sh.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/installer/mac/variables.sh b/chrome/installer/mac/variables.sh
+index 3cb206fd1f6bbd637eae2129dad8a0c6cce9a9fc..00c389cea0cad4766559b1e99bb8c98584736f01 100644
+--- a/chrome/installer/mac/variables.sh
++++ b/chrome/installer/mac/variables.sh
+@@ -19,6 +19,6 @@ enforcement_flags_installer_tools="${enforcement_flags_helpers},kill"
+ # contains the hash of the certificate used to sign Chrome. When transitioning
+ # signing certs, this may include the hash of both the old and new certificate.
+ requirement_suffix="\
+-and (certificate leaf = H\"85cee8254216185620ddc8851c7a9fc4dfe120ef\" or \
+-certificate leaf = H\"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a\") \
++and (certificate leaf = H\"${codesign_id}\" or \
++certificate leaf = H\"${codesign_id}\") \
+ "


### PR DESCRIPTION
Requires the mac_signing_identifier option to yarn to be set with the id of a codesigning cert in the mac keychain. This defaults to login but can be overridden by by setting mac_signing_keychain.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
