### PR TITLE
Fix tests in debug mode

### DIFF
--- a/patches/chrome-browser-plugins-chrome_plugin_service_filter.cc.patch
+++ b/patches/chrome-browser-plugins-chrome_plugin_service_filter.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/plugins/chrome_plugin_service_filter.cc b/chrome/browser/plugins/chrome_plugin_service_filter.cc
+index e47d5ea63e5a690e2133e24ec37141510f41f7dc..0c6a307d32efdab8b9afa67da91ee23f5a943083 100644
+--- a/chrome/browser/plugins/chrome_plugin_service_filter.cc
++++ b/chrome/browser/plugins/chrome_plugin_service_filter.cc
+@@ -42,7 +42,7 @@ class ProfileContentSettingObserver : public content_settings::Observer {
+                                const ContentSettingsPattern& secondary_pattern,
+                                ContentSettingsType content_type,
+                                std::string resource_identifier) override {
+-    if (content_type != CONTENT_SETTINGS_TYPE_PLUGINS)
++    if (content_type != CONTENT_SETTINGS_TYPE_PLUGINS || resource_identifier.length() != 0)
+       return;
+ 
+     HostContentSettingsMap* map =

--- a/renderer/brave_content_settings_observer_browsertest.cc
+++ b/renderer/brave_content_settings_observer_browsertest.cc
@@ -85,17 +85,13 @@ class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
       return iframe_pattern_;
     }
 
-    const ContentSettingsPattern& empty_pattern() {
-      return empty_pattern_;
-    }
-
     HostContentSettingsMap * content_settings() {
       return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
     }
 
     void BlockReferrers() {
       content_settings()->SetContentSettingCustomScope(top_level_page_pattern(),
-          empty_pattern(), CONTENT_SETTINGS_TYPE_PLUGINS,
+          ContentSettingsPattern::Wildcard(), CONTENT_SETTINGS_TYPE_PLUGINS,
           brave_shields::kReferrers, CONTENT_SETTING_BLOCK);
       ContentSettingsForOneType settings;
       content_settings()->GetSettingsForOneType(
@@ -269,7 +265,6 @@ class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
     ContentSettingsPattern top_level_page_pattern_;
     ContentSettingsPattern first_party_pattern_;
     ContentSettingsPattern iframe_pattern_;
-    ContentSettingsPattern empty_pattern_;
     std::unique_ptr<ChromeContentClient> content_client_;
     std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
 


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/572

2 different sets of failing tests were fixed.

One was an invalid content-setting exception which seems to have always been wrong for Debug and probably predates Debug builds.

The other one fixes a class meant only for Flash settings (when no resource identifier is set).  But since we use plugin content-settings for our custom ones, it caused a problem that needed an extra check.
I didn't check but this seems like it also probably predates Debug
tests.  This one needed a patch because the class is inline and we can't
use chromium_src override from what I can figure out.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
