### PR TITLE
Use tab id from chrome.tabs.getCurrent to map each tab's torrent state

### DIFF
--- a/components/brave_webtorrent/extension/brave_webtorrent.tsx
+++ b/components/brave_webtorrent/extension/brave_webtorrent.tsx
@@ -21,11 +21,12 @@ const store: Store<TorrentsState> = new Store({
 })
 
 store.ready().then(
-  () => {
+  async () => {
+    const tab: any = await new Promise(resolve => chrome.tabs.getCurrent(resolve))
     render(
       <Provider store={store}>
         <ThemeProvider theme={Theme}>
-          <App />
+          <App tabId={tab.id} />
         </ThemeProvider>
       </Provider>,
       document.getElementById('root'))

--- a/components/brave_webtorrent/extension/components/app.tsx
+++ b/components/brave_webtorrent/extension/components/app.tsx
@@ -35,12 +35,7 @@ export class BraveWebtorrentPage extends React.Component<Props, {}> {
       ? torrentId + window.location.hash
       : torrentId
 
-    // The active tab change might not be propagated here yet, so we might get
-    // the old active tabId here which might be a different torrent page or a
-    // non-torrent page.
-    if (!torrentState || torrentId !== torrentState.torrentId) {
-      return (<div>Loading...</div>)
-    }
+    if (!torrentState) return null
 
     if (torrentObj && typeof(torrentState.ix) === 'number') {
       return (
@@ -62,9 +57,9 @@ export class BraveWebtorrentPage extends React.Component<Props, {}> {
   }
 }
 
-export const mapStateToProps = (state: ApplicationState) => {
-  return { torrentState: getTorrentState(state.torrentsData),
-    torrentObj: getTorrentObj(state.torrentsData) }
+export const mapStateToProps = (state: ApplicationState, ownProps: { tabId: number }) => {
+  return { torrentState: getTorrentState(state.torrentsData, ownProps.tabId),
+    torrentObj: getTorrentObj(state.torrentsData, ownProps.tabId) }
 }
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/components/brave_webtorrent/extension/constants/webtorrentState.ts
+++ b/components/brave_webtorrent/extension/constants/webtorrentState.ts
@@ -2,18 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const getCurrentTabId = (state: TorrentsState) => {
-  return state.activeTabIds[state.currentWindowId]
+export const getTorrentState = (state: TorrentsState, tabId: number) => {
+  return state.torrentStateMap[tabId]
 }
 
-export const getTorrentState = (state: TorrentsState) => {
-  return state.torrentStateMap[getCurrentTabId(state)]
-}
-
-export const getTorrentObj = (state: TorrentsState) => {
+export const getTorrentObj = (state: TorrentsState, tabId: number) => {
   let torrent
 
-  const torrentState = getTorrentState(state)
+  const torrentState = getTorrentState(state, tabId)
   if (torrentState && torrentState.infoHash) {
     torrent = state.torrentObjMap[torrentState.infoHash]
   }

--- a/components/test/brave_webtorrent/components/app_test.tsx
+++ b/components/test/brave_webtorrent/components/app_test.tsx
@@ -11,7 +11,7 @@ import { BraveWebtorrentPage, mapStateToProps } from '../../../brave_webtorrent/
 describe('BraveWebtorrentPage component', () => {
   describe('mapStateToProps', () => {
     it('should map the default state', () => {
-      expect(mapStateToProps(applicationState)).toEqual({
+      expect(mapStateToProps(applicationState, { tabId: 0 })).toEqual({
         torrentState
       })
     })


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1400
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source