### PR TITLE
Use TestBrowserThreadBundle to avoid DCHECK in ChromeProfileLockTest

### DIFF
--- a/browser/importer/chrome_profile_lock_unittest.cc
+++ b/browser/importer/chrome_profile_lock_unittest.cc
@@ -15,11 +15,10 @@
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/strings/string_util.h"
-#include "base/test/test_simple_task_runner.h"
-#include "base/threading/thread_task_runner_handle.h"
 #include "build/build_config.h"
 #include "chrome/common/chrome_constants.h"
 #include "chrome/common/chrome_paths.h"
+#include "content/public/test/test_browser_thread_bundle.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 #if defined(OS_WIN)
@@ -29,12 +28,8 @@ const char kLockFile[] = "lockfile";
 class ChromeProfileLockTest : public testing::Test {
  public:
    ChromeProfileLockTest ()
-    : task_runner_(base::MakeRefCounted<base::TestSimpleTaskRunner>()),
-      thread_task_runner_handle_override_(
-        base::ThreadTaskRunnerHandle::OverrideForTesting(task_runner_)) {}
-   ~ChromeProfileLockTest () override {
-     task_runner_->RunUntilIdle();
-   }
+     : test_browser_thread_bundle_(
+         content::TestBrowserThreadBundle::REAL_IO_THREAD) {}
  protected:
   void SetUp() override {
     testing::Test::SetUp();
@@ -52,11 +47,10 @@ class ChromeProfileLockTest : public testing::Test {
 
   void LockFileExists(bool expect);
 
+  content::TestBrowserThreadBundle test_browser_thread_bundle_;
   base::ScopedTempDir temp_dir_;
   base::FilePath user_data_path_;
   base::FilePath lock_file_path_;
-  scoped_refptr<base::TestSimpleTaskRunner> task_runner_;
-  base::ScopedClosureRunner thread_task_runner_handle_override_;
 };
 
 void ChromeProfileLockTest::LockFileExists(bool expect) {


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. `yarn test brave_unit_tests`—all tests, including `ChromeProfileLockTest.*`, should pass without crashing.

I have confirmed that this PR fixes the issue on macOS and Linux; still waiting for a Windows build (which I expect to take most of the day) to confirm that it also fixes the issue there. I will update this issue with a comment once I have completed Windows testing.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
