### PR TITLE
Disable communication between autofill server.

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -135,7 +135,8 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
   disabled_features << features::kSharedArrayBuffer.name
     << "," << features::kDefaultEnableOopRasterization.name
     << "," << features::kVizDisplayCompositor.name
-    << "," << autofill::features::kAutofillSaveCardSignInAfterLocalSave.name;
+    << "," << autofill::features::kAutofillSaveCardSignInAfterLocalSave.name
+    << "," << autofill::features::kAutofillServerCommunication.name;
 
   command_line.AppendSwitchASCII(switches::kEnableFeatures,
       enabled_features.str());

--- a/browser/brave_features_browsertest.cc
+++ b/browser/brave_features_browsertest.cc
@@ -4,11 +4,19 @@
 
 #include "base/feature_list.h"
 #include "chrome/test/base/in_process_browser_test.h"
+#include "components/autofill/core/common/autofill_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
 
 using BraveFeaturesBrowserTest = InProcessBrowserTest;
 
 IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, AutoFillPasswordDefault) {
   EXPECT_TRUE(
-    base::FeatureList::IsEnabled(password_manager::features::kFillOnAccountSelect));
+    base::FeatureList::IsEnabled(
+      password_manager::features::kFillOnAccountSelect));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, AutoFillServerCommunication) {
+  EXPECT_FALSE(
+    base::FeatureList::IsEnabled(
+      autofill::features::kAutofillServerCommunication));
 }


### PR DESCRIPTION
as long as autofill_server_url_ in AutofillDownloadManager is invalid,
There won't be any communications (AutofillDownloadManager::IsEnabled)

fix https://github.com/brave/brave-browser/issues/1676
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Go to `brave://net-internals`, you won't see any events accessing https://clients1.google.com/tbproxy/af/
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source