### PR TITLE
Disable Brave Rewards button in Guest, Tor, and incognito profiles.

### DIFF
--- a/browser/extensions/brave_extension_service.cc
+++ b/browser/extensions/brave_extension_service.cc
@@ -3,7 +3,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/extensions/brave_extension_service.h"
+#include "brave/common/extensions/extension_constants.h"
 #include "chrome/browser/extensions/api/content_settings/content_settings_service.h"
+#include "chrome/browser/extensions/extension_action.h"
+#include "chrome/browser/extensions/extension_action_manager.h"
 #include "chrome/browser/profiles/profile.h"
 
 namespace extensions {
@@ -25,6 +28,22 @@ BraveExtensionService::~BraveExtensionService() {
 
 void BraveExtensionService::AddComponentExtension(const Extension* extension) {
   ExtensionService::AddComponentExtension(extension);
+
+  // Disable Brave Rewards extension action for Guest and Tor profiles on all
+  // tabs right after loading the extension for these profiles. Can't do the
+  // same for the regular off the record (incognito) profile as there doesn't
+  // appear to be a separate from the regular profile action manager for it, so
+  // disabling it would apply to the regular profile as well. Instead, catch
+  // the extension when BraveActionViewController is queried about the
+  // visibility of the action.
+  if ((extension->id() == brave_rewards_extension_id) &&
+      (profile_->IsGuestSession() || profile_->IsTorProfile())) {
+    extensions::ExtensionActionManager* extension_action_manager =
+        ExtensionActionManager::Get(profile_);
+    ExtensionAction* action =
+        extension_action_manager->GetExtensionAction(*extension);
+    action->SetIsVisible(ExtensionAction::kDefaultTabId, false);
+  }
 
   // ContentSettingsStore::RegisterExtension is only called for default components
   // on the first run with a fresh profile. All restarts of the browser after that do not call it.

--- a/browser/ui/brave_actions/brave_action_view_controller.cc
+++ b/browser/ui/brave_actions/brave_action_view_controller.cc
@@ -5,9 +5,12 @@
 #include "brave/browser/ui/brave_actions/brave_action_view_controller.h"
 
 #include "brave/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.h"
+#include "brave/common/extensions/extension_constants.h"
 #include "chrome/browser/extensions/extension_action.h"
-#include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/sessions/session_tab_helper.h"
+#include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/ui/browser.h"
 #include "components/vector_icons/vector_icons.h"
 #include "ui/base/theme_provider.h"
 #include "ui/gfx/canvas.h"
@@ -15,6 +18,15 @@
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/paint_vector_icon.h"
 #include "ui/gfx/scoped_canvas.h"
+
+bool BraveActionViewController::IsEnabled(
+    content::WebContents* web_contents) const {
+  bool is_enabled = ExtensionActionViewController::IsEnabled(web_contents);
+  if (is_enabled && extension_->id() == brave_rewards_extension_id &&
+      browser_->profile()->IsOffTheRecord())
+    is_enabled = false;
+  return is_enabled;
+}
 
 void BraveActionViewController::HideActivePopup() {
   // Usually, for an extension this should call the main extensions
@@ -59,8 +71,7 @@ std::unique_ptr<BraveActionIconWithBadgeImageSource> BraveActionViewController::
   // state
   // If the extension doesn't want to run on the active web contents, we
   // grayscale it to indicate that.
-  bool is_enabled_for_tab = extension_action()->GetIsVisible(tab_id);
-  image_source->set_grayscale(!is_enabled_for_tab);
+  image_source->set_grayscale(!IsEnabled(web_contents));
   image_source->set_paint_page_action_decoration(false);
   return image_source;
 }

--- a/browser/ui/brave_actions/brave_action_view_controller.h
+++ b/browser/ui/brave_actions/brave_action_view_controller.h
@@ -21,6 +21,7 @@ namespace ui {
 class BraveActionViewController : public ExtensionActionViewController {
   public:
     using ExtensionActionViewController::ExtensionActionViewController;
+    bool IsEnabled(content::WebContents* web_contents) const override;
     void HideActivePopup() override;
     gfx::Image GetIcon(content::WebContents* web_contents, const gfx::Size& size) override;
     bool DisabledClickOpensMenu() const override;


### PR DESCRIPTION
Fixes brave/brave-browser#1484

For Guest and Tor, the action is disabled in BraveExtensionService by setting action visibility to false for all tabs of those profiles.
For incognito profile, setting action visibility to false for all tabs also applies to the regular profile, so instead the action is disabled in BraveActionViewController when it is queried for the action visibility.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Verify that the Rewards button is enabled in regular profile:
* Start browser with a regular profile, verify that the button is not disabled and is clickable.

2. Verify that the Rewards button is disabled in Incognito profile:
* Start browser with a regular profile,
* From the menu select "New incognito window",
* In the incognito window verify that the button is grayed out and is not clickable,
* In the incognito window add a new tab, verify that the button is grayed out and is not clickable.

3. Verify that the Rewards button is disable in Guest profile:
* Start browser with a regular profile,
* From the User menu select "Open Guest window",
* In the Guest window verify that the button is grayed out and is not clickable,
* In the Guest window add a new tab, verify that the button is grayed out and is not clickable.

4. Verify that the Rewards button is disable in Tor profile:
* Start browser with a regular profile,
* From the User menu select "Open Tor window",
* In the Tor window verify that the button is grayed out and is not clickable,
* In the Tor window add a new tab, verify that the button is grayed out and is not clickable,

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source