### PR TITLE
Use incognito theme for Tor profile windows

### DIFF
--- a/browser/themes/brave_theme_service.cc
+++ b/browser/themes/brave_theme_service.cc
@@ -84,6 +84,9 @@ void BraveThemeService::Init(Profile* profile) {
 
 
 SkColor BraveThemeService::GetDefaultColor(int id, bool incognito) const {
+  // Brave Tor profiles are always 'incognito' (for now)
+  if (!incognito && profile()->IsTorProfile())
+    incognito = true;
   const BraveThemeType theme = GetActiveBraveThemeType(profile());
   const base::Optional<SkColor> braveColor = MaybeGetDefaultColorForBraveUi(id, incognito, theme);
   if (braveColor)

--- a/browser/ui/views/brave_browser_main_extra_parts_views_linux.cc
+++ b/browser/ui/views/brave_browser_main_extra_parts_views_linux.cc
@@ -33,7 +33,8 @@ ui::NativeTheme* GetNativeThemeForWindow(aura::Window* window) {
                             BraveThemeService::GetActiveBraveThemeType(profile);
   const bool dark_mode = (
       active_builtin_theme == BraveThemeType::BRAVE_THEME_TYPE_DARK ||
-      profile->GetProfileType() == Profile::INCOGNITO_PROFILE);
+      profile->GetProfileType() == Profile::INCOGNITO_PROFILE ||
+      profile->IsTorProfile());
   if (dark_mode &&
       BrowserView::GetBrowserViewForNativeWindow(window)) {
     return ui::NativeThemeDarkAura::instance();

--- a/browser/ui/views/frame/brave_browser_frame.cc
+++ b/browser/ui/views/frame/brave_browser_frame.cc
@@ -28,7 +28,8 @@ const ui::NativeTheme* BraveBrowserFrame::GetNativeTheme() const {
                               browser_view_->browser()->profile());
   if (active_builtin_theme == BraveThemeType::BRAVE_THEME_TYPE_DARK ||
       browser_view_->browser()->profile()->GetProfileType() ==
-          Profile::INCOGNITO_PROFILE) {
+          Profile::INCOGNITO_PROFILE ||
+      browser_view_->browser()->profile()->IsTorProfile()) {
     return ui::NativeThemeDarkAura::instance();
   }
 #endif

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -73,7 +73,8 @@ OmniboxTint BraveLocationBarView::GetTint() {
   // Match the user-selectable brave theme, even if there is a theme extension
   // installed, allowing non-extension-themeable elements to fit in better with
   // a theme extension.
-  if (profile()->GetProfileType() == Profile::INCOGNITO_PROFILE) {
+  if (profile()->GetProfileType() == Profile::INCOGNITO_PROFILE ||
+      profile()->IsTorProfile()) {
     return OmniboxTint::PRIVATE; // special extra enum value
   }
   // TODO: BraveThemeService can have a simpler get dark / light function


### PR DESCRIPTION
Forces tor profiles to be recognized as 'incognito' for theme.
Also ensures that complementing omnibox theme is used.
Also ensures that complementing dark 'native' theme is used.
Fix https://github.com/brave/brave-browser/issues/1383

![image](https://user-images.githubusercontent.com/741836/46330267-e0c4f200-c5c6-11e8-87c3-a88928fb0fa8.png)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- Open Tor Window
- Toolbar should be purple
- Omnibox should be purple
- Visit chrome://about
- Security chip text should be white 
![image](https://user-images.githubusercontent.com/741836/46330284-04883800-c5c7-11e8-9476-e6d55811e088.png)


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source