### PR TITLE
Block Flash by default and allow enabling with CTP

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -6,6 +6,8 @@ source_set("ui") {
     "brave_browser_command_controller.h",
     "brave_pages.cc",
     "brave_pages.h",
+    "content_settings/brave_content_setting_bubble_model.cc",
+    "content_settings/brave_content_setting_bubble_model.h",
     "toolbar/brave_app_menu_model.cc",
     "toolbar/brave_app_menu_model.h",
     "views/importer/brave_import_lock_dialog_view.cc",

--- a/browser/ui/content_settings/brave_content_setting_bubble_model.h
+++ b/browser/ui/content_settings/brave_content_setting_bubble_model.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/content_settings/content_setting_bubble_model.h"
+
+class Profile;
+
+class BraveContentSettingPluginBubbleModel : public ContentSettingSimpleBubbleModel {
+ public:
+  BraveContentSettingPluginBubbleModel(Delegate* delegate,
+                                  content::WebContents* web_contents,
+                                  Profile* profile);
+
+ private:
+  void OnLearnMoreClicked() override;
+  void OnCustomLinkClicked() override;
+
+  void RunPluginsOnPage();
+  Profile* profile_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveContentSettingPluginBubbleModel);
+};

--- a/components/brave_shields/common/brave_shield_constants.h
+++ b/components/brave_shields/common/brave_shield_constants.h
@@ -16,6 +16,7 @@ const char kFingerprinting[] = "fingerprinting";
 const char kBraveShields[] = "braveShields";
 const char kReferrers[] = "referrers";
 const char kCookies[] = "cookies";
+const char kFlash[] = "adobe-flash-player";
 
 }  // brave_shields
 

--- a/components/brave_shields/common/brave_shield_constants.h
+++ b/components/brave_shields/common/brave_shield_constants.h
@@ -16,7 +16,6 @@ const char kFingerprinting[] = "fingerprinting";
 const char kBraveShields[] = "braveShields";
 const char kReferrers[] = "referrers";
 const char kCookies[] = "cookies";
-const char kFlash[] = "adobe-flash-player";
 
 }  // brave_shields
 

--- a/components/content_settings/core/browser/brave_host_content_settings_map.cc
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.cc
@@ -18,6 +18,7 @@ BraveHostContentSettingsMap::BraveHostContentSettingsMap(
   InitializeReferrerContentSetting();
   InitializeCookieContentSetting();
   InitializeBraveShieldsContentSetting();
+  InitializeFlashContentSetting();
 }
 
 BraveHostContentSettingsMap::~BraveHostContentSettingsMap() {
@@ -59,4 +60,15 @@ void BraveHostContentSettingsMap::InitializeBraveShieldsContentSetting() {
       CONTENT_SETTINGS_TYPE_PLUGINS,
       brave_shields::kBraveShields,
       CONTENT_SETTING_ALLOW);
+}
+
+void BraveHostContentSettingsMap::InitializeFlashContentSetting() {
+  SetContentSettingCustomScope(
+      ContentSettingsPattern::Wildcard(),
+      ContentSettingsPattern::Wildcard(),
+      CONTENT_SETTINGS_TYPE_PLUGINS,
+      // One would think this should be brave_shields::kFlash; however, if you
+      // use it, it will always ask and click-to-play will not work.
+      std::string(),
+      CONTENT_SETTING_BLOCK);
 }

--- a/components/content_settings/core/browser/brave_host_content_settings_map.h
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.h
@@ -18,6 +18,7 @@ class BraveHostContentSettingsMap : public HostContentSettingsMap {
    void InitializeReferrerContentSetting();
    void InitializeCookieContentSetting();
    void InitializeBraveShieldsContentSetting();
+   void InitializeFlashContentSetting();
    ~BraveHostContentSettingsMap() override;
 };
 

