### PR TITLE
Add hulu.com to the `IsWidevineInstallableURL` list 

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -129,7 +129,7 @@ bool IsWidevineInstallableURL(const GURL& url) {
     URLPattern(URLPattern::SCHEME_ALL, "https://www.primevideo.com/*"),
     URLPattern(URLPattern::SCHEME_ALL, "https://www.spotify.com/*"),
     URLPattern(URLPattern::SCHEME_ALL, "https://shaka-player-demo.appspot.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://hulu.com/*"),
+    URLPattern(URLPattern::SCHEME_ALL, "https://*.hulu.com/*"),
     // Used for tests
     URLPattern(URLPattern::SCHEME_ALL, "http://www.netflix.com:*/*")
   });

--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -129,6 +129,7 @@ bool IsWidevineInstallableURL(const GURL& url) {
     URLPattern(URLPattern::SCHEME_ALL, "https://www.primevideo.com/*"),
     URLPattern(URLPattern::SCHEME_ALL, "https://www.spotify.com/*"),
     URLPattern(URLPattern::SCHEME_ALL, "https://shaka-player-demo.appspot.com/*"),
+    URLPattern(URLPattern::SCHEME_ALL, "https://hulu.com/*"),
     // Used for tests
     URLPattern(URLPattern::SCHEME_ALL, "http://www.netflix.com:*/*")
   });

--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -23,7 +23,8 @@ TEST_F(BraveShieldsExceptionsTest, WidevineInstallableURL) {
     GURL("https://bitmovin.com/subdir"),
     GURL("https://www.primevideo.com/subdir"),
     GURL("https://www.spotify.com/subdir"),
-    GURL("https://shaka-player-demo.appspot.com/subdir")
+    GURL("https://shaka-player-demo.appspot.com/subdir"),
+    GURL("https://hulu.com/watch/bf77880c-2f2e-4e09-b26d-5c7cc1de47ce")
   });
   std::for_each(urls.begin(), urls.end(),
       [this](GURL url){


### PR DESCRIPTION
(so that it'll show the puzzle piece and prompt to install Widevine with our disclaimer)

Fixes https://github.com/brave/brave-browser/issues/1242

Auditors: @mkarolin

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Automated Test Plan:
`npm run test -- brave_unit_tests --filter=BraveShieldsExceptionsTest.*`

## Test Plan:
1. Ensure Widevine is NOT installed (check chrome://components; you should be able to rename/delete your profile folder to simulate having a clean profile)
2. Visit https://hulu.com and login
3. Try to view a show
4. You should get an error
5. In the omnibox, you should see the puzzle piece. When clicking, it should look similar to this:
![image](https://user-images.githubusercontent.com/4733304/46036212-d16f1180-c0b9-11e8-8ceb-1cc8c96835d9.png)
6. You can click `Install and run Widevine`
7. Hulu will still fail
8. Visit chrome://components and click the `Check for update` button next to `Widevine Content Decryption Module` (which should be version `0.0.0.0`)
9. A real version should be shown (ex: `4.10.1146.0`)
10. Try to view the show again from step 3. It should work 🎉 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source