### PR TITLE
Fixes BraveDownloadItemModelTest.GetTooltipText unit test failure on Windows

### DIFF
--- a/browser/download/brave_download_item_model_unittest.cc
+++ b/browser/download/brave_download_item_model_unittest.cc
@@ -125,7 +125,7 @@ TEST_F(BraveDownloadItemModelTest, GetTooltipText) {
     // Expected tooltip text.
     const char* expected_tooltip;
   } kTestCases[] = {
-    {"http://example.com/foo.bar", "foo.bar\nNot Secure http://example.com"},
+    {"http://example.com/foo.bar", "foo.bar\nnot secure http://example.com"},
     {"https://example.com:5678/foo.bar", "foo.bar\nhttps://example.com:5678"},
   };
 
@@ -139,10 +139,9 @@ TEST_F(BraveDownloadItemModelTest, GetTooltipText) {
     const TestCase& test_case = kTestCases[i];
     EXPECT_CALL(item(), GetURL())
         .WillRepeatedly(ReturnRefOfCopy(GURL(test_case.url)));
-    EXPECT_STREQ(
-        test_case.expected_tooltip,
-        base::UTF16ToUTF8(model().GetTooltipText(font_list, kTooltipWidth))
-            .c_str());
+    EXPECT_TRUE(base::LowerCaseEqualsASCII(base::UTF16ToUTF8(
+      model().GetTooltipText(font_list, kTooltipWidth)),
+      test_case.expected_tooltip));
     Mock::VerifyAndClearExpectations(&item());
   }
 }


### PR DESCRIPTION
Updated the test to use case insensitive comparison of tooltip text due to differences in case on Mac
and Windows.

Fixes brave/brave-browser#1589

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

`npm run test -- brave_unit_tests --filter=BraveDownloadItemModelTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source