### PR TITLE
Copy and package dev/beta channel png images

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -64,6 +64,20 @@ brave_paks("packed_resources") {
   }
 }
 
+branding_dir = "//chrome/app/theme/$branding_path_component"
+copy("theme_files") {
+  visibility = [ ":*" ]
+  sources = [
+    "$branding_dir/product_logo_128_beta.png",
+    "$branding_dir/product_logo_128_dev.png",
+    "$branding_dir/product_logo_128_development.png",
+    "$branding_dir/product_logo_128_nightly.png",
+  ]
+  outputs = [
+    "$root_out_dir/installer/theme/{{source_file_part}}",
+  ]
+}
+
 group("create_dist") {
   deps = [
     ":create_dist_zips"
@@ -81,6 +95,7 @@ group("create_dist") {
     deps += [
       "//chrome/installer/linux:$linux_channel",
       "//brave/app/linux:dist_resources",
+      ":theme_files",
     ]
   }
 }

--- a/patches/chrome-installer-linux-common-installer.include.patch
+++ b/patches/chrome-installer-linux-common-installer.include.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.include b/chrome/installer/linux/common/installer.include
-index 58b80612445aa0616462805f464bcae0b3ee1c3e..5acee06845fe2f94ef51f5ddbf9261a33fa4df5d 100644
+index 58b80612445aa0616462805f464bcae0b3ee1c3e..a5cedd2a5ede73bdaf2bb2391fa419c4feb8cac5 100644
 --- a/chrome/installer/linux/common/installer.include
 +++ b/chrome/installer/linux/common/installer.include
 @@ -75,6 +75,7 @@ process_template() (
@@ -30,7 +30,23 @@ index 58b80612445aa0616462805f464bcae0b3ee1c3e..5acee06845fe2f94ef51f5ddbf9261a3
    # ICU data file; Necessary when the GN icu_use_data_file flag is true.
    install -m 644 "${BUILDDIR}/icudtl.dat" "${STAGEDIR}/${INSTALLDIR}/"
  
-@@ -381,7 +395,7 @@ stage_install_common() {
+@@ -275,11 +289,13 @@ stage_install_common() {
+ 
+   # app icons
+   local icon_regex=".*product_logo_[0-9]\+\."
+-  if [ "$BRANDING" = "google_chrome" ]; then
++  if [ "$BRANDING" = "brave" ]; then
+     if [ "$CHANNEL" = "beta" ]; then
+       icon_regex=".*product_logo_[0-9]\+_beta\."
+-    elif [ "$CHANNEL" = "unstable" ]; then
++    elif [ "$CHANNEL" = "unstable" -o "$CHANNEL" = "dev" ]; then
+       icon_regex=".*product_logo_[0-9]\+_dev\."
++    elif [ "$CHANNEL" = "nightly" ]; then
++      icon_regex=".*product_logo_[0-9]\+_nightly\."
+     fi
+   fi
+   LOGO_RESOURCES_PNG=$(find "${BUILDDIR}/installer/theme/" \
+@@ -381,7 +397,7 @@ stage_install_common() {
          exit 1
        fi
        local expected_perms=777


### PR DESCRIPTION
When building dev/beta channel on Linux, the release
png images were being packaged even though the
alternate color images should have been present in
the package. This corrects that behavior.

Fixes https://github.com/brave/brave-browser/issues/712

Replaces PR https://github.com/brave/brave-core/pull/366

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source