### PR TITLE
Don't process HTTPSE when adblock and TP already sets URL

### DIFF
--- a/browser/net/brave_httpse_network_delegate_helper.cc
+++ b/browser/net/brave_httpse_network_delegate_helper.cc
@@ -54,6 +54,11 @@ int OnBeforeURLRequest_HttpsePreFileWork(
   std::shared_ptr<BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
+  // Don't try to overwrite an already set URL by another delegate (adblock/tp)
+  if (!ctx->new_url_spec.empty()) {
+    return net::OK;
+  }
+
   GURL tab_origin = request->site_for_cookies().GetOrigin();
   bool allow_brave_shields = brave_shields::IsAllowContentSettingFromIO(
       request, tab_origin, tab_origin, CONTENT_SETTINGS_TYPE_PLUGINS,
@@ -95,7 +100,8 @@ int OnBeforeURLRequest_HttpsePreFileWork(
     } else {
       if (!ctx->new_url_spec.empty()) {
         *new_url = GURL(ctx->new_url_spec);
-        brave_shields::DispatchBlockedEventFromIO(request, "httpsEverywhere");
+        brave_shields::DispatchBlockedEventFromIO(request,
+            brave_shields::kHTTPUpgradableResources);
       }
     }
   }

--- a/browser/net/brave_httpse_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_httpse_network_delegate_helper_unittest.cc
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/brave_httpse_network_delegate_helper.h"
+
+#include "brave/browser/net/url_context.h"
+#include "brave/common/network_constants.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
+#include "net/url_request/url_request_test_util.h"
+
+namespace {
+
+class BraveHTTPSENetworkDelegateHelperTest: public testing::Test {
+ public:
+  BraveHTTPSENetworkDelegateHelperTest()
+      : thread_bundle_(content::TestBrowserThreadBundle::IO_MAINLOOP),
+        context_(new net::TestURLRequestContext(true)) {
+  }
+  ~BraveHTTPSENetworkDelegateHelperTest() override {}
+  void SetUp() override {
+    context_->Init();
+  }
+  net::TestURLRequestContext* context() { return context_.get(); }
+
+ private:
+  content::TestBrowserThreadBundle thread_bundle_;
+  std::unique_ptr<net::TestURLRequestContext> context_;
+};
+
+
+TEST_F(BraveHTTPSENetworkDelegateHelperTest, AlreadySetNewURLNoOp) {
+  net::TestDelegate test_delegate;
+  GURL url("http://bradhatesprimes.brave.com/composite_numbers_ftw");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                               TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
+  request->set_site_for_cookies(
+      GURL("http://brad.brave.com/hide_all_primes_in_ui/composites_forever"));
+  brave_request_info->new_url_spec = "data:image/png;base64,iVB";
+  brave::ResponseCallback callback;
+  GURL new_url;
+  int ret =
+    OnBeforeURLRequest_HttpsePreFileWork(request.get(), &new_url, callback,
+        brave_request_info);
+  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_EQ(ret, net::OK);
+}
+
+}  // namespace

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -37,6 +37,7 @@ test("brave_unit_tests") {
     "//brave/browser/tor/mock_tor_profile_service_factory.h",
     "//brave/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc",
+    "//brave/browser/net/brave_httpse_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_referrals_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1525

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source