### PR TITLE
Copy and package dev/beta channel png images

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -64,6 +64,22 @@ brave_paks("packed_resources") {
   }
 }
 
+branding_dir = "//chrome/app/theme/$branding_path_component"
+copy("theme_files") {
+  visibility = [ ":*" ]
+  if (!is_chrome_branded) {
+    sources = [
+      "$branding_dir/product_logo_128_beta.png",
+      "$branding_dir/product_logo_128_dev.png",
+      "$branding_dir/product_logo_128_development.png",
+      "$branding_dir/product_logo_128_nightly.png",
+    ]
+  }
+  outputs = [
+    "$root_out_dir/installer/theme/{{source_file_part}}",
+  ]
+}
+
 group("create_dist") {
   deps = [
     ":create_dist_zips"
@@ -81,6 +97,7 @@ group("create_dist") {
     deps += [
       "//chrome/installer/linux:$linux_channel",
       "//brave/app/linux:dist_resources",
+      ":theme_files",
     ]
   }
 }

--- a/patches/chrome-installer-linux-BUILD.gn.patch
+++ b/patches/chrome-installer-linux-BUILD.gn.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/installer/linux/BUILD.gn b/chrome/installer/linux/BUILD.gn
-index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794768cbfbd 100644
+index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1118dda83 100644
 --- a/chrome/installer/linux/BUILD.gn
 +++ b/chrome/installer/linux/BUILD.gn
-@@ -25,8 +25,8 @@ declare_args() {
+@@ -26,8 +26,8 @@ declare_args() {
  assert(is_linux)
  
  packaging_files_executables = [
@@ -13,7 +13,7 @@ index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794
  ]
  packaging_files_shlibs = []
  
-@@ -159,12 +159,17 @@ action("merge_rpm_dependencies") {
+@@ -156,12 +156,17 @@ action("merge_rpm_dependencies") {
  }
  
  action("strip_chrome_binary") {
@@ -32,7 +32,7 @@ index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794
    script = "//build/gn_run_binary.py"
    sources = [
      prog_name,
-@@ -246,8 +251,8 @@ copy("common_packaging_files") {
+@@ -243,8 +248,8 @@ copy("common_packaging_files") {
      ]
    } else {
      sources += [
@@ -43,21 +43,7 @@ index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794
      ]
    }
  
-@@ -310,6 +315,13 @@ copy("theme_files") {
-       "$branding_dir_100/product_logo_32_dev.png",
-     ]
-   }
-+  else {
-+    sources += [
-+      "$branding_dir/product_logo_128_beta.png",
-+      "$branding_dir/product_logo_128_dev.png",
-+      "$branding_dir/product_logo_128_development.png",
-+    ]
-+  }
-   outputs = [
-     "$root_out_dir/installer/theme/{{source_file_part}}",
-   ]
-@@ -357,6 +369,12 @@ group("installer_deps") {
+@@ -354,6 +359,12 @@ group("installer_deps") {
      "//chrome/browser/resources/media/mei_preload:component",
      "//sandbox/linux:chrome_sandbox",
    ]
@@ -70,7 +56,7 @@ index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794
    if (enable_nacl) {
      public_deps += [
        "//components/nacl/loader:nacl_helper",
-@@ -386,6 +404,9 @@ group("installer_deps") {
+@@ -379,6 +390,9 @@ group("installer_deps") {
  template("linux_package") {
    assert(defined(invoker.channel))
    channel = invoker.channel
@@ -80,7 +66,7 @@ index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794
  
    if (current_cpu == "x86") {
      # The shell scripts use "ia32" instead of "x86".
-@@ -528,3 +549,6 @@ linux_package("beta") {
+@@ -521,3 +535,6 @@ linux_package("beta") {
  linux_package("unstable") {
    channel = "unstable"
  }

--- a/patches/chrome-installer-linux-BUILD.gn.patch
+++ b/patches/chrome-installer-linux-BUILD.gn.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/installer/linux/BUILD.gn b/chrome/installer/linux/BUILD.gn
-index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1118dda83 100644
+index de0836f61cf2b0d167893a52ae37ae4631eaf1d9..e2dc53bcf3ae25bd0c9cb7e129b57794768cbfbd 100644
 --- a/chrome/installer/linux/BUILD.gn
 +++ b/chrome/installer/linux/BUILD.gn
-@@ -26,8 +26,8 @@ declare_args() {
+@@ -25,8 +25,8 @@ declare_args() {
  assert(is_linux)
  
  packaging_files_executables = [
@@ -13,7 +13,7 @@ index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1
  ]
  packaging_files_shlibs = []
  
-@@ -156,12 +156,17 @@ action("merge_rpm_dependencies") {
+@@ -159,12 +159,17 @@ action("merge_rpm_dependencies") {
  }
  
  action("strip_chrome_binary") {
@@ -32,7 +32,7 @@ index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1
    script = "//build/gn_run_binary.py"
    sources = [
      prog_name,
-@@ -243,8 +248,8 @@ copy("common_packaging_files") {
+@@ -246,8 +251,8 @@ copy("common_packaging_files") {
      ]
    } else {
      sources += [
@@ -43,7 +43,21 @@ index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1
      ]
    }
  
-@@ -354,6 +359,12 @@ group("installer_deps") {
+@@ -310,6 +315,13 @@ copy("theme_files") {
+       "$branding_dir_100/product_logo_32_dev.png",
+     ]
+   }
++  else {
++    sources += [
++      "$branding_dir/product_logo_128_beta.png",
++      "$branding_dir/product_logo_128_dev.png",
++      "$branding_dir/product_logo_128_development.png",
++    ]
++  }
+   outputs = [
+     "$root_out_dir/installer/theme/{{source_file_part}}",
+   ]
+@@ -357,6 +369,12 @@ group("installer_deps") {
      "//chrome/browser/resources/media/mei_preload:component",
      "//sandbox/linux:chrome_sandbox",
    ]
@@ -56,7 +70,7 @@ index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1
    if (enable_nacl) {
      public_deps += [
        "//components/nacl/loader:nacl_helper",
-@@ -379,6 +390,9 @@ group("installer_deps") {
+@@ -386,6 +404,9 @@ group("installer_deps") {
  template("linux_package") {
    assert(defined(invoker.channel))
    channel = invoker.channel
@@ -66,7 +80,7 @@ index 4ac4a301c73841290fac70097e379b786108f831..054b8f885497e760aa06ee9762e6acf1
  
    if (current_cpu == "x86") {
      # The shell scripts use "ia32" instead of "x86".
-@@ -521,3 +535,6 @@ linux_package("beta") {
+@@ -528,3 +549,6 @@ linux_package("beta") {
  linux_package("unstable") {
    channel = "unstable"
  }

--- a/patches/chrome-installer-linux-common-installer.include.patch
+++ b/patches/chrome-installer-linux-common-installer.include.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.include b/chrome/installer/linux/common/installer.include
-index 58b80612445aa0616462805f464bcae0b3ee1c3e..fdead2554de43afd1618f56f509406e241535cb4 100644
+index 58b80612445aa0616462805f464bcae0b3ee1c3e..5acee06845fe2f94ef51f5ddbf9261a33fa4df5d 100644
 --- a/chrome/installer/linux/common/installer.include
 +++ b/chrome/installer/linux/common/installer.include
 @@ -75,6 +75,7 @@ process_template() (
@@ -30,19 +30,6 @@ index 58b80612445aa0616462805f464bcae0b3ee1c3e..fdead2554de43afd1618f56f509406e2
    # ICU data file; Necessary when the GN icu_use_data_file flag is true.
    install -m 644 "${BUILDDIR}/icudtl.dat" "${STAGEDIR}/${INSTALLDIR}/"
  
-@@ -275,10 +289,10 @@ stage_install_common() {
- 
-   # app icons
-   local icon_regex=".*product_logo_[0-9]\+\."
--  if [ "$BRANDING" = "google_chrome" ]; then
-+  if [ "$BRANDING" = "brave" ]; then
-     if [ "$CHANNEL" = "beta" ]; then
-       icon_regex=".*product_logo_[0-9]\+_beta\."
--    elif [ "$CHANNEL" = "unstable" ]; then
-+    elif [ "$CHANNEL" = "unstable" -o "$CHANNEL" = "dev" ]; then
-       icon_regex=".*product_logo_[0-9]\+_dev\."
-     fi
-   fi
 @@ -381,7 +395,7 @@ stage_install_common() {
          exit 1
        fi

--- a/patches/chrome-installer-linux-common-installer.include.patch
+++ b/patches/chrome-installer-linux-common-installer.include.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.include b/chrome/installer/linux/common/installer.include
-index 58b80612445aa0616462805f464bcae0b3ee1c3e..5acee06845fe2f94ef51f5ddbf9261a33fa4df5d 100644
+index 58b80612445aa0616462805f464bcae0b3ee1c3e..fdead2554de43afd1618f56f509406e241535cb4 100644
 --- a/chrome/installer/linux/common/installer.include
 +++ b/chrome/installer/linux/common/installer.include
 @@ -75,6 +75,7 @@ process_template() (
@@ -30,6 +30,19 @@ index 58b80612445aa0616462805f464bcae0b3ee1c3e..5acee06845fe2f94ef51f5ddbf9261a3
    # ICU data file; Necessary when the GN icu_use_data_file flag is true.
    install -m 644 "${BUILDDIR}/icudtl.dat" "${STAGEDIR}/${INSTALLDIR}/"
  
+@@ -275,10 +289,10 @@ stage_install_common() {
+ 
+   # app icons
+   local icon_regex=".*product_logo_[0-9]\+\."
+-  if [ "$BRANDING" = "google_chrome" ]; then
++  if [ "$BRANDING" = "brave" ]; then
+     if [ "$CHANNEL" = "beta" ]; then
+       icon_regex=".*product_logo_[0-9]\+_beta\."
+-    elif [ "$CHANNEL" = "unstable" ]; then
++    elif [ "$CHANNEL" = "unstable" -o "$CHANNEL" = "dev" ]; then
+       icon_regex=".*product_logo_[0-9]\+_dev\."
+     fi
+   fi
 @@ -381,7 +395,7 @@ stage_install_common() {
          exit 1
        fi


### PR DESCRIPTION
When building dev/beta channel on Linux, the release
png images were being packaged even though the
alternate color images should have been present in
the package. This corrects that behavior.
    
Fixes https://github.com/brave/brave-browser/issues/712

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source