### PR TITLE
Fix BraveThemeServiceTest failure

### DIFF
--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -15,6 +15,11 @@ using BraveThemeServiceTest = InProcessBrowserTest;
 using BTS = BraveThemeService;
 
 namespace {
+// Copied from theme_properties.cc
+// TODO: Need to share same constants.
+const SkColor kDarkFrame = SkColorSetRGB(0x22, 0x22, 0x22);
+const SkColor kLightFrame = SkColorSetRGB(0xd5, 0xd9, 0xdc);
+
 void SetBraveThemeType(Profile* profile, BraveThemeType type) {
   profile->GetPrefs()->SetInteger(kBraveThemeType, type);
 }
@@ -22,8 +27,6 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 
 IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, BraveThemeChangeTest) {
   Profile* profile = browser()->profile();
-  const SkColor light_frame_color = SkColorSetRGB(0xD8, 0xDE, 0xE1);
-  const SkColor dark_frame_color = SkColorSetRGB(0x22, 0x22, 0x22);
 
   // Check default type is set initially.
   EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_DEFAULT, BTS::GetUserPreferredBraveThemeType(profile));
@@ -31,9 +34,9 @@ IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, BraveThemeChangeTest) {
   const ui::ThemeProvider& tp = ThemeService::GetThemeProviderForProfile(profile);
   SetBraveThemeType(browser()->profile(), BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
   EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_LIGHT, BTS::GetUserPreferredBraveThemeType(profile));
-  EXPECT_EQ(light_frame_color, tp.GetColor(ThemeProperties::COLOR_FRAME));
+  EXPECT_EQ(kLightFrame, tp.GetColor(ThemeProperties::COLOR_FRAME));
 
   SetBraveThemeType(browser()->profile(), BraveThemeType::BRAVE_THEME_TYPE_DARK);
   EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_DARK, BTS::GetUserPreferredBraveThemeType(profile));
-  EXPECT_EQ(dark_frame_color, tp.GetColor(ThemeProperties::COLOR_FRAME));
+  EXPECT_EQ(kDarkFrame, tp.GetColor(ThemeProperties::COLOR_FRAME));
 }


### PR DESCRIPTION
Recently, frame colors were changed.
Failure reason is this test uses hard-coded color value.
As a todo list, we should share these color constants instead of copying.

Issue https://github.com/brave/brave-browser/issues/961

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
`yarn test brave_browser_tests --filter=BraveThemeServiceTest.BraveThemeChangetest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source