### PR TITLE
Fix missing tor mojom symbols in Windows release build

### DIFF
--- a/browser/tor/BUILD.gn
+++ b/browser/tor/BUILD.gn
@@ -16,6 +16,7 @@ source_set("tor") {
   deps = [
     "//base",
     "//brave/common/tor",
+    "//brave/common/tor:tor_mojom_bindings",
     "//components/keyed_service/content",
     "//components/keyed_service/core",
     # for profile.h


### PR DESCRIPTION
```
 lld-link: error: undefined symbol: ?kTorLauncherServiceName@mojom@tor@@3QBDB
 lld-link: error: undefined symbol: ?SetCrashHandler@TorLauncherProxy@mojom@tor@@UEAAXV?$OnceCallback@$$A6AX_J@Z@base@@@Z
 ...
```
 in tor_config.mojom and tor_launcher.mojom

Auditor: @bbondy

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source