### PR TITLE
WIP: Update GN flags to properly do Widevine Host Verification / signing

### DIFF
--- a/chromium_src/chrome/common/media/cdm_host_file_path.cc
+++ b/chromium_src/chrome/common/media/cdm_host_file_path.cc
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GOOGLE_CHROME_BUILD
+#include "../../../../../chrome/common/media/cdm_host_file_path.cc"
+#undef GOOGLE_CHROME_BUILD

--- a/patches/chrome-installer-mini_installer-chrome.release.patch
+++ b/patches/chrome-installer-mini_installer-chrome.release.patch
@@ -1,17 +1,18 @@
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index 29da523563d3dbbe773f8843dc17db9310016311..5555da9c8d9e1f44257d815c94b7acd9db711b47 100644
+index 29da523563d3dbbe773f8843dc17db9310016311..1e982aaaed60f301810cad40ffb32110c34ffc7a 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
-@@ -6,7 +6,7 @@
+@@ -6,7 +6,8 @@
  #
  # Chrome Application dir entries, sorted alphabetically.
  #
 -chrome.exe: %(ChromeDir)s\
 +brave.exe: %(ChromeDir)s\
++brave.exe.sig: %(ChromeDir)s\
  #
  # Chrome version dir assembly manifest.
  # The name of this file must match the name of the version dir, so we cannot
-@@ -18,6 +18,8 @@ chrome.exe: %(ChromeDir)s\
+@@ -18,6 +19,8 @@ chrome.exe: %(ChromeDir)s\
  # Chrome version dir entries, sorted alphabetically.
  #
  chrome.dll: %(VersionDir)s\
@@ -20,7 +21,7 @@ index 29da523563d3dbbe773f8843dc17db9310016311..5555da9c8d9e1f44257d815c94b7acd9
  chrome_100_percent.pak: %(VersionDir)s\
  chrome_child.dll: %(VersionDir)s\
  chrome_elf.dll: %(VersionDir)s\
-@@ -68,6 +70,7 @@ swiftshader\libGLESv2.dll: %(VersionDir)s\swiftshader\
+@@ -68,6 +71,7 @@ swiftshader\libGLESv2.dll: %(VersionDir)s\swiftshader\
  
  [HIDPI]
  chrome_200_percent.pak: %(VersionDir)s\


### PR DESCRIPTION
## Current Status
This PR (as-is) works great on macOS (including the generation of the `.sig` file). Of course, you need to use https://github.com/brave/brave-browser/pull/1320 from `brave-browser` when testing this PR

### Windows Status
Windows is not working and I have discovered why (but I am not sure how to fix)

#### non-Windows builds register the UtilityServiceFactory
On macOS (and Linux), this code fires:
https://cs.chromium.org/chromium/src/content/app/content_main_runner_impl.cc?l=508-509&rcl=874d2e3f4036268425593cea23a0ae9b1b00e07f
```cpp
 UtilityProcessHost::RegisterUtilityMainThreadFactory(
      CreateInProcessUtilityThread);
```

#### UtilityServiceFactory registers implementation for CdmService
This (through a few steps) launches the utility process, which creates an instance of UtilityServiceFactory. This will then register the CdmService interface:
https://cs.chromium.org/chromium/src/content/utility/utility_service_factory.cc?l=154-156&rcl=5f75c871d1ec0f3ff08650dcb87e361daf431705
```cpp
  service_manager::EmbeddedServiceInfo info;
  info.factory = base::Bind(&CreateCdmService);
  services->emplace(media::mojom::kCdmServiceName, info);
```

#### The implementation for CdmService provides the host verification
The important part (ex: host verification) happens when this CdmService is implemented, it'll provide a method to check the `.sig` files. You can view that here:
https://cs.chromium.org/chromium/src/content/utility/utility_service_factory.cc?l=96-99&rcl=741e7070889303f4cf376dad52ae67aec69889fe
```cpp
void AddCdmHostFilePaths(
      std::vector<media::CdmHostFilePath>* cdm_host_file_paths) override {
    GetContentClient()->AddContentDecryptionModules(nullptr,
                                                    cdm_host_file_paths);
}
```

#### What exactly is broken on Windows?
Going back to the part that fails on Windows. When a page loads that uses Widevine, it creates a media player and then tries (but is unable) to find an instance of the CdmService:
https://cs.chromium.org/chromium/src/content/browser/media/media_interface_proxy.cc?l=342-346&rcl=aa20726d6256b54ba793eb290545339f49b05113
```cpp
service_manager::Connector* connector =
    ServiceManagerConnection::GetForProcess()->GetConnector();

media::mojom::CdmServicePtr cdm_service;
connector->BindInterface(identity, &cdm_service);
```

This means subsequent calls to `cdm_service` are no-ops:
https://cs.chromium.org/chromium/src/content/browser/media/media_interface_proxy.cc?rcl=aa20726d6256b54ba793eb290545339f49b05113&l=357
```cpp
cdm_service->LoadCdm(cdm_path);
```

### What is left? Where is help needed?
We need to register the CdmService on Windows (other platforms are OK because they launch the utility process).  I've tried a few ways to patch this, but haven't had any success.

**_One thing worth noting:_**
AFTER the page is finished loading, if I wait long enough... I eventually DO see a Utility process launch. A new process is launched with `utility` as an argument which gets picked up here:
https://cs.chromium.org/chromium/src/content/app/content_main_runner_impl.cc?rcl=874d2e3f4036268425593cea23a0ae9b1b00e07f&l=431-433
```cpp
if (process_type == switches::kUtilityProcess ||
        cmd->HasSwitch(switches::kSingleProcess))
      content_client->utility_ = delegate->CreateContentUtilityClient();
```

This is created via `UtilityProcessHost`. I was unable to find where Windows is creating this. The fix might be "as easy" as creating an instance of this on browser-launch (on Windows)
https://cs.chromium.org/chromium/src/content/browser/utility_process_host.cc?l=273&rcl=53453fb02b81803f64293e3002c6765286a429dd
```cpp
bool UtilityProcessHost::StartProcess() {
```

### Why does Chrome work?
I haven't done enough debugging to provide a solid answer on this... However, my best guess is that this works because some additional flags are enabled for Chrome (set to `true`):
- `enable_rlz`
- `should_bundle_widevine_cdm`
- `enable_cdm_storage_id`

One potential solution would be to enable each of those and then stub out the RLZ implementation

## Description
Fixes https://github.com/brave/brave-browser/issues/944
Fixes https://github.com/brave/brave-browser/issues/1310

Requires https://github.com/brave/brave-browser/pull/1320

**NOTE**: After this is approved / merged, we'll need to open an issue in the devops repo to track adding the new `brave_enable_cdm_host_verification` param to the `.npmrc` on the CI servers

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source