### PR TITLE
Implement `BraveLocationBarView::ChildVisibilityChanged()`

### DIFF
--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -58,6 +58,16 @@ void BraveLocationBarView::OnChanged() {
   LocationBarView::OnChanged();
 }
 
+void BraveLocationBarView::ChildVisibilityChanged(views::View* child) {
+  // We should trigger Layout() when visibility of |brave_actions_| is changed.
+  // When BraveActionsContainer::Update() is called by
+  // BraveLocationBarView::Update(), the location bar's Layout() is triggered.
+  // However, when BraveActionsContainer::Update() is called by others, the
+  // location bar isn't re-layouted.
+  if (child == brave_actions_)
+    Layout();
+}
+
 gfx::Size BraveLocationBarView::CalculatePreferredSize() const {
   gfx::Size min_size = LocationBarView::CalculatePreferredSize();
   if (brave_actions_ && brave_actions_->visible()){

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -59,6 +59,7 @@ void BraveLocationBarView::OnChanged() {
 }
 
 void BraveLocationBarView::ChildVisibilityChanged(views::View* child) {
+  LocationBarView::ChildVisibilityChanged(child);
   // We should trigger Layout() when visibility of |brave_actions_| is changed.
   // When BraveActionsContainer::Update() is called by
   // BraveLocationBarView::Update(), the location bar's Layout() is triggered.

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -25,6 +25,8 @@ class BraveLocationBarView : public LocationBarView {
   private:
     void UpdateBookmarkStarVisibility() override;
     OmniboxTint GetTint() override;
+    void ChildVisibilityChanged(views::View* child) override;
+
     BraveActionsContainer* brave_actions_ = nullptr;
 
     DISALLOW_COPY_AND_ASSIGN(BraveLocationBarView);


### PR DESCRIPTION
The `BraveActionsContainer` was not being shown when tearing off a tab
into a new window. This was due to `BraveActionsContainer::Update()` not
forcing a `Layout()` in `BraveLocationBarView`. This is now done by
implementing the aforementioned callback.

Fixes https://github.com/brave/brave-browser/issues/1276.



- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone




- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source