### PR TITLE
Fix webview referrer crash

### DIFF
--- a/components/brave_shields/browser/https_everywhere_service_browsertest.cc
+++ b/components/brave_shields/browser/https_everywhere_service_browsertest.cc
@@ -108,3 +108,19 @@ IN_PROC_BROWSER_TEST_F(HTTPSEverywhereServiceTest, NoRedirectsNotKnownSite) {
   content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
   EXPECT_STREQ("http://www.brianbondy.com/", contents->GetLastCommittedURL().spec().c_str());
 }
+
+// Make sure iframes that should redirect to HTTPS actually redirect and that
+// the header is intact.
+IN_PROC_BROWSER_TEST_F(HTTPSEverywhereServiceTest, RedirectsKnownSiteInIframe) {
+  ASSERT_TRUE(InstallHTTPSEverywhereExtension());
+  GURL url = embedded_test_server()->GetURL("a.com", "/iframe.html");
+  ui_test_utils::NavigateToURL(browser(), url);
+
+  GURL iframe_url = embedded_test_server()->GetURL("http://www.digg.com/");
+  const char kIframeID[] = "test";
+  content::WebContents* contents =  browser()->tab_strip_model()->GetActiveWebContents();
+  EXPECT_TRUE(NavigateIframeToURL(contents, kIframeID, iframe_url));
+  content::RenderFrameHost* iframe_contents = ChildFrameAt(contents->GetMainFrame(), 0);
+  WaitForLoadStop(contents);
+  EXPECT_STREQ("https://www.digg.com/", iframe_contents->GetLastCommittedURL().spec().c_str());
+}

--- a/patches/content-browser-frame_host-navigation_request.cc.patch
+++ b/patches/content-browser-frame_host-navigation_request.cc.patch
@@ -1,14 +1,17 @@
 diff --git a/content/browser/frame_host/navigation_request.cc b/content/browser/frame_host/navigation_request.cc
-index 9d8ca86d3151a5a0a46edd111322bcc3bfa3d376..8abe298e616f9cda57ff687573ceb4e3301f4bef 100644
+index 9d8ca86d3151a5a0a46edd111322bcc3bfa3d376..8396d37dd526a259f7e4c18054152778a9b2f7f9 100644
 --- a/content/browser/frame_host/navigation_request.cc
 +++ b/content/browser/frame_host/navigation_request.cc
-@@ -1410,6 +1410,22 @@ void NavigationRequest::CommitNavigation() {
+@@ -1410,6 +1410,28 @@ void NavigationRequest::CommitNavigation() {
           render_frame_host ==
               frame_tree_node_->render_manager()->speculative_frame_host());
  
 +  auto* pending_entry =
 +    frame_tree_node_->navigator()->GetController()->GetPendingEntry();
 +  if (pending_entry) {
++    if (!pending_entry->GetURL().is_empty()) {
++      common_params_.url = pending_entry->GetURL();
++    }
 +    if (!pending_entry->GetReferrer().url.is_empty()) {
 +      common_params_.referrer = pending_entry->GetReferrer();
 +    }
@@ -16,6 +19,9 @@ index 9d8ca86d3151a5a0a46edd111322bcc3bfa3d376..8abe298e616f9cda57ff687573ceb4e3
 +    auto* last_committed_entry =
 +      frame_tree_node_->navigator()->GetController()->GetLastCommittedEntry();
 +    if (last_committed_entry) {
++      if (!last_committed_entry->GetURL().is_empty()) {
++        common_params_.url = last_committed_entry->GetURL();
++      }
 +      if (!last_committed_entry->GetReferrer().url.is_empty()) {
 +        common_params_.referrer = last_committed_entry->GetReferrer();
 +      }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/234

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
