### PR TITLE
Fix patch causing build break

### DIFF
--- a/patches/build-config-BUILDCONFIG.gn.patch.new
+++ b/patches/build-config-BUILDCONFIG.gn.patch.new
@@ -1,0 +1,29 @@
+diff --git a/build/config/BUILDCONFIG.gn b/build/config/BUILDCONFIG.gn
+index 7d60dd920904d3f98573680e311096f0b9cb252e..0c0959df98d0380823a714ec4d4bb4ccb46853c9 100644
+--- a/build/config/BUILDCONFIG.gn
++++ b/build/config/BUILDCONFIG.gn
+@@ -46,6 +46,8 @@
+ # When writing build files, to do something only for the host:
+ #   if (current_toolchain == host_toolchain) { ...
+ 
++import("//brave/brave_init_settings.gni")
++
+ if (target_os == "") {
+   target_os = host_os
+ }
+@@ -535,6 +537,15 @@ default_compiler_configs = [
+   "//build/config/coverage:default_coverage",
+   "//build/config/sanitizers:default_sanitizer_flags",
+ ]
++
++if (brave_chromium_build) {
++  default_compiler_configs -= [ "//build/config/compiler:default_include_dirs" ]
++  default_compiler_configs += [
++    "//brave/build:feature_flags",
++    "//brave/build:brave_include_dirs",
++    "//build/config/compiler:default_include_dirs"
++  ]
++}
+ if (is_win) {
+   default_compiler_configs += [
+     "//build/config/win:default_crt",


### PR DESCRIPTION
I was getting error in Jenkins:

build-config-BUILDCONFIG.gn.patch failed to apply

Followed chromium rebase process to correct.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [X] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
