### PR TITLE
Add dark theme for dev channel

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -67,6 +67,7 @@ source_set("browser_process") {
     "//components/spellcheck/browser",
     "//content/public/browser",
     "//brave/chromium_src:browser",
+    "themes",
   ]
 
   if (is_win && is_official_build) {

--- a/browser/themes/BUILD.gn
+++ b/browser/themes/BUILD.gn
@@ -1,0 +1,9 @@
+source_set("themes") {
+  sources = [
+    "theme_properties.cc",
+    "theme_properties.h",
+  ]
+  deps = [
+    "//skia",
+  ]
+}

--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/themes/theme_properties.h"
+
+#include "chrome/browser/themes/theme_properties.h"
+#include "chrome/common/channel_info.h"
+#include "ui/gfx/color_palette.h"
+
+namespace {
+
+#if defined(OFFICIAL_BUILD)
+base::Optional<SkColor> MaybeGetDefaultColorForBraveUiReleaseChannel(int id, bool incognito) {
+  switch (id) {
+    // Applies when the window is active, tabs and also tab bar everywhere except active tab
+    case ThemeProperties::COLOR_FRAME:
+    case ThemeProperties::COLOR_BACKGROUND_TAB:
+      return incognito ? SkColorSetRGB(0x81, 0x85, 0x89) : SkColorSetRGB(0xD8, 0xDE, 0xE1);
+    // Window when the window is innactive, tabs and also tab bar everywhere except active tab
+    case ThemeProperties::COLOR_FRAME_INACTIVE:
+    case ThemeProperties::COLOR_BACKGROUND_TAB_INACTIVE:
+      return incognito ? SkColorSetRGB(0x71, 0x75, 0x79) : SkColorSetRGB(0xC8, 0xCE, 0xC8);
+    // Active tab and also the URL toolbar
+    // Parts of this color show up as you hover over innactive tabs too
+    case ThemeProperties::COLOR_TOOLBAR:
+    case ThemeProperties::COLOR_DETACHED_BOOKMARK_BAR_BACKGROUND:
+    case ThemeProperties::COLOR_CONTROL_BACKGROUND:
+    case ThemeProperties::COLOR_TOOLBAR_BOTTOM_SEPARATOR:
+      return incognito ? SkColorSetRGB(0x91, 0x95, 0x99) : SkColorSetRGB(0xF6, 0xF7, 0xF9);
+    case ThemeProperties::COLOR_TAB_TEXT:
+      return SkColorSetRGB(0x22, 0x23, 0x26);
+    case ThemeProperties::COLOR_BOOKMARK_TEXT:
+    case ThemeProperties::COLOR_BACKGROUND_TAB_TEXT:
+      return SkColorSetRGB(0x22, 0x23, 0x26);
+    default:
+      return base::nullopt;
+  }
+}
+#endif
+
+base::Optional<SkColor> MaybeGetDefaultColorForBraveUiDevChannel(int id, bool incognito) {
+  switch (id) {
+    // Applies when the window is active, tabs and also tab bar everywhere except active tab
+    case ThemeProperties::COLOR_FRAME:
+    case ThemeProperties::COLOR_BACKGROUND_TAB:
+      return incognito ? SkColorSetRGB(0x68, 0x6B, 0x6E) : SkColorSetRGB(0x58, 0x5B, 0x5E);
+    // Window when the window is innactive, tabs and also tab bar everywhere except active tab
+    case ThemeProperties::COLOR_FRAME_INACTIVE:
+    case ThemeProperties::COLOR_BACKGROUND_TAB_INACTIVE:
+      return incognito ? SkColorSetRGB(0x58, 0x5B, 0x5E) : SkColorSetRGB(0x48, 0x4B, 0x4E);
+    // Active tab and also the URL toolbar
+    // Parts of this color show up as you hover over innactive tabs too
+    case ThemeProperties::COLOR_TOOLBAR:
+    case ThemeProperties::COLOR_DETACHED_BOOKMARK_BAR_BACKGROUND:
+    case ThemeProperties::COLOR_CONTROL_BACKGROUND:
+    case ThemeProperties::COLOR_TOOLBAR_BOTTOM_SEPARATOR:
+      return incognito ? SkColorSetRGB(0x32, 0x33, 0x36) : SkColorSetRGB(0x22, 0x23, 0x26);
+    case ThemeProperties::COLOR_TAB_TEXT:
+      return SkColorSetRGB(0xF7, 0xF8, 0xF9);
+    case ThemeProperties::COLOR_BOOKMARK_TEXT:
+    case ThemeProperties::COLOR_BACKGROUND_TAB_TEXT:
+      return SkColorSetRGB(0x81, 0x85, 0x89);
+    default:
+      return base::nullopt;
+  }
+}
+
+}  // namespace
+
+// Returns a |nullopt| if the UI color is not handled by Brave.
+base::Optional<SkColor> MaybeGetDefaultColorForBraveUi(int id, bool incognito) {
+  if (id == BRAVE_COLOR_FOR_TEST) {
+    return SkColorSetRGB(11, 13, 17);
+  }
+#if !defined(OFFICIAL_BUILD)
+  return MaybeGetDefaultColorForBraveUiDevChannel(id, incognito);
+#else
+  switch (chrome::GetChannel()) {
+    case version_info::Channel::STABLE:
+    case version_info::Channel::BETA:
+      return MaybeGetDefaultColorForBraveUiReleaseChannel(id, incognito);
+    case version_info::Channel::DEV:
+    case version_info::Channel::CANARY:
+    case version_info::Channel::UNKNOWN:
+    default:
+      return MaybeGetDefaultColorForBraveUiDevChannel(id, incognito);
+  }
+#endif
+  return base::nullopt;
+}

--- a/browser/themes/theme_properties.h
+++ b/browser/themes/theme_properties.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_THEMES_THEME_PROPERTIES_H_
+#define BRAVE_BROWSER_THEMES_THEME_PROPERTIES_H_
+
+#include "base/optional.h"
+#include "third_party/skia/include/core/SkColor.h"
+
+#define BRAVE_COLOR_FOR_TEST 0x7FFFFFFF
+
+base::Optional<SkColor> MaybeGetDefaultColorForBraveUi(int id, bool incognito);
+
+#define MAYBE_OVERRIDE_DEFAULT_COLOR_FOR_BRAVE(id, incognito) \
+  const base::Optional<SkColor> braveColor = MaybeGetDefaultColorForBraveUi(id, incognito); \
+  if (braveColor) return braveColor.value();
+
+#endif  // BRAVE_BROWSER_THEMES_THEME_PROPERTIES_H_

--- a/browser/themes/theme_properties_unittest.cc
+++ b/browser/themes/theme_properties_unittest.cc
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
++ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
++ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/themes/theme_properties.h"
+#include "chrome/browser/themes/theme_properties.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(BraveThemeTest, ObtainsBraveOverrideColors) {
+  SkColor actualColor = ThemeProperties::GetDefaultColor(BRAVE_COLOR_FOR_TEST, false);
+  SkColor expectedColor = SkColorSetRGB(11, 13, 17);
+  ASSERT_EQ(actualColor, expectedColor);
+}

