### PR TITLE
Enable DHT client in WebTorrent

### DIFF
--- a/components/brave_webtorrent/extension/background.ts
+++ b/components/brave_webtorrent/extension/background.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { init } from './background/webtorrent'
-import './background/store'
+import './background/events/webtorrentEvents'
+import './background/events/torrentEvents'
 import './background/events/tabsEvents'
 import './background/events/windowsEvents'
-
-init()
+import './background/store'

--- a/components/brave_webtorrent/extension/background/webtorrent.ts
+++ b/components/brave_webtorrent/extension/background/webtorrent.ts
@@ -8,7 +8,7 @@ import { addWebtorrentEvents } from './events/webtorrentEvents'
 import { AddressInfo } from 'net'
 import { Instance } from 'parse-torrent'
 
-let webTorrent: WebTorrent.Instance
+let webTorrent: WebTorrent.Instance | undefined
 let servers: { [key: string]: any } = { }
 
 export const getWebTorrent = () => {
@@ -59,6 +59,12 @@ export const findTorrent = (infoHash: string) => {
   return getWebTorrent().torrents.find(torrent => torrent.infoHash === infoHash)
 }
 
+const maybeDestroyWebTorrent = () => {
+  if (!webTorrent || webTorrent.torrents.length !== 0) return
+  webTorrent.destroy()
+  webTorrent = undefined
+}
+
 export const delTorrent = (infoHash: string) => {
   const torrent = findTorrent(infoHash)
   if (torrent) torrent.destroy()
@@ -66,4 +72,6 @@ export const delTorrent = (infoHash: string) => {
     servers[infoHash].close()
     delete servers[infoHash]
   }
+
+  maybeDestroyWebTorrent()
 }

--- a/components/brave_webtorrent/extension/background/webtorrent.ts
+++ b/components/brave_webtorrent/extension/background/webtorrent.ts
@@ -11,12 +11,14 @@ import { Instance } from 'parse-torrent'
 let webTorrent: WebTorrent.Instance
 let servers: { [key: string]: any } = { }
 
-export const init = () => {
-  webTorrent = new WebTorrent({ tracker: { wrtc: false } })
-  addWebtorrentEvents(webTorrent)
-}
+export const getWebTorrent = () => {
+  if (!webTorrent) {
+    webTorrent = new WebTorrent({ tracker: { wrtc: false } })
+    addWebtorrentEvents(webTorrent)
+  }
 
-export const getWebTorrent = () => webTorrent
+  return webTorrent
+}
 
 export const createServer = (torrent: WebTorrent.Torrent, cb: (serverURL: string) => void) => {
   if (!torrent.infoHash) return // torrent is not ready
@@ -49,12 +51,12 @@ export const createServer = (torrent: WebTorrent.Torrent, cb: (serverURL: string
 }
 
 export const addTorrent = (torrentId: string | Instance) => {
-  const torrentObj = webTorrent.add(torrentId)
+  const torrentObj = getWebTorrent().add(torrentId)
   addTorrentEvents(torrentObj)
 }
 
 export const findTorrent = (infoHash: string) => {
-  return webTorrent.torrents.find(torrent => torrent.infoHash === infoHash)
+  return getWebTorrent().torrents.find(torrent => torrent.infoHash === infoHash)
 }
 
 export const delTorrent = (infoHash: string) => {

--- a/components/brave_webtorrent/extension/manifest.json
+++ b/components/brave_webtorrent/extension/manifest.json
@@ -7,7 +7,7 @@
     "scripts": ["extension/out/brave_webtorrent_background.bundle.js"],
     "persistent": true
   },
-  "permissions": ["tabs", "windows", "<all_urls>"],
+  "permissions": ["dns", "tabs", "windows", "<all_urls>"],
   "sockets": {
     "udp": {
       "send": "*",

--- a/components/common/dns.ts
+++ b/components/common/dns.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+interface ResolveInfo {
+  resultCode: number
+  address?: string
+}
+
+/*
+ * Shimming node's dns.lookup API using chrome.dns.resolve.
+ * @param {string} hostname: the hostname to be resolved
+ * @param {function} cb: a callback function for dns.lookup with error and ip arguments
+ */
+export const lookup = (hostname: string, cb: any) => {
+  chrome.dns.resolve(hostname, (resolveInfo: ResolveInfo) => {
+    if (resolveInfo.resultCode !== 0) {
+      cb(new Error('chrome.dns.resolve error'), undefined)
+    } else {
+      cb(undefined, resolveInfo.address)
+    }
+  })
+}

--- a/components/common/typescript.gni
+++ b/components/common/typescript.gni
@@ -1,5 +1,6 @@
 brave_common_typescript_includes = [
   rebase_path("classSet.ts"),
+  rebase_path("dns.ts"),
   rebase_path("debounce.ts"),
   rebase_path("locale.ts"),
 ]

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -7,3 +7,7 @@ declare namespace chrome {
   function setVariableValue (variable: string, value: any): void
   function send (stat: string, args?: any[]): void
 }
+
+declare namespace chrome.dns {
+  function resolve (hostname: string, callback: any): void
+}

--- a/components/webpack/dev.config.js
+++ b/components/webpack/dev.config.js
@@ -24,9 +24,10 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.tsx', '.ts', '.json'],
     alias: {
+      'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker'),
       'dgram': 'chrome-dgram',
-      'net': 'chrome-net',
-      'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker')
+      'dns': path.resolve(__dirname, '../common/dns.ts'),
+      'net': 'chrome-net'
     }
   },
   module: {

--- a/components/webpack/dev.config.js
+++ b/components/webpack/dev.config.js
@@ -27,7 +27,8 @@ module.exports = {
       'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker'),
       'dgram': 'chrome-dgram',
       'dns': path.resolve(__dirname, '../common/dns.ts'),
-      'net': 'chrome-net'
+      'net': 'chrome-net',
+      'torrent-discovery': path.resolve(__dirname, '../../node_modules/torrent-discovery')
     }
   },
   module: {

--- a/components/webpack/prod.config.js
+++ b/components/webpack/prod.config.js
@@ -35,9 +35,10 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.tsx', '.ts', '.json'],
     alias: {
+      'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker'),
       'dgram': 'chrome-dgram',
-      'net': 'chrome-net',
-      'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker')
+      'dns': path.resolve(__dirname, '../common/dns.ts'),
+      'net': 'chrome-net'
     }
   },
   module: {

--- a/components/webpack/prod.config.js
+++ b/components/webpack/prod.config.js
@@ -38,7 +38,8 @@ module.exports = {
       'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker'),
       'dgram': 'chrome-dgram',
       'dns': path.resolve(__dirname, '../common/dns.ts'),
-      'net': 'chrome-net'
+      'net': 'chrome-net',
+      'torrent-discovery': path.resolve(__dirname, '../../node_modules/torrent-discovery')
     }
   },
   module: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3010,9 +3010,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.2.tgz",
