### PR TITLE
Show welcome page only at first run

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -17,6 +17,8 @@ source_set("ui") {
     "webui/basic_ui.h",
     "webui/brave_web_ui_controller_factory.cc",
     "webui/brave_web_ui_controller_factory.h",
+    "webui/brave_welcome_ui.cc",
+    "webui/brave_welcome_ui.h",
     "webui/new_tab_html_source.cc",
     "webui/new_tab_html_source.h",
   ]

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -6,6 +6,7 @@
 
 #include "brave/common/webui_url_constants.h"
 #include "brave/browser/ui/webui/basic_ui.h"
+#include "brave/browser/ui/webui/brave_welcome_ui.h"
 #include "chrome/common/url_constants.h"
 #include "components/grit/brave_components_resources.h"
 #include "url/gurl.h"
@@ -24,6 +25,11 @@ typedef WebUIController* (*WebUIFactoryFunction)(WebUI* web_ui,
 template<class T>
 WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
   return new T(web_ui);
+}
+
+template<>
+WebUIController* NewWebUI<BraveWelcomeUI>(WebUI* web_ui, const GURL& url) {
+  return new BraveWelcomeUI(web_ui);
 }
 
 template<>
@@ -47,6 +53,8 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
   if (url.host_piece() == kPaymentsHost ||
       url.host_piece() ==  chrome::kChromeUINewTabHost) {
     return &NewWebUI<BasicUI>;
+  } else if (url.spec() == kWelcomeRemoteURL) {
+    return &NewWebUI<BraveWelcomeUI>;
   }
 
   return nullptr;

--- a/browser/ui/webui/brave_welcome_ui.cc
+++ b/browser/ui/webui/brave_welcome_ui.cc
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/brave_welcome_ui.h"
+
+#include "brave/browser/brave_browser_process_impl.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/common/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+BraveWelcomeUI::BraveWelcomeUI(content::WebUI* web_ui)
+    : WebUIController(web_ui) {
+  Profile* profile = Profile::FromWebUI(web_ui);
+
+  profile->GetPrefs()->SetBoolean(prefs::kHasSeenWelcomePage, true);
+#if defined(OS_WIN)
+  g_brave_browser_process->local_state()->SetBoolean(
+      prefs::kHasSeenWin10PromoPage,
+      true);
+#endif
+}
+
+BraveWelcomeUI::~BraveWelcomeUI() {
+}

--- a/browser/ui/webui/brave_welcome_ui.h
+++ b/browser/ui/webui/brave_welcome_ui.h
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_BRAVE_WELCOME_UI_H_
+#define BRAVE_BROWSER_UI_WEBUI_BRAVE_WELCOME_UI_H_
+
+#include "base/macros.h"
+#include "content/public/browser/web_ui_controller.h"
+
+class BraveWelcomeUI : public content::WebUIController {
+ public:
+  explicit BraveWelcomeUI(content::WebUI* web_ui);
+  ~BraveWelcomeUI() override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(BraveWelcomeUI);
+};
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_BRAVE_WELCOME_UI_H_

