### PR TITLE
Only creates dist package for specified channel on linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -74,8 +74,15 @@ group("create_dist") {
     deps += [ "build/mac:create_dist_mac" ]
   }
   if (is_linux) {
+    _linux_channel = brave_channel
+    if (brave_channel == "") {
+      _linux_channel = "stable"
+    } else if (brave_channel == "dev") {
+      _linux_channel = "unstable"
+    }
+
     deps += [
-      "//chrome/installer/linux",
+      "//chrome/installer/linux:$_linux_channel",
       "//brave/app/linux:dist_resources",
     ]
   }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -74,15 +74,8 @@ group("create_dist") {
     deps += [ "build/mac:create_dist_mac" ]
   }
   if (is_linux) {
-    _linux_channel = brave_channel
-    if (brave_channel == "") {
-      _linux_channel = "stable"
-    } else if (brave_channel == "dev") {
-      _linux_channel = "unstable"
-    }
-
     deps += [
-      "//chrome/installer/linux:$_linux_channel",
+      "//chrome/installer/linux:$brave_linux_channel",
       "//brave/app/linux:dist_resources",
     ]
   }

--- a/build/config.gni
+++ b/build/config.gni
@@ -25,6 +25,18 @@ if (is_win) {
   brave_exe = "$chrome_product_full_name.app"
 }
 
+if (is_linux) {
+  # Our channle name and upstream linux channel name is different.
+  brave_linux_channel = ""
+  if (brave_channel == "") {
+    brave_linux_channel = "stable"
+  } else if (brave_channel == "dev") {
+    brave_linux_channel = "unstable"
+  } else {
+    assert(brave_channel == "beta", "Not supported channel name: $brave_channel")
+  }
+}
+
 brave_icon_dir = "nightly"
 if (is_component_build) {
   brave_icon_dir = "dev"


### PR DESCRIPTION
Issue https://github.com/brave/brave-browser/issues/396

With https://github.com/brave/brave-browser/pull/459, we can create dist for all three channels.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`yarn create_dist Release --channel=dev` -> brave-browser-dev_XXX.deb`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
