### PR TITLE
Copy brave_rewards locales to mini installer staging area

### DIFF
--- a/patches/chrome-tools-build-win-create_installer_archive.py.patch
+++ b/patches/chrome-tools-build-win-create_installer_archive.py.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/tools/build/win/create_installer_archive.py b/chrome/tools/build/win/create_installer_archive.py
-index 0e12f2a17d11bdde2470330b6437f3254e3d1be7..a8f23d719fc822b26c9a6926a625d2b7dc1bf05a 100755
+index 0e12f2a17d11bdde2470330b6437f3254e3d1be7..a40a86a1d5c9baf8d01afcdf10649e2779e17d8b 100755
 --- a/chrome/tools/build/win/create_installer_archive.py
 +++ b/chrome/tools/build/win/create_installer_archive.py
-@@ -109,6 +109,33 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
+@@ -109,6 +109,60 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
    if enable_hidpi == '1':
      CopySectionFilesToStagingDir(config, 'HIDPI', staging_dir, build_dir)
  
 +  CopyBraveExtensionLocalization(config, staging_dir)
++  CopyBraveRewardsExtensionLocalization(config, staging_dir)
 +
 +def CopyBraveExtensionLocalization(config, staging_dir):
 +  """Copies extension localization files from
@@ -33,10 +34,36 @@ index 0e12f2a17d11bdde2470330b6437f3254e3d1be7..a8f23d719fc822b26c9a6926a625d2b7
 +        rel_file = os.path.join(rel_dir, name)
 +        candidate = os.path.join('.', 'resources', 'brave_extension' '_locales', rel_file)
 +        g_archive_inputs.append(candidate)
++
++def CopyBraveRewardsExtensionLocalization(config, staging_dir):
++  """Copies extension localization files from
++  \\brave\components\brave_rewards\extension\brave_rewards\_locales to
++  \\<out_gen_dir>\chrome\installer\mini_installer\mini_installer\temp_installer_archive\Chrome-bin\<version>\resources\brave_rewards\_locales
++  """
++  brave_extension_dir = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) )
++  brave_extension_dir = os.path.realpath(os.path.join(brave_extension_dir,
++    os.pardir,  os.pardir, os.pardir, os.pardir, 'brave', 'components', 'brave_rewards', 'extension', 'brave_rewards'))
++  locales_src_dir_path = os.path.join(brave_extension_dir, '_locales')
++  locales_dest_path = staging_dir
++  locales_dest_path = os.path.join(locales_dest_path, config.get('GENERAL', 'brave_resources.pak'),
++    'resources', 'brave_rewards', '_locales')
++  locales_dest_path = os.path.realpath(locales_dest_path)
++  try:
++    shutil.rmtree(locales_dest_path)
++  except:
++    pass
++  shutil.copytree(locales_src_dir_path, locales_dest_path)
++  # Files are copied, but we need to inform g_archive_inputs about that
++  for root, dirs, files in os.walk(locales_dest_path):
++    for name in files:
++        rel_dir = os.path.relpath(root, locales_dest_path)
++        rel_file = os.path.join(rel_dir, name)
++        candidate = os.path.join('.', 'resources', 'brave_rewards' '_locales', rel_file)
++        g_archive_inputs.append(candidate)
  
  def CopySectionFilesToStagingDir(config, section, staging_dir, src_dir):
    """Copies installer archive files specified in section from src_dir to
-@@ -557,6 +584,9 @@ def main(options):
+@@ -557,6 +611,9 @@ def main(options):
      version_numbers = prev_version.split('.')
      prev_build_number = version_numbers[2] + '.' + version_numbers[3]
  


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1424

I'd like to eventually find a better way to do this, but this is already done for the brave-extension so I think it's fine.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source