### PR TITLE
Add referer exception for geetest captchas

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -98,6 +98,7 @@ bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
   // It's preferred to use specific_patterns below when possible
   static std::vector<URLPattern> whitelist_patterns({
     URLPattern(URLPattern::SCHEME_ALL, "https://use.typekit.net/*"),
+    URLPattern(URLPattern::SCHEME_ALL, "https://api.geetest.com/*"),
     URLPattern(URLPattern::SCHEME_ALL, "https://cloud.typography.com/*")
   });
   return std::any_of(whitelist_patterns.begin(), whitelist_patterns.end(),

--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -71,6 +71,14 @@ TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
       GURL("https://use.typekit.net/193")));
   EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.test.com"),
       GURL("https://cloud.typography.com/199")));
+  // geetest allowed everywhere
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://binance.com"),
+      GURL("https://api.geetest.com/ajax.php?")));
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("http://binance.com"),
+      GURL("https://api.geetest.com/")));
+  // not allowed with a different scheme
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("http://binance.com"),
+      GURL("http://api.geetest.com/")));
 }
 
 }  // namespace


### PR DESCRIPTION
The captcha fails unless referer is allowed

fix https://github.com/brave/brave-browser/issues/1740

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source