### PR TITLE
Remove 'unstable' internal package name from debian

### DIFF
--- a/patches/chrome-installer-linux-BUILD.gn.patch
+++ b/patches/chrome-installer-linux-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/BUILD.gn b/chrome/installer/linux/BUILD.gn
-index fbabd6c3414f5cb69cf4c7ab6ef5f957cb391376..b9a82deb60d40228dbe67bf5d91c88888d44eda6 100644
+index fbabd6c3414f5cb69cf4c7ab6ef5f957cb391376..5c42a601d6b101e3caf43203568fb42f629f6411 100644
 --- a/chrome/installer/linux/BUILD.gn
 +++ b/chrome/installer/linux/BUILD.gn
 @@ -25,11 +25,10 @@ declare_args() {
@@ -36,7 +36,17 @@ index fbabd6c3414f5cb69cf4c7ab6ef5f957cb391376..b9a82deb60d40228dbe67bf5d91c8888
      ]
    }
  
-@@ -524,3 +523,6 @@ linux_package("beta") {
+@@ -386,6 +385,9 @@ group("installer_deps") {
+ template("linux_package") {
+   assert(defined(invoker.channel))
+   channel = invoker.channel
++  if (channel == "unstable" ) {
++    channel = "dev"
++  }
+ 
+   if (current_cpu == "x86") {
+     # The shell scripts use "ia32" instead of "x86".
+@@ -524,3 +526,6 @@ linux_package("beta") {
  linux_package("unstable") {
    channel = "unstable"
  }

--- a/patches/chrome-installer-linux-debian-build.sh.patch
+++ b/patches/chrome-installer-linux-debian-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/debian/build.sh b/chrome/installer/linux/debian/build.sh
-index 8234cafbb5f95ec608dfa5eff3d0098def1d225a..f1d5799806fc733b875e62cfd2c97662362a3ce7 100755
+index 8234cafbb5f95ec608dfa5eff3d0098def1d225a..8ac9c94863023bb0bfbe087218650f0b9893d6c4 100755
 --- a/chrome/installer/linux/debian/build.sh
 +++ b/chrome/installer/linux/debian/build.sh
 @@ -21,7 +21,7 @@ gen_changelog() {
@@ -38,8 +38,12 @@ index 8234cafbb5f95ec608dfa5eff3d0098def1d225a..f1d5799806fc733b875e62cfd2c97662
        grep '^ Depends: ' | sed 's/^ Depends: //' | sed 's/, /\n/g' | \
        LANG=C sort > "${ACTUAL_DEPENDS}"
    BAD_DIFF=0
-@@ -159,6 +159,10 @@ verify_channel() {
-       CHANNEL=unstable
+@@ -156,9 +156,13 @@ verify_channel() {
+       RELEASENOTES="http://googlechromereleases.blogspot.com/search/label/Stable%20updates"
+       ;;
+     unstable|dev|alpha )
+-      CHANNEL=unstable
++      CHANNEL=dev
        RELEASENOTES="http://googlechromereleases.blogspot.com/search/label/Dev%20updates"
        ;;
 +    nightly )
@@ -49,11 +53,17 @@ index 8234cafbb5f95ec608dfa5eff3d0098def1d225a..f1d5799806fc733b875e62cfd2c97662
      testing|beta )
        CHANNEL=beta
        RELEASENOTES="http://googlechromereleases.blogspot.com/search/label/Beta%20updates"
-@@ -259,6 +263,11 @@ fi
+@@ -259,6 +263,17 @@ fi
  eval $(sed -e "s/^\([^=]\+\)=\(.*\)$/export \1='\2'/" \
    "${BUILDDIR}/installer/theme/BRANDING")
  
 +PACKAGEANDCHANNEL="${PACKAGE}-${CHANNEL}"
++if [ "$CHANNEL" = "unstable" ]; then
++  PACKAGEANDCHANNEL="${PACKAGE}-dev"
++fi
++if [ "$CHANNEL" = "dev" ]; then
++  PACKAGEANDCHANNEL="${PACKAGE}-dev"
++fi
 +if [ "$CHANNEL" = "stable" ]; then
 +  PACKAGEANDCHANNEL="${PACKAGE}"
 +fi

--- a/patches/chrome-installer-linux-rpm-build.sh.patch
+++ b/patches/chrome-installer-linux-rpm-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/rpm/build.sh b/chrome/installer/linux/rpm/build.sh
-index 261faeaf26f34f2e89229579ae7933e23e4299e6..f4bde0a98bd7d6fa4e6c6a4f1ee63e6132b0e997 100755
+index 261faeaf26f34f2e89229579ae7933e23e4299e6..5a62bbb79e76917577b961134f23a860cf917ad9 100755
 --- a/chrome/installer/linux/rpm/build.sh
 +++ b/chrome/installer/linux/rpm/build.sh
 @@ -15,8 +15,9 @@ gen_spec() {
@@ -25,13 +25,15 @@ index 261faeaf26f34f2e89229579ae7933e23e4299e6..f4bde0a98bd7d6fa4e6c6a4f1ee63e61
    mv "$RPMBUILD_DIR/RPMS/$ARCHITECTURE/${PKGNAME}.${ARCHITECTURE}.rpm" \
       "${OUTPUTDIR}"
    # Make sure the package is world-readable, otherwise it causes problems when
-@@ -146,6 +150,9 @@ verify_channel() {
-     unstable|dev|alpha )
-       CHANNEL=unstable
+@@ -144,7 +148,10 @@ verify_channel() {
+       CHANNEL=stable
        ;;
+     unstable|dev|alpha )
+-      CHANNEL=unstable
++      CHANNEL=dev
++      ;;
 +    nightly )
 +      CHANNEL=nightly
-+      ;;
+       ;;
      testing|beta )
        CHANNEL=beta
-       ;;


### PR DESCRIPTION
This changes the apt repository from 'brave-browser-unstable'
to 'brave-browser-dev' as well as paths in the .deb which
had retained the incorrect channel.

Fixes https://github.com/brave/brave-browser/issues/596

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
