### PR TITLE
Fix stats updater to accept any 2XX HTTP response codes as success

### DIFF
--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -103,7 +103,8 @@ void BraveStatsUpdater::OnSimpleLoaderComplete(
       simple_url_loader_->ResponseInfo()->headers)
     response_code =
         simple_url_loader_->ResponseInfo()->headers->response_code();
-  if (simple_url_loader_->NetError() != net::OK || response_code != 200) {
+  if (simple_url_loader_->NetError() != net::OK || response_code < 200 ||
+      response_code > 299) {
     LOG(ERROR) << "Failed to send usage stats to update server"
                << ", error: " << simple_url_loader_->NetError()
                << ", response code: " << response_code


### PR DESCRIPTION
Fixes brave/brave-browser#1154

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source