### PR TITLE
Rewards panel can now quickly access 'Add Funds' link properly

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -149,6 +149,12 @@ export class Panel extends React.Component<Props, State> {
     })
   }
 
+  openRewardsAddFundsPage () {
+    chrome.tabs.create({
+      url: 'brave://rewards/#add-funds'
+    })
+  }
+
   showDonateToSiteDetail = () => {
     const publisher: RewardsExtension.Publisher | undefined = this.getPublisher()
     // TODO: why do we store windowId instead of active tab id in state?
@@ -233,7 +239,7 @@ export class Panel extends React.Component<Props, State> {
         actions={[
           {
             name: 'Add funds',
-            action: this.openRewardsPage,
+            action: this.openRewardsAddFundsPage,
             icon: <WalletAddIcon />
           },
           {

--- a/components/brave_rewards/resources/ui/components/pageWallet.tsx
+++ b/components/brave_rewards/resources/ui/components/pageWallet.tsx
@@ -49,6 +49,10 @@ class PageWallet extends React.Component<Props, State> {
     return this.props.actions
   }
 
+  componentDidMount () {
+    this.isAddFundsUrl()
+  }
+
   onModalBackupClose = () => {
     this.actions.onModalBackupClose()
   }
@@ -124,6 +128,25 @@ class PageWallet extends React.Component<Props, State> {
     this.setState({
       modalAddFunds: !this.state.modalAddFunds
     })
+  }
+
+  isAddFundsUrl = () => {
+    if (window && window.location && window.location.hash && window.location.hash === '#add-funds') {
+      this.setState({
+        modalAddFunds: true
+      })
+    } else {
+      this.setState({
+        modalAddFunds: false
+      })
+    }
+  }
+
+  closeModalAddFunds = () => {
+    if (window && window.location && window.location.hash && window.location.hash === '#add-funds') {
+      window.location.hash = ''
+    }
+    this.onModalAddFundsToggle()
   }
 
   onModalActivityAction (action: string) {
@@ -237,7 +260,7 @@ class PageWallet extends React.Component<Props, State> {
         {
           this.state.modalAddFunds
             ? <ModalAddFunds
-              onClose={this.onModalAddFundsToggle}
+              onClose={this.closeModalAddFunds}
               addresses={addressArray}
             />
             : null


### PR DESCRIPTION
## Submitter Checklist:
Fixes brave/brave-browser#1480

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave and create wallet.
2. Open new tab and close rewards tab.
3. On new tab click panel and click 'Add Funds'
4. Verify that rewards page opens to `brave://rewards/#add-funds` and that the 'Add Funds' dialog is displayed.
5. Close 'Add Funds' dialog
6. Verify that URL portion removes the 'add-funds'

*

1. Start Brave and create wallet.
2. On Rewards page click 'Add Funds' and verify that the 'Add Funds' dialog continues to function when accessed from Rewards page


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source