### PR TITLE
Adds QA flags for rewards

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@434f839a59ade34d6dbec1f359d08161351f8d38",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@8a45775a4df42276013d2f8aa3c69ad9f283ff15",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -26,6 +26,14 @@ const char kDisablePDFJSExtension[] = "disable-pdfjs-extension";
 // Allows disabling the Tor client updater extension.
 const char kDisableTorClientUpdaterExtension[] = "disable-tor-client-updater-extension";
 
+// Specifies which server should we use for rewards
+// Valid values are: "stag" | "prod".
+const char kRewardsEnv[] = "rewards-env";
+
+// Specifies how big is contribution interval in minutes
+// Valid value should be int.
+const char kRewardsReconcileInterval[] = "rewards-reconcile-interval";
+
 // Specifies overriding the built-in theme setting.
 // Valid values are: "dark" | "light".
 const char kUiMode[] = "ui-mode";

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -21,6 +21,10 @@ extern const char kDisablePDFJSExtension[];
 
 extern const char kDisableTorClientUpdaterExtension[];
 
+extern const char kRewardsEnv[];
+
+extern const char kRewardsReconcileInterval[];
+
 extern const char kUiMode[];
 
 }  // namespace switches


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/1161

Also adds cli flag: 
`rewards-env={stag|prod}`
`rewards-reconcile-interval=5` where 5 is custom interval that you can set

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1.
- try `npm run start -- --rewards_env=prod`
- make sure that wallet was created on production

2.
- try `npm run start -- --rewards_reconcile_interval=10`
- enable rewards
- claim grant
- add some sites to ac table
- make sure that contribution happens in 10min after wallet creation

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source