### PR TITLE
Fix extension-related browser tests

### DIFF
--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -66,6 +66,7 @@ public:
 
     g_brave_browser_process->ad_block_service()->OnComponentReady(
         ad_block_extension->id(), ad_block_extension->path());
+    WaitForAdBlockServiceThread();
 
     return true;
   }

--- a/components/brave_shields/browser/https_everywhere_service_browsertest.cc
+++ b/components/brave_shields/browser/https_everywhere_service_browsertest.cc
@@ -76,6 +76,7 @@ public:
 
     g_brave_browser_process->https_everywhere_service()->OnComponentReady(
         httpse_extension->id(), httpse_extension->path());
+    WaitForHTTPSEverywhereServiceThread();
 
     return true;
   }

--- a/components/brave_shields/browser/tracking_protection_service_browsertest.cc
+++ b/components/brave_shields/browser/tracking_protection_service_browsertest.cc
@@ -86,6 +86,7 @@ public:
 
     g_brave_browser_process->tracking_protection_service()->OnComponentReady(
         tracking_protection_extension->id(), tracking_protection_extension->path());
+    WaitForTrackingProtectionServiceThread();
 
     return true;
   }


### PR DESCRIPTION
Need to wait for thread to be ready after calling OnComponentReady, as
that function now kicks off an asynchronous task (required when enabling
support for debug builds)

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
