### PR TITLE
Fix web search from context menu in private window(also tor)

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -3,6 +3,8 @@ import("//build/config/features.gni")
 
 source_set("browser_process") {
   sources = [
+    "autocomplete/brave_autocomplete_provider_client.cc",
+    "autocomplete/brave_autocomplete_provider_client.h",
     "autocomplete/brave_autocomplete_scheme_classifier.cc",
     "autocomplete/brave_autocomplete_scheme_classifier.h",
     "brave_browser_main_extra_parts.cc",

--- a/browser/autocomplete/brave_autocomplete_provider_client.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client.cc
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+
+BraveAutocompleteProviderClient::BraveAutocompleteProviderClient(
+    Profile* profile)
+    : ChromeAutocompleteProviderClient(profile->GetOriginalProfile()),
+      profile_(profile) {
+}
+
+BraveAutocompleteProviderClient::~BraveAutocompleteProviderClient() {
+}
+
+TemplateURLService* BraveAutocompleteProviderClient::GetTemplateURLService() {
+  return TemplateURLServiceFactory::GetForProfile(profile_);
+}
+
+const TemplateURLService*
+BraveAutocompleteProviderClient::GetTemplateURLService() const {
+  return TemplateURLServiceFactory::GetForProfile(profile_);
+}

--- a/browser/autocomplete/brave_autocomplete_provider_client.h
+++ b/browser/autocomplete/brave_autocomplete_provider_client.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_H_
+#define BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_H_
+
+#include "chrome/browser/autocomplete/chrome_autocomplete_provider_client.h"
+
+// In brave, different AutocompleteClassifiers are created for normal and
+// incognito profile by changing
+// AutocompleteClassifierFactory::GetBrowserContextToUse().
+// This changes are needed to use different search engine used by web search in
+// web page context menu.
+// When context menu handles web search it gets search engine url from
+// ChromeAutocompleteProviderClient via AutocompleteClassifiers.
+// Because of this, private window will use same search engine url of normal
+// window if same AutocompleteClassifiers are used on normal and incognito.
+// So, we made this change.
+// However, ChromeAutocompleteProviderClient exposes many other services based
+// on profiles.
+// We don't want to change other services. Only wanted to get proper
+// TemplateURLService. To achieve this, BraveAutocompleteProviderClient is
+// introduced. It initializes ChromeAutocompleteProviderClient with original
+// profile and only overrided TemplateURLService getter.
+// BraveAutocompleteSchemeClassifier also initialize
+// ChromeAutocompleteSchemeClassifier with original profile for same reason.
+class BraveAutocompleteProviderClient
+    : public ChromeAutocompleteProviderClient {
+ public:
+  explicit BraveAutocompleteProviderClient(Profile* profile);
+  ~BraveAutocompleteProviderClient() override;
+
+  TemplateURLService* GetTemplateURLService() override;
+  const TemplateURLService* GetTemplateURLService() const override;
+
+ private:
+  Profile* profile_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveAutocompleteProviderClient);
+};
+
+#endif  // BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_H_

--- a/browser/autocomplete/brave_autocomplete_provider_client_browsertest.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client_browsertest.cc
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+
+#include "chrome/browser/autocomplete/autocomplete_classifier_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/testing_browser_process.h"
+
+using BraveAutocompleteProviderClientTest = InProcessBrowserTest;
+
+// BraveAutocompleteProviderClient should only use different TemplateURLService.
+// And Other service should be same for normal/incognito profile.
+IN_PROC_BROWSER_TEST_F(BraveAutocompleteProviderClientTest,
+                       DependentServiceCheckTest) {
+  Profile* profile = browser()->profile();
+  Profile* incognito_profile = profile->GetOffTheRecordProfile();
+
+  // Brave initiates different AutocompleteClassifier service for
+  // normal/incognito profile.
+  EXPECT_NE(AutocompleteClassifierFactory::GetForProfile(profile),
+            AutocompleteClassifierFactory::GetForProfile(incognito_profile));
+
+  BraveAutocompleteProviderClient normal_client(profile);
+  BraveAutocompleteProviderClient incognito_client(incognito_profile);
+
+  // Check different TemplateURLService is used.
+  EXPECT_NE(normal_client.GetTemplateURLService(),
+            incognito_client.GetTemplateURLService());
+
+  // Check same services are used except TemplateURLService.
+  EXPECT_EQ(normal_client.GetAutocompleteClassifier(),
+            incognito_client.GetAutocompleteClassifier());
+  EXPECT_EQ(normal_client.GetHistoryService(),
+            incognito_client.GetHistoryService());
+  EXPECT_EQ(normal_client.GetContextualSuggestionsService(true),
+            incognito_client.GetContextualSuggestionsService(true));
+  EXPECT_EQ(normal_client.GetDocumentSuggestionsService(true),
+            incognito_client.GetDocumentSuggestionsService(true));
+}

--- a/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
+++ b/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
@@ -6,9 +6,12 @@
 
 #include "base/strings/string_util.h"
 #include "brave/common/url_constants.h"
+#include "chrome/browser/profiles/profile.h"
 
+// See the BraveAutocompleteProviderClient why GetOriginalProfile() is fetched.
 BraveAutocompleteSchemeClassifier::BraveAutocompleteSchemeClassifier(
-    Profile* profile) : ChromeAutocompleteSchemeClassifier(profile) {
+    Profile* profile)
+    : ChromeAutocompleteSchemeClassifier(profile->GetOriginalProfile()) {
 }
 
 BraveAutocompleteSchemeClassifier::~BraveAutocompleteSchemeClassifier() {

--- a/chromium_src/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
+++ b/chromium_src/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
@@ -2,14 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/components/omnibox/browser/brave_autocomplete_controller.h"
-#include "chrome/browser/autocomplete/chrome_autocomplete_provider_client.h"
 #include "components/omnibox/browser/autocomplete_classifier.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
 
 #define AutocompleteController BraveAutocompleteController
+#define ChromeAutocompleteProviderClient BraveAutocompleteProviderClient
 #define ChromeAutocompleteSchemeClassifier BraveAutocompleteSchemeClassifier
 #include "../../../../../chrome/browser/autocomplete/autocomplete_classifier_factory.cc"
 #undef ChromeAutocompleteSchemeClassifier
+#undef ChromeAutocompleteProviderClient
 #undef AutocompleteController

--- a/patches/chrome-browser-autocomplete-autocomplete_classifier_factory.cc.patch
+++ b/patches/chrome-browser-autocomplete-autocomplete_classifier_factory.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/autocomplete/autocomplete_classifier_factory.cc b/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
+index e3159144a0b7892e5580bfa910f2db97a81179a9..8ee42d9f6f7ac50c78a03e59aa2ba34e35dae725 100644
+--- a/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
++++ b/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
+@@ -68,7 +68,12 @@ AutocompleteClassifierFactory::~AutocompleteClassifierFactory() {
+ 
+ content::BrowserContext* AutocompleteClassifierFactory::GetBrowserContextToUse(
+     content::BrowserContext* context) const {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  // See BraveAutocompleteProviderClient about why separate services are used.
++  return chrome::GetBrowserContextOwnInstanceInIncognito(context);
++#else
+   return chrome::GetBrowserContextRedirectedInIncognito(context);
++#endif
+ }
+ 
+ bool AutocompleteClassifierFactory::ServiceIsNULLWhileTesting() const {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -196,6 +196,7 @@ test("brave_browser_tests") {
   sources = [
     "//brave/app/brave_main_delegate_browsertest.cc",
     "//brave/app/sharedarraybuffer_disabledtest.cc",
+    "//brave/browser/autocomplete/brave_autocomplete_provider_client_browsertest.cc",
     "//brave/chromium_src/chrome/browser/google/chrome_google_url_tracker_client_browsertest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",


### PR DESCRIPTION
Context menu web search should use current profile's search engine url.

Fix https://github.com/brave/brave-browser/issues/1758
Fix https://github.com/brave/brave-browser/issues/1037

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveAutocompleteProviderClientTest.DependentServiceCheckTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source