### PR TITLE
Notify NativeTheme has changed when Theme changes

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -5,9 +5,25 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
+#include "ui/native_theme/native_theme.h"
+#include "ui/native_theme/native_theme_dark_aura.h"
 
 void BraveBrowserView::SetStarredState(bool is_starred) {
   BookmarkButton* button = ((BraveToolbarView *)toolbar())->bookmark_button();
   if (button)
     button->SetToggled(is_starred);
+}
+
+void BraveBrowserView::OnThemeChanged() {
+  // When the theme changes, the native theme may also change (the usage
+  // of dark or normal hinges on the browser theme), so we have to
+  // propagate both kinds of change.
+  // First, make sure we do not propagate ThemeChanged to all children again in
+  // response to the native theme change.
+  base::AutoReset<bool> reset(&handling_theme_changed_, true);
+  // Notify dark (cross-platform) and light (platform-specific) variants
+  ui::NativeThemeDarkAura::instance()->NotifyObservers();
+  ui::NativeTheme::GetInstanceForNativeUi()->NotifyObservers();
+
+  views::View::OnThemeChanged();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -11,6 +11,7 @@ class BraveBrowserView : public BrowserView {
   public:
     using BrowserView::BrowserView;
     void SetStarredState(bool is_starred) override;
+    void OnThemeChanged() override;
   private:
     DISALLOW_COPY_AND_ASSIGN(BraveBrowserView);
 };

--- a/patches/chrome-browser-ui-views-frame-browser_view.h.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_view.h.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/frame/browser_view.h b/chrome/browser/ui/views/frame/browser_view.h
+index 650d237250166dff5e39bca334d688da5c9817d6..00d67f80e65189c9eda3fea412bca5a6f49c58cb 100644
+--- a/chrome/browser/ui/views/frame/browser_view.h
++++ b/chrome/browser/ui/views/frame/browser_view.h
+@@ -102,6 +102,7 @@ class BrowserView : public BrowserWindow,
+                     public extensions::ExtensionKeybindingRegistry::Delegate,
+                     public ImmersiveModeController::Observer {
+  public:
++  friend class BraveBrowserView;
+   // The browser view's class name.
+   static const char kViewClassName[];
+ 


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1273

Chromium does this only for Private windows, we change that here to do it for all windows since the native theme can be changed via user preference.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
On https://github.com/brave/brave-browser/issues/1273

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source