### PR TITLE
warn user when they want to reset sync chain

### DIFF
--- a/components/brave_sync/ui/components/enabledContent.tsx
+++ b/components/brave_sync/ui/components/enabledContent.tsx
@@ -99,7 +99,9 @@ class SyncEnabledContent extends React.PureComponent<SyncEnabledContentProps, Sy
   }
 
   onSyncReset = () => {
-    this.props.actions.onSyncReset()
+    if (window.confirm(getLocale('areYouSure'))) {
+      this.props.actions.onSyncReset()
+    }
   }
 
   onToggleSyncThisDevice = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
fix https://gthub.com/brave/brave-browser/issues/2134

test plan

* try to reset sync
* should show a warning
* confirm resets sync
* cancel do nothing