### PR TITLE
Add missing nightly change in Chrome::GetChromeChannel() on Windows

### DIFF
--- a/chromium_src/chrome/install_static/brave_install_details_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_install_details_unittest.cc
@@ -1,0 +1,106 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/install_static/install_details.h"
+
+#include <string>
+
+#include "base/macros.h"
+#include "chrome/install_static/install_modes.h"
+#include "components/version_info/version_info_values.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using ::testing::StrEq;
+
+namespace install_static {
+
+class FakeInstallDetails : public InstallDetails {
+ public:
+  FakeInstallDetails() : InstallDetails(&payload) {
+    constants.size = sizeof(constants);
+    constants.install_suffix = L"";
+    constants.default_channel_name = L"";
+    constants.supported_multi_install = true;
+    if (kUseGoogleUpdateIntegration) {
+      constants.app_guid = L"testguid";
+      constants.channel_strategy = ChannelStrategy::FIXED;
+    } else {
+      constants.app_guid = L"";
+      constants.channel_strategy = ChannelStrategy::UNSUPPORTED;
+    }
+    payload.size = sizeof(payload);
+    payload.product_version = product_version.c_str();
+    payload.mode = &constants;
+    payload.channel = channel.c_str();
+    payload.channel_length = channel.length();
+  }
+
+  void set_product_version(const char* version) {
+    product_version.assign(version);
+    payload.product_version = product_version.c_str();
+  }
+
+  void set_payload_size(size_t size) { payload.size = size; }
+
+  void set_mode_size(size_t size) { constants.size = size; }
+
+  InstallConstants constants = InstallConstants();
+  std::wstring channel = std::wstring(L"testchannel");
+  std::string product_version = std::string(PRODUCT_VERSION);
+  Payload payload = Payload();
+
+  DISALLOW_COPY_AND_ASSIGN(FakeInstallDetails);
+};
+
+TEST(InstallDetailsTest, GetClientStateKeyPath) {
+  FakeInstallDetails details;
+  if (kUseGoogleUpdateIntegration) {
+    EXPECT_THAT(details.GetClientStateKeyPath(),
+                StrEq(L"Software\\BraveSoftware\\Update\\ClientState\\testguid"));
+  } else {
+    EXPECT_THAT(details.GetClientStateKeyPath(),
+                StrEq(std::wstring(L"Software\\").append(kProductPathName)));
+  }
+}
+
+TEST(InstallDetailsTest, GetClientStateMediumKeyPath) {
+  FakeInstallDetails details;
+  if (kUseGoogleUpdateIntegration) {
+    EXPECT_THAT(
+        details.GetClientStateMediumKeyPath(),
+        StrEq(L"Software\\BraveSoftware\\Update\\ClientStateMedium\\testguid"));
+  } else {
+    EXPECT_THAT(details.GetClientStateKeyPath(),
+                StrEq(std::wstring(L"Software\\").append(kProductPathName)));
+  }
+}
+
+TEST(InstallDetailsTest, VersionMismatch) {
+  // All is well to begin with.
+  EXPECT_FALSE(FakeInstallDetails().VersionMismatch());
+
+  // Bad product version.
+  {
+    FakeInstallDetails details;
+    details.set_product_version("0.1.2.3");
+    EXPECT_TRUE(details.VersionMismatch());
+  }
+
+  // Bad Payload size.
+  {
+    FakeInstallDetails details;
+    details.set_payload_size(sizeof(InstallDetails::Payload) + 1);
+    EXPECT_TRUE(details.VersionMismatch());
+  }
+
+  // Bad InstallConstants size.
+  {
+    FakeInstallDetails details;
+    details.set_mode_size(sizeof(InstallConstants) + 1);
+    EXPECT_TRUE(details.VersionMismatch());
+  }
+}
+
+}  // namespace install_static

