### PR TITLE
Exclude referrer patch code when url is chrome-extension

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -110,25 +110,4 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
   EXPECT_EQ(ret, net::OK);
 }
 
-
-TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyComponentUpdaterURL) {
-  net::TestDelegate test_delegate;
-  std::string query_string("?foo=bar");
-  GURL url(std::string(component_updater::kUpdaterDefaultUrl) + query_string);
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::ResponseCallback callback;
-  GURL new_url;
-  GURL expected_url(std::string(kBraveUpdatesExtensionsEndpoint + query_string));
-  int ret =
-      OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
-                                            before_url_context);
-  EXPECT_EQ(new_url, expected_url);
-  EXPECT_EQ(ret, net::OK);
-}
-
-
 }  // namespace

--- a/patches/content-browser-frame_host-navigation_request.cc.patch
+++ b/patches/content-browser-frame_host-navigation_request.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/content/browser/frame_host/navigation_request.cc b/content/browser/frame_host/navigation_request.cc
-index 37f6135b22a4472733afa38dbc3bd27ccfb60036..ea00172e369b134f4cd1cd19bf55c2e160d1e12a 100644
+index 37f6135b22a4472733afa38dbc3bd27ccfb60036..8c7e366936bd8deb1ae4e4a39727bee920261fc8 100644
 --- a/content/browser/frame_host/navigation_request.cc
 +++ b/content/browser/frame_host/navigation_request.cc
-@@ -1651,6 +1651,29 @@ void NavigationRequest::CommitNavigation() {
+@@ -1651,6 +1651,25 @@ void NavigationRequest::CommitNavigation() {
      }
      associated_site_instance_id_.reset();
    }
@@ -10,21 +10,17 @@ index 37f6135b22a4472733afa38dbc3bd27ccfb60036..ea00172e369b134f4cd1cd19bf55c2e1
 +  auto* pending_entry =
 +    frame_tree_node_->navigator()->GetController()->GetPendingEntry();
 +  if (pending_entry) {
-+    if (!pending_entry->GetURL().is_empty()) {
-+      common_params_.url = pending_entry->GetURL();
-+    }
 +    if (!pending_entry->GetReferrer().url.is_empty()) {
-+      common_params_.referrer = pending_entry->GetReferrer();
++      common_params_.referrer =
++          Referrer::SanitizeForRequest(common_params_.url, pending_entry->GetReferrer());
 +    }
 +  } else {
 +    auto* last_committed_entry =
 +      frame_tree_node_->navigator()->GetController()->GetLastCommittedEntry();
 +    if (last_committed_entry) {
-+      if (!last_committed_entry->GetURL().is_empty()) {
-+        common_params_.url = last_committed_entry->GetURL();
-+      }
 +      if (!last_committed_entry->GetReferrer().url.is_empty()) {
-+        common_params_.referrer = last_committed_entry->GetReferrer();
++        common_params_.referrer =
++          Referrer::SanitizeForRequest(common_params_.url, last_committed_entry->GetReferrer());
 +      }
 +    }
 +  }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/991

This just only runs code we patched in in one less case than it used to before. Risk should be small.
We do have referrer tests from before and they still pass. 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source