### PR TITLE
windows appears to sometimes move the unique_ptr and send an empty Pu…

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -575,9 +575,10 @@ void RewardsServiceImpl::OnPublisherStateSaved(
 void RewardsServiceImpl::SavePublisherInfo(
     std::unique_ptr<ledger::PublisherInfo> publisher_info,
     ledger::PublisherInfoCallback callback) {
+  ledger::PublisherInfo info_copy = *publisher_info;
   base::PostTaskAndReplyWithResult(file_task_runner_.get(), FROM_HERE,
       base::Bind(&SavePublisherInfoOnFileTaskRunner,
-                    *publisher_info,
+                    info_copy,
                     publisher_info_backend_.get()),
       base::Bind(&RewardsServiceImpl::OnPublisherInfoSaved,
                      AsWeakPtr(),


### PR DESCRIPTION
…blisherInfo to SavePublisherInfoOnFileTaskRunner. Explicitly make a copy before binding the callback

fix https://github.com/brave/brave-browser/issues/1326

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source