### PR TITLE
Make user change search engine provider in tor window

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -56,9 +56,10 @@ source_set("browser_process") {
     "search_engine_provider_controller_base.h",
     "search_engine_provider_util.cc",
     "search_engine_provider_util.h",
+    "tor_window_search_engine_provider_controller.cc",
+    "tor_window_search_engine_provider_controller.h",
     "update_util.cc",
     "update_util.h",
-
   ]
 
   deps = [

--- a/browser/guest_window_search_engine_provider_controller.cc
+++ b/browser/guest_window_search_engine_provider_controller.cc
@@ -13,6 +13,7 @@ GuestWindowSearchEngineProviderController::
 GuestWindowSearchEngineProviderController(Profile* profile)
     : SearchEngineProviderControllerBase(profile) {
   DCHECK_EQ(profile->GetProfileType(), Profile::GUEST_PROFILE);
+  DCHECK(!profile->IsTorProfile());
 
   // Monitor otr(off the record) profile's search engine changing to tracking
   // user's default search engine provider.
@@ -29,15 +30,6 @@ GuestWindowSearchEngineProviderController::
 void GuestWindowSearchEngineProviderController::OnTemplateURLServiceChanged() {
   if (ignore_template_url_service_changing_)
     return;
-
-  // Prevent search engine changing from settings page for tor profile.
-  // TODO(simonhong): Revisit when related ux is determined.
-  if (otr_profile_->IsTorProfile()) {
-    base::AutoReset<bool> reset(&ignore_template_url_service_changing_, true);
-    ChangeToAlternativeSearchEngineProvider();
-    return;
-  }
-
 
   // The purpose of below code is turn off alternative prefs
   // when user changes to different search engine provider from settings.

--- a/browser/search_engine_provider_controller_base.cc
+++ b/browser/search_engine_provider_controller_base.cc
@@ -75,11 +75,6 @@ void SearchEngineProviderControllerBase::OnPreferenceChanged(
 
 bool
 SearchEngineProviderControllerBase::UseAlternativeSearchEngineProvider() const {
-  // Currently, use alternative search engine provider for tor profile.
-  // TODO(simonhong): Revisit when related setting ux is determined.
-  if (otr_profile_->IsTorProfile())
-    return true;
-
   return use_alternative_search_engine_provider_.GetValue();
 }
 

--- a/browser/search_engine_provider_util.cc
+++ b/browser/search_engine_provider_util.cc
@@ -6,7 +6,9 @@
 
 #include "brave/browser/guest_window_search_engine_provider_controller.h"
 #include "brave/browser/private_window_search_engine_provider_controller.h"
+#include "brave/browser/tor_window_search_engine_provider_controller.h"
 #include "brave/common/pref_names.h"
+#include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/prefs/pref_service.h"
 #include "components/pref_registry/pref_registry_syncable.h"
@@ -27,18 +29,29 @@ void ToggleUseAlternativeSearchEngineProvider(Profile* profile) {
 void RegisterAlternativeSearchEngineProviderProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(kUseAlternativeSearchEngineProvider, false);
+  registry->RegisterIntegerPref(
+      kAlternativeSearchEngineProviderInTor,
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO);
 }
 
 void InitializeSearchEngineProviderIfNeeded(Profile* profile) {
   // These search engine provider will be destroyed when observing template url
   // service is terminated.
+  // TODO(simonhong): Refactor these controller with KeyedService.
   if (profile->GetProfileType() == Profile::INCOGNITO_PROFILE) {
     new PrivateWindowSearchEngineProviderController(profile);
     return;
   }
 
+  if (profile->IsTorProfile() &&
+      profile->GetProfileType() == Profile::GUEST_PROFILE) {
+    new TorWindowSearchEngineProviderController(profile);
+    return;
+  }
+
   if (profile->GetProfileType() == Profile::GUEST_PROFILE) {
     new GuestWindowSearchEngineProviderController(profile);
+    return;
   }
 }
 

--- a/browser/tor_window_search_engine_provider_controller.cc
+++ b/browser/tor_window_search_engine_provider_controller.cc
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/tor_window_search_engine_provider_controller.h"
+
+#include "brave/browser/search_engine_provider_util.h"
+#include "brave/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/search_engines/template_url_prepopulate_data.h"
+#include "components/search_engines/template_url_service.h"
+
+TorWindowSearchEngineProviderController::
+TorWindowSearchEngineProviderController(Profile* profile)
+    : SearchEngineProviderControllerBase(profile) {
+  DCHECK(profile->IsTorProfile());
+  DCHECK_EQ(profile->GetProfileType(), Profile::GUEST_PROFILE);
+
+  alternative_search_engine_provider_in_tor_.Init(
+      kAlternativeSearchEngineProviderInTor,
+      otr_profile_->GetOriginalProfile()->GetPrefs());
+
+  // Configure previously used provider because guest profile is off the recored
+  // profile.
+  auto provider_data =
+      TemplateURLPrepopulateData::GetPrepopulatedEngine(
+          profile->GetPrefs(),
+          alternative_search_engine_provider_in_tor_.GetValue());
+  TemplateURL provider_url(*provider_data);
+  otr_template_url_service_->SetUserSelectedDefaultSearchProvider(
+      &provider_url);
+
+  // Monitor otr(off the record) profile's search engine changing to caching
+  // in original profile.
+  otr_template_url_service_->AddObserver(this);
+}
+
+TorWindowSearchEngineProviderController::
+~TorWindowSearchEngineProviderController() {
+  otr_template_url_service_->RemoveObserver(this);
+}
+
+void TorWindowSearchEngineProviderController::OnTemplateURLServiceChanged() {
+  alternative_search_engine_provider_in_tor_.SetValue(
+     otr_template_url_service_->GetDefaultSearchProvider()->data().prepopulate_id);
+}

--- a/browser/tor_window_search_engine_provider_controller.h
+++ b/browser/tor_window_search_engine_provider_controller.h
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_TOR_WINDOW_SEARCH_ENGINE_PROVIDER_CONTROLLER_H_
+#define BRAVE_BROWSER_TOR_WINDOW_SEARCH_ENGINE_PROVIDER_CONTROLLER_H_
+
+#include "brave/browser/search_engine_provider_controller_base.h"
+#include "components/prefs/pref_member.h"
+
+class TorWindowSearchEngineProviderController
+    : public SearchEngineProviderControllerBase {
+ public:
+  explicit TorWindowSearchEngineProviderController(Profile* profile);
+  ~TorWindowSearchEngineProviderController() override;
+
+ private:
+  // TemplateURLServiceObserver overrides:
+  void OnTemplateURLServiceChanged() override;
+
+  void ConfigureSearchEngineProvider() override {}
+
+  IntegerPrefMember alternative_search_engine_provider_in_tor_;
+
+  DISALLOW_COPY_AND_ASSIGN(TorWindowSearchEngineProviderController);
+};
+
+
+#endif  // BRAVE_BROWSER_TOR_WINDOW_SEARCH_ENGINE_PROVIDER_CONTROLLER_H_

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -18,6 +18,8 @@ const char kAdBlockCurrentRegion[] = "brave.ad_block.current_region";
 const char kWidevineOptedIn[] = "brave.widevine_opted_in";
 const char kUseAlternativeSearchEngineProvider[] =
     "brave.use_alternate_private_search_engine";
+const char kAlternativeSearchEngineProviderInTor[] =
+    "brave.alternate_private_search_engine_in_tor";
 const char kBraveThemeType[] = "brave.theme.type";
 const char kLocationBarIsWide[] = "brave.location_bar_is_wide";
 const char kReferralPromoCode[] = "brave.referral.promo_code";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -18,6 +18,7 @@ extern const char kWeekOfInstallation[];
 extern const char kAdBlockCurrentRegion[];
 extern const char kWidevineOptedIn[];
 extern const char kUseAlternativeSearchEngineProvider[];
+extern const char kAlternativeSearchEngineProviderInTor[];
 extern const char kBraveThemeType[];
 extern const char kLocationBarIsWide[];
 extern const char kReferralPromoCode[];

--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave_prepopulated_engines.h"
+#include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "components/search_engines/prepopulated_engines.h"
 #include "components/search_engines/search_engine_type.h"
 


### PR DESCRIPTION
Initially, DDG is set to search engine provider.
When user changes in settings, that change will be persisted.

Fixes https://github.com/brave/brave-browser/issues/1513

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Launch browser with clean profile
2. Open tor window
3. Check search provider is DDG.
4. Change search provider to Qwant
5. Re-launch browser
6. Open tor window
7. Check search provider is Qwant

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source