### PR TITLE
Update mac app id in development build

### DIFF
--- a/app/theme/brave/BRANDING.development
+++ b/app/theme/brave/BRANDING.development
@@ -5,6 +5,6 @@ PRODUCT_SHORTNAME=Brave
 PRODUCT_INSTALLER_FULLNAME=Brave Installer
 PRODUCT_INSTALLER_SHORTNAME=Brave Installer
 COPYRIGHT=Copyright 2016 The Brave Authors. All rights reserved.
-MAC_BUNDLE_ID=org.brave.Brave
+MAC_BUNDLE_ID=com.brave.Browser
 MAC_CREATOR_CODE=Cr24
 MAC_TEAM_ID=


### PR DESCRIPTION
Seems this got missed in the development build.

Original commit for updating this ID is in https://github.com/brave/brave-core/pull/319