### PR TITLE
Don't initialize RenderFrameData when connection to renderer is closed

### DIFF
--- a/components/brave_shields/browser/brave_shields_web_contents_observer.cc
+++ b/components/brave_shields/browser/brave_shields_web_contents_observer.cc
@@ -100,6 +100,9 @@ BraveShieldsWebContentsObserver::BraveShieldsWebContentsObserver(
 
 void BraveShieldsWebContentsObserver::RenderFrameCreated(
     RenderFrameHost* rfh) {
+  if (!rfh->IsRenderFrameLive())
+    return;
+
   // Look up the extension API frame ID to force the mapping to be cached.
   // This is needed so that cached information is available for tabId in the
   // filtering callbacks.


### PR DESCRIPTION
Close https://github.com/brave/brave-browser/issues/277

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
