### PR TITLE
Fix crash in BraveStatsUpdater when computer wakes from suspend

### DIFF
--- a/browser/brave_stats_updater.h
+++ b/browser/brave_stats_updater.h
@@ -13,6 +13,10 @@
 class PrefRegistrySimple;
 class PrefService;
 
+namespace net {
+class HttpResponseHeaders;
+}
+
 namespace network {
 class SimpleURLLoader;
 }
@@ -33,7 +37,7 @@ class BraveStatsUpdater {
   // Invoked from SimpleURLLoader after download is complete.
   void OnSimpleLoaderComplete(
       std::unique_ptr<brave::BraveStatsUpdaterParams> stats_updater_params,
-      std::unique_ptr<std::string> response_body);
+      scoped_refptr<net::HttpResponseHeaders> headers);
 
   // Invoked from RepeatingTimer when server ping timer fires.
   void OnServerPingTimerFired();


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1116

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source