### PR TITLE
Fix localization in Brave web-ui pages and Brave strings in general

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -1,4 +1,5 @@
 import("//build/config/features.gni")
+import("//build/config/locales.gni")
 import("//tools/grit/grit_rule.gni")
 
 source_set("command_ids") {
@@ -12,8 +13,14 @@ grit("brave_generated_resources_grit") {
   output_dir = "$root_gen_dir/brave"
   outputs = [
     "grit/brave_generated_resources.h",
+    # This is needed for the includes and not the localized messages
     "brave_generated_resources.pak",
   ]
+
+  foreach(locale, locales_with_fake_bidi) {
+    outputs += [ "brave_generated_resources_$locale.pak" ]
+  }
+
   resource_ids = "//brave/browser/resources/resource_ids"
 }
 

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -6,6 +6,62 @@
       <emit emit_type='prepend'></emit>
     </output>
     <output filename="brave_generated_resources.pak" type="data_package" />
+    <output filename="brave_generated_resources_am.pak" type="data_package" lang="am" />
+    <output filename="brave_generated_resources_ar.pak" type="data_package" lang="ar" />
+    <output filename="brave_generated_resources_bg.pak" type="data_package" lang="bg" />
+    <output filename="brave_generated_resources_bn.pak" type="data_package" lang="bn" />
+    <output filename="brave_generated_resources_ca.pak" type="data_package" lang="ca" />
+    <output filename="brave_generated_resources_cs.pak" type="data_package" lang="cs" />
+    <output filename="brave_generated_resources_da.pak" type="data_package" lang="da" />
+    <output filename="brave_generated_resources_de.pak" type="data_package" lang="de" />
+    <output filename="brave_generated_resources_el.pak" type="data_package" lang="el" />
+    <output filename="brave_generated_resources_en-GB.pak" type="data_package" lang="en-GB" />
+    <output filename="brave_generated_resources_en-US.pak" type="data_package" lang="en" />
+    <output filename="brave_generated_resources_es.pak" type="data_package" lang="es" />
+    <output filename="brave_generated_resources_es-419.pak" type="data_package" lang="es-419" />
+    <output filename="brave_generated_resources_et.pak" type="data_package" lang="et" />
+    <output filename="brave_generated_resources_fa.pak" type="data_package" lang="fa" />
+    <output filename="brave_generated_resources_fake-bidi.pak" type="data_package" lang="fake-bidi" />
+    <output filename="brave_generated_resources_fi.pak" type="data_package" lang="fi" />
+    <output filename="brave_generated_resources_fil.pak" type="data_package" lang="fil" />
+    <output filename="brave_generated_resources_fr.pak" type="data_package" lang="fr" />
+    <output filename="brave_generated_resources_gu.pak" type="data_package" lang="gu" />
+    <output filename="brave_generated_resources_he.pak" type="data_package" lang="he" />
+    <output filename="brave_generated_resources_hi.pak" type="data_package" lang="hi" />
+    <output filename="brave_generated_resources_hr.pak" type="data_package" lang="hr" />
+    <output filename="brave_generated_resources_hu.pak" type="data_package" lang="hu" />
+    <output filename="brave_generated_resources_id.pak" type="data_package" lang="id" />
+    <output filename="brave_generated_resources_it.pak" type="data_package" lang="it" />
+    <output filename="brave_generated_resources_ja.pak" type="data_package" lang="ja" />
+    <output filename="brave_generated_resources_kn.pak" type="data_package" lang="kn" />
+    <output filename="brave_generated_resources_ko.pak" type="data_package" lang="ko" />
+    <output filename="brave_generated_resources_lt.pak" type="data_package" lang="lt" />
+    <output filename="brave_generated_resources_lv.pak" type="data_package" lang="lv" />
+    <output filename="brave_generated_resources_ml.pak" type="data_package" lang="ml" />
+    <output filename="brave_generated_resources_mr.pak" type="data_package" lang="mr" />
+    <output filename="brave_generated_resources_ms.pak" type="data_package" lang="ms" />
+    <output filename="brave_generated_resources_nl.pak" type="data_package" lang="nl" />
+    <!-- The translation console uses 'no' for Norwegian Bokmål. It should
+         be 'nb'. -->
+    <output filename="brave_generated_resources_nb.pak" type="data_package" lang="no" />
+    <output filename="brave_generated_resources_pl.pak" type="data_package" lang="pl" />
+    <output filename="brave_generated_resources_pt-BR.pak" type="data_package" lang="pt-BR" />
+    <output filename="brave_generated_resources_pt-PT.pak" type="data_package" lang="pt-PT" />
+    <output filename="brave_generated_resources_ro.pak" type="data_package" lang="ro" />
+    <output filename="brave_generated_resources_ru.pak" type="data_package" lang="ru" />
+    <output filename="brave_generated_resources_sk.pak" type="data_package" lang="sk" />
+    <output filename="brave_generated_resources_sl.pak" type="data_package" lang="sl" />
+    <output filename="brave_generated_resources_sr.pak" type="data_package" lang="sr" />
+    <output filename="brave_generated_resources_sv.pak" type="data_package" lang="sv" />
+    <output filename="brave_generated_resources_sw.pak" type="data_package" lang="sw" />
+    <output filename="brave_generated_resources_ta.pak" type="data_package" lang="ta" />
+    <output filename="brave_generated_resources_te.pak" type="data_package" lang="te" />
+    <output filename="brave_generated_resources_th.pak" type="data_package" lang="th" />
+    <output filename="brave_generated_resources_tr.pak" type="data_package" lang="tr" />
+    <output filename="brave_generated_resources_uk.pak" type="data_package" lang="uk" />
+    <output filename="brave_generated_resources_vi.pak" type="data_package" lang="vi" />
+    <output filename="brave_generated_resources_zh-CN.pak" type="data_package" lang="zh-CN" />
+    <output filename="brave_generated_resources_zh-TW.pak" type="data_package" lang="zh-TW" />
   </outputs>
   <translations>
     <file path="resources/brave_generated_resources_am.xtb" lang="am" />

--- a/brave_paks.gni
+++ b/brave_paks.gni
@@ -58,7 +58,6 @@ template("brave_extra_paks") {
       "$root_gen_dir/brave/brave_unscaled_resources.pak",
       "$root_gen_dir/brave/browser/resources/brave_settings_resources.pak",
       "$root_gen_dir/components/brave_components_resources.pak",
-      "$root_gen_dir/components/brave_components_strings.pak",
       "$root_gen_dir/brave/components/brave_rewards/resources/brave_rewards_resources.pak",
       "$root_gen_dir/brave/components/brave_rewards/resources/extension/brave_rewards_extension_resources.pak",
       "$target_gen_dir/browser/resources/brave_extension.pak",

--- a/brave_repack_locales.gni
+++ b/brave_repack_locales.gni
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+brave_locale_source_patterns = [
+  "${root_gen_dir}/components/brave_components_strings_",
+  "${root_gen_dir}/brave/brave_generated_resources_",
+]
+
+brave_locale_deps = [
+  "//brave/app:brave_generated_resources_grit",
+  "//brave/components/resources:strings",
+]

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -1,5 +1,6 @@
-import("//tools/grit/grit_rule.gni")
 import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
+import("//build/config/locales.gni")
+import("//tools/grit/grit_rule.gni")
 
 if (!is_android) {
   grit("resources") {
@@ -41,8 +42,11 @@ grit("strings") {
 
   outputs = [
     "grit/brave_components_strings.h",
-    "brave_components_strings.pak",
   ]
+
+  foreach(locale, locales_with_fake_bidi) {
+    outputs += [ "brave_components_strings_$locale.pak" ]
+  }
 
   output_dir = "$root_gen_dir/components"
   resource_ids = "//brave/browser/resources/resource_ids"

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -1,10 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grit latest_public_release="0" current_release="1" output_all_resource_defines="false">
+<grit latest_public_release="0" current_release="1" output_all_resource_defines="false" source_lang_id="en">
   <outputs>
     <output filename="grit/brave_components_strings.h" type="rc_header">
       <emit emit_type='prepend'></emit>
     </output>
-    <output filename="brave_components_strings.pak" type="data_package" />
+    <output filename="brave_components_strings_am.pak" type="data_package" lang="am" />
+    <output filename="brave_components_strings_ar.pak" type="data_package" lang="ar" />
+    <output filename="brave_components_strings_bg.pak" type="data_package" lang="bg" />
+    <output filename="brave_components_strings_bn.pak" type="data_package" lang="bn" />
+    <output filename="brave_components_strings_ca.pak" type="data_package" lang="ca" />
+    <output filename="brave_components_strings_cs.pak" type="data_package" lang="cs" />
+    <output filename="brave_components_strings_da.pak" type="data_package" lang="da" />
+    <output filename="brave_components_strings_de.pak" type="data_package" lang="de" />
+    <output filename="brave_components_strings_el.pak" type="data_package" lang="el" />
+    <output filename="brave_components_strings_en-GB.pak" type="data_package" lang="en-GB" />
+    <output filename="brave_components_strings_en-US.pak" type="data_package" lang="en" />
+    <output filename="brave_components_strings_es.pak" type="data_package" lang="es" />
+    <output filename="brave_components_strings_es-419.pak" type="data_package" lang="es-419" />
+    <output filename="brave_components_strings_et.pak" type="data_package" lang="et" />
+    <output filename="brave_components_strings_fa.pak" type="data_package" lang="fa" />
+    <output filename="brave_components_strings_fake-bidi.pak" type="data_package" lang="fake-bidi" />
+    <output filename="brave_components_strings_fi.pak" type="data_package" lang="fi" />
+    <output filename="brave_components_strings_fil.pak" type="data_package" lang="fil" />
+    <output filename="brave_components_strings_fr.pak" type="data_package" lang="fr" />
+    <output filename="brave_components_strings_gu.pak" type="data_package" lang="gu" />
+    <output filename="brave_components_strings_he.pak" type="data_package" lang="he" />
+    <output filename="brave_components_strings_hi.pak" type="data_package" lang="hi" />
+    <output filename="brave_components_strings_hr.pak" type="data_package" lang="hr" />
+    <output filename="brave_components_strings_hu.pak" type="data_package" lang="hu" />
+    <output filename="brave_components_strings_id.pak" type="data_package" lang="id" />
+    <output filename="brave_components_strings_it.pak" type="data_package" lang="it" />
+    <output filename="brave_components_strings_ja.pak" type="data_package" lang="ja" />
+    <output filename="brave_components_strings_kn.pak" type="data_package" lang="kn" />
+    <output filename="brave_components_strings_ko.pak" type="data_package" lang="ko" />
+    <output filename="brave_components_strings_lt.pak" type="data_package" lang="lt" />
+    <output filename="brave_components_strings_lv.pak" type="data_package" lang="lv" />
+    <output filename="brave_components_strings_ml.pak" type="data_package" lang="ml" />
+    <output filename="brave_components_strings_mr.pak" type="data_package" lang="mr" />
+    <output filename="brave_components_strings_ms.pak" type="data_package" lang="ms" />
+    <output filename="brave_components_strings_nl.pak" type="data_package" lang="nl" />
+    <!-- The translation console uses 'no' for Norwegian Bokmål. It should
+         be 'nb'. -->
+    <output filename="brave_components_strings_nb.pak" type="data_package" lang="no" />
+    <output filename="brave_components_strings_pl.pak" type="data_package" lang="pl" />
+    <output filename="brave_components_strings_pt-BR.pak" type="data_package" lang="pt-BR" />
+    <output filename="brave_components_strings_pt-PT.pak" type="data_package" lang="pt-PT" />
+    <output filename="brave_components_strings_ro.pak" type="data_package" lang="ro" />
+    <output filename="brave_components_strings_ru.pak" type="data_package" lang="ru" />
+    <output filename="brave_components_strings_sk.pak" type="data_package" lang="sk" />
+    <output filename="brave_components_strings_sl.pak" type="data_package" lang="sl" />
+    <output filename="brave_components_strings_sr.pak" type="data_package" lang="sr" />
+    <output filename="brave_components_strings_sv.pak" type="data_package" lang="sv" />
+    <output filename="brave_components_strings_sw.pak" type="data_package" lang="sw" />
+    <output filename="brave_components_strings_ta.pak" type="data_package" lang="ta" />
+    <output filename="brave_components_strings_te.pak" type="data_package" lang="te" />
+    <output filename="brave_components_strings_th.pak" type="data_package" lang="th" />
+    <output filename="brave_components_strings_tr.pak" type="data_package" lang="tr" />
+    <output filename="brave_components_strings_uk.pak" type="data_package" lang="uk" />
+    <output filename="brave_components_strings_vi.pak" type="data_package" lang="vi" />
+    <output filename="brave_components_strings_zh-CN.pak" type="data_package" lang="zh-CN" />
+    <output filename="brave_components_strings_zh-TW.pak" type="data_package" lang="zh-TW" />
   </outputs>
   <translations>
     <file path="strings/brave_components_resources_am.xtb" lang="am" />

--- a/patches/chrome-chrome_repack_locales.gni.patch
+++ b/patches/chrome-chrome_repack_locales.gni.patch
@@ -1,0 +1,28 @@
+diff --git a/chrome/chrome_repack_locales.gni b/chrome/chrome_repack_locales.gni
+index dd37d98b467ec9bcf5ac5fd59ac56e43412a19fa..5a200e64670e4004041934eec9a23675de6d7e4d 100644
+--- a/chrome/chrome_repack_locales.gni
++++ b/chrome/chrome_repack_locales.gni
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//brave/brave_repack_locales.gni")
+ import("//build/config/chrome_build.gni")
+ import("//build/config/features.gni")
+ import("//build/config/ui.gni")
+@@ -35,6 +36,7 @@ template("chrome_repack_locales") {
+       "${root_gen_dir}/ui/strings/app_locale_settings_",
+       "${root_gen_dir}/ui/strings/ui_strings_",
+     ]
++    source_patterns += brave_locale_source_patterns
+     if (!defined(deps)) {
+       deps = []
+     }
+@@ -51,6 +53,7 @@ template("chrome_repack_locales") {
+       "//ui/strings:app_locale_settings",
+       "//ui/strings:ui_strings",
+     ]
++    deps += brave_locale_deps
+     if (defined(invoker.deps)) {
+       deps += invoker.deps
+     }


### PR DESCRIPTION
Before this PR localization would not show up for our own custom strings.
I tried making our own version of brave_repack_locales to avoid the patch but it gave some errors about things like "fr.pak" already exists. It seemed not easy to resolve so went with this since it was working and pretty lite on patching.

Fix https://github.com/brave/brave-browser/issues/2035

After this lands I think I'll need a bit more to get it to work on Android, I'll do a PR for Android separate. 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source