### PR TITLE
Sparkle: update server url and enable background update when browser stars

### DIFF
--- a/brave_init_settings.gni
+++ b/brave_init_settings.gni
@@ -11,7 +11,7 @@ declare_args() {
   brave_dsa_file = "dsa_pub.pem"
 }
 
-_base_update_url = "https://updates-test.bravesoftware.com/sparkle/Brave-Browser"
+_base_update_url = "https://updates.bravesoftware.com/sparkle/Brave-Browser"
 _update_channel = brave_channel
 if (_update_channel == "") {
   _update_channel = "stable"

--- a/brave_init_settings.gni
+++ b/brave_init_settings.gni
@@ -8,12 +8,16 @@ declare_args() {
   # "" for stable channel release.
   brave_channel = ""
 
+  base_sparkle_update_url = ""
+
   brave_dsa_file = "dsa_pub.pem"
 }
 
-_base_update_url = "https://updates.bravesoftware.com/sparkle/Brave-Browser"
+if (base_sparkle_update_url == "") {
+  base_sparkle_update_url = "https://updates.bravesoftware.com/sparkle/Brave-Browser"
+}
 _update_channel = brave_channel
 if (_update_channel == "") {
   _update_channel = "stable"
 }
-brave_feed_url = "$_base_update_url/$_update_channel/appcast.xml"
+brave_feed_url = "$base_sparkle_update_url/$_update_channel/appcast.xml"

--- a/brave_init_settings.gni
+++ b/brave_init_settings.gni
@@ -8,10 +8,12 @@ declare_args() {
   # "" for stable channel release.
   brave_channel = ""
 
-  # Update feed url on MacOS
-  # TODO(simonhong): This url is stub. Replace with real update server or your
-  # test server.
-  brave_feed_url = "http://localhost:9090"
-
   brave_dsa_file = "dsa_pub.pem"
 }
+
+_base_update_url = "https://updates-test.bravesoftware.com/sparkle/Brave-Browser"
+_update_channel = brave_channel
+if (_update_channel == "") {
+  _update_channel = "stable"
+}
+brave_feed_url = "$_base_update_url/$_update_channel/appcast.xml"

--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -49,8 +49,18 @@ std::string GetDescriptionFromAppcastItem(id item) {
 - (void)initializeBraveUpdater {
   DCHECK(brave::UpdateEnabled());
 
+  // Background update check interval.
+  constexpr int kBraveUpdateCheckIntervalInSec = 3 * 60 * 60;
+
   sparkle_glue_ = [SparkleGlue sharedSparkleGlue];
+
   [sparkle_glue_ setDelegate:self];
+  [sparkle_glue_ setAutomaticallyChecksForUpdates:YES];
+  [sparkle_glue_ setAutomaticallyDownloadsUpdates:YES];
+  [sparkle_glue_ setUpdateCheckInterval:kBraveUpdateCheckIntervalInSec];
+
+  // Start background update.
+  [sparkle_glue_ checkForUpdatesInBackground];
 }
 
 #pragma mark - SUUpdaterDelegate

--- a/browser/sparkle_glue_mac.h
+++ b/browser/sparkle_glue_mac.h
@@ -22,6 +22,9 @@
 - (void)setDelegate:(id)delegate;
 - (void)checkForUpdates:(id)sender;
 - (void)checkForUpdatesInBackground;
+- (void)setAutomaticallyChecksForUpdates:(BOOL)enable;
+- (void)setAutomaticallyDownloadsUpdates:(BOOL)enable;
+- (void)setUpdateCheckInterval:(NSTimeInterval)interval;
 
 @end  // @interface SparkleGlue
 

--- a/browser/sparkle_glue_mac.mm
+++ b/browser/sparkle_glue_mac.mm
@@ -63,4 +63,16 @@ id GetSUUpdater() {
   [su_updater_ checkForUpdatesInBackground];
 }
 
+- (void)setAutomaticallyChecksForUpdates:(BOOL)enable {
+  [su_updater_ setAutomaticallyChecksForUpdates:enable];
+}
+
+- (void)setAutomaticallyDownloadsUpdates:(BOOL)enable {
+  [su_updater_ setAutomaticallyDownloadsUpdates:enable];
+}
+
+- (void)setUpdateCheckInterval:(NSTimeInterval)interval {
+  [su_updater_ setUpdateCheckInterval:interval];
+}
+
 @end

--- a/browser/update_util.cc
+++ b/browser/update_util.cc
@@ -10,9 +10,12 @@
 namespace brave {
 
 bool UpdateEnabled() {
-  // TODO(simonhong): Remove this flag and enable update only in official build.
-  return base::CommandLine::ForCurrentProcess()->HasSwitch(
-      switches::kEnableBraveUpdateTest);
+#if defined(OFFICIAL_BUILD)
+  return !base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kDisableBraveUpdate);
+#else
+  return false;
+#endif
 }
 
 }  //namespace brave

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -22,7 +22,8 @@ void VersionUpdaterMac::CheckForUpdate(
     const StatusCallback& status_callback,
     const PromoteCallback& promote_callback) {
   if (brave::UpdateEnabled()) {
-    [[SparkleGlue sharedSparkleGlue] checkForUpdatesInBackground];
+    [[SparkleGlue sharedSparkleGlue] checkForUpdates:nil];
+
     // TODO(simonhong): Update status from sparkle.
     status_callback.Run(DISABLED, 0, std::string(), 0, base::string16());
     NOTIMPLEMENTED();

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -14,13 +14,7 @@ const char kDisableBraveExtension[] = "disable-brave-extension";
 // Allows disabling the PDFJS extension.
 const char kDisablePDFJSExtension[] = "disable-pdfjs-extension";
 
-// This switch enables update module(Sparkle).
-// When you use this flag for update test, make sure to fix the feed URL
-// |brave_feed_url| in brave/brave_init_settings.gni.
-// This switch is introduced for update feature development.
-// When update test is fininshed, update module should be enabled only in
-// official build.
-// TODO(shong): Remove this switch when update development is done.
-const char kEnableBraveUpdateTest[] = "enable-brave-update-test";
+// This switch disables update module(Sparkle).
+const char kDisableBraveUpdate[] = "disable-brave-update";
 
 }  // namespace switches

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -11,9 +11,9 @@ namespace switches {
 // alongside the definition of their values in the .cc file.
 extern const char kDisableBraveExtension[];
 
-extern const char kDisablePDFJSExtension[];
+extern const char kDisableBraveUpdate[];
 
-extern const char kEnableBraveUpdateTest[];
+extern const char kDisablePDFJSExtension[];
 
 }  // namespace switches
 


### PR DESCRIPTION
Request explicit update check when about page loads
TODO: about page should show update status like windows version does.
issue: https://github.com/brave/brave-browser/issues/396

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
