### PR TITLE
Apply channel name to mac app name

### DIFF
--- a/build/config.gni
+++ b/build/config.gni
@@ -54,3 +54,7 @@ if (is_official_build) {
 }
 
 brave_product_dir_name = "BraveSoftware/Brave-Browser$brave_product_dir_name_suffix"
+
+if (is_mac) {
+  brave_target_app_name = "Brave-Browser$brave_product_dir_name_suffix"
+}

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -8,6 +8,16 @@ declare_args() {
 _packaging_dir = "$root_out_dir/$brave_product_name Packaging"
 keychain_db = getenv("HOME") + "/Library/Keychains/login.${mac_signing_keychain}-db"
 
+_target_app_name = "Brave-Browser"
+if (brave_channel == "beta") {
+  _target_app_name = _target_app_name + "-Beta"
+} else if (brave_channel == "dev") {
+  _target_app_name = _target_app_name + "-Dev"
+} else if (brave_channel == "nightly") {
+  _target_app_name = _target_app_name + "-Nightly"
+}
+_target_app_path = "$root_out_dir/signing/$_target_app_name.app"
+
 action("sign_app") {
   brave_app = "$root_build_dir/Brave.app"
 
@@ -20,13 +30,13 @@ action("sign_app") {
     "$_packaging_dir/sign_app.sh",
     "$_packaging_dir/sign_versioned_dir.sh",
   ]
-  outputs = [ "$root_out_dir/signing/Brave.app" ]
+  outputs = [ _target_app_path ]
   args = [
     rebase_path(shell_script, root_out_dir),
 
     # Use absolute paths needed by codesign
     rebase_path(brave_app),
-    rebase_path("$root_out_dir/signing/Brave.app"),
+    rebase_path(_target_app_path),
     rebase_path(_packaging_dir),
     keychain_db,
     mac_signing_identifier
@@ -53,7 +63,7 @@ action("create_dmg") {
     "--format", "UDBZ",
     "--verbosity", "0",
     "--volname", "Brave",
-    "--copy", rebase_path("$root_out_dir/signing/Brave.app", root_build_dir),
+    "--copy", rebase_path(_target_app_path, root_build_dir),
     "--tempdir", "/tmp",
     "--symlink", "/Applications",
   ]

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -8,15 +8,7 @@ declare_args() {
 _packaging_dir = "$root_out_dir/$brave_product_name Packaging"
 keychain_db = getenv("HOME") + "/Library/Keychains/login.${mac_signing_keychain}-db"
 
-_target_app_name = "Brave-Browser"
-if (brave_channel == "beta") {
-  _target_app_name = _target_app_name + "-Beta"
-} else if (brave_channel == "dev") {
-  _target_app_name = _target_app_name + "-Dev"
-} else if (brave_channel == "nightly") {
-  _target_app_name = _target_app_name + "-Nightly"
-}
-_target_app_path = "$root_out_dir/signing/$_target_app_name.app"
+_target_app_path = "$root_out_dir/signing/$brave_target_app_name.app"
 
 action("sign_app") {
   brave_app = "$root_build_dir/Brave.app"
@@ -48,7 +40,7 @@ action("sign_app") {
 }
 
 action("create_dmg") {
-  output = "$root_out_dir/unsigned/$_target_app_name.dmg"
+  output = "$root_out_dir/unsigned/$brave_target_app_name.dmg"
   script = "//build/gn_run_binary.py"
   shell_script = "//chrome/installer/mac/pkg-dmg"
   inputs = [
@@ -59,10 +51,10 @@ action("create_dmg") {
   args = [
     rebase_path(shell_script, root_build_dir),
     "--source", "/var/empty",
-    "--target", "unsigned/$_target_app_name.dmg",
+    "--target", "unsigned/$brave_target_app_name.dmg",
     "--format", "UDBZ",
     "--verbosity", "0",
-    "--volname", "$_target_app_name",
+    "--volname", "$brave_target_app_name",
     "--copy", rebase_path(_target_app_path, root_build_dir),
     "--tempdir", "/tmp",
     "--symlink", "/Applications",
@@ -77,16 +69,16 @@ action("sign_dmg") {
   inputs = [
     script,
     shell_script,
-    "$root_out_dir/unsigned/$_target_app_name.dmg",
+    "$root_out_dir/unsigned/$brave_target_app_name.dmg",
   ]
-  outputs = [ "${root_out_dir}/signing/$_target_app_name.dmg" ]
+  outputs = [ "${root_out_dir}/signing/$brave_target_app_name.dmg" ]
   args = [
     rebase_path(shell_script, root_build_dir),
-    rebase_path("$root_out_dir/unsigned/$_target_app_name.dmg"),
-    rebase_path("$root_out_dir/$_target_app_name.dmg"),
+    rebase_path("$root_out_dir/unsigned/$brave_target_app_name.dmg"),
+    rebase_path("$root_out_dir/$brave_target_app_name.dmg"),
     keychain_db,
     mac_signing_identifier,
-    "-r=designated => identifier \"$_target_app_name\" and certificate leaf = H\"$mac_signing_identifier\"",
+    "-r=designated => identifier \"$brave_target_app_name\" and certificate leaf = H\"$mac_signing_identifier\"",
   ]
 
   deps = [":create_dmg"]

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -48,7 +48,7 @@ action("sign_app") {
 }
 
 action("create_dmg") {
-  output = "$root_out_dir/unsigned/Brave.dmg"
+  output = "$root_out_dir/unsigned/$_target_app_name.dmg"
   script = "//build/gn_run_binary.py"
   shell_script = "//chrome/installer/mac/pkg-dmg"
   inputs = [
@@ -59,10 +59,10 @@ action("create_dmg") {
   args = [
     rebase_path(shell_script, root_build_dir),
     "--source", "/var/empty",
-    "--target", "unsigned/Brave.dmg",
+    "--target", "unsigned/$_target_app_name.dmg",
     "--format", "UDBZ",
     "--verbosity", "0",
-    "--volname", "Brave",
+    "--volname", "$_target_app_name",
     "--copy", rebase_path(_target_app_path, root_build_dir),
     "--tempdir", "/tmp",
     "--symlink", "/Applications",
@@ -77,16 +77,16 @@ action("sign_dmg") {
   inputs = [
     script,
     shell_script,
-    "$root_out_dir/unsigned/Brave.dmg",
+    "$root_out_dir/unsigned/$_target_app_name.dmg",
   ]
-  outputs = [ "${root_out_dir}/signing/Brave.dmg" ]
+  outputs = [ "${root_out_dir}/signing/$_target_app_name.dmg" ]
   args = [
     rebase_path(shell_script, root_build_dir),
-    rebase_path("$root_out_dir/unsigned/Brave.dmg"),
-    rebase_path("$root_out_dir/Brave.dmg"),
+    rebase_path("$root_out_dir/unsigned/$_target_app_name.dmg"),
+    rebase_path("$root_out_dir/$_target_app_name.dmg"),
     keychain_db,
     mac_signing_identifier,
-    "-r=designated => identifier \"Brave\" and certificate leaf = H\"$mac_signing_identifier\"",
+    "-r=designated => identifier \"$_target_app_name\" and certificate leaf = H\"$mac_signing_identifier\"",
   ]
 
   deps = [":create_dmg"]


### PR DESCRIPTION
App name is changed to use different install dir for different channel.

Ex, beta channel -> Brave-Browser-Beta.app

Issue: https://github.com/brave/brave-browser/issues/396, https://github.com/brave/brave-browser/issues/10

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Execute Brave.dmg and check app name

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
