### PR TITLE
Fix gn error in brave/BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -50,13 +50,14 @@ group("brave") {
   public_deps = [
     "//chrome",
   ]
+  deps = []
   if (is_win) {
-    deps = [
+    deps += [
       "build/win:copy_exe",
       "build/win:copy_pdb"
     ]
   }
-  deps = [
+  deps += [
     ":generate_version",
   ]
 }


### PR DESCRIPTION
nonempty list should not be overwritten.
close https://github.com/brave/brave-browser/issues/516

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Check `yarn build` is started w/o gn error

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
