### PR TITLE
Disable both WebRTC log uploaders

### DIFF
--- a/patches/chrome-browser-extensions-api-webrtc_logging_private-webrtc_logging_private_api.cc.patch
+++ b/patches/chrome-browser-extensions-api-webrtc_logging_private-webrtc_logging_private_api.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_api.cc b/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_api.cc
+index babc823c9df6..7495718e768a 100644
+--- a/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_api.cc
++++ b/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_api.cc
+@@ -85,6 +85,7 @@ std::string HashIdWithOrigin(const std::string& security_origin,
+ content::RenderProcessHost* WebrtcLoggingPrivateFunction::RphFromRequest(
+     const api::webrtc_logging_private::RequestInfo& request,
+     const std::string& security_origin) {
++  return nullptr; // feature disabled in Brave
+   // There are 2 ways these API functions can get called.
+   //
+   //  1. From a whitelisted component extension on behalf of a page with the

--- a/patches/chrome-browser-media-webrtc-webrtc_event_log_uploader.cc.patch
+++ b/patches/chrome-browser-media-webrtc-webrtc_event_log_uploader.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/media/webrtc/webrtc_event_log_uploader.cc b/chrome/browser/media/webrtc/webrtc_event_log_uploader.cc
+index 571da26670db..f0cc7c00e198 100644
+--- a/chrome/browser/media/webrtc/webrtc_event_log_uploader.cc
++++ b/chrome/browser/media/webrtc/webrtc_event_log_uploader.cc
+@@ -255,6 +255,7 @@ bool WebRtcEventLogUploaderImpl::PrepareUploadData(std::string* upload_data) {
+ }
+ 
+ void WebRtcEventLogUploaderImpl::StartUpload(const std::string& upload_data) {
++  return; // feature disabled in Brave
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+ 
+   auto resource_request = std::make_unique<network::ResourceRequest>();

--- a/patches/chrome-browser-media-webrtc-webrtc_log_uploader.cc.patch
+++ b/patches/chrome-browser-media-webrtc-webrtc_log_uploader.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/media/webrtc/webrtc_log_uploader.cc b/chrome/browser/media/webrtc/webrtc_log_uploader.cc
+index cd618497a48d..a17f017923b8 100644
+--- a/chrome/browser/media/webrtc/webrtc_log_uploader.cc
++++ b/chrome/browser/media/webrtc/webrtc_log_uploader.cc
+@@ -469,6 +469,7 @@ void WebRtcLogUploader::ResizeForNextOutput(std::string* compressed_log,
+ void WebRtcLogUploader::UploadCompressedLog(
+     const WebRtcLogUploadDoneData& upload_done_data,
+     std::unique_ptr<std::string> post_data) {
++  return; // feature disabled in Brave
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+ 
+   DecreaseLogCount();


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1993

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source