### PR TITLE
Revert "Disable geolocation in Tor profiles"

### DIFF
--- a/components/content_settings/core/browser/brave_host_content_settings_map.cc
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.cc
@@ -4,10 +4,8 @@
 
 #include "brave/components/content_settings/core/browser/brave_host_content_settings_map.h"
 
-#include "brave/common/tor/pref_names.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
-#include "components/prefs/pref_service.h"
 
 BraveHostContentSettingsMap::BraveHostContentSettingsMap(
     PrefService* prefs,
@@ -22,23 +20,9 @@ BraveHostContentSettingsMap::BraveHostContentSettingsMap(
   InitializeCookieContentSetting();
   InitializeBraveShieldsContentSetting();
   InitializeFlashContentSetting();
-
-  if (prefs->HasPrefPath(tor::prefs::kProfileUsingTor) &&
-      prefs->GetBoolean(tor::prefs::kProfileUsingTor)) {
-    BlockGeolocation();
-  }
 }
 
 BraveHostContentSettingsMap::~BraveHostContentSettingsMap() {
-}
-
-void BraveHostContentSettingsMap::BlockGeolocation() {
-  SetContentSettingCustomScope(
-      ContentSettingsPattern::Wildcard(),
-      ContentSettingsPattern::Wildcard(),
-      CONTENT_SETTINGS_TYPE_GEOLOCATION,
-      std::string(),
-      CONTENT_SETTING_BLOCK);
 }
 
 void BraveHostContentSettingsMap::InitializeFingerprintingContentSetting() {

--- a/components/content_settings/core/browser/brave_host_content_settings_map.h
+++ b/components/content_settings/core/browser/brave_host_content_settings_map.h
@@ -20,7 +20,6 @@ class BraveHostContentSettingsMap : public HostContentSettingsMap {
    void InitializeCookieContentSetting();
    void InitializeBraveShieldsContentSetting();
    void InitializeFlashContentSetting();
-   void BlockGeolocation();
    ~BraveHostContentSettingsMap() override;
 };
 


### PR DESCRIPTION
This reverts commit ecc84d4eaf84e66393af88a39b5df015a88801bf, due to the following build problem on Windows:

```
FAILED: vr_ui.dll vr_ui.dll.lib vr_ui.dll.pdb
ninja -t msvc -e environment.x64 -- ../../third_party/llvm-build/Release+Asserts/bin/lld-link.exe /nologo /IMPLIB:./vr_ui.dll.lib /DLL /OUT:./vr_ui.dll /PDB:./vr_ui.dll.pdb @./vr_ui.dll.rsp
lld-link: error: undefined symbol: ?kProfileUsingTor@prefs@tor@@3QBDB
>>> referenced by C:\brave-browser\src\brave\components\content_settings\core\browser\brave_host_content_settings_map.cc:26
>>>               obj/brave/components/content_settings/core/browser/browser/brave_host_content_settings_map.obj:(??0BraveHostContentSettingsMap@@QEAA@PEAVPrefService@@_N111@Z)
>>> referenced by C:\brave-browser\src\brave\components\content_settings\core\browser\brave_host_content_settings_map.cc:26
>>>               obj/brave/components/content_settings/core/browser/browser/brave_host_content_settings_map.obj:(??0BraveHostContentSettingsMap@@QEAA@PEAVPrefService@@_N111@Z)
```