### PR TITLE
Web sites should now not be listed in auto-contribute if user has not opted in to Rewards

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@bba76f13c7ea4d295bd93e7cfa384801d25311b2",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@29e7547133a0cc5fad697316280bcf96f6d1f2bf",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@6f5817c5a4dcabb49e22b578ecae4993159e6481",

--- a/components/brave_rewards/ui/reducers/wallet_reducer.ts
+++ b/components/brave_rewards/ui/reducers/wallet_reducer.ts
@@ -16,6 +16,8 @@ const createWallet = (state: Rewards.State) => {
   state.createdTimestamp = new Date().getTime()
   chrome.send('getReconcileStamp', [])
   chrome.send('getAddresses', [])
+  chrome.send('saveSetting', ['enabledMain', 'true'])
+  chrome.send('saveSetting', ['enabledContribute', 'true'])
 
   return state
 }


### PR DESCRIPTION
Fixes brave/brave-browser#1236

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

1. Start Brave with clean profile
(Don't enable rewards yet)
2. Visit several websites for the minimum required needed to add to auto-contribute.
3. Opt-in to rewards
4. Visit another website for minimum required time.
5. View auto-contribute and ensure that only the site visited after opting in to Rewards is listed


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source