### PR TITLE
Fix handling of invalid notification IDs

### DIFF
--- a/components/brave_rewards/browser/rewards_notification_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.cc
@@ -120,6 +120,9 @@ void RewardsNotificationServiceImpl::ReadRewardsNotifications() {
     dict_value->GetInteger("type", &notification_type);
     dict_value->GetInteger("timestamp", &notification_timestamp);
 
+    // The notification ID was originally an integer, but now it's a
+    // string. For backwards compatibility, we need to handle the
+    // case where the ID contains an invalid string or integer
     if (notification_id.empty()) {
       int old_id;
       dict_value->GetInteger("id", &old_id);
@@ -127,6 +130,8 @@ void RewardsNotificationServiceImpl::ReadRewardsNotifications() {
         notification_id = "rewards_notification_grant";
       else
         notification_id = std::to_string(old_id);
+    } else if (notification_id == "0" && notification_type == 2) {
+      notification_id = "rewards_notification_grant";
     }
 
     base::ListValue* args;


### PR DESCRIPTION
Fixes brave/brave-browser#1878

We need to handle the case where the invalid ID is a string (we were
only handling the case where it was an integer). This can happen when
installing older versions of the browser.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source