### PR TITLE
Support alternate private search engine provider

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -3,6 +3,10 @@ import("//build/config/features.gni")
 
 source_set("browser_process") {
   sources = [
+    "alternate_private_search_engine_controller.cc",
+    "alternate_private_search_engine_controller.h",
+    "alternate_private_search_engine_util.cc",
+    "alternate_private_search_engine_util.h",
     "autocomplete/brave_autocomplete_scheme_classifier.cc",
     "autocomplete/brave_autocomplete_scheme_classifier.h",
     "brave_browser_main_extra_parts.cc",
@@ -44,6 +48,8 @@ source_set("browser_process") {
     "mac/sparkle_glue.mm",
     "mac/sparkle_glue.h",
     "mac/su_updater.h",
+    "profile_creation_monitor.cc",
+    "profile_creation_monitor.h",
     "update_util.cc",
     "update_util.h",
 
@@ -57,6 +63,7 @@ source_set("browser_process") {
     "//brave/common",
     "//components/component_updater",
     "//components/safe_browsing/common:safe_browsing_prefs",
+    "//components/search_engines",
     "//components/spellcheck/browser",
     "//content/public/browser",
     "//brave/chromium_src:browser",

--- a/browser/alternate_private_search_engine_browsertest.cc
+++ b/browser/alternate_private_search_engine_browsertest.cc
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/strings/utf_string_conversions.h"
+#include "brave/browser/alternate_private_search_engine_util.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/search_engines/template_url_service.h"
+#include "components/search_engines/template_url_service_observer.h"
+
+using AlternatePrivateSearchEngineTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(AlternatePrivateSearchEngineTest, PrefTest) {
+  Profile* profile = browser()->profile();
+  Profile* incognito_profile = profile->GetOffTheRecordProfile();
+
+  auto* service = TemplateURLServiceFactory::GetForProfile(profile);
+  auto* incognito_service =
+      TemplateURLServiceFactory::GetForProfile(incognito_profile);
+
+  // Test pref is initially disabled.
+  EXPECT_FALSE(brave::UseAlternatePrivateSearchEngineEnabled(profile));
+
+  // Both mode should use same search engine if alternate pref is disabled.
+  base::string16 normal_search_engine =
+      service->GetDefaultSearchProvider()->data().short_name();
+  EXPECT_EQ(service->GetDefaultSearchProvider()->data().short_name(),
+            incognito_service->GetDefaultSearchProvider()->data().short_name());
+
+  // Toggle pref and check incognito_service uses duckduckgo search engine and
+  // normal mode service uses existing one.
+  brave::ToggleUseAlternatePrivateSearchEngine(profile);
+  EXPECT_TRUE(brave::UseAlternatePrivateSearchEngineEnabled(profile));
+  EXPECT_EQ(incognito_service->GetDefaultSearchProvider()->data().short_name(),
+            base::ASCIIToUTF16("DuckDuckGo"));
+  EXPECT_EQ(service->GetDefaultSearchProvider()->data().short_name(),
+            normal_search_engine);
+
+  // Toggle pref again and check both mode uses same search engine.
+  brave::ToggleUseAlternatePrivateSearchEngine(profile);
+  EXPECT_FALSE(brave::UseAlternatePrivateSearchEngineEnabled(profile));
+  EXPECT_EQ(service->GetDefaultSearchProvider()->data().short_name(),
+            normal_search_engine);
+  EXPECT_EQ(incognito_service->GetDefaultSearchProvider()->data().short_name(),
+            normal_search_engine);
+}

--- a/browser/alternate_private_search_engine_controller.cc
+++ b/browser/alternate_private_search_engine_controller.cc
@@ -18,7 +18,7 @@ TemplateURLData GetPrivateSearchEngineData() {
   private_search_engine_data.SetShortName(base::ASCIIToUTF16("DuckDuckGo"));
   private_search_engine_data.SetKeyword(base::ASCIIToUTF16("duckduckgo.com"));
   private_search_engine_data.SetURL(
-      "https://duckduckgo.com/?q={searchTerms}&atb=v128-6_e");
+      "https://duckduckgo.com/?q={searchTerms}&t=brave");
   private_search_engine_data.favicon_url =
       GURL("https://duckduckgo.com/favicon.ico");
   private_search_engine_data.suggestions_url =

--- a/browser/alternate_private_search_engine_controller.cc
+++ b/browser/alternate_private_search_engine_controller.cc
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/alternate_private_search_engine_controller.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "brave/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "components/prefs/pref_service.h"
+#include "components/search_engines/template_url_service.h"
+
+namespace {
+
+TemplateURLData GetPrivateSearchEngineData() {
+  TemplateURLData private_search_engine_data;
+  private_search_engine_data.SetShortName(base::ASCIIToUTF16("DuckDuckGo"));
+  private_search_engine_data.SetKeyword(base::ASCIIToUTF16("duckduckgo.com"));
+  private_search_engine_data.SetURL(
+      "https://duckduckgo.com/?q={searchTerms}&atb=v128-6_e");
+  private_search_engine_data.favicon_url =
+      GURL("https://duckduckgo.com/favicon.ico");
+  private_search_engine_data.suggestions_url =
+      "https://duckduckgo.com/ac/?q={searchTerms}&type=list";
+  return private_search_engine_data;
+}
+
+}  // namespace
+
+// static
+void AlternatePrivateSearchEngineController::Create(Profile* profile) {
+  // This controller is deleted by itself when observed TemplateURLSearvice is
+  // destroyed.
+  new AlternatePrivateSearchEngineController(profile);
+}
+
+AlternatePrivateSearchEngineController::AlternatePrivateSearchEngineController(
+    Profile* profile)
+    : profile_(profile),
+      template_url_service_(
+          TemplateURLServiceFactory::GetForProfile(profile_)) {
+  DCHECK(profile_->GetProfileType() == Profile::INCOGNITO_PROFILE);
+
+  use_alternate_private_search_engine_enabled_.Init(
+      kUseAlternatePrivateSearchEngine,
+      profile_->GetOriginalProfile()->GetPrefs(),
+      base::Bind(&AlternatePrivateSearchEngineController::OnPreferenceChanged,
+                 base::Unretained(this)));
+
+  template_url_service_->AddObserver(this);
+  private_search_engine_url_.reset(
+      new TemplateURL(GetPrivateSearchEngineData()));
+  ConfigureAlternatePrivateSearchEngineProvider();
+}
+
+AlternatePrivateSearchEngineController::
+~AlternatePrivateSearchEngineController() {
+}
+
+void AlternatePrivateSearchEngineController::OnTemplateURLServiceChanged() {
+  // When normal profile's default search provider is changed, it changes
+  // incognito's default search provider.
+  // Set alternate search engine again if needed.
+  ConfigureAlternatePrivateSearchEngineProvider();
+}
+
+void
+AlternatePrivateSearchEngineController::OnTemplateURLServiceShuttingDown() {
+  template_url_service_->RemoveObserver(this);
+  delete this;
+}
+
+void AlternatePrivateSearchEngineController::
+SetAlternateDefaultPrivateSearchEngine() {
+  template_url_service_->SetUserSelectedDefaultSearchProvider(
+      private_search_engine_url_.get());
+}
+
+void AlternatePrivateSearchEngineController::
+SetNormalModeDefaultSearchEngineAsDefaultPrivateSearchProvider() {
+  auto* normal_mode_service =
+      TemplateURLServiceFactory::GetForProfile(profile_->GetOriginalProfile());
+
+  TemplateURL normal_url(normal_mode_service->GetDefaultSearchProvider()->data());
+  template_url_service_->SetUserSelectedDefaultSearchProvider(&normal_url);
+}
+
+void AlternatePrivateSearchEngineController::
+ConfigureAlternatePrivateSearchEngineProvider() {
+  if (use_alternate_private_search_engine_enabled_.GetValue())
+    SetAlternateDefaultPrivateSearchEngine();
+  else
+    SetNormalModeDefaultSearchEngineAsDefaultPrivateSearchProvider();
+}
+
+void AlternatePrivateSearchEngineController::OnPreferenceChanged(
+    const std::string& pref_name) {
+  DCHECK(pref_name == kUseAlternatePrivateSearchEngine);
+
+  ConfigureAlternatePrivateSearchEngineProvider();
+}

--- a/browser/alternate_private_search_engine_controller.h
+++ b/browser/alternate_private_search_engine_controller.h
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_ALTERNATE_PRIVATE_SEARCH_ENGINE_CONTROLLER_H_
+#define BRAVE_BROWSER_ALTERNATE_PRIVATE_SEARCH_ENGINE_CONTROLLER_H_
+
+#include <memory>
+#include <string>
+
+#include "base/macros.h"
+#include "components/prefs/pref_member.h"
+#include "components/search_engines/template_url_service_observer.h"
+
+class Profile;
+class TemplateURL;
+class TemplateURLService;
+
+class AlternatePrivateSearchEngineController
+    : public TemplateURLServiceObserver {
+ public:
+  static void Create(Profile* profile);
+
+ private:
+  explicit AlternatePrivateSearchEngineController(Profile* profile);
+  ~AlternatePrivateSearchEngineController() override;
+
+  void SetAlternateDefaultPrivateSearchEngine();
+  void SetNormalModeDefaultSearchEngineAsDefaultPrivateSearchProvider();
+
+  void ConfigureAlternatePrivateSearchEngineProvider();
+
+  void OnPreferenceChanged(const std::string& pref_name);
+
+  // TemplateURLServiceObserver overrides:
+  void OnTemplateURLServiceChanged() override;
+  void OnTemplateURLServiceShuttingDown() override;
+
+  std::unique_ptr<TemplateURL> private_search_engine_url_;
+  BooleanPrefMember use_alternate_private_search_engine_enabled_;
+
+  Profile* profile_;
+  TemplateURLService* template_url_service_;
+
+  DISALLOW_COPY_AND_ASSIGN(AlternatePrivateSearchEngineController);
+};
+
+
+#endif  // BRAVE_BROWSER_ALTERNATE_PRIVATE_SEARCH_ENGINE_CONTROLLER_H_

--- a/browser/alternate_private_search_engine_util.cc
+++ b/browser/alternate_private_search_engine_util.cc
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/alternate_private_search_engine_util.h"
+
+#include "brave/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/prefs/pref_service.h"
+#include "components/pref_registry/pref_registry_syncable.h"
+
+namespace brave {
+
+bool UseAlternatePrivateSearchEngineEnabled(Profile* profile) {
+  return profile->GetOriginalProfile()->GetPrefs()->GetBoolean(
+      kUseAlternatePrivateSearchEngine);
+}
+
+void ToggleUseAlternatePrivateSearchEngine(Profile* profile) {
+  profile->GetOriginalProfile()->GetPrefs()->SetBoolean(
+      kUseAlternatePrivateSearchEngine,
+      !UseAlternatePrivateSearchEngineEnabled(profile));
+}
+
+void RegisterAlternatePrivateSearchEngineProfilePrefs(
+    user_prefs::PrefRegistrySyncable* registry) {
+  registry->RegisterBooleanPref(kUseAlternatePrivateSearchEngine, false);
+}
+
+}  // namespace brave

--- a/browser/alternate_private_search_engine_util.h
+++ b/browser/alternate_private_search_engine_util.h
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_ALTERNATE_PRIVATE_SEARCH_ENGINE_UTIL_H_
+#define BRAVE_BROWSER_ALTERNATE_PRIVATE_SEARCH_ENGINE_UTIL_H_
+
+class Profile;
+
+namespace user_prefs {
+class PrefRegistrySyncable;
+}
+
+namespace brave {
+
+bool UseAlternatePrivateSearchEngineEnabled(Profile* profile);
+
+void RegisterAlternatePrivateSearchEngineProfilePrefs(
+    user_prefs::PrefRegistrySyncable* registry);
+
+void ToggleUseAlternatePrivateSearchEngine(Profile* profile);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_ALTERNATE_PRIVATE_SEARCH_ENGINE_UTIL_H_

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -7,9 +7,10 @@
 #include "base/bind.h"
 #include "base/task_scheduler/post_task.h"
 #include "base/threading/sequenced_task_runner_handle.h"
-#include "brave/browser/component_updater/brave_component_updater_configurator.h"
 #include "brave/browser/brave_stats_updater.h"
+#include "brave/browser/component_updater/brave_component_updater_configurator.h"
 #include "brave/browser/extensions/brave_tor_client_updater.h"
+#include "brave/browser/profile_creation_monitor.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
 #include "brave/components/brave_shields/browser/ad_block_regional_service.h"
 #include "brave/components/brave_shields/browser/https_everywhere_service.h"
@@ -28,7 +29,8 @@ BraveBrowserProcessImpl::~BraveBrowserProcessImpl() {
 
 BraveBrowserProcessImpl::BraveBrowserProcessImpl(
     base::SequencedTaskRunner* local_state_task_runner)
-    : BrowserProcessImpl(local_state_task_runner) {
+    : BrowserProcessImpl(local_state_task_runner),
+      profile_creation_monitor_(new ProfileCreationMonitor) {
   g_browser_process = this;
   g_brave_browser_process = this;
   brave_stats_updater_ = brave::BraveStatsUpdaterFactory(local_state());

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -7,6 +7,8 @@
 
 #include "chrome/browser/browser_process_impl.h"
 
+class ProfileCreationMonitor;
+
 namespace brave {
 class BraveStatsUpdater;
 }
@@ -55,6 +57,8 @@ class BraveBrowserProcessImpl : public BrowserProcessImpl {
       google_component_updater_;
   std::unique_ptr<component_updater::ComponentUpdateService>
       brave_component_updater_;
+
+  std::unique_ptr<ProfileCreationMonitor> profile_creation_monitor_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveBrowserProcessImpl);
 };

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -4,6 +4,7 @@
 
 #include "brave/browser/brave_profile_prefs.h"
 
+#include "brave/browser/alternate_private_search_engine_util.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "chrome/browser/prefs/session_startup_pref.h"
@@ -18,6 +19,8 @@ namespace brave {
 
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   brave_shields::BraveShieldsWebContentsObserver::RegisterProfilePrefs(registry);
+
+  RegisterAlternatePrivateSearchEngineProfilePrefs(registry);
 
   registry->RegisterBooleanPref(kWidevineOptedIn, false);
 

--- a/browser/profile_creation_monitor.cc
+++ b/browser/profile_creation_monitor.cc
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/profile_creation_monitor.h"
+
+#include "brave/browser/alternate_private_search_engine_controller.h"
+#include "chrome/browser/chrome_notification_types.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/notification_service.h"
+
+ProfileCreationMonitor::ProfileCreationMonitor() {
+  registrar_.Add(this, chrome::NOTIFICATION_PROFILE_CREATED,
+                 content::NotificationService::AllSources());
+}
+
+ProfileCreationMonitor::~ProfileCreationMonitor() {}
+
+void ProfileCreationMonitor::Observe(
+    int type,
+    const content::NotificationSource& source,
+    const content::NotificationDetails& details) {
+  switch (type) {
+    case chrome::NOTIFICATION_PROFILE_CREATED: {
+      Profile* profile = content::Source<Profile>(source).ptr();
+      if (profile->GetProfileType() == Profile::INCOGNITO_PROFILE)
+        AlternatePrivateSearchEngineController::Create(profile);
+      break;
+    }
+    default:
+      NOTREACHED();
+  }
+}

--- a/browser/profile_creation_monitor.h
+++ b/browser/profile_creation_monitor.h
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_PROFILE_CREATION_MONITOR_H_
+#define BRAVE_BROWSER_PROFILE_CREATION_MONITOR_H_
+
+#include "content/public/browser/notification_observer.h"
+#include "content/public/browser/notification_registrar.h"
+
+class ProfileCreationMonitor : public content::NotificationObserver {
+ public:
+  ProfileCreationMonitor();
+  ~ProfileCreationMonitor() override;
+
+ private:
+  // content::NotificationObserver overrides:
+  void Observe(int type,
+               const content::NotificationSource& source,
+               const content::NotificationDetails& details) override;
+
+  content::NotificationRegistrar registrar_;
+
+  DISALLOW_COPY_AND_ASSIGN(ProfileCreationMonitor);
+};
+
+#endif  // BRAVE_BROWSER_PROFILE_CREATION_MONITOR_H_

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -16,3 +16,5 @@ const char kFirstCheckMade[] = "brave.stats.first_check_made";
 const char kWeekOfInstallation[] = "brave.stats.week_of_installation";
 const char kAdBlockCurrentRegion[] = "brave.ad_block.current_region";
 const char kWidevineOptedIn[] = "brave.widevine_opted_in";
+const char kUseAlternatePrivateSearchEngine[] =
+    "brave.use_alternate_private_search_engine";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -17,5 +17,6 @@ extern const char kFirstCheckMade[];
 extern const char kWeekOfInstallation[];
 extern const char kAdBlockCurrentRegion[];
 extern const char kWidevineOptedIn[];
+extern const char kUseAlternatePrivateSearchEngine[];
 
 #endif

--- a/components/brave_new_tab_ui/reducers/new_tab_reducer.tsx
+++ b/components/brave_new_tab_ui/reducers/new_tab_reducer.tsx
@@ -220,6 +220,7 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
       break
 
     case types.NEW_TAB_USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE:
+      chrome.send('toggleAlternativePrivateSearchEngine', [])
       state = { ...state, useAlternativePrivateSearchEngine: payload.shouldUse }
       break
 

--- a/components/brave_new_tab_ui/storage.ts
+++ b/components/brave_new_tab_ui/storage.ts
@@ -46,6 +46,7 @@ export const getLoadTimeData = (state: NewTab.State) => {
     'httpsUpgradesStat', 'fingerprintingBlockedStat'].forEach((stat) => {
       state.stats[stat] = parseInt(chrome.getVariableValue(stat), 10) || 0
     })
+  state.useAlternativePrivateSearchEngine = chrome.getVariableValue('useAlternativePrivateSearchEngine') === 'true'
   return state
 }
 

--- a/patches/chrome-browser-search_engines-template_url_service_factory.cc.patch
+++ b/patches/chrome-browser-search_engines-template_url_service_factory.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/search_engines/template_url_service_factory.cc b/chrome/browser/search_engines/template_url_service_factory.cc
+index c137bd1e4cfdf4a4479201d849240245741af390..36785c9794bead23ec5c3c92b2c6c7e29a2bec6a 100644
+--- a/chrome/browser/search_engines/template_url_service_factory.cc
++++ b/chrome/browser/search_engines/template_url_service_factory.cc
+@@ -86,7 +86,12 @@ void TemplateURLServiceFactory::RegisterProfilePrefs(
+ 
+ content::BrowserContext* TemplateURLServiceFactory::GetBrowserContextToUse(
+     content::BrowserContext* context) const {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  // To make different service for normal and incognito profile.
++  return chrome::GetBrowserContextOwnInstanceInIncognito(context);
++#else
+   return chrome::GetBrowserContextRedirectedInIncognito(context);
++#endif
+ }
+ 
+ bool TemplateURLServiceFactory::ServiceIsNULLWhileTesting() const {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -148,6 +148,7 @@ test("brave_browser_tests") {
     "//brave/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_containertest.cc",
+    "//brave/browser/alternate_private_search_engine_browsertest.cc",
     "//brave/browser/autoplay/autoplay_permission_context_browsertest.cc",
     "//brave/browser/brave_content_browser_client_browsertest.cc",
     "//brave/browser/brave_features_browsertest.cc",


### PR DESCRIPTION
Use different TemplateURLService for normal and incognito mode to set default search engine provider independently.

Use duckduckgo as a default search engine provider in incognito mode.

kUseAlternatePrivateSearchEngine pref is introduced to toggle alternate search engine.
If it is set to false, incognito mode uses default search engine of normal mode.
Otherwise, duckduckgo is used as private mode default search engine.

Close https://github.com/brave/brave-browser/issues/61

<img width="762" alt="screen shot 2018-08-07 at 17 07 53" src="https://user-images.githubusercontent.com/6786187/43763141-f2b3390a-9a64-11e8-8fce-fa064ff37eac.png">

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`yarn test brave_browser_tests --filter=AlternatePrivateSearchEngineTest.PrefTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
