### PR TITLE
Load magnet url instead of searching

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -110,6 +110,7 @@ source_set("browser") {
     "//base",
     "//brave/components/brave_referrals/browser",
     "//brave/components/brave_shields/browser:brave_shields",
+    "//brave/components/brave_webtorrent/browser",
     "//brave/components/resources",
     "//brave/browser/resources:brave_extension_grit",
     "//chrome/browser",

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -62,6 +62,7 @@ source_set("browser_process") {
     "//brave/components/brave_rewards/browser",
     "//brave/components/brave_shields/browser:brave_shields",
     "//brave/components/brave_sync",
+    "//brave/components/brave_webtorrent/browser",
     "//brave/components/content_settings/core/browser",
     "//chrome/common",
     "//components/component_updater",

--- a/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
+++ b/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
@@ -25,7 +25,8 @@ BraveAutocompleteSchemeClassifier::GetInputTypeForScheme(
     return metrics::OmniboxInputType::INVALID;
   }
   if (base::IsStringASCII(scheme) &&
-       base::LowerCaseEqualsASCII(scheme, kBraveUIScheme)) {
+      (base::LowerCaseEqualsASCII(scheme, kBraveUIScheme) ||
+       base::LowerCaseEqualsASCII(scheme, kMagnetScheme))) {
     return metrics::OmniboxInputType::URL;
   }
 

--- a/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
+++ b/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
@@ -6,12 +6,17 @@
 
 #include "base/strings/string_util.h"
 #include "brave/common/url_constants.h"
+#include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
 #include "chrome/browser/profiles/profile.h"
 
 // See the BraveAutocompleteProviderClient why GetOriginalProfile() is fetched.
+// All services except TemplateURLService exposed from AutocompleteClassifier
+// uses original profile. So, |profile_| should be original profile same as
+// base class does.
 BraveAutocompleteSchemeClassifier::BraveAutocompleteSchemeClassifier(
     Profile* profile)
-    : ChromeAutocompleteSchemeClassifier(profile->GetOriginalProfile()) {
+    : ChromeAutocompleteSchemeClassifier(profile->GetOriginalProfile()),
+      profile_(profile->GetOriginalProfile()) {
 }
 
 BraveAutocompleteSchemeClassifier::~BraveAutocompleteSchemeClassifier() {
@@ -26,7 +31,8 @@ BraveAutocompleteSchemeClassifier::GetInputTypeForScheme(
   }
   if (base::IsStringASCII(scheme) &&
       (base::LowerCaseEqualsASCII(scheme, kBraveUIScheme) ||
-       base::LowerCaseEqualsASCII(scheme, kMagnetScheme))) {
+       (webtorrent::IsWebtorrentEnabled(profile_) &&
+        base::LowerCaseEqualsASCII(scheme, kMagnetScheme)))) {
     return metrics::OmniboxInputType::URL;
   }
 

--- a/browser/autocomplete/brave_autocomplete_scheme_classifier.h
+++ b/browser/autocomplete/brave_autocomplete_scheme_classifier.h
@@ -16,6 +16,8 @@ class BraveAutocompleteSchemeClassifier : public ChromeAutocompleteSchemeClassif
       const std::string& scheme) const override;
 
  private:
+  Profile* profile_;
+
   DISALLOW_COPY_AND_ASSIGN(BraveAutocompleteSchemeClassifier);
 };
 

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -11,12 +11,14 @@
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "chrome/browser/extensions/extension_service.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_content_client.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_navigation_observer.h"
 #include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_system.h"
 #include "net/dns/mock_host_resolver.h"
@@ -138,6 +140,16 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteMagnetURLLink) {
   content::NavigationEntry* entry = contents->GetController().GetLastCommittedEntry();
   EXPECT_STREQ(entry->GetURL().spec().c_str(),
       extension_url().spec().c_str()) << "Real URL should be extension URL";
+}
+
+IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, TypedMagnetURL) {
+  content::WebContents* web_contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  content::TestNavigationObserver observer(web_contents);
+  LocationBar* location_bar = browser()->window()->GetLocationBar();
+  ui_test_utils::SendToOmniboxAndSubmit(location_bar, magnet_url().spec());
+  observer.Wait();
+  EXPECT_EQ(magnet_url(), web_contents->GetLastCommittedURL().spec());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, ReverseRewriteTorrentURL) {

--- a/components/brave_webtorrent/browser/BUILD.gn
+++ b/components/brave_webtorrent/browser/BUILD.gn
@@ -1,0 +1,16 @@
+source_set("browser") {
+  sources = [
+    "content_browser_client_helper.h",
+    "webtorrent_util.cc",
+    "webtorrent_util.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/common",
+    "//content/public/browser",
+    "//extensions/browser",
+    "//extensions/common",
+    "//net",
+  ]
+}

--- a/components/brave_webtorrent/browser/content_browser_client_helper.h
+++ b/components/brave_webtorrent/browser/content_browser_client_helper.h
@@ -7,6 +7,7 @@
 #include "base/task/post_task.h"
 #include "brave/common/url_constants.h"
 #include "brave/common/extensions/extension_constants.h"
+#include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
 #include "chrome/browser/external_protocol/external_protocol_handler.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -50,15 +51,6 @@ static bool HandleTorrentURLReverseRewrite(GURL* url,
   }
 
   return false;
-}
-
-static bool IsWebtorrentEnabled(content::BrowserContext* browser_context) {
-  bool isTorProfile =
-    Profile::FromBrowserContext(browser_context)->IsTorProfile();
-  extensions::ExtensionRegistry* registry =
-    extensions::ExtensionRegistry::Get(browser_context);
-  return !isTorProfile &&
-    registry->enabled_extensions().Contains(brave_webtorrent_extension_id);
 }
 
 static bool HandleTorrentURLRewrite(GURL* url,

--- a/components/brave_webtorrent/browser/webtorrent_util.cc
+++ b/components/brave_webtorrent/browser/webtorrent_util.cc
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
+
+#include "brave/common/extensions/extension_constants.h"
+#include "chrome/browser/profiles/profile.h"
+#include "extensions/browser/extension_registry.h"
+
+namespace webtorrent {
+
+bool IsWebtorrentEnabled(content::BrowserContext* browser_context) {
+  bool isTorProfile =
+    Profile::FromBrowserContext(browser_context)->IsTorProfile();
+  extensions::ExtensionRegistry* registry =
+    extensions::ExtensionRegistry::Get(browser_context);
+  return !isTorProfile &&
+    registry->enabled_extensions().Contains(brave_webtorrent_extension_id);
+}
+
+}  // webtorrent
+

--- a/components/brave_webtorrent/browser/webtorrent_util.h
+++ b/components/brave_webtorrent/browser/webtorrent_util.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_WEBTORRENT_UTIL_H_
+#define BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_WEBTORRENT_UTIL_H_
+
+namespace content {
+class BrowserContext;
+}
+
+namespace webtorrent {
+
+bool IsWebtorrentEnabled(content::BrowserContext* browser_context);
+
+}  // webtorrent
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_WEBTORRENT_UTIL_H_


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1435

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveContentBrowserClientTest.TypedMagnetURL`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source