### PR TITLE
Use BraveAutocompleteSchemeClassifier in Omnibox

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -30,6 +30,8 @@ source_set("ui") {
     "content_settings/brave_widevine_blocked_image_model.h",
     "content_settings/brave_widevine_content_setting_bubble_model.cc",
     "content_settings/brave_widevine_content_setting_bubble_model.h",
+    "omnibox/brave_omnibox_client.cc",
+    "omnibox/brave_omnibox_client.h",
     "toolbar/brave_app_menu_model.cc",
     "toolbar/brave_app_menu_model.h",
     "toolbar/brave_toolbar_actions_model.cc",

--- a/browser/ui/omnibox/brave_omnibox_client.cc
+++ b/browser/ui/omnibox/brave_omnibox_client.cc
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/omnibox/brave_omnibox_client.h"
+
+#include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/omnibox/chrome_omnibox_client.h"
+#include "chrome/browser/ui/omnibox/chrome_omnibox_edit_controller.h"
+
+BraveOmniboxClient::BraveOmniboxClient(OmniboxEditController* controller,
+                                                        Profile* profile)
+      : ChromeOmniboxClient(controller, profile),
+        scheme_classifier_(profile) {}
+
+BraveOmniboxClient::~BraveOmniboxClient() {}
+
+const AutocompleteSchemeClassifier&
+                          BraveOmniboxClient::GetSchemeClassifier() const {
+  return scheme_classifier_;
+}

--- a/browser/ui/omnibox/brave_omnibox_client.h
+++ b/browser/ui/omnibox/brave_omnibox_client.h
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_OMNIBOX_BRAVE_OMNIBOX_CLIENT_H_
+#define BRAVE_BROWSER_UI_OMNIBOX_BRAVE_OMNIBOX_CLIENT_H_
+
+#include "chrome/browser/ui/omnibox/chrome_omnibox_client.h"
+#include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
+
+class OmniboxEditController;
+class Profile;
+
+class BraveOmniboxClient : public ChromeOmniboxClient {
+  public:
+    BraveOmniboxClient(OmniboxEditController* controller,
+                                         Profile* profile);
+    ~BraveOmniboxClient() override;
+    const AutocompleteSchemeClassifier& GetSchemeClassifier() const override;
+
+  private:
+    DISALLOW_COPY_AND_ASSIGN(BraveOmniboxClient);
+    BraveAutocompleteSchemeClassifier scheme_classifier_;
+};
+
+#endif

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -1,0 +1,5 @@
+#include "brave/browser/ui/omnibox/brave_omnibox_client.h"
+
+#define ChromeOmniboxClient BraveOmniboxClient
+#include "../../../../../../../chrome/browser/ui/views/location_bar/location_bar_view.cc"
+#undef ChromeOmniboxClient


### PR DESCRIPTION
Omnibox then detects brave://xyz as URL instead of defaulting to search query.
Fix https://github.com/brave/brave-browser/issues/1560

Note that this was requested to be put in 0.55 if ready in time, along with https://github.com/brave/brave-core/pull/584

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
On https://github.com/brave/brave-browser/issues/1560

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source