### PR TITLE
Do not request permission when autoplay is allowed for the page

### DIFF
--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -200,12 +200,18 @@ bool BraveContentSettingsObserver::AllowFingerprinting(
 
   return allow;
 }
+
 bool BraveContentSettingsObserver::AllowAutoplay(bool default_value) {
   blink::WebLocalFrame* frame = render_frame()->GetWebFrame();
   auto origin = frame->GetDocument().GetSecurityOrigin();
   // default allow local files
   if (origin.IsNull() || origin.Protocol().Ascii() == url::kFileScheme)
     return true;
+
+  bool allow = ContentSettingsObserver::AllowAutoplay(default_value);
+  if (allow) {
+    return true;
+  }
 
   blink::mojom::blink::PermissionServicePtr permission_service;
 
@@ -219,5 +225,5 @@ bool BraveContentSettingsObserver::AllowAutoplay(bool default_value) {
                                           base::DoNothing());
   }
 
-  return ContentSettingsObserver::AllowAutoplay(default_value);
+  return allow;
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1120

When we allow autoplay for a page and reload it, if there are frames from different origins in this page need the autoplay permission, it will prompt the "autoplay is blocked" message in the URL bar.
The URL being shown in that bubble will always be this page's origin per https://github.com/brave/brave-core/blob/master/browser/ui/content_settings/brave_autoplay_content_setting_bubble_model.cc#L58.
The expected behavior here should be that we only need to allow for the entire page.

To fix this, this PR revise the logic in AllowAutoplay so we won't request permission when autoplay is already allowed per content setting, so those confusing prompt for subframes in different origin won't be there after the page's origin (primary_url) is allowed.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:
Reddit
1. Navigate to reddit.com/r/gifs
2. Get a autoplay block prompt and choose to allow autoplay for this domain
3. Refresh the page
4. Check that there is no autoplay block prompt and videos in the page are playing

Google Drive
1. Login to Google Drive
2. Attempt to play an .mp4 file --> see notification in URL bar about autoplay being blocked.
3. Choose to allow https://drive.google.com and refresh the page
5. Check that there is no autoplay block prompt
(Please note that we still cannot play mp4 files from google drive, there seems to be a separate issue causing that, which won't be fixed by this PR)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source