--- a/patches/chrome-browser-themes-theme_properties.cc.patch
+++ b/patches/chrome-browser-themes-theme_properties.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/browser/themes/theme_properties.cc b/chrome/browser/themes/theme_properties.cc
+index 135c5029bb1aeeab1be398388db47392069ec0c5..af1105e469f8935f55160f86220a2d38757a450d 100644
+--- a/chrome/browser/themes/theme_properties.cc
++++ b/chrome/browser/themes/theme_properties.cc
+@@ -10,6 +10,7 @@
+ #include "base/optional.h"
+ #include "base/strings/string_split.h"
+ #include "base/strings/string_util.h"
++#include "brave/browser/themes/theme_properties.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/themes/browser_theme_pack.h"
+ #include "ui/base/material_design/material_design_controller.h"
+@@ -290,6 +291,7 @@ color_utils::HSL ThemeProperties::GetDefaultTint(int id, bool incognito) {
+ 
+ // static
+ SkColor ThemeProperties::GetDefaultColor(int id, bool incognito) {
++  MAYBE_OVERRIDE_DEFAULT_COLOR_FOR_BRAVE(id, incognito)
+   const base::Optional<SkColor> color =
+       MaybeGetDefaultColorForNewerMaterialUi(id, incognito);
+   if (color)

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -32,6 +32,7 @@ test("brave_unit_tests") {
     "//brave/browser/brave_stats_updater_unittest.cc",
     "//brave/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc",
+    "//brave/browser/themes/theme_properties_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",
     "//brave/common/importer/brave_mock_importer_bridge.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/184

Dev channel + Development build default:
<img width="1103" alt="screen shot 2018-08-14 at 3 58 08 pm" src="https://user-images.githubusercontent.com/831718/44121321-7aed57aa-9fed-11e8-9cd2-45d594b3b6df.png">

Beta+Release channel default (I think those should always be in sync):
<img width="853" alt="screen shot 2018-08-14 at 4 17 23 pm" src="https://user-images.githubusercontent.com/831718/44121328-8167ef6e-9fed-11e8-9ed7-2347d3c07295.png">

For customizations of colors please do that work in a follow up PR. This is just to add dark theme support for dev channel. 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
