### PR TITLE
Use base::FilePath::CharType to path related constants

### DIFF
--- a/common/tor/tor_test_constants.cc
+++ b/common/tor/tor_test_constants.cc
@@ -4,11 +4,13 @@
 
 #include "brave/common/tor/tor_test_constants.h"
 
+#define FPL FILE_PATH_LITERAL
+
 namespace tor {
 
 const char kTestTorProxy[] = "socks5://127.0.0.1:9999";
 const char kTestTorPacString[] = "SOCKS5 127.0.0.1:9999";
-const char kTestTorPath[] = ".";
+const base::FilePath::CharType kTestTorPath[] = FPL(".");
 
 
 }  // namespace tor

--- a/common/tor/tor_test_constants.h
+++ b/common/tor/tor_test_constants.h
@@ -5,12 +5,13 @@
 #ifndef BRAVE_COMMON_TOR_TOR_TEST_CONSTANTS_H_
 #define BRAVE_COMMON_TOR_TOR_TEST_CONSTANTS_H_
 
+#include "base/files/file_path.h"
 
 namespace tor {
 
 extern const char kTestTorProxy[];
 extern const char kTestTorPacString[];
-extern const char kTestTorPath[];
+extern const base::FilePath::CharType kTestTorPath[];
 
 }  // namespace tor
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1302

Auditor: @emerick

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source