### PR TITLE
make RunIOTask safer when returning back from the task runner thread

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@8a45775a4df42276013d2f8aa3c69ad9f283ff15",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@9276e6390242b63e50e2462a6186f8a6e8daa917",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -5,6 +5,7 @@
 #ifndef BRAVE_BROWSER_PAYMENTS_PAYMENTS_SERVICE_IMPL_
 #define BRAVE_BROWSER_PAYMENTS_PAYMENTS_SERVICE_IMPL_
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -111,6 +112,9 @@ class RewardsServiceImpl : public RewardsService,
   void UpdateTipsList() override;
 
  private:
+  friend void RunIOTaskCallback(
+      base::WeakPtr<RewardsServiceImpl>,
+      std::function<void(void)>);
   typedef base::Callback<void(int, const std::string&, const std::map<std::string, std::string>& headers)> FetchCallback;
 
   const extensions::OneShotEvent& ready() const { return ready_; }
@@ -212,7 +216,6 @@ class RewardsServiceImpl : public RewardsService,
       ledger::LedgerCallbackHandler* handler) override;
 
   void RunIOTask(std::unique_ptr<ledger::LedgerTaskRunner> task) override;
-  void RunTask(std::unique_ptr<ledger::LedgerTaskRunner> task) override;
   void SetRewardsMainEnabled(bool enabled) const override;
   void SetPublisherMinVisitTime(uint64_t duration_in_seconds) const override;
   void SetPublisherMinVisits(unsigned int visits) const override;
@@ -238,6 +241,8 @@ class RewardsServiceImpl : public RewardsService,
                             const std::string& publisher_key,
                             const ledger::PUBLISHER_CATEGORY category) override;
   void GetRecurringDonations(ledger::RecurringDonationCallback callback) override;
+
+  void OnIOTaskComplete(std::function<void(void)> callback);
 
   // URLFetcherDelegate impl
   void OnURLFetchComplete(const net::URLFetcher* source) override;


### PR DESCRIPTION
before this change returning back using ledger_->RunTask could cause a free after use crash during shutdown if the task returned after the rewards service has been destroyed

Resolves https://github.com/brave/brave-browser/issues/1614

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. enable rewards
2. claim grant
3. go to a site
4. do direct donation via panel
5. make sure that while the whole process browser doesn't freeze

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

