### PR TITLE
Fix unittest fail on debug

### DIFF
--- a/browser/themes/brave_theme_service.cc
+++ b/browser/themes/brave_theme_service.cc
@@ -45,11 +45,14 @@ BraveThemeService::BraveThemeService() {}
 BraveThemeService::~BraveThemeService() {}
 
 void BraveThemeService::Init(Profile* profile) {
-  brave_theme_type_pref_.Init(
+  // In unittest, kBraveThemeType isn't registered.
+  if (profile->GetPrefs()->FindPreference(kBraveThemeType)) {
+    brave_theme_type_pref_.Init(
       kBraveThemeType,
       profile->GetPrefs(),
       base::Bind(&BraveThemeService::OnPreferenceChanged,
                  base::Unretained(this)));
+  }
   ThemeService::Init(profile);
 }
 


### PR DESCRIPTION
BraveThemeService should skip observing kBraveThemeType prefs because
it is not registered in unittest.

Close https://github.com/brave/brave-browser/issues/881

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
Run `yarn test brave_unit_tests Release` and `yarn test brave_unit_tests`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source