### PR TITLE
Refactor network delegate helpers to not have access to the request

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.h
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.h
@@ -7,16 +7,9 @@
 
 #include "brave/browser/net/url_context.h"
 
-struct BraveRequestInfo;
-
-namespace net {
-class URLRequest;
-}
-
 namespace brave {
 
-int OnBeforeURLRequest_AdBlockTPWork(
-    net::URLRequest* request,
+int OnBeforeURLRequest_AdBlockTPPreWork(
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -43,7 +43,7 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, NoChangeURL) {
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
-    OnBeforeURLRequest_AdBlockTPWork(request.get(), &new_url, callback,
+    OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
         brave_request_info);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);
@@ -59,7 +59,7 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, EmptyRequestURL) {
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
-    OnBeforeURLRequest_AdBlockTPWork(request.get(), &new_url, callback,
+    OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
         brave_request_info);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);
@@ -82,7 +82,7 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, RedirectsToEmptyDataURLs) {
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
-      OnBeforeURLRequest_AdBlockTPWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
           brave_request_info);
     EXPECT_EQ(ret, net::OK);
     EXPECT_STREQ(new_url.spec().c_str(), kEmptyDataURI);
@@ -105,7 +105,7 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, RedirectsToStubs) {
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
-      OnBeforeURLRequest_AdBlockTPWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
           brave_request_info);
     EXPECT_EQ(ret, net::OK);
     EXPECT_TRUE(new_url.SchemeIs("data"));
@@ -128,7 +128,7 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, Blocking) {
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
-      OnBeforeURLRequest_AdBlockTPWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
           brave_request_info);
     EXPECT_STREQ(new_url.spec().c_str(), kEmptyDataURI);
     EXPECT_EQ(ret, net::OK);

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -40,11 +40,13 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, NoChangeURL) {
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
-    OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
+    OnBeforeURLRequest_AdBlockTPPreWork(&new_url, callback,
         brave_request_info);
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);
 }
@@ -56,11 +58,13 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, EmptyRequestURL) {
                                TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
-    OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
+    OnBeforeURLRequest_AdBlockTPPreWork(&new_url, callback,
         brave_request_info);
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);
 }
@@ -79,11 +83,13 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, RedirectsToEmptyDataURLs) {
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
-      OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_AdBlockTPPreWork(&new_url, callback,
           brave_request_info);
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     EXPECT_EQ(ret, net::OK);
     EXPECT_STREQ(new_url.spec().c_str(), kEmptyDataURI);
   });
@@ -102,11 +108,13 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, RedirectsToStubs) {
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
-      OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_AdBlockTPPreWork(&new_url, callback,
           brave_request_info);
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     EXPECT_EQ(ret, net::OK);
     EXPECT_TRUE(new_url.SchemeIs("data"));
   });
@@ -125,11 +133,13 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, Blocking) {
                                  TRAFFIC_ANNOTATION_FOR_TESTS);
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
     GURL new_url;
     int ret =
-      OnBeforeURLRequest_AdBlockTPPreWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_AdBlockTPPreWork(&new_url, callback,
           brave_request_info);
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     EXPECT_STREQ(new_url.spec().c_str(), kEmptyDataURI);
     EXPECT_EQ(ret, net::OK);
   });

--- a/browser/net/brave_common_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper.cc
@@ -8,8 +8,6 @@
 #include "components/component_updater/component_updater_url_constants.h"
 #include "extensions/common/extension_urls.h"
 #include "extensions/common/url_pattern.h"
