### PR TITLE
Use test-specific properties for BraveThemeServiceTest, and test private profile

### DIFF
--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/themes/brave_theme_service.h"
+#include "brave/browser/themes/theme_properties.h"
 #include "brave/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/browser/profiles/profile.h"
@@ -22,18 +23,35 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 
 IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, BraveThemeChangeTest) {
   Profile* profile = browser()->profile();
-  const SkColor light_frame_color = SkColorSetRGB(0xD8, 0xDE, 0xE1);
-  const SkColor dark_frame_color = SkColorSetRGB(0x22, 0x22, 0x22);
+  Profile* profile_private = profile->GetOffTheRecordProfile();
+
+  const ui::ThemeProvider& tp = ThemeService::GetThemeProviderForProfile(profile);
+  const ui::ThemeProvider& tp_private = ThemeService::GetThemeProviderForProfile(profile_private);
+
+  auto test_theme_property = BraveThemeProperties::COLOR_FOR_TEST;
 
   // Check default type is set initially.
   EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_DEFAULT, BTS::GetUserPreferredBraveThemeType(profile));
+  EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_DEFAULT, BTS::GetUserPreferredBraveThemeType(profile_private));
 
-  const ui::ThemeProvider& tp = ThemeService::GetThemeProviderForProfile(profile);
-  SetBraveThemeType(browser()->profile(), BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+  // Test light theme
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
   EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_LIGHT, BTS::GetUserPreferredBraveThemeType(profile));
-  EXPECT_EQ(light_frame_color, tp.GetColor(ThemeProperties::COLOR_FRAME));
+  EXPECT_EQ(BraveThemeProperties::kLightColorForTest, tp.GetColor(test_theme_property));
 
-  SetBraveThemeType(browser()->profile(), BraveThemeType::BRAVE_THEME_TYPE_DARK);
+  // Test light theme private
+  SetBraveThemeType(profile_private, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+  EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_LIGHT, BTS::GetUserPreferredBraveThemeType(profile_private));
+  EXPECT_EQ(BraveThemeProperties::kPrivateColorForTest, tp_private.GetColor(test_theme_property));
+
+
+  // Test dark theme
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
   EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_DARK, BTS::GetUserPreferredBraveThemeType(profile));
-  EXPECT_EQ(dark_frame_color, tp.GetColor(ThemeProperties::COLOR_FRAME));
+  EXPECT_EQ(BraveThemeProperties::kDarkColorForTest, tp.GetColor(test_theme_property));
+
+  // Test dark theme private
+  SetBraveThemeType(profile_private, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+  EXPECT_EQ(BraveThemeType::BRAVE_THEME_TYPE_DARK, BTS::GetUserPreferredBraveThemeType(profile_private));
+  EXPECT_EQ(BraveThemeProperties::kPrivateColorForTest, tp_private.GetColor(test_theme_property));
 }

--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -39,6 +39,8 @@ base::Optional<SkColor> MaybeGetDefaultColorForBraveLightUi(int id) {
       return kLightToolbarIcon;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:
       return color_utils::AlphaBlend(kLightToolbarIcon, kLightToolbar, 77);
+    case BraveThemeProperties::COLOR_FOR_TEST:
+      return BraveThemeProperties::kLightColorForTest;
     default:
       return base::nullopt;
   }
@@ -76,6 +78,8 @@ base::Optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id) {
       return kDarkToolbarIcon;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:
       return color_utils::AlphaBlend(kDarkToolbarIcon, kDarkToolbar, 0x4d);
+    case BraveThemeProperties::COLOR_FOR_TEST:
+      return BraveThemeProperties::kDarkColorForTest;
     default:
       return base::nullopt;
   }
@@ -113,6 +117,8 @@ base::Optional<SkColor> MaybeGetDefaultColorForPrivateUi(int id) {
       return kDarkToolbarIcon;
     case ThemeProperties::COLOR_TOOLBAR_BUTTON_ICON_INACTIVE:
       return color_utils::AlphaBlend(kDarkToolbarIcon, kPrivateToolbar, 0x4d);
+    case BraveThemeProperties::COLOR_FOR_TEST:
+      return BraveThemeProperties::kPrivateColorForTest;
     // The rest is covered by a dark-appropriate value
     default:
       return MaybeGetDefaultColorForBraveDarkUi(id);

--- a/browser/themes/theme_properties.h
+++ b/browser/themes/theme_properties.h
@@ -9,7 +9,17 @@
 #include "third_party/skia/include/core/SkColor.h"
 #include "brave/browser/themes/brave_theme_service.h"
 
-#define BRAVE_COLOR_FOR_TEST 0x7FFFFFFF
+namespace BraveThemeProperties {
+
+  const SkColor kPrivateColorForTest = SkColorSetRGB(0xFF, 0x00, 0x00);
+  const SkColor kLightColorForTest = SkColorSetRGB(0xFF, 0xFF, 0xFF);
+  const SkColor kDarkColorForTest = SkColorSetRGB(0x00, 0x00, 0x00);
+
+  enum TestProperty {
+    COLOR_FOR_TEST = 9000
+  };
+
+}
 
 base::Optional<SkColor> MaybeGetDefaultColorForBraveUi(int id, bool incognito, BraveThemeType theme);
 


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1211
Fix https://github.com/brave/brave-browser/issues/1212

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
`npm run test -- brave_browser_tests --filter="BraveThemeServiceTest.*"`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source