### PR TITLE
Protect against RenderFrameHost swapping out

### DIFF
--- a/browser/ui/webui/basic_ui.cc
+++ b/browser/ui/webui/basic_ui.cc
@@ -9,6 +9,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/browser/web_ui_message_handler.h"
+#include "content/public/common/bindings_policy.h"
 
 using content::WebUIMessageHandler;
 
@@ -77,4 +78,12 @@ content::RenderViewHost* BasicUI::GetRenderViewHost() {
     return web_contents->GetRenderViewHost();
   }
   return nullptr;
+}
+
+bool BasicUI::IsSafeToSetWebUIProperties() const {
+  // Allow `web_ui()->CanCallJavascript()` to be false.
+  // Allow `web_ui()->CanCallJavascript()` to be true if `(web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI) != 0`
+  // Disallow `web_ui()->CanCallJavascript()` to be true if `(web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI) == 0`
+  DCHECK(!web_ui()->CanCallJavascript() || (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI));
+  return web_ui()->CanCallJavascript() && (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI);
 }

--- a/browser/ui/webui/basic_ui.h
+++ b/browser/ui/webui/basic_ui.h
@@ -24,6 +24,7 @@ class BasicUI : public content::WebUIController {
   ~BasicUI() override;
 
  protected:
+  bool IsSafeToSetWebUIProperties() const;
   content::RenderViewHost* GetRenderViewHost();
 
  private:

--- a/browser/ui/webui/brave_adblock_ui.cc
+++ b/browser/ui/webui/brave_adblock_ui.cc
@@ -16,7 +16,6 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/browser/web_ui_message_handler.h"
-#include "content/public/common/bindings_policy.h"
 
 BraveAdblockUI::BraveAdblockUI(content::WebUI* web_ui, const std::string& name)
     : BasicUI(web_ui, name, kAdblockJS,
@@ -46,13 +45,13 @@ void BraveAdblockUI::CustomizeWebUIProperties(content::RenderViewHost* render_vi
 }
 
 void BraveAdblockUI::RenderFrameCreated(content::RenderFrameHost* render_frame_host) {
-  if (0 != (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI)) {
+  if (IsSafeToSetWebUIProperties()) {
     CustomizeWebUIProperties(render_frame_host->GetRenderViewHost());
   }
 }
 
 void BraveAdblockUI::OnPreferenceChanged() {
-  if (0 != (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI)) {
+  if (IsSafeToSetWebUIProperties()) {
     CustomizeWebUIProperties(GetRenderViewHost());
     web_ui()->CallJavascriptFunctionUnsafe("brave_adblock.statsUpdated");
   }

--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -15,7 +15,6 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/browser/web_ui_message_handler.h"
-#include "content/public/common/bindings_policy.h"
 
 namespace {
 class NewTabDOMHandler : public content::WebUIMessageHandler {
@@ -89,13 +88,13 @@ void BraveNewTabUI::CustomizeNewTabWebUIProperties(content::RenderViewHost* rend
 }
 
 void BraveNewTabUI::RenderFrameCreated(content::RenderFrameHost* render_frame_host) {
-  if (0 != (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI)) {
+  if (IsSafeToSetWebUIProperties()) {
     CustomizeNewTabWebUIProperties(render_frame_host->GetRenderViewHost());
   }
 }
 
 void BraveNewTabUI::OnPreferenceChanged() {
-  if (0 != (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI)) {
+  if (IsSafeToSetWebUIProperties()) {
     CustomizeNewTabWebUIProperties(GetRenderViewHost());
     web_ui()->CallJavascriptFunctionUnsafe("brave_new_tab.statsUpdated");
   }

--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -11,8 +11,6 @@
 #include "chrome/browser/profiles/profile.h"
 #include "components/grit/brave_components_resources.h"
 #include "content/public/browser/web_ui_message_handler.h"
-#include "content/public/common/bindings_policy.h"
-
 
 using content::WebUIMessageHandler;
 
@@ -80,13 +78,13 @@ void RewardsDOMHandler::OnWalletCreated(
 }
 
 void RewardsDOMHandler::OnWalletCreated() {
-  if (0 != (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI)) {
+  if (web_ui()->CanCallJavascript()) {
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.walletCreated");
   }
 }
 
 void RewardsDOMHandler::OnWalletCreateFailed() {
-  if (0 != (web_ui()->GetBindings() & content::BINDINGS_POLICY_WEB_UI)) {
+  if (web_ui()->CanCallJavascript()) {
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.walletCreateFailed");
   }
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/708

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source