### PR TITLE
Add sitehacks and cosmetic filters from browser-laptop

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@bb6013ff4d0a0191ba93158f2f3b30e7fb18c5f6",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@f86b0a5752545274e32c0dbb654c3592cc131c8a",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@635780bbedff137a6a83ec23871944e22069de5b",
-  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@3f0561f0be4e51a07614dde0889ab185ad2c797a",
+  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@22a24bc1d2b0cd4bfd56488bcfa39ce56bcb0266",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",

--- a/browser/resources/brave_extension.grd
+++ b/browser/resources/brave_extension.grd
@@ -25,6 +25,10 @@
       <include name="IDR_BRAVE_EXTENSON_EN_US_MESSAGES_JSON" file="brave_extension/_locales/en_US/messages.json" type="BINDATA" />
       <include name="IDR_BRAVE_EXTENSON_BRAVE_SHIELDS_HTML" file="brave_extension/braveShieldsPanel.html" type="BINDATA" />
       <include name="IDR_BRAVE_EXTENSON_BRAVELIZER_JS" file="brave_extension/bravelizer.css" type="BINDATA" />
+      <include name="IDR_BRAVE_EXTENSON_REMOVE_EMPTY_ELEMENTS_CSS" file="brave_extension/removeEmptyElements.css" type="BINDATA" />
+      <include name="IDR_BRAVE_EXTENSON_SITEHACKS_MARKETWATCH_CSS" file="brave_extension/siteHack-marketwatch.com.css" type="BINDATA" />
+      <include name="IDR_BRAVE_EXTENSON_SITEHACKS_COINMARKETCAP_CSS" file="brave_extension/siteHack-coinmarketcap.com.css" type="BINDATA" />
+      <include name="IDR_BRAVE_EXTENSON_SITEHACKS_GLENNBECK_JS" file="brave_extension/siteHack-glennbeck.com.js" type="BINDATA" />
     </includes>
   </release>
 </grit>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1874

Before merging I'd need to udpate DEPS for brave-extensions.

brave-extension related commit that this should be merged together with:
https://github.com/brave/brave-extension/pull/77


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source