### PR TITLE
Workaround accessibility_checker.cc check failed 

### DIFF
--- a/browser/autoplay/autoplay_permission_context_browsertest.cc
+++ b/browser/autoplay/autoplay_permission_context_browsertest.cc
@@ -178,7 +178,7 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, AskByDefault) {
 }
 
 // Click allow from promt
-IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, DISABLED_ClickAllow) {
+IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, ClickAllow) {
   std::string result;
   PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
       contents());
@@ -308,7 +308,7 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, ClickBlock) {
 }
 
 // Allow autoplay
-IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, DISABLED_AllowAutoplay) {
+IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, AllowAutoplay) {
   std::string result;
   AllowAutoplay();
   PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
@@ -426,7 +426,7 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, BlockAutoplay) {
 }
 
 // Default allow autoplay on file urls
-IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, DISABLED_FileAutoplay) {
+IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, FileAutoplay) {
   std::string result;
   PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
       contents());

--- a/patches/chrome-test-views-accessibility_checker.cc.patch
+++ b/patches/chrome-test-views-accessibility_checker.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/test/views/accessibility_checker.cc b/chrome/test/views/accessibility_checker.cc
+index 6bc4c93c2788f1a190ddf50e1b26b8bbcac419ba..08a8f057588d74895d34a0028cc7ed144ca2142f 100644
+--- a/chrome/test/views/accessibility_checker.cc
++++ b/chrome/test/views/accessibility_checker.cc
+@@ -44,6 +44,7 @@ bool DoesViewHaveAccessibleNameOrLabelError(ui::AXNodeData* data) {
+   // 2) Explicitly setting the name to "" is allowed if the view uses
+   // AXNodedata.SetNameExplicitlyEmpty().
+ 
++  data->SetNameExplicitlyEmpty();
+   // It has a name, we're done.
+   if (!data->GetStringAttribute(StringAttribute::kName).empty())
+     return false;


### PR DESCRIPTION
which introduced in Chromium 68

detail logged in https://github.com/brave/brave-browser/issues/748

fix https://github.com/brave/brave-browser/issues/735

Auditor: @bbondy

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
