### PR TITLE
Add //chrome/app/theme:theme_resources deps in brave_theme_resources

### DIFF
--- a/app/theme/BUILD.gn
+++ b/app/theme/BUILD.gn
@@ -15,6 +15,10 @@ grit("brave_theme_resources") {
 
   resource_ids = "//brave/browser/resources/resource_ids"
 
+  deps = [
+    "//chrome/app/theme:theme_resources",
+  ]
+
   output_dir = "$root_gen_dir/brave"
 }
 


### PR DESCRIPTION
Resolving missing generated header in Release build
```
../../brave/chromium_src/chrome/grit/theme_resources.h:2:10: fatal
error: 'gen/chrome/grit/theme_resources.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Auditors: @bbondy, @simonhong

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source