### PR TITLE
Ensure ShieldsActionView is destroyed before its controller is destroyed

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -41,6 +41,10 @@ BraveActionsContainer::BraveActionsContainer(Browser* browser, Profile* profile)
 }
 
 BraveActionsContainer::~BraveActionsContainer() {
+  // Destroy |shields_button_view| before |shields_view_controller|.
+  // Destructor for |ToolbarActionView| tries to access controller instance.
+  shields_button_view_.reset();
+  shields_view_controller_.reset();
 }
 
 void BraveActionsContainer::Init() {


### PR DESCRIPTION
Fixes a crash most apparent whilst closing windows on Linux where the ToolbarActionView destructor attempts to call into a member of the view controller.
Due to the ordering of the smart pointer definitions in brave_actions_container.h, the view controller was getting destroyed first. Instead of relying on this implicit behavior, we explicitly destroy in the destructor to ensure this is always the case.

Fix https://github.com/brave/brave-browser/issues/894

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source