### PR TITLE
Fix build error for referrer browser tests

### DIFF
--- a/renderer/brave_content_settings_observer_browsertest.cc
+++ b/renderer/brave_content_settings_observer_browsertest.cc
@@ -470,8 +470,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowFPGetImageD
   EXPECT_EQ(400, bufLen);
 }
 
-DISABLED_IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
-    BlockReferrerByDefault) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+    DISABLED_BlockReferrerByDefault) {
   ContentSettingsForOneType settings;
   content_settings()->GetSettingsForOneType(
       CONTENT_SETTINGS_TYPE_PLUGINS, brave_shields::kReferrers, &settings);
@@ -494,7 +494,7 @@ DISABLED_IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
       child_frame()).c_str(), iframe_url().GetOrigin().spec().c_str());
 }
 
-DISABLED_DISABLED_IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrer) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, DISABLED_BlockReferrer) {
   BlockReferrers();
   NavigateToPageWithIframe();
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript,
@@ -517,7 +517,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowReferrer) {
       url().spec().c_str());
 }
 
-DISABLED_IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrerShieldsDown) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, DISABLED_BlockReferrerShieldsDown) {
   BlockReferrers();
   ShieldsDown();
   NavigateToPageWithIframe();


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1303
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
`npm run test -- brave_browser_tests --filter=BraveContentSettingsObserverBrowserTest.*Referrer*`
No build error and it should run only AllowReferrer.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source