### PR TITLE
Add ctrl.blog to UA whitelist

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -25,8 +25,9 @@ bool IsEmptyDataURLRedirect(const GURL& gurl) {
 bool IsUAWhitelisted(const GURL& gurl) {
   static std::vector<URLPattern> whitelist_patterns({
     URLPattern(URLPattern::SCHEME_ALL, "https://*.adobe.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://*.duckduckgo.com/*"),
     URLPattern(URLPattern::SCHEME_ALL, "https://*.brave.com/*"),
+    URLPattern(URLPattern::SCHEME_ALL, "https://*.ctrl.blog/*"),
+    URLPattern(URLPattern::SCHEME_ALL, "https://*.duckduckgo.com/*"),
     // For Widevine
     URLPattern(URLPattern::SCHEME_ALL, "https://*.netflix.com/*")
   });


### PR DESCRIPTION
As the domain owner, I do solemnly swear not to negatively impact or discriminate against Brave users or misuse the ability to differentiate them from Chrome users. (I first [asked for this in 2016-08](https://github.com/brave/browser-laptop/issues/3693).)

Domain ownership verification: https://www.ctrl.blog/.well-known/brave/user_agent_whitelist.txt.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