--- a/browser/ui/webui/brave_welcome_ui_browsertest.cc
+++ b/browser/ui/webui/brave_welcome_ui_browsertest.cc
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "brave/browser/ui/webui/brave_web_ui_controller_factory.h"
+#include "brave/common/webui_url_constants.h"
+#include "chrome/browser/chrome_notification_types.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/startup/startup_browser_creator.h"
+#include "chrome/browser/ui/startup/startup_browser_creator_impl.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/common/webui_url_constants.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/test/test_navigation_observer.h"
+#include "content/public/test/test_utils.h"
+
+namespace {
+Browser* OpenNewBrowser(Profile* profile) {
+  base::CommandLine dummy(base::CommandLine::NO_PROGRAM);
+  StartupBrowserCreatorImpl creator(base::FilePath(), dummy,
+                                    chrome::startup::IS_FIRST_RUN);
+  creator.Launch(profile, std::vector<GURL>(), false);
+  return chrome::FindBrowserWithProfile(profile);
+}
+}
+
+using BraveWelcomeUIBrowserTest = InProcessBrowserTest;
+
+// Check whether startup url at first run is our welcome page.
+IN_PROC_BROWSER_TEST_F(BraveWelcomeUIBrowserTest, PRE_StartupURLTest) {
+  Browser* new_browser = OpenNewBrowser(browser()->profile());
+  ASSERT_TRUE(new_browser);
+  TabStripModel* tab_strip = new_browser->tab_strip_model();
+  ASSERT_EQ(1, tab_strip->count());
+  content::WebContents* web_contents = tab_strip->GetWebContentsAt(0);
+  content::TestNavigationObserver observer(web_contents, 1);
+  observer.Wait();
+  EXPECT_EQ(kWelcomeRemoteURL,
+            tab_strip->GetWebContentsAt(0)->GetURL().possibly_invalid_spec());
+}
+
+// Check wheter startup url is not welcome ui at second run.
+IN_PROC_BROWSER_TEST_F(BraveWelcomeUIBrowserTest, StartupURLTest) {
+  Browser* new_browser = OpenNewBrowser(browser()->profile());
+  ASSERT_TRUE(new_browser);
+  TabStripModel* tab_strip = new_browser->tab_strip_model();
+  ASSERT_EQ(1, tab_strip->count());
+  content::WebContents* web_contents = tab_strip->GetWebContentsAt(0);
+  content::TestNavigationObserver observer(web_contents, 1);
+  observer.Wait();
+  EXPECT_EQ(chrome::kChromeUINewTabURL,
+            tab_strip->GetWebContentsAt(0)->GetURL().possibly_invalid_spec());
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -98,6 +98,7 @@ static_library("browser_tests_runner") {
 test("brave_browser_tests") {
   sources = [
     "//brave/browser/extensions/api/brave_shields_api_browsertest.cc",
+    "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_service_browsertest.cc",
     "//brave/components/brave_shields/browser/tracking_protection_service_browsertest.cc",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -69,6 +69,32 @@ group("brave_browser_tests_deps") {
   ]
 }
 
+static_library("browser_test_support") {
+  testonly = true
+  deps = [
+    "//chrome/test:test_support",
+  ]
+
+  sources = [
+    "base/brave_test_launcher_delegate.cc",
+    "base/brave_test_launcher_delegate.h",
+    "//brave/app/brave_main_delegate.cc",
+    "//brave/app/brave_main_delegate.h",
+  ]
+}
+
+static_library("browser_tests_runner") {
+  testonly = true
+
+  deps = [
+    ":browser_test_support",
+  ]
+
+  sources = [
+    "base/browser_tests_main.cc",
+  ]
+}
+
 test("brave_browser_tests") {
   sources = [
     "//brave/browser/extensions/api/brave_shields_api_browsertest.cc",
@@ -90,9 +116,9 @@ test("brave_browser_tests") {
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
   deps = [
     "//chrome/browser/ui",
-    "//chrome/test:browser_tests_runner",
     "//ppapi/buildflags",
     ":brave_browser_tests_deps",
+    ":browser_tests_runner",
   ]
   data_deps = [
     "//ppapi:ppapi_tests",

--- a/test/base/brave_test_launcher_delegate.cc
+++ b/test/base/brave_test_launcher_delegate.cc
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/test/base/brave_test_launcher_delegate.h"
+
+#include "brave/app/brave_main_delegate.h"
+
+BraveTestLauncherDelegate::BraveTestLauncherDelegate(
+    ChromeTestSuiteRunner* runner)
+    : ChromeTestLauncherDelegate(runner) {}
+
+BraveTestLauncherDelegate::~BraveTestLauncherDelegate() = default;
+
+content::ContentMainDelegate*
+BraveTestLauncherDelegate::CreateContentMainDelegate() {
+  return new BraveMainDelegate();
+}

--- a/test/base/brave_test_launcher_delegate.h
+++ b/test/base/brave_test_launcher_delegate.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_TEST_BASE_BRAVE_TEST_LAUNCHER_H_
+#define BRAVE_TEST_BASE_BRAVE_TEST_LAUNCHER_H_
+
+#include "chrome/test/base/chrome_test_launcher.h"
+#include "base/macros.h"
+
+class BraveTestLauncherDelegate : public ChromeTestLauncherDelegate {
+ public:
+  // Does not take ownership of ChromeTestSuiteRunner.
+  explicit BraveTestLauncherDelegate(ChromeTestSuiteRunner* runner);
+  ~BraveTestLauncherDelegate() override;
+
+ private:
+  // ChromeLauncherDelegate:
+  content::ContentMainDelegate* CreateContentMainDelegate() override;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveTestLauncherDelegate);
+};
+
+#endif  // BRAVE_TEST_BASE_BRAVE_TEST_LAUNCHER_H_

--- a/test/base/browser_tests_main.cc
+++ b/test/base/browser_tests_main.cc
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "base/test/launcher/test_launcher.h"
+#include "brave/test/base/brave_test_launcher_delegate.h"
+#include "build/build_config.h"
+
+#if defined(OS_WIN)
+#include "base/test/test_switches.h"
+#include "base/win/win_util.h"
+#endif  // defined(OS_WIN)
+
+int main(int argc, char** argv) {
+  base::CommandLine::Init(argc, argv);
+  size_t parallel_jobs = base::NumParallelJobs();
+  if (parallel_jobs == 0U) {
+    return 1;
+  } else if (parallel_jobs > 1U) {
+    parallel_jobs /= 2U;
+  }
+
+#if defined(OS_WIN)
+  // Enable high-DPI for interactive tests where the user is expected to
+  // manually verify results.
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kTestLauncherInteractive)) {
+    base::win::EnableHighDPISupport();
+  }
+#endif  // defined(OS_WIN)
+
+  ChromeTestSuiteRunner runner;
+  BraveTestLauncherDelegate delegate(&runner);
+  return LaunchChromeTests(parallel_jobs, &delegate, argc, argv);
+}


### PR DESCRIPTION
When welcome page is requested at the first run, store that this profile
has been shown the welcome page.

close https://github.com/brave/brave-browser/issues/221
close https://github.com/brave/brave-browser/issues/264

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`--filter BraveWelcomeUIBrowserTest*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
