### PR TITLE
Avoid importing stats multiple times from multiple imports

### DIFF
--- a/browser/importer/brave_profile_writer.cc
+++ b/browser/importer/brave_profile_writer.cc
@@ -44,10 +44,22 @@ void BraveProfileWriter::AddCookies(
 void BraveProfileWriter::UpdateStats(const BraveStats& stats) {
   PrefService* prefs = profile_->GetOriginalProfile()->GetPrefs();
 
-  prefs->SetUint64(kAdsBlocked,
-                   prefs->GetUint64(kAdsBlocked) + stats.adblock_count);
-  prefs->SetUint64(kTrackersBlocked,
-                   prefs->GetUint64(kTrackersBlocked) + stats.trackingProtection_count);
-  prefs->SetUint64(kHttpsUpgrades,
-                   prefs->GetUint64(kHttpsUpgrades) + stats.httpsEverywhere_count);
+  const uint64_t ads_blocked = prefs->GetUint64(kAdsBlocked);
+  const uint64_t trackers_blocked = prefs->GetUint64(kTrackersBlocked);
+  const uint64_t https_upgrades = prefs->GetUint64(kHttpsUpgrades);
+
+  // Only update the current stats if they are less than the imported
+  // stats; intended to prevent incorrectly updating the stats multiple
+  // times from multiple imports.
+  if (ads_blocked < uint64_t{stats.adblock_count}) {
+      prefs->SetUint64(kAdsBlocked, ads_blocked + stats.adblock_count);
+  }
+  if (trackers_blocked < uint64_t{stats.trackingProtection_count}) {
+    prefs->SetUint64(kTrackersBlocked,
+                     trackers_blocked + stats.trackingProtection_count);
+  }
+  if (https_upgrades < uint64_t{stats.httpsEverywhere_count}) {
+    prefs->SetUint64(kHttpsUpgrades,
+                     https_upgrades + stats.httpsEverywhere_count);
+  }
 }


### PR DESCRIPTION
Resolves brave/brave-browser#728.

Uses a simple heuristic which should work in the common case: a new brave-browser user wants to import their browser-laptop stats, and may run the import multiple times. The heuristic will fail (and stats import will fail, silently) if the brave-browser user's stats already exceed those from their browser-laptop profile.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

1. Import stats from Brave, and open a new tab page to check the current values (should be updated from the import).
2. Import stats from Brave again, then switch back to the new page (it updates automatically). The values for the stats should not have changed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
