### PR TITLE
Ignore empty EncryptionKeyCreationUtil for importer utility process

### DIFF
--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -1,5 +1,5 @@
 diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
-index 2a55469312c3cd9d1827be84a20135d0379c94a5..5971b90277060d80bc68ef5f8b29904db603f5d0 100644
+index 2a55469312c3cd9d1827be84a20135d0379c94a5..b846eb802d7334241f598029435d46ab57c0915d 100644
 --- a/components/os_crypt/keychain_password_mac.mm
 +++ b/components/os_crypt/keychain_password_mac.mm
 @@ -7,6 +7,7 @@
@@ -21,11 +21,15 @@ index 2a55469312c3cd9d1827be84a20135d0379c94a5..5971b90277060d80bc68ef5f8b29904d
  #endif
  
  KeychainPassword::KeychainPassword(
-@@ -65,7 +66,19 @@ std::string KeychainPassword::GetPassword() const {
-   DCHECK(key_creation_util_);
-   bool prevent_overwriting_enabled =
-       key_creation_util_->ShouldPreventOverwriting();
+@@ -62,10 +63,23 @@ KeychainPassword::KeychainPassword(
+ KeychainPassword::~KeychainPassword() = default;
+ 
+ std::string KeychainPassword::GetPassword() const {
+-  DCHECK(key_creation_util_);
+-  bool prevent_overwriting_enabled =
+-      key_creation_util_->ShouldPreventOverwriting();
 -
++  bool prevent_overwriting_enabled = false;
 +  const char *service_name, *account_name;
 +  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
 +  if (command_line->HasSwitch("import-chrome")) {
@@ -38,6 +42,9 @@ index 2a55469312c3cd9d1827be84a20135d0379c94a5..5971b90277060d80bc68ef5f8b29904d
 +  } else {
 +    service_name = ::KeychainPassword::service_name;
 +    account_name = ::KeychainPassword::account_name;
++    DCHECK(key_creation_util_);
++    prevent_overwriting_enabled =
++        key_creation_util_->ShouldPreventOverwriting();
 +  }
    UInt32 password_length = 0;
    void* password_data = NULL;

--- a/patches/components-os_crypt-os_crypt_mac.mm.patch
+++ b/patches/components-os_crypt-os_crypt_mac.mm.patch
@@ -1,0 +1,15 @@
+diff --git a/components/os_crypt/os_crypt_mac.mm b/components/os_crypt/os_crypt_mac.mm
+index 91a27e4f43f1e3d2078c8f1d9038bcb40c07c445..6f64e71624a5866193bacda30b01f19892638af4 100644
+--- a/components/os_crypt/os_crypt_mac.mm
++++ b/components/os_crypt/os_crypt_mac.mm
+@@ -100,6 +100,10 @@ crypto::SymmetricKey* GetEncryptionKey() {
+     DCHECK(!g_key_creation_util);
+     g_key_creation_util = new os_crypt::EncryptionKeyCreationUtilIOS();
+ #endif
++    base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
++    if (!command_line->HasSwitch("import-chrome") &&
++        command_line->HasSwitch("import-chromium") &&
++        command_line->HasSwitch("import-brave"))
+     DCHECK(g_key_creation_util);
+     AppleKeychain keychain;
+     KeychainPassword encryptor_password(


### PR DESCRIPTION
because it only access the keychain item and won't overrite

https://chromium.googlesource.com/chromium/src/+/3ca917bd3ebea51bfcf7f8b80e39e217467153d4

Resolves https://github.com/brave/brave-browser/issues/2080

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Specify `--upgrade-from-muon` for importing password and cookies
OR
import password and cookies from Brave/Chrome

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source