### PR TITLE
 Use a single sequenced task runner for HTTPSEverywehre && level_db init fix

### DIFF
--- a/browser/net/brave_httpse_network_delegate_helper.cc
+++ b/browser/net/brave_httpse_network_delegate_helper.cc
@@ -81,18 +81,14 @@ int OnBeforeURLRequest_HttpsePreFileWork(
         GetHTTPSURLFromCacheOnly(&request->url(), request->identifier(),
           ctx->new_url_spec)) {
       ctx->request_url = request->url();
-
-      scoped_refptr<base::SequencedTaskRunner> task_runner =
-          base::CreateSequencedTaskRunnerWithTraits({base::MayBlock(),
-              base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
-          task_runner->PostTaskAndReply(FROM_HERE,
-        base::Bind(OnBeforeURLRequest_HttpseFileWork,
-            base::Unretained(request), new_url, ctx),
-        base::Bind(base::IgnoreResult(
-            &OnBeforeURLRequest_HttpsePostFileWork),
-            base::Unretained(request),
-            new_url, next_callback, ctx)
-          );
+      g_brave_browser_process->https_everywhere_service()->
+        GetTaskRunner()->PostTaskAndReply(FROM_HERE,
+          base::Bind(OnBeforeURLRequest_HttpseFileWork,
+              base::Unretained(request), new_url, ctx),
+          base::Bind(base::IgnoreResult(
+              &OnBeforeURLRequest_HttpsePostFileWork),
+              base::Unretained(request),
+              new_url, next_callback, ctx));
       return net::ERR_IO_PENDING;
     } else {
       if (!ctx->new_url_spec.empty()) {

--- a/components/brave_shields/browser/https_everywhere_service.cc
+++ b/components/brave_shields/browser/https_everywhere_service.cc
@@ -83,6 +83,7 @@ std::string HTTPSEverywhereService::g_https_everywhere_component_base64_public_k
     kHTTPSEverywhereComponentBase64PublicKey);
 
 HTTPSEverywhereService::HTTPSEverywhereService() : level_db_(nullptr) {
+  DETACH_FROM_SEQUENCE(sequence_checker_);
 }
 
 HTTPSEverywhereService::~HTTPSEverywhereService() {
@@ -103,6 +104,7 @@ bool HTTPSEverywhereService::Init() {
 }
 
 void HTTPSEverywhereService::InitDB(const base::FilePath& install_dir) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   base::FilePath zip_db_file_path =
       install_dir.AppendASCII(DAT_FILE_VERSION).AppendASCII(DAT_FILE);
   base::FilePath unzipped_level_db_path = zip_db_file_path.RemoveExtension();
@@ -142,6 +144,7 @@ void HTTPSEverywhereService::OnComponentReady(
 bool HTTPSEverywhereService::GetHTTPSURL(
     const GURL* url, const uint64_t& request_identifier,
     std::string& new_url) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   base::AssertBlockingAllowed();
   if (!IsInitialized() || url->scheme() == url::kHttpsScheme) {
     return false;
@@ -358,8 +361,8 @@ std::string HTTPSEverywhereService::CorrecttoRuleToRE2Engine(
   return correctedto;
 }
 
-void HTTPSEverywhereService::CloseDatabase()
-{
+void HTTPSEverywhereService::CloseDatabase() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   if (level_db_) {
     delete level_db_;
     level_db_ = nullptr;

--- a/components/brave_shields/browser/https_everywhere_service.cc
+++ b/components/brave_shields/browser/https_everywhere_service.cc
@@ -123,6 +123,7 @@ void HTTPSEverywhereService::InitDB(const base::FilePath& install_dir) {
                         unzipped_level_db_path.AsUTF8Unsafe(),
                         &level_db_);
   if (!status.ok() || !level_db_) {
+    level_db_ = nullptr;
     LOG(ERROR) << "Level db open error "
                << unzipped_level_db_path.value().c_str()
                << ", error: " << status.ToString();
@@ -146,7 +147,7 @@ bool HTTPSEverywhereService::GetHTTPSURL(
     std::string& new_url) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   base::AssertBlockingAllowed();
-  if (!IsInitialized() || url->scheme() == url::kHttpsScheme) {
+  if (!IsInitialized() || !level_db_ || url->scheme() == url::kHttpsScheme) {
     return false;
   }
   if (!ShouldHTTPSERedirect(request_identifier)) {

--- a/components/brave_shields/browser/https_everywhere_service.h
+++ b/components/brave_shields/browser/https_everywhere_service.h
@@ -13,6 +13,7 @@
 #include <mutex>
 
 #include "base/files/file_path.h"
+#include "base/sequence_checker.h"
 #include "brave/components/brave_shields/browser/base_brave_shields_service.h"
 #include "brave/components/brave_shields/browser/https_everywhere_recently_used_cache.h"
 #include "content/public/common/resource_type.h"
@@ -89,6 +90,7 @@ class HTTPSEverywhereService : public BaseBraveShieldsService {
   HTTPSERecentlyUsedCache<std::string> recently_used_cache_;
   leveldb::DB* level_db_;
 
+  SEQUENCE_CHECKER(sequence_checker_);
   DISALLOW_COPY_AND_ASSIGN(HTTPSEverywhereService);
 };
 


### PR DESCRIPTION
Use a single sequenced task runner for HTTPSEverywehre

Otherwise we're creating lots of different threads and accessing things for the DB on different possibly overlapping threads.

Fix https://github.com/brave/brave-browser/issues/896

I think this also fixes:
- Fix brave/brave-browser#707
- Fix brave/brave-browser#708
- Fix brave/brave-browser#739
- Fix brave/brave-browser#797
- Fix brave/brave-browser#761
- Fix brave/brave-browser#762
- Fix brave/brave-browser#796
- Fix brave/brave-browser#797
- Fix brave/brave-browser#798
- Fix brave/brave-browser#861

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source