### PR TITLE
Bump version for internal release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-core",
-  "version": "0.50.8",
+  "version": "0.50.10",
   "description": "Brave Core is a set of changes, APIs, and scripts used for customizing Chromium to make Brave.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bump version for internal release. Skipping 0.50.9 because this needs to match brave-browser until we can sort out a bug in the linux packaging.