### PR TITLE
Display chrome:// urls as brave:// in the LocationBar

### DIFF
--- a/chromium_src/chrome/browser/ui/browser.cc
+++ b/chromium_src/chrome/browser/ui/browser.cc
@@ -6,9 +6,12 @@
 #include "chrome/browser/ui/browser_content_setting_bubble_model_delegate.h"
 #include "brave/browser/ui/brave_browser_content_setting_bubble_model_delegate.h"
 #include "brave/browser/ui/brave_browser_command_controller.h"
+#include "brave/components/toolbar/brave_toolbar_model_impl.h"
 
+#define ToolbarModelImpl BraveToolbarModelImpl
 #define BrowserContentSettingBubbleModelDelegate BraveBrowserContentSettingBubbleModelDelegate
 #define BrowserCommandController BraveBrowserCommandController
 #include "../../../../../chrome/browser/ui/browser.cc"
 #undef BrowserContentSettingBubbleModelDelegate
 #undef BrowserCommandController
+#undef ToolbarModelImpl

--- a/components/toolbar/BUILD.gn
+++ b/components/toolbar/BUILD.gn
@@ -1,0 +1,30 @@
+source_set("toolbar") {
+
+  sources = [
+    "brave_toolbar_model_impl.cc",
+    "brave_toolbar_model_impl.h",
+    "constants.cc",
+    "constants.h",
+  ]
+
+  deps = [
+    "//base",
+    "//components/toolbar"
+  ]
+
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [
+    "toolbar_model_impl_unittest.cc",
+  ]
+
+  deps = [
+    ":toolbar",
+    "//base",
+    "//components/toolbar",
+    "//testing/gtest",
+    "//url",
+  ]
+}

--- a/components/toolbar/brave_toolbar_model_impl.cc
+++ b/components/toolbar/brave_toolbar_model_impl.cc
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/toolbar/brave_toolbar_model_impl.h"
+
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "brave/components/toolbar/constants.h"
+#include "components/toolbar/toolbar_model_impl.h"
+
+using namespace brave_toolbar;
+
+namespace {
+
+const base::string16 original_scheme_part =
+                                  base::ASCIIToUTF16(kOriginalInternalUIScheme);
+const base::string16 replacement_scheme_part =
+                                  base::ASCIIToUTF16(kInternalUIScheme);
+
+}
+
+base::string16 BraveToolbarModelImpl::GetURLForDisplay() const {
+  base::string16 formatted_text = ToolbarModelImpl::GetURLForDisplay();
+
+  const GURL url(GetURL());
+  // Only replace chrome:// with brave:// if scheme is "chrome" and
+  // it has not been stripped from the display text
+  if (url.SchemeIs(kOriginalInternalUIScheme) &&
+      base::StartsWith(formatted_text, original_scheme_part,
+                      base::CompareCase::INSENSITIVE_ASCII)) {
+    formatted_text.replace(0, original_scheme_part.length(),
+                            replacement_scheme_part);
+  }
+  return formatted_text;
+}

--- a/components/toolbar/brave_toolbar_model_impl.h
+++ b/components/toolbar/brave_toolbar_model_impl.h
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_TOOLBAR_BRAVE_TOOLBAR_MODEL_IMPL_H_
+#define BRAVE_COMPONENTS_TOOLBAR_BRAVE_TOOLBAR_MODEL_IMPL_H_
+
+#include "components/toolbar/toolbar_model_impl.h"
+
+class BraveToolbarModelImpl : public ToolbarModelImpl {
+  public:
+    using ToolbarModelImpl::ToolbarModelImpl;
+    base::string16 GetURLForDisplay() const override;
+  private:
+    DISALLOW_COPY_AND_ASSIGN(BraveToolbarModelImpl);
+};
+
+#endif

--- a/components/toolbar/constants.cc
+++ b/components/toolbar/constants.cc
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/toolbar/constants.h"
+
+namespace brave_toolbar {
+  const char kOriginalInternalUIScheme[] = "chrome";
+  const char kInternalUIScheme[] = "brave";
+}

