### PR TITLE
Workaround "LLVM ERROR: IO failure on output stream: Invalid argument"

### DIFF
--- a/patches/build-toolchain-mac-linker_driver.py.patch
+++ b/patches/build-toolchain-mac-linker_driver.py.patch
@@ -1,0 +1,13 @@
+diff --git a/build/toolchain/mac/linker_driver.py b/build/toolchain/mac/linker_driver.py
+index 35de9d128783ed7d86c0b0b6f971c782e05023d7..6735f627c6e5fcdef48e8e7851443ad24115106c 100755
+--- a/build/toolchain/mac/linker_driver.py
++++ b/build/toolchain/mac/linker_driver.py
+@@ -142,7 +142,7 @@ def RunDsymUtil(dsym_path_prefix, full_args):
+ 
+   # Remove old dSYMs before invoking dsymutil.
+   _RemovePath(dsym_out)
+-  subprocess.check_call(['xcrun', 'dsymutil', '-o', dsym_out, linker_out])
++  subprocess.check_call(['xcrun', 'dsymutil', '-v', '-o', dsym_out, linker_out])
+   return [dsym_out]
+ 
+ 


### PR DESCRIPTION
when doing `dsymutil -o`
Try to remove this hack when there is new llvm bump

fix https://github.com/brave/brave-browser/issues/2051

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS (Debug + Release)
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS (Debug + Release)
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source