### PR TITLE
Disable reset report uploader and hide UI

### DIFF
--- a/browser/resources/settings/reset_report_uploader_unittest.cc
+++ b/browser/resources/settings/reset_report_uploader_unittest.cc
@@ -1,0 +1,40 @@
+#include "chrome/browser/profile_resetter/reset_report_uploader.h"
+
+#include "base/test/bind_test_util.h"
+#include "base/test/scoped_task_environment.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class ResetReportUploaderTest : public testing::Test {
+ public:
+  ResetReportUploaderTest()
+      : test_shared_loader_factory_(
+            base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+                &test_url_loader_factory_)) {}
+
+ protected:
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory() {
+    return test_shared_loader_factory_;
+  }
+  network::TestURLLoaderFactory* test_url_loader_factory() {
+    return &test_url_loader_factory_;
+  }
+
+ private:
+  base::test::ScopedTaskEnvironment scoped_task_environment_;
+  network::TestURLLoaderFactory test_url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> test_shared_loader_factory_;
+};
+
+TEST_F(ResetReportUploaderTest, NoFetch) {
+  bool network_access_occurred = false;
+  test_url_loader_factory()->SetInterceptor(
+    base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
+                                   network_access_occurred = true;
+                               }));
+  ResetReportUploader* uploader =
+    new ResetReportUploader(shared_url_loader_factory());
+  uploader->DispatchReportInternal("");
+  EXPECT_FALSE(network_access_occurred);
+}

