### PR TITLE
Fix crash when typing non-ascii char in omnibox

### DIFF
--- a/components/omnibox/browser/topsites_provider.cc
+++ b/components/omnibox/browser/topsites_provider.cc
@@ -30,7 +30,8 @@ void TopSitesProvider::Start(const AutocompleteInput& input,
       (input.type() == metrics::OmniboxInputType::QUERY))
     return;
 
-  const std::string input_text = base::ToLowerASCII(base::UTF16ToASCII(input.text()));
+  const std::string input_text =
+      base::ToLowerASCII(base::UTF16ToUTF8(input.text()));
 
   for (std::vector<std::string>::const_iterator i = top_sites_.begin();
     (i != top_sites_.end()) && (matches_.size() < kMaxMatches); ++i) {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2040

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Typing non ascii chars in omnibox and check not crashed in debug build

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source