### PR TITLE
Fix WebRTC IP leak in Tor profile

### DIFF
--- a/browser/profiles/BUILD.gn
+++ b/browser/profiles/BUILD.gn
@@ -7,6 +7,7 @@ source_set("profiles") {
     "//base",
     "//chrome/browser",
     "//chrome/common",
+    "//content/public/common",
     "//brave/browser/extensions",
     "//brave/browser/tor",
     "//brave/common/tor",

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -17,6 +17,7 @@
 #include "chrome/grit/generated_resources.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/common/webrtc_ip_handling_policy.h"
 #include "ui/base/l10n/l10n_util.h"
 
 using content::BrowserThread;
@@ -43,6 +44,8 @@ void BraveProfileManager::InitTorProfileUserPrefs(Profile* profile) {
     ->SetString(prefs::kProfileName,
                 l10n_util::GetStringUTF8(IDS_PROFILES_TOR_PROFILE_NAME));
   pref_service->SetBoolean(tor::prefs::kProfileUsingTor, true);
+  pref_service->SetString(prefs::kWebRTCIPHandlingPolicy,
+                          content::kWebRTCIPHandlingDisableNonProxiedUdp);
 }
 
 void BraveProfileManager::InitProfileUserPrefs(Profile* profile) {

--- a/browser/profiles/brave_profile_manager_unittest.cc
+++ b/browser/profiles/brave_profile_manager_unittest.cc
@@ -23,6 +23,7 @@
 #include "chrome/test/base/test_browser_window.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
+#include "content/public/common/webrtc_ip_handling_policy.h"
 #include "content/public/test/test_browser_thread_bundle.h"
 #include "content/public/test/test_utils.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -134,6 +135,11 @@ TEST_F(BraveProfileManagerTest, InitProfileUserPrefs) {
   EXPECT_FALSE(
     profile->GetPrefs()->GetBoolean(prefs::kProfileUsingDefaultName));
   EXPECT_TRUE(profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
+
+  // Check WebRTC IP handling policy.
+  EXPECT_EQ(
+    profile->GetPrefs()->GetString(prefs::kWebRTCIPHandlingPolicy),
+    content::kWebRTCIPHandlingDisableNonProxiedUdp);
 }
 
 // This is for tor guest window, remove it when we have persistent tor profiles


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1254
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`npm run test -- brave_unit_tests --filter=BraveProfileManagerTest.*`
Open https://browserleaks.com/webrtc in Tor window, no IP addresses should be shown.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source