### PR TITLE
Remove what turns into a double-upload (since it returns when renamin…

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -108,8 +108,6 @@ def yield_brave_packages(dir, channel, version):
           elif file == 'Brave Browser.pkg':
             if os.path.isfile(rename_and_get_desired_path(file_path, file_desired_pkg)):
               yield file_desired_pkg
-          elif file == file_desired_pkg:
-            yield file
         else:
           file_desired = 'Brave-Browser-' + channel_capitalized + '.dmg'
           if re.match(r'Brave Browser ' + channel_capitalized + r'.*\.dmg$', file):


### PR DESCRIPTION
…g and then also picks up the renamed one)

See https://staging.ci.brave.com/job/brave-browser-build-darwin-upload/63/console for an example of failure

Auditors: @mbacchi

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source