### PR TITLE
Remove cookie notification from url bar

### DIFF
--- a/browser/ui/content_settings/brave_content_setting_image_models.cc
+++ b/browser/ui/content_settings/brave_content_setting_image_models.cc
@@ -9,6 +9,16 @@
 
 void BraveGenerateContentSettingImageModels(
     std::vector<std::unique_ptr<ContentSettingImageModel>>& result) {
+  // Remove the cookies content setting image model
+  // https://github.com/brave/brave-browser/issues/1197
+  for (size_t i = 0; i < result.size(); i++) {
+    if (result[i]->image_type() ==
+        ContentSettingImageModel::ImageType::COOKIES) {
+      result.erase(result.begin() + i);
+      break;
+    }
+  }
+
   result.push_back(std::make_unique<BraveWidevineBlockedImageModel>(
       BraveWidevineBlockedImageModel::ImageType::PLUGINS,
       CONTENT_SETTINGS_TYPE_PLUGINS));


### PR DESCRIPTION
Remove the cookies content settings image model so that a `ContentSettingImageView` is never created for cookies.

Fixes https://github.com/brave/brave-browser/issues/1197



- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone




- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source