### PR TITLE
WIP: Mock google tag services instead of blocking it

### DIFF
--- a/components/brave_shields/browser/tracking_protection_service.cc
+++ b/components/brave_shields/browser/tracking_protection_service.cc
@@ -41,7 +41,10 @@ TrackingProtectionService::TrackingProtectionService()
       "scontent-sjc2-1.xx.fbcdn.net",
       "platform.twitter.com",
       "syndication.twitter.com",
-      "cdn.syndication.twimg.com"
+      "cdn.syndication.twimg.com",
+      // We whitelist this here so that the mock will get a chance
+      // to mock it instead.
+      "www.googletagservices.com"
     }),
     weak_factory_(this) {
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1430

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source