### PR TITLE
Sync device name should have restricted length

### DIFF
--- a/components/brave_sync/ui/components/enabledContent.tsx
+++ b/components/brave_sync/ui/components/enabledContent.tsx
@@ -57,7 +57,7 @@ class SyncEnabledContent extends React.PureComponent<SyncEnabledContentProps, Sy
       const cell: Row = {
         content: [
           { content: <TableRowId>{device.id}</TableRowId> },
-          { content: <TableRowDevice>{device.name}</TableRowDevice> },
+          { content: <TableRowDevice title={device.name}>{device.name}</TableRowDevice> },
           { content: device.lastActive },
           {
             content: (

--- a/components/brave_sync/ui/components/enabledContent.tsx
+++ b/components/brave_sync/ui/components/enabledContent.tsx
@@ -15,7 +15,11 @@ import {
   SwitchLabel,
   Paragraph,
   SectionBlock,
-  SubTitle
+  SubTitle,
+  TableRowId,
+  TableRowDevice,
+  TableRowRemove,
+  TableRowRemoveButton
 } from 'brave-ui/features/sync'
 
 // Modals
@@ -52,21 +56,15 @@ class SyncEnabledContent extends React.PureComponent<SyncEnabledContentProps, Sy
     return devices.map((device: any): Row => {
       const cell: Row = {
         content: [
-          { content: device.id },
-          { content: device.name },
+          { content: <TableRowId>{device.id}</TableRowId> },
+          { content: <TableRowDevice>{device.name}</TableRowDevice> },
           { content: device.lastActive },
           {
             content: (
-              <span
-                style={{ cursor: 'pointer' /* TODO: cezar make this a component */ }}
-                data-id={device.id}
-                data-name={device.name}
-                onClick={this.onRemoveDevice}
-              >
-                  &times;
-              </span>
-            ),
-            customStyle: { 'text-align': 'center' }
+              <TableRowRemoveButton data-id={device.id} data-name={device.name} onClick={this.onRemoveDevice}>
+                &times;
+              </TableRowRemoveButton>
+            )
           }
         ]
       }
@@ -76,10 +74,10 @@ class SyncEnabledContent extends React.PureComponent<SyncEnabledContentProps, Sy
 
   get header (): Cell[] {
     return [
-      { content: getLocale('id') },
-      { content: getLocale('deviceName') },
+      { content: <TableRowId>{getLocale('id')}</TableRowId> },
+      { content: <TableRowDevice>{getLocale('deviceName')}</TableRowDevice> },
       { content: getLocale('lastActive') },
-      { content: getLocale('removeDevice'), customStyle: { 'text-align': 'center' } }
+      { content: <TableRowRemove>{getLocale('removeDevice')}</TableRowRemove> }
     ]
   }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2131

<img width="845" alt="screen shot 2018-11-19 at 4 13 16 pm" src="https://user-images.githubusercontent.com/4672033/48726459-8fc09a00-ec16-11e8-95ab-89e88cc87f37.png">

test plan:

* Create a new sync chain with a very long word
* should display nicely

please note that the main "sync this device" option should be ignored since it will be removed in https://github.com/brave/brave-core/pull/913