--- a/patches/chrome-browser-ui-content_settings-content_setting_bubble_model.cc.patch
+++ b/patches/chrome-browser-ui-content_settings-content_setting_bubble_model.cc.patch
@@ -1,0 +1,21 @@
+diff --git a/chrome/browser/ui/content_settings/content_setting_bubble_model.cc b/chrome/browser/ui/content_settings/content_setting_bubble_model.cc
+index 0e1bec53e5c64024528e949d8a7a51e3877f3056..e99590efc9a2c0850e4958a76bccda53a2a09a36 100644
+--- a/chrome/browser/ui/content_settings/content_setting_bubble_model.cc
++++ b/chrome/browser/ui/content_settings/content_setting_bubble_model.cc
+@@ -15,6 +15,7 @@
+ #include "base/metrics/user_metrics.h"
+ #include "base/stl_util.h"
+ #include "base/strings/utf_string_conversions.h"
++#include "brave/browser/ui/content_settings/brave_content_setting_bubble_model.h"
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/chrome_notification_types.h"
+ #include "chrome/browser/content_settings/chrome_content_settings_utils.h"
+@@ -1712,7 +1713,7 @@ ContentSettingBubbleModel*
+                                                    profile, content_type);
+   }
+   if (content_type == CONTENT_SETTINGS_TYPE_PLUGINS) {
+-    return new ContentSettingPluginBubbleModel(delegate, web_contents, profile);
++    return new BraveContentSettingPluginBubbleModel(delegate, web_contents, profile);
+   }
+   if (content_type == CONTENT_SETTINGS_TYPE_MIXEDSCRIPT) {
+     return new ContentSettingMixedScriptBubbleModel(delegate, web_contents,

--- a/renderer/brave_content_settings_observer_flash_browsertest.cc
+++ b/renderer/brave_content_settings_observer_flash_browsertest.cc
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "brave/components/brave_shields/common/brave_shield_constants.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/permission_bubble/mock_permission_prompt_factory.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/common/content_switches.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/ppapi_test_utils.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "net/dns/mock_host_resolver.h"
+
+const char kFlashPluginExists[] =
+  "domAutomationController.send(Array.from(navigator.plugins).filter("
+  "  x => Array.from(x).some("
+  "    y => y.type === 'application/x-shockwave-flash')).length)";
+
+namespace {
+
+class PageReloadWaiter {
+ public:
+  explicit PageReloadWaiter(content::WebContents* web_contents)
+      : web_contents_(web_contents),
+        navigation_observer_(web_contents,
+                             web_contents->GetLastCommittedURL()) {}
+
+  bool Wait() {
+    navigation_observer_.WaitForNavigationFinished();
+    return content::WaitForLoadStop(web_contents_);
+  }
+
+ private:
+  content::WebContents* web_contents_;
+  content::TestNavigationManager navigation_observer_;
+};
+
+}  // namespace
+
+class BraveContentSettingsObserverFlashBrowserTest : public InProcessBrowserTest {
+  public:
+    void SetUpOnMainThread() override {
+      InProcessBrowserTest::SetUpOnMainThread();
+
+      content_client_.reset(new ChromeContentClient);
+      content::SetContentClient(content_client_.get());
+      browser_content_client_.reset(new BraveContentBrowserClient());
+      content::SetBrowserClientForTesting(browser_content_client_.get());
+
+      host_resolver()->AddRule("*", "127.0.0.1");
+      content::SetupCrossSiteRedirector(embedded_test_server());
+
+      brave::RegisterPathProvider();
+      base::FilePath test_data_dir;
+      PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+      embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+      ASSERT_TRUE(embedded_test_server()->Start());
+
+      url_ = embedded_test_server()->GetURL("a.com", "/flash.html");
+      top_level_page_pattern_ =
+          ContentSettingsPattern::FromString("http://a.com/*");
+    }
+
+    void SetUpCommandLine(base::CommandLine* command_line) override {
+      InProcessBrowserTest::SetUpCommandLine(command_line);
+      ASSERT_TRUE(ppapi::RegisterFlashTestPlugin(command_line));
+      // These tests are for the permission prompt to add and remove Flash from
+      // navigator.plugins. We disable Plugin Power Saver, because its plugin
+      // throttling make it harder to test if Flash was succcessfully enabled.
+      command_line->AppendSwitchASCII(
+          switches::kOverridePluginPowerSaverForTesting, "never");
+    }
+
+    void TearDown() override {
+      browser_content_client_.reset();
+      content_client_.reset();
+    }
+
+    const GURL& url() { return url_; }
+
+    const ContentSettingsPattern& top_level_page_pattern() {
+      return top_level_page_pattern_;
+    }
+
+    const ContentSettingsPattern& empty_pattern() {
+      return empty_pattern_;
+    }
+
+    HostContentSettingsMap * content_settings() {
+      return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+    }
+
+    void UnblockFlash() {
+      content_settings()->SetContentSettingCustomScope(
+          top_level_page_pattern_,
+          ContentSettingsPattern::Wildcard(),
+          CONTENT_SETTINGS_TYPE_PLUGINS,
+          std::string(),
+          CONTENT_SETTING_DETECT_IMPORTANT_CONTENT);
+    }
+
+    void AllowFlash() {
+      content_settings()->SetContentSettingCustomScope(
+          top_level_page_pattern_,
+          ContentSettingsPattern::Wildcard(),
+          CONTENT_SETTINGS_TYPE_PLUGINS,
+          std::string(),
+          CONTENT_SETTING_ALLOW);
+    }
+
+    content::WebContents* contents() {
+      return browser()->tab_strip_model()->GetActiveWebContents();
+    }
+
+    bool NavigateToURLUntilLoadStop(const GURL& url) {
+      ui_test_utils::NavigateToURL(browser(), url);
+      return WaitForLoadStop(contents());
+    }
+
+  private:
+    GURL url_;
+    ContentSettingsPattern top_level_page_pattern_;
+    ContentSettingsPattern empty_pattern_;
+    std::unique_ptr<ChromeContentClient> content_client_;
+    std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+
+    base::ScopedTempDir temp_user_data_dir_;
+};
+
+// Flash is blocked by default
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverFlashBrowserTest,
+    BlockFlashByDefault) {
+  NavigateToURLUntilLoadStop(url());
+  int len;
+  ASSERT_TRUE(ExecuteScriptAndExtractInt(contents(),
+      kFlashPluginExists, &len));
+  ASSERT_EQ(len, 0);
+}
+
+// Flash is unblocked and click to play eventually allows
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverFlashBrowserTest,
+    UnblockFlash) {
+  UnblockFlash();
+  NavigateToURLUntilLoadStop(url());
+  int len;
+  ASSERT_TRUE(ExecuteScriptAndExtractInt(contents(),
+      kFlashPluginExists, &len));
+  ASSERT_EQ(len, 0);
+
+  PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
+      contents());
+
+  auto popup_prompt_factory =
+      std::make_unique<MockPermissionPromptFactory>(manager);
+
+  EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
+  popup_prompt_factory->set_response_type(PermissionRequestManager::ACCEPT_ALL);
+
+  PageReloadWaiter reload_waiter(contents());
+
+  bool value;
+  EXPECT_TRUE(ExecuteScriptAndExtractBool(contents(), "triggerPrompt();",
+      &value));
+  EXPECT_TRUE(value);
+  EXPECT_TRUE(reload_waiter.Wait());
+
+  EXPECT_EQ(1, popup_prompt_factory->TotalRequestCount());
+
+  // Shut down the popup window tab, as the normal test teardown assumes there
+  // is only one test tab.
+  popup_prompt_factory.reset();
+
+  ASSERT_TRUE(ExecuteScriptAndExtractInt(contents(),
+      kFlashPluginExists, &len));
+  ASSERT_GT(len, 0);
+}
+
+// Flash is explicitly allowed
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverFlashBrowserTest,
+    AllowFlashExplicitAllows) {
+  AllowFlash();
+  NavigateToURLUntilLoadStop(url());
+  int len;
+  ASSERT_TRUE(ExecuteScriptAndExtractInt(contents(),
+      kFlashPluginExists, &len));
+  ASSERT_GT(len, 0);
+}
+

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -77,6 +77,7 @@ test("brave_browser_tests") {
     "//brave/components/brave_shields/browser/tracking_protection_service_browsertest.cc",
     "//brave/extensions/browser/brave_extension_provider_browsertest.cc",
     "//brave/renderer/brave_content_settings_observer_browsertest.cc",
+    "//brave/renderer/brave_content_settings_observer_flash_browsertest.cc",
     "//chrome/browser/extensions/browsertest_util.cc",
     "//chrome/browser/extensions/browsertest_util.h",
     "//chrome/browser/extensions/extension_browsertest.cc",
@@ -90,6 +91,11 @@ test("brave_browser_tests") {
   deps = [
     "//chrome/browser/ui",
     "//chrome/test:browser_tests_runner",
+    "//ppapi/features",
     ":brave_browser_tests_deps",
+  ]
+  data_deps = [
+    "//ppapi:ppapi_tests",
+    "//ppapi:power_saver_test_plugin",
   ]
 }

--- a/test/data/flash.html
+++ b/test/data/flash.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function triggerPrompt() {
+  document.getElementById('flash-link').click();
+  window.domAutomationController.send(true);
+}
+</script>
+</head>
+<body>
+  <object id="flash-object" data="test.swf"
+      type="application/x-shockwave-flash" width="400" height="100">
+    Flash not supported.
+    <br>
+    <a href="https://get.adobe.com/flashplayer/" id="flash-link">
+      Download Flash.
+    </a>
+  </object>
+</body>
+</html>
+


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/30

By setting the default content setting to Block, this ensures there's at least a couple steps needed to get Flash working.

---

**If Flash is not installed:**

`navigator.plugins` obviously doesn't show Flash here.

No extra code nor UI for that.

---

**If Flash is installed:**

`navigator.plugins` doesn't show Flash here.

<img width="764" alt="screen shot 2018-05-28 at 1 26 09 am" src="https://user-images.githubusercontent.com/831718/40599257-4dad7dee-621a-11e8-9043-c391571a29cf.png">

---

**Clicking on the icon in the URL bar:**

`navigator.plugins` doesn't show Flash here.

<img width="763" alt="screen shot 2018-05-28 at 1 26 26 am" src="https://user-images.githubusercontent.com/831718/40599263-5a299580-621a-11e8-8221-68444221d97c.png">

---

**Page reloads with Click to Play:**

`navigator.plugins` doesn't show Flash here.

<img width="762" alt="screen shot 2018-05-28 at 1 26 38 am" src="https://user-images.githubusercontent.com/831718/40599289-7229e9aa-621a-11e8-9e3e-28c8d74f8dc3.png">

---

**Clicking on the Flash content:**

`navigator.plugins` doesn't show Flash here.

<img width="763" alt="screen shot 2018-05-28 at 1 26 45 am" src="https://user-images.githubusercontent.com/831718/40599300-7f869080-621a-11e8-84c1-5fd553a5237e.png">


---

**Finally Flash is played:**

`navigator.plugins` will show Flash here.

<img width="763" alt="screen shot 2018-05-28 at 1 26 50 am" src="https://user-images.githubusercontent.com/831718/40599308-85202dd0-621a-11e8-8cc9-84e0786f5067.png">


---

**Limitations:**

- There is no expiry currently, once enabled, but this is expected to change upstream here: https://www.chromium.org/flash-roadmap#TOC-Non-Persisted-HTML5-by-Default-Target:-Chrome-68---July-2018- before we ship.  Issue posted to track that here: https://github.com/brave/brave-browser/issues/241
- This applies to the origin even know the content setting is only on the specific URL.  It would need extra patching to make that more specific. 


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
