### PR TITLE
Remove unused NTP check for GetEffectiveURL

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -18,6 +18,7 @@
 #include "brave/components/content_settings/core/browser/brave_cookie_settings.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/content_settings/tab_specific_content_settings.h"
+#include "chrome/browser/extensions/chrome_content_browser_client_extensions_part.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_io_data.h"
 #include "chrome/common/url_constants.h"
@@ -32,6 +33,10 @@ using content::RenderFrameHost;
 using content::WebContents;
 using content_settings::BraveCookieSettings;
 using brave_shields::BraveShieldsWebContentsObserver;
+
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+using extensions::ChromeContentBrowserClientExtensionsPart;
+#endif
 
 namespace {
 
@@ -218,4 +223,19 @@ void BraveContentBrowserClient::AdjustUtilityServiceProcessCommandLine(
     command_line->AppendSwitchPath(tor::switches::kTorExecutablePath,
                                    path.BaseName());
   }
+}
+
+GURL BraveContentBrowserClient::GetEffectiveURL(
+    content::BrowserContext* browser_context,
+    const GURL& url) {
+  Profile* profile = Profile::FromBrowserContext(browser_context);
+  if (!profile)
+    return url;
+
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  return ChromeContentBrowserClientExtensionsPart::GetEffectiveURL(profile,
+                                                                   url);
+#else
+  return url;
+#endif
 }

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -56,6 +56,9 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
       const service_manager::Identity& identity,
       base::CommandLine* command_line) override;
 
+  GURL GetEffectiveURL(content::BrowserContext* browser_context,
+                       const GURL& url) override;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(BraveContentBrowserClient);
 };


### PR DESCRIPTION
which will eventually lead to UIThread element access that cause thread inconsistency if you call
SiteInstance::GetSiteURL from IO thread

fix https://github.com/brave/brave-browser/issues/1604
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source