### PR TITLE
Actually wait for playing to fix autoplay intermittent fails

### DIFF
--- a/test/data/autoplay/autoplay_by_attr.html
+++ b/test/data/autoplay/autoplay_by_attr.html
@@ -6,14 +6,14 @@
   </head>
   <body>
 
-    <video width="320" height="240" controls autoplay onplay="playing()">
+    <video width="320" height="240" controls autoplay onplay="onPlay()">
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function playing () {
+      function onPlay () {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
         window.playing = true;
@@ -21,7 +21,7 @@
           notifyWhenPlaying();
       }
       function notifyWhenPlaying() {
-        if (playing)
+        if (window.playing)
           window.domAutomationController.send("PLAYING");
         else
           window.notifyBrowser = true;

--- a/test/data/autoplay/autoplay_by_attr_muted.html
+++ b/test/data/autoplay/autoplay_by_attr_muted.html
@@ -6,14 +6,14 @@
   </head>
   <body>
 
-    <video width="320" height="240" controls autoplay onplay="playing()" muted>
+    <video width="320" height="240" controls autoplay onplay="onPlay()" muted>
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function playing () {
+      function onPlay () {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
         window.playing = true;
@@ -21,7 +21,7 @@
           notifyWhenPlaying();
       }
       function notifyWhenPlaying() {
-        if (playing)
+        if (this.playing)
           window.domAutomationController.send("PLAYING");
         else
           window.notifyBrowser = true;

--- a/test/data/autoplay/autoplay_by_method.html
+++ b/test/data/autoplay/autoplay_by_method.html
@@ -6,14 +6,14 @@
   </head>
   <body onload="autoplay()">
 
-    <video id="autoplay" width="320" height="240" controls onplay="playing()">
+    <video id="autoplay" width="320" height="240" controls onplay="onPlay()">
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function playing () {
+      function onPlay () {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
         window.playing = true;
@@ -21,7 +21,7 @@
           notifyWhenPlaying();
       }
       function notifyWhenPlaying() {
-        if (playing)
+        if (window.playing)
           window.domAutomationController.send("PLAYING");
         else
           window.notifyBrowser = true;

--- a/test/data/autoplay/autoplay_by_method_muted.html
+++ b/test/data/autoplay/autoplay_by_method_muted.html
@@ -6,14 +6,14 @@
   </head>
   <body onload="autoplay()">
 
-    <video id="autoplay" width="320" height="240" controls onplay="playing()" muted>
+    <video id="autoplay" width="320" height="240" controls onplay="onPlay()" muted>
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function playing () {
+      function onPlay () {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
         window.playing = true;
@@ -21,7 +21,7 @@
           notifyWhenPlaying();
       }
       function notifyWhenPlaying() {
-        if (playing)
+        if (window.playing)
           window.domAutomationController.send("PLAYING");
         else
           window.notifyBrowser = true;


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/769

The problem was that `if (playing)` was always true since the function was also called `playing`.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
