### PR TITLE
Add brave disable-machine-id and disable-encryption-win switches

### DIFF
--- a/chromium_src/components/metrics/machine_id_provider_win.cc
+++ b/chromium_src/components/metrics/machine_id_provider_win.cc
@@ -1,0 +1,13 @@
+#include "base/command_line.h"
+#include "brave/common/brave_switches.h"
+
+// switches::kDisableMachineId
+const char kDisableMachineId[] = "disable-machine-id";
+
+namespace {
+bool IsMachineIdDisabled() {
+  return base::CommandLine::ForCurrentProcess()->HasSwitch(kDisableMachineId);
+}
+
+}  // namespace
+#include "../../../../components/metrics/machine_id_provider_win.cc"

--- a/chromium_src/components/os_crypt/os_crypt_win.cc
+++ b/chromium_src/components/os_crypt/os_crypt_win.cc
@@ -1,0 +1,17 @@
+#include "base/command_line.h"
+#include "brave/common/brave_switches.h"
+
+// switches::kDisableEncryptionWin
+const char kDisableEncryptionWin[] = "disable-encryption-win";
+
+namespace {
+bool IsEncryptionDisabled(const std::string& input_text, std::string* output_text) {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(kDisableEncryptionWin)) {
+    *output_text = input_text;
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+#include "../../../../components/os_crypt/os_crypt_win.cc"

--- a/chromium_src/services/preferences/tracked/device_id_win.cc
+++ b/chromium_src/services/preferences/tracked/device_id_win.cc
@@ -1,0 +1,13 @@
+#include "base/command_line.h"
+#include "brave/common/brave_switches.h"
+
+// switches::kDisableMachineId
+const char kDisableMachineId[] = "disable-machine-id";
+
+namespace {
+bool IsMachineIdDisabled() {
+  return base::CommandLine::ForCurrentProcess()->HasSwitch(kDisableMachineId);
+}
+
+}  // namespace
+#include "../../../../../services/preferences/tracked/device_id_win.cc"

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -40,4 +40,12 @@ const char kUiMode[] = "ui-mode";
 // available.
 const char kUpgradeFromMuon[] = "upgrade-from-muon";
 
+// Allows disabling the machine ID generation on Windows.
+const char kDisableMachineId[] = "disable-machine-id";
+
+// Allows disabling encryption on Windows for cookies, passwords, settings...
+// WARNING! Use ONLY if your hard drive is encrypted or if you know
+// what you are doing.
+const char kDisableEncryptionWin[] = "disable-encryption-win";
+
 }  // namespace switches

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -31,6 +31,10 @@ extern const char kUiMode[];
 
 extern const char kUpgradeFromMuon[];
 
+extern const char kDisableMachineId[];
+
+extern const char kDisableEncryptionWin[];
+
 }  // namespace switches
 
 #endif  // BRAVE_COMMON_BRAVE_SWITCHES_H_

--- a/patches/components-metrics-machine_id_provider_win.cc.patch
+++ b/patches/components-metrics-machine_id_provider_win.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/metrics/machine_id_provider_win.cc b/components/metrics/machine_id_provider_win.cc
+index eb7b0d7e8fde..1618ba826821 100644
+--- a/components/metrics/machine_id_provider_win.cc
++++ b/components/metrics/machine_id_provider_win.cc
+@@ -18,7 +18,7 @@ namespace metrics {
+ 
+ // static
+ bool MachineIdProvider::HasId() {
+-  return true;
++  return !IsMachineIdDisabled();
+ }
+ 
+ // On windows, the machine id is based on the serial number of the drive Chrome

--- a/patches/components-os_crypt-os_crypt_win.cc.patch
+++ b/patches/components-os_crypt-os_crypt_win.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/components/os_crypt/os_crypt_win.cc b/components/os_crypt/os_crypt_win.cc
+index 792233d4405f..1fb45bb390db 100644
+--- a/components/os_crypt/os_crypt_win.cc
++++ b/components/os_crypt/os_crypt_win.cc
+@@ -26,6 +26,7 @@ bool OSCrypt::DecryptString16(const std::string& ciphertext,
+ 
+ bool OSCrypt::EncryptString(const std::string& plaintext,
+                             std::string* ciphertext) {
++  if (IsEncryptionDisabled(plaintext, ciphertext)) { return true; }
+   DATA_BLOB input;
+   input.pbData = const_cast<BYTE*>(
+       reinterpret_cast<const BYTE*>(plaintext.data()));
+@@ -49,6 +50,7 @@ bool OSCrypt::EncryptString(const std::string& plaintext,
+ 
+ bool OSCrypt::DecryptString(const std::string& ciphertext,
+                             std::string* plaintext) {
++  if (IsEncryptionDisabled(ciphertext, plaintext)) { return true; }
+   DATA_BLOB input;
+   input.pbData = const_cast<BYTE*>(
+       reinterpret_cast<const BYTE*>(ciphertext.data()));

--- a/patches/services-preferences-tracked-device_id_win.cc.patch
+++ b/patches/services-preferences-tracked-device_id_win.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/services/preferences/tracked/device_id_win.cc b/services/preferences/tracked/device_id_win.cc
+index 9dbd110674a9..26d8e68ce746 100644
+--- a/services/preferences/tracked/device_id_win.cc
++++ b/services/preferences/tracked/device_id_win.cc
+@@ -15,6 +15,7 @@
+ 
+ MachineIdStatus GetDeterministicMachineSpecificId(std::string* machine_id) {
+   DCHECK(machine_id);
++  if (IsMachineIdDisabled()) { return MachineIdStatus::NOT_IMPLEMENTED; }
+ 
+   wchar_t computer_name[MAX_COMPUTERNAME_LENGTH + 1] = {};
+   DWORD computer_name_size = arraysize(computer_name);


### PR DESCRIPTION
Fix brave/brave-browser#694

See brave/brave-browser#694 portapps/brave-portable#4

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

### disable-machine-id

* Launch brave with switch `--disable-machine-id`
* Install an extension
* Close brave and copy data to a second computer
* Launch brave on the second computer
* The extension must be ok

### disable-encryption-win

* Launch brave with switch `--disable-encryption-win`
* Login to a known website with credentials and save them (will add unencrypted cookies and passwords to database)
* Close brave and copy data to a second computer
* Launch brave on the second computer
* You must be still logged in on the website and credentials must be kept intact in the database

### use both switches

* Previous and following settings must be ok too :
  * Default search engine
  * Homepage
  * Startup pages
  * Pinned tabs

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source