### PR TITLE
Can't dismiss grant notification

### DIFF
--- a/components/brave_rewards/browser/rewards_notifications_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_notifications_service_impl.cc
@@ -109,6 +109,13 @@ void RewardsNotificationsServiceImpl::ReadRewardsNotifications() {
     int notification_timestamp;
     RewardsNotificationArgs notification_args;
     dict_value->GetString("id", &notification_id);
+
+    if (notification_id.empty()) {
+      int old_id;
+      dict_value->GetInteger("id", &old_id);
+      notification_id = std::to_string(old_id);
+    }
+
     dict_value->GetInteger("type", &notification_type);
     dict_value->GetInteger("timestamp", &notification_timestamp);
 

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -144,7 +144,12 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       }
     case types.DELETE_NOTIFICATION:
       {
-        chrome.rewardsNotifications.deleteNotification(payload.id)
+        let id = payload.id
+        if (id.startsWith('n_')) {
+          id = id.toString().replace('n_', '')
+        }
+
+        chrome.rewardsNotifications.deleteNotification(id)
         break
       }
     case types.ON_NOTIFICATION_DELETED:
@@ -154,10 +159,11 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
         }
 
         let id = payload.id
-        if (id.startsWith('n_')) {
-          id = id.toString().replace('n_', '')
-        }
         let notifications: Record<number, RewardsExtension.Notification> = state.notifications
+        if (!notifications[id]) {
+          id = `n_${id}`
+        }
+
         delete notifications[id]
 
         if (state.currentNotification === id) {

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -153,7 +153,10 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
           return
         }
 
-        const id = payload.id
+        let id = payload.id
+        if (id.startsWith('n_')) {
+          id = id.toString().replace('n_', '')
+        }
         let notifications: Record<number, RewardsExtension.Notification> = state.notifications
         delete notifications[id]
 


### PR DESCRIPTION
Fixes brave/brave-browser#1878

Before we switched to using custom string-based notification IDs, we
used integer IDs and prepended them with an "n" to coerce them to
strings. For backawards compatibility reasons, we need to support
dismissing notifications that use this ID format.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- start browser version 0.55.20
- enable rewards
- make sure that you have notification in the url bar
- update to the latest
- make sure that you can remove notification

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source