### PR TITLE
FP: Return ImageData instead of nullptr in getImageData for breaking sites less

### DIFF
--- a/patches/third_party-blink-renderer-modules-canvas-canvas2d-base_rendering_context_2d.cc.patch
+++ b/patches/third_party-blink-renderer-modules-canvas-canvas2d-base_rendering_context_2d.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
-index 783f5c3e3ddf5c33f43b9cccc4070cfc7c866e86..fc24e3a739e6e73b734c6506888cc6207a8b593e 100644
+index 783f5c3e3ddf5c33f43b9cccc4070cfc7c866e86..1a8da9377eddff9fc3d6b8a3d973e80229fcae3f 100644
 --- a/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
 +++ b/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
 @@ -5,6 +5,7 @@
@@ -80,7 +80,7 @@ index 783f5c3e3ddf5c33f43b9cccc4070cfc7c866e86..fc24e3a739e6e73b734c6506888cc620
    return IsPointInStrokeInternal(dom_path->GetPath(), x, y);
  }
  
-@@ -1610,11 +1635,14 @@ ImageData* BaseRenderingContext2D::createImageData(
+@@ -1610,11 +1635,16 @@ ImageData* BaseRenderingContext2D::createImageData(
  }
  
  ImageData* BaseRenderingContext2D::getImageData(
@@ -91,7 +91,9 @@ index 783f5c3e3ddf5c33f43b9cccc4070cfc7c866e86..fc24e3a739e6e73b734c6506888cc620
      int sh,
      ExceptionState& exception_state) {
 +  LocalDOMWindow* window = LocalDOMWindow::From(script_state);
-+  if (window && !AllowFingerprinting(window->GetFrame())) return nullptr;
++  if (window && !AllowFingerprinting(window->GetFrame())) {
++    return ImageData::CreateForTest(IntSize(0, 0));
++  }
    if (!base::CheckMul(sw, sh).IsValid<int>()) {
      exception_state.ThrowRangeError("Out of memory at ImageData creation");
      return nullptr;


### PR DESCRIPTION
Fix brave/brave-browser#1111
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
```
npm run test -- brave_browser_tests --filter=BraveContentSettingsObserverBrowserTest.*GetImageData
```

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source