### PR TITLE
remove self reference to fix build break

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -57,7 +57,7 @@ def get_chrome_version():
   return version.split('+')[1]
 
 def get_brave_version():
-  return 'v' + self.get_raw_version()
+  return 'v' + get_raw_version()
 
 def get_raw_version():
   return os.environ.get('npm_config_brave_version') or brave_browser_package()['version']


### PR DESCRIPTION
Fixes break reported as: 

```
  File "/Users/garrettr/brave/src/brave/script/lib/config.py", line 60, in get_brave_version
    return 'v' + self.get_raw_version()
NameError: global name 'self' is not defined
```