### PR TITLE
Disable fetch of remote debugging files

### DIFF
--- a/patches/chrome-browser-ui-webui-devtools_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-devtools_ui.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/webui/devtools_ui.cc b/chrome/browser/ui/webui/devtools_ui.cc
+index a99cea430734..d124fa007135 100644
+--- a/chrome/browser/ui/webui/devtools_ui.cc
++++ b/chrome/browser/ui/webui/devtools_ui.cc
+@@ -269,6 +269,7 @@ void DevToolsDataSource::StartBundledDataRequest(
+ void DevToolsDataSource::StartRemoteDataRequest(
+     const GURL& url,
+     const content::URLDataSource::GotDataCallback& callback) {
++  return; // feature disabled in Brave
+   CHECK(url.is_valid());
+   net::NetworkTrafficAnnotationTag traffic_annotation =
+       net::DefineNetworkTrafficAnnotation("devtools_hard_coded_data_source", R"(


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1736

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source