### PR TITLE
Temporary (maybe?) modification of dev channel package names for Linux

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -96,6 +96,8 @@ def yield_brave_packages(dir, channel, version):
         if re.match(r'Brave-Browser-' + channel.capitalize() + r'.*\.dmg$', file):
           yield file
       elif PLATFORM == 'linux':
+        if channel == 'dev':
+           channel = 'unstable'
         if re.match(r'brave-browser-' + channel + '_' + version + r'.*\.deb$', file) \
           or re.match(r'brave-browser-' + channel + '-' + version + r'.*\.rpm$', file):
           yield file


### PR DESCRIPTION
Other channels have the name in the package name, but dev uses 'unstable'.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
