### PR TITLE
Allow referrer exception *.fbcdn.net on Facebook

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -75,6 +75,25 @@ bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
     }
   }
 
+  static std::map<GURL, std::vector<URLPattern> > whitelist_patterns_map = {{
+      GURL("https://www.facebook.com/"), {
+        URLPattern(URLPattern::SCHEME_HTTPS, "https://*.fbcdn.net/*"),
+      }
+    }
+  };
+  std::map<GURL, std::vector<URLPattern> >::iterator i =
+      whitelist_patterns_map.find(firstPartyOrigin);
+  if (i != whitelist_patterns_map.end()) {
+    std::vector<URLPattern> &exceptions = i->second;
+    bool any_match = std::any_of(exceptions.begin(), exceptions.end(),
+        [&subresourceUrl](const URLPattern& pattern) {
+          return pattern.MatchesURL(subresourceUrl);
+        });
+    if (any_match) {
+      return true;
+    }
+  }
+
   // It's preferred to use specific_patterns below when possible
   static std::vector<URLPattern> whitelist_patterns({
     URLPattern(URLPattern::SCHEME_ALL, "https://use.typekit.net/*"),

--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -10,6 +10,7 @@
 namespace {
 
 typedef testing::Test BraveShieldsExceptionsTest;
+using brave::IsWhitelistedReferrer;
 
 TEST_F(BraveShieldsExceptionsTest, WidevineInstallableURL) {
   std::vector<GURL> urls({
@@ -39,6 +40,36 @@ TEST_F(BraveShieldsExceptionsTest, NotWidevineInstallableURL) {
       [this](GURL url){
     EXPECT_FALSE(brave::IsWidevineInstallableURL(url));
   });
+}
+
+TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
+  // *.fbcdn.net not allowed on some other URL
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://test.com"),
+        GURL("https://video-zyz1-9.xy.fbcdn.net")));
+  // *.fbcdn.net allowed on Facebook
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.facebook.com"),
+        GURL("https://video-zyz1-9.xy.fbcdn.net")));
+  // Facebook doesn't allow just anything
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://www.facebook.com.com"),
+        GURL("https://test.com")));
+  // Allowed for reddit.com
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.reddit.com/"),
+        GURL("https://www.redditmedia.com/97")));
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.reddit.com/"),
+        GURL("https://cdn.embedly.com/157")));
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.reddit.com/"),
+        GURL("https://imgur.com/179")));
+  // Not allowed for reddit.com
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://www.reddit.com"),
+        GURL("https://test.com")));
+  // Not allowed imgur on another domain
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://www.test.com"),
+        GURL("https://imgur.com/173")));
+  // Fonts allowed anywhere
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.test.com"),
+      GURL("https://use.typekit.net/193")));
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.test.com"),
+      GURL("https://cloud.typography.com/199")));
 }
 
 }  // namespace


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/705

This is in parity with browser-laptop, but it's actually more restrictive than what browser-laptop allows (fbcdn anywhere there)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source