### PR TITLE
update DEPS for brave-extension

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@e67738e656244f7ab6e0ed9815071ca744f5468f",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@4b55fe39bb25bb0d8b11a43d547d75f00c6c46fb",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@9be5c63b14e094156e00c8b28f205e7794f0b92c",
-  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@6ba9928516afe0f0041be138c11ac27b3964ae26",
+  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@038a43af5294150d48ce94a326290f70aa001cd0",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",


### PR DESCRIPTION
ref https://github.com/brave/brave-extension/commit/038a43af5294150d48ce94a326290f70aa001cd0

in this change:

* add deeplink to the shields section https://github.com/brave/brave-extension/pull/80
* disallow click event when stats are 0 https://github.com/brave/brave-extension/pull/81
* set stats to 99+ if resource is aboce that number https://github.com/brave/brave-extension/pull/82