### PR TITLE
Fix linux debug build

### DIFF
--- a/build/linux/channels.gni
+++ b/build/linux/channels.gni
@@ -18,6 +18,10 @@ if (brave_channel == "") {
   linux_channel = linux_channel_dev
 } else if (brave_channel == "nightly") {
   linux_channel = brave_linux_channel_nightly
+} else if (brave_channel == "development") {
+  # To avoid gn error, just fills with stable.
+  # This doesn't have meaning in debug build.
+  linux_channel = linux_channel_stable
 } else {
   assert(false, "Not supported channel name: $brave_channel")
 }


### PR DESCRIPTION
Need to consider `development` channel name in channels.gni just to avoid gn error because
we started to set it as a channel name in debug build from https://github.com/brave/brave-browser/pull/653.
This change doesn't affect anything because we don't make debug build package.

Close https://github.com/brave/brave-browser/issues/654

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Try debug build in linux

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
