### PR TITLE
Allow redirecting to the same URL when referrer is overwritten

### DIFF
--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -180,7 +180,8 @@ void BraveNetworkDelegateBase::RunNextCallback(
 
   if (ctx->event_type == brave::kOnBeforeRequest) {
     if (!ctx->new_url_spec.empty() &&
-        ctx->new_url_spec != ctx->request_url.spec() &&
+        (ctx->new_url_spec != ctx->request_url.spec() ||
+          ctx->referrer_changed) &&
         IsRequestIdentifierValid(ctx->request_identifier)) {
       *ctx->new_url = GURL(ctx->new_url_spec);
     }

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -54,8 +54,10 @@ int OnBeforeURLRequest_SiteHacksWork(
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {
 
-  if (ApplyPotentialReferrerBlock(ctx->request))
+  if (ApplyPotentialReferrerBlock(ctx->request)) {
     ctx->new_url_spec = ctx->request_url.spec();
+    ctx->referrer_changed = true;
+  }
 
   return net::OK;
 }

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -53,6 +53,7 @@ struct BraveRequestInfo {
   bool allow_brave_shields = true;
   bool allow_ads = false;
   bool allow_http_upgradable_resource = false;
+  bool referrer_changed = false;
   int render_process_id = 0;
   int render_frame_id = 0;
   int frame_tree_node_id = 0;


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1861, document.referrer is not updated because we start to block same url redirection in https://github.com/brave/brave-core/pull/666/commits/394753b0d2885016eca8e753481741a2bf251b4c.
This PR fixes BraveContentSettingsObserverBrowserTest.BlockReferrer, BraveContentSettingsObserverBrowserTest.BlockReferrerByDefault, and HTTPSEverywhereServiceTest.RedirectsKnownSiteInIframe.

## Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
npm test brave_browser_tests

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source