### PR TITLE
Hide DDG newtab of tor window in qwant region(ger/fr) and qwant is set

### DIFF
--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -49,9 +49,10 @@ bool IsQwantUsedInQwantRegion(Profile* profile) {
       TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
           profile->GetPrefs())->prepopulate_id ==
           TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
-  bool qwant_used =
-      profile->GetPrefs()->GetInteger(kAlternativeSearchEngineProviderInTor) ==
-      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
+  bool qwant_used = profile->IsTorProfile()
+      ? profile->GetPrefs()->GetInteger(kAlternativeSearchEngineProviderInTor) ==
+          TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT
+      : true;
   return region_for_qwant && qwant_used;
 }
 

--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -7,10 +7,13 @@
 #include "brave/browser/search_engine_provider_util.h"
 #include "brave/common/pref_names.h"
 #include "brave/common/webui_url_constants.h"
+#include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/grit/brave_components_resources.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
+#include "components/search_engines/template_url_data.h"
+#include "components/search_engines/template_url_prepopulate_data.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_ui_data_source.h"
@@ -41,6 +44,17 @@ class NewTabDOMHandler : public content::WebUIMessageHandler {
   DISALLOW_COPY_AND_ASSIGN(NewTabDOMHandler);
 };
 
+bool IsQwantUsedInQwantRegion(Profile* profile) {
+  bool region_for_qwant =
+      TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
+          profile->GetPrefs())->prepopulate_id ==
+          TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
+  bool qwant_used =
+      profile->GetPrefs()->GetInteger(kAlternativeSearchEngineProviderInTor) ==
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
+  return region_for_qwant && qwant_used;
+}
+
 }  // namespace
 
 BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
@@ -57,6 +71,8 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
   pref_change_registrar_->Add(kHttpsUpgrades,
     base::Bind(&BraveNewTabUI::OnPreferenceChanged, base::Unretained(this)));
   pref_change_registrar_->Add(kUseAlternativeSearchEngineProvider,
+    base::Bind(&BraveNewTabUI::OnPreferenceChanged, base::Unretained(this)));
+  pref_change_registrar_->Add(kAlternativeSearchEngineProviderInTor,
     base::Bind(&BraveNewTabUI::OnPreferenceChanged, base::Unretained(this)));
 
   web_ui->AddMessageHandler(std::make_unique<NewTabDOMHandler>());
@@ -90,6 +106,8 @@ void BraveNewTabUI::CustomizeNewTabWebUIProperties(content::RenderViewHost* rend
                                                                : "false");
     render_view_host->SetWebUIProperty(
         "isTor", profile->IsTorProfile() ? "true" : "false");
+    render_view_host->SetWebUIProperty(
+        "isQwant", IsQwantUsedInQwantRegion(profile) ? "true" : "false");
   }
 }
 

--- a/components/brave_new_tab_ui/components/app.tsx
+++ b/components/brave_new_tab_ui/components/app.tsx
@@ -121,6 +121,7 @@ class NewTabPage extends React.Component<Props, {}> {
         <NewPrivateTab
           useAlternativePrivateSearchEngine={this.useAlternativePrivateSearchEngine}
           isTor={this.props.newTabData.isTor}
+          isQwant={this.props.newTabData.isQwant}
           onChangePrivateSearchEngine={this.onChangePrivateSearchEngine}
         />
       )

--- a/components/brave_new_tab_ui/components/privateTab/index.tsx
+++ b/components/brave_new_tab_ui/components/privateTab/index.tsx
@@ -15,32 +15,22 @@ import TorTab from './torTab'
 
 interface Props {
   isTor: boolean
+  isQwant: boolean
   useAlternativePrivateSearchEngine: boolean
   onChangePrivateSearchEngine: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 
 export default class NewPrivateTab extends React.PureComponent<Props, {}> {
-  get isQwant () {
-    // This is not technically accurately describing whether
-    // the browser has been automatically set to a Qwant region.
-    // Temporarily we are detecting language here, but we should
-    // use the same setting logic as used during first-run.
-    // https://github.com/brave/brave-browser/issues/1632
-    return navigator.language &&
-           navigator.language.startsWith('de') ||
-           navigator.language.startsWith('fr')
-  }
-
   get currentWindow () {
-    const { isTor, useAlternativePrivateSearchEngine, onChangePrivateSearchEngine } = this.props
+    const { isTor, isQwant, useAlternativePrivateSearchEngine, onChangePrivateSearchEngine } = this.props
     if (isTor) {
-      if (this.isQwant) {
+      if (isQwant) {
         return <QwantTorTab />
       }
       return <TorTab />
     }
 
-    if (this.isQwant) {
+    if (isQwant) {
       return <QwantTab />
     }
 
@@ -53,9 +43,9 @@ export default class NewPrivateTab extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { isTor } = this.props
+    const { isTor, isQwant } = this.props
     return (
-      <Page isPrivate={!isTor && !this.isQwant}>
+      <Page isPrivate={!isTor && !isQwant}>
         <PageWrapper>
           {this.currentWindow}
         </PageWrapper>

--- a/components/brave_new_tab_ui/storage.ts
+++ b/components/brave_new_tab_ui/storage.ts
@@ -21,6 +21,7 @@ const defaultState: NewTab.State = {
   isIncognito: chrome.extension.inIncognitoContext,
   useAlternativePrivateSearchEngine: false,
   isTor: chrome.getVariableValue('isTor') === 'true',
+  isQwant: chrome.getVariableValue('isQwant') === 'true',
   bookmarks: {},
   stats: {
     adsBlockedStat: 0,

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -54,6 +54,7 @@ declare namespace NewTab {
     isIncognito: boolean,
     useAlternativePrivateSearchEngine: boolean,
     isTor: boolean,
+    isQwant: boolean,
     bookmarks: Record<string, Bookmark>,
     stats: Stats
     backgroundImage?: Image


### PR DESCRIPTION
Hide DDG newtab of tor window in qwant region(ger/fr) if qwant is set to search provider.
Otherwise, DDG newetab is used in tor window newtab.

Close https://github.com/brave/brave-browser/issues/1632

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Set region to france
2. Launch new browser instance with clean profile
3. Open tor window
4. Check search provider is qwant and qwant newtab is used
5. Set region to non fr/ger
6. Launch new browser instance with clean profile
7. Open tor window
8. Check search provider is ddg and ddg newtab is used

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source