### PR TITLE
Fixes site exclude tooltip persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,13 +2206,13 @@
       }
     },
     "brave-ui": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.30.3.tgz",
-      "integrity": "sha512-gcuZaaXC3HKR7yAXnqvj2aZr5nk3NQThsjZ5gm02pm0dc/7KyxlC+ePVgkB6iSDXIgvaDvuxxLerWY34GbCXiQ==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.30.4.tgz",
+      "integrity": "sha512-7TP1FK92PEvNoL5d9An39GDQGyQpm4w/1D3RiUjzYhctVVu2fdeX7iG9z9MnnXcttBmRN25i3DMzjGjB47o5dw==",
       "dev": true,
       "requires": {
-        "emptykit.css": "^1.0.1",
-        "styled-components": "^3.2.5"
+        "emptykit.css": "1.0.1",
+        "styled-components": "3.4.5"
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.24.1",
-    "brave-ui": "^0.30.3",
+    "brave-ui": "^0.30.4",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/1850

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Defined in issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source