### PR TITLE
Fix official mode dependency error on MacOS

### DIFF
--- a/patches/chrome-BUILD.gn.patch
+++ b/patches/chrome-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index fbcf20cd0411d39a99642acf2674bf7de2804608..c3524971302bfd0d5cc297c50b562a7503d83510 100644
+index fbcf20cd0411d39a99642acf2674bf7de2804608..dd5def3bb13ff86bc0dd51e23bd439cfc35394d4 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -182,6 +182,15 @@ if (!is_android && !is_mac) {
@@ -60,7 +60,7 @@ index fbcf20cd0411d39a99642acf2674bf7de2804608..c3524971302bfd0d5cc297c50b562a75
  
 +if (brave_chromium_build) {
 +  group("chrome_app") {
-+    deps = [
++    public_deps = [
 +      "//brave:chrome_app",
 +    ]
 +  }


### PR DESCRIPTION
In official mode, //chrome:chrome_dump_syms target has source list that
includes //out/Release/Brave.app/Contents/MacOS/Brave file.
That file is generated by //brave:chrome_app.
However, //chrome:chrome_dump_syms has dependency on //chrome:chrome_app not //brave:chrome_app.
By making //brave::chrome_app target public in //chrome:chrome_app target,
//chrome:chrome_dump_syms can identify that its source lists are generated by its
dependency list.

Closes: https://github.com/brave/brave-browser/issues/245

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
