### PR TITLE
Allow all extensions, warn for unvetted, 1 component updater only now

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -110,25 +110,4 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
   EXPECT_EQ(ret, net::OK);
 }
 
-
-TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyComponentUpdaterURL) {
-  net::TestDelegate test_delegate;
-  std::string query_string("?foo=bar");
-  GURL url(std::string(component_updater::kUpdaterDefaultUrl) + query_string);
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::ResponseCallback callback;
-  GURL new_url;
-  GURL expected_url(std::string(kBraveUpdatesExtensionsEndpoint + query_string));
-  int ret =
-      OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
-                                            before_url_context);
-  EXPECT_EQ(new_url, expected_url);
-  EXPECT_EQ(ret, net::OK);
-}
-
-
 }  // namespace


### PR DESCRIPTION
Had merged the wrong branch, reverted and merging this one.

Carrying review forward from https://github.com/brave/brave-core/pull/382

Fix https://github.com/brave/brave-browser/issues/381
Fix https://github.com/brave/brave-browser/issues/931

This PR allows all extensions (except for blacklisted ones) to be installed.
All extension requests go to the brave extension server.

*Warning:* Please only review for now and don't merge, the extension servers still needs to be deployed.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source