### PR TITLE
Listen for referral for referral headers updates

### DIFF
--- a/browser/net/brave_network_delegate_base.h
+++ b/browser/net/brave_network_delegate_base.h
@@ -7,7 +7,10 @@
 
 #include "brave/browser/net/url_context.h"
 #include "chrome/browser/net/chrome_network_delegate.h"
+#include "content/public/browser/browser_thread.h"
 #include "net/base/completion_callback.h"
+
+class PrefChangeRegistrar;
 
 namespace extensions {
 class EventRouterForwarder;
@@ -73,9 +76,13 @@ class BraveNetworkDelegateBase : public ChromeNetworkDelegate {
       can_set_cookies_callbacks_;
 
  private:
+  void InitPrefChangeRegistrar();
   void GetReferralHeaders();
+  void OnReferralHeadersChanged();
   std::unique_ptr<base::ListValue> referral_headers_list_;
   std::map<uint64_t, net::CompletionOnceCallback> callbacks_;
+  std::unique_ptr<PrefChangeRegistrar, content::BrowserThread::DeleteOnUIThread>
+      pref_change_registrar_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveNetworkDelegateBase);
 };


### PR DESCRIPTION
Fixes brave/brave-browser#2020

We were previously only retrieving the referral headers on first
launch. Aside from preventing us from incorporating potential updates
to the headers, this also made it so that a browser restart was
required the first time a user initialized the referral (as the
referral headers would still be empty from the network delegate's
perspective).

Now we register for changes to that preference and pull them in on the
fly.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Delete existing profile if any
- Download referral version of Brave (e.g., `BraveBrowserSetup-dowjones-marketwatch.exe`)
- Install referral version of Brave
- Wait for promo tab to load
- Sign up for promo and visit a URL belonging to the site
- Ensure that headers include appropriate promo-specific headers, e.g. `X-Brave-Partner`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source