### PR TITLE
Add support for other ad-block types

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/ad-block": "https://github.com/brave/ad-block.git@75272a1aa83c66de6547d973f9adff776abf38ae",
+  "vendor/ad-block": "https://github.com/brave/ad-block.git@67a8a19121f40d41e75468b2c26d6bace437ae4f",
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@bb6013ff4d0a0191ba93158f2f3b30e7fb18c5f6",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@f86b0a5752545274e32c0dbb654c3592cc131c8a",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@635780bbedff137a6a83ec23871944e22069de5b",

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -20,6 +20,79 @@
 #include "brave/components/brave_shields/browser/dat_file_util.h"
 #include "brave/vendor/ad-block/ad_block_client.h"
 
+
+namespace {
+
+FilterOption ResourceTypeToFilterOption(content::ResourceType resource_type) {
+  FilterOption filter_option = FONoFilterOption;
+  switch(resource_type) {
+    // top level page
+    case content::RESOURCE_TYPE_MAIN_FRAME:
+      filter_option = FODocument;
+      break;
+    // frame or iframe
+    case content::RESOURCE_TYPE_SUB_FRAME:
+      filter_option = FOSubdocument;
+      break;
+    // a CSS stylesheet
+    case content::RESOURCE_TYPE_STYLESHEET:
+      filter_option = FOStylesheet;
+      break;
+    // an external script
+    case content::RESOURCE_TYPE_SCRIPT:
+      filter_option = FOScript;
+      break;
+    // an image (jpg/gif/png/etc)
+    case content::RESOURCE_TYPE_IMAGE:
+      filter_option = FOImage;
+      break;
+    // a font
+    case content::RESOURCE_TYPE_FONT_RESOURCE:
+      filter_option = FOFont;
+      break;
+    // an "other" subresource.
+    case content::RESOURCE_TYPE_SUB_RESOURCE:
+      filter_option = FOOther;
+      break;
+    // an object (or embed) tag for a plugin.
+    case content::RESOURCE_TYPE_OBJECT:
+      filter_option = FOObject;
+      break;
+    // a media resource.
+    case content::RESOURCE_TYPE_MEDIA:
+      filter_option = FOMedia;
+      break;
+    // a XMLHttpRequest
+    case content::RESOURCE_TYPE_XHR:
+      filter_option = FOXmlHttpRequest;
+      break;
+    // a ping request for <a ping>/sendBeacon.
+    case content::RESOURCE_TYPE_PING:
+      filter_option = FOPing;
+      break;
+    // the main resource of a dedicated
+    case content::RESOURCE_TYPE_WORKER:
+    // the main resource of a shared worker.
+    case content::RESOURCE_TYPE_SHARED_WORKER:
+    // an explicitly requested prefetch
+    case content::RESOURCE_TYPE_PREFETCH:
+    // a favicon
+    case content::RESOURCE_TYPE_FAVICON:
+    // the main resource of a service worker.
+    case content::RESOURCE_TYPE_SERVICE_WORKER:
+    // a report of Content Security Policy
+    case content::RESOURCE_TYPE_CSP_REPORT:
+    // a resource that a plugin requested.
+    case content::RESOURCE_TYPE_PLUGIN_RESOURCE:
+    case content::RESOURCE_TYPE_LAST_TYPE:
+    default:
+      break;
+  }
+  return filter_option;
+}
+
+}  // namespace
+
 namespace brave_shields {
 
 AdBlockBaseService::AdBlockBaseService()
@@ -40,16 +113,7 @@ bool AdBlockBaseService::ShouldStartRequest(const GURL& url,
     content::ResourceType resource_type,
     const std::string& tab_host) {
 
-  FilterOption current_option = FONoFilterOption;
-  content::ResourceType internalResource = (content::ResourceType)resource_type;
-  if (content::RESOURCE_TYPE_STYLESHEET == internalResource) {
-    current_option = FOStylesheet;
-  } else if (content::RESOURCE_TYPE_IMAGE == internalResource) {
-    current_option = FOImage;
-  } else if (content::RESOURCE_TYPE_SCRIPT == internalResource) {
-    current_option = FOScript;
-  }
-
+  FilterOption current_option = ResourceTypeToFilterOption(resource_type);
   if (ad_block_client_->matches(url.spec().c_str(),
         current_option,
         tab_host.c_str())) {


### PR DESCRIPTION
Fix https://github.com/brave/brave-core/commit/6675f514c5688661ead73aaaaac4722f6a32a7f6

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
  - Tests are in the ad-block lib changeset
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
