### PR TITLE
Report blocked script only when it is actually blocked

### DIFF
--- a/renderer/brave_content_settings_observer.h
+++ b/renderer/brave_content_settings_observer.h
@@ -26,6 +26,7 @@ class BraveContentSettingsObserver
 
  protected:
   bool AllowScript(bool enabled_per_settings) override;
+  void DidNotAllowScript() override;
   bool AllowScriptFromSource(bool enabled_per_settings,
       const blink::WebURL& script_url) override;
 
@@ -60,6 +61,9 @@ class BraveContentSettingsObserver
   // Origins of scripts which are temporary allowed for this frame in the
   // current load
   base::flat_set<std::string> temporarily_allowed_scripts_;
+
+  // cache blocked script url which will later be used in `DidNotAllowScript()`
+  GURL blocked_script_url_;
 
   // temporary allowed script origins we preloaded for the next load
   base::flat_set<std::string> preloaded_temporarily_allowed_scripts_;


### PR DESCRIPTION
so we can filter out problem like https://github.com/brave/muon/pull/627
which `ContentSettingsObserver::AllowScriptFromSource` informs us all the resources not just scripts

Auditors: @bridiver, @bbondy

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
