### PR TITLE
Fix blacklist/whitelist tests referring to wrong class

### DIFF
--- a/extensions/browser/brave_extension_provider_browsertest.cc
+++ b/extensions/browser/brave_extension_provider_browsertest.cc
@@ -63,7 +63,7 @@ class ExtensionFunctionalTest : public ExtensionBrowserTest {
   }
 };
 
-IN_PROC_BROWSER_TEST_F(ExtensionBrowserTest, BlacklistExtension) {
+IN_PROC_BROWSER_TEST_F(ExtensionFunctionalTest, BlacklistExtension) {
   base::FilePath test_data_dir;
   PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
   const extensions::Extension* extension =
@@ -71,7 +71,7 @@ IN_PROC_BROWSER_TEST_F(ExtensionBrowserTest, BlacklistExtension) {
   ASSERT_FALSE(extension);
 }
 
-IN_PROC_BROWSER_TEST_F(ExtensionBrowserTest, WhitelistedExtension) {
+IN_PROC_BROWSER_TEST_F(ExtensionFunctionalTest, WhitelistedExtension) {
   base::FilePath test_data_dir;
   PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
   const extensions::Extension* extension =


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
