### PR TITLE
Introduce ScopedTorLaunchPreventerForTest to prevent tor process launch

### DIFF
--- a/browser/tor/tor_launcher_factory.h
+++ b/browser/tor/tor_launcher_factory.h
@@ -51,4 +51,11 @@ class TorLauncherFactory {
   DISALLOW_COPY_AND_ASSIGN(TorLauncherFactory);
 };
 
+// Use this in tests to avoid the actual launch of the Tor process.
+class ScopedTorLaunchPreventerForTest {
+ public:
+  ScopedTorLaunchPreventerForTest();
+  ~ScopedTorLaunchPreventerForTest();
+};
+
 #endif  // BRAVE_BROWSER_TOR_TOR_LAUNCHER_FACTORY_H_


### PR DESCRIPTION
With this, tests with tor profile could be made more easily.

Fix https://github.com/brave/brave-browser/issues/1642

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=SearchEngineProviderControllerTest.CheckDefaultTorProfileSearchProviderTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source