### PR TITLE
Make mini installer for non-stable channel work properly

### DIFF
--- a/app/brave_strings.grd
+++ b/app/brave_strings.grd
@@ -137,11 +137,14 @@ If you update this file, be sure also to update google_chrome_strings.grd. -->
         Brave
       </message>
       <if expr="is_win">
-        <message name="IDS_SXS_SHORTCUT_NAME" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_SXS_SHORTCUT_NAME">
+          Brave Nightly
         </message>
-        <message name="IDS_SHORTCUT_NAME_BETA" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_SHORTCUT_NAME_BETA">
+          Brave Beta
         </message>
-        <message name="IDS_SHORTCUT_NAME_DEV" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_SHORTCUT_NAME_DEV">
+          Brave Dev
         </message>
         <message name="IDS_PRODUCT_DESCRIPTION" desc="Browser description">
           Brave is a web browser that runs webpages and applications with lightning speed. It's fast, stable, and easy to use. Browse the web more safely with malware and phishing protection built into Brave.
@@ -804,9 +807,11 @@ Signing in anyway will merge Brave information like bookmarks, history, and othe
         Brave Apps
       </message>
       <if expr="is_win">
-        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BETA" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BETA">
+          Brave Apps
         </message>
-        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_DEV" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_DEV">
+          Brave Apps
         </message>
       </if>
 
@@ -920,20 +925,26 @@ Please check your email at <ph name="ACCOUNT_EMAIL">$2<ex>jane.doe@example.com</
         <message name="IDS_INBOUND_MDNS_RULE_NAME" desc="The name of the firewall rule allowing inbound mDNS traffic.">
           Brave (mDNS-In)
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_NAME_BETA" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_INBOUND_MDNS_RULE_NAME_BETA">
+          Brave Beta (mDNS-In)
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_NAME_CANARY" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_INBOUND_MDNS_RULE_NAME_CANARY">
+          Brave Nightly (mDNS-In)
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_NAME_DEV" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_INBOUND_MDNS_RULE_NAME_DEV">
+          Brave Dev (mDNS-In)
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION" desc="The description of the firewall rule allowing inbound mDNS traffic.">
+        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION">
           Inbound rule for Brave to allow mDNS traffic.
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION_BETA" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION_BETA">
+          Inbound rule for Brave Beta to allow mDNS traffic.
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION_CANARY" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION_CANARY">
+          Inbound rule for Brave Nightly to allow mDNS traffic.
         </message>
-        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION_DEV" desc="Unused in Brave builds" translateable="false">
+        <message name="IDS_INBOUND_MDNS_RULE_DESCRIPTION_DEV">
+          Inbound rule for Brave Dev to allow mDNS traffic.
         </message>
       </if>
 

--- a/patches/chrome-installer-util-BUILD.gn.patch
+++ b/patches/chrome-installer-util-BUILD.gn.patch
@@ -1,16 +1,24 @@
 diff --git a/chrome/installer/util/BUILD.gn b/chrome/installer/util/BUILD.gn
-index c66a6f6245ebe7d4abb1993c93f279e9e8442993..d78f0f1867d4b863133f826b45116dfe62813489 100644
+index c66a6f6245ebe7d4abb1993c93f279e9e8442993..8b3eed687137c5b7cba118b78f48022bc2b30e59 100644
 --- a/chrome/installer/util/BUILD.gn
 +++ b/chrome/installer/util/BUILD.gn
-@@ -246,9 +246,16 @@ action("generate_strings") {
+@@ -246,9 +246,24 @@ action("generate_strings") {
      "$target_gen_dir/installer_util_strings.rc",
    ]
  
 +  brand = "$branding_path_component"
 +
-+  if (brave_chromium_build && !is_official_build) {
-+    # TODO(shong): Remove this.
-+    brand = brand + "-development"
++  if (brave_chromium_build) {
++    # When brave_strings.grd is modified, outputs should be re-generated.
++    # This is workaround. Need to change the way of using |brave_strings.grd|
++    # in |create_string_rc.py|.
++    sources = [
++      "//chrome/app/brave_strings.grd"
++    ]
++    if (!is_official_build) {
++      # TODO(shong): Remove this.
++      brand = brand + "-development"
++    }
 +  }
 +
    args = [


### PR DESCRIPTION
It was not installed properly because needed string was empty.
Also, brave_strings.grd is added to generate_strings's source list to trigger re-generation.

With this PR,  mini_installer.exe installs all non-stable channels well.

Issue: https://github.com/brave/brave-browser/issues/396

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`mini_installer.exe --chrome-beta` for beta channel.
`mini_installer.exe --chrome-dev` for dev channel.
`mini_installer.exe --chrome-sxs` for nightly channel.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
