### PR TITLE
Improve Korean translation

### DIFF
--- a/app/resources/chromium_strings_ko.xtb
+++ b/app/resources/chromium_strings_ko.xtb
@@ -19,13 +19,13 @@
 <translation id="4651430425715739110">Copyright <ph name="YEAR"/> The Brave Authors. All rights reserved.</translation>
 <translation id="2310890394934209120">Brave OS는 추가 <ph name="BEGIN_LINK_CROS_OSS"/>오픈소스 소프트웨어<ph name="END_LINK_CROS_OSS"/>를 사용했습니다.</translation>
 <translation id="8160794320557846790"><ph name="BEGIN_LINK_LINUX_OSS"/>Linux(베타)<ph name="END_LINK_LINUX_OSS"/>와 마찬가지로, Brave OS는 추가 <ph name="BEGIN_LINK_CROS_OSS"/>오픈소스 소프트웨어<ph name="END_LINK_CROS_OSS"/>를 사용하여 개발되었습니다.</translation>
-<translation id="5019879183386042809">Brave을 기본 브라우저로 설정</translation>
+<translation id="5019879183386042809">Brave를 기본 브라우저로 설정</translation>
 <translation id="5063987220091207247">Brave OS에서 이 페이지를 열 수 없음</translation>
-<translation id="4065288863231444640">백그라운드에서 Brave을 실행</translation>
+<translation id="4065288863231444640">백그라운드에서 Brave를 실행</translation>
 <translation id="2585240446624043880">Brave에서 데이터 디렉토리를 읽고 쓸 수 없습니다.
 
 <ph name="USER_DATA_DIRECTORY"/></translation>
-<translation id="8417700129970341035">선택사항: 사용 통계 및 비정상 종료 보고서가 Brave Software로 자동 전송되도록 선택하시면 Brave을 개선하는 데 도움이 됩니다.</translation>
+<translation id="8417700129970341035">선택사항: 사용 통계 및 비정상 종료 보고서가 Brave Software로 자동 전송되도록 선택하시면 Brave를 개선하는 데 도움이 됩니다.</translation>
 <translation id="1489465648257900784">Brave의 최신 버전을 사용하기 때문에 프로필을 사용할 수 없습니다.
 
 일부 기능을 사용할 수 없습니다. 다른 프로필 디렉토리를 지정하거나 Brave의 새로운 버전을 사용하시기 바랍니다.</translation>
@@ -56,17 +56,17 @@ Brave에서 설정을 복구할 수 없습니다.</translation>
 <translation id="777113543093865885">Brave에서 제거...</translation>
 <translation id="6078442581074612226">Brave에서</translation>
 <translation id="8148611988012584308">Brave 맞춤설정 및 제어</translation>
-<translation id="5849446944780602366">Brave을 맞춤설정하고 제어하세요. 업데이트가 출시되었습니다.</translation>
+<translation id="5849446944780602366">Brave를 맞춤설정하고 제어하세요. 업데이트가 출시되었습니다.</translation>
 <translation id="9071554113102421877">&amp;Brave에서 열기</translation>
 <translation id="1421502046520299169">Brave OS 정보</translation>
 <translation id="2534623228451928732">Brave OS 업데이트</translation>
-<translation id="3360368475735266712">로그인하여 모든 기기에서 Brave을 동기화하고 맞춤설정하세요.</translation>
-<translation id="5477319665405831211">모든 기기에서 Brave을 동기화하고 맞춤설정하세요.</translation>
+<translation id="3360368475735266712">로그인하여 모든 기기에서 Brave를 동기화하고 맞춤설정하세요.</translation>
+<translation id="5477319665405831211">모든 기기에서 Brave를 동기화하고 맞춤설정하세요.</translation>
 <translation id="4934157190377700991">이제 Brave에 로그인되었습니다.</translation>
 <translation id="4100716194836114130">나만의 Brave</translation>
-<translation id="8296145982386097283">컴퓨터를 공유하시겠습니까? 이제 원하는 대로 Brave을 설정할 수 있습니다.</translation>
+<translation id="8296145982386097283">컴퓨터를 공유하시겠습니까? 이제 원하는 대로 Brave를 설정할 수 있습니다.</translation>
 <translation id="1672124279374861424">Brave에서 계정을 삭제한 후 열려 있는 탭을 새로고침해야 적용됩니다.</translation>
