### PR TITLE
Pass isWindows property to GrantCaptcha

### DIFF
--- a/components/brave_rewards/ui/components/grant.tsx
+++ b/components/brave_rewards/ui/components/grant.tsx
@@ -84,7 +84,7 @@ class Grant extends React.Component<Props, State> {
               title={grant.status === 'wrongPosition' ? getLocale('notQuite') : getLocale('almostThere')}
               text={getLocale('proveHuman')}
             >
-              <GrantCaptcha onSolution={this.onSolution} dropBgImage={grant.captcha} hint={grant.hint} />
+              <GrantCaptcha onSolution={this.onSolution} dropBgImage={grant.captcha} hint={grant.hint} isWindows={navigator.platform === 'Win32'} />
             </GrantWrapper>
             : null
         }


### PR DESCRIPTION
Fixes brave/brave-browser#1350

Without that property, captchas don't work as expected when resolution
is scaled.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source