### PR TITLE
Apply brave version to update on Mac

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -334,6 +334,7 @@ if (is_mac) {
       "--brave_product_dir_name=" + brave_product_dir_name,
       "--brave_feed_url=" + brave_feed_url,
       "--brave_dsa_file=" + brave_dsa_file,
+      "--version=" + "$brave_version.$brave_version_patch"
     ]
 
     deps = [

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -59,6 +59,8 @@ def Main(argv):
       type='string', default=None, help='Target url for update feed')
   parser.add_option('--brave_dsa_file', dest='brave_dsa_file', action='store',
       type='string', default=None, help='Public DSA file for update')
+  parser.add_option('--version', dest='version', action='store', type='string',
+      default=None, help='The version string [major.minor.build.patch]')
   parser.add_option('--format', choices=('binary1', 'xml1', 'json'),
       default='xml1', help='Format to use when writing property list '
           '(default: %(default)s)')
@@ -97,6 +99,43 @@ def Main(argv):
 
   # Explicitly disable profiling
   plist['SUEnableSystemProfiling'] = False
+
+  version_format_for_key = {
+    'CFBundleShortVersionString': '@MAJOR@.@MINOR@.@BUILD@.@PATCH@',
+    'CFBundleVersion': '@BUILD@.@PATCH@',
+  }
+
+  def _GetVersion(version_format, values):
+    """Generates a version number according to |version_format| using the values
+    from |values|."""
+    result = version_format
+    for key in values:
+      value = values[key]
+      result = result.replace('@%s@' % key, value)
+    return result
+
+  def _AddVersionKeys(plist, version_format_for_key, version):
+    if not version:
+      return False
+
+    # Parse the given version number, that should be in MAJOR.MINOR.BUILD.PATCH
+    # format (where each value is a number). Note that str.isdigit() returns
+    # True if the string is composed only of digits (and thus match \d+ regexp).
+    groups = version.split('.')
+    if len(groups) != 4 or not all(element.isdigit() for element in groups):
+      print >>sys.stderr, 'Invalid version string specified: "%s"' % version
+      return False
+    values = dict(zip(('MAJOR', 'MINOR', 'BUILD', 'PATCH'), groups))
+
+    for key in version_format_for_key:
+      plist[key] = _GetVersion(version_format_for_key[key], values)
+
+    # Return with no error.
+    return True
+
+  # Insert the product version.
+  if not _AddVersionKeys(plist, version_format_for_key, options.version):
+    return 2
 
   # Now that all keys have been mutated, rewrite the file.
   with tempfile.NamedTemporaryFile() as temp_info_plist:


### PR DESCRIPTION
This version will be used by sparkle update to check version.

Confirmed that user agent string is not affected by this change.

Issue https://github.com/brave/brave-browser/issues/396

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
