### PR TITLE
Remove border radius from brave extension popup windows

### DIFF
--- a/patches/chrome-browser-ui-views-extensions-extension_popup.cc.patch
+++ b/patches/chrome-browser-ui-views-extensions-extension_popup.cc.patch
@@ -1,0 +1,38 @@
+diff --git a/chrome/browser/ui/views/extensions/extension_popup.cc b/chrome/browser/ui/views/extensions/extension_popup.cc
+index 4ee33a9f9b77b55f1d5848d06c25dd2ae6e31c2e..343f00bbb94c7e53ee08a9d9e55718f8476b7484 100644
+--- a/chrome/browser/ui/views/extensions/extension_popup.cc
++++ b/chrome/browser/ui/views/extensions/extension_popup.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "chrome/browser/ui/views/extensions/extension_popup.h"
+ 
++#include "brave/common/extensions/extension_constants.h"
+ #include "chrome/browser/chrome_notification_types.h"
+ #include "chrome/browser/devtools/devtools_window.h"
+ #include "chrome/browser/extensions/extension_view_host.h"
+@@ -142,8 +143,23 @@ gfx::Size ExtensionPopup::CalculatePreferredSize() const {
+ }
+ 
+ void ExtensionPopup::AddedToWidget() {
+-  const int radius =
+-      GetBubbleFrameView()->bubble_border()->GetBorderCornerRadius();
++
++  // HACK: removes border radius for brave extensions
++  //        as webview does not support radius clipping which results
++  //        in white strips at top and bottom of popup.
++  // TODO: add brave extension radius back in when macOS and Windows
++  //        popups support web dialog window radius clipping.
++
++  bool shouldDisableRadiusForPopup = false;
++  // Clipping issue is not present on linux
++#if defined(OS_MACOSX) || defined(OS_WIN)
++  const auto extensionId = host_->extension()->id();
++  const bool isBraveExtension = (extensionId == brave_extension_id ||
++      extensionId == brave_rewards_extension_id);
++  shouldDisableRadiusForPopup = isBraveExtension;
++#endif
++  const int radius = shouldDisableRadiusForPopup ? 0
++      : GetBubbleFrameView()->bubble_border()->GetBorderCornerRadius();
+   const bool contents_has_rounded_corners =
+       GetExtensionView()->holder()->SetCornerRadius(radius);
+   SetBorder(views::CreateEmptyBorder(


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1028

This is unfortunate in two ways:
1. It's an ugly patch. ExtensionPopup is both instantiated on its own (macOS) and as a parent class of ExtensionPopupAura. I believe attempting to create a BraveExtensionPopup that both replaces ExtensionPopup and the parent class of ExtensionPopupAura would lead to a larger web of patches, but happy to be shown otherwise.
2. It fixes the issue of the white strips by removing the border radius entirely. The much preferred option is to support the native window radius clipping the webview, but chromium does not yet support this.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- Ensure that Rewards and Shields popups have no white strip top and bottom (and no border radius except on Linux, which supports the webview clipping)
- Ensure that non-Brave extensions do still have border radius

![image](https://user-images.githubusercontent.com/741836/46899823-6bbaad80-ce4d-11e8-8831-3878af85ba0c.png)

![image](https://user-images.githubusercontent.com/741836/46899825-6fe6cb00-ce4d-11e8-8734-fe05611a29c2.png)


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source