### PR TITLE
Don't use singleton for rewards notification service

### DIFF
--- a/browser/extensions/api/rewards_notifications_api.cc
+++ b/browser/extensions/api/rewards_notifications_api.cc
@@ -24,8 +24,7 @@ ExtensionFunction::ResponseAction RewardsNotificationsAddNotificationFunction::R
       rewards_notifications::AddNotification::Params::Create(*args_));
   Profile* profile = Profile::FromBrowserContext(browser_context());
   RewardsNotificationService* rewards_notification_service =
-      RewardsServiceFactory::GetForProfile(profile)->notification_service(
-          profile);
+      RewardsServiceFactory::GetForProfile(profile)->GetNotificationService();
   if (rewards_notification_service) {
     rewards_notification_service->AddNotification(
         static_cast<RewardsNotificationService::RewardsNotificationType>(
@@ -43,8 +42,7 @@ ExtensionFunction::ResponseAction RewardsNotificationsDeleteNotificationFunction
       rewards_notifications::DeleteNotification::Params::Create(*args_));
   Profile* profile = Profile::FromBrowserContext(browser_context());
   RewardsNotificationService* rewards_notification_service =
-      RewardsServiceFactory::GetForProfile(profile)->notification_service(
-          profile);
+      RewardsServiceFactory::GetForProfile(profile)->GetNotificationService();
   if (rewards_notification_service) {
     rewards_notification_service->DeleteNotification(params->id);
   }
@@ -57,8 +55,7 @@ RewardsNotificationsDeleteAllNotificationsFunction::~RewardsNotificationsDeleteA
 ExtensionFunction::ResponseAction RewardsNotificationsDeleteAllNotificationsFunction::Run() {
   Profile* profile = Profile::FromBrowserContext(browser_context());
   RewardsNotificationService* rewards_notification_service =
-      RewardsServiceFactory::GetForProfile(profile)->notification_service(
-          profile);
+      RewardsServiceFactory::GetForProfile(profile)->GetNotificationService();
   if (rewards_notification_service) {
     rewards_notification_service->DeleteAllNotifications();
   }
@@ -73,8 +70,7 @@ ExtensionFunction::ResponseAction RewardsNotificationsGetNotificationFunction::R
       rewards_notifications::GetNotification::Params::Create(*args_));
   Profile* profile = Profile::FromBrowserContext(browser_context());
   RewardsNotificationService* rewards_notification_service =
-      RewardsServiceFactory::GetForProfile(profile)->notification_service(
-          profile);
+      RewardsServiceFactory::GetForProfile(profile)->GetNotificationService();
   if (rewards_notification_service) {
     rewards_notification_service->GetNotification(params->id);
   }
@@ -87,8 +83,7 @@ RewardsNotificationsGetAllNotificationsFunction::~RewardsNotificationsGetAllNoti
 ExtensionFunction::ResponseAction RewardsNotificationsGetAllNotificationsFunction::Run() {
   Profile* profile = Profile::FromBrowserContext(browser_context());
   RewardsNotificationService* rewards_notification_service =
-      RewardsServiceFactory::GetForProfile(profile)->notification_service(
-          profile);
+      RewardsServiceFactory::GetForProfile(profile)->GetNotificationService();
   if (rewards_notification_service) {
     rewards_notification_service->GetAllNotifications();
   }

--- a/components/brave_rewards/browser/rewards_notification_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_notification_service_browsertest.cc
@@ -22,8 +22,7 @@ class BraveRewardsNotificationBrowserTest
     InProcessBrowserTest::SetUpOnMainThread();
     rewards_service_ =
         RewardsServiceFactory::GetForProfile(browser()->profile());
-    rewards_notification_service_ =
-        rewards_service_->notification_service(browser()->profile());
+    rewards_notification_service_ = rewards_service_->GetNotificationService();
   }
 
   void TearDown() override {

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -4,7 +4,6 @@
 #include "brave/components/brave_rewards/browser/rewards_service.h"
 
 #include "base/logging.h"
-#include "base/no_destructor.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service_impl.h"
@@ -37,11 +36,6 @@ void RewardsService::AddObserver(RewardsServiceObserver* observer) {
 
 void RewardsService::RemoveObserver(RewardsServiceObserver* observer) {
   observers_.RemoveObserver(observer);
-}
-
-RewardsNotificationService* RewardsService::notification_service(Profile* profile) {
-  static base::NoDestructor<RewardsNotificationServiceImpl> instance(profile);
-  return instance.get();
 }
 
 // static

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -96,11 +96,10 @@ class RewardsService : public KeyedService {
   virtual void UpdateTipsList() = 0;
   virtual void SetContributionAutoInclude(
     std::string publisher_key, bool excluded, uint64_t windowId) = 0;
+  virtual RewardsNotificationService* GetNotificationService() const = 0;
 
   void AddObserver(RewardsServiceObserver* observer);
   void RemoveObserver(RewardsServiceObserver* observer);
-
-  RewardsNotificationService* notification_service(Profile* profile);
 
   static void RegisterProfilePrefs(PrefRegistrySimple* registry);
 

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -113,6 +113,7 @@ class RewardsServiceImpl : public RewardsService,
   void UpdateTipsList() override;
   void SetContributionAutoInclude(
     std::string publisher_key, bool excluded, uint64_t windowId) override;
+  RewardsNotificationService* GetNotificationService() const override;
 
  private:
   friend void RunIOTaskCallback(
@@ -256,8 +257,6 @@ class RewardsServiceImpl : public RewardsService,
   // URLFetcherDelegate impl
   void OnURLFetchComplete(const net::URLFetcher* source) override;
 
-  RewardsNotificationService* notification_service();
-
   Profile* profile_;  // NOT OWNED
   std::unique_ptr<ledger::Ledger> ledger_;
   const scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
@@ -266,6 +265,7 @@ class RewardsServiceImpl : public RewardsService,
   const base::FilePath publisher_info_db_path_;
   const base::FilePath publisher_list_path_;
   std::unique_ptr<PublisherInfoDatabase> publisher_info_backend_;
+  std::unique_ptr<RewardsNotificationService> notification_service_;
 
   extensions::OneShotEvent ready_;
   std::map<const net::URLFetcher*, FetchCallback> fetchers_;


### PR DESCRIPTION
Fixes brave/brave-browser#2000

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source