### PR TITLE
Fix newtab button isn't clickable

### DIFF
--- a/browser/ui/views/tabs/brave_new_tab_button.cc
+++ b/browser/ui/views/tabs/brave_new_tab_button.cc
@@ -44,3 +44,16 @@ void BraveNewTabButton::PaintPlusIcon(gfx::Canvas* canvas, int offset, int size)
   const int fixed_offset = (GetContentsBounds().width() / 2) - (size / 2);
   NewTabButton::PaintPlusIcon(canvas, fixed_offset, size);
 }
+
+SkPath BraveNewTabButton::GetNewerMaterialUiButtonPath(float button_y,
+                                                       float scale,
+                                                       bool extend_to_top,
+                                                       bool for_fill) const {
+  SkPath path;
+  const gfx::Rect contents_bounds = GetContentsBounds();
+  path.addRect(0, extend_to_top ? 0 : button_y,
+               contents_bounds.width() * scale,
+               button_y + contents_bounds.height() * scale);
+  path.close();
+  return path;
+}

--- a/browser/ui/views/tabs/brave_new_tab_button.h
+++ b/browser/ui/views/tabs/brave_new_tab_button.h
@@ -19,6 +19,10 @@ class BraveNewTabButton : public NewTabButton {
   private:
     gfx::Size CalculatePreferredSize() const override;
     void PaintPlusIcon(gfx::Canvas* canvas, int offset, int size) override;
+    SkPath GetNewerMaterialUiButtonPath(float button_y,
+                                        float scale,
+                                        bool extend_to_top,
+                                        bool for_fill) const override;
     DISALLOW_COPY_AND_ASSIGN(BraveNewTabButton);
 };
 

--- a/patches/chrome-browser-ui-views-tabs-new_tab_button.h.patch
+++ b/patches/chrome-browser-ui-views-tabs-new_tab_button.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/tabs/new_tab_button.h b/chrome/browser/ui/views/tabs/new_tab_button.h
-index ee40211315f979cfc34a7373195b2179b72429d4..9b3715cfe72390310b277f1ed0361821558da189 100644
+index ee40211315f979cfc34a7373195b2179b72429d4..6b0e87c2a7ae38b47c4a452ff0d6bacb1cb2620f 100644
 --- a/chrome/browser/ui/views/tabs/new_tab_button.h
 +++ b/chrome/browser/ui/views/tabs/new_tab_button.h
 @@ -25,6 +25,7 @@ class NewTabButton : public views::ImageButton,
@@ -19,3 +19,11 @@ index ee40211315f979cfc34a7373195b2179b72429d4..9b3715cfe72390310b277f1ed0361821
  
    SkColor GetButtonFillColor(bool opaque) const;
    SkColor GetIconColor() const;
+@@ -120,6 +121,7 @@ class NewTabButton : public views::ImageButton,
+   // the path will be shrunk by 1px from all sides to allow room for the stroke
+   // to show up. If |extend_to_top| is true, the path is extended vertically to
+   // y = 0.
++  virtual
+   SkPath GetNewerMaterialUiButtonPath(float button_y,
+                                       float scale,
+                                       bool extend_to_top,


### PR DESCRIPTION
With chromium's recent change, this button's border path rect is
calculated by using corder radius with layout value of EMPHASIS_MAXIMUM.
However, we changed that value to 4. Because of this, path rect is
calculated much smaller than buttons size.
So, most hittest was failed.

This also fixes the problem that a blob is visible on newtab button when theme is installed.
The blob's rect is also same as above small clickable rect.
W/o theme, button background and tab strip background color is same.
So, we didn't see that blob but it was there.

Close https://github.com/brave/brave-browser/issues/1092
Close https://github.com/brave/brave-browser/issues/983

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
Check new tab button work with mouse click

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source