### PR TITLE
Youtube and Twitch videos now provide more accurate times than before

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@695193e9de23bb8e275e5bed62882674768211f5",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@283fed2eeea6b633ddb8e162dff9194ba415fafa",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@0559543f458a949b83b58035273ef7f8f1a1b111",


### PR DESCRIPTION
Fixes brave/brave-browser#971
Fixes brave/brave-browser#1277

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Needed or QA/No-QA-Needed) to include the closed issue in milestone 

## Test Plan:

* See Additional Information for testing caveats

1. Start Brave with clean profile and enable Rewards
2. View a youtube video and ensure time is reflected properly in `publisher_info_db` with actual viewing time.

#

1. Start Brave with clean profile and enable Rewards
2. View a youtube video using a combination of pause and seek and ensure time is reflected properly with actual viewing time.

#

1. Start Brave with clean profile and enable Rewards
2. View four youtube videos and play all at once and ensure time is reflected properly with actual viewing time of each video.

#

1. Start Brave with clean profile and enable Rewards
2. View four youtube videos and play all at once using a combination of pause and seek and ensure time is reflected properly with actual viewing time of each video.

#

Repeat Previous tests using Youtube live streams

#

1. Start Brave with clean profile and enable Rewards
2. View a Twitch live stream and ensure time is reflected properly in `publisher_info_db` with actual viewing time.

#

1. Start Brave with clean profile and enable Rewards
2. View a Twitch VOD and ensure time is reflected properly in `publisher_info_db` with actual viewing time.



## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## Additional Information
* Entries in `publisher_info.db` are updated at 10 seconds and then once every ~40 seconds after
* Tabbing off of a video or closing a video tab will discard the current interval if it hasn't been polled yet. Example: If you watch 2 minutes of a video and have 120 logged, closing at 2:10 before the time interval has been polled will discard the last 10 seconds