### PR TITLE
Publisher list now fetches at expected interval

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@a37a77fc2febe8477573d64cd245a54f4a32e67b",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@695193e9de23bb8e275e5bed62882674768211f5",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@0559543f458a949b83b58035273ef7f8f1a1b111",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/972

A description of the issue at the native-ledger level can be found here:
https://github.com/brave-intl/bat-native-ledger/pull/123#issue-219269328

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Build Brave fresh from this branch.
2. Enable rewards
3. After a few seconds, confirm via HTTP debug messages in console that publisher list was fetched.
4. Restart browser
5. Confirm that publishers list was not fetched.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source