### PR TITLE
Update grd/grdp files with auto-generated warning message

### DIFF
--- a/app/bookmarks_strings.grdp
+++ b/app/bookmarks_strings.grdp
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <!-- Bookmarks specific strings (included from generated_resources.grd). -->
 <grit-part>
   <!-- Begin of Bookmarks Bar strings-->

--- a/app/brave_strings.grd
+++ b/app/brave_strings.grd
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <!-- This file contains definitions of strings that are distribution specific.
 If you update this file, be sure also to update google_chrome_strings.grd. -->
 

--- a/app/components_brave_strings.grd
+++ b/app/components_brave_strings.grd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 
 <grit latest_public_release="0" current_release="1"
       output_all_resource_defines="false" source_lang_id="en" enc_check="möl">

--- a/app/generated_resources.grd
+++ b/app/generated_resources.grd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 
 <!--
 This file contains definitions of resources that will be translated for each

--- a/app/md_extensions_strings.grdp
+++ b/app/md_extensions_strings.grdp
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <!-- MD Extensions strings (included from generated_resources.grd). -->
 <grit-part>
   <message name="IDS_MD_EXTENSIONS_DEVELOPER_MODE" desc="The text displayed next to the checkbox to toggle developer mode in the extensions page.">

--- a/app/media_router_strings.grdp
+++ b/app/media_router_strings.grdp
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <!-- Media Router-specific strings (included from generated_resources.grd). -->
 <grit-part>
   <!-- General -->

--- a/app/settings_brave_strings.grdp
+++ b/app/settings_brave_strings.grdp
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <!-- Settings-specific Brave strings (included from chromium_strings.grd). -->
 <grit-part>
   <!-- About Page -->

--- a/app/settings_strings.grdp
+++ b/app/settings_strings.grdp
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <!-- Settings-specific strings (included from generated_resources.grd). -->
 <grit-part>
   <!-- Main Page -->
@@ -3409,6 +3410,7 @@
     <message name="IDS_SETTINGS_IMPORT_AUTOFILL_FORM_DATA_CHECKBOX" desc="Checkbox for importing form data for autofill">
       Autofill form data
     </message>
+
     <message name="IDS_SETTINGS_IMPORT_CHOOSE_FILE" desc="Text for the Choose File on dialog">
       Choose File
     </message>

--- a/browser/resources/md_extensions/extensions_resources.grd
+++ b/browser/resources/md_extensions/extensions_resources.grd
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <grit latest_public_release="0" current_release="1" output_all_resource_defines="false">
   <outputs>
     <output filename="grit/extensions_resources.h" type="rc_header">

--- a/browser/resources/settings/settings_resources.grd
+++ b/browser/resources/settings/settings_resources.grd
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is created by l10nUtil.js. Do not edit manually. -->
 <grit latest_public_release="0" current_release="1" output_all_resource_defines="false">
   <outputs>
     <output filename="grit/settings_resources.h" type="rc_header">


### PR DESCRIPTION
Update current l10nUtils files with auto-generated warning messages.
These changes is the result of running chromium_rebase_l10n with https://github.com/brave/brave-browser/pull/456.
This should only need to be updated once this time, it will automatically applied in future chromium rebases.