### PR TITLE
Forward preferred size changes from `BraveActionsContainer`

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -105,18 +105,20 @@ void BraveActionsContainer::AddAction(const extensions::Extension* extension,
     // The button view
     actions_[id].view_ = std::make_unique<ToolbarActionView>(
         actions_[id].view_controller_.get(), this);
-    // we control destruction
-    actions_[id].view_->set_owned_by_client();
-    // Sets overall size of button but not image graphic. We set a large width
-    // in order to give space for the bubble.
-    actions_[id].view_->SetPreferredSize(gfx::Size(32, 24));
     // Add extension view after separator view
+    // `AddChildView` should be called first, so that changes that modify
+    // layout (e.g. preferred size) are forwarded to its parent
     if (actions_[id].position_ != ACTION_ANY_POSITION) {
       DCHECK(actions_[id].position_ > 0);
       AddChildViewAt(actions_[id].view_.get(), actions_[id].position_);
     } else {
       AddChildView(actions_[id].view_.get());
     }
+    // we control destruction
+    actions_[id].view_->set_owned_by_client();
+    // Sets overall size of button but not image graphic. We set a large width
+    // in order to give space for the bubble.
+    actions_[id].view_->SetPreferredSize(gfx::Size(32, 24));
     Update();
   }
 }
@@ -244,3 +246,7 @@ void BraveActionsContainer::OnExtensionActionUpdated(
     UpdateActionState(extension_action->extension_id());
 }
 // end ExtensionActionAPI::Observer
+
+void BraveActionsContainer::ChildPreferredSizeChanged(views::View* child) {
+  PreferredSizeChanged();
+}

--- a/browser/ui/views/brave_actions/brave_actions_container.h
+++ b/browser/ui/views/brave_actions/brave_actions_container.h
@@ -70,6 +70,9 @@ class BraveActionsContainer : public views::View,
         content::WebContents* web_contents,
         content::BrowserContext* browser_context) override;
 
+    // views::View:
+    void ChildPreferredSizeChanged(views::View* child) override;
+
   private:
     // Special positions in the container designators
     enum ActionPosition : int {

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -100,6 +100,13 @@ void BraveLocationBarView::OnThemeChanged() {
   RefreshBackground();
 }
 
+void BraveLocationBarView::ChildPreferredSizeChanged(views::View* child) {
+  if (child != brave_actions_)
+    return;
+
+  Layout();
+}
+
 // Provide base class implementation for Update override that has been added to
 // header via a patch. This should never be called as the only instantiated
 // implementation should be our |BraveLocationBarView|.

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -19,8 +19,11 @@ class BraveLocationBarView : public LocationBarView {
     void Layout() override;
     void Update(const content::WebContents* contents) override;
     void OnChanged() override;
+
+    // views::View:
     gfx::Size CalculatePreferredSize() const override;
     void OnThemeChanged() override;
+    void ChildPreferredSizeChanged(views::View* child) override;
 
   private:
     void UpdateBookmarkStarVisibility() override;


### PR DESCRIPTION
When a `BraveAction` is added, the size change isn't properly notified
to `BraveLocationBarView`. This commit implements
`ChildPreferredSizeChanged()` in both `BraveActionsContainer` and
`BraveLocationBarView`, and makes sure the action's preferred size is
set after calling `AddChildView()`.

Fixes https://github.com/brave/brave-browser/issues/1276

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ x Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source