### PR TITLE
Fix location bar layout isn't triggered by page action icon change

### DIFF
--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -101,6 +101,8 @@ void BraveLocationBarView::OnThemeChanged() {
 }
 
 void BraveLocationBarView::ChildPreferredSizeChanged(views::View* child) {
+  LocationBarView::ChildPreferredSizeChanged(child);
+
   if (child != brave_actions_)
     return;
 


### PR DESCRIPTION
When page action icon is changed, location bar layout should be done.
This is regression of recent change of
BraveLocationBarView::ChildPreferredSizeChanged(). It should call
base class base method call.

Fixes https://github.com/brave/brave-browser/issues/1561

I missed this when I reviewed https://github.com/brave/brave-core/pull/587.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Make omnibox unfocused
2. Click omnibox
3. Check findbar icon is overlapped or not

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source