### PR TITLE
Fix private search engine controller crash

### DIFF
--- a/browser/search_engine_provider_controller_base.h
+++ b/browser/search_engine_provider_controller_base.h
@@ -24,9 +24,6 @@ class SearchEngineProviderControllerBase : public TemplateURLServiceObserver {
  protected:
   virtual void ConfigureSearchEngineProvider() = 0;
 
-  // TemplateURLServiceObserver overrides:
-  void OnTemplateURLServiceShuttingDown() override;
-
   bool UseAlternativeSearchEngineProvider() const;
   void ChangeToAlternativeSearchEngineProvider();
   void ChangeToNormalWindowSearchEngineProvider();
@@ -42,6 +39,11 @@ class SearchEngineProviderControllerBase : public TemplateURLServiceObserver {
 
  private:
   void OnPreferenceChanged(const std::string& pref_name);
+
+  // |destroyer_| controls the lifecycle of this class and it is destroyed
+  // by itself.
+  class Destroyer;
+  Destroyer* destroyer_ = nullptr;
 
   BooleanPrefMember use_alternative_search_engine_provider_;
 

--- a/browser/search_engine_provider_controller_browsertest.cc
+++ b/browser/search_engine_provider_controller_browsertest.cc
@@ -75,6 +75,16 @@ IN_PROC_BROWSER_TEST_F(SearchEngineProviderControllerTest, PrefTest) {
             base::ASCIIToUTF16("test1"));
 }
 
+// Check crash isn't happened with multiple private window is used.
+IN_PROC_BROWSER_TEST_F(SearchEngineProviderControllerTest,
+                       MultiplePrivateWindowTest) {
+  Browser* private_window_1 = CreateIncognitoBrowser();
+  CloseBrowserSynchronously(private_window_1);
+
+  Browser* private_window_2 = CreateIncognitoBrowser();
+  brave::ToggleUseAlternativeSearchEngineProvider(private_window_2->profile());
+}
+
 // This test crashes with below. I don't know how to deal with now.
 // [FATAL:brave_content_browser_client.cc(217)] Check failed: !path.empty().
 // TODO(simonhong): Enable this later.


### PR DESCRIPTION
This crash was caused by accessing dangling off the record profile.
To fix this, search engine controller should be destroyed when otr profile's template url service is destroyed.

Fixes https://github.com/brave/brave-browser/issues/1452

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=SearchEngineProviderControllerTest.Multiple*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source