### PR TITLE
Specify installer signing key when signing .pkg on Mac

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -2,6 +2,7 @@ import("//brave/build/config.gni")
 
 declare_args() {
   mac_signing_identifier = ""
+  mac_installer_signing_identifier = ""
   mac_signing_keychain = "login"
 }
 
@@ -83,7 +84,7 @@ action("sign_pkg") {
     rebase_path("$root_out_dir/unsigned/$brave_pkg"),
     rebase_path("$root_out_dir/$brave_pkg"),
     keychain_db,
-    mac_signing_identifier,
+    mac_installer_signing_identifier,
   ]
 
   deps = [":create_pkg"]

--- a/build/mac/sign_pkg.sh
+++ b/build/mac/sign_pkg.sh
@@ -3,14 +3,14 @@
 set -euo pipefail
 
 if [[ $# -lt "4" ]]; then
-  echo "usage: $0 <pkg_src> <pkg_dst> <mac_signing_keychain> <mac_signing_identifier>"
+  echo "usage: $0 <pkg_src> <pkg_dst> <mac_signing_keychain> <mac_installer_signing_identifier>"
   exit 1
 fi
 
 SOURCE="${1}"
 DEST="${2}"
 MAC_SIGNING_KEYCHAIN="${3}"
-MAC_SIGNING_IDENTIFIER="${4}"
+MAC_INSTALLER_SIGNING_IDENTIFIER="${4}"
 
 function check_exit() {
     return=$?;
@@ -29,4 +29,4 @@ if [[ -f $DEST ]]; then
   rm -f "$DEST"
 fi
 
-/usr/bin/productsign --sign "$MAC_SIGNING_IDENTIFIER" --keychain "$MAC_SIGNING_KEYCHAIN" "$SOURCE" "$DEST"
+/usr/bin/productsign --sign "$MAC_INSTALLER_SIGNING_IDENTIFIER" --keychain "$MAC_SIGNING_KEYCHAIN" "$SOURCE" "$DEST"


### PR DESCRIPTION
Fixes brave/brave-browser#1412

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source