### PR TITLE
Update `brave-extension` with hash for extension which sets scope on …

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@bb6013ff4d0a0191ba93158f2f3b30e7fb18c5f6",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@f86b0a5752545274e32c0dbb654c3592cc131c8a",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@635780bbedff137a6a83ec23871944e22069de5b",
-  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@c654fdc8b01fa8af20717d8961879657e8049121",
+  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@0a628254dd6f7d5990ddf145626587c083c82fc0",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",


### PR DESCRIPTION
…content settings calls

Contingent on https://github.com/brave/brave-extension/pull/68 being reviewed/accepted/merged

If https://github.com/brave/brave-extension/pull/68 is merged, this PR needs to have the `vendor/brave-extension` hash updated

This will fix https://github.com/brave/brave-browser/issues/1198