### PR TITLE
New Tab Button for C71

### DIFF
--- a/browser/ui/views/tabs/brave_new_tab_button.cc
+++ b/browser/ui/views/tabs/brave_new_tab_button.cc
@@ -1,12 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
 #include "ui/gfx/geometry/size.h"
+#include "ui/gfx/scoped_canvas.h"
+#include "ui/gfx/skia_util.h"
 
 namespace {
   // Returns the size of the button without any margin
@@ -15,19 +17,8 @@ namespace {
   }
 }
 
-BraveNewTabButton::BraveNewTabButton(
-                          TabStrip* tab_strip, views::ButtonListener* listener)
-      : NewTabButton(tab_strip, listener) {
-  // Overriden so that we use Brave's custom button size
-  const int margin_vertical = (GetLayoutConstant(TAB_HEIGHT) -
-                                   GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP) -
-                                   GetButtonSize().height()) / 2;
-  SetBorder(
-    views::CreateEmptyBorder(gfx::Insets(margin_vertical, 8, 0, 8))
-  );
-}
-
-BraveNewTabButton::~BraveNewTabButton() {}
+// static
+const gfx::Size BraveNewTabButton::kButtonSize{20, 20};
 
 gfx::Size BraveNewTabButton::CalculatePreferredSize() const {
   // Overriden so that we use Brave's custom button size
@@ -35,4 +26,37 @@ gfx::Size BraveNewTabButton::CalculatePreferredSize() const {
   const auto insets = GetInsets();
   size.Enlarge(insets.width(), insets.height());
   return size;
+}
+
+gfx::Path BraveNewTabButton::GetBorderPath(const gfx::Point& origin,
+                                      float scale,
+                                      bool extend_to_top) const {
+  // Overriden to use Brave's non-circular shape
+  gfx::PointF scaled_origin(origin);
+  scaled_origin.Scale(scale);
+  const float radius = GetCornerRadius() * scale;
+
+  gfx::Path path;
+  const gfx::Rect contents_bounds = GetContentsBounds();
+  const gfx::Rect path_rect(scaled_origin.x(), extend_to_top ? 0 : scaled_origin.y(),
+              contents_bounds.width() * scale,
+              scaled_origin.y() + contents_bounds.height() * scale);
+  path.addRoundRect(RectToSkRect(path_rect), radius, radius);
+  path.close();
+  return path;
+}
+
+void BraveNewTabButton::PaintPlusIcon(gfx::Canvas* canvas) const {
+  // Overriden to fix chromium assumption that border radius
+  // will be 50% of width.
+  gfx::ScopedCanvas scoped_canvas(canvas);
+  // Offset that we want to use
+  const int correct_offset = (GetContentsBounds().width() / 2);
+  // Incorrect offset that base class will use
+  const int chromium_offset = GetCornerRadius();
+  // Difference
+  const int offset = correct_offset - chromium_offset;
+  // Shim base implementation's painting
+  canvas->Translate(gfx::Vector2d(offset, offset));
+  NewTabButton::PaintPlusIcon(canvas);
 }

--- a/browser/ui/views/tabs/brave_new_tab_button.h
+++ b/browser/ui/views/tabs/brave_new_tab_button.h
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
-+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_NEW_TAB_BUTTON_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_NEW_TAB_BUTTON_H_
@@ -14,10 +14,16 @@ namespace views {
 
 class BraveNewTabButton : public NewTabButton {
   public:
-    BraveNewTabButton(TabStrip* tab_strip, views::ButtonListener* listener);
-    ~BraveNewTabButton() override;
+    static const gfx::Size kButtonSize;
+
+    using NewTabButton::NewTabButton;
+
   private:
     gfx::Size CalculatePreferredSize() const override;
+    gfx::Path GetBorderPath(const gfx::Point& origin,
+                          float scale,
+                          bool extend_to_top) const override;
+    void PaintPlusIcon(gfx::Canvas* canvas) const override;
     DISALLOW_COPY_AND_ASSIGN(BraveNewTabButton);
 };
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -1,0 +1,5 @@
+#include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
+
+#define NewTabButton BraveNewTabButton
+#include "../../../../../../chrome/browser/ui/views/tabs/tab_strip.cc"
+#undef NewTabButton

--- a/patches/chrome-browser-ui-views-tabs-new_tab_button.h.patch
+++ b/patches/chrome-browser-ui-views-tabs-new_tab_button.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/tabs/new_tab_button.h b/chrome/browser/ui/views/tabs/new_tab_button.h
-index 9c729b9b79aec8edd1d7de4857772a60bfcc8c6e..82b765dbdc6a33e9cc062e6015700dd3125e1f41 100644
+index 9c729b9b79aec8edd1d7de4857772a60bfcc8c6e..932dd1874456ce3d25c349e4676f57a645c19523 100644
 --- a/chrome/browser/ui/views/tabs/new_tab_button.h
 +++ b/chrome/browser/ui/views/tabs/new_tab_button.h
 @@ -60,6 +60,7 @@ class NewTabButton : public views::ImageButton,
@@ -10,7 +10,7 @@ index 9c729b9b79aec8edd1d7de4857772a60bfcc8c6e..82b765dbdc6a33e9cc062e6015700dd3
  // views::ImageButton:
  #if defined(OS_WIN)
    void OnMouseReleased(const ui::MouseEvent& event) override;
-@@ -91,6 +92,7 @@ class NewTabButton : public views::ImageButton,
+@@ -91,12 +92,14 @@ class NewTabButton : public views::ImageButton,
    void PaintFill(gfx::Canvas* canvas) const;
  
    // Paints a properly sized plus (+) icon into the center of the button.
@@ -18,3 +18,10 @@ index 9c729b9b79aec8edd1d7de4857772a60bfcc8c6e..82b765dbdc6a33e9cc062e6015700dd3
    void PaintPlusIcon(gfx::Canvas* canvas) const;
  
    SkColor GetButtonFillColor() const;
+ 
+   // Returns the path for the given |origin| and |scale|.  If |extend_to_top| is
+   // true, the path is extended vertically to y = 0.
++  virtual
+   gfx::Path GetBorderPath(const gfx::Point& origin,
+                           float scale,
+                           bool extend_to_top) const;


### PR DESCRIPTION
Re-implements Brave's style for the New Tab Button against C71.
Previously implemented against C70 in https://github.com/brave/brave-core/pull/391/commits/966b6d55bf83f283f8da4615159e399f37f882bd

![image](https://user-images.githubusercontent.com/741836/47600621-53807d80-d979-11e8-91c3-f98df7d0397a.png)
