### PR TITLE
Use Dark NativeTheme when the active Brave theme mode is Dark

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -66,8 +66,17 @@ source_set("ui") {
     "webui/settings/brave_appearance_handler.h",
   ]
 
+  if (is_mac || is_win || is_chromeos) {
+    sources += [
+      "views/frame/brave_browser_frame.cc",
+      "views/frame/brave_browser_frame.h",
+    ]
+  }
+
   if (is_linux) {
     sources += [
+      "views/brave_browser_main_extra_parts_views_linux.cc",
+      "views/brave_browser_main_extra_parts_views_linux.h",
       "views/brave_views_delegate_linux.cc",
       "views/brave_views_delegate_linux.h",
     ]

--- a/browser/ui/views/brave_browser_main_extra_parts_views_linux.cc
+++ b/browser/ui/views/brave_browser_main_extra_parts_views_linux.cc
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_browser_main_extra_parts_views_linux.h"
+
+#include "base/bind.h"
+#include "brave/browser/themes/brave_theme_service.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/themes/theme_service_factory.h"
+#include "chrome/browser/ui/libgtkui/gtk_ui.h"
+#include "chrome/browser/ui/views/theme_profile_key.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/common/pref_names.h"
+#include "ui/views/linux_ui/linux_ui.h"
+#include "ui/native_theme/native_theme_aura.h"
+#include "ui/native_theme/native_theme_dark_aura.h"
+
+namespace {
+
+ui::NativeTheme* GetNativeThemeForWindow(aura::Window* window) {
+  if (!window)
+    return nullptr;
+
+  Profile* profile = GetThemeProfileForWindow(window);
+
+  if (!profile) {
+    return nullptr;
+  }
+
+  // Use the appropriate native theme for the color mode pref
+  BraveThemeType active_builtin_theme =
+                            BraveThemeService::GetActiveBraveThemeType(profile);
+  const bool dark_mode = (
+      active_builtin_theme == BraveThemeType::BRAVE_THEME_TYPE_DARK ||
+      profile->GetProfileType() == Profile::INCOGNITO_PROFILE);
+  if (dark_mode &&
+      BrowserView::GetBrowserViewForNativeWindow(window)) {
+    return ui::NativeThemeDarkAura::instance();
+  }
+
+  return ui::NativeTheme::GetInstanceForNativeUi();
+}
+
+}
+
+void BraveBrowserMainExtraPartsViewsLinux::PreEarlyInitialization() {
+  views::LinuxUI* gtk_ui = BuildGtkUi();
+  gtk_ui->SetNativeThemeOverride(base::Bind(&GetNativeThemeForWindow));
+  views::LinuxUI::SetInstance(gtk_ui);
+}

--- a/browser/ui/views/brave_browser_main_extra_parts_views_linux.h
+++ b/browser/ui/views/brave_browser_main_extra_parts_views_linux.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_BROWSER_MAIN_EXTRA_PARTS_VIEWS_LINUX_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_BROWSER_MAIN_EXTRA_PARTS_VIEWS_LINUX_H_
+
+#include "chrome/browser/ui/views/chrome_browser_main_extra_parts_views_linux.h"
+
+class BraveBrowserMainExtraPartsViewsLinux
+                                : public ChromeBrowserMainExtraPartsViewsLinux {
+  public:
+    using ChromeBrowserMainExtraPartsViewsLinux::ChromeBrowserMainExtraPartsViewsLinux;
+    void PreEarlyInitialization() override;
+  private:
+    DISALLOW_COPY_AND_ASSIGN(BraveBrowserMainExtraPartsViewsLinux);
+};
+
+#endif

--- a/browser/ui/views/frame/brave_browser_frame.cc
+++ b/browser/ui/views/frame/brave_browser_frame.cc
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_browser_frame.h"
+
+#include "brave/browser/themes/brave_theme_service.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "ui/native_theme/native_theme_dark_aura.h"
+#include "ui/views/widget/native_widget.h"
+
+BraveBrowserFrame::BraveBrowserFrame(BrowserView* browser_view)
+    : BrowserFrame(browser_view),
+      browser_view_(browser_view) {
+}
+
+BraveBrowserFrame::~BraveBrowserFrame() {
+}
+
+const ui::NativeTheme* BraveBrowserFrame::GetNativeTheme() const {
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+  BraveThemeType active_builtin_theme =
+            BraveThemeService::GetActiveBraveThemeType(
+                              browser_view_->browser()->profile());
+  if (active_builtin_theme == BraveThemeType::BRAVE_THEME_TYPE_DARK ||
+      browser_view_->browser()->profile()->GetProfileType() ==
+          Profile::INCOGNITO_PROFILE) {
+    return ui::NativeThemeDarkAura::instance();
+  }
+#endif
+  return views::Widget::GetNativeTheme();
+}

--- a/browser/ui/views/frame/brave_browser_frame.h
+++ b/browser/ui/views/frame/brave_browser_frame.h
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_H_
+
+#include "chrome/browser/ui/views/frame/browser_frame.h"
+
+class BrowserView;
+
+class BraveBrowserFrame : public BrowserFrame {
+  public:
+    explicit BraveBrowserFrame(BrowserView* browser_view);
+    ~BraveBrowserFrame() override;
+    const ui::NativeTheme* GetNativeTheme() const override;
+
+  private:
+    // The BrowserView is our ClientView. This is a pointer to it.
+    BrowserView* browser_view_;
+
+    DISALLOW_COPY_AND_ASSIGN(BraveBrowserFrame);
+};
+
+#endif

--- a/chromium_src/chrome/browser/chrome_content_browser_client.cc
+++ b/chromium_src/chrome/browser/chrome_content_browser_client.cc
@@ -10,4 +10,13 @@
 #define ChromeBrowserMainPartsMac BraveBrowserMainPartsMac
 #endif
 
+#if defined(OS_LINUX)
+#include "brave/browser/ui/views/brave_browser_main_extra_parts_views_linux.h"
+#define ChromeBrowserMainExtraPartsViewsLinux BraveBrowserMainExtraPartsViewsLinux
+#endif
+
 #include "../../../../chrome/browser/chrome_content_browser_client.cc"
+
+#if defined(OS_LINUX)
+#undef ChromeBrowserMainExtraPartsViewsLinux
+#endif

--- a/chromium_src/chrome/browser/ui/views/frame/browser_window_factory.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_window_factory.cc
@@ -1,4 +1,17 @@
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+
+// For now, BraveBrowserFrame only needs to run on !linux
+// and build complains of unused variables if we include it.
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#include "brave/browser/ui/views/frame/brave_browser_frame.h"
+#define BrowserFrame BraveBrowserFrame
+#endif
+
 #define BrowserView BraveBrowserView
 #include "../../../../../../../chrome/browser/ui/views/frame/browser_window_factory.cc"
+#undef BrowserView
+
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#undef BrowserFrame
+#endif


### PR DESCRIPTION
For now, we do not remove this theme choice when a user extension theme is installed, since that matches what the non-native theme does, as well as allow a choice for Brave's UI to match any extension theme (manually via user preference).

Fix https://github.com/brave/brave-browser/issues/978

Note that this creates a known issue: When changing the theme via Preferences between dark and light, the user must switch tabs before the LocationBar re-paints with the new colors. I think that's ok for a follow-up since this fixes the overwhelming majority of use, it's a current issue already with other LocationBar colors, and the issue can be worked around pretty quickly. https://github.com/brave/brave-browser/issues/982

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
Dark mode, check security chip text is white.
Light mode, check security chip text is dark.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source