### PR TITLE
 Generate brave-browser package.json version for C++ and use it

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,6 +34,18 @@ group("browser_dependencies") {
   ]
 }
 
+action("generate_version") {
+  script = "//brave/script/version.py"
+  gen_dir = rebase_path(root_gen_dir, "//")
+  args = [
+    "--target_gen_dir=$gen_dir"
+  ]
+  inputs = [ "../../package.json" ]
+  outputs = [
+    "$root_out_dir/version"
+  ]
+}
+
 group("brave") {
   public_deps = [
     "//chrome",
@@ -44,6 +56,9 @@ group("brave") {
       "build/win:copy_pdb"
     ]
   }
+  deps = [
+    ":generate_version",
+  ]
 }
 
 group("brave_tests") {
@@ -83,14 +98,6 @@ group("create_dist") {
       "//brave/app/linux:dist_resources",
     ]
   }
-}
-
-action("generate_version") {
-  script = "//brave/script/version.py"
-
-  outputs = [
-    "$root_out_dir/version"
-  ]
 }
 
 copy("brave_dist_resources") {

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -41,6 +41,8 @@ source_set("browser_process") {
     "sparkle_glue_mac.h",
     "update_util.cc",
     "update_util.h",
+    "version_info_values.cc",
+    "version_info_values.h",
   ]
 
   deps = [

--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -7,6 +7,7 @@
 #include "base/sys_info.h"
 #include "brave/browser/brave_stats_updater_params.h"
 #include "brave/common/pref_names.h"
+#include "brave/version.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/net/system_network_context_manager.h"
 #include "chrome/common/channel_info.h"
@@ -64,7 +65,7 @@ GURL GetUpdateURL(const brave::BraveStatsUpdaterParams& stats_updater_params) {
   update_url =
       net::AppendQueryParameter(update_url, "channel", GetChannelName());
   update_url = net::AppendQueryParameter(update_url, "version",
-                                         version_info::GetVersionNumber());
+                                         BRAVE_BROWSER_VERSION);
   update_url = net::AppendQueryParameter(update_url, "daily",
                                          stats_updater_params.GetDailyParam());
   update_url = net::AppendQueryParameter(update_url, "weekly",

--- a/browser/version_info_values.cc
+++ b/browser/version_info_values.cc
@@ -4,6 +4,8 @@
 
 #include "brave/browser/version_info_values.h"
 
-#define GetVersionNumber GetBraveVersionNumber
-#include "../../../../../../../chrome/browser/ui/webui/settings/about_handler.cc"
-#undef GetVersionNumber
+namespace version_info {
+std::string GetBraveVersionNumber() {
+  return std::string(BRAVE_BROWSER_VERSION) + "  Chromium: " + PRODUCT_VERSION;
+}
+}  // namespace version_info

--- a/browser/version_info_values.h
+++ b/browser/version_info_values.h
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_VERSION_INFO_VALUES_H_
+#define BRAVE_BROWSER_VERSION_INFO_VALUES_H_
+
+#include <string>
+#include "brave/version.h"
+#include "components/version_info/version_info_values.h"
+
+namespace version_info {
+std::string GetBraveVersionNumber();
+}  // namespace version_info
+
+#endif  // BRAVE_BROWSER_VERSION_INFO_VALUES_H_

--- a/chromium_src/chrome/browser/ui/webui/settings/about_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/about_handler.cc
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <string>
+#include "brave/version.h"
+#include "components/version_info/version_info_values.h"
+
+namespace version_info {
+std::string GetBraveVersionNumber() {
+  return std::string(BRAVE_BROWSER_VERSION) + "  Chromium: " + PRODUCT_VERSION;
+}
+}  // namespace version_info
+
+#define GetVersionNumber GetBraveVersionNumber
+#include "../../../../../../../chrome/browser/ui/webui/settings/about_handler.cc"
+#undef GetVersionNumber

--- a/chromium_src/chrome/browser/ui/webui/version_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/version_ui.cc
@@ -5,5 +5,5 @@
 #include "brave/browser/version_info_values.h"
 
 #define GetVersionNumber GetBraveVersionNumber
-#include "../../../../../../../chrome/browser/ui/webui/settings/about_handler.cc"
+#include "../../../../../../../chrome/browser/ui/webui/version_ui.cc"
 #undef GetVersionNumber

--- a/script/version.py
+++ b/script/version.py
@@ -1,19 +1,38 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
 
-from lib.config import output_dir, get_brave_version
+from lib.config import CHROMIUM_ROOT, get_brave_version
 
 
 def main():
-  create_version()
+  args = parse_args()
+  create_version(args.target_gen_dir[0])
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Transpile web-uis')
+  parser.add_argument('-p', '--production',
+                      action='store_true',
+                      help='Uses production config')
+  parser.add_argument('--target_gen_dir',
+                      nargs=1)
+  return parser.parse_args()
 
 
-def create_version():
-  version_path = os.path.join(output_dir(), 'version')
+def create_version(target_gen_dir):
+  version_path = os.path.abspath(os.path.join(CHROMIUM_ROOT, target_gen_dir, '..', 'version'))
   with open(version_path, 'w') as version_file:
     version_file.write(get_brave_version())
+
+  version_h_path = os.path.join(CHROMIUM_ROOT, target_gen_dir, 'brave', 'version.h')
+  with open(version_h_path, 'w') as version_h_file:
+    # Strip off the v prefix.
+    version = get_brave_version()[1:]
+    version_h_file.write(''.join(['#define BRAVE_BROWSER_VERSION "', version, '"']))
+
+  print("version_path is: ", version_path, get_brave_version())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**This PR is meant to:**

- This PR is meant to generate the package.json version in brave-browser for future use in some areas.
- Use it for stats
- Use it for displaying in About Brave
- Use it for displaying in chrome://version

**This PR is not meant to:**

- Fix all instances of where the package.json version is needed (I think that's only updates and crash reports)

**Alternate approach considered:**

I considered instead patching `chrome/VERSION` file so it generates a new `PRODUCT_VERSION` which gets defined in `./out/Debug/gen/components/version_info/version_info_values.h`.  Various parts of the code access this version via `PRODUCT_VERSION` and other parts via `components/version_info/version_info.cc`'s:
```
std::string GetVersionNumber() {
  return PRODUCT_VERSION;
}
```

The downsides of this is that some of the Chromium code parse the version string and get the version in int form.  I don't see anything that would cause a major problem for us but I don't know for sure.  

Doing this would be a bit confusing too because we need to do several releases per base Chromium version.  So we'd have to maintain 2 Chromium versions at the same time.

Our server side for stats and crash reporting also expect to have 3 component version strings.  They currently aren't working because they fail on semver code that expects a different format. 

We also need to show both our version and the Chromium base version.

Lastly this approach wasn't used because we want to eventually have a 1.0 event of our own.


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
