### PR TITLE
re-allow sites to be bookmarked from new tab top sites

### DIFF
--- a/components/brave_new_tab_ui/components/app.tsx
+++ b/components/brave_new_tab_ui/components/app.tsx
@@ -58,7 +58,7 @@ class NewTabPage extends React.Component<Props, {}> {
   }
 
   onToggleBookmark (site: NewTab.Site) {
-    if (site.bookmarked) {
+    if (site.bookmarked === undefined) {
       this.actions.bookmarkAdded(site.url)
     } else {
       this.actions.bookmarkRemoved(site.url)

--- a/components/brave_new_tab_ui/reducers/new_tab_reducer.tsx
+++ b/components/brave_new_tab_ui/reducers/new_tab_reducer.tsx
@@ -26,6 +26,7 @@ const updateBookmarkInfo = (state: NewTab.State, url: string, bookmarkTreeNode?:
     gridSite.bookmarked = topSite.bookmarked = pinnedTopSite.bookmarked = bookmarkTreeNode
   } else {
     delete bookmarks[url]
+    gridSite.bookmarked = topSite.bookmarked = pinnedTopSite.bookmarked = undefined
   }
   state = { ...state, bookmarks, gridSites }
 
@@ -82,7 +83,7 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
   const payload = action.payload
   switch (action.type) {
     case types.BOOKMARK_ADDED:
-      const topSite: NewTab.Site | undefined = state.topSites.find((site) => site.url === action.url)
+      const topSite: NewTab.Site | undefined = state.topSites.find((site) => site.url === payload.url)
       if (topSite) {
         chrome.bookmarks.create({
           title: topSite.title,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/558

## Test Plan
Toggle bookmark star in topsite's tile and ensure it adds/removes and that the star state changes between on/off