### PR TITLE
Autoplay is blocked by default

### DIFF
--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -6,7 +6,7 @@ void ContentSettingsRegistry::BraveInit() {
   // Add CONTENT_SETTING_ASK and make it default for autoplay
   content_settings_info_.erase(CONTENT_SETTINGS_TYPE_AUTOPLAY);
   website_settings_registry_->UnRegister(CONTENT_SETTINGS_TYPE_AUTOPLAY);
-  Register(CONTENT_SETTINGS_TYPE_AUTOPLAY, "autoplay", CONTENT_SETTING_ASK,
+  Register(CONTENT_SETTINGS_TYPE_AUTOPLAY, "autoplay", CONTENT_SETTING_BLOCK,
            WebsiteSettingsInfo::UNSYNCABLE, WhitelistedSchemes(),
            ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK,
                          CONTENT_SETTING_ASK),


### PR DESCRIPTION
Fixes brave/brave-browser#1047

Changed registration of autoplay with block instead of ask.
Changed browser test to expect blocked autoplay content. Changed tests that expect the "ask" prompt to set the ask setting before the tests.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [x] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source