### PR TITLE
Fix spellcheck dictionary test on Windows

### DIFF
--- a/components/spellcheck/spellcheck_unittest.cc
+++ b/components/spellcheck/spellcheck_unittest.cc
@@ -82,7 +82,8 @@ TEST_F(SpellcheckTest, DictionaryFilenames) {
     {"vi", "vi-VN-3-0.bdic"}
   };
   for (const auto& lang_file : kExpectedSpellCheckerFilenames) {
-      base::FilePath dict_dir = base::FilePath(lang_file.filename);
+      base::FilePath::StringType filename(lang_file.filename);
+      base::FilePath dict_dir = base::FilePath(filename);
       EXPECT_EQ(spellcheck::GetVersionedFileName(
                     lang_file.language, base::FilePath()), dict_dir);
   }


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source