### PR TITLE
Update ad-block lib for Twitch fix

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/ad-block": "https://github.com/brave/ad-block.git@67a8a19121f40d41e75468b2c26d6bace437ae4f",
+  "vendor/ad-block": "https://github.com/brave/ad-block.git@a4f73962e9d852fbe3f75e3a766deb96f0d9065e",
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@bb6013ff4d0a0191ba93158f2f3b30e7fb18c5f6",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@f86b0a5752545274e32c0dbb654c3592cc131c8a",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@635780bbedff137a6a83ec23871944e22069de5b",

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -43,6 +43,7 @@ FilterOption ResourceTypeToFilterOption(content::ResourceType resource_type) {
       filter_option = FOScript;
       break;
     // an image (jpg/gif/png/etc)
+    case content::RESOURCE_TYPE_FAVICON:
     case content::RESOURCE_TYPE_IMAGE:
       filter_option = FOImage;
       break;
@@ -76,8 +77,6 @@ FilterOption ResourceTypeToFilterOption(content::ResourceType resource_type) {
     case content::RESOURCE_TYPE_SHARED_WORKER:
     // an explicitly requested prefetch
     case content::RESOURCE_TYPE_PREFETCH:
-    // a favicon
-    case content::RESOURCE_TYPE_FAVICON:
     // the main resource of a service worker.
     case content::RESOURCE_TYPE_SERVICE_WORKER:
     // a report of Content Security Policy


### PR DESCRIPTION
Mainly when no filter option was specified we were matching rule types that weren't meant to be generic

Test exists in the ad-block repo with the fix here:
https://github.com/brave/ad-block/commit/a4f73962e9d852fbe3f75e3a766deb96f0d9065e

After this is merged, I will need you to increase the extension version and deploy a new fixed extension DAT file for ad-block too.

Fix https://github.com/brave/brave-browser/issues/760

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source