### PR TITLE
Don't use polyfill when allowing ads

### DIFF
--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -26,6 +26,10 @@ int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 
+
+bool GetPolyfillForAdBlock(bool allow_brave_shields, bool allow_ads,
+    const GURL& tab_origin, const GURL& gurl, GURL *new_url);
+
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_H_

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -10,6 +10,8 @@
 #include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
 #include "net/url_request/url_request_test_util.h"
 
+using brave::GetPolyfillForAdBlock;
+
 namespace {
 
 class BraveSiteHacksNetworkDelegateHelperTest: public testing::Test {
@@ -349,5 +351,40 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerCleared) {
   });
 }
 
+
+TEST_F(BraveSiteHacksNetworkDelegateHelperTest, GetPolyfill) {
+  GURL tab_origin("https://test.com");
+  GURL tag_manager_url(kGoogleTagManagerPattern);
+  GURL tag_services_url(kGoogleTagServicesPattern);
+  GURL normal_url("https://a.com");
+  GURL out_url;
+  // Shields up, block ads, tag manager should get polyfill
+  ASSERT_TRUE(GetPolyfillForAdBlock(true, false, tab_origin, tag_manager_url, &out_url));
+  // Shields up, block ads, tag services should get polyfill
+  ASSERT_TRUE(GetPolyfillForAdBlock(true, false, tab_origin, tag_services_url, &out_url));
+  // Shields up, block ads, normal URL should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(true, false, tab_origin, normal_url, &out_url));
+
+  // Shields up, allow ads, tag manager should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(true, true, tab_origin, tag_manager_url, &out_url));
+  // Shields up, allow ads, tag services should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(true, true, tab_origin, tag_services_url, &out_url));
+  // Shields up, allow ads, normal URL should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(true, true, tab_origin, normal_url, &out_url));
+
+  // Shields down, allow ads, tag manager should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, true, tab_origin, tag_manager_url, &out_url));
+  // Shields down, allow ads, tag services should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, true, tab_origin, tag_services_url, &out_url));
+  // Shields down, allow ads, normal URL should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, true, tab_origin, normal_url, &out_url));
+
+  // Shields down, block ads, tag manager should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, false, tab_origin, tag_manager_url, &out_url));
+  // Shields down, block ads, tag services should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, false, tab_origin, tag_services_url, &out_url));
+  // Shields down, block ads, normal URL should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, false, tab_origin, normal_url, &out_url));
+}
 
 }  // namespace


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/651

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
