### PR TITLE
Check BUILDFLAG for Widevine

### DIFF
--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -13,10 +13,12 @@
 #include "brave/common/extensions/extension_constants.h"
 #include "components/component_updater/component_updater_service.h"
 #include "components/prefs/pref_service.h"
+#include "third_party/widevine/cdm/buildflags.h"
 
 namespace component_updater {
 
-#if defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+#if BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
+
 
 void OnWidevineRegistered() {
   ComponentsUI demand_updater;
@@ -36,11 +38,11 @@ void RegisterAndInstallWidevine() {
       base::Bind(&OnWidevineRegistered));
 }
 
-#endif  // defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+#endif
 
 // Do nothing unless the user opts in!
 void RegisterWidevineCdmComponent(ComponentUpdateService* cus) {
-#if defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+#if BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   PrefService* prefs = ProfileManager::GetActiveUserProfile()->GetPrefs();
   bool widevine_opted_in =
@@ -48,7 +50,7 @@ void RegisterWidevineCdmComponent(ComponentUpdateService* cus) {
   if (widevine_opted_in) {
     RegisterAndInstallWidevine();
   }
-#endif  // defined(WIDEVINE_CDM_AVAILABLE) && defined(WIDEVINE_CDM_IS_COMPONENT)
+#endif  // defined(ENABLE_WIDEVINE_CDM_COMPONENT)
 }
 
 }  // namespace component_updater

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer_unittest.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer_unittest.cc
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/widevine/cdm/buildflags.h"
+
+// This test looks a bit strange but it will protect us against if Chromium changes
+// the build flags for Widevine.
+TEST(WidevineBuildFlag, MustBeEnabledForNonLinux) {
+  ASSERT_TRUE(
+#if BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
+      true
+#else
+      false
+#endif
+  );
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -88,6 +88,12 @@ test("brave_unit_tests") {
     ]
   }
 
+  if (is_win || is_mac) {
+    sources += [
+      "//brave/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer_unittest.cc",
+    ]
+  }
+
   if (is_mac) {
     sources += [
       "//brave/chromium_src/chrome/common/chrome_constants_unittest_mac.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2076

See also this Chromium commit:
commit 609ff09001b66c32c3fd972fda85203ce6b86a63
Author: Xiaohan Wang <xhwang@chromium.org>
Date:   Fri Sep 28 02:31:40 2018 +0000

    media: Add ENABLE_WIDEVINE_CDM_COMPONENT buildflag

    This replaces the current WIDEVINE_CDM_IS_COMPONENT macro defined in
    widevine_cdm_common.h. Buildflag is safer, also this avoids tricky cases
    where widevine_cdm_common.h must be included before the define can be
    evaluated.

    Bug: 349182

And see also this Chromium commit:
commit f170c737755811ca5d7ded0700d8aa17ec310024
Author: Xiaohan Wang <xhwang@chromium.org>
Date:   Thu Sep 27 05:45:26 2018 +0000

    media: Replace WIDEVINE_CDM_AVAILABLE with ENABLE_WIDEVINE buildflag

    - Add ENABLE_WIDEVINE buildflag
    - Check BUILDFLAG(ENABLE_WIDEVINE) instead of
      defined(WIDEVINE_CDM_AVAILABLE)
    - Since WIDEVINE_CDM_AVAILABLE is not needed, remove a lot of
      dependencies on widevine_cdm_version.h
    - widevine_cdm_version.h is still needed to get
      WIDEVINE_CDM_VERSION_STRING and WIDEVINE_CDM_MIN_GLIBC_VERSION.
    - Some BUILD.gn cleanup to use "enable_widevine". Previously this wasn't
      possible since WIDEVINE_CDM_AVAILABLE is a define.
    - Remove third_party/widevine/cdm/stub/, whose sole purpose was to define
      WIDEVINE_CDM_AVAILABLE when "enable_widevine" is enabled.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source