### PR TITLE
Allow IO on UI thread in ChromeProfileLock

### DIFF
--- a/browser/importer/chrome_profile_lock.cc
+++ b/browser/importer/chrome_profile_lock.cc
@@ -6,6 +6,7 @@
 
 #include "base/bind.h"
 #include "base/bind_helpers.h"
+#include "base/threading/thread_restrictions.h"
 
 ChromeProfileLock::ChromeProfileLock(
     const base::FilePath& user_data_dir)
@@ -22,12 +23,14 @@ ChromeProfileLock::~ChromeProfileLock() {
 }
 
 void ChromeProfileLock::Lock() {
+  base::ThreadRestrictions::ScopedAllowIO allow_io;
   if (HasAcquired())
     return;
   lock_acquired_ = process_singleton_->Create();
 }
 
 void ChromeProfileLock::Unlock() {
+  base::ThreadRestrictions::ScopedAllowIO allow_io;
   if (!HasAcquired())
     return;
   process_singleton_->Cleanup();


### PR DESCRIPTION
Fixes #250.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. Do a debug build so thread restrictions checking is enabled. Currently, `yarn build` defaults to doing a debug build.
2. Follow the "Manual Testing" test plan from https://github.com/brave/brave-core/pull/101.
3. At the end of Step 5, Brave should _not_ crash with a debug error after you click the **Import** button.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
