### PR TITLE
Use signing keychain for sign_app.sh

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -2,11 +2,11 @@ import("//brave/build/config.gni")
 
 declare_args() {
   mac_signing_identifier = ""
-  mac_signing_keychain = "keychain"
+  mac_signing_keychain = "login"
 }
 
 _packaging_dir = "$root_out_dir/$chrome_product_full_name Packaging"
-keychain_db = getenv("HOME") + "/Library/Keychains/signing.${mac_signing_keychain}-db"
+keychain_db = getenv("HOME") + "/Library/Keychains/${mac_signing_keychain}.keychain-db"
 
 _target_app_path = "$root_out_dir/signing/$brave_exe"
 

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -2,11 +2,11 @@ import("//brave/build/config.gni")
 
 declare_args() {
   mac_signing_identifier = ""
-  mac_signing_keychain = "login"
+  mac_signing_keychain = "keychain"
 }
 
 _packaging_dir = "$root_out_dir/$chrome_product_full_name Packaging"
-keychain_db = getenv("HOME") + "/Library/Keychains/login.${mac_signing_keychain}-db"
+keychain_db = getenv("HOME") + "/Library/Keychains/signing.${mac_signing_keychain}-db"
 
 _target_app_path = "$root_out_dir/signing/$brave_exe"
 


### PR DESCRIPTION
`yarn run create_dist` has been failing with keychain errors
recently, this corrects the keychain file name.

Partial fix for https://github.com/brave/brave-browser/issues/387

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source