### PR TITLE
Make user data dir independent to BRANDING file on MacOS

### DIFF
--- a/build/config.gni
+++ b/build/config.gni
@@ -44,7 +44,22 @@ if (is_win) {
 } else if (is_mac) {
   brave_exe = "$chrome_product_full_name.app"
   brave_dmg = "$chrome_product_full_name.dmg"
-  brave_product_dir_name = "BraveSoftware/$chrome_product_full_name"
+
+  brave_product_dir_name_suffix = ""
+  if (is_official_build) {
+    if (brave_channel == "beta") {
+      brave_product_dir_name_suffix = "-Beta"
+    } else if (brave_channel == "dev") {
+      brave_product_dir_name_suffix = "-Dev"
+    } else if (brave_channel == "nightly") {
+      brave_product_dir_name_suffix = "-Nightly"
+    } else {
+      assert(brave_channel == "", "Unknown channel name")
+    }
+  } else {
+    brave_product_dir_name_suffix = "-Development"
+  }
+  brave_product_dir_name = "BraveSoftware/Brave-Browser$brave_product_dir_name_suffix"
 }
 
 brave_platform = "darwin"


### PR DESCRIPTION
User data should be always brave-browser-xxx format.
This is prerequisite for https://github.com/brave/brave-core/pull/437

close https://github.com/brave/brave-browser/issues/1106

It's hard to add test for this because user dir is set to Information Property List that test doesn't have.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source