### PR TITLE
Iterate the UI light theme

### DIFF
--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -9,37 +9,43 @@
 
 namespace {
 
+const SkColor kLightToolbar = SkColorSetRGB(0xf3, 0xf3, 0xf3);
+const SkColor kLightFrame = SkColorSetRGB(0xd5, 0xd9, 0xdc);
+const SkColor kLightToolbarIcon = SkColorSetRGB(0x42, 0x42, 0x42);
+
 base::Optional<SkColor> MaybeGetDefaultColorForBraveLightUi(int id) {
   switch (id) {
     // Applies when the window is active, tabs and also tab bar everywhere except active tab
     case ThemeProperties::COLOR_FRAME:
     case ThemeProperties::COLOR_BACKGROUND_TAB:
-      return SkColorSetRGB(0xD8, 0xDE, 0xE1);
+    case ThemeProperties::COLOR_TOOLBAR_CONTENT_AREA_SEPARATOR:
+      return kLightFrame;
     // Window when the window is innactive, tabs and also tab bar everywhere except active tab
     case ThemeProperties::COLOR_FRAME_INACTIVE:
     case ThemeProperties::COLOR_BACKGROUND_TAB_INACTIVE:
-      return SkColorSetRGB(0xC8, 0xCE, 0xC8);
+      return color_utils::HSLShift(kLightFrame, { -1, -1, 0.6 });
     // Active tab and also the URL toolbar
     // Parts of this color show up as you hover over innactive tabs too
     case ThemeProperties::COLOR_TOOLBAR:
+    case ThemeProperties::COLOR_TOOLBAR_TOP_SEPARATOR:
+    case ThemeProperties::COLOR_TOOLBAR_TOP_SEPARATOR_INACTIVE:
     case ThemeProperties::COLOR_DETACHED_BOOKMARK_BAR_BACKGROUND:
     case ThemeProperties::COLOR_CONTROL_BACKGROUND:
-    case ThemeProperties::COLOR_TOOLBAR_CONTENT_AREA_SEPARATOR:
-      return SkColorSetRGB(0xF6, 0xF7, 0xF9);
+      return kLightToolbar;
     case ThemeProperties::COLOR_TAB_TEXT:
-      return SkColorSetRGB(0x22, 0x23, 0x26);
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
     case ThemeProperties::COLOR_BACKGROUND_TAB_TEXT:
-      return SkColorSetRGB(0x22, 0x23, 0x26);
-    case ThemeProperties::COLOR_LOCATION_BAR_BORDER:
-      return SkColorSetRGB(0xd5, 0xd9, 0xdc);
+    case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
+      return kLightToolbarIcon;
+    case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:
+      return color_utils::AlphaBlend(kLightToolbarIcon, kLightToolbar, 77);
     default:
       return base::nullopt;
   }
 }
 
-const SkColor kDarkFrame = SkColorSetRGB(0x22, 0x22, 0x22);
 const SkColor kDarkToolbar = SkColorSetRGB(0x39, 0x39, 0x39);
+const SkColor kDarkFrame = SkColorSetRGB(0x22, 0x22, 0x22);
 const SkColor kDarkToolbarIcon = SkColorSetRGB(0xed, 0xed, 0xed);
 
 base::Optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id) {
@@ -66,11 +72,6 @@ base::Optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id) {
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
     case ThemeProperties::COLOR_BACKGROUND_TAB_TEXT:
       return SkColorSetRGB(0xFF, 0xFF, 0xFF);
-    case ThemeProperties::COLOR_LOCATION_BAR_BORDER:
-      // TODO: Should be location bar background, but location bar has hover
-      // color which we don't have access to here.
-      // Consider increasing height instead.
-      return kDarkToolbar;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
       return kDarkToolbarIcon;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:
@@ -108,11 +109,6 @@ base::Optional<SkColor> MaybeGetDefaultColorForPrivateUi(int id) {
     case ThemeProperties::COLOR_BOOKMARK_TEXT:
     case ThemeProperties::COLOR_BACKGROUND_TAB_TEXT:
       return SkColorSetRGB(0xFF, 0xFF, 0xFF);
-    case ThemeProperties::COLOR_LOCATION_BAR_BORDER:
-      // TODO: Should be location bar background, but location bar has hover
-      // color which we don't have access to here.
-      // Consider increasing height instead.
-      return kPrivateToolbar;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON:
       return kDarkToolbarIcon;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:

--- a/chromium_src/chrome/browser/ui/omnibox/omnibox_theme.cc
+++ b/chromium_src/chrome/browser/ui/omnibox/omnibox_theme.cc
@@ -62,8 +62,10 @@ SkColor GetOmniboxColor(OmniboxPart part,
                                   -1,
                                   -1,
                                   hovered ? 0.54 : 0.52 })
-                          : (hovered ? gfx::kGoogleGrey100
-                                        : SkColorSetRGB(0xff, 0xff, 0xff)));
+                          : (hovered ? color_utils::AlphaBlend(SK_ColorWHITE,
+                                              SkColorSetRGB(0xf3, 0xf3, 0xf3),
+                                              178)
+                                      : SK_ColorWHITE));
     }
     case OmniboxPart::LOCATION_BAR_TEXT_DEFAULT:
     case OmniboxPart::RESULTS_TEXT_DEFAULT: {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/961

Hardcoded colors for now, will follow-up with variables for the palette and re-using from Omnibox to ThemeProperties when we validate these values with the designers in the build.

![image](https://user-images.githubusercontent.com/741836/45730645-cda63100-bb87-11e8-8896-99b0b14a455c.png)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source