### PR TITLE
Fix missing include for Official builds

### DIFF
--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -6,6 +6,7 @@
 
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/common/channel_info.h"
+#include "components/version_info/channel.h"
 #include "ui/gfx/color_palette.h"
 
 namespace {


### PR DESCRIPTION
Fix for a build issue introduced for official builds from https://github.com/brave/brave-browser/issues/184

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
