### PR TITLE
Add more comments to BraveShieldsContentSettingSetFunction

### DIFF
--- a/browser/extensions/api/brave_shields_api.cc
+++ b/browser/extensions/api/brave_shields_api.cc
@@ -226,6 +226,11 @@ BraveShieldsContentSettingSetFunction::Run() {
     // TODO(simonhong): Need to check why generating pattern with
     // content_settings_helpers::ParseExtensionPattern() causes javascript
     // set fail.
+    // Without this separate handling, shields can't toggle block script setting
+    // anymore after user changes js permission from page info bubble.
+    // page info bubble uses SetNarrowestContentSetting() for setting and it
+    // gets pattern by using GetPatternsForContentSettingsType() same as
+    // SetContentSettingDefaultScope().
     const GURL primary_url(params->details.primary_pattern);
     if (!primary_url.is_valid())
       return RespondNow(Error("Invalid url"));


### PR DESCRIPTION
About why it handles js settings differently than others.

Issue: brave/brave-browser#232
This supplements https://github.com/brave/brave-core/pull/439
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source