### PR TITLE
Show Themes option in apperance setting

### DIFF
--- a/browser/resources/settings/brave_page_visibility.js
+++ b/browser/resources/settings/brave_page_visibility.js
@@ -15,7 +15,7 @@ cr.define('settings', function() {
 
   const appearanceHandler = {
     get: function(obj, prop) {
-      return prop === 'setTheme' ? false : true;
+      return true;
     }
   };
 

--- a/patches/chrome-browser-resources-settings-appearance_page-appearance_page.html.patch
+++ b/patches/chrome-browser-resources-settings-appearance_page-appearance_page.html.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/resources/settings/appearance_page/appearance_page.html b/chrome/browser/resources/settings/appearance_page/appearance_page.html
-index 720d25d126a118315a08cef90d77d1fc78775254..b000205ff1ca4d4d62c53abffa93df237fc05756 100644
+index 720d25d126a118315a08cef90d77d1fc78775254..d78a87d0f592d74e7f69cc2b003fe94b8b0f0075 100644
 --- a/chrome/browser/resources/settings/appearance_page/appearance_page.html
 +++ b/chrome/browser/resources/settings/appearance_page/appearance_page.html
 @@ -19,6 +19,10 @@
@@ -13,13 +13,13 @@ index 720d25d126a118315a08cef90d77d1fc78775254..b000205ff1ca4d4d62c53abffa93df23
  <dom-module id="settings-appearance-page">
    <template>
      <style include="settings-shared md-select iron-flex">
-@@ -102,6 +106,9 @@
-           </div>
- </if>
-         </div>
-+ <if expr="not _google_chrome">
-+        <settings-brave-appearance-page></settings-brave-appearance-page>
+@@ -63,6 +67,9 @@
+           </template>
+         </cr-link-row>
+         <div class="hr"></div>
 +</if>
-         <settings-toggle-button elide-label
-             hidden="[[!pageVisibility.homeButton]]"
-             pref="{{prefs.browser.show_home_button}}"
++<if expr="not _google_chrome">
++        <settings-brave-appearance-page></settings-brave-appearance-page>
+ </if>
+         <div class="settings-row continuation" id="themeRow"
+             hidden="[[!pageVisibility.setTheme]]">


### PR DESCRIPTION
Close https://github.com/brave/brave-browser/issues/985

When theme is installed, theme name and reset button is visible.
<img width="723" alt="screen shot 2018-09-07 at 07 20 23" src="https://user-images.githubusercontent.com/6786187/45188272-9de55800-b26e-11e8-94c0-fb289b9516cd.png">

<img width="787" alt="screen shot 2018-09-07 at 08 19 15" src="https://user-images.githubusercontent.com/6786187/45190139-3bdd2080-b277-11e8-91ad-643d367a6e1d.png">


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source