### PR TITLE
Recalculate auto-contribute table after exclude

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@0396fb47a0cfc55c0a7e271bae4c88c548e1574a",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@3ce25e3820378021b935ab537e390916e91e823c",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/components/brave_rewards/browser/publisher_info_database.cc
+++ b/components/brave_rewards/browser/publisher_info_database.cc
@@ -470,8 +470,14 @@ std::string PublisherInfoDatabase::BuildClauses(int start,
   if (filter.min_duration > 0)
     clauses += " AND ai.duration >= ?";
 
-  if (filter.excluded != ledger::PUBLISHER_EXCLUDE::ALL)
+  if (filter.excluded != ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL &&
+      filter.excluded !=
+        ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED)
     clauses += " AND pi.excluded = ?";
+
+  if (filter.excluded ==
+    ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED)
+    clauses += " AND pi.excluded != ?";
 
   for (const auto& it : filter.order_by) {
     clauses += " ORDER BY " + it.first;
@@ -510,8 +516,14 @@ void PublisherInfoDatabase::BindFilter(sql::Statement& statement,
   if (filter.min_duration > 0)
     statement.BindInt(column++, filter.min_duration);
 
-  if (filter.excluded != ledger::PUBLISHER_EXCLUDE::ALL)
+  if (filter.excluded != ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL &&
+      filter.excluded !=
+      ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED)
     statement.BindInt(column++, filter.excluded);
+
+  if (filter.excluded ==
+    ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED)
+    statement.BindInt(column++, ledger::PUBLISHER_EXCLUDE::EXCLUDED);
 }
 
 bool PublisherInfoDatabase::InsertContributionInfo(const brave_rewards::ContributionInfo& info) {

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -319,6 +319,8 @@ void RewardsServiceImpl::GetContentSiteList(
   filter.min_duration = ledger_->GetPublisherMinVisitTime();
   filter.order_by.push_back(std::pair<std::string, bool>("ai.percent", false));
   filter.reconcile_stamp = ledger_->GetReconcileStamp();
+  filter.excluded =
+    ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED;
 
   ledger_->GetPublisherInfoList(start, limit,
       filter,


### PR DESCRIPTION
Fixes brave/brave-browser#1410

Ledger implementation: https://github.com/brave-intl/bat-native-ledger/pull/161
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave and enable Rewards
2. Add some sites to auto-contribute
3. Exclude some sites and verify the percentages are recalculated correctly
4. Restore excluded publishers and verify the percentages are recalculated correctly


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source