### PR TITLE
disable account consistency

### DIFF
--- a/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc
+++ b/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc
@@ -1,0 +1,100 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/signin/account_consistency_mode_manager.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/test/scoped_feature_list.h"
+#include "build/buildflag.h"
+#include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/browser/supervised_user/supervised_user_constants.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/prefs/pref_notifier_impl.h"
+#include "components/prefs/testing_pref_store.h"
+#include "components/signin/core/browser/profile_management_switches.h"
+#include "components/signin/core/browser/scoped_account_consistency.h"
+#include "components/signin/core/browser/signin_buildflags.h"
+#include "components/signin/core/browser/signin_pref_names.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/common/content_features.h"
+#include "content/public/test/test_browser_thread_bundle.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+// Checks that new profiles are migrated at creation.
+TEST(AccountConsistencyDisabledTest, NewProfile) {
+  content::TestBrowserThreadBundle test_thread_bundle;
+  base::test::ScopedFeatureList scoped_site_isolation;
+  scoped_site_isolation.InitAndEnableFeature(features::kSignInProcessIsolation);
+  TestingProfile::Builder profile_builder;
+  {
+    TestingPrefStore* user_prefs = new TestingPrefStore();
+
+    // Set the read error so that Profile::IsNewProfile() returns true.
+    user_prefs->set_read_error(PersistentPrefStore::PREF_READ_ERROR_NO_FILE);
+
+    std::unique_ptr<sync_preferences::TestingPrefServiceSyncable> pref_service =
+        std::make_unique<sync_preferences::TestingPrefServiceSyncable>(
+            new TestingPrefStore(), new TestingPrefStore(), user_prefs,
+            new TestingPrefStore(), new user_prefs::PrefRegistrySyncable(),
+            new PrefNotifierImpl());
+    RegisterUserProfilePrefs(pref_service->registry());
+    profile_builder.SetPrefService(std::move(pref_service));
+  }
+  std::unique_ptr<TestingProfile> profile = profile_builder.Build();
+  ASSERT_TRUE(profile->IsNewProfile());
+  EXPECT_FALSE(signin::IsDiceEnabledForProfile(profile->GetPrefs()));
+}
+
+TEST(AccountConsistencyDisabledTest, DiceFixAuthErrorsForAllProfiles) {
+  content::TestBrowserThreadBundle test_thread_bundle;
+
+  {
+    // Regular profile.
+    TestingProfile profile;
+    EXPECT_FALSE(
+        AccountConsistencyModeManager::IsDiceEnabledForProfile(&profile));
+    EXPECT_EQ(signin::AccountConsistencyMethod::kDiceFixAuthErrors,
+              AccountConsistencyModeManager::GetMethodForProfile(&profile));
+
+    // Incognito profile.
+    Profile* incognito_profile = profile.GetOffTheRecordProfile();
+    EXPECT_FALSE(AccountConsistencyModeManager::IsDiceEnabledForProfile(
+        incognito_profile));
+    EXPECT_FALSE(
+        AccountConsistencyModeManager::GetForProfile(incognito_profile));
+    EXPECT_EQ(
+        signin::AccountConsistencyMethod::kDiceFixAuthErrors,
+        AccountConsistencyModeManager::GetMethodForProfile(incognito_profile));
+  }
+
+  {
+    // Guest profile.
+    TestingProfile::Builder profile_builder;
+    profile_builder.SetGuestSession();
+    std::unique_ptr<Profile> profile = profile_builder.Build();
+    ASSERT_TRUE(profile->IsGuestSession());
+    EXPECT_FALSE(
+        AccountConsistencyModeManager::IsDiceEnabledForProfile(profile.get()));
+    EXPECT_EQ(
+        signin::AccountConsistencyMethod::kDiceFixAuthErrors,
+        AccountConsistencyModeManager::GetMethodForProfile(profile.get()));
+  }
+
+  {
+    // Legacy supervised profile.
+    TestingProfile::Builder profile_builder;
+    profile_builder.SetSupervisedUserId("supervised_id");
+    std::unique_ptr<Profile> profile = profile_builder.Build();
+    ASSERT_TRUE(profile->IsLegacySupervised());
+    EXPECT_FALSE(
+        AccountConsistencyModeManager::IsDiceEnabledForProfile(profile.get()));
+    EXPECT_EQ(
+        signin::AccountConsistencyMethod::kDiceFixAuthErrors,
+        AccountConsistencyModeManager::GetMethodForProfile(profile.get()));
+  }
+}
+#endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)

--- a/patches/components-signin-core-browser-profile_management_switches.cc.patch
+++ b/patches/components-signin-core-browser-profile_management_switches.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/components/signin/core/browser/profile_management_switches.cc b/components/signin/core/browser/profile_management_switches.cc
+index a26592c75da20daf487cc1c2205bba567be9268b..568d654093292647de5a4ff196fc8620ffd6c664 100644
+--- a/components/signin/core/browser/profile_management_switches.cc
++++ b/components/signin/core/browser/profile_management_switches.cc
+@@ -96,6 +96,9 @@ void RegisterAccountConsistencyProfilePrefs(
+ }
+ 
+ AccountConsistencyMethod GetAccountConsistencyMethod() {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  return AccountConsistencyMethod::kDiceFixAuthErrors;
++#endif
+ #if BUILDFLAG(ENABLE_MIRROR)
+   // Mirror is always enabled on Android and iOS.
+   return AccountConsistencyMethod::kMirror;

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -29,6 +29,7 @@ test("brave_unit_tests") {
   sources = [
     "//brave/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc",
+    "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/common/importer/brave_mock_importer_bridge.cc",
     "//brave/common/importer/brave_mock_importer_bridge.h",
     "//chrome/common/importer/mock_importer_bridge.cc",
@@ -44,6 +45,19 @@ test("brave_unit_tests") {
   configs += [
     "//brave/build/geolocation",
     "//brave/build/safebrowsing",
+  ]
+
+  deps = [
+    "//chrome:browser_dependencies",
+    "//chrome:child_dependencies",
+    "//chrome/test:test_support",
+    "//components/prefs",
+    "//components/prefs:test_support",
+    "//content/test:test_support",
+    "//components/signin/core/browser",
+    "//components/signin/core/browser:test_support",
+    "//components/sync_preferences",
+    "//content/public/common",
   ]
 
   public_deps = [


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/338

requires https://github.com/brave/brave-core/pull/172 for test

I tried setting prefs and several other methods to avoid patching, but this was the only thing that worked reliably

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
