### PR TITLE
add proper spacing to webtorrent action buttons

### DIFF
--- a/components/brave_webtorrent/extension/components/torrentViewerHeader.tsx
+++ b/components/brave_webtorrent/extension/components/torrentViewerHeader.tsx
@@ -64,17 +64,19 @@ export default class TorrentViewerHeader extends React.PureComponent<Props, {}> 
           />
         </Column>
         <Column size={3} customStyle={theme.headerColumnRight}>
-          <Button
-            type='accent'
-            text={mainButtonText}
-            onClick={this.onClick}
-          />
-          <Button
-            type='accent'
-            level='secondary'
-            text={copyButtonText}
-            onClick={this.onCopyClick}
-          />
+          <div style={theme.buttonContainer}>
+            <Button
+              type='accent'
+              text={mainButtonText}
+              onClick={this.onClick}
+            />
+            <Button
+              type='accent'
+              level='secondary'
+              text={copyButtonText}
+              onClick={this.onCopyClick}
+            />
+          </div>
         </Column>
       </Grid>
     )

--- a/components/brave_webtorrent/extension/constants/theme.ts
+++ b/components/brave_webtorrent/extension/constants/theme.ts
@@ -13,5 +13,12 @@ export const theme = {
   },
   privacyNoticeBody: {
     fontSize: '12px'
+  },
+  buttonContainer: {
+    display: 'grid',
+    height: '100%',
+    gridTemplateColumns: '1fr 1fr',
+    gridTemplateRows: '1fr',
+    gridGap: '15px'
   }
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1045

Test Plan: open a magnet link. Check on top-right screen that buttons now have padding between them