-<translation id="9197493712748167998">Brave 콘텐츠를 동기화하기 위해 <ph name="PROFILE_EMAIL"/>을(를) 사용 중입니다. 동기화 환경설정을 업데이트하거나 Brave Software 계정 없이 Brave을 사용하려면 <ph name="SETTINGS_LINK"/>(으)로 이동하세요.</translation>
+<translation id="9197493712748167998">Brave 콘텐츠를 동기화하기 위해 <ph name="PROFILE_EMAIL"/>을(를) 사용 중입니다. 동기화 환경설정을 업데이트하거나 Brave Software 계정 없이 Brave를 사용하려면 <ph name="SETTINGS_LINK"/>(으)로 이동하세요.</translation>
 <translation id="3968006371075376562">Brave OS에서 데이터를 동기화하지 못했습니다. 동기화 암호를 업데이트하세요.</translation>
 <translation id="6746636977031158624">계정의 로그인 세부정보가 오래되어 Brave OS에서 데이터를 동기화하지 못했습니다.</translation>
 <translation id="2999152167963026588">내 도메인에서 동기화를 사용할 수 없으므로 Brave OS에서 데이터를 동기화하지 못했습니다.</translation>
@@ -80,33 +80,33 @@ Brave에서 설정을 복구할 수 없습니다.</translation>
 <translation id="3293668930608086049">Brave이 카메라와 마이크를 사용 중입니다.</translation>
 <translation id="8919461291440820124">Brave이 마이크를 사용 중입니다.</translation>
 <translation id="3205074487970075628">Brave이 카메라를 사용 중입니다.</translation>
-<translation id="3813272600615358652">Brave을 시작하면 표시되는 페이지가 이 확장 프로그램으로 인해 변경되었습니다.</translation>
-<translation id="2576129394594491151">Brave을 시작하면 표시되는 페이지가 '<ph name="EXTENSION_NAME"/>' 확장 프로그램으로 인해 변경되었습니다.</translation>
-<translation id="2675662665675552980">또한 Brave을 시작할 때 표시되는 페이지를 설정합니다.</translation>
-<translation id="3215652305414474626">또한 Brave을 시작하거나 홈 버튼을 클릭할 때 표시되는 페이지를 설정합니다.</translation>
-<translation id="2433912322225810055">또한 Brave을 시작하거나 검색주소창에서 검색할 때 표시되는 페이지를 설정합니다.</translation>
+<translation id="3813272600615358652">Brave를 시작하면 표시되는 페이지가 이 확장 프로그램으로 인해 변경되었습니다.</translation>
+<translation id="2576129394594491151">Brave를 시작하면 표시되는 페이지가 '<ph name="EXTENSION_NAME"/>' 확장 프로그램으로 인해 변경되었습니다.</translation>
+<translation id="2675662665675552980">또한 Brave를 시작할 때 표시되는 페이지를 설정합니다.</translation>
+<translation id="3215652305414474626">또한 Brave를 시작하거나 홈 버튼을 클릭할 때 표시되는 페이지를 설정합니다.</translation>
+<translation id="2433912322225810055">또한 Brave를 시작하거나 검색주소창에서 검색할 때 표시되는 페이지를 설정합니다.</translation>
 <translation id="2871190378186459992">Brave에 유용한 앱, 게임, 확장 프로그램, 테마를 찾아보세요.</translation>
 <translation id="2522086024276534909">Brave OS 다시 시작</translation>
 <translation id="8183252473547465084">업데이트를 적용하려면 Brave OS를 다시 시작해야 합니다.</translation>
 <translation id="5895138241574237353">다시 시작</translation>
 <translation id="5875673934455379806">Brave 재설치</translation>
 <translation id="2097604701283463988">Brave이 이전 버전임</translation>
