### PR TITLE
Notification badge shows on first run when rewards is not enabled

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/background.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background.ts
@@ -7,3 +7,37 @@ import './background/events/rewardsEvents'
 import './background/events/tabEvents'
 
 chrome.browserAction.setBadgeBackgroundColor({ color: '#FF0000' })
+
+chrome.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === 'install') {
+    const initialNotificationDismissed = 'false'
+    chrome.storage.local.set({
+      'is_dismissed': initialNotificationDismissed
+    }, function () {
+      chrome.browserAction.setBadgeText({
+        text: '1'
+      })
+    })
+  }
+})
+
+chrome.runtime.onStartup.addListener(function () {
+  chrome.storage.local.get(['is_dismissed'], function (result) {
+    if (result && result['is_dismissed'] === 'false') {
+      chrome.browserAction.setBadgeText({
+        text: '1'
+      })
+    }
+  })
+})
+
+chrome.runtime.onConnect.addListener(function () {
+  chrome.storage.local.get(['is_dismissed'], function (result) {
+    if (result && result['is_dismissed'] === 'false') {
+      chrome.browserAction.setBadgeText({
+        text: ''
+      })
+      chrome.storage.local.remove(['is_dismissed'])
+    }
+  })
+})

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -41,6 +41,14 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
     case types.ON_WALLET_CREATED:
       state = { ...state }
       state.walletCreated = true
+      chrome.storage.local.get(['is_dismissed'], function (result) {
+        if (result && result['is_dismissed'] === 'false') {
+          chrome.browserAction.setBadgeText({
+            text: ''
+          })
+          chrome.storage.local.remove(['is_dismissed'])
+        }
+      })
       break
     case types.ON_WALLET_CREATE_FAILED:
       state = { ...state }

--- a/components/brave_rewards/resources/extension/brave_rewards/manifest.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/manifest.json
@@ -9,6 +9,7 @@
     "persistent": true
   },
   "permissions": [
+    "storage",
     "tabs",
     "chrome://favicon/*"
   ],


### PR DESCRIPTION
Fixes brave/brave-browser#1439

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave with clean profile
2. Verify badge notification appears on BAT icon
3. Close Brave and reopen.
4. Verify badge still appears on BAT icon
5. Click on BAT icon
6. Verify badge notification goes away
7. Close Brave and reopen.
8. Verify badge notification does not appear

*

1. Start Brave with clean profile
2. Verify badge notification appears on BAT icon
3. Enable Rewards
4. Verify badge notification goes away (will be replaced by grant notification [look for slight flicker on badge])
5. Close Brave and reopen.
6. Verify badge notification is still set to 1 and is for grant

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source