### PR TITLE
Replace learn more links in content setting bubbles

### DIFF
--- a/browser/ui/brave_browser_content_setting_bubble_model_delegate.cc
+++ b/browser/ui/brave_browser_content_setting_bubble_model_delegate.cc
@@ -8,6 +8,8 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 
+const char kBraveCommunitySupportUrl[] = "https://community.brave.com/";
+
 BraveBrowserContentSettingBubbleModelDelegate::
 BraveBrowserContentSettingBubbleModelDelegate(Browser* browser) :
     BrowserContentSettingBubbleModelDelegate(browser),
@@ -21,6 +23,14 @@ BraveBrowserContentSettingBubbleModelDelegate::
 void
 BraveBrowserContentSettingBubbleModelDelegate::ShowWidevineLearnMorePage() {
   GURL learn_more_url = GURL(kWidevineTOS);
+  chrome::AddSelectedTabWithURL(browser_, learn_more_url,
+                                ui::PAGE_TRANSITION_LINK);
+}
+
+void BraveBrowserContentSettingBubbleModelDelegate::ShowLearnMorePage(
+    ContentSettingsType type) {
+  // TODO: Use specific support pages for each content setting type
+  GURL learn_more_url(kBraveCommunitySupportUrl);
   chrome::AddSelectedTabWithURL(browser_, learn_more_url,
                                 ui::PAGE_TRANSITION_LINK);
 }

--- a/browser/ui/brave_browser_content_setting_bubble_model_delegate.h
+++ b/browser/ui/brave_browser_content_setting_bubble_model_delegate.h
@@ -14,6 +14,7 @@ class BraveBrowserContentSettingBubbleModelDelegate
   ~BraveBrowserContentSettingBubbleModelDelegate() override;
 
   void ShowWidevineLearnMorePage();
+  void ShowLearnMorePage(ContentSettingsType type) override;
 
  private:
   Browser* const browser_;


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/517
Besides the mixed script case reported in the issue, this PR also fixes the link for ad and plugin cases.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
1. Navigate to https://mixed-script.badssl.com/
2. Click the insecure script in the url bar to open the content setting bubble
3. Click on the learn more link
4. Verify that a brave community page is opened in a new tab

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source