### PR TITLE
Consider brave theme type to devtools' theme

### DIFF
--- a/browser/devtools/BUILD.gn
+++ b/browser/devtools/BUILD.gn
@@ -1,0 +1,29 @@
+source_set("devtools") {
+  deps = [
+    "//base",
+    "//content/public/browser",
+    "//net",
+    "//services/viz/privileged/interfaces/compositing",
+    "//third_party/blink/public:buildflags",
+    "//ui/events:dom_keycode_converter",
+  ]
+
+  if (!is_android) {
+    sources = [
+      "brave_devtools_ui_bindings.cc",
+      "brave_devtools_ui_bindings.h",
+    ]
+
+    deps += [
+      "//chrome:extra_resources",
+      "//chrome:resources",
+      "//chrome:strings",
+      "//chrome/app/theme:theme_resources",
+      "//chrome/common",
+      "//components/viz/host",
+      "//skia",
+      "//third_party/icu",
+      "//third_party/leveldatabase",
+    ]
+  }
+}

--- a/browser/devtools/brave_devtools_ui_bindings.cc
+++ b/browser/devtools/brave_devtools_ui_bindings.cc
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/devtools/brave_devtools_ui_bindings.h"
+
+#include "base/values.h"
+#include "brave/browser/themes/brave_theme_service.h"
+#include "chrome/common/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+namespace {
+std::string GetDevToolsUIThemeValue(Profile* profile) {
+  BraveThemeType theme_type =
+      BraveThemeService::GetActiveBraveThemeType(profile);
+  // In devtools' theme, default is translated to light.
+  return theme_type == BRAVE_THEME_TYPE_DARK ? "\"dark\"" : "\"default\"";
+}
+}
+
+void BraveDevToolsUIBindings::GetPreferences(const DispatchCallback& callback) {
+  const base::DictionaryValue* prefs =
+      profile_->GetPrefs()->GetDictionary(prefs::kDevToolsPreferences);
+
+  if (prefs->FindKey("uiTheme"))
+    return DevToolsUIBindings::GetPreferences(callback);
+
+  base::Value new_prefs(prefs->Clone());
+  new_prefs.SetKey("uiTheme", base::Value(GetDevToolsUIThemeValue(profile())));
+  callback.Run(&new_prefs);
+}

--- a/browser/devtools/brave_devtools_ui_bindings.h
+++ b/browser/devtools/brave_devtools_ui_bindings.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_DEVTOOLS_BRAVE_DEVTOOLS_UI_BINDINGS_H_
+#define BRAVE_BROWSER_DEVTOOLS_BRAVE_DEVTOOLS_UI_BINDINGS_H_
+
+#include "chrome/browser/devtools/devtools_ui_bindings.h"
+
+class BraveDevToolsUIBindings : public DevToolsUIBindings {
+ public:
+  using DevToolsUIBindings::DevToolsUIBindings;
+
+ private:
+  FRIEND_TEST_ALL_PREFIXES(BraveDevToolsUIBindingsBrowserTest, ThemeTest);
+
+  // DevToolsUIBindings overrides:
+  void GetPreferences(const DispatchCallback& callback) override;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveDevToolsUIBindings);
+};
+
+#endif  // BRAVE_BROWSER_DEVTOOLS_BRAVE_DEVTOOLS_UI_BINDINGS_H_

--- a/browser/devtools/brave_devtools_ui_bindings_browsertest.cc
+++ b/browser/devtools/brave_devtools_ui_bindings_browsertest.cc
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/devtools/brave_devtools_ui_bindings.h"
+
+#include <string>
+
+#include "base/bind.h"
+#include "base/values.h"
+#include "brave/browser/themes/brave_theme_service.h"
+#include "brave/common/pref_names.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/browser/web_contents.h"
+#include "components/prefs/pref_service.h"
+
+using BTS = BraveThemeService;
+
+namespace {
+void SetBraveThemeType(Profile* profile, BraveThemeType type) {
+  profile->GetPrefs()->SetInteger(kBraveThemeType, type);
+}
+}  // namespace
+
+class BraveDevToolsUIBindingsBrowserTest : public InProcessBrowserTest {
+ public:
+  void GetPreferenceCallback(const base::Value* value) {
+    ui_theme_ = value->FindKey("uiTheme")->GetString();
+  }
+
+  std::string ui_theme_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveDevToolsUIBindingsBrowserTest, ThemeTest) {
+  auto* profile = browser()->profile();
+  auto* tab_strip_model = browser()->tab_strip_model();
+  content::WebContents* web_contents = tab_strip_model->GetActiveWebContents();
+  DCHECK(web_contents);
+
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+  auto* devtools_ui_bindings = new BraveDevToolsUIBindings(web_contents);
+  DCHECK(devtools_ui_bindings);
+  devtools_ui_bindings->GetPreferences(
+      base::Bind(&BraveDevToolsUIBindingsBrowserTest::GetPreferenceCallback,
+                 base::Unretained(this)));
+  // Check current devtools' theme is same as native theme when user doesn't
+  // change devtools' theme explicitely.
+  EXPECT_EQ(ui_theme_, "\"dark\"");
+
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+  devtools_ui_bindings->GetPreferences(
+      base::Bind(&BraveDevToolsUIBindingsBrowserTest::GetPreferenceCallback,
+                 base::Unretained(this)));
+  // In devtools, default is used as light.
+  EXPECT_EQ(ui_theme_, "\"default\"");
+
+  // When user sets devtools' theme explicitely, respect user's setting.
+  devtools_ui_bindings->SetPreference("uiTheme", "\"dark\"");
+  devtools_ui_bindings->GetPreferences(
+      base::Bind(&BraveDevToolsUIBindingsBrowserTest::GetPreferenceCallback,
+                 base::Unretained(this)));
+  EXPECT_EQ(ui_theme_, "\"dark\"");
+}

