### PR TITLE
Use different ports tor process in different channels

### DIFF
--- a/browser/tor/tor_profile_service.cc
+++ b/browser/tor/tor_profile_service.cc
@@ -6,8 +6,10 @@
 
 #include "brave/browser/tor/tor_launcher_service_observer.h"
 #include "brave/common/tor/pref_names.h"
+#include "chrome/common/channel_info.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/pref_registry/pref_registry_syncable.h"
+#include "components/version_info/channel.h"
 
 
 namespace tor {
@@ -25,8 +27,28 @@ void TorProfileService::RegisterProfilePrefs(
 }
 // static
 void TorProfileService::RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
-   registry->RegisterStringPref(tor::prefs::kTorProxyString,
-                                "socks5://127.0.0.1:9050");
+  switch (chrome::GetChannel()) {
+    case version_info::Channel::STABLE:
+      registry->RegisterStringPref(tor::prefs::kTorProxyString,
+                                   "socks5://127.0.0.1:9350");
+      break;
+    case version_info::Channel::BETA:
+      registry->RegisterStringPref(tor::prefs::kTorProxyString,
+                                   "socks5://127.0.0.1:9360");
+      break;
+    case version_info::Channel::DEV:
+      registry->RegisterStringPref(tor::prefs::kTorProxyString,
+                                   "socks5://127.0.0.1:9370");
+      break;
+    case version_info::Channel::CANARY:
+      registry->RegisterStringPref(tor::prefs::kTorProxyString,
+                                   "socks5://127.0.0.1:9380");
+      break;
+    case version_info::Channel::UNKNOWN:
+    default:
+      registry->RegisterStringPref(tor::prefs::kTorProxyString,
+                                   "socks5://127.0.0.1:9390");
+  }
 }
 
 void TorProfileService::AddObserver(TorLauncherServiceObserver* observer) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1345
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Tor will use 
1. port 9350 for release channel
2. port 9360 for beta channel
3. port 9370 for dev channel
4. port 9380 for nightly channel
5. port 9390 for development build

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source