### PR TITLE
[WIP] Fix path to signtool

### DIFF
--- a/script/sign_binaries.py
+++ b/script/sign_binaries.py
@@ -12,10 +12,8 @@ assert (cert or signtool_args), 'One or both of the CERT or SIGNTOOL_ARGS must b
 
 def get_sign_cmd(file):
   # https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
-  sdk_dir = os.path.normpath(os.environ.get(
-      'WINDOWSSDKDIR',
-      'C:\\Program Files (x86)\\Windows Kits\\10'))
-  cmd = "{}\\bin\\x64\\signtool.exe {}".format(sdk_dir, signtool_args)
+  # signtool should be in the path if it was set up correctly by gn through src/build/vs_toolchain.py
+  cmd = 'signtool ' + format(signtool_args)
   if cert:
     cmd = cmd + ' /n "' + cert + '"'
   return (cmd + ' "' + file + '"')


### PR DESCRIPTION
Hoping to get some advice on GN configuration here.

The script https://github.com/brave/brave-core/blob/fix/win-signing/script/sign_binaries.py#L16 calls signtool in the winsdk directory. This of course shouldn't be hardcoded, I'm trying to figure out how this should be setup so that it isn't using a hardcoded path?

sign_binaries.py is called from:

> https://github.com/brave/brave-core/blob/master/build/win/BUILD.gn#L30
> https://github.com/brave/brave-core/blob/master/script/create-signed-installer.py#L24

and:

> https://github.com/brave/brave-core/blob/fix/win-signing/patches/chrome-tools-build-win-create_installer_archive.py.patch#L44



## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
