### PR TITLE
Import browser laptop stats

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -89,6 +89,9 @@
       <message name="IDS_SETTINGS_IMPORT_COOKIES_CHECKBOX" desc="Checkbox for importing cookies">
         Cookies
       </message>
+      <message name="IDS_SETTINGS_IMPORT_STATS_CHECKBOX" desc="Checkbox for importing stats">
+        Stats
+      </message>
       <message name="IDS_WIDEVINE_NOT_INSTALLED_EXPLANATORY_TEXT" desc="Explanatory animated text that appears (and then disappears) in the address line when Widevine is blocked">
         Widevine is not installed
       </message>

--- a/browser/importer/brave_external_process_importer_client.cc
+++ b/browser/importer/brave_external_process_importer_client.cc
@@ -45,4 +45,12 @@ void BraveExternalProcessImporterClient::OnCookiesImportGroup(
     bridge_->SetCookies(cookies_);
 }
 
+void BraveExternalProcessImporterClient::OnStatsImportReady(
+    const BraveStats& stats) {
+  if (cancelled_)
+    return;
+
+  bridge_->UpdateStats(stats);
+}
+
 BraveExternalProcessImporterClient::~BraveExternalProcessImporterClient() {}

--- a/browser/importer/brave_external_process_importer_client.h
+++ b/browser/importer/brave_external_process_importer_client.h
@@ -11,6 +11,8 @@
 #include "chrome/browser/importer/external_process_importer_client.h"
 #include "net/cookies/canonical_cookie.h"
 
+struct BraveStats;
+
 class BraveExternalProcessImporterClient : public ExternalProcessImporterClient {
  public:
   BraveExternalProcessImporterClient(
@@ -26,6 +28,8 @@ class BraveExternalProcessImporterClient : public ExternalProcessImporterClient 
       uint32_t total_cookies_count) override;
   void OnCookiesImportGroup(
       const std::vector<net::CanonicalCookie>& cookies_group) override;
+  void OnStatsImportReady(
+       const BraveStats& stats) override;
 
  private:
   ~BraveExternalProcessImporterClient() override;

--- a/browser/importer/brave_in_process_importer_bridge.cc
+++ b/browser/importer/brave_in_process_importer_bridge.cc
@@ -16,4 +16,8 @@ void BraveInProcessImporterBridge::SetCookies(
   writer_->AddCookies(cookies);
 }
 
+void BraveInProcessImporterBridge::UpdateStats(const BraveStats& stats) {
+  writer_->UpdateStats(stats);
+}
+
 BraveInProcessImporterBridge::~BraveInProcessImporterBridge() {}

--- a/browser/importer/brave_in_process_importer_bridge.h
+++ b/browser/importer/brave_in_process_importer_bridge.h
@@ -24,6 +24,7 @@ class BraveInProcessImporterBridge : public InProcessImporterBridge {
 
   void SetCookies(
       const std::vector<net::CanonicalCookie>& cookies) override;
+  void UpdateStats(const BraveStats& stats) override;
 
  private:
   ~BraveInProcessImporterBridge() override;

--- a/browser/importer/brave_profile_writer.cc
+++ b/browser/importer/brave_profile_writer.cc
@@ -3,12 +3,16 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/importer/brave_profile_writer.h"
+#include "brave/common/importer/brave_stats.h"
+#include "brave/common/pref_names.h"
+#include "brave/utility/importer/brave_importer.h"
 
 #include "base/time/time.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"
+#include "components/prefs/pref_service.h"
 #include "net/cookies/canonical_cookie.h"
 #include "net/cookies/cookie_constants.h"
 #include "net/url_request/url_request_context.h"
@@ -35,4 +39,15 @@ void BraveProfileWriter::AddCookies(
         // Fire and forget
         network::mojom::CookieManager::SetCanonicalCookieCallback());
   }
+}
+
+void BraveProfileWriter::UpdateStats(const BraveStats& stats) {
+  PrefService* prefs = profile_->GetOriginalProfile()->GetPrefs();
+
+  prefs->SetUint64(kAdsBlocked,
+                   prefs->GetUint64(kAdsBlocked) + stats.adblock_count);
+  prefs->SetUint64(kTrackersBlocked,
+                   prefs->GetUint64(kTrackersBlocked) + stats.trackingProtection_count);
+  prefs->SetUint64(kHttpsUpgrades,
+                   prefs->GetUint64(kHttpsUpgrades) + stats.httpsEverywhere_count);
 }

