### PR TITLE
Fix first run startup crash due to welcome ui

### DIFF
--- a/patches/extensions-browser-api-web_request-web_request_permissions.cc.patch
+++ b/patches/extensions-browser-api-web_request-web_request_permissions.cc.patch
@@ -1,14 +1,15 @@
 diff --git a/extensions/browser/api/web_request/web_request_permissions.cc b/extensions/browser/api/web_request/web_request_permissions.cc
-index 426bdc336021722db43af2c984ae5675a878f7fd..f15ed0c6e9c9051dadd841ee12ed4959cabce009 100644
+index 426bdc336021722db43af2c984ae5675a878f7fd..4315e66ff33d4aecb6610ed2125aed70e66449b2 100644
 --- a/extensions/browser/api/web_request/web_request_permissions.cc
 +++ b/extensions/browser/api/web_request/web_request_permissions.cc
-@@ -87,6 +87,10 @@ bool IsWebUIAllowedToMakeNetworkRequests(const url::Origin& origin) {
+@@ -87,6 +87,11 @@ bool IsWebUIAllowedToMakeNetworkRequests(const url::Origin& origin) {
    return
        // https://crbug.com/829414
        origin.host() == "print" ||
 +#if defined(BRAVE_CHROMIUM_BUILD)
 +      // https://github.com/brave/brave-browser/issues/273
 +      origin.host() == "newtab" ||
++      origin.host() == "brave.com" ||
 +#endif
        // https://crbug.com/831812
        origin.host() == "sync-confirmation" ||


### PR DESCRIPTION
This seems the regression from https://github.com/brave/brave-core/pull/130.
In that CL, BraveWelcomeUI WebUIController is introduced.
Because of this, current welcome ui page treated as webui.
This CL could be reverted when our local welcome ui is implemented.

close https://github.com/brave/brave-browser/issues/315

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
