### PR TITLE
Only allow whitelisted protocols to load in Tor

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -31,6 +31,8 @@ source_set("net") {
     "//brave/components/brave_webtorrent/browser/net",
     "//chrome/browser",
     "//content/public/browser",
+    "//content/public/common",
+    "//extensions/common:common_constants",
     "//net",
   ]
 }

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -131,7 +131,7 @@ void BraveNetworkDelegateBase::RunNextCallback(
       if (rv == net::ERR_IO_PENDING) {
         return;
       }
-      if (rv == net::ERR_ABORTED) {
+      if (rv != net::OK) {
         break;
       }
     }
@@ -146,7 +146,7 @@ void BraveNetworkDelegateBase::RunNextCallback(
       if (rv == net::ERR_IO_PENDING) {
         return;
       }
-      if (rv == net::ERR_ABORTED) {
+      if (rv != net::OK) {
         break;
       }
     }
@@ -163,13 +163,13 @@ void BraveNetworkDelegateBase::RunNextCallback(
       if (rv == net::ERR_IO_PENDING) {
         return;
       }
-      if (rv == net::ERR_ABORTED) {
+      if (rv != net::OK) {
         break;
       }
     }
   }
 
-  if (rv == net::ERR_ABORTED) {
+  if (rv != net::OK) {
     RunCallbackForRequestIdentifier(ctx->request_identifier, rv);
     return;
   }

--- a/browser/net/brave_tor_network_delegate_helper.cc
+++ b/browser/net/brave_tor_network_delegate_helper.cc
@@ -8,6 +8,8 @@
 #include "brave/browser/tor/tor_profile_service.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/resource_request_info.h"
+#include "content/public/common/url_constants.h"
+#include "extensions/common/constants.h"
 #include "net/url_request/url_request_context.h"
 
 using content::BrowserThread;
@@ -24,18 +26,31 @@ int OnBeforeURLRequest_TorWork(
 
   const ResourceRequestInfo* resource_info =
     ResourceRequestInfo::ForRequest(request);
-  if (resource_info) {
-    const BraveNavigationUIData* ui_data =
-      static_cast<const BraveNavigationUIData*>(
-        resource_info->GetNavigationUIData());
-    if (!ui_data)
-      return net::OK;
-    auto* tor_profile_service = ui_data->GetTorProfileService();
-    if (!tor_profile_service)
-      return net::OK;
-    auto* proxy_service = request->context()->proxy_resolution_service();
-    tor_profile_service->SetProxy(proxy_service, request->url(), false);
+  if (!resource_info) {
+    return net::OK;
   }
+
+  const BraveNavigationUIData* ui_data =
+    static_cast<const BraveNavigationUIData*>(
+        resource_info->GetNavigationUIData());
+  if (!ui_data) {
+    return net::OK;
+  }
+
+  auto* tor_profile_service = ui_data->GetTorProfileService();
+  if (!tor_profile_service) {
+    return net::OK;
+  }
+
+  if (!(request->url().SchemeIsHTTPOrHTTPS() ||
+        request->url().SchemeIs(content::kChromeUIScheme) ||
+        request->url().SchemeIs(extensions::kExtensionScheme) ||
+        request->url().SchemeIs(content::kChromeDevToolsScheme))) {
+    return net::ERR_DISALLOWED_URL_SCHEME;
+  }
+
+  auto* proxy_service = request->context()->proxy_resolution_service();
+  tor_profile_service->SetProxy(proxy_service, request->url(), false);
 
   return net::OK;
 }

--- a/browser/renderer_host/brave_navigation_ui_data.cc
+++ b/browser/renderer_host/brave_navigation_ui_data.cc
@@ -7,6 +7,9 @@
 #include <memory>
 
 #include "base/memory/ptr_util.h"
+#include "brave/browser/tor/tor_profile_service_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/web_contents.h"
 
 BraveNavigationUIData::BraveNavigationUIData()
     : ChromeNavigationUIData(),
@@ -18,6 +21,25 @@ BraveNavigationUIData::BraveNavigationUIData(
       tor_profile_service_(nullptr) {}
 
 BraveNavigationUIData::~BraveNavigationUIData() {}
+
+// static
+std::unique_ptr<ChromeNavigationUIData>
+BraveNavigationUIData::CreateForMainFrameNavigation(
+    content::WebContents* web_contents,
+    WindowOpenDisposition disposition) {
+  auto navigation_ui_data =
+    ChromeNavigationUIData::CreateForMainFrameNavigation(
+        web_contents, disposition);
+  BraveNavigationUIData* ui_data =
+    static_cast<BraveNavigationUIData*>(navigation_ui_data.get());
+
+  Profile* profile = Profile::FromBrowserContext(web_contents->GetBrowserContext());
+  TorProfileServiceFactory::SetTorNavigationUIData(
+      profile,
+      ui_data);
+
+  return navigation_ui_data;
+}
 
 std::unique_ptr<content::NavigationUIData> BraveNavigationUIData::Clone()
     const {

--- a/browser/renderer_host/brave_navigation_ui_data.h
+++ b/browser/renderer_host/brave_navigation_ui_data.h
@@ -12,11 +12,17 @@
 using content::NavigationHandle;
 using tor::TorProfileService;
 
+enum class WindowOpenDisposition;
+
 class BraveNavigationUIData : public ChromeNavigationUIData {
  public:
   BraveNavigationUIData();
   explicit BraveNavigationUIData(NavigationHandle* navigation_handle);
   ~BraveNavigationUIData() override;
+
+  static std::unique_ptr<ChromeNavigationUIData> CreateForMainFrameNavigation(
+      content::WebContents* web_contents,
+      WindowOpenDisposition disposition);
 
   std::unique_ptr<content::NavigationUIData> Clone() const override;
 

--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/renderer_host/brave_navigation_ui_data.h"
+#include "chrome/browser/renderer_host/chrome_navigation_ui_data.h"
+
+#define ChromeNavigationUIData BraveNavigationUIData
+#include "../../../../chrome/browser/ui/browser_navigator.cc"
+#undef ChromeNavigationUIData

--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -3,7 +3,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/renderer_host/brave_navigation_ui_data.h"
-#include "chrome/browser/renderer_host/chrome_navigation_ui_data.h"
 
 #define ChromeNavigationUIData BraveNavigationUIData
 #include "../../../../chrome/browser/ui/browser_navigator.cc"


### PR DESCRIPTION
Close https://github.com/brave/brave-browser/issues/1378
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
manual test:
Open a tor window and try to navigate to file://test should show an error page.
auto test:
`npm test brave_unit_tests -- --filter=BraveTorNetworkDelegateHelperTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source