--- a/chromium_src/chrome/install_static/brave_install_modes_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_install_modes_unittest.cc
@@ -1,0 +1,187 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/install_static/install_modes.h"
+
+#include <windows.h>
+
+#include <cguid.h>
+#include <ctype.h>
+
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using ::testing::Eq;
+using ::testing::Gt;
+using ::testing::Le;
+using ::testing::Ne;
+using ::testing::Not;
+using ::testing::ResultOf;
+using ::testing::StrEq;
+using ::testing::StrNe;
+
+namespace install_static {
+
+namespace {
+
+// A matcher that returns true if |arg| contains a character that is neither
+// alpha-numeric nor a period.
+MATCHER(ContainsIllegalProgIdChar, "") {
+  const wchar_t* scan = arg;
+  wint_t c;
+  while ((c = *scan++) != 0) {
+    if (!iswalnum(c) && c != L'.')
+      return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(InstallModes, VerifyModes) {
+  ASSERT_THAT(NUM_INSTALL_MODES, Gt(0));
+  for (int i = 0; i < NUM_INSTALL_MODES; ++i) {
+    const InstallConstants& mode = kInstallModes[i];
+
+    // The modes must be listed in order.
+    ASSERT_THAT(mode.index, Eq(i));
+
+    // The first mode must have no install switch; the rest must have one.
+    if (i == 0)
+      ASSERT_THAT(mode.install_switch, StrEq(""));
+    else
+      ASSERT_THAT(mode.install_switch, StrNe(""));
+
+    // The first mode must have no suffix; the rest must have one.
+    if (i == 0)
+      ASSERT_THAT(mode.install_suffix, StrEq(L""));
+    else
+      ASSERT_THAT(mode.install_suffix, StrNe(L""));
+
+    // The first mode must have no logo suffix; the rest must have one.
+    if (i == 0)
+      ASSERT_THAT(mode.logo_suffix, StrEq(L""));
+    else
+      ASSERT_THAT(mode.logo_suffix, StrNe(L""));
+
+    // The modes must have an appguid if Google Update integration is supported.
+    if (kUseGoogleUpdateIntegration)
+      ASSERT_THAT(mode.app_guid, StrNe(L""));
+    else
+      ASSERT_THAT(mode.app_guid, StrEq(L""));
+
+    // Every mode must have a base app name.
+    ASSERT_THAT(mode.base_app_name, StrNe(L""));
+
+    // Every mode must have a base app id.
+    ASSERT_THAT(mode.base_app_id, StrNe(L""));
+
+    // The ProgID prefix must not be empty, must be no greater than 11
+    // characters long, must contain no punctuation, and may not start with a
+    // digit (https://msdn.microsoft.com/library/windows/desktop/dd542719.aspx).
+    ASSERT_THAT(mode.prog_id_prefix, StrNe(L""));
+    ASSERT_THAT(lstrlen(mode.prog_id_prefix), Le(11));
+    ASSERT_THAT(mode.prog_id_prefix, Not(ContainsIllegalProgIdChar()));
+    ASSERT_THAT(*mode.prog_id_prefix, ResultOf(iswdigit, Eq(0)));
+
+    // The ProgID description must not be empty.
+    ASSERT_THAT(mode.prog_id_description, StrNe(L""));
+
+    // Every mode must have an Active Setup GUID.
+    ASSERT_THAT(mode.active_setup_guid, StrNe(L""));
+
+    // Every mode must have a toast activator CLSID.
+    ASSERT_THAT(mode.toast_activator_clsid, Ne(CLSID_NULL));
+
+    // UNSUPPORTED and kUseGoogleUpdateIntegration are mutually exclusive.
+    if (kUseGoogleUpdateIntegration)
+      ASSERT_THAT(mode.channel_strategy, Ne(ChannelStrategy::UNSUPPORTED));
+    else
+      ASSERT_THAT(mode.channel_strategy, Eq(ChannelStrategy::UNSUPPORTED));
+  }
+}
+
+TEST(InstallModes, VerifyBrand) {
+  if (kUseGoogleUpdateIntegration) {
+    // Binaries were registered via an app guid with Google Update integration.
+    ASSERT_THAT(kBinariesAppGuid, StrNe(L""));
+    ASSERT_THAT(kBinariesPathName, StrEq(L""));
+  } else {
+    // Binaries were registered via a different path name without.
+    ASSERT_THAT(kBinariesAppGuid, StrEq(L""));
+    ASSERT_THAT(kBinariesPathName, StrNe(L""));
+  }
+}
+
+TEST(InstallModes, GetClientsKeyPath) {
+  constexpr wchar_t kAppGuid[] = L"test";
+
+  if (kUseGoogleUpdateIntegration) {
+    ASSERT_THAT(GetClientsKeyPath(kAppGuid),
+                StrEq(L"Software\\BraveSoftware\\Update\\Clients\\test"));
+  } else {
+    ASSERT_THAT(GetClientsKeyPath(kAppGuid),
+                StrEq(std::wstring(L"Software\\").append(kProductPathName)));
+  }
+}
+
+TEST(InstallModes, GetClientStateKeyPath) {
+  constexpr wchar_t kAppGuid[] = L"test";
+
+  if (kUseGoogleUpdateIntegration) {
+    ASSERT_THAT(GetClientStateKeyPath(kAppGuid),
+                StrEq(L"Software\\BraveSoftware\\Update\\ClientState\\test"));
+  } else {
+    ASSERT_THAT(GetClientStateKeyPath(kAppGuid),
+                StrEq(std::wstring(L"Software\\").append(kProductPathName)));
+  }
+}
+
+TEST(InstallModes, GetBinariesClientsKeyPath) {
+  if (kUseGoogleUpdateIntegration) {
+    ASSERT_THAT(GetBinariesClientsKeyPath(),
+                StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\Clients\\")
+                          .append(kBinariesAppGuid)));
+  } else {
+    ASSERT_THAT(GetBinariesClientsKeyPath(),
+                StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));
+  }
+}
+
+TEST(InstallModes, GetBinariesClientStateKeyPath) {
+  if (kUseGoogleUpdateIntegration) {
+    ASSERT_THAT(GetBinariesClientStateKeyPath(),
+                StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\ClientState\\")
+                          .append(kBinariesAppGuid)));
+  } else {
+    ASSERT_THAT(GetBinariesClientStateKeyPath(),
+                StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));
+  }
+}
+
+TEST(InstallModes, GetClientStateMediumKeyPath) {
+  constexpr wchar_t kAppGuid[] = L"test";
+
+  if (kUseGoogleUpdateIntegration) {
+    ASSERT_THAT(GetClientStateMediumKeyPath(kAppGuid),
+                StrEq(L"Software\\BraveSoftware\\Update\\ClientStateMedium\\test"));
+  } else {
+    ASSERT_THAT(GetClientStateMediumKeyPath(kAppGuid),
+                StrEq(std::wstring(L"Software\\").append(kProductPathName)));
+  }
+}
+
+TEST(InstallModes, GetBinariesClientStateMediumKeyPath) {
+  if (kUseGoogleUpdateIntegration) {
+    ASSERT_THAT(
+        GetBinariesClientStateMediumKeyPath(),
+        StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\ClientStateMedium\\")
+                  .append(kBinariesAppGuid)));
+  } else {
+    ASSERT_THAT(GetBinariesClientStateMediumKeyPath(),
+                StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));
+  }
+}
+
+}  // namespace install_static

