### PR TITLE
Pass origin and hostname for torrent.createServer

### DIFF
--- a/components/brave_webtorrent/extension/background/webtorrent.ts
+++ b/components/brave_webtorrent/extension/background/webtorrent.ts
@@ -21,7 +21,16 @@ export const getWebTorrent = () => webTorrent
 export const createServer = (torrent: WebTorrent.Torrent, cb: (serverURL: string) => void) => {
   if (!torrent.infoHash) return // torrent is not ready
 
-  const server = torrent.createServer()
+  const opts = {
+    // Only allow requests from this origin ('chrome-extension://...) so
+    // websites cannot violate same-origin policy by reading contents of
+    // active torrents.
+    origin: window.location.origin,
+    // Use hostname option to mitigate DNS rebinding
+    // Ref: https://github.com/brave/browser-laptop/issues/12616
+    hostname: 'localhost'
+  }
+  const server = torrent.createServer(opts)
   if (!server) return
 
   try {

--- a/components/definitions/webtorrent.d.ts
+++ b/components/definitions/webtorrent.d.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ /// <reference path="../../node_modules/@types/webtorrent/index.d.ts" />
+
+import { Server } from 'http'
+
+interface CreateServerOpts {
+  origin: string
+  hostname: string
+}
+
+declare namespace WebTorrent {
+  interface Torrent extends NodeJS.EventEmitter {
+    createServer (opts?: CreateServerOpts): Server
+  }
+}
+
+export = WebTorrent


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1085
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
Original test steps are from https://github.com/webtorrent/webtorrent/pull/1260#issuecomment-357169944

- origin arg
1. Start a torrent download by visiting https://webtorrent.io/torrents/sintel.torrent and check the port the local http server is using by hover over the save file links.

2. Serve the following HTML file on a localhost server and then load it in your browser:
```
<div id='result'></div>
<script>
    const PORT = $PORT // replace this with $PORT number from step 1
    const serverUrl = `http://localhost:${PORT}/0`
    fetch(serverUrl).then((response) => {
      response.text().then((text) => result.innerText = text)
    })
</script>
```
3.  The page should not load any texts from the torrent file.

- hostname arg
A bit tricky because right now since I manually remove the origin arg and rebuilt to check this argument alone.
Add a record `127.0.0.1 evil.localhost` in /etc/hosts.
Take the same steps from origin arg, but modify serverUrl to `http://evil.localhost:${PORT}/0` and make sure the page won't load texts from the torrent file.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source