### PR TITLE
Make brave browser set as a default browser in linux

### DIFF
--- a/patches/chrome-browser-shell_integration_linux.cc.patch
+++ b/patches/chrome-browser-shell_integration_linux.cc.patch
@@ -1,8 +1,25 @@
 diff --git a/chrome/browser/shell_integration_linux.cc b/chrome/browser/shell_integration_linux.cc
-index bfd0f1c16666ef8071b00e9a1f85e80b9806ed87..dcfff5e3b9fd84ad852fcb4de180f9631b9a4a28 100644
+index bfd0f1c16666ef8071b00e9a1f85e80b9806ed87..031127a027327ce98355e7166b0d0633f4263519 100644
 --- a/chrome/browser/shell_integration_linux.cc
 +++ b/chrome/browser/shell_integration_linux.cc
-@@ -431,7 +431,7 @@ std::string GetDesktopName(base::Environment* env) {
+@@ -425,13 +425,24 @@ std::string GetDesktopName(base::Environment* env) {
+       return "google-chrome.desktop";
+   }
+ #else  // CHROMIUM_BUILD
++#if defined(OFFICIAL_BUILD)
++  version_info::Channel product_channel(chrome::GetChannel());
++  switch (product_channel) {
++    case version_info::Channel::DEV:
++      return "brave-browser-dev.desktop";
++    case version_info::Channel::BETA:
++      return "brave-browser-beta.desktop";
++    default:
++      return "brave-browser.desktop";
++  }
++#endif  // defined(OFFICIAL_BUILD)
+   // Allow $CHROME_DESKTOP to override the built-in value, so that development
+   // versions can set themselves as the default without interfering with
+   // non-official, packaged versions using the built-in value.
    std::string name;
    if (env->GetVar("CHROME_DESKTOP", &name) && !name.empty())
      return name;
@@ -11,7 +28,7 @@ index bfd0f1c16666ef8071b00e9a1f85e80b9806ed87..dcfff5e3b9fd84ad852fcb4de180f963
  #endif
  }
  
-@@ -439,7 +439,7 @@ std::string GetIconName() {
+@@ -439,7 +450,7 @@ std::string GetIconName() {
  #if defined(GOOGLE_CHROME_BUILD)
    return "google-chrome";
  #else  // CHROMIUM_BUILD


### PR DESCRIPTION
With this PR, all channel except nightly can be a default browser.

Fix https://github.com/brave/brave-browser/issues/1274

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source