### PR TITLE
Switch to using -exported_symbols_list on MacOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -396,13 +396,13 @@ if (is_mac) {
       deps += [ "chrome:chrome_helpers" ]
     }
 
-    # Remove the default strip configuration (which strips all symbols) so that
-    # a saves file can be specified.
     if (enable_stripping) {
-      remove_configs = [ "//build/config/mac:strip_all" ]
-
-      ldflags =
-          [ "-Wcrl,strip,-s," + rebase_path("//chrome/app/app.saves", root_build_dir) ]
+      # At link time, preserve the global symbols specified in the .exports
+      # file. All other global symbols will be marked as private. The default
+      # //build/config/mac:strip_all config will then remove the remaining
+      # local and debug symbols.
+      ldflags = [ "-Wl,-exported_symbols_list," +
+                  rebase_path("//chrome/app/app.exports", root_build_dir) ]
     }
   }
 }


### PR DESCRIPTION
https://chromium-review.googlesource.com/c/chromium/src/+/922987
close https://github.com/brave/brave-browser/issues/274

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
