### PR TITLE
Fix brave_install_details_unittests build fail

### DIFF
--- a/chromium_src/chrome/install_static/brave_install_details_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_install_details_unittest.cc
@@ -8,7 +8,7 @@
 
 #include "base/macros.h"
 #include "chrome/install_static/install_modes.h"
-#include "components/version_info/version_info.h"
+#include "components/version_info/version_info_values.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 


### PR DESCRIPTION
There is one more unit test target specific on Windows

Close https://github.com/brave/brave-browser/issues/1075

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
`yarn test brave_install_details_unittests`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source