### PR TITLE
Fix loading of PDF protected by cookie-based login

### DIFF
--- a/components/content_settings/core/browser/brave_cookie_settings.cc
+++ b/components/content_settings/core/browser/brave_cookie_settings.cc
@@ -49,6 +49,11 @@ void BraveCookieSettings::GetCookieSetting(const GURL& url,
   GURL primary_brave_url = tab_url == GURL("about:blank") ?
       first_party_url : tab_url;
 
+  if (primary_brave_url.SchemeIs("chrome-extension")) {
+    *cookie_setting = CONTENT_SETTING_ALLOW;
+    return;
+  }
+
   // Check the Brave shields setting, if it is off, just return without
   // blocking anything.
   ContentSetting brave_shields_setting =


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/1287 was fixed in 0.57.x and later by https://github.com/brave/brave-core/pull/744.
This PR fixes it for 0.56.x without refactoring how we do cookie blocking.
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
See https://github.com/brave/brave-browser/issues/1788#issuecomment-432091546

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source