### PR TITLE
Disable google services in privacy settings

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -51,6 +51,8 @@ source_set("browser_process") {
     "//brave/components/content_settings/core/browser",
     "//brave/common",
     "//components/component_updater",
+    "//components/safe_browsing/common:safe_browsing_prefs",
+    "//components/spellcheck/browser",
     "//content/public/browser",
     "//brave/chromium_src:browser",
   ]

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -10,7 +10,9 @@
 #include "chrome/common/pref_names.h"
 #include "components/content_settings/core/common/pref_names.h"
 #include "components/pref_registry/pref_registry_syncable.h"
+#include "components/safe_browsing/common/safe_browsing_prefs.h"
 #include "components/signin/core/browser/signin_pref_names.h"
+#include "components/spellcheck/browser/pref_names.h"
 
 namespace brave {
 
@@ -28,6 +30,18 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   // Show download prompt by default
   registry->SetDefaultPrefValue(prefs::kPromptForDownload, base::Value(true));
+
+  // Not using chrome's web service for resolving navigation errors
+  registry->SetDefaultPrefValue(prefs::kAlternateErrorPagesEnabled, base::Value(false));
+
+  // Disable spell check service
+  registry->SetDefaultPrefValue(spellcheck::prefs::kSpellCheckUseSpellingService, base::Value(false));
+
+  // Disable safebrowsing reporting
+  registry->SetDefaultPrefValue(prefs::kSafeBrowsingExtendedReportingOptInAllowed, base::Value(false));
+
+  // Disable search suggestion
+  registry->SetDefaultPrefValue(prefs::kSearchSuggestEnabled, base::Value(false));
 }
 
 }  // namespace brave

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -8,6 +8,8 @@
 #include "chrome/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/prefs/pref_service.h"
+#include "components/safe_browsing/common/safe_browsing_prefs.h"
+#include "components/spellcheck/browser/pref_names.h"
 
 using BraveProfilePrefsBrowserTest = InProcessBrowserTest;
 
@@ -17,4 +19,15 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DownloadPromptDefault) {
       browser()->profile()->GetPrefs()->GetBoolean(prefs::kPromptForDownload));
   EXPECT_FALSE(
       browser()->profile()->GetPrefs()->GetBoolean(kWidevineOptedIn));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DisableGoogleServicesByDefault) {
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kAlternateErrorPagesEnabled));
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(spellcheck::prefs::kSpellCheckUseSpellingService));
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kSafeBrowsingExtendedReportingOptInAllowed));
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kSearchSuggestEnabled));
 }

--- a/browser/resources/settings/brave_page_visibility.js
+++ b/browser/resources/settings/brave_page_visibility.js
@@ -19,9 +19,16 @@ cr.define('settings', function() {
     }
   };
 
+  const privacyHandler = {
+    get: function(obj, prop) {
+      return prop === 'searchPrediction' ? false : true;
+    }
+  }
+
   const handler = {
     get: function(obj, prop) {
       if (prop === 'appearance') return new Proxy({}, appearanceHandler);
+      if (prop === 'privacy') return new Proxy({}, privacyHandler);
       return prop === 'a11y' ? false : true;
     }
   };

--- a/patches/chrome-browser-resources-settings-privacy_page-privacy_page.html.patch
+++ b/patches/chrome-browser-resources-settings-privacy_page-privacy_page.html.patch
@@ -1,0 +1,31 @@
+diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page.html b/chrome/browser/resources/settings/privacy_page/privacy_page.html
+index c938b42ff11691e4e5e915e7c4d6f36de58d82cb..48febf5e052144fcaed8fd30c62a09a0e9d21b38 100644
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page.html
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page.html
+@@ -68,9 +68,11 @@
+         <div class="settings-box first">
+           <p class="privacy-explanation">$i18nRaw{improveBrowsingExperience}</p>
+         </div>
++<if expr="_google_chrome">
+         <settings-toggle-button pref="{{prefs.alternate_error_pages.enabled}}"
+             label="$i18n{linkDoctorPref}">
+         </settings-toggle-button>
++</if>
+         <settings-toggle-button hidden="[[!pageVisibility.searchPrediction]]"
+             pref="{{prefs.search.suggest_enabled}}"
+             label="$i18n{searchSuggestPref}">
+@@ -80,12 +82,14 @@
+             label="$i18n{networkPredictionEnabled}"
+             numeric-unchecked-value="[[networkPredictionEnum_.NEVER]]">
+         </settings-toggle-button>
++<if expr="_google_chrome">
+         <settings-toggle-button id="safeBrowsingExtendedReportingControl"
+             pref="[[safeBrowsingExtendedReportingPref_]]"
+             label="$i18n{safeBrowsingEnableExtendedReporting}"
+             on-settings-boolean-control-change="onSberChange_"
+             no-set-pref>
+         </settings-toggle-button>
++</if>
+         <settings-toggle-button pref="{{prefs.safebrowsing.enabled}}"
+             label="$i18n{safeBrowsingEnableProtection}">
+         </settings-toggle-button>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/512
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
npm run test -- brave_browser_tests --filter=BraveProfilePrefsBrowserTest.*

Open chrome://settings/privacy, below items should not be shown
- Use a web service to help resolve navigation errors
- Use a prediction service to help complete searches and URLs typed in the address bar
- Automatically send some system information and page content to Google to help detect dangerous apps and sites
- Use a web service to help resolve spelling errors
<img width="986" alt="screen shot 2018-07-11 at 11 14 03 am" src="https://user-images.githubusercontent.com/4730197/42591458-975dbfcc-84fb-11e8-8469-85988020db6c.png">

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
