### PR TITLE
Issue 2160: Proxy requests for CRLSets through crlsets[n].brave.com

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -15,6 +15,10 @@ int OnBeforeURLRequest_StaticRedirectWork(
   GURL::Replacements replacements;
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS, kSafeBrowsingPrefix);
+  static URLPattern crlSet_pattern1(URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+    kCRLSetPrefix1);
+  static URLPattern crlSet_pattern2(URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+    kCRLSetPrefix2);
 
   if (geo_pattern.MatchesURL(ctx->request_url)) {
     ctx->new_url_spec = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY).spec();
@@ -23,6 +27,20 @@ int OnBeforeURLRequest_StaticRedirectWork(
 
   if (safeBrowsing_pattern.MatchesHost(ctx->request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern1.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets1.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern2.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets2.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
@@ -58,9 +76,14 @@ int OnBeforeURLRequest_StaticRedirectWork(
     URLPattern(URLPattern::SCHEME_HTTPS, "https://safebrowsing.brave.com/v4/*"),
     URLPattern(URLPattern::SCHEME_HTTPS, "https://ssl.gstatic.com/safebrowsing/*"),
 
+    //CRLSets
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets1.brave.com/*"),
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets2.brave.com/*"),
+
     // Will be removed when https://github.com/brave/brave-browser/issues/663 is fixed
     URLPattern(URLPattern::SCHEME_HTTPS, "https://www.gstatic.com/*"),
   });
+
   // Check to make sure the URL being requested matches at least one of the allowed patterns
   bool is_url_allowed = std::any_of(allowed_patterns.begin(), allowed_patterns.end(),
     [&gurl](URLPattern pattern) {

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -68,6 +68,46 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet1) {
+  net::TestDelegate test_delegate;
+  GURL url("https://dl.google.com/release2/chrome_component/AJ4r388iQSJq_4819/"
+    "4819_all_crl-set-5934829738003798040.data.crx3");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url("https://crlsets1.brave.com/release2/chrome_component/"
+    "AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret =
+      OnBeforeURLRequest_StaticRedirectWork(callback,
+                                            before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet2) {
+  net::TestDelegate test_delegate;
+  GURL url("https://r2---sn-8xgp1vo-qxoe.gvt1.com/edgedl/release2/chrome_compone"
+    "nt/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url("https://crlsets2.brave.com/edgedl/release2/chrome_compone"
+    "nt/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret =
+      OnBeforeURLRequest_StaticRedirectWork(callback,
+                                            before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
   net::TestDelegate test_delegate;
   GURL url("https://safebrowsing.googleapis.com/v4/threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -14,6 +14,8 @@ const char kEmptyImageDataURI[] = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP/
 const char kJSDataURLPrefix[] = "data:application/javascript;base64,";
 const char kGeoLocationsPattern[] = "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kSafeBrowsingPrefix[] = "https://safebrowsing.googleapis.com/";
+const char kCRLSetPrefix1[] = "https://dl.google.com/release2/chrome_component/*crl-set*";
+const char kCRLSetPrefix2[] = "https://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
 const char kGoogleTagManagerPattern[] = "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] = "https://www.googletagservices.com/tag/js/gpt.js";
 const char kForbesPattern[] = "https://www.forbes.com/*";

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -17,6 +17,8 @@ extern const char kGoogleTagServicesPattern[];
 extern const char kForbesPattern[];
 extern const char kForbesExtraCookies[];
 extern const char kSafeBrowsingPrefix[];
+extern const char kCRLSetPrefix1[];
+extern const char kCRLSetPrefix2[];
 extern const char kTwitterPattern[];
 extern const char kTwitterReferrer[];
 extern const char kTwitterRedirectURL[];


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/2160

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Delete the user data directory 
2. Start brave and start network monitor like `Little Snitch`   
3. Verify no connections are made to `dl.google.com` or `*.gvt.com` for fetching CRLSets
4. Verify if CRLSets exist in `<data-dir>/CertificateRevocation/`
5. Navigate to `revoked.badssl.com` to verify certificate error is displayed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source