--- a/patches/chrome-browser-profile_resetter-reset_report_uploader.cc
+++ b/patches/chrome-browser-profile_resetter-reset_report_uploader.cc
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/profile_resetter/reset_report_uploader.cc b/chrome/browser/profile_resetter/reset_report_uploader.cc
+index 696cd4a6127f..24e6ce8873ed 100644
+--- a/chrome/browser/profile_resetter/reset_report_uploader.cc
++++ b/chrome/browser/profile_resetter/reset_report_uploader.cc
+@@ -48,6 +48,7 @@ void ResetReportUploader::DispatchReport(
+ 
+ void ResetReportUploader::DispatchReportInternal(
+     const std::string& request_data) {
++  return; // feature disabled in Brave
+   // Create traffic annotation tag.
+   net::NetworkTrafficAnnotationTag traffic_annotation =
+       net::DefineNetworkTrafficAnnotation("profile_resetter_upload", R"(

--- a/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.html.patch
+++ b/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.html.patch
@@ -1,0 +1,15 @@
+diff --git a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
+index 64a6823036ba..714324e2a13f 100644
+--- a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
++++ b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
+@@ -44,10 +44,6 @@
+           $i18n{resetDialogCommit}
+         </paper-button>
+       </div>
+-      <div slot="footer">
+-        <cr-checkbox id="sendSettings" checked>
+-          $i18nRaw{resetPageFeedback}</cr-checkbox>
+-      </div>
+     </cr-dialog>
+   </template>
+   <script src="reset_profile_dialog.js"></script>

--- a/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.html.patch
+++ b/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.html.patch
@@ -1,15 +1,17 @@
 diff --git a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
-index 64a6823036ba..714324e2a13f 100644
+index 64a6823036ba..e29c828edc69 100644
 --- a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
 +++ b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
-@@ -44,10 +44,6 @@
+@@ -44,10 +44,12 @@
            $i18n{resetDialogCommit}
          </paper-button>
        </div>
--      <div slot="footer">
--        <cr-checkbox id="sendSettings" checked>
--          $i18nRaw{resetPageFeedback}</cr-checkbox>
--      </div>
++<!--
+       <div slot="footer">
+         <cr-checkbox id="sendSettings" checked>
+           $i18nRaw{resetPageFeedback}</cr-checkbox>
+       </div>
++-->
      </cr-dialog>
    </template>
    <script src="reset_profile_dialog.js"></script>

--- a/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.js.patch
+++ b/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.js.patch
@@ -1,0 +1,23 @@
+diff --git a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
+index 0291bfffdcd5..12ff081941f1 100644
+--- a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
++++ b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
+@@ -75,9 +75,6 @@ Polymer({
+     this.addEventListener('cancel', () => {
+       this.browserProxy_.onHideResetProfileDialog();
+     });
+-
+-    this.$$('cr-checkbox a')
+-        .addEventListener('click', this.onShowReportedSettingsTap_.bind(this));
+   },
+ 
+   /** @private */
+@@ -123,7 +120,7 @@ Polymer({
+     this.clearingInProgress_ = true;
+     this.browserProxy_
+         .performResetProfileSettings(
+-            this.$.sendSettings.checked, this.resetRequestOrigin_)
++            false, this.resetRequestOrigin_)
+         .then(() => {
+           this.clearingInProgress_ = false;
+           if (this.$.dialog.open)

--- a/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.js.patch
+++ b/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.js.patch
@@ -1,23 +1,30 @@
 diff --git a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
-index 0291bfffdcd5..12ff081941f1 100644
+index 0291bfffdcd5..ee783f93ddd9 100644
 --- a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
 +++ b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
-@@ -75,9 +75,6 @@ Polymer({
-     this.addEventListener('cancel', () => {
+@@ -76,8 +76,10 @@ Polymer({
        this.browserProxy_.onHideResetProfileDialog();
      });
--
--    this.$$('cr-checkbox a')
--        .addEventListener('click', this.onShowReportedSettingsTap_.bind(this));
+ 
++    // <if expr="_google_chrome">
+     this.$$('cr-checkbox a')
+         .addEventListener('click', this.onShowReportedSettingsTap_.bind(this));
++    // </if>
    },
  
    /** @private */
-@@ -123,7 +120,7 @@ Polymer({
+@@ -123,7 +125,13 @@ Polymer({
      this.clearingInProgress_ = true;
      this.browserProxy_
          .performResetProfileSettings(
 -            this.$.sendSettings.checked, this.resetRequestOrigin_)
-+            false, this.resetRequestOrigin_)
++            // <if expr="_google_chrome">
++            this.$.sendSettings.checked,
++            // <else>
++            false,
++            // </if>
++            this.resetRequestOrigin_);
++ 
          .then(() => {
            this.clearingInProgress_ = false;
            if (this.$.dialog.open)

--- a/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.js.patch
+++ b/patches/chrome-browser-resources-settings-reset_page-reset_profile_dialog.js.patch
@@ -1,30 +1,22 @@
 diff --git a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
-index 0291bfffdcd5..ee783f93ddd9 100644
+index 0291bfffdcd5..62b9f8bc662b 100644
 --- a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
 +++ b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.js
-@@ -76,8 +76,10 @@ Polymer({
+@@ -75,9 +75,6 @@ Polymer({
+     this.addEventListener('cancel', () => {
        this.browserProxy_.onHideResetProfileDialog();
      });
- 
-+    // <if expr="_google_chrome">
-     this.$$('cr-checkbox a')
-         .addEventListener('click', this.onShowReportedSettingsTap_.bind(this));
-+    // </if>
+-
+-    this.$$('cr-checkbox a')
+-        .addEventListener('click', this.onShowReportedSettingsTap_.bind(this));
    },
  
    /** @private */
-@@ -123,7 +125,13 @@ Polymer({
+@@ -121,6 +118,7 @@ Polymer({
+   /** @private */
+   onResetTap_: function() {
      this.clearingInProgress_ = true;
++    this.$.sendSettings.checked = { checked: false };
      this.browserProxy_
          .performResetProfileSettings(
--            this.$.sendSettings.checked, this.resetRequestOrigin_)
-+            // <if expr="_google_chrome">
-+            this.$.sendSettings.checked,
-+            // <else>
-+            false,
-+            // </if>
-+            this.resetRequestOrigin_);
-+ 
-         .then(() => {
-           this.clearingInProgress_ = false;
-           if (this.$.dialog.open)
+             this.$.sendSettings.checked, this.resetRequestOrigin_)

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -46,6 +46,7 @@ test("brave_unit_tests") {
     "//brave/browser/profiles/tor_unittest_profile_manager.cc",
     "//brave/browser/profiles/tor_unittest_profile_manager.h",
     "//brave/browser/profiles/brave_profile_manager_unittest.cc",
+    "//brave/browser/resources/settings/reset_report_uploader_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave\chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1844

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source