### PR TITLE
Fix folder image in bookmark sub-folder is invisible

### DIFF
--- a/patches/chrome-browser-ui-views-bookmarks-bookmark_menu_delegate.cc.patch
+++ b/patches/chrome-browser-ui-views-bookmarks-bookmark_menu_delegate.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/ui/views/bookmarks/bookmark_menu_delegate.cc b/chrome/browser/ui/views/bookmarks/bookmark_menu_delegate.cc
+index c1ea98b4aa05ca0d6670d6a40b146cf001ad3188..f7c78ed1ec3685594395cdfca5130c71ff0e79a0 100644
+--- a/chrome/browser/ui/views/bookmarks/bookmark_menu_delegate.cc
++++ b/chrome/browser/ui/views/bookmarks/bookmark_menu_delegate.cc
+@@ -47,10 +47,12 @@ namespace {
+ const int kMaxMenuWidth = 400;
+ 
+ SkColor TextColorForMenu(MenuItemView* menu, views::Widget* widget) {
++#if defined(BRAVE_CHROMIUM_BUILD) && !defined(OS_MACOSX)
+   if (widget && widget->GetThemeProvider()) {
+     return widget->GetThemeProvider()->GetColor(
+         ThemeProperties::COLOR_BOOKMARK_TEXT);
+   }
++#endif
+   return menu->GetNativeTheme()->GetSystemColor(
+       ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor);
+ }


### PR DESCRIPTION
This was upstream issue (https://chromium-review.googlesource.com/c/chromium/src/+/1194463)

Close https://github.com/brave/brave-browser/issues/979

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source