### PR TITLE
Development no longer restricted to dark theme only

### DIFF
--- a/browser/themes/brave_theme_service.cc
+++ b/browser/themes/brave_theme_service.cc
@@ -4,8 +4,13 @@
 
 #include "brave/browser/themes/brave_theme_service.h"
 
+#include <string>
+
+#include "brave/common/brave_switches.h"
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/common/pref_names.h"
+#include "base/command_line.h"
+#include "base/strings/string_util.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service_factory.h"
 #include "components/pref_registry/pref_registry_syncable.h"
@@ -19,6 +24,18 @@ void BraveThemeService::RegisterProfilePrefs(
 
 // static
 BraveThemeService::BraveThemeType BraveThemeService::GetBraveThemeType(Profile* profile) {
+  // allow override via cli flag
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  if (command_line.HasSwitch(switches::kUiMode)) {
+    std::string requested_theme_value = command_line.GetSwitchValueASCII(switches::kUiMode);
+    std::string requested_theme_value_lower = base::ToLowerASCII(requested_theme_value);
+    if (requested_theme_value_lower == "light")
+      return BraveThemeService::BraveThemeType::BRAVE_THEME_TYPE_LIGHT;
+    if (requested_theme_value_lower == "light")
+      return BraveThemeService::BraveThemeType::BRAVE_THEME_TYPE_DARK;
+  }
+  // get value from preferences
   return static_cast<BraveThemeService::BraveThemeType>(
       profile->GetPrefs()->GetInteger(kBraveThemeType));
 }

--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -22,9 +22,7 @@ void SetBraveThemeType(Profile* profile, BTS::BraveThemeType type) {
 
 IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, BraveThemeChangeTest) {
   Profile* profile = browser()->profile();
-#if defined(OFFICIAL_BUILD)
   const SkColor light_frame_color = SkColorSetRGB(0xD8, 0xDE, 0xE1);
-#endif
   const SkColor dark_frame_color = SkColorSetRGB(0x58, 0x5B, 0x5E);
 
   // Check default type is set initially.
@@ -33,12 +31,7 @@ IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, BraveThemeChangeTest) {
   const ui::ThemeProvider& tp = ThemeService::GetThemeProviderForProfile(profile);
   SetBraveThemeType(browser()->profile(), BTS::BRAVE_THEME_TYPE_LIGHT);
   EXPECT_EQ(BTS::BRAVE_THEME_TYPE_LIGHT, BTS::GetBraveThemeType(profile));
-#if defined(OFFICIAL_BUILD)
   EXPECT_EQ(light_frame_color, tp.GetColor(ThemeProperties::COLOR_FRAME));
-#else
-  // Non-official build always uses dark theme.
-  EXPECT_EQ(dark_frame_color, tp.GetColor(ThemeProperties::COLOR_FRAME));
-#endif
 
   SetBraveThemeType(browser()->profile(), BTS::BRAVE_THEME_TYPE_DARK);
   EXPECT_EQ(BTS::BRAVE_THEME_TYPE_DARK, BTS::GetBraveThemeType(profile));

--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -14,8 +14,7 @@
 
 namespace {
 
-#if defined(OFFICIAL_BUILD)
-base::Optional<SkColor> MaybeGetDefaultColorForBraveUiReleaseChannel(int id, bool incognito) {
+base::Optional<SkColor> MaybeGetDefaultColorForBraveLightUi(int id, bool incognito) {
   switch (id) {
     // Applies when the window is active, tabs and also tab bar everywhere except active tab
     case ThemeProperties::COLOR_FRAME:
@@ -41,9 +40,8 @@ base::Optional<SkColor> MaybeGetDefaultColorForBraveUiReleaseChannel(int id, boo
       return base::nullopt;
   }
 }
-#endif
 
-base::Optional<SkColor> MaybeGetDefaultColorForBraveUiDevChannel(int id, bool incognito) {
+base::Optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id, bool incognito) {
   switch (id) {
     // Applies when the window is active, tabs and also tab bar everywhere except active tab
     case ThemeProperties::COLOR_FRAME:
@@ -74,29 +72,25 @@ base::Optional<SkColor> MaybeGetDefaultColorForBraveUiDevChannel(int id, bool in
 
 // Returns a |nullopt| if the UI color is not handled by Brave.
 base::Optional<SkColor> MaybeGetDefaultColorForBraveUi(int id, bool incognito, Profile* profile) {
-#if !defined(OFFICIAL_BUILD)
-  return MaybeGetDefaultColorForBraveUiDevChannel(id, incognito);
-#else
   switch (BraveThemeService::GetBraveThemeType(profile)) {
     case BraveThemeService::BRAVE_THEME_TYPE_DEFAULT:
       switch (chrome::GetChannel()) {
         case version_info::Channel::STABLE:
         case version_info::Channel::BETA:
-          return MaybeGetDefaultColorForBraveUiReleaseChannel(id, incognito);
+          return MaybeGetDefaultColorForBraveLightUi(id, incognito);
         case version_info::Channel::DEV:
         case version_info::Channel::CANARY:
         case version_info::Channel::UNKNOWN:
         default:
-          return MaybeGetDefaultColorForBraveUiDevChannel(id, incognito);
+          return MaybeGetDefaultColorForBraveDarkUi(id, incognito);
       }
     case BraveThemeService::BRAVE_THEME_TYPE_LIGHT:
-      return MaybeGetDefaultColorForBraveUiReleaseChannel(id, incognito);
+      return MaybeGetDefaultColorForBraveLightUi(id, incognito);
     case BraveThemeService::BRAVE_THEME_TYPE_DARK:
-      return MaybeGetDefaultColorForBraveUiDevChannel(id, incognito);
+      return MaybeGetDefaultColorForBraveDarkUi(id, incognito);
     default:
       NOTREACHED();
 
   }
-#endif
   return base::nullopt;
 }

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -23,4 +23,8 @@ const char kDisablePDFJSExtension[] = "disable-pdfjs-extension";
 // Allows disabling the Tor client updater extension.
 const char kDisableTorClientUpdaterExtension[] = "disable-tor-client-updater-extension";
 
+// Specifies overriding the built-in theme setting.
+// Valid values are: "dark" | "light".
+const char kUiMode[] = "ui-mode";
+
 }  // namespace switches

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -19,6 +19,8 @@ extern const char kDisablePDFJSExtension[];
 
 extern const char kDisableTorClientUpdaterExtension[];
 
+extern const char kUiMode[];
+
 }  // namespace switches
 
 #endif  // BRAVE_COMMON_BRAVE_SWITCHES_H_


### PR DESCRIPTION
Theme user preference can apply to any development build, not just official build, so that we can actually develop with the different themes and use the setting in development builds.

Also adds cli flag: `ui-mode={light,dark}`
This overrides the light / dark / default setting to aid developer productivity when testing UI changes on both modes (developer doesn't have to open settings page and make a change in order to switch between the two options).

Renames 'DevChannel' theme to DarkUi and 'ReleaseChannel' theme to LightUi.
Fix https://github.com/brave/brave-browser/issues/863

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source