### PR TITLE
Issue 1729: Proxy all safe browsing requests through safebrowsing.brave.com

### DIFF
--- a/patches/components-safe_browsing-db-v4_protocol_manager_util.cc.patch
+++ b/patches/components-safe_browsing-db-v4_protocol_manager_util.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/safe_browsing/db/v4_protocol_manager_util.cc b/components/safe_browsing/db/v4_protocol_manager_util.cc
+index f4ed6ece672c82eca92a1d41015366a989874176..a6a0e791ad41129f5d6c2388ea4b00eeb8b4dedf 100644
+--- a/components/safe_browsing/db/v4_protocol_manager_util.cc
++++ b/components/safe_browsing/db/v4_protocol_manager_util.cc
+@@ -27,7 +27,7 @@ namespace safe_browsing {
+ // Can be overriden by tests.
+ const char* g_sbv4_url_prefix_for_testing = nullptr;
+ 
+-const char kSbV4UrlPrefix[] = "https://safebrowsing.googleapis.com/v4";
++const char kSbV4UrlPrefix[] = "https://safebrowsing.brave.com/v4";
+ 
+ const base::FilePath::CharType kStoreSuffix[] = FILE_PATH_LITERAL(".store");
+ 


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/1729

https://github.com/brave/brave-browser/commit/c2a7a0321ebe425e5f2f5b8ae1e42505c9bc744e - Here we set the `safe browsing endpoint` to `safebrowsing.brave.com` which internally redirects all requests to `safebrowsing.googleapis.com` to `safebrowsing.brave.com`.  `brave://net-internals` displays the original request to `safebrowsing.googleapis.com` which is internally redirected to `safebrowsing.brave.com`. This change is to ensures that all requests are sent to `safebrowsing.brave.com`.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave and wait for the Safe Browsing API to download the *.store files in <data-dir>/Safe Browsing
2. Navigate to testsafebrowsing.appspot.com
3. Open chrome://net-internals in a new tab
4. Open different URL test pages. Verify that the correct warning pages are displayed and no requests are sent to `safebrowsing.googleapis.com`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source