-          "integrity": "sha512-E3RfQoPuKDBhec0s8fOsgFXDVFlEipbsheGBX/NNByfKMfzPEEQJXcLy6fJ7bDD820HG/d+eXQ1ezCj29KoAJA==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.3.tgz",
+          "integrity": "sha512-CzN1eAu5Pmh4EaDlJp1g5E37LIHR24b82XlMWRQlPFjhvOYKa4HhClRsQO21zhdDWUpdWfiKt9/L/ZL2+vwxCw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -10336,9 +10336,8 @@
       }
     },
     "torrent-discovery": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.1.1.tgz",
-      "integrity": "sha512-3mHf+bxVCVLrlkPJdAoMbPMY1hpTZVeWw5hNc2pPFm+HCc2DS0HgVFTBTSWtB8vQPWA1hSEZpqJ+3QfdXxDE1g==",
+      "version": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
+      "from": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
       "requires": {
         "bittorrent-dht": "^9.0.0",
         "bittorrent-tracker": "^9.0.0",
@@ -11286,8 +11285,8 @@
       }
     },
     "webtorrent": {
-      "version": "github:brave/webtorrent#600664249258dd7e893789e991d4cc5f481a7bae",
-      "from": "github:brave/webtorrent#600664249258dd7e893789e991d4cc5f481a7bae",
+      "version": "github:brave/webtorrent#8ae3aead004bb3f1220c8d5103f8b04193e410ad",
+      "from": "github:brave/webtorrent#8ae3aead004bb3f1220c8d5103f8b04193e410ad",
       "requires": {
         "addr-to-ip-port": "^1.4.2",
         "bitfield": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2056,15 +2056,15 @@
       "integrity": "sha512-4xM4DYejOHQ/qWBfeqBXNA4mJ12PwcOibFYnH1kYh5U9BHciCqEJBqGNVnMJXUhm8mflujNRLSv7IiVQxovgjw=="
     },
     "bittorrent-dht": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-8.4.0.tgz",
-      "integrity": "sha512-FRe/+MYBePev7Yb+BXSclkVuDxb/w+gUbao6nVHYQRaKO7aXE+ARRlL3phqm6Rdhw5CRVoLMbLd49nxmCuUhUQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-9.0.0.tgz",
+      "integrity": "sha512-X5ax4G/PLtEPfqOUjqDZ2nmPENndWRMK4sT2jcQ4sXor904zhR40r4KqTyTvWYAljh5/hPPqM9DCUUtqWzRXoQ==",
       "requires": {
         "bencode": "^2.0.0",
         "buffer-equals": "^1.0.3",
         "debug": "^3.1.0",
         "inherits": "^2.0.1",
-        "k-bucket": "^4.0.0",
+        "k-bucket": "^5.0.0",
         "k-rpc": "^5.0.0",
         "last-one-wins": "^1.0.4",
         "lru": "^3.1.0",
@@ -2072,6 +2072,16 @@
         "record-cache": "^1.0.2",
         "safe-buffer": "^5.0.1",
         "simple-sha1": "^2.1.0"
+      },
+      "dependencies": {
+        "k-bucket": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.0.0.tgz",
+          "integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
+          "requires": {
+            "randombytes": "^2.0.3"
+          }
+        }
       }
     },
     "bittorrent-peerid": {
@@ -11285,32 +11295,31 @@
       }
     },
     "webtorrent": {
-      "version": "github:brave/webtorrent#8ae3aead004bb3f1220c8d5103f8b04193e410ad",
-      "from": "github:brave/webtorrent#8ae3aead004bb3f1220c8d5103f8b04193e410ad",
+      "version": "github:brave/webtorrent#7742597c9cee74100dcd1f241e1a55aff93adf5c",
+      "from": "github:brave/webtorrent#7742597c9cee74100dcd1f241e1a55aff93adf5c",
       "requires": {
         "addr-to-ip-port": "^1.4.2",
         "bitfield": "^2.0.0",
-        "bittorrent-dht": "^8.0.0",
+        "bittorrent-dht": "^9.0.0",
         "bittorrent-protocol": "^3.0.0",
-        "chunk-store-stream": "^3.0.0",
-        "create-torrent": "^3.24.5",
-        "debug": "^3.1.0",
+        "chunk-store-stream": "^3.0.1",
+        "create-torrent": "^3.33.0",
+        "debug": "^4.0.1",
         "end-of-stream": "^1.1.0",
         "fs-chunk-store": "^1.6.2",
         "immediate-chunk-store": "^2.0.0",
-        "inherits": "^2.0.1",
         "load-ip-set": "^2.1.0",
         "memory-chunk-store": "^1.2.0",
         "mime": "^2.2.0",
         "multistream": "^2.0.5",
         "package-json-versionify": "^1.0.2",
         "parse-numeric-range": "^0.0.2",
-        "parse-torrent": "^6.0.0",
+        "parse-torrent": "^6.1.2",
         "pump": "^3.0.0",
         "random-iterate": "^1.0.1",
         "randombytes": "^2.0.3",
         "range-parser": "^1.2.0",
-        "readable-stream": "^2.1.4",
+        "readable-stream": "^3.0.2",
         "render-media": "^3.0.0",
         "run-parallel": "^1.1.6",
         "run-parallel-limit": "^1.0.3",
@@ -11323,14 +11332,100 @@
         "stream-to-blob": "^1.0.0",
         "stream-to-blob-url": "^2.1.0",
         "stream-with-known-length-to-buffer": "^1.0.0",
-        "torrent-discovery": "^9.0.2",
+        "torrent-discovery": "^9.1.1",
         "torrent-piece": "^2.0.0",
         "uniq": "^1.0.1",
         "unordered-array-remove": "^1.0.2",
-        "ut_metadata": "^3.0.8",
-        "ut_pex": "^1.1.1",
-        "xtend": "^4.0.1",
-        "zero-fill": "^2.2.3"
+        "ut_metadata": "^3.3.0",
+        "ut_pex": "^1.1.1"
+      },
+      "dependencies": {
+        "bittorrent-tracker": {
+          "version": "9.10.1",
+          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.10.1.tgz",
+          "integrity": "sha512-n5zTL/g6Wt0rb2EnkiyiaGYhth7I/N0/xMqGUpvGX/7g1scDGBVPhJnXR8lfp3/OMj681fv40o4q/otECMtZSA==",
+          "requires": {
+            "bencode": "^2.0.0",
+            "bittorrent-peerid": "^1.0.2",
+            "bn.js": "^4.4.0",
+            "bufferutil": "^4.0.0",
+            "compact2string": "^1.2.0",
+            "debug": "^3.1.0",
+            "inherits": "^2.0.1",
+            "ip": "^1.0.1",
+            "lru": "^3.0.0",
+            "minimist": "^1.1.1",
+            "once": "^1.3.0",
+            "random-iterate": "^1.0.1",
+            "randombytes": "^2.0.3",
+            "run-parallel": "^1.1.2",
+            "run-series": "^1.0.2",
+            "safe-buffer": "^5.0.0",
+            "simple-get": "^3.0.0",
+            "simple-peer": "^9.0.0",
+            "simple-websocket": "^7.0.1",
+            "string2compact": "^1.1.1",
+            "uniq": "^1.0.1",
+            "unordered-array-remove": "^1.0.2",
+            "utf-8-validate": "^5.0.1",
+            "ws": "^6.0.0",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.5",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+              "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
+          "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "readable-stream": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.3.tgz",
+          "integrity": "sha512-CzN1eAu5Pmh4EaDlJp1g5E37LIHR24b82XlMWRQlPFjhvOYKa4HhClRsQO21zhdDWUpdWfiKt9/L/ZL2+vwxCw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "torrent-discovery": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.1.1.tgz",
+          "integrity": "sha512-3mHf+bxVCVLrlkPJdAoMbPMY1hpTZVeWw5hNc2pPFm+HCc2DS0HgVFTBTSWtB8vQPWA1hSEZpqJ+3QfdXxDE1g==",
+          "requires": {
+            "bittorrent-dht": "^9.0.0",
+            "bittorrent-tracker": "^9.0.0",
+            "debug": "^3.1.0",
+            "run-parallel": "^1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.5",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+              "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        }
       }
     },
     "whatwg-encoding": {
@@ -11568,11 +11663,6 @@
           "dev": true
         }
       }
-    },
-    "zero-fill": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/zero-fill/-/zero-fill-2.2.3.tgz",
-      "integrity": "sha1-o97wa6XjmuZEhQu0yirUEStIVek="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -138,6 +138,6 @@
     "react-chrome-redux": "^1.5.1",
     "throttleit": "^1.0.0",
     "torrent-discovery": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
-    "webtorrent": "github:brave/webtorrent#8ae3aead004bb3f1220c8d5103f8b04193e410ad"
+    "webtorrent": "github:brave/webtorrent#7742597c9cee74100dcd1f241e1a55aff93adf5c"
   }
 }

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "qr-image": "^3.2.0",
     "react-chrome-redux": "^1.5.1",
     "throttleit": "^1.0.0",
-    "webtorrent": "github:brave/webtorrent#600664249258dd7e893789e991d4cc5f481a7bae"
+    "torrent-discovery": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
+    "webtorrent": "github:brave/webtorrent#8ae3aead004bb3f1220c8d5103f8b04193e410ad"
   }
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/857
DHT client using by WebTorrent wasn't enabled in my first implementation because we don't have shim API for dns.lookup.
This PR adds a shim for that using chrome.dns.resolve API and enables DHT client.
The WebTorrent construction is also deferred by this PR to after starting the torrent so we won't connect to DHT before that.
DHT client is now enabled in our webtorrent fork by https://github.com/brave/webtorrent/commit/8ae3aead004bb3f1220c8d5103f8b04193e410ad
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
1. Navigate to
`magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny`, which is a trackerless magnet link.
2. Click start download, it should be able to discover peers and start downloading.
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source