### PR TITLE
Fixes unit test build failure in brave_template_url_prepopulate_data_unittest.cc

### DIFF
--- a/components/search_engines/brave_prepopulated_engines.h
+++ b/components/search_engines/brave_prepopulated_engines.h
@@ -7,9 +7,7 @@
 
 #include <cstddef>
 
-#include "components/search_engines/search_engine_type.h"
-
-struct PrepopulatedEngine;
+#include "components/search_engines/prepopulated_engines.h"
 
 namespace TemplateURLPrepopulateData {
 


### PR DESCRIPTION
Fixes brave/brave-browser#1416

Adds include with the defenition of PrepopulatedEngine to, and removes
incorrectly scoped forward declaration from, brave_prepopulated_engines.h

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Run:
npm run test -- brave_unit_tests Debug --filter=BraveTemplateURLPrepopulateDataTest.*

and verify that it builds with no errors.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source