### PR TITLE
Consider Qwant search provider as a initial provider in tor window

### DIFF
--- a/browser/search_engine_provider_util.cc
+++ b/browser/search_engine_provider_util.cc
@@ -31,7 +31,7 @@ void RegisterAlternativeSearchEngineProviderProfilePrefs(
   registry->RegisterBooleanPref(kUseAlternativeSearchEngineProvider, false);
   registry->RegisterIntegerPref(
       kAlternativeSearchEngineProviderInTor,
-      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO);
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_INVALID);
 }
 
 void InitializeSearchEngineProviderIfNeeded(Profile* profile) {

--- a/browser/tor_window_search_engine_provider_controller.h
+++ b/browser/tor_window_search_engine_provider_controller.h
@@ -20,6 +20,8 @@ class TorWindowSearchEngineProviderController
 
   void ConfigureSearchEngineProvider() override {}
 
+  int GetInitialSearchEngineProvider() const;
+
   IntegerPrefMember alternative_search_engine_provider_in_tor_;
 
   DISALLOW_COPY_AND_ASSIGN(TorWindowSearchEngineProviderController);

--- a/components/search_engines/brave_prepopulated_engines.h
+++ b/components/search_engines/brave_prepopulated_engines.h
@@ -21,6 +21,8 @@ extern const int kBraveCurrentDataVersion;
 // additions by Chromium, so starting our ids from 500. Potential problem:
 // Chromium adds one of these engines to their list with a different id.
 enum BravePrepopulatedEngineID : unsigned int {
+  PREPOPULATED_ENGINE_ID_INVALID = 0,
+
   // These engine IDs are already defined in prepopulated_engines.json
   PREPOPULATED_ENGINE_ID_GOOGLE = 1,
   PREPOPULATED_ENGINE_ID_YAHOO = 2,


### PR DESCRIPTION
If Qwant is default prepopulate search provider, use it as an
initial search engine provider of tor window. Otherwise, DDG is used.
When user changes search provider setting, it will be persisted.

Fixes https://github.com/brave/brave-browser/issues/1514

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Set Region as non German/France
2. Start Browser with clean profile
3. Launch Tor window and check search provider is DDG
4. Close Browser
5. Set Region as German or France
6. Start Browser with clean profile
7. Launch Tor window and check search provider is Qwant.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source