### PR TITLE
Handle invalid grant notification ID

### DIFF
--- a/components/brave_rewards/browser/rewards_notification_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.cc
@@ -21,11 +21,9 @@ namespace brave_rewards {
 
 RewardsNotificationServiceImpl::RewardsNotificationServiceImpl(Profile* profile)
     : profile_(profile) {
-  ReadRewardsNotifications();
 }
 
 RewardsNotificationServiceImpl::~RewardsNotificationServiceImpl() {
-  StoreRewardsNotifications();
 }
 
 void RewardsNotificationServiceImpl::AddNotification(
@@ -102,15 +100,17 @@ void RewardsNotificationServiceImpl::ReadRewardsNotifications() {
     int notification_timestamp;
     RewardsNotificationArgs notification_args;
     dict_value->GetString("id", &notification_id);
+    dict_value->GetInteger("type", &notification_type);
+    dict_value->GetInteger("timestamp", &notification_timestamp);
 
     if (notification_id.empty()) {
       int old_id;
       dict_value->GetInteger("id", &old_id);
-      notification_id = std::to_string(old_id);
+      if (old_id == 0 && notification_type == 2)
+        notification_id = "rewards_notification_grant";
+      else
+        notification_id = std::to_string(old_id);
     }
-
-    dict_value->GetInteger("type", &notification_type);
-    dict_value->GetInteger("timestamp", &notification_timestamp);
 
     base::ListValue* args;
     dict_value->GetList("args", &args);


### PR DESCRIPTION
Fixes brave/brave-browser#2004

We recently changed the format of the grant notification ID from an
integer to a string. We've encountered a scenario where an old install
may erroneously set the ID to 0 (which was never a valid value). Once
you're in this state, it's impossible to dismiss the notification. To
fix this, we look for this case on startup and modify the notification
to have the correct ID.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

   1. Delete your existing profile
   2. Launch Brave
   3. Opt-in to Rewards
   4. Close Brave without dismissing the grant notification
   5. In your profile directory, open the `Preferences` file and in the `brave.rewards.notifications` section set id to `0`
   6. Save the `Preferences` file
   7. Launch Brave
   8. Try to dismiss grant notification by clicking its OK button

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source