### PR TITLE
Fix call to release_channel() in upload.py

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -204,10 +204,10 @@ def create_release_draft(repo, tag):
 
 These builds are an unpolished and unfinished early preview for the new version of Brave on the desktop. These builds show our work in progress and they aren't for the faint-of-heart. Features may be missing or broken in new and exciting ways; familiar functionality may have unfamiliar side-effects. These builds showcase the newest advances that we're bringing to your browser, but this is still a prototype, not a reliable daily driver. Try it out only if you're looking for a little extra spice and adventure in your browsing.'''
 
-  if channel in 'dev':
+  if release_channel() in 'dev':
     winstallers = dev_winstallers
     warning = dev_beta_warning
-  elif channel in 'beta':
+  elif release_channel() in 'beta':
     winstallers = beta_winstallers
     warning = dev_beta_warning
   else:


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source