### PR TITLE
Fix startup crash when using Barrons or MarketWatch promotions

### DIFF
--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -29,8 +29,10 @@ BraveNetworkDelegateBase::~BraveNetworkDelegateBase() {
 }
 
 void BraveNetworkDelegateBase::GetReferralHeaders() {
-  referral_headers_list_ =
+  const base::ListValue* referral_headers =
       g_browser_process->local_state()->GetList(kReferralHeaders);
+  if (referral_headers)
+    referral_headers_list_ = referral_headers->CreateDeepCopy();
 }
 
 int BraveNetworkDelegateBase::OnBeforeURLRequest(net::URLRequest* request,
@@ -61,7 +63,7 @@ int BraveNetworkDelegateBase::OnBeforeStartTransaction(net::URLRequest* request,
   brave::BraveRequestInfo::FillCTXFromRequest(request, ctx);
   ctx->event_type = brave::kOnBeforeStartTransaction;
   ctx->headers = headers;
-  ctx->referral_headers_list = referral_headers_list_;
+  ctx->referral_headers_list = referral_headers_list_.get();
   callbacks_[request->identifier()] = std::move(callback);
   RunNextCallback(request, ctx);
   return net::ERR_IO_PENDING;

--- a/browser/net/brave_network_delegate_base.h
+++ b/browser/net/brave_network_delegate_base.h
@@ -61,7 +61,7 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
 
  private:
   void GetReferralHeaders();
-  const base::ListValue* referral_headers_list_;
+  std::unique_ptr<base::ListValue> referral_headers_list_;
   std::map<uint64_t, net::CompletionOnceCallback> callbacks_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveNetworkDelegateBase);


### PR DESCRIPTION
Fixes brave/brave-browser#1813
Fixes brave/brave-browser#1805

We weren't making a copy of the referral headers, which led to them
eventually getting trashed in memory.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source