### PR TITLE
Disable WebTorrent in Tor profile

### DIFF
--- a/components/brave_webtorrent/browser/content_browser_client_helper.h
+++ b/components/brave_webtorrent/browser/content_browser_client_helper.h
@@ -67,11 +67,13 @@ static bool HandleTorrentURLRewrite(GURL* url,
   return false;
 }
 
-static bool IsWebtorrentInstalled(content::BrowserContext* browser_context) {
+static bool IsWebtorrentEnabled(content::BrowserContext* browser_context) {
+  bool isTorProfile =
+    Profile::FromBrowserContext(browser_context)->IsTorProfile();
   extensions::ExtensionRegistry* registry =
     extensions::ExtensionRegistry::Get(browser_context);
-  return registry->enabled_extensions().Contains(
-      brave_webtorrent_extension_id);
+  return !isTorProfile &&
+    registry->enabled_extensions().Contains(brave_webtorrent_extension_id);
 }
 
 static void LoadOrLaunchMagnetURL(
@@ -83,7 +85,7 @@ static void LoadOrLaunchMagnetURL(
   if (!web_contents)
     return;
 
-  if (IsWebtorrentInstalled(web_contents->GetBrowserContext())) {
+  if (IsWebtorrentEnabled(web_contents->GetBrowserContext())) {
     web_contents->GetController().LoadURL(url, content::Referrer(),
         page_transition, std::string());
   } else {
@@ -96,7 +98,7 @@ static void LoadOrLaunchMagnetURL(
 
 static bool HandleMagnetURLRewrite(GURL* url,
     content::BrowserContext* browser_context) {
-  if (IsWebtorrentInstalled(browser_context) && url->SchemeIs(kMagnetScheme)) {
+  if (IsWebtorrentEnabled(browser_context) && url->SchemeIs(kMagnetScheme)) {
     *url = TranslateMagnetURL(*url);
     return true;
   }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1134
Don't redirect magnet and .torrent URLs to webtorrent component extension in Tor profile so they won't use WebTorrent.
Only added tests in brave_torrent_redirect_network_delegate_helper for .torrent case but didn't add tests for IsWebtorrentEnabled change because it's quite trivial.

## Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
manual test:
1. Click "Open Tor Window" under user's profile image and visit https://webtorrent.io/free-torrents in the tor window
2. Click a torrent file link will prompt to download the torrent file
3. Click a magnet link will prompt to ask if user wants to open his/her default external application for magnet links like below.
<img width="449" alt="screen shot 2018-10-02 at 4 48 38 pm" src="https://user-images.githubusercontent.com/4730197/46383076-5a122280-c663-11e8-8a80-bede3bb667c0.png">
4. Right click a magnet link to open it in a new tab will shows the same prompt as 3 in the new tab.

unit test:
`npm run test -- brave_unit_tests --filter=BraveTorrentRedirectNetworkDelegateHelperTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source