### PR TITLE
Restrict target list that can depend on brave/components/omnibox/browser

### DIFF
--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -1,4 +1,8 @@
 source_set("browser") {
+  # Only //components/omnibox/browser target can depend on this target
+  # because this target expands //components/omnibox/browser implementation.
+  visibility = [ "//components/omnibox/browser" ]
+
   sources = [
     "brave_autocomplete_controller.cc",
     "brave_autocomplete_controller.h",
@@ -7,8 +11,6 @@ source_set("browser") {
     "topsites_provider.h",
   ]
 
-  # Don't make this target depends on chrome layer.
-  # This target is compiled together with //components/omnibox/browser static lib.
   deps = [
      "//skia",
      "//third_party/metrics_proto",


### PR DESCRIPTION
By using visibility gn variable, explicitly restrict target list
that can depend on //brave/components/omnibox/browser.

Issue https://github.com/brave/brave-browser/issues/671

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
