### PR TITLE
Promo code is never claimed if user closes browser too soon

### DIFF
--- a/browser/referrals/brave_referrals_service.h
+++ b/browser/referrals/brave_referrals_service.h
@@ -31,10 +31,9 @@ class BraveReferralsService {
   void Stop();
 
  private:
-  void PerformFirstRunTasks();
   void GetFirstRunTime();
   base::FilePath GetPromoCodeFileName() const;
-  bool ReadPromoCode();
+  void ReadPromoCode();
   void DeletePromoCodeFile() const;
   void MaybeCheckForReferralFinalization();
   void MaybeDeletePromoCodePref() const;
@@ -61,8 +60,8 @@ class BraveReferralsService {
   void OnReferralFinalizationCheckLoadComplete(
       std::unique_ptr<std::string> response_body);
 
-  // Invoked after first run tasks are complete.
-  void OnFirstRunTasksComplete();
+  // Invoked after reading contents of promo code file.
+  void OnReadPromoCodeComplete();
 
   bool initialized_;
   base::Time first_run_timestamp_;

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -28,6 +28,7 @@ const char kReferralTimestamp[] = "brave.referral.timestamp";
 const char kReferralAttemptTimestamp[] = "brave.referral.referral_attempt_timestamp";
 const char kReferralAttemptCount[] = "brave.referral.referral_attempt_count";
 const char kReferralHeaders[] = "brave.referral.headers";
+const char kReferralCheckedForPromoCodeFile[] = "brave.referral.checked_for_promo_code_file";
 const char kHTTPSEVerywhereControlType[] = "brave.https_everywhere_default";
 const char kNoScriptControlType[] = "brave.no_script_default";
 const char kRewardsNotifications[] = "brave.rewards.notifications";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -27,6 +27,7 @@ extern const char kReferralTimestamp[];
 extern const char kReferralAttemptTimestamp[];
 extern const char kReferralAttemptCount[];
 extern const char kReferralHeaders[];
+extern const char kReferralCheckedForPromoCodeFile[];
 extern const char kHTTPSEVerywhereControlType[];
 extern const char kNoScriptControlType[];
 extern const char kRewardsNotifications[];


### PR DESCRIPTION
Fixes brave/brave-browser#1811

We previously only looked for the promoCode file on first
run. However, since there's a short delay before we launch the task to
read the promoCode file, there's a window of opportunity for a user to
close the browser before we read the file. This puts the user in a
state where the first run has occurred but the promoCode file wasn't
read (and therefore won't ever be read).

We now use a Boolean preference to achieve the same effect, but since
it's not tied to first-run it will allow us to continue to look for
the promoCode file even in the above scenario. Once we've checked for
the promoCode file we flip the flag so that there's no long-term
cost.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source