### PR TITLE
Remove unused pref for Google sign-in

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -66,6 +66,10 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   // Make sync managed to dsiable some UI after password saving.
   registry->SetDefaultPrefValue(syncer::prefs::kSyncManaged, base::Value(true));
+
+  // Make sure sign into Brave is not enabled
+  // The older kSigninAllowed is deprecated and only in use in Android until C71.
+  registry->SetDefaultPrefValue(prefs::kSigninAllowedOnNextStartup, base::Value(false));
 }
 
 }  // namespace brave

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -44,5 +44,6 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DisableGoogleServicesByDefa
   EXPECT_EQ(
       browser()->profile()->GetPrefs()->GetInteger(prefs::kNetworkPredictionOptions),
       chrome_browser_net::NETWORK_PREDICTION_NEVER);
-
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kSigninAllowedOnNextStartup));
 }

--- a/patches/chrome-browser-resources-settings-privacy_page-privacy_page.html.patch
+++ b/patches/chrome-browser-resources-settings-privacy_page-privacy_page.html.patch
@@ -1,8 +1,23 @@
 diff --git a/chrome/browser/resources/settings/privacy_page/privacy_page.html b/chrome/browser/resources/settings/privacy_page/privacy_page.html
-index 5342af963014ded14e36c4a42764cc0d1008cec3..55fcaf1a38356caae45569804ef3ccfff9037ab9 100644
+index 5342af963014ded14e36c4a42764cc0d1008cec3..c7ad9addc332a18198c263622e5e8af8fb84b512 100644
 --- a/chrome/browser/resources/settings/privacy_page/privacy_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/privacy_page.html
-@@ -217,6 +217,7 @@
+@@ -90,12 +90,14 @@
+           </div>
+         </template>
+ <if expr="not chromeos">
++<!--
+         <settings-toggle-button id="signinAllowedToggle"
+             pref="{{prefs.signin.allowed_on_next_startup}}"
+             label="$i18n{signinAllowedTitle}"
+             sub-label="$i18n{signinAllowedDescription}"
+             on-settings-boolean-control-change="onSigninAllowedChange_">
+         </settings-toggle-button>
++-->
+ </if><!-- not chromeos -->
+         <template is="dom-if" if="[[!unifiedConsentEnabled_]]">
+           <settings-personalization-options prefs="{{prefs}}"
+@@ -217,6 +219,7 @@
            </category-setting-exceptions>
          </settings-subpage>
        </template>
@@ -10,7 +25,7 @@ index 5342af963014ded14e36c4a42764cc0d1008cec3..55fcaf1a38356caae45569804ef3ccff
        <template is="dom-if" route-path="/content/backgroundSync" no-search>
          <settings-subpage page-title="$i18n{siteSettingsBackgroundSync}">
            <category-default-setting
-@@ -231,6 +232,7 @@
+@@ -231,6 +234,7 @@
            </category-setting-exceptions>
          </settings-subpage>
        </template>
@@ -18,7 +33,7 @@ index 5342af963014ded14e36c4a42764cc0d1008cec3..55fcaf1a38356caae45569804ef3ccff
        <template is="dom-if" route-path="/content/camera" no-search>
          <settings-subpage page-title="$i18n{siteSettingsCategoryCamera}">
            <media-picker label="$i18n{siteSettingsCameraLabel}" type="camera">
-@@ -253,11 +255,13 @@
+@@ -253,11 +257,13 @@
                toggle-on-label="$i18n{siteSettingsCookiesAllowedRecommended}"
                sub-option-label="$i18n{deleteDataPostSession}">
            </category-default-setting>
@@ -32,7 +47,7 @@ index 5342af963014ded14e36c4a42764cc0d1008cec3..55fcaf1a38356caae45569804ef3ccff
            <div id="site-data-trigger" class="settings-box" actionable
                on-click="onSiteDataTap_">
               <div class="start" id="cookiesLink">
-@@ -327,11 +331,13 @@
+@@ -327,11 +333,13 @@
        </template>
        <template is="dom-if" route-path="/content/javascript" no-search>
          <settings-subpage page-title="$i18n{siteSettingsCategoryJavascript}">
@@ -46,7 +61,7 @@ index 5342af963014ded14e36c4a42764cc0d1008cec3..55fcaf1a38356caae45569804ef3ccff
            <category-setting-exceptions
                category="{{ContentSettingsTypes.JAVASCRIPT}}"
                block-header="$i18n{siteSettingsBlock}">
-@@ -406,6 +412,19 @@
+@@ -406,6 +414,19 @@
            </category-setting-exceptions>
          </settings-subpage>
        </template>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1516

Fix is also tested with: chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Launch Brave and open Settings
2. Search (in the top of settings) for `sign-in` or `Allow`
3. No results should show `Allow Brave sign-in`

## Automated test plan
`npm run test -- brave_browser_tests --filter=BraveProfilePrefsBrowserTest.DisableGoogleServicesByDefault`


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source