### PR TITLE
Legacy Niceware based passphrases can now be used to restore wallets

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@ca5d4b6d1a39c7e8e2fb149bbd62f9e71631eba6",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@fa06a4b1153b5a1a87f1af8becfa0803e82bc6f3",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@0559543f458a949b83b58035273ef7f8f1a1b111",

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -37,6 +37,9 @@
 #include "extensions/browser/event_router.h"
 #include "extensions/browser/extension_api_frame_id_map.h"
 #include "brave/common/extensions/api/brave_rewards.h"
+#include "components/grit/brave_components_resources.h"
+#include "ui/base/resource/resource_bundle.h"
+
 using extensions::Event;
 using extensions::EventRouter;
 
@@ -576,6 +579,19 @@ void RewardsServiceImpl::OnPublisherStateSaved(
     bool success) {
   handler->OnPublisherStateSaved(success ? ledger::Result::LEDGER_OK
                                          : ledger::Result::LEDGER_ERROR);
+}
+
+void RewardsServiceImpl::LoadNicewareList(
+  ledger::GetNicewareListCallback callback) {
+  std::string data = ui::ResourceBundle::GetSharedInstance().GetRawDataResource(
+  IDR_BRAVE_REWARDS_NICEWARE_LIST).as_string();
+
+  if (data.empty()) {
+    LOG(ERROR) << "Failed to read in niceware list";
+  }
+  callback(data.empty() ? ledger::Result::LEDGER_ERROR
+                                             : ledger::Result::LEDGER_OK,
+                                data);
 }
 
 void RewardsServiceImpl::SavePublisherInfo(

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -108,6 +108,7 @@ class RewardsServiceImpl : public RewardsService,
                           bool success);
   void OnLedgerStateLoaded(ledger::LedgerCallbackHandler* handler,
                               const std::string& data);
+  void LoadNicewareList(ledger::GetNicewareListCallback callback) override;
   void OnPublisherStateSaved(ledger::LedgerCallbackHandler* handler,
                              bool success);
   void OnPublisherStateLoaded(ledger::LedgerCallbackHandler* handler,

--- a/components/resources/brave_components_resources.grd
+++ b/components/resources/brave_components_resources.grd
@@ -135,7 +135,7 @@
       <include name="IDR_BRAVE_REWARDS_IMG_BTC" file="../img/rewards/BTC.svg" type="BINDATA" />
       <include name="IDR_BRAVE_REWARDS_IMG_ETH" file="../img/rewards/ETH.svg" type="BINDATA" />
       <include name="IDR_BRAVE_REWARDS_IMG_LTC" file="../img/rewards/LTC.svg" type="BINDATA" />
-
+      <include name="IDR_BRAVE_REWARDS_NICEWARE_LIST" file="../../vendor/bat-native-ledger/niceware/wordlist" type="BINDATA" />
     </includes>
     <messages fallback_to_english="true">
       <!-- WebUI newtab resources -->

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -63,6 +63,12 @@ test("brave_unit_tests") {
     "../utility/importer/firefox_importer_unittest.cc",
   ]
 
+  if (brave_rewards_enabled) {
+    sources += [
+      "//brave/vendor/bat-native-ledger/src/test/niceware_partial_unittest.cc",
+    ]
+  }
+
   # On Windows, brave_install_static_unittests covers channel test.
   if (is_mac || is_linux) {
     sources += [


### PR DESCRIPTION
Fixes brave/brave-browser#1193

Requires https://github.com/brave-intl/bat-native-ledger/pull/121

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave with clean profile and enable rewards.
2. Restore a legacy 16 word key wallet.
3. Ensure the wallet is restored successfully.

-

1. Start Brave with clean profile and enable rewards.
2. Restore a 24 word key wallet.
3. Ensure the wallet is restored successfully.

-

1. Start Brave with clean profile and enable rewards.
2. Try to restore a wallet using an invalid word key
3. Ensure the appropriate error is displayed


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source