### PR TITLE
Disabling SharedArrayBuffer

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -21,6 +21,7 @@
 #include "chrome/common/chrome_paths_internal.h"
 #include "chrome/common/chrome_switches.h"
 #include "components/password_manager/core/common/password_manager_features.h"
+#include "content/public/common/content_features.h"
 #include "extensions/common/extension_features.h"
 #include "ui/base/ui_base_features.h"
 
@@ -122,7 +123,13 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
     << "," << features::kDesktopPWAWindowing.name
     << "," << password_manager::features::kFillOnAccountSelect.name
     << "," << extensions::features::kNewExtensionUpdaterService.name;
+
+  std::stringstream disabled_features;
+  disabled_features << features::kSharedArrayBuffer.name;
+
   command_line.AppendSwitchASCII(switches::kEnableFeatures,
       enabled_features.str());
+  command_line.AppendSwitchASCII(switches::kDisableFeatures,
+      disabled_features.str());
   return ChromeMainDelegate::BasicStartupComplete(exit_code);
 }

--- a/app/sharedarraybuffer_disabledtest.cc
+++ b/app/sharedarraybuffer_disabledtest.cc
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+
+const char kSharedArrayBufferTest[] = "/sharedarraybuffer.html";
+
+class SharedArrayBufferDisabledTest : public InProcessBrowserTest {
+  public:
+    void SetUpOnMainThread() override {
+      InProcessBrowserTest::SetUpOnMainThread();
+
+      content_client_.reset(new ChromeContentClient);
+      content::SetContentClient(content_client_.get());
+      browser_content_client_.reset(new BraveContentBrowserClient());
+      content::SetBrowserClientForTesting(browser_content_client_.get());
+      content::SetupCrossSiteRedirector(embedded_test_server());
+
+      brave::RegisterPathProvider();
+      base::FilePath test_data_dir;
+      base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+      embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+      ASSERT_TRUE(embedded_test_server()->Start());
+    }
+
+    void TearDown() override {
+      browser_content_client_.reset();
+      content_client_.reset();
+    }
+
+  private:
+    std::unique_ptr<ChromeContentClient> content_client_;
+    std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+    base::ScopedTempDir temp_user_data_dir_;
+};
+
+IN_PROC_BROWSER_TEST_F(SharedArrayBufferDisabledTest, IsDisabled) {
+  GURL url = embedded_test_server()->GetURL(kSharedArrayBufferTest);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool getSharedArrayBufferDisabled;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "window.domAutomationController.send(isSharedArrayBufferDisabled())",
+      &getSharedArrayBufferDisabled));
+  EXPECT_TRUE(getSharedArrayBufferDisabled);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -147,6 +147,7 @@ static_library("browser_tests_runner") {
 test("brave_browser_tests") {
   sources = [
     "//brave/app/brave_main_delegate_browsertest.cc",
+    "//brave/app/sharedarraybuffer_disabledtest.cc",
     "//brave/chromium_src/chrome/browser/google/chrome_google_url_tracker_client_browsertest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",

--- a/test/data/sharedarraybuffer.html
+++ b/test/data/sharedarraybuffer.html
@@ -1,0 +1,10 @@
+<script>
+  function isSharedArrayBufferDisabled() {
+    try {
+      new SharedArrayBuffer();
+    } catch (err) {
+      return true;
+    }
+    return false;
+  }
+</script>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1051

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

```
<script>
  function isSharedArrayBufferDisabled() {
    try {
      new SharedArrayBuffer();
    } catch (err) {
      return "Disabled";
    }
    return "Enabled";
  }
  document.write(isSharedArrayBufferDisabled());
</script>
```

1. Load poc.html in brave.
2. Output should say `Disabled`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source