### PR TITLE
Fix env var reference in instructions for uploading

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -233,7 +233,7 @@ def publish_release(github, release_id):
 
 def auth_token():
   token = get_env_var('GITHUB_TOKEN')
-  message = ('Error: Please set the $BRAVE_GITHUB_TOKEN '
+  message = ('Error: Please set the $GITHUB_TOKEN '
              'environment variable, which is your personal token')
   assert token, message
   return token


### PR DESCRIPTION
## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Run the script/upload.py script with the env var set

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
