### PR TITLE
Request for promo URL doesn't include correct headers

### DIFF
--- a/browser/referrals/brave_referrals_service.h
+++ b/browser/referrals/brave_referrals_service.h
@@ -12,6 +12,8 @@
 #include "base/memory/weak_ptr.h"
 #include "base/sequenced_task_runner.h"
 #include "base/timer/timer.h"
+#include "base/values.h"
+#include "url/gurl.h"
 
 class PrefRegistrySimple;
 class PrefService;
@@ -30,6 +32,11 @@ class BraveReferralsService {
   void Start();
   void Stop();
 
+  static bool GetMatchingReferralHeaders(
+      const base::ListValue& referral_headers_list,
+      const base::DictionaryValue** request_headers_dict,
+      const GURL& url);
+
  private:
   void GetFirstRunTime();
   base::FilePath GetPromoCodeFileName() const;
@@ -42,6 +49,8 @@ class BraveReferralsService {
   std::string BuildReferralFinalizationCheckPayload() const;
   void FetchReferralHeaders();
   void CheckForReferralFinalization();
+  std::string FormatExtraHeaders(const base::Value* referral_headers,
+                                 const GURL& url);
 
   // Invoked from RepeatingTimer when referral headers timer fires.
   void OnFetchReferralHeadersTimerFired();


### PR DESCRIPTION
Fixes brave/brave-browser#1805

When starting with a clean profile, referral headers haven't been
fetched yet so use the referral headers from the referral
initialization response.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Delete existing profile
- Rename stub installer to `BraveBrowserSetup-dowjones-barrons.exe`
- Run the stub installer
- Wait for the https://brave.com/dowjones-barrons subscription page to display

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source