--- a/chromium_src/chrome/browser/ui/webui/devtools_ui.h
+++ b/chromium_src/chrome/browser/ui/webui/devtools_ui.h
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/devtools/brave_devtools_ui_bindings.h"
+
+#define DevToolsUIBindings BraveDevToolsUIBindings
+#include "../../../../../../chrome/browser/ui/webui/devtools_ui.h"
+#undef DevToolsUIBindings

--- a/patches/chrome-browser-devtools-BUILD.gn.patch
+++ b/patches/chrome-browser-devtools-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/devtools/BUILD.gn b/chrome/browser/devtools/BUILD.gn
+index 8e4c3ab3e21896576f4816c9c985a5a0f56e2c08..fc9662f85c93ab16685e7205034a539bf3ad7435 100644
+--- a/chrome/browser/devtools/BUILD.gn
++++ b/chrome/browser/devtools/BUILD.gn
+@@ -100,6 +100,7 @@ static_library("devtools") {
+     "//third_party/blink/public:buildflags",
+     "//ui/events:dom_keycode_converter",
+   ]
++  if (brave_chromium_build) { deps += [ "//brave/browser/devtools" ] }
+ 
+   if (!is_android) {
+     deps += [

--- a/patches/chrome-browser-devtools-devtools_ui_bindings.h.patch
+++ b/patches/chrome-browser-devtools-devtools_ui_bindings.h.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/devtools/devtools_ui_bindings.h b/chrome/browser/devtools/devtools_ui_bindings.h
+index 35ea228f2f3a0e469d8cd50f07b6a1a1f754fb5d..13a9d3c5d59458d17eee66600e1974da19dbb1be 100644
+--- a/chrome/browser/devtools/devtools_ui_bindings.h
++++ b/chrome/browser/devtools/devtools_ui_bindings.h
+@@ -90,6 +90,9 @@ class DevToolsUIBindings : public DevToolsEmbedderMessageDispatcher::Delegate,
+   bool IsAttachedTo(content::DevToolsAgentHost* agent_host);
+ 
+  private:
++  friend class BraveDevToolsUIBindings;
++  FRIEND_TEST_ALL_PREFIXES(BraveDevToolsUIBindingsBrowserTest, ThemeTest);
++
+   void HandleMessageFromDevToolsFrontend(const std::string& message);
+ 
+   // content::DevToolsAgentHostClient implementation.

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -220,6 +220,7 @@ test("brave_browser_tests") {
     "//brave/browser/brave_features_browsertest.cc",
     "//brave/browser/brave_profile_prefs_browsertest.cc",
     "//brave/browser/brave_resources_browsertest.cc",
+    "//brave/browser/devtools/brave_devtools_ui_bindings_browsertest.cc",
     "//brave/browser/extensions/brave_tor_client_updater_browsertest.cc",
     "//brave/browser/extensions/api/brave_shields_api_browsertest.cc",
     "//brave/browser/renderer_context_menu/brave_mock_render_view_context_menu.cc",


### PR DESCRIPTION
When devtool ui is loaded, kDevToolsPreferences pref values are fetched.
In that dictionary prefs, uiTheme represents theme type(light/dark) of devtool.
To apply brave theme type to devtools, uiTheme value is replaced with brave
native theme type. If user sets devtools' theme type explicitely, that value
is used instead of brave theme type. Otherwise, brave theme type is applied.

Fix https://github.com/brave/brave-browser/issues/784

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveDevToolsUIBindingsBrowserTest.ThemeTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source