### PR TITLE
Disable GCM client registration

### DIFF
--- a/patches/components-gcm_driver-gcm_client_impl.cc.patch
+++ b/patches/components-gcm_driver-gcm_client_impl.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/gcm_driver/gcm_client_impl.cc b/components/gcm_driver/gcm_client_impl.cc
+index 168bef640e08..60ed5a554221 100644
+--- a/components/gcm_driver/gcm_client_impl.cc
++++ b/components/gcm_driver/gcm_client_impl.cc
+@@ -865,6 +865,7 @@ void GCMClientImpl::ResetCache() {
+ 
+ void GCMClientImpl::Register(
+     const linked_ptr<RegistrationInfo>& registration_info) {
++  return; // GCM disabled in Brave
+   DCHECK_EQ(state_, READY);
+ 
+   // Registrations should never pass as an app_id the special category used


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1716

Disabling the GCM client registration should disable the entire GCM subsystem. No other GCM-related classes will function until the client is registered.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source