### PR TITLE
Update web_request_api patch file to 71.0.3578.31

### DIFF
--- a/patches/extensions-browser-api-web_request-web_request_api.cc.patch
+++ b/patches/extensions-browser-api-web_request-web_request_api.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/extensions/browser/api/web_request/web_request_api.cc b/extensions/browser/api/web_request/web_request_api.cc
-index 9f342968c4c4c839037cbae944b65b44171d0178..17e3db28e5b683bb74ea1f64dab149f96b26360b 100644
+index ff5926b4ae372e5567a9e77484a5666a0ed285c3..9caf6a820a7db9c03a5e04d7d3f0ad5e13a63c4a 100644
 --- a/extensions/browser/api/web_request/web_request_api.cc
 +++ b/extensions/browser/api/web_request/web_request_api.cc
-@@ -1135,6 +1135,9 @@ ExtensionWebRequestEventRouter::OnAuthRequired(
+@@ -1137,6 +1137,9 @@ ExtensionWebRequestEventRouter::OnAuthRequired(
      const net::AuthChallengeInfo& auth_info,
      net::NetworkDelegate::AuthCallback callback,
      net::AuthCredentials* credentials) {


### PR DESCRIPTION
Follow up of https://github.com/brave/brave-core/pull/784 for fixing brave/brave-browser#1788
The patch was generated using 71.0.3578.20, should be updated to .31.
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source