### PR TITLE
Fix link error on windows release build

### DIFF
--- a/common/extensions/api/BUILD.gn
+++ b/common/extensions/api/BUILD.gn
@@ -44,8 +44,8 @@ brave_extensions_api_schema_include_rules =
 
 brave_extensions_api_deps = [
   "//chrome/common/extensions/api",
-  "//extensions/browser",
   "//extensions/common/api",
+  "//skia",
   ":api_features",
   ":permission_features",
   ":manifest_features",


### PR DESCRIPTION
chrome_child target should not depend on //extensions/browser.

Close https://github.com/brave/brave-browser/issues/874

Link error was undefined symbol DisplayInfoProvider::Create() in chrome_child.dll.
This interface is defined in `//extensions/browser` target and implementation is in `//chrome/browser/extensions` target.
That means `chrome_child` target depends on `//extensions/browser` and not `//chrome/browser/extensions`.
`chrome_child` also should not depend on `//extensions/browser/.

With `gn path` result, `//chrome::chrome_child` has dependency to it by `//brave/common/extensions/api:generated_api_bundles`.

```
simon@DESKTOP-3M15BTP MINGW64 /c/Projects/brave/brave-browser/src ((70.0.3528.4))
$ gn path ./out/Release //chrome:chrome_child //extensions/browser
//chrome:chrome_child --[private]-->
//chrome:child_dependencies --[public]-->
//brave:child_dependencies --[public]-->
//brave/common:common --[private]-->
//brave/common/extensions/api:api --[public]-->
//brave/common/extensions/api:generated_api_bundles --[private]-->
//extensions/browser:browser

Showing one of 2 "interesting" non-data paths. 0 of them are public.
Use --all to print all paths.

simon@DESKTOP-3M15BTP MINGW64 /c/Projects/brave/brave-browser/src ((70.0.3528.4))
$ gn path ./out/Release //chrome:chrome_child //chrome/browser/extensions
No non-data paths found between these two targets.
```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
run `yarn build Release` on Windows.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source