### PR TITLE
Use component updater for installing PDF.js

### DIFF
--- a/browser/component_updater/brave_component_installer.cc
+++ b/browser/component_updater/brave_component_installer.cc
@@ -57,6 +57,21 @@ bool RewriteManifestFile(
   return true;
 }
 
+std::string GetManifestString(const base::DictionaryValue& manifest,
+    const std::string &public_key) {
+  std::unique_ptr<base::DictionaryValue> final_manifest(manifest.DeepCopy());
+  final_manifest->SetString(extensions::manifest_keys::kPublicKey, public_key);
+
+  std::string manifest_json;
+  JSONStringValueSerializer serializer(&manifest_json);
+  serializer.set_pretty_print(true);
+  if (!serializer.Serialize(*final_manifest)) {
+    return "";
+  }
+  return manifest_json;
+}
+
+
 }  // namespace
 
 namespace brave {
@@ -107,7 +122,7 @@ void BraveComponentInstallerPolicy::ComponentReady(
   const base::Version& version,
   const base::FilePath& install_dir,
   std::unique_ptr<base::DictionaryValue> manifest) {
-  ready_callback_.Run(install_dir);
+  ready_callback_.Run(install_dir, GetManifestString(*manifest, base64_public_key_));
 }
 
 base::FilePath BraveComponentInstallerPolicy::GetRelativeInstallDir() const {

--- a/browser/component_updater/brave_component_installer.h
+++ b/browser/component_updater/brave_component_installer.h
@@ -22,7 +22,8 @@ namespace base {
 class FilePath;
 }  // namespace base
 
-using ReadyCallback = base::Callback<void(const base::FilePath&)>;
+using ReadyCallback = base::Callback<void(const base::FilePath&,
+    const std::string& manifest)>;
 
 namespace brave {
 

--- a/browser/extensions/brave_component_extension.cc
+++ b/browser/extensions/brave_component_extension.cc
@@ -57,5 +57,6 @@ void BraveComponentExtension::OnComponentRegistered(const std::string& component
 
 void BraveComponentExtension::OnComponentReady(
     const std::string& component_id,
-    const base::FilePath& install_dir) {
+    const base::FilePath& install_dir,
+    const std::string& manifest) {
 }

--- a/browser/extensions/brave_component_extension.h
+++ b/browser/extensions/brave_component_extension.h
@@ -29,7 +29,8 @@ class BraveComponentExtension : public ComponentsUI {
  protected:
   virtual void OnComponentRegistered(const std::string& component_id);
   virtual void OnComponentReady(const std::string& component_id,
-                                const base::FilePath& install_dir);
+                                const base::FilePath& install_dir,
+                                const std::string& manifest);
 
  private:
   std::string component_name_;

--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_rewards/extension/grit/brave_rewards_resources.h"
 #include "brave/components/brave_webtorrent/grit/brave_webtorrent_resources.h"
 #include "components/grit/brave_components_resources.h"
+#include "extensions/browser/extension_prefs.h"
 
 namespace extensions {
 
@@ -22,7 +23,8 @@ BraveComponentLoader::BraveComponentLoader(
     PrefService* profile_prefs,
     PrefService* local_state,
     Profile* profile)
-    : ComponentLoader(extension_service, profile_prefs, local_state, profile) {
+    : ComponentLoader(extension_service, profile_prefs, local_state, profile),
+      profile_(profile) {
 }
 
 BraveComponentLoader::~BraveComponentLoader() {
@@ -37,9 +39,14 @@ void BraveComponentLoader::OnComponentRegistered(std::string extension_id) {
 }
 
 void BraveComponentLoader::OnComponentReady(std::string extension_id,
+    bool allow_file_access,
     const base::FilePath& install_dir,
     const std::string& manifest) {
   Add(manifest, install_dir);
+  if (allow_file_access) {
+    ExtensionPrefs::Get((content::BrowserContext *)profile_)->
+        SetAllowFileAccess(extension_id, true);
+  }
 }
 
 void BraveComponentLoader::AddExtension(const std::string& extension_id,
@@ -50,7 +57,7 @@ void BraveComponentLoader::AddExtension(const std::string& extension_id,
     base::Bind(&BraveComponentLoader::OnComponentRegistered,
         base::Unretained(this), extension_id),
     base::Bind(&BraveComponentLoader::OnComponentReady,
-        base::Unretained(this), extension_id));
+        base::Unretained(this), extension_id, true));
 }
 
 void BraveComponentLoader::AddDefaultComponentExtensions(

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -5,6 +5,7 @@
 #ifndef BRAVE_BROWSER_EXTENSIONS_BRAVE_COMPONENT_LOADER_H_
 #define BRAVE_BROWSER_EXTENSIONS_BRAVE_COMPONENT_LOADER_H_
 
+#include "base/files/file_path.h"
 #include "chrome/browser/extensions/component_loader.h"
 
 namespace extensions {
@@ -23,6 +24,13 @@ class BraveComponentLoader : public ComponentLoader {
   // be loaded unless we are in signed user session (ChromeOS). For all other
   // platforms this |skip_session_components| is expected to be unset.
   void AddDefaultComponentExtensions(bool skip_session_components) override;
+  void OnComponentRegistered(std::string extension_id);
+  void OnComponentReady(std::string extension_id,
+    const base::FilePath& install_dir,
+    const std::string& manifest);
+  void AddExtension(const std::string& id,
+      const std::string& name, const std::string& public_key);
+ 
 
   DISALLOW_COPY_AND_ASSIGN(BraveComponentLoader);
 };

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -26,12 +26,14 @@ class BraveComponentLoader : public ComponentLoader {
   void AddDefaultComponentExtensions(bool skip_session_components) override;
   void OnComponentRegistered(std::string extension_id);
   void OnComponentReady(std::string extension_id,
+    bool allow_file_access,
     const base::FilePath& install_dir,
     const std::string& manifest);
   void AddExtension(const std::string& id,
       const std::string& name, const std::string& public_key);
  
-
+ private:
+  Profile* profile_;
   DISALLOW_COPY_AND_ASSIGN(BraveComponentLoader);
 };
 

--- a/browser/extensions/brave_extension_management.cc
+++ b/browser/extensions/brave_extension_management.cc
@@ -21,23 +21,10 @@ BraveExtensionManagement::BraveExtensionManagement(
     : ExtensionManagement(pref_service, is_signin_profile) {
   providers_.push_back(
       std::make_unique<BraveExtensionProvider>());
-  const base::CommandLine& command_line =
-      *base::CommandLine::ForCurrentProcess();
-  if (!command_line.HasSwitch(switches::kDisablePDFJSExtension)) {
-    RegisterForceInstalledExtensions();
-  }
   RegisterBraveExtensions();
 }
 
 BraveExtensionManagement::~BraveExtensionManagement() {
-}
-
-void BraveExtensionManagement::RegisterForceInstalledExtensions() {
-  base::DictionaryValue forced_list_pref;
-  extensions::ExternalPolicyLoader::AddExtension(
-      &forced_list_pref, pdfjs_extension_id,
-      extension_urls::kChromeWebstoreUpdateURL);
-  UpdateForcedExtensions(&forced_list_pref);
 }
 
 void BraveExtensionManagement::RegisterBraveExtensions() {

--- a/browser/extensions/brave_extension_management.h
+++ b/browser/extensions/brave_extension_management.h
@@ -15,7 +15,6 @@ class BraveExtensionManagement : public ExtensionManagement {
   ~BraveExtensionManagement() override;
 
  private:
-  void RegisterForceInstalledExtensions();
   void RegisterBraveExtensions();
   DISALLOW_COPY_AND_ASSIGN(BraveExtensionManagement);
 };

--- a/browser/extensions/brave_tor_client_updater.cc
+++ b/browser/extensions/brave_tor_client_updater.cc
@@ -78,7 +78,8 @@ void BraveTorClientUpdater::InitExecutablePath(
 
 void BraveTorClientUpdater::OnComponentReady(
     const std::string& component_id,
-    const base::FilePath& install_dir) {
+    const base::FilePath& install_dir,
+    const std::string& manifest) {
   GetTaskRunner()->PostTask(
       FROM_HERE, base::Bind(&BraveTorClientUpdater::InitExecutablePath,
                             base::Unretained(this), install_dir));

--- a/browser/extensions/brave_tor_client_updater.h
+++ b/browser/extensions/brave_tor_client_updater.h
@@ -61,7 +61,8 @@ class BraveTorClientUpdater : public BraveComponentExtension {
 
  protected:
   void OnComponentReady(const std::string& component_id,
-      const base::FilePath& install_dir) override;
+      const base::FilePath& install_dir,
+      const std::string& manifest) override;
 
  private:
   friend class ::BraveTorClientUpdaterTest;

--- a/browser/extensions/brave_tor_client_updater_browsertest.cc
+++ b/browser/extensions/brave_tor_client_updater_browsertest.cc
@@ -87,7 +87,7 @@ public:
       return false;
 
     g_brave_browser_process->tor_client_updater()->OnComponentReady(
-        tor_client_updater->id(), tor_client_updater->path());
+        tor_client_updater->id(), tor_client_updater->path(), "");
     WaitForTorClientUpdaterThread();
 
     return true;

--- a/chromium_src/chrome/browser/extensions/component_extensions_whitelist/whitelist.cc
+++ b/chromium_src/chrome/browser/extensions/component_extensions_whitelist/whitelist.cc
@@ -16,6 +16,7 @@ namespace extensions {
   bool IsComponentExtensionWhitelisted(const std::string& extension_id) {
     const char* const kAllowed[] = {
       brave_extension_id,
+      pdfjs_extension_id,
       brave_rewards_extension_id,
       brave_webtorrent_extension_id
     };

--- a/common/extensions/extension_constants.cc
+++ b/common/extensions/extension_constants.cc
@@ -7,5 +7,8 @@
 const char brave_extension_id[] = "mnojpmjdmbbfmejpflffifhffcmidifd";
 const char brave_rewards_extension_id[] = "jidkidbbcafjabdphckchenhfomhnfma";
 const char brave_webtorrent_extension_id[] = "lgjmpdmojkpocjcopdikifhejkkjglho";
-const char pdfjs_extension_id[] = "oemmndcbldboiebfnladdacbdfmadadm";
 const char widevine_extension_id[] = "oimompecagnajdejgnnjijobebaeigek";
+
+const char pdfjs_extension_id[] = "oemmndcbldboiebfnladdacbdfmadadm";
+const char pdfjs_extension_name[] = "PDF Viewer (PDF.js)";
+const char pdfjs_extension_public_key[] = "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDb5PIb8ayK6vHvEIY1nJKRSCDE8iJ1T43qFN+5dvCVQrmyEkgqB9ZuZNT24Lwot96HV51VoITHKRNIVKI2Nrbfn0M49t7qtaP34g/GXJ7mAIbSzsY4+i+Wsz8EL2SNEIw6uH8RmXG7nZ29NJ7sk7jn17QmMsO2UJ01UT8hfOOOEQIDAQAB";

--- a/common/extensions/extension_constants.h
+++ b/common/extensions/extension_constants.h
@@ -5,5 +5,8 @@
 extern const char brave_extension_id[];
 extern const char brave_rewards_extension_id[];
 extern const char brave_webtorrent_extension_id[];
-extern const char pdfjs_extension_id[];
 extern const char widevine_extension_id[];
+
+extern const char pdfjs_extension_id[];
+extern const char pdfjs_extension_name[];
+extern const char pdfjs_extension_public_key[];

--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -39,7 +39,8 @@ bool IsUAWhitelisted(const GURL& gurl) {
 bool IsBlockedResource(const GURL& gurl) {
   static std::vector<URLPattern> blocked_patterns({
     URLPattern(URLPattern::SCHEME_ALL, "https://www.lesechos.fr/xtcore.js"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://*.y8.com/js/sdkloader/outstream.js")
+    URLPattern(URLPattern::SCHEME_ALL, "https://*.y8.com/js/sdkloader/outstream.js"),
+    URLPattern(URLPattern::SCHEME_ALL, "https://pdfjs.robwu.nl/*")
   });
   return std::any_of(blocked_patterns.begin(), blocked_patterns.end(),
       [&gurl](URLPattern pattern){

--- a/components/brave_shields/browser/ad_block_regional_service.cc
+++ b/components/brave_shields/browser/ad_block_regional_service.cc
@@ -103,7 +103,8 @@ void AdBlockRegionalService::OnComponentRegistered(
 
 void AdBlockRegionalService::OnComponentReady(
     const std::string& component_id,
-    const base::FilePath& install_dir) {
+    const base::FilePath& install_dir,
+    const std::string& manifest) {
   base::FilePath dat_file_path =
       install_dir.AppendASCII(g_ad_block_regional_dat_file_version_)
           .AppendASCII(uuid_)

--- a/components/brave_shields/browser/ad_block_regional_service.h
+++ b/components/brave_shields/browser/ad_block_regional_service.h
@@ -35,7 +35,8 @@ class AdBlockRegionalService : public AdBlockBaseService {
   bool Init() override;
   void OnComponentRegistered(const std::string& component_id) override;
   void OnComponentReady(const std::string& component_id,
-                        const base::FilePath& install_dir) override;
+                        const base::FilePath& install_dir,
+                        const std::string& manifest) override;
 
  private:
   friend class ::AdBlockServiceTest;

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -43,7 +43,8 @@ bool AdBlockService::Init() {
 }
 
 void AdBlockService::OnComponentReady(const std::string& component_id,
-                                      const base::FilePath& install_dir) {
+                                      const base::FilePath& install_dir,
+                                      const std::string& manifest) {
   base::FilePath dat_file_path =
       install_dir.AppendASCII(g_ad_block_dat_file_version_)
           .AppendASCII(DAT_FILE);

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -40,7 +40,8 @@ class AdBlockService : public AdBlockBaseService {
  protected:
   bool Init() override;
   void OnComponentReady(const std::string& component_id,
-                        const base::FilePath& install_dir) override;
+                        const base::FilePath& install_dir,
+                        const std::string& manifest) override;
 
  private:
   friend class ::AdBlockServiceTest;

--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -98,7 +98,7 @@ public:
       return false;
 
     g_brave_browser_process->ad_block_service()->OnComponentReady(
-        ad_block_extension->id(), ad_block_extension->path());
+        ad_block_extension->id(), ad_block_extension->path(), "");
     WaitForDefaultAdBlockServiceThread();
 
     return true;
@@ -116,7 +116,7 @@ public:
       return false;
 
     g_brave_browser_process->ad_block_regional_service()->OnComponentReady(
-        ad_block_extension->id(), ad_block_extension->path());
+        ad_block_extension->id(), ad_block_extension->path(), "");
     WaitForRegionalAdBlockServiceThread();
 
     return true;

--- a/components/brave_shields/browser/https_everywhere_service.cc
+++ b/components/brave_shields/browser/https_everywhere_service.cc
@@ -134,7 +134,8 @@ void HTTPSEverywhereService::InitDB(const base::FilePath& install_dir) {
 
 void HTTPSEverywhereService::OnComponentReady(
     const std::string& component_id,
-    const base::FilePath& install_dir) {
+    const base::FilePath& install_dir,
+    const std::string& manifest) {
   GetTaskRunner()->PostTask(
       FROM_HERE,
       base::Bind(&HTTPSEverywhereService::InitDB,

--- a/components/brave_shields/browser/https_everywhere_service.h
+++ b/components/brave_shields/browser/https_everywhere_service.h
@@ -63,7 +63,8 @@ class HTTPSEverywhereService : public BaseBraveShieldsService {
   bool Init() override;
   void Cleanup() override;
   void OnComponentReady(const std::string& component_id,
-      const base::FilePath& install_dir) override;
+      const base::FilePath& install_dir,
+      const std::string& manifest) override;
 
   void AddHTTPSEUrlToRedirectList(const uint64_t& request_id);
   bool ShouldHTTPSERedirect(const uint64_t& request_id);

--- a/components/brave_shields/browser/https_everywhere_service_browsertest.cc
+++ b/components/brave_shields/browser/https_everywhere_service_browsertest.cc
@@ -82,7 +82,7 @@ public:
       return false;
 
     g_brave_browser_process->https_everywhere_service()->OnComponentReady(
-        httpse_extension->id(), httpse_extension->path());
+        httpse_extension->id(), httpse_extension->path(), "");
     WaitForHTTPSEverywhereServiceThread();
 
     return true;

--- a/components/brave_shields/browser/tracking_protection_service.cc
+++ b/components/brave_shields/browser/tracking_protection_service.cc
@@ -111,7 +111,8 @@ void TrackingProtectionService::OnDATFileDataReady() {
 
 void TrackingProtectionService::OnComponentReady(
     const std::string& component_id,
-    const base::FilePath& install_dir) {
+    const base::FilePath& install_dir,
+    const std::string& manifest) {
   base::FilePath dat_file_path =
       install_dir.AppendASCII(DAT_FILE_VERSION).AppendASCII(DAT_FILE);
 

--- a/components/brave_shields/browser/tracking_protection_service.h
+++ b/components/brave_shields/browser/tracking_protection_service.h
@@ -52,7 +52,8 @@ class TrackingProtectionService : public BaseBraveShieldsService {
   bool Init() override;
   void Cleanup() override;
   void OnComponentReady(const std::string& component_id,
-      const base::FilePath& install_dir) override;
+      const base::FilePath& install_dir,
+      const std::string& manifest) override;
 
  private:
   friend class ::TrackingProtectionServiceTest;

--- a/components/brave_shields/browser/tracking_protection_service_browsertest.cc
+++ b/components/brave_shields/browser/tracking_protection_service_browsertest.cc
@@ -92,7 +92,7 @@ public:
       return false;
 
     g_brave_browser_process->tracking_protection_service()->OnComponentReady(
-        tracking_protection_extension->id(), tracking_protection_extension->path());
+        tracking_protection_extension->id(), tracking_protection_extension->path(), "");
     WaitForTrackingProtectionServiceThread();
 
     return true;


### PR DESCRIPTION
This test neither helps nor hurts the PDF.js intermittent failure that sometimes happens by the way.
I think that one just needs a longer test timeout default.

Note that after this change PDF.js won't show up in the extensions pane, only in chrome://components

Fix brave/brave-browser#1375
Fix brave/brave-browser#1253
Fix brave/brave-browser#1072
Fix brave/brave-browser#1372
Fix brave/brave-browser#1388

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source