### PR TITLE
remove useBabel query from awesome-typescript-loader

### DIFF
--- a/components/webpack/prod.config.js
+++ b/components/webpack/prod.config.js
@@ -39,10 +39,7 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'awesome-typescript-loader',
-        query: {
-          useBabel: true
-        }
+        loader: 'awesome-typescript-loader'
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
follow-up of https://github.com/brave/brave-core/pull/151