### PR TITLE
Show notification badge on Rewards extension button.

### DIFF
--- a/components/brave_rewards/extension/brave_rewards/background.ts
+++ b/components/brave_rewards/extension/brave_rewards/background.ts
@@ -5,3 +5,5 @@
 import './background/store'
 import './background/events/rewardsEvents'
 import './background/events/tabEvents'
+
+chrome.browserAction.setBadgeBackgroundColor({ color: '#FF0000' })

--- a/components/brave_rewards/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -6,16 +6,25 @@ import { types } from '../../constants/rewards_panel_types'
 import * as storage from '../storage'
 import { getTabData } from '../api/tabs_api'
 
-export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, action: any) => {
-  function setBadgeText (count: number): void {
-    chrome.browserAction.setBadgeText(count > 0
-      ? { text: count.toString() }
-      : { text: '' })
+function setBadgeText (state: RewardsExtension.State): void {
+  let text = ''
+
+  if (state && state.notifications) {
+    const count = Object.keys(state.notifications).length
+    if (count > 0) {
+      text = count.toString()
+    }
   }
 
+  chrome.browserAction.setBadgeText({
+    text
+  })
+}
+
+export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, action: any) => {
   if (state === undefined) {
     state = storage.load()
-    setBadgeText(Object.keys(state.notifications).length)
+    setBadgeText(state)
   }
 
   const startingState = state
@@ -112,7 +121,7 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
           state.currentNotification = id
         }
 
-        setBadgeText(Object.keys(notifications).length)
+        setBadgeText(state)
         break
       }
     case types.DELETE_NOTIFICATION:
@@ -151,7 +160,7 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
           notifications
         }
 
-        setBadgeText(Object.keys(notifications).length)
+        setBadgeText(state)
         break
       }
   }

--- a/components/brave_rewards/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -7,8 +7,15 @@ import * as storage from '../storage'
 import { getTabData } from '../api/tabs_api'
 
 export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, action: any) => {
+  function setBadgeText (count: number): void {
+    chrome.browserAction.setBadgeText(count > 0
+      ? { text: count.toString() }
+      : { text: '' })
+  }
+
   if (state === undefined) {
     state = storage.load()
+    setBadgeText(Object.keys(state.notifications).length)
   }
 
   const startingState = state
@@ -105,6 +112,7 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
           state.currentNotification = id
         }
 
+        setBadgeText(Object.keys(notifications).length)
         break
       }
     case types.DELETE_NOTIFICATION:
@@ -142,6 +150,9 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
           ...state,
           notifications
         }
+
+        setBadgeText(Object.keys(notifications).length)
+        break
       }
   }
 


### PR DESCRIPTION
Sets the badge color in background.ts
Sets the badge count in rewards_panel_reducer.ts when state is loaded and when notification added/deleted events are processed.

Fixes brave/brave-browser#1482

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Test notification badge showing up and clearing:
- Start browser with a fresh profile,
- Click on the Rewards button and in the popup click "Join Rewards",
- In the popup click "Rewards Settings",
- As the "brave://rewards" page loads verify that badge with number 1 appears on the Rewards button,
- Click on the Rewards button and click OK in the Token Grant section,
- Verify that the badge on the Rewards button disappears.

2. Test notification badge for more than one notification:
- Start browser and navigate to brave://rewards,
- Verify that the badge with number 1 appears,
- Reload the page a number of times,
- Verify that every time the page reloads the badge number increases by 1 (this is actually a bug in the underlying service code, I think, but helps with testing),
- Click on the Rewards button and then keep clicking on OK button,
- Verify that after each click on OK the badge number decreases by 1.

3. Test that the badge count is preserved on restart:
- Start browser, open a new tab and navigate to brave://rewards,
- Reload the page a few times (to increase the badge counter),
- Exit the browser,
- Start the browser again and verify that the badge count was preserved.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source