--- a/chromium_src/chrome/install_static/brave_install_util_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_install_util_unittest.cc
@@ -1,0 +1,637 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/install_static/install_util.h"
+
+#include <objbase.h>
+
+#include <tuple>
+
+#include "base/macros.h"
+#include "base/test/test_reg_util_win.h"
+#include "chrome/install_static/install_details.h"
+#include "chrome/install_static/install_modes.h"
+#include "chrome/install_static/test/scoped_install_details.h"
+#include "chrome_elf/nt_registry/nt_registry.h"
+#include "components/version_info/channel.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using ::testing::ElementsAre;
+using ::testing::StrCaseEq;
+using version_info::Channel;
+
+namespace install_static {
+
+// Tests the MatchPattern function in the install_static library.
+TEST(InstallStaticTest, MatchPattern) {
+  EXPECT_TRUE(MatchPattern(L"", L""));
+  EXPECT_TRUE(MatchPattern(L"", L"*"));
+  EXPECT_FALSE(MatchPattern(L"", L"*a"));
+  EXPECT_FALSE(MatchPattern(L"", L"abc"));
+  EXPECT_TRUE(MatchPattern(L"Hello1234", L"He??o*1*"));
+  EXPECT_TRUE(MatchPattern(L"Foo", L"F*?"));
+  EXPECT_TRUE(MatchPattern(L"Foo", L"F*"));
+  EXPECT_FALSE(MatchPattern(L"Foo", L"F*b"));
+  EXPECT_TRUE(MatchPattern(L"abcd", L"*c*d"));
+  EXPECT_TRUE(MatchPattern(L"abcd", L"*?c*d"));
+  EXPECT_FALSE(MatchPattern(L"abcd", L"abcd*efgh"));
+  EXPECT_TRUE(MatchPattern(L"foobarabc", L"*bar*"));
+}
+
+// Tests the install_static::GetSwitchValueFromCommandLine function.
+TEST(InstallStaticTest, GetSwitchValueFromCommandLineTest) {
+  // Simple case with one switch.
+  std::wstring value =
+      GetSwitchValueFromCommandLine(L"c:\\temp\\bleh.exe --type=bar", L"type");
+  EXPECT_EQ(L"bar", value);
+
+  // Multiple switches with trailing spaces between them.
+  value = GetSwitchValueFromCommandLine(
+      L"c:\\temp\\bleh.exe --type=bar  --abc=def bleh", L"abc");
+  EXPECT_EQ(L"def", value);
+
+  // Multiple switches with trailing spaces and tabs between them.
+  value = GetSwitchValueFromCommandLine(
+      L"c:\\temp\\bleh.exe --type=bar \t\t\t --abc=def bleh", L"abc");
+  EXPECT_EQ(L"def", value);
+
+  // Non existent switch.
+  value = GetSwitchValueFromCommandLine(
+      L"c:\\temp\\bleh.exe --foo=bar  --abc=def bleh", L"type");
+  EXPECT_EQ(L"", value);
+
+  // Non existent switch.
+  value = GetSwitchValueFromCommandLine(L"c:\\temp\\bleh.exe", L"type");
+  EXPECT_EQ(L"", value);
+
+  // Non existent switch.
+  value =
+      GetSwitchValueFromCommandLine(L"c:\\temp\\bleh.exe type=bar", L"type");
+  EXPECT_EQ(L"", value);
+
+  // Trailing spaces after the switch.
+  value = GetSwitchValueFromCommandLine(
+      L"c:\\temp\\bleh.exe --type=bar      \t\t", L"type");
+  EXPECT_EQ(L"bar", value);
+
+  // Multiple switches with trailing spaces and tabs between them.
+  value = GetSwitchValueFromCommandLine(
+      L"c:\\temp\\bleh.exe --type=bar      \t\t --foo=bleh", L"foo");
+  EXPECT_EQ(L"bleh", value);
+
+  // Nothing after a switch.
+  value = GetSwitchValueFromCommandLine(L"c:\\temp\\bleh.exe --type=", L"type");
+  EXPECT_TRUE(value.empty());
+
+  // Whitespace after a switch.
+  value =
+      GetSwitchValueFromCommandLine(L"c:\\temp\\bleh.exe --type= ", L"type");
+  EXPECT_TRUE(value.empty());
+
+  // Just tabs after a switch.
+  value = GetSwitchValueFromCommandLine(L"c:\\temp\\bleh.exe --type=\t\t\t",
+                                        L"type");
+  EXPECT_TRUE(value.empty());
+}
+
+TEST(InstallStaticTest, SpacesAndQuotesInCommandLineArguments) {
+  std::vector<std::wstring> tokenized;
+
+  tokenized = TokenizeCommandLineToArray(L"\"C:\\a\\b.exe\"");
+  ASSERT_EQ(1u, tokenized.size());
+  EXPECT_EQ(L"C:\\a\\b.exe", tokenized[0]);
+
+  tokenized = TokenizeCommandLineToArray(L"x.exe");
+  ASSERT_EQ(1u, tokenized.size());
+  EXPECT_EQ(L"x.exe", tokenized[0]);
+
+  tokenized = TokenizeCommandLineToArray(L"\"c:\\with space\\something.exe\"");
+  ASSERT_EQ(1u, tokenized.size());
+  EXPECT_EQ(L"c:\\with space\\something.exe", tokenized[0]);
+
+  tokenized = TokenizeCommandLineToArray(L"\"C:\\a\\b.exe\" arg");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\a\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"arg", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(L"\"C:\\with space\\b.exe\" \"arg\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\with space\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"arg", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(L"\"C:\\a\\b.exe\" c:\\tmp\\");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\a\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"c:\\tmp\\", tokenized[1]);
+
+  tokenized =
+      TokenizeCommandLineToArray(L"\"C:\\a\\b.exe\" \"c:\\some file path\\\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\a\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"c:\\some file path\"", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"C:\\with space\\b.exe\" \\\\x\\\\ \\\\y\\\\");
+  ASSERT_EQ(3u, tokenized.size());
+  EXPECT_EQ(L"C:\\with space\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"\\\\x\\\\", tokenized[1]);
+  EXPECT_EQ(L"\\\\y\\\\", tokenized[2]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"C:\\with space\\b.exe\" \"\\\\space quoted\\\\\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\with space\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"\\\\space quoted\\", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"C:\\with space\\b.exe\" --stuff    -x -Y   \"c:\\some thing\\\"    "
+      L"weewaa    ");
+  ASSERT_EQ(5u, tokenized.size());
+  EXPECT_EQ(L"C:\\with space\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"--stuff", tokenized[1]);
+  EXPECT_EQ(L"-x", tokenized[2]);
+  EXPECT_EQ(L"-Y", tokenized[3]);
+  EXPECT_EQ(L"c:\\some thing\"    weewaa    ", tokenized[4]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"C:\\with space\\b.exe\" --stuff=\"d:\\stuff and things\"");
+  EXPECT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\with space\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"--stuff=d:\\stuff and things", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"C:\\with space\\b.exe\" \\\\\\\"\"");
+  EXPECT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"C:\\with space\\b.exe", tokenized[0]);
+  EXPECT_EQ(L"\\\"", tokenized[1]);
+}
+
+// Test cases from
+// https://blogs.msdn.microsoft.com/oldnewthing/20100917-00/?p=12833.
+TEST(InstallStaticTest, SpacesAndQuotesOldNewThing) {
+  std::vector<std::wstring> tokenized;
+
+  tokenized = TokenizeCommandLineToArray(L"program.exe \"hello there.txt\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"program.exe", tokenized[0]);
+  EXPECT_EQ(L"hello there.txt", tokenized[1]);
+
+  tokenized =
+      TokenizeCommandLineToArray(L"program.exe \"C:\\Hello there.txt\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"program.exe", tokenized[0]);
+  EXPECT_EQ(L"C:\\Hello there.txt", tokenized[1]);
+
+  tokenized =
+      TokenizeCommandLineToArray(L"program.exe \"hello\\\"there\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"program.exe", tokenized[0]);
+  EXPECT_EQ(L"hello\"there", tokenized[1]);
+
+  tokenized =
+      TokenizeCommandLineToArray(L"program.exe \"hello\\\\\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"program.exe", tokenized[0]);
+  EXPECT_EQ(L"hello\\", tokenized[1]);
+}
+
+// Test cases from
+// http://www.windowsinspired.com/how-a-windows-programs-splits-its-command-line-into-individual-arguments/.
+// These are mostly about the special handling of argv[0], which uses different
+// quoting than the rest of the arguments.
+TEST(InstallStaticTest, SpacesAndQuotesWindowsInspired) {
+  std::vector<std::wstring> tokenized;
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"They said \"you can't do this!\", didn't they?\"");
+  ASSERT_EQ(5u, tokenized.size());
+  EXPECT_EQ(L"They said ", tokenized[0]);
+  EXPECT_EQ(L"you", tokenized[1]);
+  EXPECT_EQ(L"can't", tokenized[2]);
+  EXPECT_EQ(L"do", tokenized[3]);
+  EXPECT_EQ(L"this!, didn't they?", tokenized[4]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"test.exe \"c:\\Path With Spaces\\Ending In Backslash\\\" Arg2 Arg3");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"test.exe", tokenized[0]);
+  EXPECT_EQ(L"c:\\Path With Spaces\\Ending In Backslash\" Arg2 Arg3",
+            tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"FinalProgram.exe \"first second \"\"embedded quote\"\" third\"");
+  ASSERT_EQ(4u, tokenized.size());
+  EXPECT_EQ(L"FinalProgram.exe", tokenized[0]);
+  EXPECT_EQ(L"first second \"embedded", tokenized[1]);
+  EXPECT_EQ(L"quote", tokenized[2]);
+  EXPECT_EQ(L"third", tokenized[3]);
+
+  tokenized = TokenizeCommandLineToArray(
+      L"\"F\"i\"r\"s\"t S\"e\"c\"o\"n\"d\" T\"h\"i\"r\"d\"");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"F", tokenized[0]);
+  EXPECT_EQ(L"irst Second Third", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(L"F\"\"ir\"s\"\"t \\\"Second Third\"");
+  ASSERT_EQ(3u, tokenized.size());
+  EXPECT_EQ(L"F\"\"ir\"s\"\"t", tokenized[0]);
+  EXPECT_EQ(L"\"Second", tokenized[1]);
+  EXPECT_EQ(L"Third", tokenized[2]);
+
+  tokenized = TokenizeCommandLineToArray(L"  Something Else");
+  ASSERT_EQ(3u, tokenized.size());
+  EXPECT_EQ(L"", tokenized[0]);
+  EXPECT_EQ(L"Something", tokenized[1]);
+  EXPECT_EQ(L"Else", tokenized[2]);
+
+  tokenized = TokenizeCommandLineToArray(L" Something Else");
+  ASSERT_EQ(3u, tokenized.size());
+  EXPECT_EQ(L"", tokenized[0]);
+  EXPECT_EQ(L"Something", tokenized[1]);
+  EXPECT_EQ(L"Else", tokenized[2]);
+
+  tokenized = TokenizeCommandLineToArray(L"\"123 456\tabc\\def\"ghi");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"123 456\tabc\\def", tokenized[0]);
+  EXPECT_EQ(L"ghi", tokenized[1]);
+
+  tokenized = TokenizeCommandLineToArray(L"123\"456\"\tabc");
+  ASSERT_EQ(2u, tokenized.size());
+  EXPECT_EQ(L"123\"456\"", tokenized[0]);
+  EXPECT_EQ(L"abc", tokenized[1]);
+}
+
+TEST(InstallStaticTest, BrowserProcessTest) {
+  EXPECT_FALSE(IsProcessTypeInitialized());
+  InitializeProcessType();
+  EXPECT_FALSE(IsNonBrowserProcess());
+}
+
+class InstallStaticUtilTest
+    : public ::testing::TestWithParam<
+          std::tuple<InstallConstantIndex, const char*>> {
+ protected:
+  InstallStaticUtilTest()
+      : system_level_(std::string(std::get<1>(GetParam())) != "user"),
+        scoped_install_details_(system_level_, std::get<0>(GetParam())),
+        mode_(&InstallDetails::Get().mode()),
+        root_key_(system_level_ ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER),
+        nt_root_key_(system_level_ ? nt::HKLM : nt::HKCU) {}
+
+  void SetUp() override {
+    ASSERT_TRUE(!system_level_ || mode_->supports_system_level);
+    base::string16 path;
+    ASSERT_NO_FATAL_FAILURE(
+        override_manager_.OverrideRegistry(root_key_, &path));
+    nt::SetTestingOverride(nt_root_key_, path);
+  }
+
+  void TearDown() override {
+    nt::SetTestingOverride(nt_root_key_, base::string16());
+  }
+
+  bool system_level() const { return system_level_; }
+
+  const wchar_t* default_channel() const { return mode_->default_channel_name; }
+
+  void SetUsageStat(DWORD value, bool medium) {
+    ASSERT_TRUE(!medium || system_level_);
+    ASSERT_EQ(ERROR_SUCCESS,
+              base::win::RegKey(root_key_, GetUsageStatsKeyPath(medium).c_str(),
+                                KEY_SET_VALUE | KEY_WOW64_32KEY)
+                  .WriteValue(L"usagestats", value));
+  }
+
+  void SetMetricsReportingPolicy(DWORD value) {
+#if defined(OFFICIAL_BUILD)
+    static constexpr wchar_t kPolicyKey[] =
+        L"Software\\Policies\\BraveSoftware\\Brave-Browser";
+#else
+    static constexpr wchar_t kPolicyKey[] =
+        L"Software\\Policies\\BraveSoftware\\Brave-Browser-Development";
+#endif
+
+    ASSERT_EQ(ERROR_SUCCESS,
+              base::win::RegKey(root_key_, kPolicyKey, KEY_SET_VALUE)
+                  .WriteValue(L"MetricsReportingEnabled", value));
+  }
+
+ private:
+  // Returns the registry path for the key holding the product's usagestats
+  // value. |medium| = true returns the path for ClientStateMedium.
+  std::wstring GetUsageStatsKeyPath(bool medium) {
+    EXPECT_TRUE(!medium || system_level_);
+
+    std::wstring result(L"Software\\");
+    if (kUseGoogleUpdateIntegration) {
+      result.append(L"BraveSoftware\\Update\\ClientState");
+      if (medium)
+        result.append(L"Medium");
+      result.push_back(L'\\');
+      result.append(mode_->app_guid);
+    } else {
+      result.append(kProductPathName);
+    }
+    return result;
+  }
+
+  const bool system_level_;
+  const ScopedInstallDetails scoped_install_details_;
+  const InstallConstants* mode_;
+  const HKEY root_key_;
+  const nt::ROOT_KEY nt_root_key_;
+  registry_util::RegistryOverrideManager override_manager_;
+
+  DISALLOW_COPY_AND_ASSIGN(InstallStaticUtilTest);
+};
+
+TEST_P(InstallStaticUtilTest, GetChromeInstallSubDirectory) {
+#if defined(OFFICIAL_BUILD)
+  // The directory strings for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr const wchar_t* kInstallDirs[] = {
+      L"BraveSoftware\\Brave-Browser", L"BraveSoftware\\Brave-Browser-Beta",
+      L"BraveSoftware\\Brave-Browser-Dev", L"BraveSoftware\\Brave-Browser-Nightly",
+  };
+#else
+  // The directory strings for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr const wchar_t* kInstallDirs[] = {
+      L"BraveSoftware\\Brave-Browser-Development",
+  };
+#endif
+  static_assert(arraysize(kInstallDirs) == NUM_INSTALL_MODES,
+                "kInstallDirs out of date.");
+  EXPECT_THAT(GetChromeInstallSubDirectory(),
+              StrCaseEq(kInstallDirs[std::get<0>(GetParam())]));
+}
+
+TEST_P(InstallStaticUtilTest, GetRegistryPath) {
+#if defined(OFFICIAL_BUILD)
+  // The registry path strings for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr const wchar_t* kRegistryPaths[] = {
+      L"Software\\BraveSoftware\\Brave-Browser",
+      L"Software\\BraveSoftware\\Brave-Browser-Beta",
+      L"Software\\BraveSoftware\\Brave-Browser-Dev",
+      L"Software\\BraveSoftware\\Brave-Browser-Nightly",
+  };
+#else
+  // The registry path strings for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr const wchar_t* kRegistryPaths[] = {
+      L"Software\\BraveSoftware\\Brave-Browser-Development",
+  };
+#endif
+  static_assert(arraysize(kRegistryPaths) == NUM_INSTALL_MODES,
+                "kRegistryPaths out of date.");
+  EXPECT_THAT(GetRegistryPath(),
+              StrCaseEq(kRegistryPaths[std::get<0>(GetParam())]));
+}
+
+TEST_P(InstallStaticUtilTest, GetUninstallRegistryPath) {
+#if defined(OFFICIAL_BUILD)
+  // The uninstall registry path strings for the brand's install modes; parallel
+  // to kInstallModes.
+  static constexpr const wchar_t* kUninstallRegistryPaths[] = {
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"  // (cont'd)
+      L"BraveSoftware Brave-Browser",
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"  // (cont'd)
+      L"BraveSoftware Brave-Browser-Beta",
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"  // (cont'd)
+      L"BraveSoftware Brave-Browser-Dev",
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"  // (cont'd)
+      L"BraveSoftware Brave-Browser-Nightly",
+  };
+#else
+  // The registry path strings for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr const wchar_t* kUninstallRegistryPaths[] = {
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\" // (cont'd)
+      L"BraveSoftware Brave-Browser-Development",
+  };
+#endif
+  static_assert(arraysize(kUninstallRegistryPaths) == NUM_INSTALL_MODES,
+                "kUninstallRegistryPaths out of date.");
+  EXPECT_THAT(GetUninstallRegistryPath(),
+              StrCaseEq(kUninstallRegistryPaths[std::get<0>(GetParam())]));
+}
+
+TEST_P(InstallStaticUtilTest, GetAppGuid) {
+  // For brands that do not integrate with Omaha/Google Update, the app guid is
+  // an empty string.
+  if (!kUseGoogleUpdateIntegration) {
+    EXPECT_STREQ(L"", GetAppGuid());
+    return;
+  }
+
+#if defined(OFFICIAL_BUILD)
+  // The app guids for the brand's install modes; parallel to kInstallModes.
+  static constexpr const wchar_t* kAppGuids[] = {
+      L"{AFE6A462-C574-4B8A-AF43-4CC60DF4563B}",  // Brave-Browser.
+      L"{103BD053-949B-43A8-9120-2E424887DE11}",  // Brave-Browser-Beta.
+      L"{CB2150F2-595F-4633-891A-E39720CE0531}",  // Brave-Browser-Dev.
+      L"{C6CB981E-DB30-4876-8639-109F8933582C}",  // Brave-Browser-Nightly.
+  };
+  static_assert(arraysize(kAppGuids) == NUM_INSTALL_MODES,
+                "kAppGuids out of date.");
+  EXPECT_THAT(GetAppGuid(), StrCaseEq(kAppGuids[std::get<0>(GetParam())]));
+#else
+  FAIL() << "Not implemented.";
+#endif
+}
+
+TEST_P(InstallStaticUtilTest, GetBaseAppId) {
+#if defined(OFFICIAL_BUILD)
+  // The base app ids for the brand's install modes; parallel to kInstallModes.
+  static constexpr const wchar_t* kBaseAppIds[] = {
+      L"Brave", L"BraveBeta", L"BraveDev", L"BraveNightly",
+  };
+#else
+  // The base app ids for the brand's install modes; parallel to kInstallModes.
+  static constexpr const wchar_t* kBaseAppIds[] = {
+      L"BraveDevelopment",
+  };
+#endif
+  static_assert(arraysize(kBaseAppIds) == NUM_INSTALL_MODES,
+                "kBaseAppIds out of date.");
+  EXPECT_THAT(GetBaseAppId(), StrCaseEq(kBaseAppIds[std::get<0>(GetParam())]));
+}
+
+TEST_P(InstallStaticUtilTest, GetToastActivatorClsid) {
+#if defined(OFFICIAL_BUILD)
+  // The toast activator CLSIDs for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr CLSID kToastActivatorClsids[] = {
+      { 0x6c9646d,
+        0x2807,
+        0x44c0,
+        { 0x97, 0xd2, 0x6d, 0xa0, 0xdb, 0x62, 0x3d,
+          0xb4 } },  // Brave-Browser.
+      { 0x9560028d,
+        0xcca,
+        0x49f0,
+        { 0x8d, 0x47, 0xef, 0x22, 0xbb, 0xc4, 0xb,
+          0xa7 } },  // Brave-Browser-Beta.
+      { 0x20b22981,
+        0xf63a,
+        0x47a6,
+        { 0xa5, 0x47, 0x69, 0x1c, 0xc9, 0x4c, 0xae,
+          0xe0 } },  // Brave-Browser-Dev.
+      { 0xf2edbc59,
+        0x7217,
+        0x4da5,
+        { 0xa2, 0x59, 0x3, 0x2, 0xda, 0x6a, 0x0,
+          0xe1 } },  // Brave-Browser-Nightly.
+  };
+
+  // The string representation of the CLSIDs above.
+  static constexpr const wchar_t* kToastActivatorClsidsString[] = {
+      L"{06C9646D-2807-44C0-97D2-6DA0DB623DB4}",  // Brave-Browser.
+      L"{9560028D-0CCA-49F0-8D47-EF22BBC40BA7}",  // Brave-Browser-Beta.
+      L"{20B22981-F63A-47A6-A547-691CC94CAEE0}",  // Brave-Browser-Dev.
+      L"{F2EDBC59-7217-4DA5-A259-0302DA6A00E1}",  // Brave-Browser-Nightly.
+  };
+#else
+  // The toast activator CLSIDs for the brand's install modes; parallel to
+  // kInstallModes.
+  static constexpr CLSID kToastActivatorClsids[] = {
+      { 0xeb41c6e8,
+        0xba35,
+        0x4c06,
+        { 0x96, 0xe8, 0x6f, 0x30, 0xf1, 0x8c, 0xa5,
+          0x5c } },  // Brave-Browser-Development.
+  };
+
+  // The string representation of the CLSIDs above.
+  static constexpr const wchar_t* kToastActivatorClsidsString[] = {
+      L"{EB41C6E8-BA35-4C06-96E8-6F30F18CA55C}"  // Brave-Browser-Development.
+  };
+#endif
+  static_assert(arraysize(kToastActivatorClsids) == NUM_INSTALL_MODES,
+                "kToastActivatorClsids out of date.");
+
+  EXPECT_EQ(GetToastActivatorClsid(),
+            kToastActivatorClsids[std::get<0>(GetParam())]);
+
+  const int kCLSIDSize = 39;
+  wchar_t clsid_str[kCLSIDSize];
+  ASSERT_EQ(::StringFromGUID2(GetToastActivatorClsid(), clsid_str, kCLSIDSize),
+            kCLSIDSize);
+  EXPECT_THAT(clsid_str,
+              StrCaseEq(kToastActivatorClsidsString[std::get<0>(GetParam())]));
+}
+
+TEST_P(InstallStaticUtilTest, UsageStatsAbsent) {
+  EXPECT_FALSE(GetCollectStatsConsent());
+}
+
+TEST_P(InstallStaticUtilTest, UsageStatsZero) {
+  SetUsageStat(0, false);
+  EXPECT_FALSE(GetCollectStatsConsent());
+}
+
+TEST_P(InstallStaticUtilTest, UsageStatsZeroMedium) {
+  if (!system_level())
+    return;
+  SetUsageStat(0, true);
+  EXPECT_FALSE(GetCollectStatsConsent());
+}
+
+TEST_P(InstallStaticUtilTest, UsageStatsOne) {
+  SetUsageStat(1, false);
+  EXPECT_TRUE(GetCollectStatsConsent());
+}
+
+TEST_P(InstallStaticUtilTest, UsageStatsOneMedium) {
+  if (!system_level())
+    return;
+  SetUsageStat(1, true);
+  EXPECT_TRUE(GetCollectStatsConsent());
+}
+
+TEST_P(InstallStaticUtilTest, ReportingIsEnforcedByPolicy) {
+  bool reporting_enabled = false;
+  EXPECT_FALSE(ReportingIsEnforcedByPolicy(&reporting_enabled));
+
+  SetMetricsReportingPolicy(0);
+  EXPECT_TRUE(ReportingIsEnforcedByPolicy(&reporting_enabled));
+  EXPECT_FALSE(reporting_enabled);
+
+  SetMetricsReportingPolicy(1);
+  EXPECT_TRUE(ReportingIsEnforcedByPolicy(&reporting_enabled));
+  EXPECT_TRUE(reporting_enabled);
+}
+
+TEST_P(InstallStaticUtilTest, UsageStatsPolicy) {
+  // Policy alone.
+  SetMetricsReportingPolicy(0);
+  EXPECT_FALSE(GetCollectStatsConsent());
+
+  SetMetricsReportingPolicy(1);
+  EXPECT_TRUE(GetCollectStatsConsent());
+
+  // Policy trumps usagestats.
+  SetMetricsReportingPolicy(1);
+  SetUsageStat(0, false);
+  EXPECT_TRUE(GetCollectStatsConsent());
+
+  SetMetricsReportingPolicy(0);
+  SetUsageStat(1, false);
+  EXPECT_FALSE(GetCollectStatsConsent());
+}
+
+TEST_P(InstallStaticUtilTest, GetChromeChannelName) {
+  EXPECT_EQ(default_channel(), GetChromeChannelName());
+}
+
+TEST_P(InstallStaticUtilTest, GetChromeChannel) {
+#if defined(OFFICIAL_BUILD)
+  // Parallel to kInstallModes.
+  static constexpr version_info::Channel kChannels[] = {
+      version_info::Channel::STABLE,  // Brave-Browser.
+      version_info::Channel::BETA,    // Brave-Browser-Beta.
+      version_info::Channel::DEV,     // Brave-Browser-Dev.
+      version_info::Channel::CANARY,  // Brave-Browser-Nightly.
+  };
+#else
+  // Parallel to kInstallModes.
+  static constexpr version_info::Channel kChannels[] = {
+    version_info::Channel::UNKNOWN,
+  };
+#endif
+  EXPECT_EQ(kChannels[std::get<0>(GetParam())], GetChromeChannel());
+}
+
+#if defined(OFFICIAL_BUILD)
+// Stable supports user and system levels.
+INSTANTIATE_TEST_CASE_P(Stable,
+                        InstallStaticUtilTest,
+                        testing::Combine(testing::Values(STABLE_INDEX),
+                                         testing::Values("user", "system")));
+// Beta supports user and system levels.
+INSTANTIATE_TEST_CASE_P(Beta,
+                        InstallStaticUtilTest,
+                        testing::Combine(testing::Values(BETA_INDEX),
+                                         testing::Values("user", "system")));
+// Dev supports user and system levels.
+INSTANTIATE_TEST_CASE_P(Dev,
+                        InstallStaticUtilTest,
+                        testing::Combine(testing::Values(DEV_INDEX),
+                                         testing::Values("user", "system")));
+// Canary is only at user level.
+INSTANTIATE_TEST_CASE_P(Nightly,
+                        InstallStaticUtilTest,
+                        testing::Combine(testing::Values(NIGHTLY_INDEX),
+                                         testing::Values("user")));
+#else   // OFFICIAL_BUILD
+// Chromium supports user and system levels.
+INSTANTIATE_TEST_CASE_P(Development,
+                        InstallStaticUtilTest,
+                        testing::Combine(testing::Values(DEVELOPER_INDEX),
+                                         testing::Values("user", "system")));
+#endif  // !OFFICIAL_BUILD
+
+}  // namespace install_static

