### PR TITLE
Disable geolocation in Tor profiles

### DIFF
--- a/components/content_settings/core/browser/brave_host_content_settings_map.cc
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.cc
@@ -4,8 +4,10 @@
 
 #include "brave/components/content_settings/core/browser/brave_host_content_settings_map.h"
 
+#include "brave/common/tor/pref_names.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
+#include "components/prefs/pref_service.h"
 
 BraveHostContentSettingsMap::BraveHostContentSettingsMap(
     PrefService* prefs,
@@ -20,9 +22,23 @@ BraveHostContentSettingsMap::BraveHostContentSettingsMap(
   InitializeCookieContentSetting();
   InitializeBraveShieldsContentSetting();
   InitializeFlashContentSetting();
+
+  if (prefs->HasPrefPath(tor::prefs::kProfileUsingTor) &&
+      prefs->GetBoolean(tor::prefs::kProfileUsingTor)) {
+    BlockGeolocation();
+  }
 }
 
 BraveHostContentSettingsMap::~BraveHostContentSettingsMap() {
+}
+
+void BraveHostContentSettingsMap::BlockGeolocation() {
+  SetContentSettingCustomScope(
+      ContentSettingsPattern::Wildcard(),
+      ContentSettingsPattern::Wildcard(),
+      CONTENT_SETTINGS_TYPE_GEOLOCATION,
+      std::string(),
+      CONTENT_SETTING_BLOCK);
 }
 
 void BraveHostContentSettingsMap::InitializeFingerprintingContentSetting() {

--- a/components/content_settings/core/browser/brave_host_content_settings_map.h
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.h
@@ -20,6 +20,7 @@ class BraveHostContentSettingsMap : public HostContentSettingsMap {
    void InitializeCookieContentSetting();
    void InitializeBraveShieldsContentSetting();
    void InitializeFlashContentSetting();
+   void BlockGeolocation();
    ~BraveHostContentSettingsMap() override;
 };
 

--- a/components/content_settings/core/browser/brave_host_content_settings_map_unittest.cc
+++ b/components/content_settings/core/browser/brave_host_content_settings_map_unittest.cc
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/content_settings/core/browser/brave_host_content_settings_map.h"
+
+#include "base/files/file_path.h"
+#include "base/files/scoped_temp_dir.h"
+#include "brave/browser/profiles/brave_profile_manager.h"
+#include "brave/browser/profiles/tor_unittest_profile_manager.h"
+#include "brave/common/tor/pref_names.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/test/base/scoped_testing_local_state.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "content/public/test/test_browser_thread_bundle.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class BraveHostContentSettingsMapTest: public testing::Test {
+ public:
+  BraveHostContentSettingsMapTest()
+    : local_state_(TestingBrowserProcess::GetGlobal()),
+      thread_bundle_(content::TestBrowserThreadBundle::IO_MAINLOOP) {
+  }
+
+  void SetUp() override {
+    // Create a new temporary directory, and store the path
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    TestingBrowserProcess::GetGlobal()->SetProfileManager(
+        new TorUnittestProfileManager(temp_dir_.GetPath()));
+
+    url_ = GURL("http://testing.com/");
+  }
+
+  void TearDown() override {
+    TestingBrowserProcess::GetGlobal()->SetProfileManager(nullptr);
+  }
+
+
+  const GURL& url() {
+    return url_;
+  }
+
+ protected:
+  // The path to temporary directory used to contain the test operations.
+  base::ScopedTempDir temp_dir_;
+  ScopedTestingLocalState local_state_;
+
+ private:
+  GURL url_;
+  content::TestBrowserThreadBundle thread_bundle_;
+};
+
+TEST_F(BraveHostContentSettingsMapTest, AskGeolocationNotInTorProfile) {
+  TestingProfile profile;
+  HostContentSettingsMap* host_content_settings_map =
+    HostContentSettingsMapFactory::GetForProfile(&profile);
+  EXPECT_EQ(CONTENT_SETTING_ASK,
+            host_content_settings_map->GetContentSetting(
+              url(),
+              url(),
+              CONTENT_SETTINGS_TYPE_GEOLOCATION,
+              std::string()));
+}
+
+TEST_F(BraveHostContentSettingsMapTest, BlockGeolocationInTorProfile) {
+  ProfileManager* profile_manager = g_browser_process->profile_manager();
+  base::FilePath tor_path = BraveProfileManager::GetTorProfilePath();
+  Profile* profile = profile_manager->GetProfile(tor_path);
+  ASSERT_TRUE(profile);
+
+  HostContentSettingsMap* host_content_settings_map =
+    HostContentSettingsMapFactory::GetForProfile(profile);
+  EXPECT_EQ(CONTENT_SETTING_BLOCK,
+            host_content_settings_map->GetContentSetting(
+              url(),
+              url(),
+              CONTENT_SETTINGS_TYPE_GEOLOCATION,
+              std::string()));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -54,6 +54,7 @@ test("brave_unit_tests") {
     "//brave/common/tor/tor_test_constants.h",
     "//brave/components/brave_shields/browser/ad_block_regional_service_unittest.cc",
     "//brave/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc",
+    "//brave/components/content_settings/core/browser/brave_host_content_settings_map_unittest.cc",
     "//chrome/common/importer/mock_importer_bridge.cc",
     "//chrome/common/importer/mock_importer_bridge.h",
     "../browser/importer/chrome_profile_lock_unittest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1353
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Manual test:
1. Visit https://browserleaks.com/geo in a normal window, will get a geolocation permission prompt.
2. Visit https://browserleaks.com/geo in a Tor window, result should be as below without any prompt:
<img width="595" alt="screen shot 2018-10-04 at 11 06 38 am" src="https://user-images.githubusercontent.com/4730197/46496093-f3f4df00-c7cb-11e8-9e14-996c3ededf9c.png">

Unit test:
`npm test brave_unit_tests -- --filter=BraveHostContentSettingsMapTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source