--- a/components/toolbar/constants.h
+++ b/components/toolbar/constants.h
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_TOOLBAR_CONSTANTS_H_
+#define BRAVE_COMPONENTS_TOOLBAR_CONSTANTS_H_
+
+namespace brave_toolbar {
+  extern const char kOriginalInternalUIScheme[];
+  extern const char kInternalUIScheme[];
+}
+
+#endif

--- a/components/toolbar/toolbar_model_impl_unittest.cc
+++ b/components/toolbar/toolbar_model_impl_unittest.cc
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/toolbar/brave_toolbar_model_impl.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "components/toolbar/toolbar_model_delegate.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace {
+
+class FakeToolbarModelDelegate : public ToolbarModelDelegate {
+ public:
+  void SetURL(const GURL& url) { url_ = url; }
+
+  // ToolbarModelDelegate:
+  base::string16 FormattedStringWithEquivalentMeaning(
+      const GURL& url,
+      const base::string16& formatted_url) const override {
+    return formatted_url;
+  }
+
+  bool GetURL(GURL* url) const override {
+    *url = url_;
+    return true;
+  }
+
+ private:
+  GURL url_;
+};
+
+TEST(BraveToolbarModelImplTest,
+     DisplayUrlRewritesScheme) {
+  FakeToolbarModelDelegate delegate;
+  auto model = std::make_unique<BraveToolbarModelImpl>(&delegate, 1024);
+
+  delegate.SetURL(GURL("chrome://page"));
+
+  // Verify that both the full formatted URL and the display URL add the test
+  // suffix.
+  EXPECT_EQ(base::ASCIIToUTF16("brave://page"),
+            model->GetURLForDisplay());
+}
+
+}  // namespace

--- a/patches/chrome-browser-ui-BUILD.gn.patch
+++ b/patches/chrome-browser-ui-BUILD.gn.patch
@@ -1,16 +1,19 @@
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
-index ea8b1a687eb567635a04e613b89b9a143b7c6af2..bc9ee6c3e5ac900df61a989661066039d4588da1 100644
+index ea8b1a687eb567635a04e613b89b9a143b7c6af2..5e43eddc4274bfbe8d618ba5eaa0bb4648d1b9d4 100644
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -1010,6 +1010,7 @@ jumbo_split_static_library("ui") {
+@@ -1010,6 +1010,10 @@ jumbo_split_static_library("ui") {
      "//ui/webui",
      "//v8:v8_version",
    ]
-+  deps += [ "//brave/browser/ui" ]
++  deps += [
++    "//brave/browser/ui",
++    "//brave/components/toolbar",
++  ]
    allow_circular_includes_from +=
        [ "//chrome/browser/ui/webui/bluetooth_internals" ]
  
-@@ -2649,10 +2650,13 @@ jumbo_split_static_library("ui") {
+@@ -2649,10 +2653,13 @@ jumbo_split_static_library("ui") {
        ]
        deps += [ "//google_update" ]
      } else {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -104,6 +104,7 @@ test("brave_unit_tests") {
     "//chrome/test:test_support",
     "//components/prefs",
     "//components/prefs:test_support",
+    "//brave/components/toolbar:unit_tests",
     "//components/version_info",
     "//content/test:test_support",
     "//components/signin/core/browser",


### PR DESCRIPTION
This only affects the DisplayURL in that, when the url is being edited or copied, the actual chrome://*** url will be present.
This seems acceptable given:
- These urls 99% of the time are for display purposes only, as a result of another UI action, and will not be typed manually
- We intend to support brave://*** actual urls, redirecting to chrome://*** actual URLs automatically, which will get displayed as brave://*** URLs (https://github.com/brave/brave-browser/issues/810)

This is the same strategy used to hide the scheme (and some subdomains) in certain cases.

Fix https://github.com/brave/brave-browser/issues/1458

![image](https://user-images.githubusercontent.com/741836/46643949-1d4a9d80-cb33-11e8-9fd3-512953a9bddf.png)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Automated test included, manual test on https://github.com/brave/brave-browser/issues/1458

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source