### PR TITLE
Fix webui stats are empty when it loaded by navigation back

### DIFF
--- a/browser/ui/webui/basic_ui.cc
+++ b/browser/ui/webui/basic_ui.cc
@@ -7,6 +7,7 @@
 #include "brave/browser/ui/webui/brave_webui_source.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/common/bindings_policy.h"
 
@@ -24,12 +25,38 @@ content::WebUIDataSource* CreateBasicUIHTMLSource(Profile* profile,
   return source;
 }
 
+// This is used to know proper timing for setting webui properties.
+// So far, content::WebUIController::RenderFrameCreated() is used.
+// However, it doesn't get called sometimes when reloading, or called when
+// RenderFrameHost is not prepared during renderer process is in changing.
+class BasicUI::BasicUIWebContentsObserver
+    : public content::WebContentsObserver {
+ public:
+  BasicUIWebContentsObserver(BasicUI* host, content::WebContents* web_contents)
+      : WebContentsObserver(web_contents),
+        host_(host) {
+  }
+  ~BasicUIWebContentsObserver() override {}
+
+  // content::WebContentsObserver overrides:
+  void RenderViewReady() override {
+    host_->UpdateWebUIProperties();
+  }
+
+ private:
+  BasicUI* host_;
+
+  DISALLOW_COPY_AND_ASSIGN(BasicUIWebContentsObserver);
+};
+
 BasicUI::BasicUI(content::WebUI* web_ui,
     const std::string& name,
     const std::string& js_file,
     int js_resource_id,
     int html_resource_id)
     : WebUIController(web_ui) {
+  observer_.reset(
+      new BasicUIWebContentsObserver(this, web_ui->GetWebContents()));
   Profile* profile = Profile::FromWebUI(web_ui);
   content::WebUIDataSource* source = CreateBasicUIHTMLSource(profile, name,
       js_file, js_resource_id, html_resource_id);

--- a/browser/ui/webui/basic_ui.cc
+++ b/browser/ui/webui/basic_ui.cc
@@ -8,10 +8,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_data_source.h"
-#include "content/public/browser/web_ui_message_handler.h"
 #include "content/public/common/bindings_policy.h"
-
-using content::WebUIMessageHandler;
 
 content::WebUIDataSource* CreateBasicUIHTMLSource(Profile* profile,
                                                   const std::string& name,
@@ -27,28 +24,6 @@ content::WebUIDataSource* CreateBasicUIHTMLSource(Profile* profile,
   return source;
 }
 
-// The handler for Javascript messages for Brave about: pages
-class BasicDOMHandler : public WebUIMessageHandler {
- public:
-  BasicDOMHandler() {
-  }
-  ~BasicDOMHandler() override {}
-
-  void Init();
-
-  // WebUIMessageHandler implementation.
-  void RegisterMessages() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(BasicDOMHandler);
-};
-
-void BasicDOMHandler::RegisterMessages() {
-}
-
-void BasicDOMHandler::Init() {
-}
-
 BasicUI::BasicUI(content::WebUI* web_ui,
     const std::string& name,
     const std::string& js_file,
@@ -56,10 +31,6 @@ BasicUI::BasicUI(content::WebUI* web_ui,
     int html_resource_id)
     : WebUIController(web_ui) {
   Profile* profile = Profile::FromWebUI(web_ui);
-  auto handler_owner = std::make_unique<BasicDOMHandler>();
-  BasicDOMHandler* handler = handler_owner.get();
-  web_ui->AddMessageHandler(std::move(handler_owner));
-  handler->Init();
   content::WebUIDataSource* source = CreateBasicUIHTMLSource(profile, name,
       js_file, js_resource_id, html_resource_id);
   content::WebUIDataSource::Add(profile, source);

--- a/browser/ui/webui/basic_ui.h
+++ b/browser/ui/webui/basic_ui.h
@@ -5,6 +5,8 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_BASIC_UI_H_
 #define BRAVE_BROWSER_UI_WEBUI_BASIC_UI_H_
 
+#include <memory>
+
 #include <string>
 
 #include "base/compiler_specific.h"
@@ -31,11 +33,18 @@ class BasicUI : public content::WebUIController {
       const std::string& js_file, int js_resource_id, int html_resource_id);
   ~BasicUI() override;
 
+  // Called when subclass can set its webui properties.
+  virtual void UpdateWebUIProperties() {}
+
  protected:
   bool IsSafeToSetWebUIProperties() const;
   content::RenderViewHost* GetRenderViewHost();
 
  private:
+  class BasicUIWebContentsObserver;
+
+  std::unique_ptr<BasicUIWebContentsObserver> observer_;
+
   DISALLOW_COPY_AND_ASSIGN(BasicUI);
 };
 

--- a/browser/ui/webui/brave_adblock_ui.cc
+++ b/browser/ui/webui/brave_adblock_ui.cc
@@ -32,6 +32,8 @@ BraveAdblockUI::~BraveAdblockUI() {
 }
 
 void BraveAdblockUI::CustomizeWebUIProperties(content::RenderViewHost* render_view_host) {
+  DCHECK(IsSafeToSetWebUIProperties());
+
   Profile* profile = Profile::FromWebUI(web_ui());
   PrefService* prefs = profile->GetPrefs();
   if (render_view_host) {
@@ -44,15 +46,13 @@ void BraveAdblockUI::CustomizeWebUIProperties(content::RenderViewHost* render_vi
   }
 }
 
-void BraveAdblockUI::RenderFrameCreated(content::RenderFrameHost* render_frame_host) {
-  if (IsSafeToSetWebUIProperties()) {
-    CustomizeWebUIProperties(render_frame_host->GetRenderViewHost());
-  }
-}
-
-void BraveAdblockUI::OnPreferenceChanged() {
+void BraveAdblockUI::UpdateWebUIProperties() {
   if (IsSafeToSetWebUIProperties()) {
     CustomizeWebUIProperties(GetRenderViewHost());
     web_ui()->CallJavascriptFunctionUnsafe("brave_adblock.statsUpdated");
   }
+}
+
+void BraveAdblockUI::OnPreferenceChanged() {
+  UpdateWebUIProperties();
 }

--- a/browser/ui/webui/brave_adblock_ui.h
+++ b/browser/ui/webui/brave_adblock_ui.h
@@ -16,7 +16,9 @@ class BraveAdblockUI : public BasicUI {
   ~BraveAdblockUI() override;
 
  private:
-  void RenderFrameCreated(content::RenderFrameHost* render_frame_host) override;
+  // BasicUI overrides:
+  void UpdateWebUIProperties() override;
+
   void CustomizeWebUIProperties(content::RenderViewHost* render_view_host);
   void OnPreferenceChanged();
 

--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -77,6 +77,7 @@ BraveNewTabUI::~BraveNewTabUI() {
 }
 
 void BraveNewTabUI::CustomizeNewTabWebUIProperties(content::RenderViewHost* render_view_host) {
+  DCHECK(IsSafeToSetWebUIProperties());
   Profile* profile = Profile::FromWebUI(web_ui());
   PrefService* prefs = profile->GetPrefs();
   if (render_view_host) {
@@ -106,15 +107,13 @@ void BraveNewTabUI::CustomizeNewTabWebUIProperties(content::RenderViewHost* rend
   }
 }
 
-void BraveNewTabUI::RenderFrameCreated(content::RenderFrameHost* render_frame_host) {
-  if (IsSafeToSetWebUIProperties()) {
-    CustomizeNewTabWebUIProperties(render_frame_host->GetRenderViewHost());
-  }
-}
-
-void BraveNewTabUI::OnPreferenceChanged() {
+void BraveNewTabUI::UpdateWebUIProperties() {
   if (IsSafeToSetWebUIProperties()) {
     CustomizeNewTabWebUIProperties(GetRenderViewHost());
     web_ui()->CallJavascriptFunctionUnsafe("brave_new_tab.statsUpdated");
   }
+}
+
+void BraveNewTabUI::OnPreferenceChanged() {
+  UpdateWebUIProperties();
 }

--- a/browser/ui/webui/brave_new_tab_ui.h
+++ b/browser/ui/webui/brave_new_tab_ui.h
@@ -6,6 +6,7 @@
 #define BRAVE_BROWSER_UI_WEBUI_BRAVE_NEW_TAB_UI_H_
 
 #include <memory>
+
 #include "brave/browser/ui/webui/basic_ui.h"
 
 class PrefChangeRegistrar;
@@ -16,7 +17,9 @@ class BraveNewTabUI : public BasicUI {
   ~BraveNewTabUI() override;
 
  private:
-  void RenderFrameCreated(content::RenderFrameHost* render_frame_host) override;
+  // BasicUI overrides
+  void UpdateWebUIProperties() override;
+
   void CustomizeNewTabWebUIProperties(content::RenderViewHost* render_view_host);
   void OnPreferenceChanged();
 


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1490
Fix https://github.com/brave/brave-browser/issues/307

To know more proper timing to set webui properties, BasicUI::UpdateWebUIProperties() callback
is introduced.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
* newtab
  1. open chrome://newtab/ and navigate other site in the same tab
  2. navigate back
  3. check proper newtab stats are visible

* private newtab
  1. open private window and toggle on ddg and navigate other site in the same tab
  2. navigate back
  3. check ddg button is on

* adblock
  1. open chrome://adblock/ and navigate other site in the same tab
  2. navigate back
  3. check proper adblock info are visible

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source