### PR TITLE
Fix release mode brave_unit_tests crash on Windows

### DIFF
--- a/test/base/brave_unit_test_suite.cc
+++ b/test/base/brave_unit_test_suite.cc
@@ -6,12 +6,17 @@
 
 #include "base/logging.h"
 #include "brave/common/brave_paths.h"
+#include "chrome/install_static/product_install_details.h"
 #include "chrome/test/base/chrome_unit_test_suite.h"
 
 BraveUnitTestSuite::BraveUnitTestSuite(int argc, char** argv)
     : ChromeUnitTestSuite(argc, argv) {}
 
 void BraveUnitTestSuite::Initialize() {
+#if defined(OS_WIN) && defined(OFFICIAL_BUILD)
+  // When ChromeExtensionsBrowserClient is initialized, it needs
+  install_static::InitializeProductDetailsForPrimaryModule();
+#endif
   ChromeUnitTestSuite::Initialize();
 
   brave::RegisterPathProvider();


### PR DESCRIPTION
This is regression of https://github.com/brave/brave-core/pull/158.
During the initialization of unit test, channel info is accessed.
However, |g_module_details| isn't initialized in test.
Before the above PR, channel was always Channel::UNKNOWN.
So, channel info can be fetched without accessing |g_module_details|.
After the above PR, channel info is fetched via |g_module_details| in
release mode. So crash is happened because |g_module_details| is
nullptr.
Fixed by initializing install details explicitly.

Close: https://github.com/brave/brave-browser/issues/443

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Run `yarn test brave_unit_tests Release` on Windows

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
