### PR TITLE
allow default device name as a way to sync a device

### DIFF
--- a/components/brave_sync/ui/components/modals/newToSync.tsx
+++ b/components/brave_sync/ui/components/modals/newToSync.tsx
@@ -40,7 +40,7 @@ class NewToSyncModal extends React.PureComponent<NewToSyncModalProps, NewToSyncM
   }
 
   onSetupNewToSync = () => {
-    this.props.actions.onSetupNewToSync(this.state.deviceName)
+    this.props.actions.onSetupNewToSync(this.deviceName)
   }
 
   render () {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2126

test plan:

1. create a new sync chian
2. leave device name empty
3. should sync w/ default device name