### PR TITLE
Fix crash in canceled requests with GURL access

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.h
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.h
@@ -10,12 +10,11 @@
 namespace brave {
 
 int OnBeforeURLRequest_AdBlockTPPreWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 
 bool GetPolyfillForAdBlock(bool allow_brave_shields, bool allow_ads,
-    const GURL& tab_origin, const GURL& gurl, GURL *new_url);
+    const GURL& tab_origin, const GURL& gurl, std::string* new_url_spec);
 
 }  // namespace brave
 

--- a/browser/net/brave_common_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper.cc
@@ -27,13 +27,12 @@ bool IsUpdaterURL(const GURL& gurl) {
 }
 
 int OnBeforeURLRequest_CommonStaticRedirectWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
   GURL::Replacements replacements;
   if (IsUpdaterURL(ctx->request_url)) {
     replacements.SetQueryStr(ctx->request_url.query_piece());
-    *new_url = GURL(kBraveUpdatesExtensionsEndpoint).ReplaceComponents(replacements);
+    ctx->new_url_spec = GURL(kBraveUpdatesExtensionsEndpoint).ReplaceComponents(replacements).spec();
     return net::OK;
   }
   return net::OK;

--- a/browser/net/brave_common_static_redirect_network_delegate_helper.h
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper.h
@@ -10,7 +10,6 @@
 namespace brave {
 
 int OnBeforeURLRequest_CommonStaticRedirectWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 

--- a/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
@@ -44,12 +44,10 @@ TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, ModifyComponentUpdate
       before_url_context(new brave::BraveRequestInfo());
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
-  GURL new_url;
   GURL expected_url(std::string(kBraveUpdatesExtensionsEndpoint + query_string));
   int ret =
-      OnBeforeURLRequest_CommonStaticRedirectWork(&new_url, callback,
-                                                  before_url_context);
-  EXPECT_EQ(new_url, expected_url);
+      OnBeforeURLRequest_CommonStaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(GURL(before_url_context->new_url_spec), expected_url);
   EXPECT_EQ(ret, net::OK);
 }
 
@@ -64,12 +62,10 @@ TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, NoModifyComponentUpda
       before_url_context(new brave::BraveRequestInfo());
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
-  GURL new_url;
   GURL expected_url;
   int ret =
-      OnBeforeURLRequest_CommonStaticRedirectWork(&new_url, callback,
-                                                  before_url_context);
-  EXPECT_EQ(new_url, expected_url);
+      OnBeforeURLRequest_CommonStaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
 

--- a/browser/net/brave_httpse_network_delegate_helper.h
+++ b/browser/net/brave_httpse_network_delegate_helper.h
@@ -10,7 +10,6 @@
 namespace brave {
 
 int OnBeforeURLRequest_HttpsePreFileWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 

--- a/browser/net/brave_httpse_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_httpse_network_delegate_helper_unittest.cc
@@ -42,11 +42,9 @@ TEST_F(BraveHTTPSENetworkDelegateHelperTest, AlreadySetNewURLNoOp) {
       GURL("http://brad.brave.com/hide_all_primes_in_ui/composites_forever"));
   brave_request_info->new_url_spec = "data:image/png;base64,iVB";
   brave::ResponseCallback callback;
-  GURL new_url;
   int ret =
-    OnBeforeURLRequest_HttpsePreFileWork(&new_url, callback,
-        brave_request_info);
-  EXPECT_TRUE(new_url.is_empty());
+    OnBeforeURLRequest_HttpsePreFileWork(callback, brave_request_info);
+  EXPECT_EQ(brave_request_info->new_url_spec, brave_request_info->new_url_spec);
   EXPECT_EQ(ret, net::OK);
 }
 

--- a/browser/net/brave_network_delegate_base.h
+++ b/browser/net/brave_network_delegate_base.h
@@ -29,6 +29,8 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
   BraveNetworkDelegateBase(extensions::EventRouterForwarder* event_router);
   ~BraveNetworkDelegateBase() override;
 
+  bool IsRequestIdentifierValid(uint64_t request_identifier);
+
   // NetworkDelegate implementation.
   int OnBeforeURLRequest(net::URLRequest* request,
                          net::CompletionOnceCallback callback,
@@ -49,7 +51,6 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
  protected:
   void RunNextCallback(
     net::URLRequest* request,
-    GURL *new_url,
     std::shared_ptr<brave::BraveRequestInfo> ctx);
   std::vector<brave::OnBeforeURLRequestCallback>
       before_url_request_callbacks_;

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -51,12 +51,11 @@ bool ApplyPotentialReferrerBlock(net::URLRequest* request) {
 namespace brave {
 
 int OnBeforeURLRequest_SiteHacksWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
 
   if (ApplyPotentialReferrerBlock(ctx->request))
-    *new_url = ctx->request_url;
+    ctx->new_url_spec = ctx->request_url.spec();
 
   return net::OK;
 }

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -16,7 +16,6 @@ class URLRequest;
 namespace brave {
 
 int OnBeforeURLRequest_SiteHacksWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -235,12 +235,10 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerPreserved) {
         brave_request_info(new brave::BraveRequestInfo());
     brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
-    GURL new_url;
-    int ret = brave::OnBeforeURLRequest_SiteHacksWork(&new_url,
-        callback, brave_request_info);
+    int ret = brave::OnBeforeURLRequest_SiteHacksWork(callback, brave_request_info);
     EXPECT_EQ(ret, net::OK);
     // new_url should not be set
-    EXPECT_STREQ(new_url.spec().c_str(), "");
+    EXPECT_TRUE(brave_request_info->new_url_spec.empty());
     EXPECT_STREQ(request->referrer().c_str(), original_referrer.c_str());
   });
 }
