### PR TITLE
Disable flash in Tor

### DIFF
--- a/browser/ui/content_settings/brave_content_setting_bubble_model.cc
+++ b/browser/ui/content_settings/brave_content_setting_bubble_model.cc
@@ -7,6 +7,7 @@
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/plugins/plugin_utils.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/subresource_filter/chrome_subresource_filter_client.h"
 #include "chrome/browser/ui/content_settings/content_setting_bubble_model_delegate.h"
 #include "chrome/grit/generated_resources.h"
@@ -25,15 +26,24 @@ BraveContentSettingPluginBubbleModel::BraveContentSettingPluginBubbleModel(
   GURL url = web_contents->GetURL();
   std::unique_ptr<base::Value> value =
       map->GetWebsiteSetting(url, url, content_type(), std::string(), &info);
+
+  set_show_learn_more(true);
+
+  // Do not show "Run flash this time" and "Manage" button in Tor profile.
+  if (profile->IsTorProfile()) {
+    set_manage_text_style(ContentSettingBubbleModel::ManageTextStyle::kNone);
+    return;
+  }
+
   // If the setting is not managed by the user, hide the "Manage" button.
   if (info.source != content_settings::SETTING_SOURCE_USER)
     set_manage_text_style(ContentSettingBubbleModel::ManageTextStyle::kNone);
+
   set_custom_link(l10n_util::GetStringUTF16(IDS_BLOCKED_PLUGINS_LOAD_ALL));
   set_custom_link_enabled(
       web_contents &&
       TabSpecificContentSettings::FromWebContents(web_contents)
           ->load_plugins_link_enabled());
-  set_show_learn_more(true);
 }
 
 void BraveContentSettingPluginBubbleModel::OnLearnMoreClicked() {

--- a/chromium_src/chrome/browser/ui/page_info/page_info.cc
+++ b/chromium_src/chrome/browser/ui/page_info/page_info.cc
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "content/public/browser/web_contents.h"
+#include "chrome/browser/ui/page_info/page_info_ui.h"
+#include "chrome/browser/profiles/profile.h"
+
+namespace {
+
+bool BraveShouldShowPermission(
+    const PageInfoUI::PermissionInfo& info,
+    content::WebContents* web_contents) {
+  if ((info.type == CONTENT_SETTINGS_TYPE_PLUGINS ||
+        info.type == CONTENT_SETTINGS_TYPE_GEOLOCATION) &&
+      Profile::FromBrowserContext(web_contents->GetBrowserContext())->IsTorProfile()) {
+    return false;
+  }
+
+  return true;
+}
+
+}
+
+#include "../../../../../../chrome/browser/ui/page_info/page_info.cc"

--- a/patches/chrome-browser-ui-page_info-page_info.cc.patch
+++ b/patches/chrome-browser-ui-page_info-page_info.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/browser/ui/page_info/page_info.cc b/chrome/browser/ui/page_info/page_info.cc
-index e7e7c5d1c2c0699f8892d4be90281c2bb7c7d1b9..1a6713c6604bab2f05d4d2de89a83f488e6be089 100644
+index e7e7c5d1c2c0699f8892d4be90281c2bb7c7d1b9..91c46da0bddfcf3ea3e2b4bc587a26138d79a3c3 100644
 --- a/chrome/browser/ui/page_info/page_info.cc
 +++ b/chrome/browser/ui/page_info/page_info.cc
-@@ -197,7 +197,7 @@ bool ShouldShowPermission(
+@@ -152,6 +152,7 @@ bool ShouldShowPermission(
+     HostContentSettingsMap* content_settings,
+     content::WebContents* web_contents,
+     TabSpecificContentSettings* tab_specific_content_settings) {
++  if (!BraveShouldShowPermission(info, web_contents)) return false;
+   // Note |CONTENT_SETTINGS_TYPE_ADS| will show up regardless of its default
+   // value when it has been activated on the current origin.
+   if (info.type == CONTENT_SETTINGS_TYPE_ADS) {
+@@ -197,7 +198,7 @@ bool ShouldShowPermission(
    }
  #endif
  
@@ -11,7 +19,7 @@ index e7e7c5d1c2c0699f8892d4be90281c2bb7c7d1b9..1a6713c6604bab2f05d4d2de89a83f48
    // Autoplay is Android-only at the moment.
    if (info.type == CONTENT_SETTINGS_TYPE_AUTOPLAY)
      return false;
-@@ -1001,7 +1001,7 @@ void PageInfo::PresentSiteIdentity() {
+@@ -1001,7 +1002,7 @@ void PageInfo::PresentSiteIdentity() {
  std::vector<ContentSettingsType> PageInfo::GetAllPermissionsForTesting() {
    std::vector<ContentSettingsType> permission_list;
    for (size_t i = 0; i < arraysize(kPermissionType); ++i) {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1078
Flash is blocked by default right now, with this PR, users won't be able to enable it through content settings bubble or page info in Tor profile, so the settings should always stay blocked.
BTW, changing flash permissions in the normal profile won't be propagated to Tor profile either.
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Open a new Tor window
2. Visit http://homestarrunner.com/main1.html
3. Click the plugin blocked bubble, there should be no "Run flash this time" and "Manage" button
<img width="1154" alt="screen shot 2018-10-12 at 1 42 33 pm" src="https://user-images.githubusercontent.com/4730197/46893155-e3281700-ce24-11e8-9e3c-c20561b8e645.png">
4. Click the page info, there should be no flash entry to change permission.
<img width="1156" alt="screen shot 2018-10-12 at 1 44 43 pm" src="https://user-images.githubusercontent.com/4730197/46893205-0357d600-ce25-11e8-9abb-e4257fbab57e.png">

5. Click on the flash element won't have any effect
6. Right click on the flash element, should not be able to click "Run this plugin"
<img width="285" alt="screen shot 2018-10-12 at 1 53 05 pm" src="https://user-images.githubusercontent.com/4730197/46893590-4bc3c380-ce26-11e8-8407-a0705d0e2549.png">

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source