### PR TITLE
Show download prompt by default

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -22,6 +22,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // Restore last profile on restart
   registry->SetDefaultPrefValue(prefs::kRestoreOnStartup,
       base::Value(SessionStartupPref::kPrefValueLast));
+
+  // Show download prompt by default
+  registry->SetDefaultPrefValue(prefs::kPromptForDownload, base::Value(true));
 }
 
 }  // namespace brave

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/pref_names.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
+
+using BraveProfilePrefsBrowserTest = InProcessBrowserTest;
+
+// Check download prompt preference is set to true by default.
+IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DownloadPromptDefault) {
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kPromptForDownload));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -97,6 +97,7 @@ static_library("browser_tests_runner") {
 
 test("brave_browser_tests") {
   sources = [
+    "//brave/browser/brave_profile_prefs_browsertest.cc",
     "//brave/browser/extensions/api/brave_shields_api_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",


### PR DESCRIPTION
close https://github.com/brave/brave-browser/issues/308

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
BraveProfilePrefsBrowserTest.DownloadPromptDefault

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
