### PR TITLE
Replace chrome cast support urls with brave community page

### DIFF
--- a/chromium_src/chrome/browser/ui/singleton_tabs.cc
+++ b/chromium_src/chrome/browser/ui/singleton_tabs.cc
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define ShowSingletonTab ShowSingletonTab_ChromiumImpl
+#include "../../../../../chrome/browser/ui/singleton_tabs.cc"
+#undef ShowSingletonTab
+
+void ShowSingletonTab(Browser* browser, const GURL& url) {
+  GURL new_url = url.DomainIs("google.com") ?
+    GURL("https://community.brave.com/") : url;
+
+  ShowSingletonTab_ChromiumImpl(browser, new_url);
+}

--- a/patches/chrome-browser-ui-webui-media_router-media_router_webui_message_handler.cc.patch
+++ b/patches/chrome-browser-ui-webui-media_router-media_router_webui_message_handler.cc.patch
@@ -1,0 +1,35 @@
+diff --git a/chrome/browser/ui/webui/media_router/media_router_webui_message_handler.cc b/chrome/browser/ui/webui/media_router/media_router_webui_message_handler.cc
+index bcc329103d17a7716fddf5dc957e7e9345915ba2..5f8fa78ca260644c2de1e3541f96e8f79585eda3 100644
+--- a/chrome/browser/ui/webui/media_router/media_router_webui_message_handler.cc
++++ b/chrome/browser/ui/webui/media_router/media_router_webui_message_handler.cc
+@@ -36,8 +36,12 @@ namespace media_router {
+ 
+ namespace {
+ 
++#if defined(BRAVE_CHROMIUM_BUILD)
++const char kCastLearnMorePageUrl[] = "https://community.brave.com/";
++#else
+ const char kCastLearnMorePageUrl[] =
+     "https://www.google.com/chrome/devices/chromecast/learn.html";
++#endif
+ const char kHelpPageUrlPrefix[] =
+     "https://support.google.com/chromecast/answer/%d";
+ 
+@@ -226,6 +230,9 @@ bool IsValidIssueActionTypeNum(int issue_action_type_num) {
+ // Composes a "learn more" URL. The URL depends on template arguments in |args|.
+ // Returns an empty string if |args| is invalid.
+ std::string GetLearnMoreUrl(const base::DictionaryValue* args) {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  return kCastLearnMorePageUrl;
++#endif
+   // TODO(imcheng): The template arguments for determining the learn more URL
+   // should come from the Issue object in the browser, not from WebUI.
+   int help_page_id = -1;
+@@ -529,6 +536,7 @@ void MediaRouterWebUIMessageHandler::OnRequestInitialData(
+   // "No Cast devices found?" Chromecast help center page.
+   initial_data.SetString("deviceMissingUrl",
+                          base::StringPrintf(kHelpPageUrlPrefix, 3249268));
++  initial_data.SetString("deviceMissingUrl", kCastLearnMorePageUrl);
+ 
+   std::unique_ptr<base::DictionaryValue> sinks_and_identity(
+       SinksAndIdentityToValue(media_router_ui_->GetEnabledSinks(),


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/377
Neither override or subclass technique could be used in these cases AFAIK.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