--- a/chromium_src/chrome/install_static/brave_user_data_dir_win_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_user_data_dir_win_unittest.cc
@@ -1,0 +1,166 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <algorithm>
+
+#include "base/test/test_reg_util_win.h"
+#include "chrome/install_static/install_details.h"
+#include "chrome/install_static/user_data_dir.h"
+#include "chrome_elf/nt_registry/nt_registry.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace install_static {
+namespace {
+
+inline bool EndsWith(const std::wstring& value, const std::wstring& ending) {
+  if (ending.size() > value.size())
+    return false;
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
+#if defined(OFFICIAL_BUILD)
+const wchar_t kPolicyRegistryKey[] = L"SOFTWARE\\Policies\\BraveSoftware\\Brave-Browser";
+const wchar_t kUserDataDirNameSuffix[] = L"\\BraveSoftware\\Brave-Browser\\User Data";
+#else
+const wchar_t kPolicyRegistryKey[] =
+    L"SOFTWARE\\Policies\\BraveSoftware\\Brave-Browser-Development";
+const wchar_t kUserDataDirNameSuffix[] = L"\\BraveSoftware\\Brave-Browser-Development\\User Data";
+#endif
+
+const wchar_t kUserDataDirRegistryKey[] = L"UserDataDir";
+
+const InstallConstants kFakeInstallConstants = {
+    sizeof(InstallConstants), 0, "", L"", L"", L"", L""};
+
+class ScopedNTRegistryTestingOverride {
+ public:
+  ScopedNTRegistryTestingOverride(nt::ROOT_KEY root, const std::wstring& path)
+      : root_(root) {
+    EXPECT_TRUE(nt::SetTestingOverride(root_, path));
+  }
+  ~ScopedNTRegistryTestingOverride() {
+    nt::SetTestingOverride(root_, base::string16());
+  }
+
+ private:
+  nt::ROOT_KEY root_;
+};
+
+TEST(UserDataDir, EmptyResultsInDefault) {
+  std::wstring result, invalid;
+
+  install_static::GetUserDataDirectoryImpl(L"", kFakeInstallConstants, &result,
+                                           &invalid);
+  EXPECT_TRUE(EndsWith(result, kUserDataDirNameSuffix));
+  EXPECT_EQ(std::wstring(), invalid);
+}
+
+TEST(UserDataDir, InvalidResultsInDefault) {
+  std::wstring result, invalid;
+
+  install_static::GetUserDataDirectoryImpl(L"<>|:", kFakeInstallConstants,
+                                           &result, &invalid);
+  EXPECT_TRUE(EndsWith(result, kUserDataDirNameSuffix));
+  EXPECT_EQ(L"<>|:", invalid);
+}
+
+TEST(UserDataDir, RegistrySettingsInHKLMOverrides) {
+  std::wstring result, invalid;
+
+  // Override the registry to say one value in HKLM, and confirm it takes
+  // precedence over the command line in both implementations.
+  registry_util::RegistryOverrideManager override_manager;
+  base::string16 temp;
+  ASSERT_NO_FATAL_FAILURE(
+      override_manager.OverrideRegistry(HKEY_LOCAL_MACHINE, &temp));
+  ScopedNTRegistryTestingOverride nt_override(nt::HKLM, temp);
+
+  base::win::RegKey key(HKEY_LOCAL_MACHINE, kPolicyRegistryKey, KEY_WRITE);
+  LONG rv = key.WriteValue(kUserDataDirRegistryKey, L"yyy");
+  ASSERT_EQ(rv, ERROR_SUCCESS);
+
+  install_static::GetUserDataDirectoryImpl(L"xxx", kFakeInstallConstants,
+                                           &result, &invalid);
+
+  EXPECT_TRUE(EndsWith(result, L"\\yyy"));
+  EXPECT_EQ(std::wstring(), invalid);
+}
+
+TEST(UserDataDir, RegistrySettingsInHKCUOverrides) {
+  std::wstring result, invalid;
+
+  // Override the registry to say one value in HKCU, and confirm it takes
+  // precedence over the command line in both implementations.
+  registry_util::RegistryOverrideManager override_manager;
+  base::string16 temp;
+  ASSERT_NO_FATAL_FAILURE(
+      override_manager.OverrideRegistry(HKEY_CURRENT_USER, &temp));
+  ScopedNTRegistryTestingOverride nt_override(nt::HKCU, temp);
+
+  base::win::RegKey key(HKEY_CURRENT_USER, kPolicyRegistryKey, KEY_WRITE);
+  LONG rv = key.WriteValue(kUserDataDirRegistryKey, L"yyy");
+  ASSERT_EQ(rv, ERROR_SUCCESS);
+
+  install_static::GetUserDataDirectoryImpl(L"xxx", kFakeInstallConstants,
+                                           &result, &invalid);
+
+  EXPECT_TRUE(EndsWith(result, L"\\yyy"));
+  EXPECT_EQ(std::wstring(), invalid);
+}
+
+TEST(UserDataDir, RegistrySettingsInHKLMTakesPrecedenceOverHKCU) {
+  std::wstring result, invalid;
+
+  // Override the registry in both HKLM and HKCU, and confirm HKLM takes
+  // precedence.
+  registry_util::RegistryOverrideManager override_manager;
+  base::string16 temp;
+  ASSERT_NO_FATAL_FAILURE(
+      override_manager.OverrideRegistry(HKEY_LOCAL_MACHINE, &temp));
+  ScopedNTRegistryTestingOverride nt_override(nt::HKLM, temp);
+  LONG rv;
+  base::win::RegKey key1(HKEY_LOCAL_MACHINE, kPolicyRegistryKey, KEY_WRITE);
+  rv = key1.WriteValue(kUserDataDirRegistryKey, L"111");
+  ASSERT_EQ(rv, ERROR_SUCCESS);
+
+  ASSERT_NO_FATAL_FAILURE(
+      override_manager.OverrideRegistry(HKEY_CURRENT_USER, &temp));
+  ScopedNTRegistryTestingOverride nt_override2(nt::HKCU, temp);
+  base::win::RegKey key2(HKEY_CURRENT_USER, kPolicyRegistryKey, KEY_WRITE);
+  rv = key2.WriteValue(kUserDataDirRegistryKey, L"222");
+  ASSERT_EQ(rv, ERROR_SUCCESS);
+
+  install_static::GetUserDataDirectoryImpl(L"xxx", kFakeInstallConstants,
+                                           &result, &invalid);
+
+  EXPECT_TRUE(EndsWith(result, L"\\111"));
+  EXPECT_EQ(std::wstring(), invalid);
+}
+
+TEST(UserDataDir, RegistrySettingWithPathExpansionHKCU) {
+  std::wstring result, invalid;
+
+  registry_util::RegistryOverrideManager override_manager;
+  base::string16 temp;
+  ASSERT_NO_FATAL_FAILURE(
+      override_manager.OverrideRegistry(HKEY_CURRENT_USER, &temp));
+  ScopedNTRegistryTestingOverride nt_override(nt::HKCU, temp);
+  base::win::RegKey key(HKEY_CURRENT_USER, kPolicyRegistryKey, KEY_WRITE);
+  LONG rv = key.WriteValue(kUserDataDirRegistryKey, L"${windows}");
+  ASSERT_EQ(rv, ERROR_SUCCESS);
+
+  install_static::GetUserDataDirectoryImpl(L"xxx", kFakeInstallConstants,
+                                           &result, &invalid);
+
+  EXPECT_EQ(strlen("X:\\WINDOWS"), result.size());
+  EXPECT_EQ(std::wstring::npos, result.find(L"${windows}"));
+  std::wstring upper;
+  std::transform(result.begin(), result.end(), std::back_inserter(upper),
+                 toupper);
+  EXPECT_TRUE(EndsWith(upper, L"\\WINDOWS"));
+  EXPECT_EQ(std::wstring(), invalid);
+}
+
+}  // namespace
+}  // namespace install_static

