### PR TITLE
Autoplay some sites in absence of explicit block rule

### DIFF
--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -222,9 +222,35 @@ bool BraveContentSettingsObserver::AllowAutoplay(bool default_value) {
   }
 
   // in the absence of an explicit block rule, whitelist the following sites
+  std::string kWhitelistPatterns[] = {
+      "[*.]youtube.com",
+      "[*.]khanacademy.org",
+      "[*.]twitch.tv",
+      "[*.]vimeo.com",
+      "[*.]udemy.com",
+      "[*.]duolingo.com",
+      "[*.]giphy.com",
+      "[*.]imgur.com",
+      "[*.]netflix.com",
+      "[*.]hulu.com",
+      "[*.]primevideo.com",
+      "[*.]dailymotion.com",
+      "[*.]tv.com",
+      "[*.]viewster.com",
+      "[*.]metacafe.com",
+      "[*.]d.tube",
+      "[*.]spotify.com",
+      "[*.]lynda.com",
+      "[*.]soundcloud.com",
+      "[*.]pandora.com",
+      "[*.]periscope.tv",
+      "[*.]pscp.tv",
+  };
   const GURL& primary_url = GetOriginOrURL(frame);
-  if (ContentSettingsPattern::FromString("[*.]youtube.com").Matches(primary_url)) {
-      return true;
+  for (const auto& pattern : kWhitelistPatterns) {
+    if (ContentSettingsPattern::FromString(pattern).Matches(primary_url)) {
+        return true;
+    }
   }
 
   blink::mojom::blink::PermissionServicePtr permission_service;

--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -213,6 +213,20 @@ bool BraveContentSettingsObserver::AllowAutoplay(bool default_value) {
     return true;
   }
 
+  // respect user's blocklist, if any
+  if (GetContentSettingFromRules(
+      content_setting_rules_->autoplay_rules, frame,
+      url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL()) ==
+      CONTENT_SETTING_BLOCK) {
+      return false;
+  }
+
+  // in the absence of an explicit block rule, whitelist the following sites
+  const GURL& primary_url = GetOriginOrURL(frame);
+  if (ContentSettingsPattern::FromString("[*.]youtube.com").Matches(primary_url)) {
+      return true;
+  }
+
   blink::mojom::blink::PermissionServicePtr permission_service;
 
   render_frame()->GetRemoteInterfaces()

--- a/renderer/brave_content_settings_observer_autoplay_browsertest.cc
+++ b/renderer/brave_content_settings_observer_autoplay_browsertest.cc
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/permission_bubble/mock_permission_prompt_factory.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/test/browser_test_utils.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "net/dns/mock_host_resolver.h"
+
+const char kVideoPlaying[] = "Video playing";
+const char kVideoPlayingDetect[] =
+  "window.domAutomationController.send(document.getElementById('status')."
+  "textContent);";
+
+class BraveContentSettingsObserverAutoplayTest : public InProcessBrowserTest {
+  public:
+    void SetUpOnMainThread() override {
+      InProcessBrowserTest::SetUpOnMainThread();
+
+      content_client_.reset(new ChromeContentClient);
+      content::SetContentClient(content_client_.get());
+      browser_content_client_.reset(new BraveContentBrowserClient());
+      content::SetBrowserClientForTesting(browser_content_client_.get());
+
+      host_resolver()->AddRule("*", "127.0.0.1");
+      content::SetupCrossSiteRedirector(embedded_test_server());
+
+      brave::RegisterPathProvider();
+      base::FilePath test_data_dir;
+      base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+      embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+      ASSERT_TRUE(embedded_test_server()->Start());
+
+      whitelisted_attr_url_ = embedded_test_server()->GetURL("example.com", "/autoplay/autoplay_by_attr.html");
+
+      top_level_page_pattern_ =
+          ContentSettingsPattern::FromString("http://example.com/*");
+    }
+
+    void TearDown() override {
+      browser_content_client_.reset();
+      content_client_.reset();
+    }
+
+    const GURL& whitelisted_attr_url() { return whitelisted_attr_url_; }
+
+    const ContentSettingsPattern& top_level_page_pattern() {
+      return top_level_page_pattern_;
+    }
+
+    HostContentSettingsMap * content_settings() {
+      return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+    }
+
+    void BlockAutoplay() {
+      content_settings()->SetContentSettingCustomScope(
+          top_level_page_pattern_,
+          ContentSettingsPattern::Wildcard(),
+          CONTENT_SETTINGS_TYPE_AUTOPLAY,
+          std::string(),
+          CONTENT_SETTING_BLOCK);
+    }
+
+    content::WebContents* contents() {
+      return browser()->tab_strip_model()->GetActiveWebContents();
+    }
+
+    bool NavigateToURLUntilLoadStop(const GURL& url) {
+      ui_test_utils::NavigateToURL(browser(), url);
+      return WaitForLoadStop(contents());
+    }
+
+    void WaitForPlaying() {
+      std::string msg_from_renderer;
+      ASSERT_TRUE(ExecuteScriptAndExtractString(contents(), "notifyWhenPlaying();",
+                                                &msg_from_renderer));
+      ASSERT_EQ("PLAYING", msg_from_renderer);
+    }
+
+  private:
+    GURL whitelisted_attr_url_;
+    ContentSettingsPattern top_level_page_pattern_;
+    std::unique_ptr<ChromeContentClient> content_client_;
+    std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+};
+
+// Allow autoplay on whitelisted URL
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest, AllowAutoplay) {
+  std::string result;
+  PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
+      contents());
+  auto popup_prompt_factory =
+      std::make_unique<MockPermissionPromptFactory>(manager);
+
+  EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
+
+  NavigateToURLUntilLoadStop(whitelisted_attr_url());
+  EXPECT_FALSE(popup_prompt_factory->is_visible());
+  EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
+              PermissionRequestType::PERMISSION_AUTOPLAY));
+  EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
+  WaitForPlaying();
+  EXPECT_TRUE(ExecuteScriptAndExtractString(contents(),
+      kVideoPlayingDetect, &result));
+  EXPECT_EQ(result, kVideoPlaying);
+}
+
+// Block autoplay on whitelisted URL if user has blocklist pattern that matches URL
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest, BlockAutoplay) {
+  std::string result;
+  BlockAutoplay();
+  PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
+      contents());
+  auto popup_prompt_factory =
+      std::make_unique<MockPermissionPromptFactory>(manager);
+
+  EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
+
+  NavigateToURLUntilLoadStop(whitelisted_attr_url());
+  EXPECT_FALSE(popup_prompt_factory->is_visible());
+  EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
+              PermissionRequestType::PERMISSION_AUTOPLAY));
+  EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
+  EXPECT_TRUE(ExecuteScriptAndExtractString(contents(),
+      kVideoPlayingDetect, &result));
+  EXPECT_NE(result, kVideoPlaying);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -215,6 +215,7 @@ test("brave_browser_tests") {
     "//brave/components/brave_shields/browser/tracking_protection_service_browsertest.cc",
     "//brave/browser/extensions/brave_extension_provider_browsertest.cc",
     "//brave/renderer/brave_content_settings_observer_browsertest.cc",
+    "//brave/renderer/brave_content_settings_observer_autoplay_browsertest.cc",
     "//brave/renderer/brave_content_settings_observer_flash_browsertest.cc",
     "//brave/browser/themes/brave_theme_service_browsertest.cc",
     "//chrome/browser/extensions/browsertest_util.cc",


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1089

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source