### PR TITLE
Add test for TopSitesProvider

### DIFF
--- a/components/omnibox/browser/topsites_provider_unittest.cc
+++ b/components/omnibox/browser/topsites_provider_unittest.cc
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/omnibox/browser/topsites_provider.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "components/omnibox/browser/mock_autocomplete_provider_client.h"
+#include "components/omnibox/browser/test_scheme_classifier.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class TopSitesProviderTest : public testing::Test {
+ public:
+  TopSitesProviderTest() : provider_(new TopSitesProvider(&client_)) {
+  }
+
+  AutocompleteInput CreateAutocompleteInput(base::StringPiece text) {
+    AutocompleteInput input(base::UTF8ToUTF16(text),
+                            metrics::OmniboxEventProto::OTHER,
+                            classifier_);
+    return input;
+ }
+
+ protected:
+  TestSchemeClassifier classifier_;
+  MockAutocompleteProviderClient client_;
+  scoped_refptr<TopSitesProvider> provider_;
+};
+
+// Checks that the top sites list is not empty and that non-ASCII inputs do not
+// blow the matcher.
+TEST_F(TopSitesProviderTest, SmokeTest) {
+  provider_->Start(CreateAutocompleteInput(""), false);
+  EXPECT_TRUE(provider_->matches().empty());
+
+  provider_->Start(CreateAutocompleteInput("dex"), false);
+  EXPECT_FALSE(provider_->matches().empty());
+
+  provider_->Start(CreateAutocompleteInput("тест"), false);
+  EXPECT_TRUE(provider_->matches().empty());
+
+  provider_->Start(CreateAutocompleteInput("테스트"), false);
+  EXPECT_TRUE(provider_->matches().empty());
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -65,6 +65,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_sync/client/bookmark_change_processor_unittest.cc",
     "//brave/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc",
     "//brave/components/gcm_driver/gcm_unittest.cc",
+    "//brave/components/omnibox/browser/topsites_provider_unittest.cc",
     "//brave/components/spellcheck/spellcheck_unittest.cc",
     "//brave/third_party/libaddressinput/chromium/chrome_metadata_source_unittest.cc",
     "//chrome/common/importer/mock_importer_bridge.cc",


### PR DESCRIPTION
Checks that the top sites list is not empty and that non-ASCII inputs do not
blow the matcher.

Issue: https://github.com/brave/brave-browser/issues/2040

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_unit_tests --filter=TopSitesProviderTest*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source