### PR TITLE
Disable chrome.braveShields only for brave-extension

### DIFF
--- a/browser/extensions/brave_shields_apitest.cc
+++ b/browser/extensions/brave_shields_apitest.cc
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/browser/extensions/extension_apitest.h"
+#include "extensions/test/result_catcher.h"
+
+namespace extensions {
+namespace {
+
+class BraveShieldsExtensionApiTest : public ExtensionApiTest {
+ public:
+  void SetUp() override {
+    brave::RegisterPathProvider();
+    base::PathService::Get(brave::DIR_TEST_DATA, &extension_dir_);
+    extension_dir_ = extension_dir_.AppendASCII("extensions/api_test");
+    ExtensionApiTest::SetUp();
+  }
+  void TearDown() override {
+    ExtensionApiTest::TearDown();
+  }
+  base::FilePath extension_dir_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveShieldsExtensionApiTest, BraveExtensionHasAccess) {
+  const Extension* extension =
+    LoadExtension(extension_dir_.AppendASCII("braveShields"));
+  ASSERT_TRUE(extension);
+  ResultCatcher catcher;
+  ASSERT_TRUE(catcher.GetNextResult()) << message_;
+}
+
+IN_PROC_BROWSER_TEST_F(BraveShieldsExtensionApiTest, NotBraveExtensionHasNoAccess) {
+  LOG(ERROR) << "======= This is an intentional fail:";
+  const Extension* extension =
+    LoadExtension(extension_dir_.AppendASCII("notBraveShields"));
+  ASSERT_TRUE(extension);
+  ResultCatcher catcher;
+  ASSERT_FALSE(catcher.GetNextResult()) << message_;
+}
+
+}  // namespace
+}  // extensions

--- a/common/extensions/api/_api_features.json
+++ b/common/extensions/api/_api_features.json
@@ -1,12 +1,16 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Command to get whitelist ID: echo -n mnojpmjdmbbfmejpflffifhffcmidifd | openssl sha1
 
 {
   "braveShields": {
     "channel": "stable",
     "dependencies": [],
-    "contexts": ["blessed_extension"]
+    "contexts": ["blessed_extension"],
+    "whitelist": [
+      "A321D47A2B4CA86898167A55CA8B2E02385EA7CD"
+    ]
   },
   "topSites": [{
     "dependencies": ["permission:topSites"],

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -164,6 +164,14 @@ test("brave_browser_tests") {
     "//chrome/browser/extensions/updater/extension_cache_fake.cc",
     "//chrome/browser/extensions/updater/extension_cache_fake.h",
   ]
+
+  # API tests
+  sources += [
+    "//brave/browser/extensions/brave_shields_apitest.cc",
+    "//chrome/browser/extensions/extension_apitest.cc",
+    "//chrome/browser/extensions/extension_apitest.h",
+  ]
+
   if (is_linux && is_official_build) {
     sources += [
       # BraveViewsDelegateLinuxBrowserTest only works in release(official) build.

--- a/test/data/extensions/api_test/braveShields/background.js
+++ b/test/data/extensions/api_test/braveShields/background.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+chrome.test.runTests([
+  function braveShieldsExtensionHasAccess() {
+    if (chrome.braveShields) {
+      chrome.test.succeed();
+    } else {
+      chrome.test.fail();
+    }
+  },
+]);
+

--- a/test/data/extensions/api_test/braveShields/manifest.json
+++ b/test/data/extensions/api_test/braveShields/manifest.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "name": "Brave",
+  "manifest_version": 2,
+  "description": "API test for braveShields",
+  "web_accessible_resources": [
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "permissions": [ "contentSettings", "tabs", "storage", "webNavigation" ],
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAupOLMy5Fd4dCSOtjcApsAQOnuBdTs+OvBVt/3P93noIrf068x0xXkvxbn+fpigcqfNamiJ5CjGyfx9zAIs7zcHwbxjOw0Uih4SllfgtK+svNTeE0r5atMWE0xR489BvsqNuPSxYJUmW28JqhaSZ4SabYrRx114KcU6ko7hkjyPkjQa3P+chStJjIKYgu5tWBiMJp5QVLelKoM+xkY6S7efvJ8AfajxCViLGyDQPDviGr2D0VvIBob0D1ZmAoTvYOWafcNCaqaejPDybFtuLFX3pZBqfyOCyyzGhucyCmfBXJALKbhjRAqN5glNsUmGhhPK87TuGATQfVuZtenMvXMQIDAQAB"
+}

--- a/test/data/extensions/api_test/notBraveShields/background.js
+++ b/test/data/extensions/api_test/notBraveShields/background.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+chrome.test.runTests([
+  function braveShieldsExtensionHasAccess() {
+    if (chrome.braveShields) {
+      chrome.test.succeed();
+    } else {
+      chrome.test.fail();
+    }
+  },
+]);

--- a/test/data/extensions/api_test/notBraveShields/manifest.json
+++ b/test/data/extensions/api_test/notBraveShields/manifest.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "name": "Brave",
+  "manifest_version": 2,
+  "description": "API test for something that is not braveShields",
+  "web_accessible_resources": [
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs4TIQXRCftLpGmQZxmm6AU8pqGKLoDyi537HGQyRKcK7j/CSXCf3vwJr7xkV72p7bayutuzyNZ3740QxBPiesfBOp8bBb8d2VgTHP3b+SuNmK/rsSRsMRhT05x8AAr/7ab6U3rW0Gsalm2653xnnQS8vt0s62xQTmC+UMXowaSLUZ0Be/TOu6lHZhOeo0NBMKc6PkOu0R1EEfP7dJR6SM/v4dBUBZ1HXcuziVbCXVyU51opZCMjlxyUlQR9pTGk+Zh5sDn1Vw1MwLnWiEfQ4EGL1V7GeI4vgLoOLgq7tmhEratHGCfC1IHm9luMACRr/ybMI6DQJOvgBvecb292FxQIDAQAB",
+  "permissions": [ "contentSettings", "tabs", "storage", "webNavigation" ]
+}


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/602

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
