### PR TITLE
Clear notification when grant is claimed

### DIFF
--- a/browser/extensions/api/rewards_notifications_api.cc
+++ b/browser/extensions/api/rewards_notifications_api.cc
@@ -28,7 +28,7 @@ ExtensionFunction::ResponseAction RewardsNotificationsAddNotificationFunction::R
     rewards_notifications_service->AddNotification(
         static_cast<RewardsNotificationsService::RewardsNotificationType>(
             params->type),
-        params->args);
+        params->args, params->id);
   }
   return RespondNow(NoArguments());
 }

--- a/common/extensions/api/rewards_notifications.json
+++ b/common/extensions/api/rewards_notifications.json
@@ -17,7 +17,7 @@
         "parameters": [
           {
             "name": "id",
-            "type": "integer"
+            "type": "string"
           },
           {
             "name": "type",
@@ -44,7 +44,7 @@
         "parameters": [
           {
             "name": "id",
-            "type": "integer"
+            "type": "string"
           },
           {
             "name": "type",
@@ -69,7 +69,7 @@
         "parameters": [
           {
             "name": "id",
-            "type": "integer"
+            "type": "string"
           },
           {
             "name": "type",
@@ -101,7 +101,7 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "integer",
+                  "type": "string",
                   "description": "The rewards notification ID"
                 },
                 "type": {
@@ -143,6 +143,10 @@
               "name": "value",
               "type": "string"
             }
+          },
+          {
+            "name": "id",
+            "type": "string"
           }
         ]
       },
@@ -153,7 +157,7 @@
         "parameters": [
           {
             "name": "id",
-            "type": "integer"
+            "type": "string"
           }
         ]
       },
@@ -170,7 +174,7 @@
         "parameters": [
           {
             "name": "id",
-            "type": "integer"
+            "type": "string"
           }
         ]
       },

--- a/components/brave_rewards/browser/rewards_notifications_service.cc
+++ b/components/brave_rewards/browser/rewards_notifications_service.cc
@@ -18,10 +18,11 @@ RewardsNotificationsService::RewardsNotification::RewardsNotification() {}
 
 RewardsNotificationsService::RewardsNotification::RewardsNotification(const RewardsNotificationsService::RewardsNotification& prop) = default;
 
-RewardsNotificationsService::RewardsNotification::RewardsNotification(RewardsNotificationsService::RewardsNotificationID id,
-                    RewardsNotificationsService::RewardsNotificationType type,
-                    RewardsNotificationsService::RewardsNotificationTimestamp timestamp,
-                    RewardsNotificationsService::RewardsNotificationArgs args)
+RewardsNotificationsService::RewardsNotification::RewardsNotification(
+    RewardsNotificationsService::RewardsNotificationID id,
+    RewardsNotificationsService::RewardsNotificationType type,
+    RewardsNotificationsService::RewardsNotificationTimestamp timestamp,
+    RewardsNotificationsService::RewardsNotificationArgs args)
     : id_(id), type_(type), timestamp_(timestamp), args_(args) {}
 
 RewardsNotificationsService::RewardsNotification::~RewardsNotification() {}

