### PR TITLE
Show DDG newtab in Qwant region if Qwant is not used

### DIFF
--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -18,6 +18,8 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/browser/web_ui_message_handler.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "components/search_engines/template_url_service.h"
 
 namespace {
 class NewTabDOMHandler : public content::WebUIMessageHandler {
@@ -44,16 +46,20 @@ class NewTabDOMHandler : public content::WebUIMessageHandler {
   DISALLOW_COPY_AND_ASSIGN(NewTabDOMHandler);
 };
 
+bool IsRegionForQwant(Profile* profile) {
+  return TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
+      profile->GetPrefs())->prepopulate_id ==
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
+}
+
+bool IsQwantUsed(Profile* profile) {
+ return TemplateURLServiceFactory::GetForProfile(profile)->
+     GetDefaultSearchProvider()->prepopulate_id() ==
+     TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
+}
+
 bool IsQwantUsedInQwantRegion(Profile* profile) {
-  bool region_for_qwant =
-      TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
-          profile->GetPrefs())->prepopulate_id ==
-          TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
-  bool qwant_used = profile->IsTorProfile()
-      ? profile->GetPrefs()->GetInteger(kAlternativeSearchEngineProviderInTor) ==
-          TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT
-      : true;
-  return region_for_qwant && qwant_used;
+  return IsRegionForQwant(profile) && IsQwantUsed(profile);
 }
 
 }  // namespace

--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -18,8 +18,6 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/browser/web_ui_message_handler.h"
-#include "chrome/browser/search_engines/template_url_service_factory.h"
-#include "components/search_engines/template_url_service.h"
 
 namespace {
 class NewTabDOMHandler : public content::WebUIMessageHandler {
@@ -50,16 +48,6 @@ bool IsRegionForQwant(Profile* profile) {
   return TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
       profile->GetPrefs())->prepopulate_id ==
       TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
-}
-
-bool IsQwantUsed(Profile* profile) {
- return TemplateURLServiceFactory::GetForProfile(profile)->
-     GetDefaultSearchProvider()->prepopulate_id() ==
-     TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT;
-}
-
-bool IsQwantUsedInQwantRegion(Profile* profile) {
-  return IsRegionForQwant(profile) && IsQwantUsed(profile);
 }
 
 }  // namespace
@@ -114,7 +102,7 @@ void BraveNewTabUI::CustomizeNewTabWebUIProperties(content::RenderViewHost* rend
     render_view_host->SetWebUIProperty(
         "isTor", profile->IsTorProfile() ? "true" : "false");
     render_view_host->SetWebUIProperty(
-        "isQwant", IsQwantUsedInQwantRegion(profile) ? "true" : "false");
+        "isQwant", IsRegionForQwant(profile) ? "true" : "false");
   }
 }
 


### PR DESCRIPTION
In Qwant region, DDG newtab should be used when user uses non-Qwant
search engine provider.
In non-Qwant region, user always see DDG newtab.

Close https://github.com/brave/brave-browser/issues/1666

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Set region to France.
2. Start Browser with clean profile
3. Open private window and check non-ddg newtab is used
4. Change search engine setting
5. Then reopen private window and checks ddg newtab is used

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source