### PR TITLE
Keep the menu items in private windows with Tor same as in others.

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -7,6 +7,7 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/prefs/incognito_mode_prefs.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 
@@ -23,6 +24,16 @@ void BraveAppMenuModel::Build() {
   InsertBraveMenuItems();
 }
 
+bool BraveAppMenuModel::ShouldShowNewIncognitoWindowMenuItem() {
+  // The profile for private windows with Tor is a guest session,
+  // which ordinarily suppresses the menu item to open new private
+  // windows, but we don't want to suppress that here.
+  if (browser_->profile()->IsTorProfile())
+    return true;
+
+  return AppMenuModel::ShouldShowNewIncognitoWindowMenuItem();
+}
+
 void BraveAppMenuModel::InsertBraveMenuItems() {
   InsertItemWithStringIdAt(
       GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
@@ -32,15 +43,14 @@ void BraveAppMenuModel::InsertBraveMenuItems() {
       GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
       IDC_SHOW_BRAVE_ADBLOCK,
       IDS_SHOW_BRAVE_ADBLOCK);
+  InsertItemWithStringIdAt(
+      GetIndexOfCommandId(IDC_NEW_INCOGNITO_WINDOW) + 1,
+      IDC_NEW_OFFTHERECORD_WINDOW_TOR,
+      IDS_NEW_OFFTHERECORD_WINDOW_TOR);
   if (browser_->profile()->IsTorProfile()) {
     InsertItemWithStringIdAt(
-        GetIndexOfCommandId(IDC_NEW_WINDOW),
+        GetIndexOfCommandId(IDC_NEW_INCOGNITO_WINDOW) + 2,
         IDC_NEW_TOR_IDENTITY,
         IDS_NEW_TOR_IDENTITY);
-   } else {
-    InsertItemWithStringIdAt(
-        GetIndexOfCommandId(IDC_NEW_INCOGNITO_WINDOW) + 1,
-        IDC_NEW_OFFTHERECORD_WINDOW_TOR,
-        IDS_NEW_OFFTHERECORD_WINDOW_TOR);
-  }
+   }
 }

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -17,6 +17,7 @@ class BraveAppMenuModel : public AppMenuModel {
   // AppMenuModel overrides:
   void Build() override;
 
+  bool ShouldShowNewIncognitoWindowMenuItem() override;
   void InsertBraveMenuItems();
 
   Browser* const browser_;  // weak

--- a/patches/chrome-browser-ui-browser_command_controller.cc.patch
+++ b/patches/chrome-browser-ui-browser_command_controller.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/ui/browser_command_controller.cc b/chrome/browser/ui/browser_command_controller.cc
+index 1d929e1556b5d48b73efec0d25ebe9f75043b992..3dbf84aebbe63a4c8932d8a843bc9e56118418ae 100644
+--- a/chrome/browser/ui/browser_command_controller.cc
++++ b/chrome/browser/ui/browser_command_controller.cc
+@@ -968,7 +968,8 @@ void BrowserCommandController::UpdateSharedCommandsForIncognitoAvailability(
+       incognito_availability != IncognitoModePrefs::FORCED);
+   command_updater->UpdateCommandEnabled(
+       IDC_NEW_INCOGNITO_WINDOW,
+-      incognito_availability != IncognitoModePrefs::DISABLED && !guest_session);
++      (incognito_availability != IncognitoModePrefs::DISABLED &&
++       (!guest_session || profile->IsTorProfile())));
+ 
+   const bool forced_incognito =
+       incognito_availability == IncognitoModePrefs::FORCED ||

--- a/patches/chrome-browser-ui-toolbar-app_menu_model.h.patch
+++ b/patches/chrome-browser-ui-toolbar-app_menu_model.h.patch
@@ -1,0 +1,15 @@
+diff --git a/chrome/browser/ui/toolbar/app_menu_model.h b/chrome/browser/ui/toolbar/app_menu_model.h
+index 85bccd4c88e45c3fe68d3a0bd387d7d01de5ff57..7b5440096810c18037509af19e5c453c9d7ea8a0 100644
+--- a/chrome/browser/ui/toolbar/app_menu_model.h
++++ b/chrome/browser/ui/toolbar/app_menu_model.h
+@@ -181,7 +181,9 @@ class AppMenuModel : public ui::SimpleMenuModel,
+   class HelpMenuModel;
+   friend class ::MockAppMenuModel;
+ 
+-  bool ShouldShowNewIncognitoWindowMenuItem();
++ protected:
++  virtual bool ShouldShowNewIncognitoWindowMenuItem();
++ private:
+ 
+   // Adds actionable global error menu items to the menu.
+   // Examples: Extension permissions and sign in errors.


### PR DESCRIPTION
fix brave/brave-browser#1627

The result is a little silly -- because private windows with Tor are
implemented in a guest session, all new windows open in the same
session, whether with 'New window' or 'New incognito window' (soon to
be 'New private window') or 'New private window with Tor').

On the other hand, this is perhaps justifiable because we don't want
to make it easy to accidentally _stop_ using Tor.  You can do that
explicitly through the profile menu -- but not just by casually
hitting Ctrl-N.

On the third hand, control-click on links _greys out_ the 'Open link
in private window' item when you're in a private window, rather than
making it just...do what it says.  ('Open link in new window' also
opens in a new private window in that case.)  For consistency, maybe
we should do that instead, when we are on less of a deadline?

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source