### PR TITLE
Fix the logic of BraveContentSettingsObserver::IsBraveShieldsDown

### DIFF
--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -136,7 +136,7 @@ GURL BraveContentSettingsObserver::GetOriginOrURL(const blink::WebFrame* frame) 
   return top_origin.GetURL();
 }
 
-ContentSetting BraveContentSettingsObserver::GetContentSettingFromRules(
+ContentSetting BraveContentSettingsObserver::GetFPContentSettingFromRules(
     const ContentSettingsForOneType& rules,
     const blink::WebFrame* frame,
     const GURL& secondary_url) {
@@ -170,9 +170,16 @@ bool BraveContentSettingsObserver::IsBraveShieldsDown(
     const blink::WebFrame* frame,
     const GURL& secondary_url) {
   ContentSetting setting = CONTENT_SETTING_DEFAULT;
+  const GURL& primary_url = GetOriginOrURL(frame);
+
   if (content_setting_rules_) {
-    setting = GetContentSettingFromRules(
-        content_setting_rules_->brave_shields_rules, frame, secondary_url);
+    for (const auto& rule : content_setting_rules_->brave_shields_rules) {
+      if (rule.primary_pattern.Matches(primary_url) &&
+          rule.secondary_pattern.Matches(secondary_url)) {
+        setting = rule.GetContentSetting();
+        break;
+      }
+    }
   }
 
   return setting == CONTENT_SETTING_BLOCK;
@@ -199,7 +206,7 @@ bool BraveContentSettingsObserver::AllowFingerprinting(
                                   std::string(),
                                   false);
   rules.push_back(default_rule);
-  ContentSetting setting = GetContentSettingFromRules(rules, frame, secondary_url);
+  ContentSetting setting = GetFPContentSettingFromRules(rules, frame, secondary_url);
   rules.pop_back();
   bool allow = setting != CONTENT_SETTING_BLOCK;
   allow = allow || IsWhitelistedForContentSettings();

--- a/renderer/brave_content_settings_observer.h
+++ b/renderer/brave_content_settings_observer.h
@@ -42,7 +42,7 @@ class BraveContentSettingsObserver
  private:
   GURL GetOriginOrURL(const blink::WebFrame* frame);
 
-  ContentSetting GetContentSettingFromRules(
+  ContentSetting GetFPContentSettingFromRules(
       const ContentSettingsForOneType& rules,
       const blink::WebFrame* frame,
       const GURL& secondary_url);

--- a/renderer/brave_content_settings_observer_browsertest.cc
+++ b/renderer/brave_content_settings_observer_browsertest.cc
@@ -640,3 +640,19 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockScriptsShie
       NavigateToURLUntilLoadStop("a.com", "/load_js_from_origins.html"));
   EXPECT_EQ(contents()->GetAllFrames().size(), 3u);
 }
+
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockScriptsShieldsDownInOtherTab) {
+  // Turn off shields in a.com.
+  ShieldsDown();
+  // Block scripts in b.com.
+  content_settings()->SetContentSettingCustomScope(
+      iframe_pattern(),
+      ContentSettingsPattern::Wildcard(),
+      CONTENT_SETTINGS_TYPE_JAVASCRIPT,
+      "",
+      CONTENT_SETTING_BLOCK);
+
+  EXPECT_TRUE(
+      NavigateToURLUntilLoadStop("b.com", "/load_js_from_origins.html"));
+  EXPECT_EQ(contents()->GetAllFrames().size(), 1u);
+}


### PR DESCRIPTION
Close brave/brave-browser#1991

The logic is broken after the default shields rule is removed.
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
manual test: STR specified in brave/brave-browser#1991
browser test: `npm test brave_browser_tests -- --filter=BraveContentSettingsObserverBrowserTest.BlockScriptsShieldsDownInOtherTab`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source