### PR TITLE
Fix darwin dmg name in upload script

### DIFF
--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -32,5 +32,20 @@ class TestGetDraft(unittest.TestCase):
     upload.get_draft(self.repo, 'new')
     self.assertEquals(upload.get_draft(self.repo, 'test'), None)
 
+class TestYieldBravePackages(unittest.TestCase):
+  def setUp(self):
+    self.yield_pkgs_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_yield_pkgs')
+
+  def test_only_returns_dev_darwin_package(self):
+    upload.PLATFORM = 'darwin'
+    pkgs = list(upload.yield_brave_packages(os.path.join(self.yield_pkgs_dir, upload.PLATFORM), 'dev', '0.50.8'))
+    self.assertEquals(pkgs, ['Brave-Browser-Dev.dmg'])
+
+  def test_only_returns_dev_linux_packages(self):
+    upload.PLATFORM = 'linux'
+    pkgs = list(upload.yield_brave_packages(os.path.join(self.yield_pkgs_dir, upload.PLATFORM), 'dev', '0.50.8'))
+    self.assertEquals(sorted(pkgs), sorted(['brave-browser-dev-0.50.8-1.x86_64.rpm', 'brave-browser-dev_0.50.8_amd64.deb']))
+
+
 if __name__ == '__main__':
   print unittest.main()

--- a/script/test/test_yield_pkgs/darwin/Brave-Browser-Dev.dmg
+++ b/script/test/test_yield_pkgs/darwin/Brave-Browser-Dev.dmg
@@ -1,0 +1,1 @@
+dev darwin dmg

--- a/script/test/test_yield_pkgs/darwin/Brave-Browser-Release.dmg
+++ b/script/test/test_yield_pkgs/darwin/Brave-Browser-Release.dmg
@@ -1,0 +1,1 @@
+release darwin dmg

--- a/script/test/test_yield_pkgs/linux/brave-browser-dev-0.50.8-1.x86_64.rpm
+++ b/script/test/test_yield_pkgs/linux/brave-browser-dev-0.50.8-1.x86_64.rpm
@@ -1,0 +1,1 @@
+mock linux x64 rpm

--- a/script/test/test_yield_pkgs/linux/brave-browser-dev_0.50.8_amd64.deb
+++ b/script/test/test_yield_pkgs/linux/brave-browser-dev_0.50.8_amd64.deb
@@ -1,0 +1,1 @@
+mock linux x64 rpm

--- a/script/test/test_yield_pkgs/linux/brave-browser-release-0.50.8-1.x86_64.rpm
+++ b/script/test/test_yield_pkgs/linux/brave-browser-release-0.50.8-1.x86_64.rpm
@@ -1,0 +1,1 @@
+mock linux x64 rpm

--- a/script/test/test_yield_pkgs/linux/brave-browser-release_0.50.8_amd64.deb
+++ b/script/test/test_yield_pkgs/linux/brave-browser-release_0.50.8_amd64.deb
@@ -1,0 +1,1 @@
+mock linux x64 rpm

--- a/script/upload.py
+++ b/script/upload.py
@@ -56,8 +56,10 @@ def main():
   chromedriver = get_zip_name('chromedriver', get_chromedriver_version())
   upload_brave(repo, release, os.path.join(dist_dir(), chromedriver), force=args.force)
 
+  pkgs = yield_brave_packages(output_dir(), release_channel(), get_raw_version())
+
   if PLATFORM == 'darwin':
-    for pkg in yield_brave_packages():
+    for pkg in pkgs:
       upload_brave(repo, release, os.path.join(output_dir(), pkg), force=args.force)
   elif PLATFORM == 'win32':
     if get_target_arch() == 'x64':
@@ -68,7 +70,7 @@ def main():
           'brave_installer.exe'), 'brave_installer-ia32.exe', force=args.force)
   else:
     if get_target_arch() == 'x64':
-      for pkg in yield_brave_packages():
+      for pkg in pkgs:
         upload_brave(repo, release, os.path.join(output_dir(), pkg), force=args.force)
     else:
       upload_brave(repo, release, os.path.join(output_dir(), 'brave-i386.rpm'), force=args.force)
@@ -86,14 +88,12 @@ def main():
   print('[INFO] Finished upload')
 
 
-def yield_brave_packages():
+def yield_brave_packages(dir, channel, version):
   # NOTE: mbacchi - before official release this must handle stable release channel which is ""
-  channel = release_channel()
-  version = get_raw_version()
-  for _, _, files in os.walk(output_dir()):
+  for _, _, files in os.walk(dir):
     for file in files:
       if PLATFORM == 'darwin':
-        if re.match(r'Brave-Browser-' + get_channel_display_name(channel) + r'.*\.dmg$'):
+        if re.match(r'Brave-Browser-' + channel.capitalize() + r'.*\.dmg$', file):
           yield file
       elif PLATFORM == 'linux':
         if re.match(r'brave-browser-' + channel + '_' + version + r'.*\.deb$', file) \


### PR DESCRIPTION
Fix darwin dmg name in upload script
    
This resolves brave/brave-browser#565 by passing the filename and changing the match pattern to:
> 'Brave-Browser-' + channel.capitalize() + r'.*\.dmg$'

Also adds tests for yield_brave_packages in scripts/upload.py

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

https://staging.ci.brave.com/view/all/job/brave-browser-build-darwin-upload/15/console

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions
