### PR TITLE
Integrate omaha build into brave-core

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -115,6 +115,12 @@ group("create_dist") {
       "//chrome/installer/mini_installer",
       "build/win:create_signed_installer"
     ]
+
+    if (build_omaha) {
+      deps += [
+        "//brave/vendor/omaha",
+      ]
+    }
   }
   if (is_mac) {
     deps += [ "build/mac:create_dist_mac" ]

--- a/DEPS
+++ b/DEPS
@@ -9,6 +9,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@5c633e867efafb9013c57ca830212d1ff6ea5076",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
   "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@0396fb47a0cfc55c0a7e271bae4c88c548e1574a",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",

--- a/build/config.gni
+++ b/build/config.gni
@@ -21,6 +21,9 @@ declare_args() {
   brave_version_build = ""
   brave_version_patch = 0
   chrome_version_string = ""
+  chrome_version_major = ""
+  build_omaha = false
+  tag_ap =""
 }
 
 if (base_sparkle_update_url == "") {
@@ -41,6 +44,32 @@ if (brave_exe == "") {
 brave_dist_dir = "$root_out_dir/dist"
 if (is_win) {
   brave_exe = "$brave_exe.exe"
+  brave_underline_full_version = "_$chrome_version_major" + "_$brave_version_major" + "_$brave_version_minor" + "_$brave_version_build"
+  _channel = ""
+  brave_app_guid = "{AFE6A462-C574-4B8A-AF43-4CC60DF4563B}"
+  if (is_official_build) {
+    if (brave_channel == "beta") {
+      _channel = "Beta"
+      brave_app_guid = "{103BD053-949B-43A8-9120-2E424887DE11}"
+    } else if (brave_channel == "dev") {
+      _channel = "Dev"
+      brave_app_guid = "{CB2150F2-595F-4633-891A-E39720CE0531}"
+    } else if (brave_channel == "nightly") {
+      _channel = "Nightly"
+      brave_app_guid = "{C6CB981E-DB30-4876-8639-109F8933582C}"
+    } else {
+      assert(brave_channel == "", "Unknown channel name")
+    }
+  } else {
+    _channel = "Development"
+  }
+  _arch = ""
+  if (target_cpu == "x86") {
+    _arch = "32"
+  }
+  brave_installer_exe = "brave_installer$brave_underline_full_version.exe"
+  brave_stub_installer_exe = "BraveBrowser$_channel" + "Setup$_arch$brave_underline_full_version.exe"
+  brave_standalone_installer_exe = "BraveBrowserStandalone$_channel" + "Setup$_arch$brave_underline_full_version.exe"
 } else if (is_mac) {
   brave_exe = "$chrome_product_full_name.app"
   brave_dmg = "$chrome_product_full_name.dmg"

--- a/build/win/BUILD.gn
+++ b/build/win/BUILD.gn
@@ -1,3 +1,5 @@
+import("//brave/build/config.gni")
+
 group("brave") {
   public_deps = [
     ":copy_exe",
@@ -40,10 +42,12 @@ action("create_signed_installer") {
   ]
   outputs = [
     "$root_out_dir/brave_installer.exe",
+    "$root_out_dir/$brave_installer_exe",
   ]
   out_dir = rebase_path(root_out_dir, "//")
   args = [
-    "--root_out_dir=$out_dir"
+    "--root_out_dir=$out_dir",
+    "--brave_installer_exe=$brave_installer_exe",
   ]
   deps = [
     "//chrome/installer/mini_installer"

--- a/script/create-signed-installer.py
+++ b/script/create-signed-installer.py
@@ -9,19 +9,24 @@ def main():
   root_out_dir = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))),
     args.root_out_dir[0])
-  create_signed_installer(root_out_dir)
+  create_signed_installer(root_out_dir, args.brave_installer_exe[0])
 
 def parse_args():
   parser = argparse.ArgumentParser(description='Create signed installer')
   parser.add_argument('--root_out_dir',
                       nargs=1)
+  parser.add_argument('--brave_installer_exe',
+                      nargs=1)
   return parser.parse_args()
 
 
-def create_signed_installer(root_out_dir, env=None):
+def create_signed_installer(root_out_dir, brave_installer_exe, env=None):
   installer_file = os.path.join(root_out_dir, 'brave_installer.exe')
   shutil.copyfile(os.path.join(root_out_dir, 'mini_installer.exe'), installer_file)
   sign_binary(installer_file)
+  # Copy signed installer to version appended name
+  installer_file_with_version = os.path.join(root_out_dir, brave_installer_exe)
+  shutil.copyfile(installer_file, installer_file_with_version)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When build_omaha is set, create_dist target has omaha dependency and
omaha clients(stub/standalone) are built under src/out/Release.

Issue: https://github.com/brave/brave-browser/issues/1784
Close: https://github.com/brave/brave-browser/issues/976
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source