@@ -265,12 +263,10 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ReferrerCleared) {
         brave_request_info(new brave::BraveRequestInfo());
     brave::BraveRequestInfo::FillCTXFromRequest(request.get(), brave_request_info);
     brave::ResponseCallback callback;
-    GURL new_url;
-    int ret = brave::OnBeforeURLRequest_SiteHacksWork(&new_url,
-        callback, brave_request_info);
+    int ret = brave::OnBeforeURLRequest_SiteHacksWork(callback, brave_request_info);
     EXPECT_EQ(ret, net::OK);
-    // new_url must be set to trigger an internal redirect
-    EXPECT_STREQ(new_url.spec().c_str(), url.spec().c_str());
+    // new_url_spec must be set to trigger an internal redirect
+    EXPECT_STREQ(brave_request_info->new_url_spec.c_str(), url.spec().c_str());
     EXPECT_STREQ(request->referrer().c_str(), url.GetOrigin().spec().c_str());
   });
 }

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -10,7 +10,6 @@
 namespace brave {
 
 int OnBeforeURLRequest_StaticRedirectWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
   GURL::Replacements replacements;
@@ -18,13 +17,13 @@ int OnBeforeURLRequest_StaticRedirectWork(
   static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS, kSafeBrowsingPrefix);
 
   if (geo_pattern.MatchesURL(ctx->request_url)) {
-    *new_url = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);
+    ctx->new_url_spec = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY).spec();
     return net::OK;
   }
 
   if (safeBrowsing_pattern.MatchesHost(ctx->request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
-    *new_url = ctx->request_url.ReplaceComponents(replacements);
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
 

--- a/browser/net/brave_static_redirect_network_delegate_helper.h
+++ b/browser/net/brave_static_redirect_network_delegate_helper.h
@@ -12,7 +12,6 @@ struct BraveRequestInfo;
 namespace brave {
 
 int OnBeforeURLRequest_StaticRedirectWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -43,11 +43,10 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
       before_url_context(new brave::BraveRequestInfo());
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
-  GURL new_url;
   int ret =
-    OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
+    OnBeforeURLRequest_StaticRedirectWork(callback,
         before_url_context);
-  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_TRUE(before_url_context->new_url_spec.empty());
   EXPECT_EQ(ret, net::OK);
 }
 
@@ -61,12 +60,11 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
       before_url_context(new brave::BraveRequestInfo());
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
-  GURL new_url;
   GURL expected_url(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);
   int ret =
-      OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
+      OnBeforeURLRequest_StaticRedirectWork(callback,
                                             before_url_context);
-  EXPECT_EQ(new_url, expected_url);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
 
@@ -80,14 +78,13 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
       before_url_context(new brave::BraveRequestInfo());
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
-  GURL new_url;
   GURL::Replacements replacements;
   replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
   GURL expected_url(url.ReplaceComponents(replacements));
   int ret =
-      OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
+      OnBeforeURLRequest_StaticRedirectWork(callback,
                                             before_url_context);
-  EXPECT_EQ(new_url, expected_url);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
 
@@ -101,14 +98,13 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
       before_url_context(new brave::BraveRequestInfo());
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
   brave::ResponseCallback callback;
-  GURL new_url;
   GURL::Replacements replacements;
   replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
   GURL expected_url(url.ReplaceComponents(replacements));
   int ret =
-      OnBeforeURLRequest_StaticRedirectWork(&new_url, callback,
+      OnBeforeURLRequest_StaticRedirectWork(callback,
                                             before_url_context);
-  EXPECT_EQ(new_url, expected_url);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
 

--- a/browser/net/brave_tor_network_delegate_helper.cc
+++ b/browser/net/brave_tor_network_delegate_helper.cc
@@ -18,7 +18,6 @@ using content::ResourceRequestInfo;
 namespace brave {
 
 int OnBeforeURLRequest_TorWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);

--- a/browser/net/brave_tor_network_delegate_helper.h
+++ b/browser/net/brave_tor_network_delegate_helper.h
@@ -12,7 +12,6 @@ struct BraveRequestInfo;
 namespace brave {
 
 int OnBeforeURLRequest_TorWork(
-    GURL* new_url,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 

--- a/browser/net/brave_tor_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_tor_network_delegate_helper_unittest.cc
@@ -88,11 +88,10 @@ TEST_F(BraveTorNetworkDelegateHelperTest, NotTorProfile) {
     kRenderProcessId, /*render_view_id=*/-1, kRenderFrameId,
     /*is_main_frame=*/true, /*allow_download=*/false, /*is_async=*/true,
     content::PREVIEWS_OFF, std::move(navigation_ui_data));
-  GURL new_url;
   int ret =
-    brave::OnBeforeURLRequest_TorWork(&new_url, callback,
+    brave::OnBeforeURLRequest_TorWork(callback,
                                       before_url_context);
-  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_TRUE(before_url_context->new_url_spec.empty());
   auto* proxy_service = request->context()->proxy_resolution_service();
   net::ProxyInfo info;
   proxy_service->TryResolveProxySynchronously(url, std::string(), &info,
@@ -131,11 +130,10 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfile) {
 
   MockTorProfileServiceFactory::SetTorNavigationUIData(profile,
                                                    navigation_ui_data_ptr);
-  GURL new_url;
   int ret =
-    brave::OnBeforeURLRequest_TorWork(&new_url, callback,
+    brave::OnBeforeURLRequest_TorWork(callback,
                                       before_url_context);
-  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_TRUE(before_url_context->new_url_spec.empty());
   auto* proxy_service = request->context()->proxy_resolution_service();
   net::ProxyInfo info;
   std::unique_ptr<net::ProxyResolutionService::Request> proxy_request;
@@ -178,10 +176,9 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockFile) {
 
   MockTorProfileServiceFactory::SetTorNavigationUIData(profile,
                                                    navigation_ui_data_ptr);
-  GURL new_url;
   int ret =
-    brave::OnBeforeURLRequest_TorWork(&new_url, callback,
+    brave::OnBeforeURLRequest_TorWork(callback,
                                       before_url_context);
-  EXPECT_TRUE(new_url.is_empty());
+  EXPECT_TRUE(before_url_context->new_url_spec.empty());
   EXPECT_EQ(ret, net::ERR_DISALLOWED_URL_SCHEME);
 }

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -13,6 +13,8 @@
 #include "net/url_request/url_request.h"
 #include "url/gurl.h"
 
+class BraveNetworkDelegateBase;
+
 namespace brave {
 
 struct BraveRequestInfo;
@@ -22,7 +24,6 @@ using ResponseCallback = base::Callback<void()>;
 
 namespace brave_rewards {
   int OnBeforeURLRequest(
-      GURL* new_url,
       const brave::ResponseCallback& next_callback,
       std::shared_ptr<brave::BraveRequestInfo> ctx);
 }  // namespace brave_rewards
@@ -67,28 +68,27 @@ struct BraveRequestInfo {
   // Please don't add any more friends here if it can be avoided.
   // We should also remove the ones below.
   friend int OnBeforeURLRequest_SiteHacksWork(
-      GURL* new_url,
       const ResponseCallback& next_callback,
       std::shared_ptr<BraveRequestInfo> ctx);
   friend int brave_rewards::OnBeforeURLRequest(
-      GURL* new_url,
       const brave::ResponseCallback& next_callback,
       std::shared_ptr<brave::BraveRequestInfo> ctx);
   friend int OnBeforeURLRequest_TorWork(
-      GURL* new_url,
       const ResponseCallback& next_callback,
       std::shared_ptr<BraveRequestInfo> ctx);
+  friend class ::BraveNetworkDelegateBase;
+
   // Don't use this directly after any dispatch
   // request is deprecated, do not use it.
   net::URLRequest* request;
+  GURL* new_url = nullptr;
 
   DISALLOW_COPY_AND_ASSIGN(BraveRequestInfo);
 };
 
 //ResponseListener
 using OnBeforeURLRequestCallback =
-    base::Callback<int(GURL* new_url,
-        const ResponseCallback& next_callback,
+    base::Callback<int(const ResponseCallback& next_callback,
         std::shared_ptr<BraveRequestInfo> ctx)>;
 using OnBeforeStartTransactionCallback =
     base::Callback<int(net::URLRequest* request,

--- a/components/brave_rewards/browser/net/network_delegate_helper.cc
+++ b/components/brave_rewards/browser/net/network_delegate_helper.cc
@@ -123,7 +123,6 @@ void DispatchOnUI(
 }  // namespace
 
 int OnBeforeURLRequest(
-  GURL* new_url,
   const brave::ResponseCallback& next_callback,
   std::shared_ptr<brave::BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::IO);

--- a/components/brave_rewards/browser/net/network_delegate_helper.h
+++ b/components/brave_rewards/browser/net/network_delegate_helper.h
@@ -10,7 +10,6 @@
 namespace brave_rewards {
 
 int OnBeforeURLRequest(
-    GURL* new_url,
     const brave::ResponseCallback& next_callback,
     std::shared_ptr<brave::BraveRequestInfo> ctx);
 


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1664

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source