--- a/components/brave_rewards/browser/rewards_notifications_service.h
+++ b/components/brave_rewards/browser/rewards_notifications_service.h
@@ -20,7 +20,7 @@ class RewardsNotificationsService : public KeyedService {
   RewardsNotificationsService();
   ~RewardsNotificationsService() override;
 
-  typedef uint32_t RewardsNotificationID;
+  typedef std::string RewardsNotificationID;
   typedef uint64_t RewardsNotificationTimestamp;
   typedef std::vector<std::string> RewardsNotificationArgs;
 
@@ -41,7 +41,7 @@ class RewardsNotificationsService : public KeyedService {
                         RewardsNotificationTimestamp timestamp,
                         RewardsNotificationArgs args);
     ~RewardsNotification();
-    RewardsNotificationID id_ = 0;
+    RewardsNotificationID id_;
     RewardsNotificationType type_ = RewardsNotificationsService::REWARDS_NOTIFICATION_INVALID;
     RewardsNotificationTimestamp timestamp_ = 0;
     RewardsNotificationArgs args_;
@@ -50,7 +50,8 @@ class RewardsNotificationsService : public KeyedService {
   typedef std::vector<RewardsNotification> RewardsNotificationsList;
 
   virtual void AddNotification(RewardsNotificationType type,
-                               RewardsNotificationArgs args) = 0;
+                               RewardsNotificationArgs args,
+                               RewardsNotificationID id = "") = 0;
   virtual void DeleteNotification(RewardsNotificationID id) = 0;
   virtual void DeleteAllNotifications() = 0;
   virtual void GetNotification(RewardsNotificationID id) = 0;

--- a/components/brave_rewards/browser/rewards_notifications_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_notifications_service_browsertest.cc
@@ -33,7 +33,7 @@ class BraveRewardsNotificationsBrowserTest
     EXPECT_STREQ(notification.args_.at(0).c_str(), "foo");
     EXPECT_STREQ(notification.args_.at(1).c_str(), "bar");
 
-    EXPECT_TRUE(notification.id_ != 0);
+    EXPECT_STREQ(notification.id_.c_str(), "rewards_notification_grant");
     EXPECT_TRUE(notification.timestamp_ != 0);
 
     notification_id_ = notification.id_;
@@ -44,7 +44,7 @@ class BraveRewardsNotificationsBrowserTest
   void OnNotificationDeleted(
       RewardsNotificationsService* rewards_notifications_service,
       const RewardsNotificationsService::RewardsNotification& notification) override {
-    EXPECT_TRUE(notification.id_ != 0);
+    EXPECT_STREQ(notification.id_.c_str(), "rewards_notification_grant");
     EXPECT_TRUE(notification.timestamp_ != 0);
 
     delete_notification_callback_was_called_ = true;
@@ -75,7 +75,7 @@ class BraveRewardsNotificationsBrowserTest
 
   RewardsNotificationsService* rewards_notifications_service_;
 
-  RewardsNotificationsService::RewardsNotificationID notification_id_ = 0;
+  RewardsNotificationsService::RewardsNotificationID notification_id_;
 
   bool add_notification_callback_was_called_ = false;
   bool delete_notification_callback_was_called_ = false;
@@ -87,9 +87,10 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsNotificationsBrowserTest, AddGrantNotificatio
   RewardsNotificationsService::RewardsNotificationArgs args;
   args.push_back("foo");
   args.push_back("bar");
-  
+
   rewards_notifications_service_->AddNotification(
-      RewardsNotificationsService::REWARDS_NOTIFICATION_GRANT, args);
+      RewardsNotificationsService::REWARDS_NOTIFICATION_GRANT, args,
+      "rewards_notification_grant");
   WaitForAddNotificationCallback();
 
   rewards_notifications_service_->RemoveObserver(this);
@@ -101,12 +102,13 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsNotificationsBrowserTest, AddGrantNotificatio
   RewardsNotificationsService::RewardsNotificationArgs args;
   args.push_back("foo");
   args.push_back("bar");
-  
+
   rewards_notifications_service_->AddNotification(
-      RewardsNotificationsService::REWARDS_NOTIFICATION_GRANT, args);
+      RewardsNotificationsService::REWARDS_NOTIFICATION_GRANT, args,
+      "rewards_notification_grant");
   WaitForAddNotificationCallback();
 
-  EXPECT_TRUE(notification_id_ != 0);
+  EXPECT_STREQ(notification_id_.c_str(), "rewards_notification_grant");
 
   rewards_notifications_service_->DeleteNotification(notification_id_);
   WaitForDeleteNotificationCallback();

--- a/components/brave_rewards/browser/rewards_notifications_service_impl.h
+++ b/components/brave_rewards/browser/rewards_notifications_service_impl.h
@@ -26,7 +26,8 @@ class RewardsNotificationsServiceImpl
 
   void Init();
   void AddNotification(RewardsNotificationType type,
-                       RewardsNotificationArgs args) override;
+                       RewardsNotificationArgs args,
+                       RewardsNotificationID id = "") override;
   void DeleteNotification(RewardsNotificationID id) override;
   void DeleteAllNotifications() override;
   void GetNotification(RewardsNotificationID id) override;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -533,7 +533,8 @@ void RewardsServiceImpl::OnGrant(ledger::Result result,
   if (result == ledger::Result::LEDGER_OK) {
     RewardsNotificationsService::RewardsNotificationArgs args;
     rewards_notifications_service_->AddNotification(
-        RewardsNotificationsService::REWARDS_NOTIFICATION_GRANT, args);
+        RewardsNotificationsService::REWARDS_NOTIFICATION_GRANT, args,
+        "rewards_notification_grant");
   }
 }
 
@@ -559,6 +560,8 @@ void RewardsServiceImpl::OnGrantFinish(ledger::Result result,
   }
 
   TriggerOnGrantFinish(result, grant);
+  rewards_notifications_service_->DeleteNotification(
+      "rewards_notification_grant");
 }
 
 void RewardsServiceImpl::OnReconcileComplete(ledger::Result result,

--- a/components/brave_rewards/resources/extension/brave_rewards/actions/rewards_panel_actions.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/actions/rewards_panel_actions.ts
@@ -38,20 +38,20 @@ export const onCurrentReport = (properties: RewardsExtension.Report) => action(t
   properties
 })
 
