### PR TITLE
Set the version string on Linux packages to the Brave version

### DIFF
--- a/chromium_src/chrome/installer/linux/common/brave-browser/chromium-browser.info
+++ b/chromium_src/chrome/installer/linux/common/brave-browser/chromium-browser.info
@@ -27,3 +27,5 @@ FULLDESC="Browse faster by blocking ads and trackers that violate your privacy a
 MAINTNAME="Brave Software"
 MAINTMAIL="support+laptop@brave.com"
 PRODUCTURL="https://brave.com/"
+VERSION=$(cat $BUILDDIR/version | tr -d 'v,')
+VERSIONFULL=$VERSION


### PR DESCRIPTION
rather than the Chromium version.

Fixes https://github.com/brave/brave-browser/issues/500

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
