### PR TITLE
Fix BraveContentBrowserClientTest.CanLoadCustomBravePages

### DIFF
--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -7,6 +7,7 @@
 #include "base/path_service.h"
 #include "brave/browser/brave_content_browser_client.h"
 #include "brave/common/brave_paths.h"
+#include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/common/chrome_content_client.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -84,7 +85,9 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadChromeURL) {
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadCustomBravePages) {
   std::vector<GURL> urls {
     GURL("chrome://adblock/"),
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
     GURL("chrome://rewards/"),
+#endif
     GURL("chrome://welcome/")
   };
   std::for_each(urls.begin(), urls.end(), [this](const GURL& url) {


### PR DESCRIPTION
On windows, chrome://rewards cannot be loaded because rewards is
disabled on Windows.

Close https://github.com/brave/brave-browser/issues/1144

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
`yarn test brave_browser_tests --filter=BraveContentBrowserClientTest.CanLoadCustomBravePages`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source