### PR TITLE
Allow CRX3 without publisher key for websotre installs

### DIFF
--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/crx_file/crx_verifier.h"
+#define CRX3_WITH_PUBLISHER_PROOF CRX3
+#include "../../../../components/component_updater/component_installer.cc"
+#undef CRX3_WITH_PUBLISHER_PROOF


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/848

Related PR and commits:
https://github.com/brave/brave-core-crx-packager/pull/13

https://github.com/brave/vault-updater/commit/a03de304c3d458167ecc82a80b32152ead4026c4

https://github.com/brave/unzip-crx/commit/85baf0b54c243c4ed836d161bcf145a4d4611567
https://github.com/brave/unzip-crx/commit/9a5497b0bd9232b56572b487229513bee957db12
Which is published to npm here: 
https://www.npmjs.com/package/unzip-crx-3

Counter issue posted here to eventually revert this:
https://github.com/brave/brave-browser/issues/873



## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source