### PR TITLE
Remove chrome web store URL for extensions

### DIFF
--- a/patches/extensions-common-manifest_url_handlers.cc.patch
+++ b/patches/extensions-common-manifest_url_handlers.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/extensions/common/manifest_url_handlers.cc b/extensions/common/manifest_url_handlers.cc
+index ac932cc21b18606a3a40b85699a3a99e061eaf8a..9f2cb18472ae0fbf88c37b9af62a8d10ab62bdfd 100644
+--- a/extensions/common/manifest_url_handlers.cc
++++ b/extensions/common/manifest_url_handlers.cc
+@@ -55,6 +55,9 @@ const GURL ManifestURL::GetManifestHomePageURL(const Extension* extension) {
+ 
+ // static
+ const GURL ManifestURL::GetWebStoreURL(const Extension* extension) {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  return GURL::EmptyGURL();
++#endif
+   bool use_webstore_url = UpdatesFromGallery(extension) &&
+                           !SharedModuleInfo::IsSharedModule(extension);
+   return use_webstore_url


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/311
Make the hidden condition below to be true so we won't see the row to view the extension in web store.  https://cs.chromium.org/chromium/src/chrome/browser/resources/md_extensions/detail_view.html?type=cs&q=viewinstore&sq=package:chromium&g=0&l=389-392
This PR will also need to be revised once we have our own extension store ready, tracked in https://github.com/brave/brave-browser/issues/415

I've try to avoid patch, but seems not possible in this case,
1) Can't use subclass technique because this is a static method
2) Can't use chromium_src override technique because this is a member function, the replace of original method name will also change the member function definition in the header file.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Go to chrome://extensions and see details of PDF Viewer extension, won't see the row for calling out to chrome web store.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
