### PR TITLE
Modify build settings to allow sccache support on Windows

### DIFF
--- a/patches/build-config-clang-BUILD.gn.patch
+++ b/patches/build-config-clang-BUILD.gn.patch
@@ -1,0 +1,15 @@
+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+index 11dba3580ad216e6ebd209a333f39f6307bd2baf..fc72f423f60306081fa77fc80f1ed2bb30ec8f21 100644
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -58,6 +58,10 @@ config("find_bad_constructs") {
+         "check-ipc",
+       ]
+     }
++
++    if (host_os == "win" && !is_official_build) {
++      cflags = []
++    }
+   }
+ }
+ 

--- a/patches/build-config-pch.gni.patch
+++ b/patches/build-config-pch.gni.patch
@@ -1,0 +1,12 @@
+diff --git a/build/config/pch.gni b/build/config/pch.gni
+index 93bd2fedc38090e0604e974bbeed3a1e1ebbd29c..2e3bc92261b1905c93f15405fda82c8cb1f723c1 100644
+--- a/build/config/pch.gni
++++ b/build/config/pch.gni
+@@ -9,4 +9,7 @@ declare_args() {
+   # but for distributed build system uses (like goma) or when
+   # doing official builds.
+   enable_precompiled_headers = !is_official_build && !use_goma
++  if (!is_official_build && host_os == "win") {
++    enable_precompiled_headers = false
++  }
+ }

--- a/patches/build-config-win-BUILD.gn.patch
+++ b/patches/build-config-win-BUILD.gn.patch
@@ -1,0 +1,15 @@
+diff --git a/build/config/win/BUILD.gn b/build/config/win/BUILD.gn
+index ce8128b4092272df18ad748c19812a1646936af8..60865407f0cc1d1cbe7f44dae979149024dc9643 100644
+--- a/build/config/win/BUILD.gn
++++ b/build/config/win/BUILD.gn
+@@ -103,7 +103,9 @@ config("compiler") {
+     # lld and get more deterministic compiler output in return.
+     # In LTO builds, the compiler doesn't write .obj files containing mtimes,
+     # so /Brepro is ignored there.
+-    cflags += [ "/Brepro" ]
++    if (is_official_build) {
++      cflags += [ "/Brepro" ]
++    }
+   }
+ 
+   if (!is_debug && !is_component_build) {


### PR DESCRIPTION
This PR modifies the build settings to allow using sccache on Windows. Three changes were required:

1. Don't pass the `-XClang find-bad-constructs` arg, as sccache incorrectly interprets the argument as an additional source file on Windows.
1. Don't pass `/Brepro`, as it causes the following error when compiling with sccache enabled: `warning: argument unused during compilation: '-mno-incremental-linker-compatible'`.
1. Don't pass `/Fp`, as this setting seems to conflict with sccache. This was accomplished by disabling precompiled headers on Windows for non-official builds.

These modifications are only made for non-official Windows builds for now.
---
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
