### PR TITLE
Remove Apps shortcut from the bookmarks bar

### DIFF
--- a/chromium_src/chrome/browser/ui/bookmarks/bookmark_utils.cc
+++ b/chromium_src/chrome/browser/ui/bookmarks/bookmark_utils.cc
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define IsAppsShortcutEnabled IsAppsShortcutEnabled_Unused
+#define ShouldShowAppsShortcutInBookmarkBar ShouldShowAppsShortcutInBookmarkBar_Unused
+#include "../../../../../chrome/browser/ui/bookmarks/bookmark_utils.cc"
+#undef IsAppsShortcutEnabled
+#undef ShouldShowAppsShortcutInBookmarkBar
+
+namespace chrome {
+
+bool IsAppsShortcutEnabled(Profile* profile) {
+  return false;
+}
+
+bool ShouldShowAppsShortcutInBookmarkBar(Profile* profile) {
+  return false;
+}
+
+} // namespace chrome

--- a/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/bookmarks/bookmark_context_menu_controller.h"
+
+#include <stddef.h>
+
+#include <memory>
+#include <string>
+
+#include "base/values.h"
+#include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/bookmarks/bookmark_model_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/bookmarks/bookmark_utils.h"
+#include "chrome/browser/ui/bookmarks/bookmark_utils_desktop.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/bookmarks/browser/bookmark_model.h"
+#include "components/bookmarks/browser/bookmark_node.h"
+#include "components/bookmarks/common/bookmark_pref_names.h"
+#include "components/bookmarks/test/bookmark_test_helpers.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/test_browser_thread.h"
+#include "content/public/test/test_browser_thread_bundle.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using bookmarks::BookmarkModel;
+using bookmarks::BookmarkNode;
+using content::BrowserThread;
+
+class BraveBookmarkContextMenuControllerTest : public testing::Test {
+ public:
+  BraveBookmarkContextMenuControllerTest() : model_(nullptr) {}
+
+  void SetUp() override {
+    TestingProfile::Builder builder;
+    profile_ = builder.Build();
+    profile_->CreateBookmarkModel(true);
+    model_ = BookmarkModelFactory::GetForBrowserContext(profile_.get());
+    bookmarks::test::WaitForBookmarkModelToLoad(model_);
+  }
+
+ protected:
+  content::TestBrowserThreadBundle thread_bundle_;
+  std::unique_ptr<TestingProfile> profile_;
+  BookmarkModel* model_;
+};
+
+TEST_F(BraveBookmarkContextMenuControllerTest,
+       DontShowAppsShortcutContextMenuInBookmarksBar) {
+  BookmarkContextMenuController controller(NULL, NULL, NULL, profile_.get(),
+                                           NULL, model_->bookmark_bar_node(),
+                                           std::vector<const BookmarkNode*>());
+
+  // Show apps command is not present by default.
+  sync_preferences::TestingPrefServiceSyncable* prefs =
+      profile_->GetTestingPrefService();
+  EXPECT_FALSE(prefs->IsManagedPreference(
+      bookmarks::prefs::kShowAppsShortcutInBookmarkBar));
+  EXPECT_EQ(controller.menu_model()->GetIndexOfCommandId(
+                IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT),
+            -1);
+
+  // Disabling the shorcut by policy doesn't cause the command to be added.
+  prefs->SetManagedPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar,
+                        std::make_unique<base::Value>(false));
+  EXPECT_EQ(controller.menu_model()->GetIndexOfCommandId(
+                IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT),
+            -1);
+
+  // And enabling the shortcut by policy doesn't cause the command to be added.
+  prefs->SetManagedPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar,
+                        std::make_unique<base::Value>(true));
+  EXPECT_EQ(controller.menu_model()->GetIndexOfCommandId(
+                IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT),
+            -1);
+
+  // And enabling the shortcut by user doesn't cause the command to be added.
+  prefs->RemoveManagedPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar);
+  prefs->SetUserPref(bookmarks::prefs::kShowAppsShortcutInBookmarkBar,
+                 std::make_unique<base::Value>(true));
+  EXPECT_EQ(controller.menu_model()->GetIndexOfCommandId(
+                IDC_BOOKMARK_BAR_SHOW_APPS_SHORTCUT),
+            -1);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -47,6 +47,7 @@ test("brave_unit_tests") {
     "//brave/browser/profiles/tor_unittest_profile_manager.h",
     "//brave/browser/profiles/brave_profile_manager_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
+    "//brave\chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",


### PR DESCRIPTION
Redefines `bookmark_utils.cc`'s `IsAppsShortcutEnabled` and `ShouldShowAppsShortcutInBookmarkBar` functions to always return false and, as such, prevents bookmarks bar from showing Apps shortcut and prevents bookmarks bar context menu from offering to show Apps shortcut as an option.

Fixes brave/brave-browser#878

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Automated Test Plan:

`npm run test -- brave_unit_tests --filter=BraveBookmarkContextMenuControllerTest.DontShowAppsShortcutContextMenuInBookmarksBar`

## Test Plan:

1. Verify that "Apps" shortcut is not shown in the bookmarks bar:
- Start browser, go to Settings -> Appearance, turn `Show bookmarks bar` to `on`,
- Verify that there is no "Apps" shortcut in the bookmarks bar.

2. Verify that "Show apps shortcut" is not shown in the bookmarks bar context menu:
- Start browser, go to Settings -> Appearance, turn `Show bookmarks bar` to `on`,
- Right-click on the bookmarks bar,
- Verify that "Show apps shortcut" is not shown as a menu option.

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source