### PR TITLE
Rewards tests now use v2 endpoint for data

### DIFF
--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -65,7 +65,7 @@ void BraveURLFetcher::DetermineURLResponsePath(std::string url) {
     PREFIX_V2, braveledger_bat_helper::SERVER_TYPES::BALANCE)) == 0) {
     SetResponseString(brave_test_resp::wallet_);
   } else if (url.find(braveledger_bat_helper::buildURL(GET_SET_PROMOTION,
-    PREFIX_V1, braveledger_bat_helper::SERVER_TYPES::LEDGER)) == 0) {
+    PREFIX_V2, braveledger_bat_helper::SERVER_TYPES::LEDGER)) == 0) {
     SetResponseString(brave_test_resp::grant_);
   } else if (url.find(braveledger_bat_helper::buildURL(GET_PUBLISHERS_LIST_V1,
     "", braveledger_bat_helper::SERVER_TYPES::PUBLISHER)) == 0) {


### PR DESCRIPTION
Fixes brave/brave-browser#1246

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

Run `npm run test -- brave_browser_tests --filter=BraveRewardsBrowserTest.*` and ensure build is successful and tests pass


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source