### PR TITLE
Fix BraveShieldsExtensionApiTest time out by creating ResultCatcher b…

### DIFF
--- a/browser/extensions/brave_shields_apitest.cc
+++ b/browser/extensions/brave_shields_apitest.cc
@@ -25,19 +25,19 @@ class BraveShieldsExtensionApiTest : public ExtensionApiTest {
 };
 
 IN_PROC_BROWSER_TEST_F(BraveShieldsExtensionApiTest, BraveExtensionHasAccess) {
+  ResultCatcher catcher;
   const Extension* extension =
     LoadExtension(extension_dir_.AppendASCII("braveShields"));
   ASSERT_TRUE(extension);
-  ResultCatcher catcher;
   ASSERT_TRUE(catcher.GetNextResult()) << message_;
 }
 
 IN_PROC_BROWSER_TEST_F(BraveShieldsExtensionApiTest, NotBraveExtensionHasNoAccess) {
   LOG(ERROR) << "======= This is an intentional fail:";
+  ResultCatcher catcher;
   const Extension* extension =
     LoadExtension(extension_dir_.AppendASCII("notBraveShields"));
   ASSERT_TRUE(extension);
-  ResultCatcher catcher;
   ASSERT_FALSE(catcher.GetNextResult()) << message_;
 }
 


### PR DESCRIPTION
…efore loading the extension

Fix https://github.com/brave/brave-browser/issues/1880
ResultCatcher should be created (start the observation) before loading extensions so we won't miss the result.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`npm test brave_browser_tests` or
`npm test brave_browser_tests -- --filter=BraveShieldsExtensionApiTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source