### PR TITLE
Fix crash on empty URL adblock / TP checks

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -49,6 +49,23 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, NoChangeURL) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, EmptyRequestURL) {
+  net::TestDelegate test_delegate;
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(GURL(), net::IDLE, &test_delegate,
+                               TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      brave_request_info(new brave::BraveRequestInfo());
+  brave::ResponseCallback callback;
+  GURL new_url;
+  int ret =
+    OnBeforeURLRequest_AdBlockTPWork(request.get(), &new_url, callback,
+        brave_request_info);
+  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_EQ(ret, net::OK);
+}
+
+
 TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, RedirectsToEmptyDataURLs) {
   std::vector<GURL> urls({
     GURL("https://sp1.nypost.com"),


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/762

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source