### PR TITLE
Update ad-block DEPS for not wrongly blocking blob: URLs

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,10 +1,10 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/ad-block": "https://github.com/brave/ad-block.git@8d7c0bdbaa1d2c0a390859e58575a9e53cfafa94",
-  "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@77dab19f002d968a2ef841a1d317c57c695f7734",
-  "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@edd90e8215ea34582811446a143a7c8063f535f0",
-  "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@d511cf872ea1d650ab8dc4662f6036dac012d197",
+  "vendor/ad-block": "https://github.com/brave/ad-block.git@75272a1aa83c66de6547d973f9adff776abf38ae",
+  "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@bb6013ff4d0a0191ba93158f2f3b30e7fb18c5f6",
+  "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@f86b0a5752545274e32c0dbb654c3592cc131c8a",
+  "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@635780bbedff137a6a83ec23871944e22069de5b",
   "vendor/brave-extension": "https://github.com/brave/brave-extension.git@eb9b8172421503aa172fad924fb4864b8adabfe8",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/428
Which is this fix: https://github.com/brave/ad-block/commit/fa3cd87a549725fb9693d1b0b8b4e4600b538cd5

Auditors: @emerick

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
