### PR TITLE
Fixes crashes when downloading an item (repro'd with a .crx)

### DIFF
--- a/browser/ui/views/download/brave_download_item_view.cc
+++ b/browser/ui/views/download/brave_download_item_view.cc
@@ -81,7 +81,9 @@ void BraveDownloadItemView::OnDownloadUpdated(
   download::DownloadItem* download) {
   // Check for conditions that would disregard origin url change and fall back
   // onto base implementation to handle them.
-  if (!model_.ShouldShowInShelf()) {
+  if (!model_.ShouldShowInShelf() ||
+      (DownloadItemView::download()->GetState() == DownloadItem::COMPLETE &&
+       model_.ShouldRemoveFromShelfWhenComplete())) {
     DownloadItemView::OnDownloadUpdated(download);
     return;
   }


### PR DESCRIPTION
Fixes crashes when downloading and item due to using BraveDownloadItemView after it is deleted by the base class on download completion.

Fixes brave/brave-browser#1628

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source