### PR TITLE
Add test for string used by installer

### DIFF
--- a/browser/brave_resources_util_unittest.cc
+++ b/browser/brave_resources_util_unittest.cc
@@ -11,6 +11,12 @@
 #include "build/build_config.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
+#if defined(OS_WIN)
+#include "brave/common/resource_bundle_helper.h"
+#include "chrome/grit/chromium_strings.h"
+#include "ui/base/l10n/l10n_util.h"
+#endif
+
 TEST(BraveResourcesUtil, CheckIds) {
   const struct {
     const char* name;
@@ -26,3 +32,24 @@ TEST(BraveResourcesUtil, CheckIds) {
   for (size_t i = 0; i < arraysize(kCases); ++i)
     EXPECT_EQ(kCases[i].id, ResourcesUtil::GetThemeResourceId(kCases[i].name));
 }
+
+#if defined(OS_WIN)
+TEST(BraveResourcesWinTest, CheckStringsForInstaller) {
+  // Test whether strings for installer are filled.
+  // This test is added because these strings are initially empty and filled
+  // with brave's one.
+  brave::InitializeResourceBundle();
+
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_SXS_SHORTCUT_NAME).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_SHORTCUT_NAME_BETA).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_SHORTCUT_NAME_DEV).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_APP_SHORTCUTS_SUBDIR_NAME_BETA).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_APP_SHORTCUTS_SUBDIR_NAME_DEV).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_INBOUND_MDNS_RULE_NAME_BETA).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_INBOUND_MDNS_RULE_NAME_CANARY).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_INBOUND_MDNS_RULE_NAME_DEV).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_INBOUND_MDNS_RULE_DESCRIPTION_BETA).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_INBOUND_MDNS_RULE_DESCRIPTION_CANARY).empty());
+  EXPECT_FALSE(l10n_util::GetStringUTF16(IDS_INBOUND_MDNS_RULE_DESCRIPTION_DEV).empty());
+}
+#endif


### PR DESCRIPTION
This test is added because these strings are initially empty and filled
with brave's one.

Close https://github.com/brave/brave-browser/issues/628

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`yarn test brave_unit_tests --filter=BraveResourcesWinTest.CheckStringsForInstaller`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
