### PR TITLE
Add brave theme resource targets to deps of chrome's corresponding theme target

### DIFF
--- a/app/theme/BUILD.gn
+++ b/app/theme/BUILD.gn
@@ -15,10 +15,6 @@ grit("brave_theme_resources") {
 
   resource_ids = "//brave/browser/resources/resource_ids"
 
-  deps = [
-    "//chrome/app/theme:theme_resources",
-  ]
-
   output_dir = "$root_gen_dir/brave"
 }
 

--- a/patches/chrome-app-theme-BUILD.gn.patch
+++ b/patches/chrome-app-theme-BUILD.gn.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/app/theme/BUILD.gn b/chrome/app/theme/BUILD.gn
+index 57e8917e359a2fc59f567bd33f9340e400e55b1f..b127c994019d8ba1e5750b33c300c2ec9dcf3463 100644
+--- a/chrome/app/theme/BUILD.gn
++++ b/chrome/app/theme/BUILD.gn
+@@ -21,6 +21,7 @@ grit("theme_resources") {
+     ":chrome_unscaled_resources",
+     "//ui/resources",
+   ]
++  if (brave_chromium_build) { deps += ["//brave/app/theme:brave_theme_resources"]}
+ 
+   output_dir = "$root_gen_dir/chrome"
+ }
+@@ -32,6 +33,7 @@ grit("chrome_unscaled_resources") {
+     "grit/chrome_unscaled_resources.h",
+     "chrome_unscaled_resources.pak",
+   ]
++  if (brave_chromium_build) { deps = ["//brave/app/theme:brave_unscaled_resources"]}
+ 
+   output_dir = "$root_gen_dir/chrome"
+ }


### PR DESCRIPTION
We are overriding theme_resources.h and chrome_unscaled_resources.h.
They are including brave's corresponding resource files.
When some files refers upstream headers and our header is not generated yet,
build error could be happened.

Close https://github.com/brave/brave-browser/issues/2001

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source