--- a/chromium_src/chrome/install_static/chromium_install_modes.cc
+++ b/chromium_src/chrome/install_static/chromium_install_modes.cc
@@ -28,8 +28,12 @@ const wchar_t kBinariesAppGuid[] = L"{F7526127-0B8A-406F-8998-282BEA40103A}";
 const wchar_t kBinariesAppGuid[] = L"";
 #endif
 
+#if defined(OFFICIAL_BUILD)
 // Brave integrates with Brave Update, so the app GUID above is used.
 const wchar_t kBinariesPathName[] = L"";
+#else
+const wchar_t kBinariesPathName[] = L"Brave Binaries";
+#endif
 
 #if defined(OFFICIAL_BUILD)
 // Regarding to install switch, use same value in
@@ -158,10 +162,10 @@ const InstallConstants kInstallModes[] = {
         L"",              // Empty install_suffix for the primary install mode.
         L"",              // No logo suffix for the primary install mode.
         L"",              // Empty app_guid since no integraion with Brave Update.
-        L"Brave Developer",  // A distinct base_app_name.
-        L"BraveDeveloper",   // A distinct base_app_id.
+        L"Brave Development",  // A distinct base_app_name.
+        L"BraveDevelopment",   // A distinct base_app_id.
         L"BraveDevHTM",                             // ProgID prefix.
-        L"Brave Developer HTML Document",           // ProgID description.
+        L"Brave Development HTML Document",           // ProgID description.
         L"{D6527C63-5CDD-4EF3-9299-1504E17CBD18}",  // Active Setup GUID.
         L"{B2863926-AF5D-43A2-99CC-29EC43790C89}",  // CommandExecuteImpl CLSID.
         { 0xeb41c6e8,

--- a/patches/chrome-install_static-install_util.cc.patch
+++ b/patches/chrome-install_static-install_util.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/install_static/install_util.cc b/chrome/install_static/install_util.cc
-index 73b38a84d81d26ff4b80ae4bb41ce726ee44158f..e62a2bdf90272331f5632392b51e53f3a8b49133 100644
+index 73b38a84d81d26ff4b80ae4bb41ce726ee44158f..1b847f3d33b3d6154fc5e3faacf4de28cb928851 100644
 --- a/chrome/install_static/install_util.cc
 +++ b/chrome/install_static/install_util.cc
 @@ -616,7 +616,7 @@ void GetExecutableVersionDetails(const std::wstring& exe_path,
@@ -11,3 +11,12 @@ index 73b38a84d81d26ff4b80ae4bb41ce726ee44158f..e62a2bdf90272331f5632392b51e53f3
    std::wstring channel_name(GetChromeChannelName());
    if (channel_name.empty()) {
      return version_info::Channel::STABLE;
+@@ -627,7 +627,7 @@ version_info::Channel GetChromeChannel() {
+   if (channel_name == L"dev") {
+     return version_info::Channel::DEV;
+   }
+-  if (channel_name == L"canary") {
++  if (channel_name == L"nightly") {
+     return version_info::Channel::CANARY;
+   }
+ #endif

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -153,7 +153,11 @@ test("brave_browser_tests") {
 if (is_win) {
   test("brave_install_static_unittests") {
     sources = [
+      "//brave/chromium_src/chrome/install_static/brave_install_details_unittest.cc",
+      "//brave/chromium_src/chrome/install_static/brave_install_modes_unittest.cc",
+      "//brave/chromium_src/chrome/install_static/brave_install_util_unittest.cc",
       "//brave/chromium_src/chrome/install_static/brave_product_install_details_unittest.cc",
+      "//brave/chromium_src/chrome/install_static/brave_user_data_dir_win_unittest.cc",
     ]
     include_dirs = [ "$target_gen_dir" ]
     deps = [


### PR DESCRIPTION
Also, ported all unit tests from chrome/install_static.

Issue https://github.com/brave/brave-browser/issues/394

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
'yarn test brave_install_static_unittests`
`yarn test brave_install_static_unittests Release`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
