### PR TITLE
Adds PublisherInfoDatabase::Count

### DIFF
--- a/components/brave_rewards/browser/publisher_info_database.h
+++ b/components/brave_rewards/browser/publisher_info_database.h
@@ -39,6 +39,8 @@ class PublisherInfoDatabase {
             int limit,
             const ledger::PublisherInfoFilter& filter,
             ledger::PublisherInfoList* list);
+  int Count(const ledger::PublisherInfoFilter& filter);
+
   std::unique_ptr<ledger::PublisherInfo> GetMediaPublisherInfo(
       const std::string& media_key);
 
@@ -61,6 +63,12 @@ class PublisherInfoDatabase {
   bool CreateActivityInfoTable();
   bool CreateContributionInfoIndex();
   bool CreateActivityInfoIndex();
+
+  std::string BuildClauses(int start,
+                           int limit,
+                           const ledger::PublisherInfoFilter& filter);
+  void BindFilter(sql::Statement& statement,
+                  const ledger::PublisherInfoFilter& filter);
 
   sql::Database& GetDB();
   sql::MetaTable& GetMetaTable();


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/1191

This PR adds a Count method to PublisherInfoDatabase that given a PublisherInfoFilter, can return just the count of the dataset that meets the filter criteria.

There were some common operations between `Count` and `Find` so those were refactored in to separate methods `BuildClauses` and `BindFilter`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source