### PR TITLE
Wallet panel is now cleared when wallet is restored

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ deps = {
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/omaha":  "https://github.com/brave/omaha.git@5c633e867efafb9013c57ca830212d1ff6ea5076",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@dd88d2192d6db435ab15f48fc2443564d1472552",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@6c198464110bfb3e1969067807ce0794fef110af",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -198,26 +198,22 @@ void RewardsDOMHandler::Init() {
 void RewardsDOMHandler::GetAllBalanceReports() {
   if (rewards_service_ && web_ui()->CanCallJavascript()) {
     std::map<std::string, brave_rewards::BalanceReport> reports = rewards_service_->GetAllBalanceReports();
-
-    if (reports.empty()) {
-      return;
-    }
-
     base::DictionaryValue newReports;
-
-    for (auto const& report : reports) {
-      const brave_rewards::BalanceReport oldReport = report.second;
-      auto newReport = std::make_unique<base::DictionaryValue>();
-      newReport->SetString("opening", oldReport.opening_balance);
-      newReport->SetString("closing", oldReport.closing_balance);
-      newReport->SetString("grant", oldReport.grants);
-      newReport->SetString("deposit", oldReport.deposits);
-      newReport->SetString("ads", oldReport.earning_from_ads);
-      newReport->SetString("contribute", oldReport.auto_contribute);
-      newReport->SetString("donation", oldReport.recurring_donation);
-      newReport->SetString("tips", oldReport.one_time_donation);
-      newReport->SetString("total", oldReport.total);
-      newReports.SetDictionary(report.first, std::move(newReport));
+    if (!reports.empty()) {
+      for (auto const& report : reports) {
+        const brave_rewards::BalanceReport oldReport = report.second;
+        auto newReport = std::make_unique<base::DictionaryValue>();
+        newReport->SetString("opening", oldReport.opening_balance);
+        newReport->SetString("closing", oldReport.closing_balance);
+        newReport->SetString("grant", oldReport.grants);
+        newReport->SetString("deposit", oldReport.deposits);
+        newReport->SetString("ads", oldReport.earning_from_ads);
+        newReport->SetString("contribute", oldReport.auto_contribute);
+        newReport->SetString("donation", oldReport.recurring_donation);
+        newReport->SetString("tips", oldReport.one_time_donation);
+        newReport->SetString("total", oldReport.total);
+        newReports.SetDictionary(report.first, std::move(newReport));
+      }
     }
 
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.balanceReports", newReports);
@@ -364,6 +360,7 @@ void RewardsDOMHandler::OnRecoverWallet(
     unsigned int result,
     double balance,
     std::vector<brave_rewards::Grant> grants) {
+  GetAllBalanceReports();
   if (web_ui()->CanCallJavascript()) {
     base::DictionaryValue* recover = new base::DictionaryValue();
     recover->SetInteger("result", result);


### PR DESCRIPTION
Fixes brave/brave-browser#1559

Ledger implementation: https://github.com/brave-intl/bat-native-ledger/pull/166

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave.
2. Perform Rewards activities to fill a wallet summary (accept grant, page tip, etc)
3. Restore wallet with a previously saved wallet
4. Verify that wallet summary in Rewards page and Rewards panel is cleared.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source