-<translation id="6389268239133412586">Brave을 업데이트하지 못함</translation>
-<translation id="7963515534397191222">Brave을 최신 버전으로 업데이트하지 못했기 때문에 새로운 기능과 보안 수정 사항이 적용되지 않았습니다.</translation>
+<translation id="6389268239133412586">Brave를 업데이트하지 못함</translation>
+<translation id="7963515534397191222">Brave를 최신 버전으로 업데이트하지 못했기 때문에 새로운 기능과 보안 수정 사항이 적용되지 않았습니다.</translation>
 <translation id="3472158705945346956">관리자가 나를 삭제한 후 다시 Brave에 추가해야 합니다.</translation>
 <translation id="5173820533850252773">Brave이 이전 버전임</translation>
 <translation id="1705567146636171298">Brave 업데이트</translation>
 <translation id="4050175100176540509">최신 버전에는 중요한 보안 개선사항 및 새로운 기능이 포함되어 있습니다.</translation>
 <translation id="2513524988380267210">{SECONDS,plural, =1{1초 후에 Brave이 다시 시작됩니다}other{#초 후에 Brave이 다시 시작됩니다}}</translation>
-<translation id="9159286371333817139">지금 Brave을 다시 시작해야 합니다.</translation>
+<translation id="9159286371333817139">지금 Brave를 다시 시작해야 합니다.</translation>
 <translation id="9203540365585059272">Brave 특별 보안 업데이트를 방금 적용했습니다. 실행하려면 지금 다시 시작하세요. 다시 시작 후 탭은 복원됩니다.</translation>
 <translation id="763369711159699222">Brave 개선에 참여</translation>
-<translation id="1156940037717341650">Brave Software에 발생할 수 있는 보안 문제의 세부정보를 자동으로 보고하도록 설정하면 Brave을 더 안전하고 편리하게 사용할 수 있습니다.</translation>
+<translation id="1156940037717341650">Brave Software에 발생할 수 있는 보안 문제의 세부정보를 자동으로 보고하도록 설정하면 Brave를 더 안전하고 편리하게 사용할 수 있습니다.</translation>
 <translation id="6791166902140255175">Brave 탭</translation>
-<translation id="8899693649891674038">휴대전화에 Brave을 설치하세요. 휴대전화로 SMS를 보내 드리겠습니다.</translation>
-<translation id="1570795130102031380">휴대전화에 Brave을 설치하세요. 다음 휴대전화로 SMS를 보내 드리겠습니다. <ph name="PHONE_NUMBER"/></translation>
-<translation id="1609678321160597289">휴대전화에 Brave을 설치하세요. 계정 복구 전화번호로 SMS를 보내 드리겠습니다.</translation>
-<translation id="2965084188004448871">휴대전화에 Brave을 설치하세요. 다음의 계정 복구 전화번호로 SMS를 보내 드리겠습니다. <ph name="PHONE_NUMBER"/></translation>
+<translation id="8899693649891674038">휴대전화에 Brave를 설치하세요. 휴대전화로 SMS를 보내 드리겠습니다.</translation>
+<translation id="1570795130102031380">휴대전화에 Brave를 설치하세요. 다음 휴대전화로 SMS를 보내 드리겠습니다. <ph name="PHONE_NUMBER"/></translation>
+<translation id="1609678321160597289">휴대전화에 Brave를 설치하세요. 계정 복구 전화번호로 SMS를 보내 드리겠습니다.</translation>
+<translation id="2965084188004448871">휴대전화에 Brave를 설치하세요. 다음의 계정 복구 전화번호로 SMS를 보내 드리겠습니다. <ph name="PHONE_NUMBER"/></translation>
 <translation id="8358191771897395012">iPhone에 Brave 다운로드하기</translation>
 <translation id="1744365871163268756">Brave에서 최신 시스템 업데이트를 설치하는 동안 잠시 기다려 주세요.</translation>
 <translation id="5693614905241031118">Brave은 자동으로 업데이트되므로 항상 최신 버전을 사용할 수 있습니다.</translation>
@@ -118,7 +118,7 @@ Brave에서 설정을 복구할 수 없습니다.</translation>
 <translation id="7977435741986383568">Brave에서 사용자에게 더 나은 인터넷 사용 환경을 제공하기 위해 웹 서비스를 사용할 수 있습니다. 원하는 경우 서비스를 사용 중지하실 수 있습니다. <ph name="BEGIN_LINK"/>자세히 알아보기<ph name="END_LINK"/></translation>
 <translation id="2312399718665761438">맞춤법 오류를 수정하기 위해 Brave에서 사용자가 입력하는 텍스트를 Brave Software로 전송합니다.</translation>
 <translation id="815816884817177844">Brave Software과 통신하여 인터넷 탐색 환경 및 Brave 개선</translation>
-<translation id="8586264863973514035">변경사항을 적용하려면 Brave을 다시 실행하세요.</translation>
+<translation id="8586264863973514035">변경사항을 적용하려면 Brave를 다시 실행하세요.</translation>
 <translation id="7021823858304886493">Brave 로그인 허용</translation>
 <translation id="1649714546770135458">이 기능을 사용 중지하면 Brave에 로그인하지 않고도 Gmail 등의 Brave Software 사이트에 로그인할 수 있습니다.</translation>
 <translation id="6274110506580702455">이 기기의 관리자에 의해 Brave 로그인이 사용 중지되었습니다.</translation>

--- a/app/resources/generated_resources_ko.xtb
+++ b/app/resources/generated_resources_ko.xtb
@@ -815,7 +815,7 @@
 <translation id="8251578425305135684">미리보기 이미지가 삭제되었습니다.</translation>
 <translation id="4495419450179050807">이 페이지에 표시하지 않음</translation>
 <translation id="2948300991547862301"><ph name="PAGE_TITLE"/>(으)로 이동</translation>
-<translation id="3838486795898716504"><ph name="PAGE_TITLE"/> 더보기</translation>
+<translation id="3838486795898716504"><ph name="PAGE_TITLE"/> 더 보기</translation>
 <translation id="6169040057125497443">마이크를 확인하세요.</translation>
 <translation id="6007240208646052708">사용자의 언어로 음성 검색을 이용할 수 없습니다.</translation>
 <translation id="3141318088920353606">듣는 중...</translation>
@@ -838,9 +838,9 @@
 <translation id="6860427144121307915">탭에서 열기</translation>
 <translation id="3074037959626057712">로그인하고 동기화를 사용 설정함</translation>
 <translation id="1231733316453485619">동기화를 사용하시겠습니까?</translation>
-<translation id="9125982323641182972">Brave Software로 Brave을 더욱 스마트하게</translation>
-<translation id="7988117629517051942">더욱 스마트한 Brave Software을 사용하세요</translation>
-<translation id="5596627076506792578">옵션 더보기</translation>
+<translation id="9125982323641182972">Brave Software로 Brave를 더욱 스마트하게</translation>
+<translation id="7988117629517051942">더욱 스마트한 Brave Software를 사용하세요</translation>
+<translation id="5596627076506792578">옵션 더 보기</translation>
 <translation id="4419556793104466535">동기화, 맞춤설정 등 관리</translation>
 <translation id="184568702928428857">Brave에서 동기화, 맞춤설정 및 기타 Brave Software 서비스를 관리하는 설정이 변경되었습니다. 이로 인해 현재 설정이 영향을 받을 수 있습니다.</translation>
 <translation id="4192273449750167573">다음 화면에서 설정 검토</translation>
@@ -858,7 +858,7 @@
 <translation id="2532167245710864499">시스템 정보와 사용 기록을 Brave Software에 전송하여 Brave 및 보안 개선</translation>
 <translation id="2709453993673701466">동기화 및 맞춤설정을 관리한 다음 사용 설정하시겠습니까? <ph name="BEGIN_LINK"/>설정<ph name="END_LINK"/>으로 이동하세요.</translation>
 <translation id="2668128414154024727"><ph name="BEGIN_LINK"/>설정<ph name="END_LINK"/>에서 언제든지 Brave Software에서 수집하는 정보를 맞춤설정할 수 있습니다.</translation>
-<translation id="6035247993547372482">Brave Software에서 Brave을 비롯한 번역, Brave Software 검색과 같은 기타 Brave Software 서비스 및 광고를 맞춤설정하기 위해 사용자가 방문한 사이트의 콘텐츠, 브라우저 활동 및 상호작용 기록을 사용할 수 있습니다. 이는 설정에서 변경할 수 있습니다.</translation>
+<translation id="6035247993547372482">Brave Software에서 Brave를 비롯한 번역, Brave Software 검색과 같은 기타 Brave Software 서비스 및 광고를 맞춤설정하기 위해 사용자가 방문한 사이트의 콘텐츠, 브라우저 활동 및 상호작용 기록을 사용할 수 있습니다. 이는 설정에서 변경할 수 있습니다.</translation>
 <translation id="741204030948306876">사용</translation>
 <translation id="8428213095426709021">설정</translation>
 <translation id="2497852260688568942">관리자가 동기화를 사용 중지했습니다.</translation>
@@ -890,7 +890,7 @@
 <translation id="6664774537677393800">프로필을 여는 동안 문제가 발생했습니다. 로그아웃했다가 다시 로그인하세요.</translation>
 <translation id="1794791083288629568">이 문제를 해결하는 데 도움이 되도록 의견 전송</translation>
 <translation id="8234795456569844941">Brave Software 엔지니어가 이 문제를 해결하도록 도와주세요. 프로필 오류 메시지가 표시되기 직전에 무슨 일이 있었는지 알려 주시기 바랍니다.</translation>
-<translation id="6500340165622970282">프로필을 여는 동안 문제가 발생했기 때문에 Brave을 시작할 수 없습니다. Brave을 다시 시작해 보세요.</translation>
+<translation id="6500340165622970282">프로필을 여는 동안 문제가 발생했기 때문에 Brave를 시작할 수 없습니다. Brave를 다시 시작해 보세요.</translation>
 <translation id="6812349420832218321"><ph name="PRODUCT_NAME"/>은(는) 루트로 실행할 수 없습니다.</translation>
 <translation id="2292848386125228270">일반 사용자로 <ph name="PRODUCT_NAME"/>을(를) 시작하세요. 개발용 루트로 실행해야 하는 경우 --no-sandbox 플래그를 사용하여 다시 실행하세요.</translation>
 <translation id="3122496702278727796">데이터 디렉토리 만들기 실패</translation>
@@ -925,7 +925,7 @@
 <translation id="9037008143807155145">https://www.google.com/calendar/render?cid=%s</translation>
 <translation id="5426179911063097041"><ph name="SITE"/>에서 알림을 보내려고 합니다.</translation>
 <translation id="7221855153210829124">알림 표시</translation>
-<translation id="6042308850641462728">더보기</translation>
+<translation id="6042308850641462728">더 보기</translation>
 <translation id="8393700583063109961">메시지 보내기</translation>
 <translation id="3016780570757425217">내 위치 확인</translation>
 <translation id="4068506536726151626">이 페이지에는 사용자 위치를 추적하는 다음 사이트의 요소가 포함되어 있습니다.</translation>
@@ -1147,7 +1147,7 @@
 <translation id="1122960773616686544">북마크 이름</translation>
 <translation id="3527085408025491307">폴더</translation>
 <translation id="2815693974042551705">북마크 폴더</translation>
-<translation id="457386861538956877">더보기...</translation>
+<translation id="457386861538956877">더 보기...</translation>
 <translation id="3508920295779105875">다른 폴더 선택...</translation>
 <translation id="3530305684079447434">어느 기기에서나 북마크를 사용하려면 <ph name="SIGN_IN_LINK"/>.</translation>
 <translation id="1140610710803014750">어느 기기에서나 내 북마크를 사용하려면 로그인하고 동기화를 사용 설정하세요.</translation>
@@ -1193,7 +1193,7 @@
 <translation id="1173894706177603556">이름 바꾸기</translation>
 <translation id="5170568018924773124">폴더 열기</translation>
 <translation id="6825184156888454064">이름순 정렬</translation>
-<translation id="3440663250074896476"><ph name="BOOKMARK_NAME"/>의 작업 메뉴 더보기</translation>
+<translation id="3440663250074896476"><ph name="BOOKMARK_NAME"/>의 작업 메뉴 더 보기</translation>
 <translation id="2903457445916429186">선택한 항목 열기</translation>
 <translation id="962802172452141067">북마크 폴더 구조</translation>
 <translation id="1338776410427958681"><ph name="FOLDER_NAME"/> 접기</translation>
@@ -2096,7 +2096,7 @@
 <translation id="7661259717474717992">사이트에서 쿠키 데이터 저장 및 읽기 허용</translation>
 <translation id="2913331724188855103">사이트에서 쿠키 데이터를 저장하고 읽도록 허용(권장)</translation>
 <translation id="5908769186679515905">사이트에서 Flash를 실행하지 못하도록 차단</translation>
-<translation id="6096007141921397775">Brave을 종료할 때까지 Flash 설정이 유지됩니다.</translation>
+<translation id="6096007141921397775">Brave를 종료할 때까지 Flash 설정이 유지됩니다.</translation>
 <translation id="2972642118232180842">중요한 콘텐츠만 실행(권장)</translation>
 <translation id="7084192839369222683">중요한 콘텐츠만 실행</translation>
 <translation id="8074127646604999664">최근에 닫은 사이트에서 데이터 전송 및 수신을 완료하도록 허용</translation>
@@ -2340,7 +2340,7 @@
 <translation id="8785622406424941542">스타일러스</translation>
 <translation id="4673442866648850031">스타일러스가 분리되면 스타일러스 도구가 열립니다.</translation>
 <translation id="5862109781435984885">실행기에 스타일러스 도구 표시</translation>
-<translation id="4244238649050961491">스타일러스 앱 더보기</translation>
+<translation id="4244238649050961491">스타일러스 앱 더 보기</translation>
 <translation id="1163818598439831131">Brave Software Play 열기</translation>
 <translation id="9116799625073598554">메모 앱</translation>
 <translation id="5458998536542739734">잠금 화면 메모</translation>
@@ -2473,7 +2473,7 @@
 <translation id="9063208415146866933"><ph name="ERROR_LINE_START"/>행부터 <ph name="ERROR_LINE_END"/>행까지에 오류가 있음</translation>
 <translation id="1890674179660343635">&lt;span&gt;ID: &lt;/span&gt;<ph name="EXTENSION_ID"/></translation>
 <translation id="1805822111539868586">뷰 검사</translation>
-<translation id="181577467034453336"><ph name="NUMBER_OF_VIEWS"/>개 더보기...</translation>
+<translation id="181577467034453336"><ph name="NUMBER_OF_VIEWS"/>개 더 보기...</translation>
 <translation id="2450849356604136918">활성화된 뷰 없음</translation>
 <translation id="5488468185303821006">시크릿 모드에서 허용</translation>
 <translation id="6124650939968185064">이 확장 프로그램에 종속되는 확장 프로그램:</translation>
@@ -2552,7 +2552,7 @@
 <translation id="7681095912841365527">사이트에서 블루투스를 사용할 수 있습니다.</translation>
 <translation id="3085412380278336437">사이트에서 카메라를 사용할 수 있습니다.</translation>
 <translation id="9180380851667544951">사이트에서 화면을 공유할 수 있습니다.</translation>
-<translation id="4992630054488400221">Brave을 VR로 사용하려면 Daydream 키보드를 설치하거나 업데이트하세요</translation>
+<translation id="4992630054488400221">Brave를 VR로 사용하려면 Daydream 키보드를 설치하거나 업데이트하세요</translation>
 <translation id="983511809958454316">이 기능은 VR에서 지원되지 않습니다</translation>
 <translation id="4008291085758151621">VR에서 사이트 정보를 사용할 수 없습니다</translation>
 <translation id="1439926347196400598">Brave에서 오디오를 녹음하도록 허용하시겠습니까?</translation>

--- a/components/resources/strings/brave_components_resources_ko.xtb
+++ b/components/resources/strings/brave_components_resources_ko.xtb
@@ -34,7 +34,7 @@
 <translation id="2043261199283617849">도구바에서 Brave 로고를 클릭하여 보호 수준을 확인하고 조정합니다. 환경 설정 패널에서 전체 차단 설정을 관리하십시오.</translation>
 <translation id="3366308997091824722">차단 설정</translation>
 <translation id="7024124499777560832">환경 설정 사용자 정의</translation>
-<translation id="2498783234010887316">탭, 모양, 확장 프로그램 및 방문 기록 설정은 환경 설정 패널에서 구성 할 수 있습니다. 여기에서 어두운 테마가 있을 수도 있습니다 ;)</translation>
+<translation id="2498783234010887316">탭, 모양, 확장 프로그램 및 방문 기록 설정은 환경 설정 패널에서 구성할 수 있습니다. 여기에서 어두운 테마가 있을 수도 있습니다 ;)</translation>
 <translation id="5801568494490449797">환경 설정</translation>
 <translation id="3829010735958850433">시작 안내 건너뛰기</translation>
 <translation id="1201402288615127009">다음</translation>
@@ -114,7 +114,7 @@
 <translation id="279567716178902927">그랜트 만료일</translation>
 <translation id="2104073734684466851">보조금</translation>
 <translation id="1389143276807887637">불러오기</translation>
-<translation id="7335371657242627509">자동 기부에 포함시키기</translation>
+<translation id="7335371657242627509">자동 기부에 포함하기</translation>
 <translation id="3250511771491660127">이것을 매달 하기</translation>
 <translation id="7886389832052393750">4월</translation>
 <translation id="4736221692378411923">8월</translation>


### PR DESCRIPTION
This PR improves the following korean translations:
* `Brave을` -> `Brave를`
* `Software을` -> `Software를`
* `더보기 ` -> `더 보기`
* `포함시키기 ` -> `포함하기`
* `구성 할 ` -> `구성할`
I validated those with http://speller.cs.pusan.ac.kr/.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source