### PR TITLE
Fix potential crash with binding with ref'd string

### DIFF
--- a/components/brave_shields/browser/brave_shields_web_contents_observer.cc
+++ b/components/brave_shields/browser/brave_shields_web_contents_observer.cc
@@ -178,8 +178,8 @@ GURL BraveShieldsWebContentsObserver::GetTabURLFromRenderFrameInfo(
 }
 
 void BraveShieldsWebContentsObserver::DispatchBlockedEvent(
-    const std::string& block_type,
-    const std::string& subresource,
+    std::string block_type,
+    std::string subresource,
     int render_process_id,
     int render_frame_id,
     int frame_tree_node_id) {

--- a/components/brave_shields/browser/brave_shields_web_contents_observer.h
+++ b/components/brave_shields/browser/brave_shields_web_contents_observer.h
@@ -31,8 +31,8 @@ class BraveShieldsWebContentsObserver : public content::WebContentsObserver,
       const std::string& subresource,
       content::WebContents* web_contents);
   static void DispatchBlockedEvent(
-      const std::string& block_type,
-      const std::string& subresource,
+      std::string block_type,
+      std::string subresource,
       int render_process_id,
       int render_frame_id, int frame_tree_node_id);
   static GURL GetTabURLFromRenderFrameInfo(int render_process_id, int render_frame_id);


### PR DESCRIPTION
With BraveShieldsWebContentsObserver::DispatchBlockedEvent

Fix https://github.com/brave/brave-browser/issues/932

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source