### PR TITLE
Add copy_pdb as a dependency of generate_breakpad_symbols

### DIFF
--- a/app/win/BUILD.gn
+++ b/app/win/BUILD.gn
@@ -19,6 +19,7 @@ action("generate_breakpad_symbols") {
 
   deps = [
     "//third_party/breakpad:dump_syms",
+    "//brave/build/win:copy_pdb",
   ]
 }
 


### PR DESCRIPTION
This makes sure all the symbol files have been copied to the
output directory before generating breakpad symbols.

Fixes https://github.com/brave/brave-browser/issues/809

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source