### PR TITLE
Adds retries into contribution flow for rewards

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ deps = {
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/omaha":  "https://github.com/brave/omaha.git@dc2582d63a5b92dd39bf7bfd07612e501e133143",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@14a6eafed51cfcdadc425620de3bd4a4f4068bf8",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@03903ad51c2f2ae131aa88ef7ee713855834975b",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -585,8 +585,19 @@ void RewardsServiceImpl::OnReconcileComplete(ledger::Result result,
   const std::string& viewing_id,
   ledger::PUBLISHER_CATEGORY category,
   const std::string& probi) {
+
+  RewardsNotificationService::RewardsNotificationArgs args;
+  args.push_back(viewing_id);
+  args.push_back(std::to_string(result));
+  args.push_back(std::to_string(category));
+  args.push_back(probi);
+
+  notification_service_->AddNotification(
+      RewardsNotificationService::REWARDS_NOTIFICATION_AUTO_CONTRIBUTE,
+      args,
+      "contribution_" + viewing_id);
+
   if (result == ledger::Result::LEDGER_OK) {
-    // TODO add notification service when implemented
     auto now = base::Time::Now();
     FetchWalletProperties();
     ledger_->OnReconcileCompleteSuccess(viewing_id,

--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_GB/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_GB/messages.json
@@ -168,10 +168,10 @@
     "description": ""
   },
   "braveContributeTitle": {
-    "message": "Auto-Contribute",
+    "message": "Contribute",
     "description": ""
   },
-  "contributeNotification": {
+  "contributeNotificationSuccess": {
     "message": "You've contributed $amount$BAT",
     "description": "",
     "placeholders": {
@@ -187,6 +187,10 @@
   },
   "braveRewardsCreatingText": {
     "message": "Creating wallet",
+    "description": ""
+  },
+  "contributeNotificationError": {
+    "message": "There was a problem processing your contribution.",
     "description": ""
   }
 }

--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -191,19 +191,28 @@ export class Panel extends React.Component<Props, State> {
 
     const notification: RewardsExtension.Notification = notifications[currentNotification]
 
-    let type: NotificationType
+    let type: NotificationType = ''
     let text = ''
     switch (notification.type) {
       case 1:
-        type = 'contribute'
-        text = getMessage('contributeNotification')
-        break
+        {
+          if (!notification.args ||
+            !Array.isArray(notification.args) ||
+            notification.args.length < 3) {
+            break
+          }
+
+          if (notification.args[1] === '0') {
+            text = getMessage('contributeNotificationSuccess')
+          } else {
+            text = getMessage('contributeNotificationError')
+          }
+          type = 'contribute'
+          break
+        }
       case 2:
         type = 'grant'
         text = getMessage('grantNotification')
-        break
-      default:
-        type = ''
         break
     }
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/1483

Native implementation: https://github.com/brave-intl/bat-native-ledger/pull/175

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
For easier debugging you can uncomment this sections https://github.com/brave-intl/bat-native-ledger/pull/175/files#diff-e91798fe1b25491970c7c977e168c25cR91
- try doing a contribution where you disconnect internet in between
- make sure that contribution finishes when you connect internet again (if nothing happens try restarting browser as this will retry it as well)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## Notes
Will be also adding flags for QA as wel https://github.com/brave/brave-browser/issues/2102