### PR TITLE
UI: Create BraveActionsContainer and add Shields extension button to it

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -9,6 +9,10 @@ source_set("ui") {
     "brave_browser_content_setting_bubble_model_delegate.h",
     "brave_pages.cc",
     "brave_pages.h",
+    "brave_actions/shields_action_view_controller.cc",
+    "brave_actions/shields_action_view_controller.h",
+    "brave_actions/brave_action_icon_with_badge_image_source.cc",
+    "brave_actions/brave_action_icon_with_badge_image_source.h",
     "content_settings/brave_autoplay_blocked_image_model.cc",
     "content_settings/brave_autoplay_blocked_image_model.h",
     "content_settings/brave_autoplay_content_setting_bubble_model.cc",
@@ -25,10 +29,16 @@ source_set("ui") {
     "location_bar/brave_location_bar.h",
     "toolbar/brave_app_menu_model.cc",
     "toolbar/brave_app_menu_model.h",
+    "toolbar/brave_toolbar_actions_model.cc",
+    "toolbar/brave_toolbar_actions_model.h",
+    "views/brave_actions/brave_actions_container.cc",
+    "views/brave_actions/brave_actions_container.h",
     "views/frame/brave_browser_view.cc",
     "views/frame/brave_browser_view.h",
     "views/importer/brave_import_lock_dialog_view.cc",
     "views/importer/brave_import_lock_dialog_view.h",
+    "views/location_bar/brave_location_bar_view.cc",
+    "views/location_bar/brave_location_bar_view.h",
     "views/toolbar/bookmark_button.cc",
     "views/toolbar/bookmark_button.h",
     "views/toolbar/brave_toolbar_view.cc",
@@ -68,12 +78,17 @@ source_set("ui") {
   ]
 
   deps = [
+    "//base",
     "//brave/app:command_ids",
     "//brave/app/theme:brave_unscaled_resources",
     "//brave/app/theme:brave_theme_resources",
     "//brave/browser/payments",
     "//brave/components/resources:brave_components_resources_grit",
     "//chrome/app:command_ids",
+    "//skia",
+    "//ui/accessibility",
+    "//ui/base",
+    "//ui/gfx",
   ]
 
   if (is_win && is_official_build) {

--- a/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.cc
+++ b/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.cc
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "cc/paint/paint_flags.h"
+#include "chrome/browser/extensions/extension_action.h"
+#include "chrome/browser/ui/toolbar/toolbar_actions_bar.h"
+#include "chrome/grit/theme_resources.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/base/resource/resource_bundle.h"
+#include "ui/gfx/canvas.h"
+#include "ui/gfx/color_palette.h"
+#include "ui/gfx/font.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/image/image_skia_operations.h"
+#include "ui/gfx/skia_paint_util.h"
+
+void BraveActionIconWithBadgeImageSource::PaintBadge(gfx::Canvas* canvas) {
+    if (!badge_ || badge_->text.empty())
+    return;
+
+  SkColor text_color = SkColorGetA(badge_->text_color) == SK_AlphaTRANSPARENT
+                           ? SK_ColorWHITE
+                           : badge_->text_color;
+
+  SkColor background_color = SkColorSetA(badge_->background_color, SK_AlphaOPAQUE);
+
+  // Always use same height to avoid jumping up and down with different
+  // characters which will differ slightly,
+  // but vary the width so we cover as little of the icon as possible.
+  constexpr int kBadgeHeight = 12;
+  constexpr int kBadgeMaxWidth = 14;
+  constexpr int kVPadding = 1;
+  const int kTextHeightTarget = kBadgeHeight - (kVPadding * 2);
+  int h_padding = 2;
+  int text_max_width = kBadgeMaxWidth - (h_padding * 2);
+
+  ui::ResourceBundle* rb = &ui::ResourceBundle::GetSharedInstance();
+  gfx::FontList base_font = rb->GetFontList(ui::ResourceBundle::BaseFont)
+                                .DeriveWithHeightUpperBound(kTextHeightTarget);
+  base::string16 utf16_text = base::UTF8ToUTF16(badge_->text);
+
+  // Calculate best font size to fit maximum Width and constant Height
+  int text_height = 0;
+  int text_width = 0;
+  gfx::Canvas::SizeStringInt(utf16_text, base_font, &text_width,
+                             &text_height,
+                             0, gfx::Canvas::NO_ELLIPSIS);
+  // Leaving extremely verbose log lines commented in case we want to change
+  // any sizes in this algorithm, these logs are helpful.
+  // LOG(ERROR) << "BraveAction badge text size initial, "
+  //            << "w:"
+  //            << text_width
+  //            << " h:"
+  //            << text_height;
+  if (text_width > text_max_width) {
+    // Too wide
+    // Reduce the padding
+    h_padding -= 1;
+    text_max_width += 2; // 2 * padding delta
+    // If still cannot squeeze it in, reduce font size
+    if (text_width > text_max_width) {
+      // Reduce font size until we find the first one that fits within the width
+      // TODO: Consider adding minimum font-size and adjusting
+      //  |max_decrement_attempts| accordingly
+      int max_decrement_attempts = base_font.GetFontSize() - 1;
+      for (int i = 0; i < max_decrement_attempts; ++i) {
+        base_font =
+            base_font.Derive(-1, 0, gfx::Font::Weight::NORMAL);
+        gfx::Canvas::SizeStringInt(utf16_text, base_font, &text_width, &text_height, 0,
+                                  gfx::Canvas::NO_ELLIPSIS);
+        // LOG(ERROR) << "reducing to font size - w:" << text_width << " h:" << text_height;
+        if (text_width <= text_max_width)
+          break;
+      }
+    }
+  } else if (text_height < kTextHeightTarget) {
+    // Narrow enough, but could grow taller
+    // Increase font size until text fills height and is not too wide
+    // LOG(ERROR) << "can increase height";
+    constexpr int kMaxIncrementAttempts = 5;
+    for (size_t i = 0; i < kMaxIncrementAttempts; ++i) {
+      int w = 0;
+      int h = 0;
+      gfx::FontList bigger_font =
+          base_font.Derive(1, 0, gfx::Font::Weight::NORMAL);
+      gfx::Canvas::SizeStringInt(utf16_text, bigger_font, &w, &h, 0,
+                                gfx::Canvas::NO_ELLIPSIS);
+      if (h > kTextHeightTarget || w > text_max_width)
+        break;
+      base_font = bigger_font;
+      text_width = w;
+      text_height = h;
+      // LOG(ERROR) << "increasing to font size - w:"
+      //            << text_width
+      //            << " h:" << text_height;
+    }
+  }
+
+  // Calculate badge size. It is clamped to a min width just because it looks
+  // silly if it is too skinny.
+  int badge_width = text_width + h_padding * 2;
+  // Has to at least be as wide as it is tall, otherwise it looks weird
+  badge_width = std::max(kBadgeHeight, badge_width);
+
+  const gfx::Rect icon_area = GetIconAreaRect();
+  // Force the pixel width of badge to be either odd (if the icon width is odd)
+  // or even otherwise. If there is a mismatch you get http://crbug.com/26400.
+  if (icon_area.width() != 0 && (badge_width % 2 != icon_area.width() % 2))
+    badge_width += 1;
+
+  // Calculate the badge background rect. It is usually right-aligned, but it
+  // can also be center-aligned if it is large.
+  const int badge_offset_x = icon_area.width() - badge_width;
+  const int badge_offset_y = 0;
+  gfx::Rect rect(icon_area.x() + badge_offset_x, icon_area.y() + badge_offset_y,
+                 badge_width, kBadgeHeight);
+  cc::PaintFlags rect_flags;
+  rect_flags.setStyle(cc::PaintFlags::kFill_Style);
+  rect_flags.setAntiAlias(true);
+  rect_flags.setColor(background_color);
+
+  // Paint the backdrop.
+  constexpr int kOuterCornerRadius = 5;
+  canvas->DrawRoundRect(rect, kOuterCornerRadius, rect_flags);
+
+  // Paint the text.
+  const int kTextExtraVerticalPadding = (kTextHeightTarget - text_height) / 2;
+  const int kVerticalPadding = kVPadding + kTextExtraVerticalPadding;
+  // l, t, r, b
+  rect.Inset(0, kVerticalPadding, 0, kVerticalPadding);
+  // Draw string with ellipsis if it does not fit
+  canvas->DrawStringRectWithFlags(utf16_text, base_font, text_color, rect,
+                                  gfx::Canvas::TEXT_ALIGN_CENTER);
+}
+
+gfx::Rect BraveActionIconWithBadgeImageSource::GetIconAreaRect() const {
+  return gfx::Rect(size());
+}

--- a/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.h
+++ b/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.h
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_BRAVE_ACTIONS_BRAVE_ACTION_ICON_WITH_BADGE_IMAGE_SOURCE_H_
+#define BRAVE_BROWSER_UI_BRAVE_ACTIONS_BRAVE_ACTION_ICON_WITH_BADGE_IMAGE_SOURCE_H_
+
+#include "chrome/browser/ui/extensions/icon_with_badge_image_source.h"
+
+namespace gfx {
+  class Canvas;
+  class Rect;
+}
+
+// The purpose of this subclass is to:
+// - Paint the BraveAction badge in a custom location and with a different size
+//   to regular BrowserAction extensions.
+class BraveActionIconWithBadgeImageSource : public IconWithBadgeImageSource {
+  public:
+    using IconWithBadgeImageSource::IconWithBadgeImageSource;
+  private:
+    void PaintBadge(gfx::Canvas* canvas) override;
+    gfx::Rect GetIconAreaRect() const override;
+    DISALLOW_COPY_AND_ASSIGN(BraveActionIconWithBadgeImageSource);
+};
+
+#endif

--- a/browser/ui/brave_actions/shields_action_view_controller.cc
+++ b/browser/ui/brave_actions/shields_action_view_controller.cc
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_actions/shields_action_view_controller.h"
+
+#include "brave/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.h"
+#include "chrome/browser/extensions/extension_action.h"
+#include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/sessions/session_tab_helper.h"
+#include "components/vector_icons/vector_icons.h"
+#include "ui/base/theme_provider.h"
+#include "ui/gfx/canvas.h"
+#include "ui/gfx/image/canvas_image_source.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/paint_vector_icon.h"
+#include "ui/gfx/scoped_canvas.h"
+
+void ShieldsActionViewController::HideActivePopup() {
+  // Usually, for an extension this should call the main extensions
+  // toolbar_actions_bar_->HideActivePopup(), but we don't have a reference
+  // to that, and it doesn't seem neccessary, whether the extension is opened
+  // via mouse or keyboard (if a `commands` extension property is present)
+}
+
+bool ShieldsActionViewController::DisabledClickOpensMenu() const {
+  // disabled is a per-tab state
+  return false;
+}
+
+ui::MenuModel* ShieldsActionViewController::GetContextMenu() {
+  // no context menu for shields button
+  return nullptr;
+}
+
+gfx::Image ShieldsActionViewController::GetIcon(content::WebContents* web_contents, const gfx::Size& size) {
+  return gfx::Image(gfx::ImageSkia(GetIconImageSource(web_contents, size), size));
+}
+
+std::unique_ptr<BraveActionIconWithBadgeImageSource> ShieldsActionViewController::GetIconImageSource(
+  content::WebContents* web_contents, const gfx::Size& size) {
+  int tab_id = SessionTabHelper::IdForTab(web_contents).id();
+  // generate icon
+  std::unique_ptr<BraveActionIconWithBadgeImageSource> image_source(
+      new BraveActionIconWithBadgeImageSource(size));
+  image_source->SetIcon(icon_factory_.GetIcon(tab_id));
+  // set text
+  std::unique_ptr<IconWithBadgeImageSource::Badge> badge;
+  std::string badge_text = extension_action()->GetBadgeText(tab_id);
+  if (!badge_text.empty()) {
+    badge.reset(new IconWithBadgeImageSource::Badge(
+            badge_text,
+            extension_action()->GetBadgeTextColor(tab_id),
+            extension_action()->GetBadgeBackgroundColor(tab_id)));
+  }
+  image_source->SetBadge(std::move(badge));
+  // state
+  // If the extension doesn't want to run on the active web contents, we
+  // grayscale it to indicate that.
+  bool is_enabled_for_tab = extension_action()->GetIsVisible(tab_id);
+  image_source->set_grayscale(!is_enabled_for_tab);
+  image_source->set_paint_page_action_decoration(false);
+  return image_source;
+}

--- a/browser/ui/brave_actions/shields_action_view_controller.h
+++ b/browser/ui/brave_actions/shields_action_view_controller.h
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_BRAVE_ACTIONS_SHIELDS_ACTION_VIEW_CONTROLLER_H_
+#define BRAVE_BROWSER_UI_BRAVE_ACTIONS_SHIELDS_ACTION_VIEW_CONTROLLER_H_
+
+#include "chrome/browser/ui/extensions/extension_action_view_controller.h"
+
+class BraveActionIconWithBadgeImageSource;
+
+namespace ui {
+  class MenuModel;
+}
+
+// The purposes of this subclass are to:
+// - Overcome the DCHECK in HideActivePopup since a toolbar will not be provided
+// - Use our custom class for painting the badge differently compared to
+//   user-installed extensions
+// - Remove the context menu from the button since we do not allow uninstall
+class ShieldsActionViewController : public ExtensionActionViewController {
+  public:
+    using ExtensionActionViewController::ExtensionActionViewController;
+    void HideActivePopup() override;
+    gfx::Image GetIcon(content::WebContents* web_contents, const gfx::Size& size) override;
+    bool DisabledClickOpensMenu() const override;
+    ui::MenuModel* GetContextMenu() override;
+  private:
+    // Returns the image source for the icon.
+    std::unique_ptr<BraveActionIconWithBadgeImageSource> GetIconImageSource(
+        content::WebContents* web_contents,
+        const gfx::Size& size);
+    DISALLOW_COPY_AND_ASSIGN(ShieldsActionViewController);
+};
+
+#endif

--- a/browser/ui/toolbar/brave_toolbar_actions_model.cc
+++ b/browser/ui/toolbar/brave_toolbar_actions_model.cc
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/toolbar/brave_toolbar_actions_model.h"
+
+#include "brave/common/extensions/extension_constants.h"
+#include "chrome/browser/ui/toolbar/toolbar_actions_model.h"
+#include "extensions/common/extension.h"
+
+bool BraveToolbarActionsModel::ShouldAddExtension(const extensions::Extension* extension) {
+  // Don't show the Brave 'extension' in the ToolbarActions extensions area. It
+  // will instead be shown in the BraveActions area.
+  if (extension->id() == brave_extension_id) {
+    return false;
+  }
+  return ToolbarActionsModel::ShouldAddExtension(extension);
+}

--- a/browser/ui/toolbar/brave_toolbar_actions_model.h
+++ b/browser/ui/toolbar/brave_toolbar_actions_model.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_TOOLBAR_TOOLBAR_ACTIONS_MODEL_H_
+#define BRAVE_BROWSER_UI_TOOLBAR_TOOLBAR_ACTIONS_MODEL_H_
+
+#include "chrome/browser/ui/toolbar/toolbar_actions_model.h"
+
+#include "extensions/common/extension.h"
+
+// The purposes of this subclass are to:
+// - Hide the Brave 'extension' item from the |ToolbarActionsBar|, since it is
+//   displayed in the |BraveActionsContainer|
+class BraveToolbarActionsModel : public ToolbarActionsModel {
+  public:
+    using ToolbarActionsModel::ToolbarActionsModel;
+    bool ShouldAddExtension(const extensions::Extension* extension) override;
+  private:
+    DISALLOW_COPY_AND_ASSIGN(BraveToolbarActionsModel);
+};
+
+#endif

--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -1,0 +1,203 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_actions/brave_actions_container.h"
+
+#include <memory>
+
+#include "brave/common/extensions/extension_constants.h"
+#include "brave/browser/ui/brave_actions/shields_action_view_controller.h"
+#include "chrome/browser/extensions/extension_action_manager.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/toolbar/toolbar_action_view_controller.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_action_view.h"
+#include "extensions/browser/extension_system.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/browser/extension_registry_observer.h"
+#include "extensions/common/one_shot_event.h"
+#include "ui/views/controls/separator.h"
+#include "ui/views/layout/box_layout.h"
+#include "ui/views/layout/grid_layout.h"
+#include "ui/views/view.h"
+
+BraveActionsContainer::BraveActionsContainer(Browser* browser, Profile* profile)
+  : views::View(),
+    browser_(browser),
+    extension_action_api_(extensions::ExtensionActionAPI::Get(profile)),
+    extension_registry_(extensions::ExtensionRegistry::Get(profile)),
+    extension_action_manager_(
+      extensions::ExtensionActionManager::Get(profile)
+    ),
+    extension_registry_observer_(this),
+    extension_action_observer_(this),
+    weak_ptr_factory_(this) {
+  // Handle when the extension system is ready
+  extensions::ExtensionSystem::Get(profile)->ready().Post(
+      FROM_HERE, base::Bind(&BraveActionsContainer::OnExtensionSystemReady,
+                            weak_ptr_factory_.GetWeakPtr()));
+}
+
+BraveActionsContainer::~BraveActionsContainer() {
+}
+
+void BraveActionsContainer::Init() {
+  // automatic layout
+  auto vertical_container_layout = std::make_unique<views::BoxLayout>(
+                                                views::BoxLayout::kHorizontal);
+  vertical_container_layout->set_main_axis_alignment(
+                                  views::BoxLayout::MAIN_AXIS_ALIGNMENT_CENTER);
+  vertical_container_layout->set_cross_axis_alignment(views::BoxLayout::CROSS_AXIS_ALIGNMENT_CENTER);
+  SetLayoutManager(std::move(vertical_container_layout));
+
+  // children
+  views::Separator* brave_button_separator_ = new views::Separator();
+  // TODO: theme color
+  brave_button_separator_->SetColor(SkColorSetRGB(0xb2, 0xb5, 0xb7));
+  brave_button_separator_->SetPreferredSize(gfx::Size(2,
+                            GetLayoutConstant(LOCATION_BAR_ICON_SIZE)));
+  // Just in case the extensions load before this function does (not likely!)
+  // make sure separator is at index 0
+  AddChildViewAt(brave_button_separator_, 0);
+}
+
+void BraveActionsContainer::AddShields(
+                                const extensions::Extension* brave_extension) {
+  DCHECK(brave_extension);
+  VLOG(1) << "AddShields, was already loaded: " << (bool)shields_button_view_;
+  if (!shields_button_view_) {
+    // Create a ExtensionActionViewController for the extension
+    // Passing |nullptr| instead of ToolbarActionsBar since we
+    // do not require that logic.
+    // If we do require notifications when popups are open or closed,
+    // then we should inherit and pass |this| through.
+    shields_view_controller_ = std::make_unique<ShieldsActionViewController>(
+                                                    brave_extension, browser_,
+               extension_action_manager_->GetExtensionAction(*brave_extension),
+                                                                      nullptr);
+    // The button view
+    shields_button_view_ = std::make_unique<ToolbarActionView>(
+                                          shields_view_controller_.get(), this);
+    // we control destruction
+    shields_button_view_->set_owned_by_client();
+    // Sets overall size of button but not image graphic. We set a large width
+    // in order to give space for the bubble.
+    shields_button_view_->SetPreferredSize(gfx::Size(32, 24));
+    // Add extension view after separator view
+    AddChildView(shields_button_view_.get());
+    Update();
+  }
+}
+
+void BraveActionsContainer::RemoveShields() {
+  VLOG(1) << "RemoveShields, was already loaded: " << (bool)shields_button_view_;
+  if (shields_button_view_) {
+    // Reset references for next extension install
+    // (will automatically remove the child from the parent (us)
+    shields_button_view_.reset();
+    shields_view_controller_.reset();
+    // layout
+    Update();
+  }
+}
+
+void BraveActionsContainer::Update() {
+  if (shields_view_controller_)
+    shields_view_controller_->UpdateState();
+  // only show separator if we're showing any buttons
+  const bool visible = !should_hide_ && shields_button_view_;
+  SetVisible(visible);
+  Layout();
+}
+
+void BraveActionsContainer::SetShouldHide(bool should_hide) {
+  should_hide_ = should_hide;
+  Update();
+}
+
+content::WebContents* BraveActionsContainer::GetCurrentWebContents() {
+  return browser_->tab_strip_model()->GetActiveWebContents();
+}
+
+bool BraveActionsContainer::ShownInsideMenu() const {
+  return false;
+}
+
+void BraveActionsContainer::OnToolbarActionViewDragDone() {
+}
+
+views::MenuButton* BraveActionsContainer::GetOverflowReferenceView() {
+  // Our action views should always be visible,
+  // so we should not need another view.
+  NOTREACHED();
+  return nullptr;
+}
+
+// ToolbarActionView::Delegate members
+gfx::Size BraveActionsContainer::GetToolbarActionSize() {
+  // Shields icon should be square, and full-height
+  gfx::Rect rect(gfx::Size(height(), height()));
+  rect.Inset(-GetLayoutInsets(LOCATION_BAR_ICON_INTERIOR_PADDING));
+  return rect.size();
+}
+
+void BraveActionsContainer::WriteDragDataForView(View* sender,
+                                                   const gfx::Point& press_pt,
+                                                   OSExchangeData* data) {
+  // Not supporting drag for action buttons inside this container
+}
+
+int BraveActionsContainer::GetDragOperationsForView(View* sender,
+                                                      const gfx::Point& p) {
+  return ui::DragDropTypes::DRAG_NONE;
+}
+
+bool BraveActionsContainer::CanStartDragForView(View* sender,
+                                                  const gfx::Point& press_pt,
+                                                  const gfx::Point& p) {
+  return false;
+}
+// end ToolbarActionView::Delegate members
+
+void BraveActionsContainer::OnExtensionSystemReady() {
+  // observe changes in extension system
+  extension_registry_observer_.Add(extension_registry_);
+  extension_action_observer_.Add(extension_action_api_);
+  // Check if brave extension already loaded
+  const extensions::Extension* extension =
+          extension_registry_->enabled_extensions().GetByID(brave_extension_id);
+  if (extension)
+    AddShields(extension);
+};
+
+// ExtensionRegistry::Observer
+void BraveActionsContainer::OnExtensionLoaded(
+    content::BrowserContext* browser_context,
+    const extensions::Extension* extension) {
+  if (extension->id() == brave_extension_id) {
+    AddShields(extension);
+  }
+}
+
+void BraveActionsContainer::OnExtensionUnloaded(
+    content::BrowserContext* browser_context,
+    const extensions::Extension* extension,
+    extensions::UnloadedExtensionReason reason) {
+  if (extension->id() == brave_extension_id) {
+    RemoveShields();
+  }
+}
+// end ExtensionRegistry::Observer
+
+// ExtensionActionAPI::Observer
+void BraveActionsContainer::OnExtensionActionUpdated(
+    ExtensionAction* extension_action,
+    content::WebContents* web_contents,
+    content::BrowserContext* browser_context) {
+  if (extension_action->extension_id() == brave_extension_id && shields_view_controller_) {
+    shields_view_controller_->UpdateState();
+  }
+}
+// end ExtensionActionAPI::Observer

--- a/browser/ui/views/brave_actions/brave_actions_container.h
+++ b/browser/ui/views/brave_actions/brave_actions_container.h
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_ACTIONS_BRAVE_ACTIONS_CONTAINER_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_ACTIONS_BRAVE_ACTIONS_CONTAINER_H_
+
+#include "chrome/browser/ui/views/toolbar/toolbar_action_view.h"
+#include "chrome/browser/ui/toolbar/toolbar_action_view_controller.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/extensions/api/extension_action/extension_action_api.h"
+#include "extensions/common/extension.h"
+#include "ui/views/view.h"
+
+namespace extensions {
+  class ExtensionActionManager;
+  class ExtensionRegistry;
+  class ExtensionRegistryObserver;
+}
+
+// This View contains all the built-in BraveActions such as Shields and Payments
+// TODO: consider splitting to separate model, like ToolbarActionsModel and
+// ToolbarActionsBar
+class BraveActionsContainer : public views::View,
+                             public extensions::ExtensionActionAPI::Observer,
+                             public extensions::ExtensionRegistryObserver,
+                             public ToolbarActionView::Delegate {
+  public:
+    BraveActionsContainer(Browser* browser, Profile* profile);
+    ~BraveActionsContainer() override;
+    void Init();
+    void Update();
+    void SetShouldHide(bool should_hide);
+
+    // ToolbarActionView::Delegate
+    content::WebContents* GetCurrentWebContents() override;
+    bool ShownInsideMenu() const override;
+    // Notifies that a drag completed.
+    void OnToolbarActionViewDragDone() override;
+    // Returns the view of the toolbar actions overflow menu to use as a
+    // reference point for a popup when this view isn't visible.
+    views::MenuButton* GetOverflowReferenceView() override;
+    // Returns the preferred size of the ToolbarActionView.
+    gfx::Size GetToolbarActionSize() override;
+    // Overridden from views::DragController (required by ToolbarActionView::Delegate):
+    void WriteDragDataForView(View* sender,
+                              const gfx::Point& press_pt,
+                              ui::OSExchangeData* data) override;
+    int GetDragOperationsForView(View* sender, const gfx::Point& p) override;
+    bool CanStartDragForView(View* sender,
+                            const gfx::Point& press_pt,
+                            const gfx::Point& p) override;
+
+    // ExtensionRegistryObserver:
+    void OnExtensionLoaded(content::BrowserContext* browser_context,
+                          const extensions::Extension* extension) override;
+    void OnExtensionUnloaded(content::BrowserContext* browser_context,
+                            const extensions::Extension* extension,
+                            extensions::UnloadedExtensionReason reason) override;
+
+    // ExtensionActionAPI::Observer
+    // Called when there is a change to the given |extension_action|.
+    // |web_contents| is the web contents that was affected, and
+    // |browser_context| is the associated BrowserContext. (The latter is
+    // included because ExtensionActionAPI is shared between normal and
+    // incognito contexts, so |browser_context| may not equal
+    // |browser_context_|.)
+    void OnExtensionActionUpdated(
+        ExtensionAction* extension_action,
+        content::WebContents* web_contents,
+        content::BrowserContext* browser_context) override;
+
+  private:
+    void AddShields(const extensions::Extension* brave_extension);
+    void RemoveShields();
+
+    bool should_hide_ = false;
+
+    std::unique_ptr<ToolbarActionView> shields_button_view_;
+    // The Browser this LocationBarView is in.  Note that at least
+    // chromeos::SimpleWebViewDialog uses a LocationBarView outside any browser
+    // window, so this may be NULL.
+    Browser* const browser_;
+
+    void OnExtensionSystemReady();
+
+    extensions::ExtensionActionAPI* extension_action_api_;
+    extensions::ExtensionRegistry* extension_registry_;
+    extensions::ExtensionActionManager* extension_action_manager_;
+    std::unique_ptr<ToolbarActionViewController> shields_view_controller_;
+
+    // Listen to extension load, unloaded notifications.
+    ScopedObserver<extensions::ExtensionRegistry, ExtensionRegistryObserver>
+        extension_registry_observer_;
+
+    // Listen to when the action is updated
+    ScopedObserver<extensions::ExtensionActionAPI,
+                extensions::ExtensionActionAPI::Observer>
+        extension_action_observer_;
+
+    base::WeakPtrFactory<BraveActionsContainer> weak_ptr_factory_;
+
+    DISALLOW_COPY_AND_ASSIGN(BraveActionsContainer);
+};
+
+#endif

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// We want the subclass to inherit from BraveLocationBar, not LocationBar
+#include "chrome/browser/ui/location_bar/location_bar.h"
+#include "brave/browser/ui/location_bar/brave_location_bar.h"
+#define LocationBar BraveLocationBar
+
+#include "brave/browser/ui/views/brave_actions/brave_actions_container.h"
+#include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
+#include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+
+void BraveLocationBarView::Init() {
+  // base method calls Update and Layout
+  LocationBarView::Init();
+  // brave action buttons
+  brave_actions_ = new BraveActionsContainer(browser_, profile());
+  brave_actions_->Init();
+  AddChildView(brave_actions_);
+  // Call Update again to cause a Layout
+  Update(nullptr);
+}
+
+void BraveLocationBarView::Layout() {
+  LocationBarView::Layout(brave_actions_ ? brave_actions_ : nullptr);
+}
+
+void BraveLocationBarView::Update(const content::WebContents* contents) {
+  // base Init calls update before our Init is run, so our children
+  // may not be initialized yet
+  if (brave_actions_) {
+    brave_actions_->Update();
+  }
+  LocationBarView::Update(contents);
+}
+
+void BraveLocationBarView::OnChanged() {
+  if (brave_actions_) {
+    // Do not show actions whilst omnibar is open or url is being edited
+    const bool should_hide = GetToolbarModel()->input_in_progress() &&
+                      !omnibox_view_->text().empty();
+    brave_actions_->SetShouldHide(should_hide);
+  }
+
+  // OnChanged calls Layout
+  LocationBarView::OnChanged();
+}
+
+gfx::Size BraveLocationBarView::CalculatePreferredSize() const {
+  gfx::Size min_size = LocationBarView::CalculatePreferredSize();
+  if (brave_actions_ && brave_actions_->visible()){
+    const int brave_actions_min = brave_actions_->GetMinimumSize().width();
+    const int extra_width = brave_actions_min +
+                              GetLayoutConstant(LOCATION_BAR_ELEMENT_PADDING);
+    min_size.Enlarge(extra_width, 0);
+  }
+  return min_size;
+}
+
+// Provide base class implementation for Update override that has been added to
+// header via a patch. This should never be called as the only instantiated
+// implementation should be our |BraveLocationBarView|.
+void LocationBarView::Layout() {
+  Layout(nullptr);
+}

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_LOCATION_BAR_BRAVE_LOCATION_BAR_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_LOCATION_BAR_BRAVE_LOCATION_BAR_VIEW_H_
+
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+
+class BraveActionsContainer;
+
+// The purposes of this subclass are to:
+// - Add the BraveActionsContainer to the location bar
+class BraveLocationBarView : public LocationBarView {
+  public:
+    using LocationBarView::LocationBarView;
+    void Init() override;
+    void Layout() override;
+    void Update(const content::WebContents* contents) override;
+    void OnChanged() override;
+    gfx::Size CalculatePreferredSize() const override;
+  private:
+    BraveActionsContainer* brave_actions_ = nullptr;
+
+    DISALLOW_COPY_AND_ASSIGN(BraveLocationBarView);
+};
+
+#endif

--- a/chromium_src/chrome/browser/ui/toolbar/toolbar_actions_model_factory.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/toolbar_actions_model_factory.cc
@@ -1,0 +1,6 @@
+#include "chrome/browser/ui/toolbar/toolbar_actions_model.h"
+#include "brave/browser/ui/toolbar/brave_toolbar_actions_model.h"
+
+#define ToolbarActionsModel BraveToolbarActionsModel
+
+#include "../../../../../../../chrome/browser/ui/toolbar/toolbar_actions_model_factory.cc"

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -1,6 +1,0 @@
-#include "chrome/browser/ui/location_bar/location_bar.h"
-#include "brave/browser/ui/location_bar/brave_location_bar.h"
-
-#define LocationBar BraveLocationBar
-
-#include "../../../../../../../chrome/browser/ui/views/location_bar/location_bar_view.cc"

--- a/chromium_src/chrome/browser/ui/views/toolbar/toolbar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/toolbar_view.cc
@@ -1,0 +1,6 @@
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+#include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
+
+#define LocationBarView BraveLocationBarView
+
+#include "../../../../../../../chrome/browser/ui/views/toolbar/toolbar_view.cc"

--- a/patches/chrome-browser-ui-extensions-extension_action_view_controller.h.patch
+++ b/patches/chrome-browser-ui-extensions-extension_action_view_controller.h.patch
@@ -1,0 +1,29 @@
+diff --git a/chrome/browser/ui/extensions/extension_action_view_controller.h b/chrome/browser/ui/extensions/extension_action_view_controller.h
+index dbef20f1ec8eede60dc4a9aebc93e4a656530f93..68fd9071330c8dea56f4374e17d21f41936539a1 100644
+--- a/chrome/browser/ui/extensions/extension_action_view_controller.h
++++ b/chrome/browser/ui/extensions/extension_action_view_controller.h
+@@ -14,6 +14,7 @@
+ #include "extensions/browser/extension_host_observer.h"
+ #include "ui/gfx/image/image.h"
+ 
++class ShieldsActionViewController;
+ class Browser;
+ class ExtensionAction;
+ class ExtensionActionPlatformDelegate;
+@@ -39,6 +40,7 @@ class ExtensionActionViewController
+       public extensions::ExtensionContextMenuModel::PopupDelegate,
+       public extensions::ExtensionHostObserver {
+  public:
++  friend class ShieldsActionViewController;
+   // The different options for showing a popup.
+   enum PopupShowAction { SHOW_POPUP, SHOW_POPUP_AND_INSPECT };
+ 
+@@ -73,7 +75,7 @@ class ExtensionActionViewController
+   void InspectPopup() override;
+ 
+   // Closes the active popup (whether it was this action's popup or not).
+-  void HideActivePopup();
++  virtual void HideActivePopup();
+ 
+   // Populates |command| with the command associated with |extension|, if one
+   // exists. Returns true if |command| was populated.

--- a/patches/chrome-browser-ui-extensions-icon_with_badge_image_source.h.patch
+++ b/patches/chrome-browser-ui-extensions-icon_with_badge_image_source.h.patch
@@ -1,0 +1,38 @@
+diff --git a/chrome/browser/ui/extensions/icon_with_badge_image_source.h b/chrome/browser/ui/extensions/icon_with_badge_image_source.h
+index addf0c4d1cd795eab24e538fbb136dcccd92f957..33577a779c5a038e9c32ce3d7a83797a75df6606 100644
+--- a/chrome/browser/ui/extensions/icon_with_badge_image_source.h
++++ b/chrome/browser/ui/extensions/icon_with_badge_image_source.h
+@@ -13,6 +13,7 @@
+ #include "ui/gfx/image/canvas_image_source.h"
+ #include "ui/gfx/image/image.h"
+ 
++class BraveActionIconWithBadgeImageSource;
+ namespace gfx {
+ class Size;
+ }
+@@ -20,6 +21,7 @@ class Size;
+ // CanvasImageSource for creating extension icon with a badge.
+ class IconWithBadgeImageSource : public gfx::CanvasImageSource {
+  public:
++  friend class BraveActionIconWithBadgeImageSource;
+   // The data representing a badge to be painted over the base image.
+   struct Badge {
+     Badge(const std::string& text,
+@@ -60,7 +62,7 @@ class IconWithBadgeImageSource : public gfx::CanvasImageSource {
+   void Draw(gfx::Canvas* canvas) override;
+ 
+   // Paints |badge_|, if any, on |canvas|.
+-  void PaintBadge(gfx::Canvas* canvas);
++  virtual void PaintBadge(gfx::Canvas* canvas);
+ 
+   // Paints a decoration over the base icon to indicate that the action wants to
+   // run.
+@@ -75,7 +77,7 @@ class IconWithBadgeImageSource : public gfx::CanvasImageSource {
+   // all cases, our badges and decorations should be positions at the corners of
+   // the area where the icon exists (ignoring all the paddings).
+   // https://crbug.com/831946.
+-  gfx::Rect GetIconAreaRect() const;
++  virtual gfx::Rect GetIconAreaRect() const;
+ 
+   // The base icon to draw.
+   gfx::Image icon_;

--- a/patches/chrome-browser-ui-toolbar-toolbar_actions_model.h.patch
+++ b/patches/chrome-browser-ui-toolbar-toolbar_actions_model.h.patch
@@ -1,0 +1,29 @@
+diff --git a/chrome/browser/ui/toolbar/toolbar_actions_model.h b/chrome/browser/ui/toolbar/toolbar_actions_model.h
+index bd0aab4315526945f41db7e5330e9518b7eb8208..f88516e816698ac0548d1db1535bf8aca914820f 100644
+--- a/chrome/browser/ui/toolbar/toolbar_actions_model.h
++++ b/chrome/browser/ui/toolbar/toolbar_actions_model.h
+@@ -27,6 +27,7 @@ class PrefService;
+ class Profile;
+ class ToolbarActionsBar;
+ class ToolbarActionViewController;
++class BraveToolbarActionsModel;
+ 
+ namespace extensions {
+ class ExtensionActionManager;
+@@ -47,6 +48,7 @@ class ToolbarActionsModel : public extensions::ExtensionActionAPI::Observer,
+                             public KeyedService,
+                             public ComponentActionDelegate {
+  public:
++  friend class BraveToolbarActionsModel;
+   // The different options for highlighting.
+   enum HighlightType {
+     HIGHLIGHT_NONE,
+@@ -258,7 +260,7 @@ class ToolbarActionsModel : public extensions::ExtensionActionAPI::Observer,
+   size_t FindNewPositionFromLastKnownGood(const ToolbarItem& action);
+ 
+   // Returns true if the given |extension| should be added to the toolbar.
+-  bool ShouldAddExtension(const extensions::Extension* extension);
++  virtual bool ShouldAddExtension(const extensions::Extension* extension);
+ 
+   // Adds or removes the given |extension| from the toolbar model.
+   void AddExtension(const extensions::Extension* extension);

--- a/patches/chrome-browser-ui-views-location_bar-location_bar_view.cc.patch
+++ b/patches/chrome-browser-ui-views-location_bar-location_bar_view.cc.patch
@@ -1,0 +1,25 @@
+diff --git a/chrome/browser/ui/views/location_bar/location_bar_view.cc b/chrome/browser/ui/views/location_bar/location_bar_view.cc
+index ec6eafd7bd7d471a74cec798b993446d99b09703..f31533cf2696cb7f3bde1428672ae547451f67d1 100644
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
+@@ -464,7 +464,7 @@ gfx::Size LocationBarView::CalculatePreferredSize() const {
+   return min_size;
+ }
+ 
+-void LocationBarView::Layout() {
++void LocationBarView::Layout(views::View* right_most) {
+   if (!IsInitialized())
+     return;
+ 
+@@ -563,6 +563,11 @@ void LocationBarView::Layout() {
+     }
+   };
+ 
++  if (right_most && right_most->visible())
++    trailing_decorations.AddDecoration(0,
++                              height(),
++                              false, 0, item_padding, item_padding, right_most);
++
+   if (star_view_)
+     add_trailing_decoration(star_view_);
+   add_trailing_decoration(page_action_icon_container_view_);

--- a/patches/chrome-browser-ui-views-location_bar-location_bar_view.h.patch
+++ b/patches/chrome-browser-ui-views-location_bar-location_bar_view.h.patch
@@ -1,0 +1,46 @@
+diff --git a/chrome/browser/ui/views/location_bar/location_bar_view.h b/chrome/browser/ui/views/location_bar/location_bar_view.h
+index d32fe4bf3e5f95b1be19d90f0cb1bb85dd48b7e6..2bcc385a1bc3ce38e9b7c93a1407a02b7c24e796 100644
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.h
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.h
+@@ -50,6 +50,7 @@ class Profile;
+ class SelectedKeywordView;
+ class StarView;
+ class TranslateIconView;
++class BraveLocationBarView;
+ 
+ namespace autofill {
+ class LocalCardMigrationIconView;
+@@ -79,6 +80,7 @@ class LocationBarView : public LocationBar,
+                         public views::ButtonListener,
+                         public ContentSettingImageView::Delegate,
+                         public PageActionIconView::Delegate {
++ friend class BraveLocationBarView;
+  public:
+   class Delegate {
+    public:
+@@ -117,7 +119,7 @@ class LocationBarView : public LocationBar,
+   float GetBorderRadius() const;
+ 
+   // Initializes the LocationBarView.
+-  void Init();
++  virtual void Init();
+ 
+   // True if this instance has been initialized by calling Init, which can only
+   // be called when the receiving instance is attached to a view container.
+@@ -212,7 +214,7 @@ class LocationBarView : public LocationBar,
+ 
+   // Updates the controller, and, if |contents| is non-null, restores saved
+   // state that the tab holds.
+-  void Update(const content::WebContents* contents);
++  virtual void Update(const content::WebContents* contents);
+ 
+   // Clears the location bar's state for |contents|.
+   void ResetTabState(content::WebContents* contents);
+@@ -231,6 +233,7 @@ class LocationBarView : public LocationBar,
+   void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
+   gfx::Size CalculatePreferredSize() const override;
+   void Layout() override;
++  void Layout(views::View* trailing_view);
+   void OnThemeChanged() override;
+   void OnNativeThemeChanged(const ui::NativeTheme* theme) override;
+   void ChildPreferredSizeChanged(views::View* child) override;


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/668

Intention is for Shields 'extension' to feel built-in.
BraveActionsContainer hooks in to extension system in order to display and update the button icon when necessary.
Removes the Shields extension button from main extensions area (ToolbarActionsBar / BrowserActionsContainer).
Disable context menu for shields extension button in brave actions area since there are no valid actions.
Patches the content of a method at LocationBarView::Layout since it could be more harmful to copy that functionality to our subclass because it is complex and somewhat functional logic. Attempts to minimize the patching necessary by passing in a new argument to the method.

_This PR goes hand-in-hand with https://github.com/brave/brave-extension/pull/57 which controls the badge color, restricts the text from growing too wide (`"99+"`) and uses a vector icon for better rendering._ <-- **Now merged**

`BraveActionsContainer` will also contain the Brave Rewards button, which will be implemented in a subsequent PR, as either a button observing the Rewards Service, or another extension with a browser action.

A subsequent PR will implement a less-rounded Location Bar that will prevent cutting off the badge:

![image](https://user-images.githubusercontent.com/741836/44622423-e7947280-a86c-11e8-88ca-c7126b9d0109.png)

With this PR only it looks like this:
![image](https://user-images.githubusercontent.com/741836/44623011-4bbd3380-a879-11e8-8c21-9edbf130bbcc.png)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
