### PR TITLE
Bump bat-native-ledger for allow video check box

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@e8015a75518cecb85cc5eaa37b9d27bada8c45e5",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@3262a8ecc5fc9a4b48f164b9b34a3758794c9307",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@6f5817c5a4dcabb49e22b578ecae4993159e6481",


### PR DESCRIPTION
Addresses https://github.com/brave-intl/bat-native-ledger/issues/56

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

1. Open brave with clean profile and enable rewards.
2. Open youtube video and watch for the required time 
2a. make sure channel pub is added to autocontribute
3. Open autocontribute settings and uncheck allow videos.
4. Repeat step 2 with a different publisher and make sure channel pub is not added
5. Open autocontribute settings and check allow videos
6. Turn the autocontribute toggle off.
7. Repeat step 2 with a different publisher and make sure channel pub is not added
8. Turn autocontribute on and turn off rewards
9. Repeat step 2 with a different publisher and make sure channel pub is not added
10. Enable rewards turn autocontribute off and turn main rewards off
11. Repeat step 2 with a different publisher and make sure channel pub is not added
12. Enable rewards and autocontribute.
13. Repeat step 2 with a different publisher and make sure channel pub -IS- added


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source