### PR TITLE
Disable hyperlink auditing by appending kNoPings option

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -114,6 +114,7 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
   command_line.AppendSwitch(switches::kEnableTabAudioMuting);
   command_line.AppendSwitch(switches::kDisableDomainReliability);
   command_line.AppendSwitch(switches::kDisableChromeGoogleURLTrackingClient);
+  command_line.AppendSwitch(switches::kNoPings);
 
   std::stringstream enabled_features;
   enabled_features << features::kEnableEmojiContextMenu.name

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -3,10 +3,13 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/common/chrome_switches.h"
 #include "chrome/browser/domain_reliability/service_factory.h"
 #include "components/domain_reliability/service.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/common/web_preferences.h"
 
 using BraveMainDelegateBrowserTest = InProcessBrowserTest;
 
@@ -15,4 +18,14 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DomainReliabilityServiceDis
       switches::kDisableDomainReliability));
   ASSERT_EQ(domain_reliability::DomainReliabilityServiceFactory::GetForBrowserContext(
         ((content::BrowserContext *)browser()->profile())), nullptr);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisableHyperlinkAuditing) {
+  EXPECT_TRUE(base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kNoPings));
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  const content::WebPreferences prefs =
+      contents->GetRenderViewHost()->GetWebkitPreferences();
+  EXPECT_FALSE(prefs.hyperlink_auditing_enabled);
 }


### PR DESCRIPTION
This option disables sending pings for anchor elements

Close https://github.com/brave/brave-browser/issues/764

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`yarn test brave_browser_tests --filter=BraveMainDelegateBrowserTest.DisableHyperlinkAuditing`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
