### PR TITLE
Remove post-uninstall-survey on Windows

### DIFF
--- a/chromium_src/chrome/installer/util/browser_distribution.cc
+++ b/chromium_src/chrome/installer/util/browser_distribution.cc
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/installer/util/brave_distribution.h"
+#undef GoogleChromeDistribution
+#define GoogleChromeDistribution BraveDistribution
+#include "../../../../../chrome/installer/util/browser_distribution.cc"

--- a/installer/util/brave_distribution.h
+++ b/installer/util/brave_distribution.h
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_INSTALLER_UTIL_BRAVE_DISTRIBUTION_H_
+#define BRAVE_INSTALLER_UTIL_BRAVE_DISTRIBUTION_H_
+
+#include "chrome/installer/util/google_chrome_distribution.h"
+
+class BraveDistribution : public GoogleChromeDistribution {
+ public:
+  void DoPostUninstallOperations(
+      const base::Version& version,
+      const base::FilePath& local_data_path,
+      const base::string16& distribution_data) override { };
+
+  BraveDistribution() { };
+
+  DISALLOW_COPY_AND_ASSIGN(BraveDistribution);
+};
+
+#endif // BRAVE_INSTALLER_UTIL_BRAVE_DISTRIBUTION_H_


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/489
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
run `yarn create_dist Release` on Windows, install the created installer.
Then uninstall the application from the control panel, uninstall should be performed without survey.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
