### PR TITLE
Don't save stats preferences when update server request fails

### DIFF
--- a/browser/brave_stats_updater.h
+++ b/browser/brave_stats_updater.h
@@ -19,6 +19,8 @@ class SimpleURLLoader;
 
 namespace brave {
 
+class BraveStatsUpdaterParams;
+
 class BraveStatsUpdater {
  public:
   BraveStatsUpdater(PrefService* pref_service);
@@ -29,7 +31,9 @@ class BraveStatsUpdater {
 
  private:
   // Invoked from SimpleURLLoader after download is complete.
-  void OnSimpleLoaderComplete(std::unique_ptr<std::string> response_body);
+  void OnSimpleLoaderComplete(
+      std::unique_ptr<brave::BraveStatsUpdaterParams> stats_updater_params,
+      std::unique_ptr<std::string> response_body);
 
   // Invoked from RepeatingTimer when server ping timer fires.
   void OnServerPingTimerFired();

--- a/browser/brave_stats_updater_params.cc
+++ b/browser/brave_stats_updater_params.cc
@@ -30,7 +30,6 @@ BraveStatsUpdaterParams::BraveStatsUpdaterParams(PrefService* pref_service,
 }
 
 BraveStatsUpdaterParams::~BraveStatsUpdaterParams() {
-  SavePrefs();
 }
 
 std::string BraveStatsUpdaterParams::GetDailyParam() const {

--- a/browser/brave_stats_updater_params.h
+++ b/browser/brave_stats_updater_params.h
@@ -32,7 +32,9 @@ class BraveStatsUpdaterParams {
   std::string GetFirstCheckMadeParam() const;
   std::string GetWeekOfInstallationParam() const;
 
- private:
+  void SavePrefs();
+
+private:
   PrefService* pref_service_;
   std::string ymd_;
   int woy_;
@@ -44,7 +46,6 @@ class BraveStatsUpdaterParams {
   std::string week_of_installation_;
 
   void LoadPrefs();
-  void SavePrefs();
 
   std::string BooleanToString(bool bool_value) const;
 


### PR DESCRIPTION
We currently update the stats preferences when initiating the request
to the server, but that's the wrong thing to do in the case where the
request fails. Instead, only update the stats preferences after
receiving a successful response from the server.

Fixes brave/brave-browser#1155

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source