### PR TITLE
removed referrer exception rule for moremorewin.net

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -55,8 +55,7 @@ bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
   // It's preferred to use specific_patterns below when possible
   static std::vector<URLPattern> whitelist_patterns({
     URLPattern(URLPattern::SCHEME_ALL, "https://use.typekit.net/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://cloud.typography.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://www.moremorewin.net/*")
+    URLPattern(URLPattern::SCHEME_ALL, "https://cloud.typography.com/*")
   });
   return std::any_of(whitelist_patterns.begin(), whitelist_patterns.end(),
     [&subresourceUrl](URLPattern pattern){


### PR DESCRIPTION
We currently allow referrer headers to be set on moremorewin.net.  This site seems abandoned and has a bad cert.  This PR removes that domain from the exception list.

Fixes issue https://github.com/brave/brave-browser/issues/327

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
