### PR TITLE
rewards tests should be disabled when rewards is disabled

### DIFF
--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1,4 +1,5 @@
 import("//brave/build/config.gni")
+import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
 import("//testing/test.gni")
 
 static_library("brave_test_support_unit") {
@@ -163,7 +164,6 @@ test("brave_browser_tests") {
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",
-    "//brave/components/brave_rewards/browser/rewards_service_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_service_browsertest.cc",
     "//brave/components/brave_shields/browser/tracking_protection_service_browsertest.cc",
@@ -180,6 +180,12 @@ test("brave_browser_tests") {
     "//chrome/browser/extensions/updater/extension_cache_fake.cc",
     "//chrome/browser/extensions/updater/extension_cache_fake.h",
   ]
+
+  if (brave_rewards_enabled) {
+    sources += [
+      "//brave/components/brave_rewards/browser/rewards_service_browsertest.cc",
+    ]
+  }
 
   # API tests
   sources += [


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source