### PR TITLE
Fixes remove publisher from ac table when clicking fast

### DIFF
--- a/components/brave_rewards/resources/ui/reducers/publishers_reducer.ts
+++ b/components/brave_rewards/resources/ui/reducers/publishers_reducer.ts
@@ -25,12 +25,25 @@ const publishersReducer: Reducer<Rewards.State | undefined> = (state: Rewards.St
       }
       break
     case types.ON_EXCLUDE_PUBLISHER:
-      if (!action.payload.publisherKey) {
+      {
+        const publisherKey: string = action.payload.publisherKey
+        if (!publisherKey) {
+          break
+        }
+
+        if (!state.excluded.includes(publisherKey)) {
+          chrome.send('brave_rewards.excludePublisher', [publisherKey])
+          state.excluded.push(publisherKey)
+          state = {
+            ...state,
+            excluded: state.excluded
+          }
+        }
         break
       }
-      chrome.send('brave_rewards.excludePublisher', [action.payload.publisherKey])
-      break
     case types.ON_RESTORE_PUBLISHERS:
+      state = { ...state }
+      state.excluded = []
       chrome.send('brave_rewards.restorePublishers', [])
       break
     case types.ON_RECURRING_DONATION_UPDATE:

--- a/components/brave_rewards/resources/ui/storage.ts
+++ b/components/brave_rewards/resources/ui/storage.ts
@@ -43,7 +43,8 @@ export const defaultState: Rewards.State = {
   tipsList: [],
   contributeLoad: false,
   recurringLoad: false,
-  tipsLoad: false
+  tipsLoad: false,
+  excluded: []
 }
 
 const cleanData = (state: Rewards.State) => state

--- a/components/definitions/rewards.d.ts
+++ b/components/definitions/rewards.d.ts
@@ -39,6 +39,7 @@ declare namespace Rewards {
     enabledAds: boolean
     enabledContribute: boolean
     enabledMain: boolean
+    excluded: string[]
     firstLoad: boolean | null
     grant?: Grant
     numExcludedSites: number


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/1873

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- add some sites to ac table
- open see all modal
- try to break the exclude counter
- make sure that you can't

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source