### PR TITLE
Disable cloud print

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -70,6 +70,12 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // Make sure sign into Brave is not enabled
   // The older kSigninAllowed is deprecated and only in use in Android until C71.
   registry->SetDefaultPrefValue(prefs::kSigninAllowedOnNextStartup, base::Value(false));
+
+  // Disable cloud print
+  // Cloud Print: Don't allow this browser to act as Cloud Print server
+  registry->SetDefaultPrefValue(prefs::kCloudPrintProxyEnabled, base::Value(false));
+  // Cloud Print: Don't allow jobs to be submitted
+  registry->SetDefaultPrefValue(prefs::kCloudPrintSubmitEnabled, base::Value(false));
 }
 
 }  // namespace brave

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -46,4 +46,9 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DisableGoogleServicesByDefa
       chrome_browser_net::NETWORK_PREDICTION_NEVER);
   EXPECT_FALSE(
       browser()->profile()->GetPrefs()->GetBoolean(prefs::kSigninAllowedOnNextStartup));
+  // Verify cloud print is disabled.
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kCloudPrintProxyEnabled));
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kCloudPrintSubmitEnabled));
 }


### PR DESCRIPTION
- Disables default preference to print to Google cloud-connected printers via accounts
that accounts.google.com recognises
- Disables default preference to act as a server for Google Cloud Printing
- Disables "Save to Google Drive" as print destination (keeps "Save as PDF")

Fix https://github.com/brave/brave-browser/issues/1402

## Comparison whilst signed-in to google.com

### Before
![image](https://user-images.githubusercontent.com/741836/46968306-c16aa200-d067-11e8-8aa1-4aaa83682360.png)


### After
![image](https://user-images.githubusercontent.com/741836/46967967-f296a280-d066-11e8-91a0-ccd470278755.png)

## Comparison when **not** signed-in to google.com
### Before
![image](https://user-images.githubusercontent.com/741836/46968286-b152c280-d067-11e8-9a8d-6a5a2fb71410.png)


### After
![image](https://user-images.githubusercontent.com/741836/46968206-7a7cac80-d067-11e8-818a-f10e93d726a0.png)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
On https://github.com/brave/brave-browser/issues/1402

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source