### PR TITLE
Issue #585: Passwords should be autofilled only on user interaction

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -20,6 +20,7 @@
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_paths_internal.h"
 #include "chrome/common/chrome_switches.h"
+#include "components/password_manager/core/common/password_manager_features.h"
 #include "ui/base/ui_base_features.h"
 
 #if !defined(CHROME_MULTIPLE_DLL_BROWSER)
@@ -116,7 +117,8 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
 
   std::stringstream enabled_features;
   enabled_features << features::kEnableEmojiContextMenu.name
-    << "," << features::kDesktopPWAWindowing.name;
+    << "," << features::kDesktopPWAWindowing.name
+    << "," << password_manager::features::kFillOnAccountSelect.name;
   command_line.AppendSwitchASCII(switches::kEnableFeatures,
       enabled_features.str());
   return ChromeMainDelegate::BasicStartupComplete(exit_code);

--- a/browser/brave_features_browsertest.cc
+++ b/browser/brave_features_browsertest.cc
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_list.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/password_manager/core/common/password_manager_features.h"
+
+using BraveFeaturesBrowserTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, AutoFillPasswordDefault) {
+  EXPECT_TRUE(
+    base::FeatureList::IsEnabled(password_manager::features::kFillOnAccountSelect));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -143,6 +143,7 @@ test("brave_browser_tests") {
     "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_containertest.cc",
     "//brave/browser/brave_content_browser_client_browsertest.cc",
+    "//brave/browser/brave_features_browsertest.cc",
     "//brave/browser/brave_profile_prefs_browsertest.cc",
     "//brave/browser/brave_resources_browsertest.cc",
     "//brave/browser/extensions/api/brave_shields_api_browsertest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/585

## Test Plan

1. Go to github.com
2. Enter your credentials
3. Save your credentials to the password manager
4. Logout and verify that the credentials are not auto-populated
5. Click on password and verify if you see the `Fill password for:` dialog