### PR TITLE
Allow chormedriver to run e2e extension tests

### DIFF
--- a/extensions/browser/brave_extension_provider.cc
+++ b/extensions/browser/brave_extension_provider.cc
@@ -57,6 +57,8 @@ bool IsWhitelisted(const std::string& id) {
     "kbmfpngjjgdllneeigpgjifpgocmfgmb",
     // Web Store
     "ahfgeienlihckogmohjhadlkjgocpleb",
+    // Brave Automation Extension
+    "aapnijgdinlhnhlmodcfapnahmbfebeb",
     // Test ID: Brave Default Ad Block Updater
     "naccapggpomhlhoifnlebfoocegenbol",
     // Test ID: Brave Regional Ad Block Updater (9852EFC4-99E4-4F2D-A915-9C3196C7A1DE)


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/268

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