-export const onNotificationAdded = (id: number, type: number, timestamp: number, args: string[]) => action(types.ON_NOTIFICATION_ADDED, {
+export const onNotificationAdded = (id: string, type: number, timestamp: number, args: string[]) => action(types.ON_NOTIFICATION_ADDED, {
   id,
   type,
   timestamp,
   args
 })
 
-export const onNotificationDeleted = (id: number, type: number, timestamp: number) => action(types.ON_NOTIFICATION_DELETED, {
+export const onNotificationDeleted = (id: string, type: number, timestamp: number) => action(types.ON_NOTIFICATION_DELETED, {
   id,
   timestamp,
   type
 })
 
-export const deleteNotification = (id: number) => action(types.DELETE_NOTIFICATION, {
+export const deleteNotification = (id: string) => action(types.DELETE_NOTIFICATION, {
   id
 })
 

--- a/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
@@ -20,10 +20,10 @@ chrome.braveRewards.onCurrentReport.addListener((properties: RewardsExtension.Re
   rewardsPanelActions.onCurrentReport(properties)
 })
 
-chrome.rewardsNotifications.onNotificationAdded.addListener((id: number, type: number, timestamp: number, args: string[]) => {
+chrome.rewardsNotifications.onNotificationAdded.addListener((id: string, type: number, timestamp: number, args: string[]) => {
   rewardsPanelActions.onNotificationAdded(id, type, timestamp, args)
 })
 
-chrome.rewardsNotifications.onNotificationDeleted.addListener((id: number, type: number, timestamp: number) => {
+chrome.rewardsNotifications.onNotificationDeleted.addListener((id: string, type: number, timestamp: number) => {
   rewardsPanelActions.onNotificationDeleted(id, type, timestamp)
 })

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -25,10 +25,6 @@ const getWindowId = (id: number) => {
   return `id_${id}`
 }
 
-const getNotificationId = (id: number) => {
-  return `n_${id}`
-}
-
 export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, action: any) => {
   if (state === undefined) {
     state = storage.load()
@@ -116,11 +112,11 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       }
     case types.ON_NOTIFICATION_ADDED:
       {
-        if (!payload || !payload.id) {
+        if (!payload || payload.id === '') {
           return
         }
 
-        const id = getNotificationId(payload.id)
+        const id = payload.id
         let notifications: Record<number, RewardsExtension.Notification> = state.notifications
 
         if (!notifications) {
@@ -148,17 +144,16 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       }
     case types.DELETE_NOTIFICATION:
       {
-        const id = payload.id.toString().replace('n_', '')
-        chrome.rewardsNotifications.deleteNotification(parseInt(id, 10))
+        chrome.rewardsNotifications.deleteNotification(payload.id)
         break
       }
     case types.ON_NOTIFICATION_DELETED:
       {
-        if (!payload || !payload.id) {
+        if (!payload || payload.id === '') {
           return
         }
 
-        const id = getNotificationId(payload.id)
+        const id = payload.id
         let notifications: Record<number, RewardsExtension.Notification> = state.notifications
         delete notifications[id]
 

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -34,21 +34,21 @@ declare namespace chrome.braveRewards {
 }
 
 declare namespace chrome.rewardsNotifications {
-  const addNotification: (type: number, args: string[]) => {}
-  const deleteNotification: (id: number) => {}
+  const addNotification: (type: number, args: string[], id: string) => {}
+  const deleteNotification: (id: string) => {}
   const deleteAllNotifications: () => {}
-  const getNotification: (id: number) => {}
+  const getNotification: (id: string) => {}
 
   const onNotificationAdded: {
-    addListener: (callback: (id: number, type: number, timestamp: number, args: string[]) => void) => void
+    addListener: (callback: (id: string, type: number, timestamp: number, args: string[]) => void) => void
   }
   const onNotificationDeleted: {
-    addListener: (callback: (id: number, type: number, timestamp: number) => void) => void
+    addListener: (callback: (id: string, type: number, timestamp: number) => void) => void
   }
   const onAllNotificationsDeleted: {
     addListener: (callback: () => void) => void
   }
   const onGetNotification: {
-    addListener: (callback: (id: number, type: number, timestamp: number) => void) => void
+    addListener: (callback: (id: string, type: number, timestamp: number) => void) => void
   }
 }


### PR DESCRIPTION
Fixes brave/brave-browser#1615
Fixes brave/brave-browser#1691

Most of the changes here involve switching the notification ID from
a randomly-generated integer to a client-provided string. Deleting the
grant notification is handled by RewardsServiceImpl::OnGrantFinish.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source