### PR TITLE
Fix platform identification in Brave stats updater

### DIFF
--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -45,7 +45,7 @@ std::string GetPlatformIdentifier() {
   std::string os_type = version_info::GetOSType();
   if (os_type == "Linux")
     return kPlatformIdentifierLinux;
-  else if (os_type == "Mac")
+  else if (os_type == "Mac OS X")
     return kPlatformIdentifierMac;
   else if (os_type == "Windows") {
     if (base::SysInfo::OperatingSystemArchitecture() == "x86")

--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -21,11 +21,6 @@
 
 const char kBaseUpdateURL[] = "https://laptop-updates.brave.com/1/usage/brave-core";
 
-const char kPlatformIdentifierLinux[] = "linux-bc";
-const char kPlatformIdentifierMac[] = "osx-bc";
-const char kPlatformIdentifierWinIA32[] = "winia32-bc";
-const char kPlatformIdentifierWinx64[] = "winx64-bc";
-
 // Ping the update server once an hour.
 const int kUpdateServerPingFrequency = 60 * 60;
 
@@ -42,20 +37,18 @@ std::string GetChannelName() {
 }
 
 std::string GetPlatformIdentifier() {
-  std::string os_type = version_info::GetOSType();
-  if (os_type == "Linux")
-    return kPlatformIdentifierLinux;
-  else if (os_type == "Mac OS X")
-    return kPlatformIdentifierMac;
-  else if (os_type == "Windows") {
-    if (base::SysInfo::OperatingSystemArchitecture() == "x86")
-      return kPlatformIdentifierWinIA32;
-    else
-      return kPlatformIdentifierWinx64;
-  } else {
-    NOTREACHED();
-    return std::string();
-  }
+#if defined(OS_WIN)
+  if (base::SysInfo::OperatingSystemArchitecture() == "x86")
+    return "winia32-bc";
+  else
+    return "winx64-bc";
+#elif defined(OS_MACOSX)
+  return "osx-bc";
+#elif defined(OS_LINUX)
+  return "linux-bc";
+#else
+  return std::string();
+#endif
 }
 
 GURL GetUpdateURL(const brave::BraveStatsUpdaterParams& stats_updater_params) {


### PR DESCRIPTION
This is throwing an exception in debug builds on Mac.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
