### PR TITLE
Disable super annoying 'Hold to quit' dialog. This completely non-sta…

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -57,11 +57,13 @@ source_set("browser_process") {
 
   deps = [
     ":version_info",
+    "//base",
     "//brave/components/brave_rewards/browser",
     "//brave/components/brave_shields/browser:brave_shields",
     "//brave/components/content_settings/core/browser",
     "//brave/common",
     "//components/component_updater",
+    "//components/prefs",
     "//components/safe_browsing/common:safe_browsing_prefs",
     "//components/search_engines",
     "//components/spellcheck/browser",

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -4,12 +4,18 @@
 
 #include "brave/browser/brave_local_state_prefs.h"
 
+#include "base/values.h"
 #include "brave/browser/brave_stats_updater.h"
+#include "chrome/common/pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
 
 namespace brave {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   RegisterPrefsForBraveStatsUpdater(registry);
+  // Turn off super annoying 'Hold to quit'
+  registry->SetDefaultPrefValue(prefs::kConfirmToQuitEnabled,
+      base::Value(false));
 }
 
 }  // namespace brave

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -1,0 +1,2 @@
+#include "brave/browser/brave_local_state_prefs.h"
+#include "../../../../chrome/browser/prefs/browser_prefs.cc"

--- a/patches/chrome-browser-prefs-browser_prefs.cc.patch
+++ b/patches/chrome-browser-prefs-browser_prefs.cc.patch
@@ -1,20 +1,12 @@
 diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
-index b8232737dbf4dabada561044e522e44c906c53c8..cb55e2b38a40ae9141d30c5dfc27bc27a7bcc497 100644
+index b8232737dbf4dabada561044e522e44c906c53c8..8bef715a4e713238d814f45e9563f2dc81638e69 100644
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
-@@ -8,6 +8,7 @@
- 
- #include "base/metrics/histogram_macros.h"
- #include "base/trace_event/trace_event.h"
-+#include "brave/browser/brave_local_state_prefs.h"
- #include "build/build_config.h"
- #include "chrome/browser/about_flags.h"
- #include "chrome/browser/accessibility/accessibility_ui.h"
-@@ -378,6 +379,7 @@ void RegisterProfilePrefsForMigration(
- 
- void RegisterLocalState(PrefRegistrySimple* registry) {
-   // Please keep this list alphabetized.
+@@ -513,6 +513,7 @@ void RegisterLocalState(PrefRegistrySimple* registry) {
+ #if defined(TOOLKIT_VIEWS)
+   RegisterBrowserViewLocalPrefs(registry);
+ #endif
 +  brave::RegisterLocalStatePrefs(registry);
-   browser_shutdown::RegisterPrefs(registry);
-   BrowserProcessImpl::RegisterPrefs(registry);
-   ChromeContentBrowserClient::RegisterLocalStatePrefs(registry);
+ }
+ 
+ // Register prefs applicable to all profiles.


### PR DESCRIPTION
…ndard app behavior might make sense in Chrome where they also annoyingly default to not saving tab/window state, but not in Brave

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source