-#include "net/url_request/url_request.h"
-
 
 namespace brave {
 
@@ -29,13 +27,12 @@ bool IsUpdaterURL(const GURL& gurl) {
 }
 
 int OnBeforeURLRequest_CommonStaticRedirectWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
   GURL::Replacements replacements;
-  if (IsUpdaterURL(request->url())) {
-    replacements.SetQueryStr(request->url().query_piece());
+  if (IsUpdaterURL(ctx->request_url)) {
+    replacements.SetQueryStr(ctx->request_url.query_piece());
     *new_url = GURL(kBraveUpdatesExtensionsEndpoint).ReplaceComponents(replacements);
     return net::OK;
   }

--- a/browser/net/brave_common_static_redirect_network_delegate_helper.h
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper.h
@@ -5,19 +5,11 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_COMMON_STATIC_REDIRECT_NETWORK_DELEGATE_H_
 #define BRAVE_BROWSER_NET_BRAVE_COMMON_STATIC_REDIRECT_NETWORK_DELEGATE_H_
 
-#include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
-
-struct BraveRequestInfo;
-
-namespace net {
-class URLRequest;
-}
 
 namespace brave {
 
 int OnBeforeURLRequest_CommonStaticRedirectWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
@@ -42,11 +42,12 @@ TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, ModifyComponentUpdate
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
   GURL new_url;
   GURL expected_url(std::string(kBraveUpdatesExtensionsEndpoint + query_string));
   int ret =
-      OnBeforeURLRequest_CommonStaticRedirectWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_CommonStaticRedirectWork(&new_url, callback,
                                                   before_url_context);
   EXPECT_EQ(new_url, expected_url);
   EXPECT_EQ(ret, net::OK);
@@ -61,11 +62,12 @@ TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, NoModifyComponentUpda
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
   GURL new_url;
   GURL expected_url;
   int ret =
-      OnBeforeURLRequest_CommonStaticRedirectWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_CommonStaticRedirectWork(&new_url, callback,
                                                   before_url_context);
   EXPECT_EQ(new_url, expected_url);
   EXPECT_EQ(ret, net::OK);

--- a/browser/net/brave_httpse_network_delegate_helper.h
+++ b/browser/net/brave_httpse_network_delegate_helper.h
@@ -5,19 +5,11 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_HTTPSE_NETWORK_DELEGATE_H_
 #define BRAVE_BROWSER_NET_BRAVE_HTTPSE_NETWORK_DELEGATE_H_
 
-#include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
-
-struct BraveRequestInfo;
-
-namespace net {
-class URLRequest;
-}
 
 namespace brave {
 
 int OnBeforeURLRequest_HttpsePreFileWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_httpse_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_httpse_network_delegate_helper_unittest.cc
@@ -44,7 +44,7 @@ TEST_F(BraveHTTPSENetworkDelegateHelperTest, AlreadySetNewURLNoOp) {
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
-    OnBeforeURLRequest_HttpsePreFileWork(request.get(), &new_url, callback,
+    OnBeforeURLRequest_HttpsePreFileWork(&new_url, callback,
         brave_request_info);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);

--- a/browser/net/brave_profile_network_delegate.cc
+++ b/browser/net/brave_profile_network_delegate.cc
@@ -25,7 +25,7 @@ BraveProfileNetworkDelegate::BraveProfileNetworkDelegate(
   before_url_request_callbacks_.push_back(callback);
 
   callback =
-      base::Bind(brave::OnBeforeURLRequest_AdBlockTPWork);
+      base::Bind(brave::OnBeforeURLRequest_AdBlockTPPreWork);
   before_url_request_callbacks_.push_back(callback);
 
   callback =

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -51,13 +51,12 @@ bool ApplyPotentialReferrerBlock(net::URLRequest* request) {
 namespace brave {
 
 int OnBeforeURLRequest_SiteHacksWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
 
-  if (ApplyPotentialReferrerBlock(request))
-    *new_url = request->url();
+  if (ApplyPotentialReferrerBlock(ctx->request))
+    *new_url = ctx->request_url;
 
   return net::OK;
 }
@@ -96,7 +95,6 @@ int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
       URLPattern(URLPattern::SCHEME_ALL, kForbesPattern), headers,
       kForbesExtraCookies);
   if (IsBlockTwitterSiteHack(request, headers)) {
-    request->Cancel();
     return net::ERR_ABORTED;
   }
   if (IsUAWhitelisted(request->url())) {

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -16,7 +16,6 @@ class URLRequest;
 namespace brave {
 
 int OnBeforeURLRequest_SiteHacksWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -39,8 +39,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithCookieHeader) {
   headers.SetHeader(kCookieHeader, "name=value; name2=value2; name3=value3");
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
       callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -57,8 +58,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithoutCookieHeader) {
   net::HttpRequestHeaders headers;
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
       callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -77,8 +79,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NotForbesNoCookieChange) {
   headers.SetHeader(kCookieHeader, "name=value; name2=value2; name3=value3");
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
       callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -96,8 +99,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoScriptTwitterMobileRedirect) {
   headers.SetHeader(kRefererHeader, "https://twitter.com/");
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
       callback, brave_request_info);
   EXPECT_EQ(ret, net::ERR_ABORTED);
 }
@@ -112,8 +116,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, AllowTwitterMobileRedirectFromDi
   headers.SetHeader(kRefererHeader, "https://brianbondy.com/");
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
       callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
@@ -128,8 +133,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, TwitterNoCancelWithReferer) {
   headers.SetHeader(kRefererHeader, "https://twitter.com/");
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
       callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
@@ -165,8 +171,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, UAWhitelistedTest) {
         "(KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36");
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
-    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
         callback, brave_request_info);
     std::string user_agent;
     headers.GetHeader(kUserAgentHeader, &user_agent);
@@ -195,8 +202,9 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NOTUAWhitelistedTest) {
         "(KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36");
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
-    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
+    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
         callback, brave_request_info);
     std::string user_agent;
     headers.GetHeader(kUserAgentHeader, &user_agent);
@@ -225,6 +233,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerPreserved) {
 
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
     GURL new_url;
     int ret = brave::OnBeforeURLRequest_SiteHacksWork(&new_url,
@@ -254,6 +263,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerCleared) {
 
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
+    brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
     GURL new_url;
     int ret = brave::OnBeforeURLRequest_SiteHacksWork(&new_url,

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -40,7 +40,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithCookieHeader) {
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
       callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -58,7 +58,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithoutCookieHeader) {
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
       callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -78,7 +78,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NotForbesNoCookieChange) {
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
       callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -97,7 +97,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoScriptTwitterMobileRedirect) {
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
       callback, brave_request_info);
   EXPECT_EQ(ret, net::ERR_ABORTED);
 }
@@ -113,7 +113,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, AllowTwitterMobileRedirectFromDi
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
       callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
@@ -129,7 +129,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, TwitterNoCancelWithReferer) {
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
       callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
@@ -166,7 +166,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, UAWhitelistedTest) {
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
-    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
         callback, brave_request_info);
     std::string user_agent;
     headers.GetHeader(kUserAgentHeader, &user_agent);
@@ -196,7 +196,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NOTUAWhitelistedTest) {
     std::shared_ptr<brave::BraveRequestInfo>
         brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
-    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(), &headers,
+    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(&headers,
         callback, brave_request_info);
     std::string user_agent;
     headers.GetHeader(kUserAgentHeader, &user_agent);
@@ -227,7 +227,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerPreserved) {
         brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
     GURL new_url;
-    int ret = brave::OnBeforeURLRequest_SiteHacksWork(request.get(), &new_url,
+    int ret = brave::OnBeforeURLRequest_SiteHacksWork(&new_url,
         callback, brave_request_info);
     EXPECT_EQ(ret, net::OK);
     // new_url should not be set
@@ -256,7 +256,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerCleared) {
         brave_request_info(new brave::BraveRequestInfo());
     brave::ResponseCallback callback;
     GURL new_url;
-    int ret = brave::OnBeforeURLRequest_SiteHacksWork(request.get(), &new_url,
+    int ret = brave::OnBeforeURLRequest_SiteHacksWork(&new_url,
         callback, brave_request_info);
     EXPECT_EQ(ret, net::OK);
     // new_url must be set to trigger an internal redirect

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -6,12 +6,10 @@
 
 #include "brave/common/network_constants.h"
 #include "extensions/common/url_pattern.h"
-#include "net/url_request/url_request.h"
 
 namespace brave {
 
 int OnBeforeURLRequest_StaticRedirectWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
@@ -19,19 +17,19 @@ int OnBeforeURLRequest_StaticRedirectWork(
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS, kSafeBrowsingPrefix);
 
-  if (geo_pattern.MatchesURL(request->url())) {
+  if (geo_pattern.MatchesURL(ctx->request_url)) {
     *new_url = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);
     return net::OK;
   }
 
-  if (safeBrowsing_pattern.MatchesHost(request->url())) {
+  if (safeBrowsing_pattern.MatchesHost(ctx->request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
-    *new_url = request->url().ReplaceComponents(replacements);
+    *new_url = ctx->request_url.ReplaceComponents(replacements);
     return net::OK;
   }
 
 #if !defined(NDEBUG)
-  GURL gurl = request->url();
+  GURL gurl = ctx->request_url;
   static std::vector<URLPattern> allowed_patterns({
     // Brave updates
     URLPattern(URLPattern::SCHEME_HTTPS, "https://go-updater.brave.com/*"),

--- a/browser/net/brave_static_redirect_network_delegate_helper.h
+++ b/browser/net/brave_static_redirect_network_delegate_helper.h
@@ -5,19 +5,13 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_STATIC_REDIRECT_NETWORK_DELEGATE_H_
 #define BRAVE_BROWSER_NET_BRAVE_STATIC_REDIRECT_NETWORK_DELEGATE_H_
 
-#include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
 struct BraveRequestInfo;
 
-namespace net {
-class URLRequest;
-}
-
 namespace brave {
 
 int OnBeforeURLRequest_StaticRedirectWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -33,7 +33,6 @@ class BraveStaticRedirectNetworkDelegateHelperTest: public testing::Test {
   std::unique_ptr<net::TestURLRequestContext> context_;
 };
 
-
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
   net::TestDelegate test_delegate;
   GURL url("https://bradhatesprimes.brave.com/composite_numbers_ftw");
@@ -42,15 +41,15 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
   GURL new_url;
   int ret =
-    OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
+    OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
         before_url_context);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::OK);
 }
-
 
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   net::TestDelegate test_delegate;
@@ -60,11 +59,12 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
   GURL new_url;
   GURL expected_url(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);
   int ret =
-      OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
                                             before_url_context);
   EXPECT_EQ(new_url, expected_url);
   EXPECT_EQ(ret, net::OK);
@@ -78,13 +78,14 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
   GURL new_url;
   GURL::Replacements replacements;
   replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
   GURL expected_url(url.ReplaceComponents(replacements));
   int ret =
-      OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
                                             before_url_context);
   EXPECT_EQ(new_url, expected_url);
   EXPECT_EQ(ret, net::OK);
@@ -98,13 +99,14 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
   GURL new_url;
   GURL::Replacements replacements;
   replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
   GURL expected_url(url.ReplaceComponents(replacements));
   int ret =
-      OnBeforeURLRequest_StaticRedirectWork(request.get(), &new_url, callback,
+      OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
                                             before_url_context);
   EXPECT_EQ(new_url, expected_url);
   EXPECT_EQ(ret, net::OK);

--- a/browser/net/brave_system_network_delegate.h
+++ b/browser/net/brave_system_network_delegate.h
@@ -7,7 +7,6 @@
 
 #include "brave/browser/net/brave_network_delegate_base.h"
 
-
 class BraveSystemNetworkDelegate : public BraveNetworkDelegateBase {
  public:
   BraveSystemNetworkDelegate(extensions::EventRouterForwarder* event_router);

--- a/browser/net/brave_tor_network_delegate_helper.cc
+++ b/browser/net/brave_tor_network_delegate_helper.cc
@@ -18,14 +18,13 @@ using content::ResourceRequestInfo;
 namespace brave {
 
 int OnBeforeURLRequest_TorWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   const ResourceRequestInfo* resource_info =
-    ResourceRequestInfo::ForRequest(request);
+    ResourceRequestInfo::ForRequest(ctx->request);
   if (!resource_info) {
     return net::OK;
   }
@@ -42,15 +41,15 @@ int OnBeforeURLRequest_TorWork(
     return net::OK;
   }
 
-  if (!(request->url().SchemeIsHTTPOrHTTPS() ||
-        request->url().SchemeIs(content::kChromeUIScheme) ||
-        request->url().SchemeIs(extensions::kExtensionScheme) ||
-        request->url().SchemeIs(content::kChromeDevToolsScheme))) {
+  if (!(ctx->request_url.SchemeIsHTTPOrHTTPS() ||
+        ctx->request_url.SchemeIs(content::kChromeUIScheme) ||
+        ctx->request_url.SchemeIs(extensions::kExtensionScheme) ||
+        ctx->request_url.SchemeIs(content::kChromeDevToolsScheme))) {
     return net::ERR_DISALLOWED_URL_SCHEME;
   }
 
-  auto* proxy_service = request->context()->proxy_resolution_service();
-  tor_profile_service->SetProxy(proxy_service, request->url(), false);
+  auto* proxy_service = ctx->request->context()->proxy_resolution_service();
+  tor_profile_service->SetProxy(proxy_service, ctx->request_url, false);
 
   return net::OK;
 }

--- a/browser/net/brave_tor_network_delegate_helper.h
+++ b/browser/net/brave_tor_network_delegate_helper.h
@@ -5,19 +5,13 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_TOR_NETWORK_DELEGATE_H_
 #define BRAVE_BROWSER_NET_BRAVE_TOR_NETWORK_DELEGATE_H_
 
-#include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
 struct BraveRequestInfo;
 
-namespace net {
-class URLRequest;
-}
-
 namespace brave {
 
 int OnBeforeURLRequest_TorWork(
-    net::URLRequest* request,
     GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_tor_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_tor_network_delegate_helper_unittest.cc
@@ -78,6 +78,7 @@ TEST_F(BraveTorNetworkDelegateHelperTest, NotTorProfile) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
@@ -89,7 +90,7 @@ TEST_F(BraveTorNetworkDelegateHelperTest, NotTorProfile) {
     content::PREVIEWS_OFF, std::move(navigation_ui_data));
   GURL new_url;
   int ret =
-    brave::OnBeforeURLRequest_TorWork(request.get(), &new_url, callback,
+    brave::OnBeforeURLRequest_TorWork(&new_url, callback,
                                       before_url_context);
   EXPECT_TRUE(new_url.is_empty());
   auto* proxy_service = request->context()->proxy_resolution_service();
@@ -116,6 +117,7 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfile) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
@@ -131,7 +133,7 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfile) {
                                                    navigation_ui_data_ptr);
   GURL new_url;
   int ret =
-    brave::OnBeforeURLRequest_TorWork(request.get(), &new_url, callback,
+    brave::OnBeforeURLRequest_TorWork(&new_url, callback,
                                       before_url_context);
   EXPECT_TRUE(new_url.is_empty());
   auto* proxy_service = request->context()->proxy_resolution_service();
@@ -162,6 +164,7 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockFile) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
@@ -177,7 +180,7 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockFile) {
                                                    navigation_ui_data_ptr);
   GURL new_url;
   int ret =
-    brave::OnBeforeURLRequest_TorWork(request.get(), &new_url, callback,
+    brave::OnBeforeURLRequest_TorWork(&new_url, callback,
                                       before_url_context);
   EXPECT_TRUE(new_url.is_empty());
   EXPECT_EQ(ret, net::ERR_DISALLOWED_URL_SCHEME);

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -7,6 +7,10 @@
 
 #include <string>
 
+#include "brave/components/brave_shields/browser/brave_shields_util.h"
+#include "brave/components/brave_shields/common/brave_shield_constants.h"
+#include "content/public/browser/resource_request_info.h"
+
 namespace brave {
 
 BraveRequestInfo::BraveRequestInfo() {
@@ -14,5 +18,29 @@ BraveRequestInfo::BraveRequestInfo() {
 
 BraveRequestInfo::~BraveRequestInfo() {
 }
+
+void BraveRequestInfo::FillCTXFromRequest(net::URLRequest* request,
+    std::shared_ptr<brave::BraveRequestInfo> ctx) {
+  ctx->request_identifier = request->identifier();
+  ctx->request_url = request->url();
+  ctx->tab_origin = request->site_for_cookies().GetOrigin();
+  auto* request_info = content::ResourceRequestInfo::ForRequest(request);
+  if (request_info) {
+    ctx->resource_type = request_info->GetResourceType();
+  }
+  brave_shields::GetRenderFrameInfo(request, &ctx->render_process_id, &ctx->render_frame_id,
+      &ctx->frame_tree_node_id);
+  ctx->allow_brave_shields = brave_shields::IsAllowContentSettingFromIO(
+      request, ctx->tab_origin, ctx->tab_origin, CONTENT_SETTINGS_TYPE_PLUGINS,
+      brave_shields::kBraveShields);
+  ctx->allow_ads = brave_shields::IsAllowContentSettingFromIO(
+      request, ctx->tab_origin, ctx->tab_origin, CONTENT_SETTINGS_TYPE_PLUGINS,
+      brave_shields::kAds);
+  ctx->allow_http_upgradable_resource = brave_shields::IsAllowContentSettingFromIO(
+      request, ctx->tab_origin, ctx->tab_origin, CONTENT_SETTINGS_TYPE_PLUGINS,
+      brave_shields::kHTTPUpgradableResources);
+  ctx->request = request;
+}
+
 
 }  // namespace brave

--- a/components/brave_rewards/browser/net/network_delegate_helper.cc
+++ b/components/brave_rewards/browser/net/network_delegate_helper.cc
@@ -123,24 +123,23 @@ void DispatchOnUI(
 }  // namespace
 
 int OnBeforeURLRequest(
-  net::URLRequest* request,
   GURL* new_url,
   const brave::ResponseCallback& next_callback,
   std::shared_ptr<brave::BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
 
-  if (IsMediaLink(request->url(),
-                  request->site_for_cookies(),
-                  GURL(request->referrer()))) {
+  if (IsMediaLink(ctx->request_url,
+                  ctx->request->site_for_cookies(),
+                  GURL(ctx->request->referrer()))) {
     std::string post_data;
-    if (GetPostData(request, &post_data)) {
+    if (GetPostData(ctx->request, &post_data)) {
       int render_process_id, render_frame_id, frame_tree_node_id;
-      GetRenderFrameInfo(request, &render_frame_id, &render_process_id,
+      GetRenderFrameInfo(ctx->request, &render_frame_id, &render_process_id,
           &frame_tree_node_id);
       content::BrowserThread::PostTask(content::BrowserThread::UI, FROM_HERE,
           base::BindOnce(&DispatchOnUI,
               post_data,
-              request->url(), request->site_for_cookies(), request->referrer(),
+              ctx->request_url, ctx->request->site_for_cookies(), ctx->request->referrer(),
               render_process_id, render_frame_id, frame_tree_node_id));
     }
   }

--- a/components/brave_rewards/browser/net/network_delegate_helper.h
+++ b/components/brave_rewards/browser/net/network_delegate_helper.h
@@ -7,16 +7,9 @@
 
 #include "brave/browser/net/url_context.h"
 
-class GURL;
-
-namespace net {
-class URLRequest;
-}
-
 namespace brave_rewards {
 
 int OnBeforeURLRequest(
-    net::URLRequest* request,
     GURL* new_url,
     const brave::ResponseCallback& next_callback,
     std::shared_ptr<brave::BraveRequestInfo> ctx);

--- a/components/brave_shields/browser/base_brave_shields_service.cc
+++ b/components/brave_shields/browser/base_brave_shields_service.cc
@@ -23,7 +23,9 @@ namespace brave_shields {
 BaseBraveShieldsService::BaseBraveShieldsService()
     : initialized_(false),
       task_runner_(
-          base::CreateSequencedTaskRunnerWithTraits({base::MayBlock()})) {
+          base::CreateSequencedTaskRunnerWithTraits({base::MayBlock(),
+              base::TaskPriority::USER_VISIBLE,
+              base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})) {
 }
 
 BaseBraveShieldsService::~BaseBraveShieldsService() {

--- a/components/brave_shields/browser/brave_shields_util.cc
+++ b/components/brave_shields/browser/brave_shields_util.cc
@@ -99,15 +99,13 @@ void GetRenderFrameInfo(URLRequest* request,
   }
 }
 
-void DispatchBlockedEventFromIO(URLRequest* request,
+void DispatchBlockedEventFromIO(const GURL &request_url, int render_frame_id,
+    int render_process_id, int frame_tree_node_id,
     const std::string& block_type) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
-  int render_process_id, render_frame_id, frame_tree_node_id;
-  GetRenderFrameInfo(request, &render_frame_id, &render_process_id,
-      &frame_tree_node_id);
   BrowserThread::PostTask(BrowserThread::UI, FROM_HERE,
       base::BindOnce(&BraveShieldsWebContentsObserver::DispatchBlockedEvent,
-          block_type, request->url().spec(),
+          block_type, request_url.spec(),
           render_process_id, render_frame_id, frame_tree_node_id));
 }
 

--- a/components/brave_shields/browser/brave_shields_util.h
+++ b/components/brave_shields/browser/brave_shields_util.h
@@ -28,7 +28,8 @@ bool IsAllowContentSettingFromIO(net::URLRequest* request,
     ContentSettingsType setting_type,
     const std::string& resource_identifier);
 
-void DispatchBlockedEventFromIO(net::URLRequest* request,
+void DispatchBlockedEventFromIO(const GURL &request_url, int render_frame_id,
+    int render_process_id, int frame_tree_node_id,
     const std::string& block_type);
 
 void GetRenderFrameInfo(net::URLRequest* request,


### PR DESCRIPTION
Fix: https://github.com/brave/brave-browser/issues/1574
Fix: https://github.com/brave/brave-browser/issues/1576

Also don't call Cancel() before a request is started

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source