### PR TITLE
Use brave-core specific crash reporting end point

### DIFF
--- a/patches/chrome-browser-resources-settings-privacy_page-privacy_page.html.patch
+++ b/patches/chrome-browser-resources-settings-privacy_page-privacy_page.html.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page.html b/chrome/browser/resources/settings/privacy_page/privacy_page.html
+index c938b42ff11691e4e5e915e7c4d6f36de58d82cb..2dde6c32cf91eebd7084fe3c3e6470648bedd1a2 100644
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page.html
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page.html
+@@ -89,7 +89,7 @@
+         <settings-toggle-button pref="{{prefs.safebrowsing.enabled}}"
+             label="$i18n{safeBrowsingEnableProtection}">
+         </settings-toggle-button>
+-<if expr="_google_chrome">
++<if expr="_chromium">
+ <if expr="chromeos">
+         <settings-toggle-button pref="{{prefs.cros.metrics.reportingEnabled}}"
+             label="$i18n{enableLogging}">

--- a/patches/chrome-browser-resources-settings-privacy_page-privacy_page.js.patch
+++ b/patches/chrome-browser-resources-settings-privacy_page-privacy_page.js.patch
@@ -1,0 +1,31 @@
+diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page.js b/chrome/browser/resources/settings/privacy_page/privacy_page.js
+index c8a41ea859437ec0c494f05bdbc15ee5fd5423ec..5def6736ec607bd367ecc650f128786b5e5314e5 100644
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page.js
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page.js
+@@ -52,7 +52,7 @@ Polymer({
+       }
+     },
+ 
+-    // <if expr="_google_chrome and not chromeos">
++    // <if expr="_chromium and not chromeos">
+     // TODO(dbeam): make a virtual.* pref namespace and set/get this normally
+     // (but handled differently in C++).
+     /** @private {chrome.settingsPrivate.PrefObject} */
+@@ -169,7 +169,7 @@ Polymer({
+ 
+     this.browserProxy_ = settings.PrivacyPageBrowserProxyImpl.getInstance();
+ 
+-    // <if expr="_google_chrome and not chromeos">
++    // <if expr="_chromium and not chromeos">
+     const setMetricsReportingPref = this.setMetricsReportingPref_.bind(this);
+     this.addWebUIListener('metrics-reporting-change', setMetricsReportingPref);
+     this.browserProxy_.getMetricsReporting().then(setMetricsReportingPref);
+@@ -301,7 +301,7 @@ Polymer({
+     this.browserProxy_.setSafeBrowsingExtendedReportingEnabled(enabled);
+   },
+ 
+-  // <if expr="_google_chrome and not chromeos">
++  // <if expr="_chromium and not chromeos">
+   /** @private */
+   onMetricsReportingChange_: function() {
+     const enabled = this.$.metricsReportingControl.checked;

--- a/patches/chrome-browser-resources-settings-privacy_page-privacy_page_browser_proxy.js.patch
+++ b/patches/chrome-browser-resources-settings-privacy_page-privacy_page_browser_proxy.js.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page_browser_proxy.js b/chrome/browser/resources/settings/privacy_page/privacy_page_browser_proxy.js
+index 63790dfadb2e17f3c2bbc1193a26dca3bab4d8c3..4566637ad24d5d9b3de414474085c7cc852c8a4e 100644
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page_browser_proxy.js
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page_browser_proxy.js
+@@ -13,7 +13,7 @@ let SberPrefState;
+ cr.define('settings', function() {
+   /** @interface */
+   class PrivacyPageBrowserProxy {
+-    // <if expr="_google_chrome and not chromeos">
++    // <if expr="_chromium and not chromeos">
+     /** @return {!Promise<!MetricsReporting>} */
+     getMetricsReporting() {}
+ 
+@@ -39,7 +39,7 @@ cr.define('settings', function() {
+    * @implements {settings.PrivacyPageBrowserProxy}
+    */
+   class PrivacyPageBrowserProxyImpl {
+-    // <if expr="_google_chrome and not chromeos">
++    // <if expr="_chromium and not chromeos">
+     /** @override */
+     getMetricsReporting() {
+       return cr.sendWithPromise('getMetricsReporting');

--- a/patches/chrome-browser-ui-webui-settings-metrics_reporting_handler.cc.patch
+++ b/patches/chrome-browser-ui-webui-settings-metrics_reporting_handler.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/webui/settings/metrics_reporting_handler.cc b/chrome/browser/ui/webui/settings/metrics_reporting_handler.cc
+index 7d8fb6922a81f4758c3cebbc0d06555647d56a66..dc13086ac5a5c66edf748900f6bcbfc68316b51f 100644
+--- a/chrome/browser/ui/webui/settings/metrics_reporting_handler.cc
++++ b/chrome/browser/ui/webui/settings/metrics_reporting_handler.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#if defined(GOOGLE_CHROME_BUILD) && !defined(OS_CHROMEOS)
++#if (defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))) && !defined(OS_CHROMEOS)
+ 
+ #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
+ 

--- a/patches/chrome-browser-ui-webui-settings-metrics_reporting_handler.h.patch
+++ b/patches/chrome-browser-ui-webui-settings-metrics_reporting_handler.h.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/webui/settings/metrics_reporting_handler.h b/chrome/browser/ui/webui/settings/metrics_reporting_handler.h
+index 73cc5bd9572e3b49ed94697be0f48bb089347a70..d2e1a4a82eb5fff290f077fa0b5f9ba83e0fa9d2 100644
+--- a/chrome/browser/ui/webui/settings/metrics_reporting_handler.h
++++ b/chrome/browser/ui/webui/settings/metrics_reporting_handler.h
+@@ -5,7 +5,7 @@
+ #ifndef CHROME_BROWSER_UI_WEBUI_SETTINGS_METRICS_REPORTING_HANDLER_H_
+ #define CHROME_BROWSER_UI_WEBUI_SETTINGS_METRICS_REPORTING_HANDLER_H_
+ 
+-#if defined(GOOGLE_CHROME_BUILD) && !defined(OS_CHROMEOS)
++#if (defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))) && !defined(OS_CHROMEOS)
+ 
+ #include <memory>
+ 

--- a/patches/components-crash-content-app-crashpad_linux.cc.patch
+++ b/patches/components-crash-content-app-crashpad_linux.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/components/crash/content/app/crashpad_linux.cc b/components/crash/content/app/crashpad_linux.cc
+index 05767fe2a26e16a0152ba419ed38a944f919cbde..47c474ed3221583973d16456443902c83e133ae4 100644
+--- a/components/crash/content/app/crashpad_linux.cc
++++ b/components/crash/content/app/crashpad_linux.cc
+@@ -143,6 +143,8 @@ bool BuildHandlerArgs(base::FilePath* handler_path,
+ 
+ #if defined(GOOGLE_CHROME_BUILD) && defined(OFFICIAL_BUILD)
+   *url = "https://clients2.google.com/cr/report";
++#elif defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD)
++  *url = "https://laptop-updates.brave.com/1/bc-crashes";
+ #else
+   *url = std::string();
+ #endif
+@@ -155,7 +157,7 @@ bool BuildHandlerArgs(base::FilePath* handler_path,
+   (*process_annotations)["prod"] = std::string(product_name);
+   (*process_annotations)["ver"] = std::string(product_version);
+ 
+-#if defined(GOOGLE_CHROME_BUILD)
++#if defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))
+   // Empty means stable.
+   const bool allow_empty_channel = true;
+ #else

--- a/patches/components-crash-content-app-crashpad_mac.mm.patch
+++ b/patches/components-crash-content-app-crashpad_mac.mm.patch
@@ -1,0 +1,22 @@
+diff --git a/components/crash/content/app/crashpad_mac.mm b/components/crash/content/app/crashpad_mac.mm
+index eb82f44053cec67f7e98c798d8e1e58228aa7fe6..3e6189b8dd2106d79059268b1fc2d445ff93da92 100644
+--- a/components/crash/content/app/crashpad_mac.mm
++++ b/components/crash/content/app/crashpad_mac.mm
+@@ -55,6 +55,8 @@ base::FilePath PlatformCrashpadInitialization(bool initial_client,
+       // Only allow the possibility of report upload in official builds. This
+       // crash server won't have symbols for any other build types.
+       std::string url = "https://clients2.google.com/cr/report";
++#elif defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD)
++      std::string url = "https://laptop-updates.brave.com/1/bc-crashes";
+ #else
+       std::string url;
+ #endif
+@@ -67,7 +69,7 @@ base::FilePath PlatformCrashpadInitialization(bool initial_client,
+       process_annotations["prod"] =
+           base::SysNSStringToUTF8(product).append("_Mac");
+ 
+-#if defined(GOOGLE_CHROME_BUILD)
++#if defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))
+       // Empty means stable.
+       const bool allow_empty_channel = true;
+ #else

--- a/patches/components-crash-content-app-crashpad_win.cc.patch
+++ b/patches/components-crash-content-app-crashpad_win.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/components/crash/content/app/crashpad_win.cc b/components/crash/content/app/crashpad_win.cc
+index 8b0edef1b59403f819e3c1b4d3b378f849c68f26..a6e691f58c2925daa5a6a82c58716b7caebe4855 100644
+--- a/components/crash/content/app/crashpad_win.cc
++++ b/components/crash/content/app/crashpad_win.cc
+@@ -36,7 +36,7 @@ void GetPlatformCrashpadAnnotations(
+       exe_file, &product_name, &version, &special_build, &channel_name);
+   (*annotations)["prod"] = base::UTF16ToUTF8(product_name);
+   (*annotations)["ver"] = base::UTF16ToUTF8(version);
+-#if defined(GOOGLE_CHROME_BUILD)
++#if defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))
+   // Empty means stable.
+   const bool allow_empty_channel = true;
+ #else
+@@ -82,6 +82,9 @@ base::FilePath PlatformCrashpadInitialization(bool initial_client,
+ 
+ #if defined(GOOGLE_CHROME_BUILD)
+     std::string url = "https://clients2.google.com/cr/report";
++#elif defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD)
++    // std::string url = "https://laptop-updates.brave.com/1/bc-crashes";
++    std::string url = "http://localhost:8192/1/bc-crashes";
+ #else
+     std::string url;
+ #endif

--- a/patches/components-metrics-metrics_service_accessor.cc.patch
+++ b/patches/components-metrics-metrics_service_accessor.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/metrics/metrics_service_accessor.cc b/components/metrics/metrics_service_accessor.cc
+index f00d2e8523f6f80aedd0dedcf7c8d2bc2985a0f1..7b457eda0dbdf725d37032a981476ef50f1c3673 100644
+--- a/components/metrics/metrics_service_accessor.cc
++++ b/components/metrics/metrics_service_accessor.cc
+@@ -30,7 +30,7 @@ bool IsMetricsReportingEnabledForOfficialBuild(PrefService* pref_service) {
+ // static
+ bool MetricsServiceAccessor::IsMetricsReportingEnabled(
+     PrefService* pref_service) {
+-#if defined(GOOGLE_CHROME_BUILD)
++#if defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))
+   return IsMetricsReportingEnabledForOfficialBuild(pref_service);
+ #else
+   // In non-official builds, disable metrics reporting completely.


### PR DESCRIPTION
Fixes brave/brave-browser#424

Updated to use new brave-core specific crash reporting endpoint. Also updated webui Settings pages to allow enabling/disabling crash reporting on the Privacy page and to allow interacting with chrome://crashes/.

By default, the browser looks for pending crash reports every 15 minutes and uploads at most one per hour.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
