### PR TITLE
Completely remove sign in messages from chrome://devices

### DIFF
--- a/patches/chrome-browser-resources-local_discovery-local_discovery.html.patch
+++ b/patches/chrome-browser-resources-local_discovery-local_discovery.html.patch
@@ -1,40 +1,66 @@
 diff --git a/chrome/browser/resources/local_discovery/local_discovery.html b/chrome/browser/resources/local_discovery/local_discovery.html
-index 6a699bafec2866046a71e7b203321c7b38c088f8..3dba711a3e62e938fcb0a2df51f86ab174b67051 100644
+index 6a699bafec2866046a71e7b203321c7b38c088f8..a501ffb1b28f4914700918d5a33e11f0e346fe47 100644
 --- a/chrome/browser/resources/local_discovery/local_discovery.html
 +++ b/chrome/browser/resources/local_discovery/local_discovery.html
-@@ -34,9 +34,11 @@
-                    class="inline-login-promo"
-                    hidden>
-                 <span>$i18n{registerNeedLogin}</span>
+@@ -29,6 +29,7 @@
+               $i18nRaw{registerPrinterInformationMessage}
+             </div>
+ 
 +<if expr="_google_chrome">
-                 <a is="action-link" id="register-overlay-login-button">
-                   $i18n{cloudDevicesLogin}
-                 </a>
-+</if>
-               </div>
+             <div class="button-list">
+               <div id="register-overlay-login-promo"
+                    class="inline-login-promo"
+@@ -41,6 +42,7 @@
                <button class="register-cancel">$i18n{cancel}</button>
                <button id="register-continue">$i18n{confirm}</button>
-@@ -112,9 +114,11 @@
+             </div>
++</if>
+           </div>
+         </div>
+ 
+@@ -109,6 +111,7 @@
+     <div class="controls" id="printers">
+       <h2>$i18n{availableDevicesTitle}</h2>
+ 
++<if expr="_google_chrome">
        <div id="register-login-promo" class="login-promo cloud-print-message"
             hidden>
          <span>$i18n{registerNeedLogin}</span>
-+<if expr="_google_chrome">
-         <a is="action-link" id="register-login-link">
+@@ -116,12 +119,14 @@
            $i18n{cloudDevicesLogin}
          </a>
-+</if>
        </div>
++</if>
        <div id="no-printers-message" class="cloud-print-message">
          $i18n{noPrintersOnNetworkExplanation}
-@@ -144,9 +148,11 @@
+       </div>
+ 
+       <div class="devices" id="register-device-list"></div>
+ 
++<if expr="_google_chrome">
+       <if expr="not chromeos">
+         <section id="cloud-print-connector-section">
+           <h2>$i18n{titleConnector}</h2>
+@@ -135,12 +140,14 @@
+         </section>
+       </if>
+     </div>
++</if>
+ 
+     <div id="my-devices-container">
+     <h2>$i18n{myDevicesTitle}</h2>
+     <div id="cloud-devices-loading" class="cloud-print-message" hidden>
+       <div class="inline-spinner"> </div> <span>$i18n{loading}</span>
+     </div>
++<if expr="_google_chrome">
      <div id="cloud-devices-login-promo" class="login-promo cloud-print-message"
           hidden>
        <span>$i18n{cloudDevicesNeedLogin}</span>
-+<if expr="_google_chrome">
-       <a is="action-link" id="cloud-devices-login-link">
+@@ -148,6 +155,7 @@
          $i18n{cloudDevicesLogin}
        </a>
-+</if>
      </div>
++</if>
      <div id="cloud-devices-unavailable"
           class="cloud-print-message" hidden>
+       <span>$i18n{cloudDevicesUnavailable}</span>


### PR DESCRIPTION
This is a follow up patch to
https://github.com/brave/brave-core/commit/a0609ecc79288559ae4fbe16dee592f403b88458
in order to remove the remaining Google sign in messages and the whole
"Classic printers" div. Fixes
https://github.com/brave/brave-browser/issues/1279.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source