### PR TITLE
Set kUseGoogleUpdateIntegration to false in non-official mode

### DIFF
--- a/chromium_src/chrome/install_static/chromium_install_modes.h
+++ b/chromium_src/chrome/install_static/chromium_install_modes.h
@@ -10,7 +10,11 @@
 namespace install_static {
 
 enum : bool {
+#if defined(OFFICIAL_BUILD)
   kUseGoogleUpdateIntegration = true,
+#else
+  kUseGoogleUpdateIntegration = false,
+#endif
 };
 
 // Note: This list of indices must be kept in sync with the brand-specific


### PR DESCRIPTION
This commit was missed when I pushed previous PR that enables debug build.

In non-official mode, brave doesn't use Omaha.
Close https://github.com/brave/brave-browser/issues/259

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
