### PR TITLE
Fix pdf not loading by PDFJS after basic auth

### DIFF
--- a/patches/extensions-browser-api-web_request-web_request_api.cc.patch
+++ b/patches/extensions-browser-api-web_request-web_request_api.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/extensions/browser/api/web_request/web_request_api.cc b/extensions/browser/api/web_request/web_request_api.cc
+index 9f342968c4c4c839037cbae944b65b44171d0178..17e3db28e5b683bb74ea1f64dab149f96b26360b 100644
+--- a/extensions/browser/api/web_request/web_request_api.cc
++++ b/extensions/browser/api/web_request/web_request_api.cc
+@@ -1135,6 +1135,9 @@ ExtensionWebRequestEventRouter::OnAuthRequired(
+     const net::AuthChallengeInfo& auth_info,
+     net::NetworkDelegate::AuthCallback callback,
+     net::AuthCredentials* credentials) {
++  ClearSignaled(request->id, kOnBeforeSendHeaders);
++  ClearSignaled(request->id, kOnSendHeaders);
++  ClearSignaled(request->id, kOnHeadersReceived);
+   // No browser_context means that this is for authentication challenges in the
+   // system context. Skip in that case. Also skip sensitive requests.
+   if (!browser_context ||


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1788

Fix chromium upstream bug: https://bugs.chromium.org/p/chromium/issues/detail?id=805476
webRequest.onBeforeSendHeaders, webRequest.onSendHeaders, and webRequest.onHeadersReceived should be dispatched as the life cycle specified in https://developer.chrome.com/extensions/webRequest.
- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
See https://github.com/brave/brave-browser/issues/1788#issue-372773910

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source