### PR TITLE
Apply brave version to chrome/VERSION

### DIFF
--- a/browser/version_info_values.cc
+++ b/browser/version_info_values.cc
@@ -6,6 +6,7 @@
 
 namespace version_info {
 std::string GetBraveVersionNumber() {
-  return std::string(BRAVE_BROWSER_VERSION) + "  Chromium: " + PRODUCT_VERSION;
+  return std::string(BRAVE_BROWSER_VERSION) +
+      "  Chromium: " + CHROMIUM_VERSION_STRING;
 }
 }  // namespace version_info

--- a/chromium_src/components/version_info/version_info.cc
+++ b/chromium_src/components/version_info/version_info.cc
@@ -3,10 +3,16 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #define GetChannelString GetChannelString_ChromiumImpl
+#define GetProductNameAndVersionForUserAgent GetProductNameAndVersionForUserAgent_Unused
 #include "../../../../components/version_info/version_info.cc"
 #undef GetChannelString
+#undef GetProductNameAndVersionForUserAgent
 
 namespace version_info {
+
+std::string GetProductNameAndVersionForUserAgent() {
+  return std::string("Chrome/") + CHROMIUM_VERSION_STRING;
+}
 
 // We use |nightly| instead of |canary|.
 std::string GetChannelString(Channel channel) {

--- a/chromium_src/components/version_info/version_info_values.h
+++ b/chromium_src/components/version_info/version_info_values.h
@@ -1,0 +1,4 @@
+#include "gen/components/version_info/version_info_values.h"
+
+#define CHROMIUM_VERSION 67,0,3396,103
+#define CHROMIUM_VERSION_STRING "67.0.3396.103"

--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,0 +1,11 @@
+diff --git a/chrome/VERSION b/chrome/VERSION
+index 3c03c34dbf7ecdf3673cb796c44c769bc14b1dba..43f26ebad722c3ea1e62f4280e00b7531efeb52f 100644
+--- a/chrome/VERSION
++++ b/chrome/VERSION
+@@ -1,4 +1,4 @@
+ MAJOR=67
+ MINOR=0
+-BUILD=3396
+-PATCH=103
++BUILD=50
++PATCH=10


### PR DESCRIPTION
Set brave version to chrome/VERSION.

Using chromium and brave version both internally can case version inconsistency and  make windows update logic complex.
To simplify use brave version and only visible chromium version in some places such as about/version and user agent.

https://github.com/brave/brave-core/pull/249 should be reverted for using this.

Close https://github.com/brave/brave-browser/issues/553

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
