### PR TITLE
Don't use absolute path for signtool in sign_binaries.py

### DIFF
--- a/script/sign_binaries.py
+++ b/script/sign_binaries.py
@@ -12,10 +12,8 @@ assert (cert or signtool_args), 'One or both of the CERT or SIGNTOOL_ARGS must b
 
 def get_sign_cmd(file):
   # https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
-  sdk_dir = os.path.normpath(os.environ.get(
-      'WINDOWSSDKDIR',
-      'C:\\Program Files (x86)\\Windows Kits\\10'))
-  cmd = "{}\\bin\\x64\\signtool.exe {}".format(sdk_dir, signtool_args)
+  # signtool should be in the path if it was set up correctly by gn through src/build/vs_toolchain.py
+  cmd = 'signtool {}'.format(signtool_args)
   if cert:
     cmd = cmd + ' /n "' + cert + '"'
   return (cmd + ' "' + file + '"')


### PR DESCRIPTION
The env var checked before doesn't seem to get passed to this script and the fallback signtool path doesn't exist in a standard visual studios setup.

There's likely a better way to do this but this with setting the path before hand is the simplest fix for now. During the build it will look something like this:

```
$env:PATH = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\;$env:PATH"
yarn run create_dist Release --debug_build=false --official_build=false --channel=beta
```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
