### PR TITLE
Fix brave/extensions/renderer build error

### DIFF
--- a/extensions/renderer/BUILD.gn
+++ b/extensions/renderer/BUILD.gn
@@ -8,7 +8,10 @@ source_set("renderer") {
     "brave_shields_content_setting.h",
   ]
 
-  # Didn't add any dependencies because sources of this target
-  # will compiled together with //extensions/renderer target and these files
-  # doesn't add additional dependencies.
+  deps = [
+    "//base",
+    "//extensions/common",
+    "//extensions/common/api",
+    "//gin",
+  ]
 }


### PR DESCRIPTION
Add proper dependency list.

Close https://github.com/brave/brave-browser/issues/1352

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Check `gn path out/Debug //brave/extensions/renderer //extensions/buildflags`
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source