### PR TITLE
Fix linux build error

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -101,7 +101,6 @@ source_set("browser") {
 
   deps = [
     "//brave/components/brave_shields/browser:brave_shields",
-    "//brave/components/omnibox/browser:brave_autocomplete",
     "extensions",
     "net",
   ]

--- a/chromium_src/chrome/common/channel_info_posix.cc
+++ b/chromium_src/chrome/common/channel_info_posix.cc
@@ -9,10 +9,6 @@
 #include "build/build_config.h"
 #include "components/version_info/version_info.h"
 
-// Including here instead of build config because
-// our brave/common BUILD config still gets linking errors.
-#include "brave/common/brave_channel_info_posix.cc"
-
 namespace chrome {
 
 std::string GetChannelName() {

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -1,3 +1,16 @@
+source_set("channel_info") {
+  if (is_linux) {
+    sources = [
+      "brave_channel_info_posix.cc",
+      "brave_channel_info_posix.h",
+    ]
+
+    configs += [
+      "//brave/build/linux:linux_channel_names",
+    ]
+  }
+}
+
 source_set("common") {
   sources = [
     "brave_paths.cc",
@@ -44,10 +57,6 @@ source_set("common") {
     sources += [
       "importer/brave_importer_utils_linux.cc",
       "importer/chrome_importer_utils_linux.cc",
-    ]
-
-    configs += [
-      "//brave/build/linux:linux_channel_names",
     ]
   }
 

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -1,4 +1,4 @@
-source_set("brave_autocomplete") {
+source_set("browser") {
   sources = [
     "brave_autocomplete_controller.cc",
     "brave_autocomplete_controller.h",
@@ -7,9 +7,10 @@ source_set("brave_autocomplete") {
     "topsites_provider.h",
   ]
 
+  # Don't make this target depends on chrome layer.
+  # This target is compiled together with //components/omnibox/browser static lib.
   deps = [
-  ]
-  public_deps = [
-    "//chrome/common",
+     "//skia",
+     "//third_party/metrics_proto",
   ]
 }

--- a/patches/chrome-common-BUILD.gn.patch
+++ b/patches/chrome-common-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/common/BUILD.gn b/chrome/common/BUILD.gn
+index 9a21e268447a0ea984101132329073dca486f6ad..a916c8e70e8f19a52f2a0993fc78712f8cb15778 100644
+--- a/chrome/common/BUILD.gn
++++ b/chrome/common/BUILD.gn
+@@ -77,6 +77,7 @@ source_set("channel_info") {
+   if (is_android) {
+     public_deps += [ "//components/version_info/android:channel_getter" ]
+   }
++  if (brave_chromium_build) { deps = [ "//brave/common:channel_info" ] }
+ }
+ 
+ source_set("ini_parser") {

--- a/patches/components-omnibox-browser-BUILD.gn.patch
+++ b/patches/components-omnibox-browser-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/omnibox/browser/BUILD.gn b/components/omnibox/browser/BUILD.gn
+index c06139016ea7e4228c7442f4a1bd0ce0fc7c79bc..3b45fd207ba726dd6f1a23ac3992c83f6cf188e7 100644
+--- a/components/omnibox/browser/BUILD.gn
++++ b/components/omnibox/browser/BUILD.gn
+@@ -194,6 +194,7 @@ static_library("browser") {
+     "//ui/gfx",
+     "//url",
+   ]
++  if (brave_chromium_build) {  deps += [ "//brave/components/omnibox/browser" ] }
+ 
+   if ((!is_android || enable_vr) && !is_ios) {
+     sources += get_target_outputs(":omnibox_vector_icons")


### PR DESCRIPTION
This build error came from `vr_common` target.
In C69, it is changed from static lib to shared lib and it is only built on linux for now.

Close https://github.com/brave/brave-browser/issues/671

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
