### PR TITLE
Disable super annoying 'Hold to quit' dialog. This completely non-sta…

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -29,6 +29,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   registry->RegisterBooleanPref(kWidevineOptedIn, false);
 
+  // Turn off super annoying 'Hold to quit'
+  registry->SetDefaultPrefValue(prefs::kConfirmToQuitEnabled, base::Value(false));
+
   // No sign into Brave functionality
   registry->SetDefaultPrefValue(prefs::kSigninAllowed, base::Value(false));
 


### PR DESCRIPTION
…ndard app behavior might make sense in Chrome where they also annoyingly default to not saving tab/window state, but not in Brave

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source