### PR TITLE
Hide 'Missing API keys' message bar

### DIFF
--- a/chromium_src/google_apis/google_api_keys.cc
+++ b/chromium_src/google_apis/google_api_keys.cc
@@ -1,0 +1,13 @@
+#define HasOAuthClientConfigured HasOAuthClientConfigured_ChromiumImpl
+#include "../../../../google_apis/google_api_keys.cc"
+#undef HasOAuthClientConfigured
+
+namespace google_apis {
+
+bool HasOAuthClientConfigured() {
+  // While safe browsing & geo location are working correctly, skip checking
+  // if OAuthClient is configured to avoid 'Missing API Keys' message bar.
+  return true;
+}
+
+}  // namespace google_apis


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1152

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

Launch brave with a clean profile, and no "API Keys are missing. Some functionality will be disabled" will be shown.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source