--- a/browser/importer/brave_profile_writer.h
+++ b/browser/importer/brave_profile_writer.h
@@ -11,11 +11,14 @@
 #include "chrome/browser/importer/profile_writer.h"
 #include "net/cookies/canonical_cookie.h"
 
+struct BraveStats;
+
 class BraveProfileWriter : public ProfileWriter {
  public:
   explicit BraveProfileWriter(Profile* profile);
 
   virtual void AddCookies(const std::vector<net::CanonicalCookie>& cookies);
+  virtual void UpdateStats(const BraveStats& stats);
 
  protected:
   friend class base::RefCountedThreadSafe<BraveProfileWriter>;

--- a/chromium_src/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
@@ -9,7 +9,8 @@ namespace settings {
 #if !defined(OS_CHROMEOS)
 void BraveAddImportDataStrings(content::WebUIDataSource* html_source) {
   LocalizedString localized_strings[] = {
-    {"importCookies", IDS_SETTINGS_IMPORT_COOKIES_CHECKBOX}
+    {"importCookies", IDS_SETTINGS_IMPORT_COOKIES_CHECKBOX},
+    {"importStats", IDS_SETTINGS_IMPORT_STATS_CHECKBOX}
   };
   AddLocalizedStringsBulk(html_source, localized_strings,
                           arraysize(localized_strings));

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -27,6 +27,7 @@ source_set("common") {
     "extensions/manifest_handlers/pdfjs_manifest_override.h",
     "importer/brave_importer_utils.cc",
     "importer/brave_importer_utils.h",
+    "importer/brave_stats.h",
     "importer/chrome_importer_utils.cc",
     "importer/chrome_importer_utils.h",
     "network_constants.cc",

--- a/common/importer/brave_importer_utils.cc
+++ b/common/importer/brave_importer_utils.cc
@@ -29,7 +29,7 @@ bool BraveImporterCanImport(const base::FilePath& profile,
   if (base::PathExists(history))
     *services_supported |= importer::HISTORY;
   if (base::PathExists(session_store))
-    *services_supported |= importer::FAVORITES;
+    *services_supported |= importer::FAVORITES | importer::STATS;
   if (base::PathExists(passwords))
     *services_supported |= importer::PASSWORDS;
   if (base::PathExists(cookies))

--- a/common/importer/brave_mock_importer_bridge.h
+++ b/common/importer/brave_mock_importer_bridge.h
@@ -11,12 +11,16 @@
 #include "net/cookies/canonical_cookie.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
+struct BraveStats;
+
 class BraveMockImporterBridge : public MockImporterBridge {
  public:
   BraveMockImporterBridge();
 
   MOCK_METHOD1(SetCookies,
                void(const std::vector<net::CanonicalCookie>&));
+  MOCK_METHOD1(UpdateStats,
+               void(const BraveStats&));
 
  private:
   ~BraveMockImporterBridge() override;

--- a/common/importer/brave_mock_importer_bridge.h
+++ b/common/importer/brave_mock_importer_bridge.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "brave/common/importer/brave_stats.h"
 #include "chrome/common/importer/mock_importer_bridge.h"
 #include "net/cookies/canonical_cookie.h"
 #include "testing/gmock/include/gmock/gmock.h"

--- a/common/importer/brave_stats.h
+++ b/common/importer/brave_stats.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMMON_IMPORTER_BRAVE_STATS_H_
+#define BRAVE_COMMON_IMPORTER_BRAVE_STATS_H_
+
+struct BraveStats {
+  int adblock_count;
+  int trackingProtection_count;
+  int httpsEverywhere_count;
+
+  BraveStats()
+    : adblock_count(0),
+      trackingProtection_count(0),
+      httpsEverywhere_count(0) {}
+};
+
+#endif  // BRAVE_COMMON_IMPORTER_BRAVE_STATS_H_

--- a/patches/chrome-browser-extensions-api-settings_private-prefs_util.cc.patch
+++ b/patches/chrome-browser-extensions-api-settings_private-prefs_util.cc.patch
@@ -1,12 +1,14 @@
 diff --git a/chrome/browser/extensions/api/settings_private/prefs_util.cc b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-index b4019834b8be721576b0c832e722696584bb38c6..15f69c83ab5063202c6d22f52842bd23a52b4e61 100644
+index b4019834b8be721576b0c832e722696584bb38c6..93173d1a8a1e313b7f741397a95ee220d609d010 100644
 --- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
 +++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-@@ -499,6 +499,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetWhitelistedKeys() {
+@@ -499,6 +499,10 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetWhitelistedKeys() {
        settings_api::PrefType::PREF_TYPE_BOOLEAN;
    (*s_whitelist)[::prefs::kImportDialogSearchEngine] =
        settings_api::PrefType::PREF_TYPE_BOOLEAN;
 +  (*s_whitelist)[::prefs::kImportDialogCookies] =
++      settings_api::PrefType::PREF_TYPE_BOOLEAN;
++  (*s_whitelist)[::prefs::kImportDialogStats] =
 +      settings_api::PrefType::PREF_TYPE_BOOLEAN;
  #endif
  

--- a/patches/chrome-browser-importer-external_process_importer_client.h.patch
+++ b/patches/chrome-browser-importer-external_process_importer_client.h.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/importer/external_process_importer_client.h b/chrome/browser/importer/external_process_importer_client.h
-index 864a6951115dda5ed74963f18b35692960397d50..477c51b320a3f41b75ab36bf7e1780d1aae6e701 100644
+index 864a6951115dda5ed74963f18b35692960397d50..ba056b13fbae07f151286f531e1a8d86e0eac2c5 100644
 --- a/chrome/browser/importer/external_process_importer_client.h
 +++ b/chrome/browser/importer/external_process_importer_client.h
-@@ -24,6 +24,7 @@
+@@ -24,10 +24,12 @@
  #include "components/favicon_base/favicon_usage_data.h"
  #include "components/history/core/browser/history_types.h"
  #include "mojo/public/cpp/bindings/binding.h"
@@ -10,12 +10,18 @@ index 864a6951115dda5ed74963f18b35692960397d50..477c51b320a3f41b75ab36bf7e1780d1
  
  class ExternalProcessImporterHost;
  struct ImportedBookmarkEntry;
-@@ -88,6 +89,8 @@ class ExternalProcessImporterClient
+ class InProcessImporterBridge;
++struct BraveStats;
+ 
+ namespace autofill {
+ struct PasswordForm;
+@@ -88,6 +90,9 @@ class ExternalProcessImporterClient
    void OnAutofillFormDataImportGroup(
        const std::vector<ImporterAutofillFormDataEntry>&
            autofill_form_data_entry_group) override;
 +  void OnCookiesImportStart(uint32_t total_cookies_count) override {};
 +  void OnCookiesImportGroup(const std::vector<net::CanonicalCookie>& cookies_group) override {};
++  void OnStatsImportReady(const BraveStats& stats) override {};
    void OnIE7PasswordReceived(
        const importer::ImporterIE7PasswordInfo& importer_password_info) override;
  

--- a/patches/chrome-browser-resources-settings-people_page-import_data_dialog.html.patch
+++ b/patches/chrome-browser-resources-settings-people_page-import_data_dialog.html.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/resources/settings/people_page/import_data_dialog.html b/chrome/browser/resources/settings/people_page/import_data_dialog.html
-index fdd6f9d2265fe069d159ceed6e1e7ec561a2915e..a3f47eca2998e76569bff76a467807013403bff3 100644
+index fdd6f9d2265fe069d159ceed6e1e7ec561a2915e..e0dee6f2af7b92dd2b7f88fefbfda92f7a9b3f02 100644
 --- a/chrome/browser/resources/settings/people_page/import_data_dialog.html
 +++ b/chrome/browser/resources/settings/people_page/import_data_dialog.html
-@@ -94,6 +94,11 @@
+@@ -94,6 +94,16 @@
                pref="{{prefs.import_dialog_autofill_form_data}}"
                label="$i18n{importAutofillFormData}">
            </settings-checkbox>
@@ -10,6 +10,11 @@ index fdd6f9d2265fe069d159ceed6e1e7ec561a2915e..a3f47eca2998e76569bff76a46780701
 +              hidden="[[!selected_.cookies]]"
 +              pref="{{prefs.import_dialog_cookies}}"
 +              label="$i18n{importCookies}">
++          </settings-checkbox>
++          <settings-checkbox
++              hidden="[[!selected_.stats]]"
++              pref="{{prefs.import_dialog_stats}}"
++              label="$i18n{importStats}">
 +          </settings-checkbox>
          </div>
        </div>

--- a/patches/chrome-browser-resources-settings-people_page-import_data_dialog.js.patch
+++ b/patches/chrome-browser-resources-settings-people_page-import_data_dialog.js.patch
@@ -1,15 +1,17 @@
 diff --git a/chrome/browser/resources/settings/people_page/import_data_dialog.js b/chrome/browser/resources/settings/people_page/import_data_dialog.js
-index f59448f4b4a25ab8b5e13c23feafa7957e83fa82..1dcdb0fbfa38deb10418074b9c0f02ee75221591 100644
+index f59448f4b4a25ab8b5e13c23feafa7957e83fa82..bfcb5e3e5c846b99f59ba49274881dece8302e87 100644
 --- a/chrome/browser/resources/settings/people_page/import_data_dialog.js
 +++ b/chrome/browser/resources/settings/people_page/import_data_dialog.js
-@@ -84,7 +84,9 @@ Polymer({
+@@ -84,7 +84,11 @@ Polymer({
          !(this.getPref('import_dialog_search_engine').value &&
            this.selected_.search) &&
          !(this.getPref('import_dialog_autofill_form_data').value &&
 -          this.selected_.autofillFormData);
 +          this.selected_.autofillFormData) &&
 +        !(this.getPref('import_dialog_cookies').value &&
-+          this.selected_.cookies);
++          this.selected_.cookies) &&
++        !(this.getPref('import_dialog_stats').value &&
++          this.selected_.stats);
    },
  
    /**

--- a/patches/chrome-browser-ui-webui-settings-md_settings_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-settings-md_settings_ui.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/ui/webui/settings/md_settings_ui.cc b/chrome/browser/ui/webui/settings/md_settings_ui.cc
-index 954647cb963e995c15d903e91689c4927ba3ad29..3d9a2ad9d363cf1504ac7beea248d368f4cb5ace 100644
+index 954647cb963e995c15d903e91689c4927ba3ad29..7ba86990b1f630398bc373c680dd977d9b540d89 100644
 --- a/chrome/browser/ui/webui/settings/md_settings_ui.cc
 +++ b/chrome/browser/ui/webui/settings/md_settings_ui.cc
-@@ -131,6 +131,7 @@ void MdSettingsUI::RegisterProfilePrefs(
+@@ -131,6 +131,8 @@ void MdSettingsUI::RegisterProfilePrefs(
    registry->RegisterBooleanPref(prefs::kImportDialogHistory, true);
    registry->RegisterBooleanPref(prefs::kImportDialogSavedPasswords, true);
    registry->RegisterBooleanPref(prefs::kImportDialogSearchEngine, true);
 +  registry->RegisterBooleanPref(prefs::kImportDialogCookies, true);
++  registry->RegisterBooleanPref(prefs::kImportDialogStats, true);
  }
  
  MdSettingsUI::MdSettingsUI(content::WebUI* web_ui)

--- a/patches/chrome-browser-ui-webui-settings-settings_import_data_handler.cc.patch
+++ b/patches/chrome-browser-ui-webui-settings-settings_import_data_handler.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/webui/settings/settings_import_data_handler.cc b/chrome/browser/ui/webui/settings/settings_import_data_handler.cc
-index 32deebd14fb3383010af01381af9b34442d19b6e..4ee9444e28d9041c3b1dd97fd81f0ce387635982 100644
+index 32deebd14fb3383010af01381af9b34442d19b6e..750216677fccfd62a36937cf020341c0b180732c 100644
 --- a/chrome/browser/ui/webui/settings/settings_import_data_handler.cc
 +++ b/chrome/browser/ui/webui/settings/settings_import_data_handler.cc
 @@ -18,6 +18,8 @@
@@ -26,21 +26,25 @@ index 32deebd14fb3383010af01381af9b34442d19b6e..4ee9444e28d9041c3b1dd97fd81f0ce3
  
    importer::LogImporterUseToMetrics("ImportDataHandler",
                                      source_profile.importer_type);
-@@ -126,6 +128,8 @@ void ImportDataHandler::ImportData(const base::ListValue* args) {
+@@ -126,6 +128,10 @@ void ImportDataHandler::ImportData(const base::ListValue* args) {
      selected_items |= importer::PASSWORDS;
    if (prefs->GetBoolean(prefs::kImportDialogSearchEngine))
      selected_items |= importer::SEARCH_ENGINES;
 +  if (prefs->GetBoolean(prefs::kImportDialogCookies))
 +    selected_items |= importer::COOKIES;
++  if (prefs->GetBoolean(prefs::kImportDialogStats))
++    selected_items |= importer::STATS;
  
    const importer::SourceProfile& source_profile =
        importer_list_->GetSourceProfileAt(browser_index);
-@@ -179,6 +183,8 @@ void ImportDataHandler::SendBrowserProfileData(const std::string& callback_id) {
+@@ -179,6 +185,10 @@ void ImportDataHandler::SendBrowserProfileData(const std::string& callback_id) {
      browser_profile->SetBoolean(
          "autofillFormData",
          (browser_services & importer::AUTOFILL_FORM_DATA) != 0);
 +    browser_profile->SetBoolean("cookies",
 +        (browser_services & importer::COOKIES) != 0);
++    browser_profile->SetBoolean("stats",
++        (browser_services & importer::STATS) != 0);
  
      browser_profiles.Append(std::move(browser_profile));
    }

--- a/patches/chrome-common-importer-importer_bridge.h.patch
+++ b/patches/chrome-common-importer-importer_bridge.h.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/common/importer/importer_bridge.h b/chrome/common/importer/importer_bridge.h
-index 56d4259aba433df997802109cf5a8d28c03ebd13..dcbb15bba51eb79c086e2b1dec05e04683796993 100644
+index 56d4259aba433df997802109cf5a8d28c03ebd13..26bb05d70c9674cab27112704b8957972ff2dab5 100644
 --- a/chrome/common/importer/importer_bridge.h
 +++ b/chrome/common/importer/importer_bridge.h
-@@ -15,6 +15,7 @@
+@@ -15,10 +15,12 @@
  #include "chrome/common/importer/importer_data_types.h"
  #include "chrome/common/importer/importer_url_row.h"
  #include "components/favicon_base/favicon_usage_data.h"
@@ -10,12 +10,20 @@ index 56d4259aba433df997802109cf5a8d28c03ebd13..dcbb15bba51eb79c086e2b1dec05e046
  
  class GURL;
  struct ImportedBookmarkEntry;
-@@ -66,6 +67,9 @@ class ImporterBridge : public base::RefCountedThreadSafe<ImporterBridge> {
+ struct ImporterAutofillFormDataEntry;
++struct BraveStats;
+ 
+ namespace autofill {
+ struct PasswordForm;
+@@ -66,6 +68,12 @@ class ImporterBridge : public base::RefCountedThreadSafe<ImporterBridge> {
    virtual void SetAutofillFormData(
        const std::vector<ImporterAutofillFormDataEntry>& entries) = 0;
  
 +  virtual void SetCookies(
 +      const std::vector<net::CanonicalCookie>& cookies) {};
++
++  virtual void UpdateStats(
++      const BraveStats& stats) {};
 +
    // Notifies the coordinator that the import operation has begun.
    virtual void NotifyStarted() = 0;

--- a/patches/chrome-common-importer-importer_data_types.h.patch
+++ b/patches/chrome-common-importer-importer_data_types.h.patch
@@ -1,8 +1,18 @@
 diff --git a/chrome/common/importer/importer_data_types.h b/chrome/common/importer/importer_data_types.h
-index 0fc90c62398a93eb89568ce78c8ded2bc9b232b6..cd3301cdbab878231050dbdf66d4572852d0a331 100644
+index 0fc90c62398a93eb89568ce78c8ded2bc9b232b6..875839c01d9b18dc705c421a4287c82cb401c376 100644
 --- a/chrome/common/importer/importer_data_types.h
 +++ b/chrome/common/importer/importer_data_types.h
-@@ -83,6 +83,8 @@ enum VisitSource {
+@@ -31,7 +31,8 @@ enum ImportItem {
+   SEARCH_ENGINES     = 1 << 4,
+   HOME_PAGE          = 1 << 5,
+   AUTOFILL_FORM_DATA = 1 << 6,
+-  ALL                = (1 << 7) - 1  // All the bits should be 1, hence the -1.
++  STATS              = 1 << 7,
++  ALL                = (1 << 8) - 1  // All the bits should be 1, hence the -1.
+ };
+ 
+ // Information about a profile needed by an importer to do import work.
+@@ -83,6 +84,8 @@ enum VisitSource {
    VISIT_SOURCE_FIREFOX_IMPORTED = 1,
    VISIT_SOURCE_IE_IMPORTED = 2,
    VISIT_SOURCE_SAFARI_IMPORTED = 3,

--- a/patches/chrome-common-importer-profile_import.mojom.patch
+++ b/patches/chrome-common-importer-profile_import.mojom.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/common/importer/profile_import.mojom b/chrome/common/importer/profile_import.mojom
-index 625b5ddec268292acf11f3c060c07c336ca1317f..6461206ff781150ed59c66cc8ae8dffafbb5b30f 100644
+index 625b5ddec268292acf11f3c060c07c336ca1317f..1738d9d68a93ec1940688caa3352d55f898c7c63 100644
 --- a/chrome/common/importer/profile_import.mojom
 +++ b/chrome/common/importer/profile_import.mojom
 @@ -6,6 +6,7 @@ module chrome.mojom;
@@ -10,12 +10,23 @@ index 625b5ddec268292acf11f3c060c07c336ca1317f..6461206ff781150ed59c66cc8ae8dffa
  import "url/mojom/url.mojom";
  
  const string kProfileImportServiceName = "profile_import";
-@@ -64,6 +65,8 @@ interface ProfileImportObserver {
+@@ -31,6 +32,9 @@ struct FaviconUsageDataList;
+ [Native]
+ struct ImporterIE7PasswordInfo;
+ 
++[Native]
++struct BraveStats;
++
+ [Native]
+ enum ImportItem;
+ 
+@@ -64,6 +68,9 @@ interface ProfileImportObserver {
    OnAutofillFormDataImportStart(uint32 total_autofill_form_data_entry_count);
    OnAutofillFormDataImportGroup(
        array<ImporterAutofillFormDataEntry> autofill_form_data_entry_group);
 +  OnCookiesImportStart(uint32 total_cookies_count);
 +  OnCookiesImportGroup(array<network.mojom.CanonicalCookie> cookies_group);
++  OnStatsImportReady(BraveStats stats);
    // Windows only:
    OnIE7PasswordReceived(ImporterIE7PasswordInfo importer_password_info);
  };

--- a/patches/chrome-common-importer-profile_import.typemap.patch
+++ b/patches/chrome-common-importer-profile_import.typemap.patch
@@ -1,0 +1,26 @@
+diff --git a/chrome/common/importer/profile_import.typemap b/chrome/common/importer/profile_import.typemap
+index 6283f2bf6871a10f710694772b5da0bc9b70c2ad..1c0b74b2fc728e07fb59adc5c0f5ed257900357c 100644
+--- a/chrome/common/importer/profile_import.typemap
++++ b/chrome/common/importer/profile_import.typemap
+@@ -4,6 +4,7 @@
+ 
+ mojom = "//chrome/common/importer/profile_import.mojom"
+ public_headers = [
++  "//brave/common/importer/brave_stats.h",
+   "//chrome/common/importer/imported_bookmark_entry.h",
+   "//chrome/common/importer/importer_autofill_form_data_entry.h",
+   "//chrome/common/importer/importer_data_types.h",
+@@ -13,6 +14,7 @@ public_headers = [
+ traits_headers =
+     [ "//chrome/common/importer/profile_import_process_param_traits.h" ]
+ deps = [
++  "//brave/common",
+   "//chrome/common",
+   "//components/favicon_base",
+   "//ipc",
+@@ -26,4 +28,5 @@ type_mappings = [
+   "chrome.mojom.SearchEngineInfo=::importer::SearchEngineInfo",
+   "chrome.mojom.SourceProfile=::importer::SourceProfile",
+   "chrome.mojom.ImportItem=::importer::ImportItem",
++  "chrome.mojom.BraveStats=::BraveStats",
+ ]

--- a/patches/chrome-common-importer-profile_import_process_param_traits_macros.h.patch
+++ b/patches/chrome-common-importer-profile_import_process_param_traits_macros.h.patch
@@ -1,0 +1,23 @@
+diff --git a/chrome/common/importer/profile_import_process_param_traits_macros.h b/chrome/common/importer/profile_import_process_param_traits_macros.h
+index dd005641f4349c017bc65d843d8fe49ec6122f64..b04d43977cfe6d6bb3aa98427be7fe4fa87aa697 100644
+--- a/chrome/common/importer/profile_import_process_param_traits_macros.h
++++ b/chrome/common/importer/profile_import_process_param_traits_macros.h
+@@ -14,6 +14,7 @@
+ #include "base/strings/string16.h"
+ #include "base/values.h"
+ #include "build/build_config.h"
++#include "brave/common/importer/brave_stats.h"
+ #include "chrome/common/common_param_traits_macros.h"
+ #include "chrome/common/importer/imported_bookmark_entry.h"
+ #include "chrome/common/importer/importer_autofill_form_data_entry.h"
+@@ -91,4 +92,10 @@ IPC_STRUCT_TRAITS_BEGIN(importer::ImporterIE7PasswordInfo)
+   IPC_STRUCT_TRAITS_MEMBER(date_created)
+ IPC_STRUCT_TRAITS_END()
+ 
++IPC_STRUCT_TRAITS_BEGIN(BraveStats)
++  IPC_STRUCT_TRAITS_MEMBER(adblock_count)
++  IPC_STRUCT_TRAITS_MEMBER(trackingProtection_count)
++  IPC_STRUCT_TRAITS_MEMBER(httpsEverywhere_count)
++IPC_STRUCT_TRAITS_END()
++
+ #endif  // CHROME_COMMON_IMPORTER_PROFILE_IMPORT_PROCESS_PARAM_TRAITS_MACROS_H_

--- a/patches/chrome-common-pref_names.cc.patch
+++ b/patches/chrome-common-pref_names.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/common/pref_names.cc b/chrome/common/pref_names.cc
-index 7ad9c3fdf2044a5f6fa55fddde76a377dd0960e4..b1338fc73c16e7243514d69e7f7f031da802b5ea 100644
+index 7ad9c3fdf2044a5f6fa55fddde76a377dd0960e4..74681cedd4fd12d27145caca097e770a635cc5b6 100644
 --- a/chrome/common/pref_names.cc
 +++ b/chrome/common/pref_names.cc
-@@ -1075,6 +1075,7 @@ const char kImportDialogBookmarks[] = "import_dialog_bookmarks";
+@@ -1075,6 +1075,8 @@ const char kImportDialogBookmarks[] = "import_dialog_bookmarks";
  const char kImportDialogHistory[] = "import_dialog_history";
  const char kImportDialogSavedPasswords[] = "import_dialog_saved_passwords";
  const char kImportDialogSearchEngine[] = "import_dialog_search_engine";
 +const char kImportDialogCookies[] = "import_dialog_cookies";
++const char kImportDialogStats[] = "import_dialog_stats";
  
  // Profile avatar and name
  const char kProfileAvatarIndex[] = "profile.avatar_index";

--- a/patches/chrome-common-pref_names.h.patch
+++ b/patches/chrome-common-pref_names.h.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/common/pref_names.h b/chrome/common/pref_names.h
-index 387ef15845fb7d48a886dbc27a506085db8ef173..76e4eab361d3c4f28159b707d88c3f16f25cacb7 100644
+index 387ef15845fb7d48a886dbc27a506085db8ef173..f5bd4fb304767ce89ba36c1ed6e9f00d14642bf8 100644
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -358,6 +358,7 @@ extern const char kImportDialogBookmarks[];
+@@ -358,6 +358,8 @@ extern const char kImportDialogBookmarks[];
  extern const char kImportDialogHistory[];
  extern const char kImportDialogSavedPasswords[];
  extern const char kImportDialogSearchEngine[];
 +extern const char kImportDialogCookies[];
++extern const char kImportDialogStats[];
  
  extern const char kProfileAvatarIndex[];
  extern const char kProfileUsingDefaultName[];

--- a/utility/importer/brave_external_process_importer_bridge.cc
+++ b/utility/importer/brave_external_process_importer_bridge.cc
@@ -39,6 +39,11 @@ void BraveExternalProcessImporterBridge::SetCookies(
   DCHECK_EQ(0, cookies_left);
 }
 
+void BraveExternalProcessImporterBridge::UpdateStats(
+    const BraveStats& stats) {
+  (*observer_)->OnStatsImportReady(stats);
+}
+
 BraveExternalProcessImporterBridge::BraveExternalProcessImporterBridge(
     const base::flat_map<uint32_t, std::string>& localized_strings,
     scoped_refptr<chrome::mojom::ThreadSafeProfileImportObserverPtr> observer)

--- a/utility/importer/brave_external_process_importer_bridge.h
+++ b/utility/importer/brave_external_process_importer_bridge.h
@@ -20,6 +20,8 @@ class BraveExternalProcessImporterBridge :
           observer);
 
   void SetCookies(const std::vector<net::CanonicalCookie>& cookies) override;
+  void UpdateStats(const BraveStats& stats) override;
+
  private:
   ~BraveExternalProcessImporterBridge() override;
 

--- a/utility/importer/brave_importer.h
+++ b/utility/importer/brave_importer.h
@@ -32,6 +32,9 @@ class BraveImporter : public ChromeImporter {
 
   void ImportBookmarks() override;
   void ImportHistory() override;
+  void ImportStats();
+
+  std::unique_ptr<base::Value> ParseBraveSessionStore();
 
   void ParseBookmarks(std::vector<ImportedBookmarkEntry>* bookmarks);
   void RecursiveReadBookmarksFolder(

--- a/utility/importer/brave_importer_unittest.cc
+++ b/utility/importer/brave_importer_unittest.cc
@@ -5,6 +5,7 @@
 #include "brave/utility/importer/brave_importer.h"
 #include "brave/common/brave_paths.h"
 #include "brave/common/importer/brave_mock_importer_bridge.h"
+#include "brave/common/importer/brave_stats.h"
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -209,3 +210,20 @@ TEST_F(BraveImporterTest, ImportCookies) {
   OSCryptMocker::TearDown();
 }
 #endif
+
+TEST_F(BraveImporterTest, ImportStats) {
+  BraveStats stats;
+
+  EXPECT_CALL(*bridge_, NotifyStarted());
+  EXPECT_CALL(*bridge_, NotifyItemStarted(importer::STATS));
+  EXPECT_CALL(*bridge_, UpdateStats(_))
+      .WillOnce(::testing::SaveArg<0>(&stats));
+  EXPECT_CALL(*bridge_, NotifyItemEnded(importer::STATS));
+  EXPECT_CALL(*bridge_, NotifyEnded());
+
+  importer_->StartImport(profile_, importer::STATS, bridge_.get());
+
+  EXPECT_EQ(9, stats.adblock_count);
+  EXPECT_EQ(0, stats.trackingProtection_count);
+  EXPECT_EQ(0, stats.httpsEverywhere_count);
+}


### PR DESCRIPTION
Closes brave/brave-browser#630.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

### Manual

1. Have a browser-laptop profile with some non-zero values for the new tab stats. You can verify this quickly with `jq '.adblock, .httpsEverywhere, .trackingProtection | .count' ~/Library/Application\ Support/brave/session-store-1`.
2. Delete your Brave-Browser-Development directory to reset stats values to 0; alternatively, check the current values so you can compare before/after import.
3. `yarn start`
4. Open the main menu (e.g. **Brave** on macOS) and choose **Import Bookmarks and Settings...**
5. Choose the Brave profile from the dropdown menu of browser profiles.
6. Make sure the **Stats** checkbox is activated.
7. Click **Import**.
8. Open a new tab and confirm that the stats have the expected imported values.

### Automated

`yarn test brave_unit_tests`. `BraveImporter.ImportStats` should pass.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
