### PR TITLE
Perform stats ping immediately on startup

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -48,14 +48,12 @@ BraveBrowserProcessImpl::BraveBrowserProcessImpl(ChromeFeatureListCreator* chrom
       base::TimeDelta::FromSeconds(3));
 
   brave_stats_updater_ = brave::BraveStatsUpdaterFactory(local_state());
-  base::SequencedTaskRunnerHandle::Get()->PostDelayedTask(
-      FROM_HERE,
-      base::BindOnce(
-          [](brave::BraveStatsUpdater* stats_updater) {
-            stats_updater->Start();
-          },
-          base::Unretained(brave_stats_updater_.get())),
-      base::TimeDelta::FromMinutes(2));
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE, base::BindOnce(
+                     [](brave::BraveStatsUpdater* stats_updater) {
+                       stats_updater->Start();
+                     },
+                     base::Unretained(brave_stats_updater_.get())));
 }
 
 component_updater::ComponentUpdateService*

--- a/browser/brave_stats_updater.h
+++ b/browser/brave_stats_updater.h
@@ -7,9 +7,12 @@
 
 #include <memory>
 
+#include "base/callback.h"
 #include "base/macros.h"
 #include "base/memory/scoped_refptr.h"
+#include "url/gurl.h"
 
+class BraveStatsUpdaterBrowserTest;
 class PrefRegistrySimple;
 class PrefService;
 
@@ -38,16 +41,25 @@ class BraveStatsUpdater {
   void Start();
   void Stop();
 
+  using StatsUpdatedCallback = base::RepeatingCallback<void()>;
+
+  void SetStatsUpdatedCallback(StatsUpdatedCallback stats_updated_callback);
+
  private:
   // Invoked from SimpleURLLoader after download is complete.
   void OnSimpleLoaderComplete(
       std::unique_ptr<brave::BraveStatsUpdaterParams> stats_updater_params,
       scoped_refptr<net::HttpResponseHeaders> headers);
 
-  // Invoked from RepeatingTimer when server ping timer fires.
+  // Invoked when server ping timer fires.
   void OnServerPingTimerFired();
 
+  friend class ::BraveStatsUpdaterBrowserTest;
+  static void SetBaseUpdateURLForTest(const GURL& base_update_url);
+  static GURL g_base_update_url_;
+
   PrefService* pref_service_;
+  StatsUpdatedCallback stats_updated_callback_;
   std::unique_ptr<network::SimpleURLLoader> simple_url_loader_;
   std::unique_ptr<base::OneShotTimer> server_ping_startup_timer_;
   std::unique_ptr<base::RepeatingTimer> server_ping_periodic_timer_;

--- a/browser/brave_stats_updater.h
+++ b/browser/brave_stats_updater.h
@@ -8,10 +8,15 @@
 #include <memory>
 
 #include "base/macros.h"
-#include "base/timer/timer.h"
+#include "base/memory/scoped_refptr.h"
 
 class PrefRegistrySimple;
 class PrefService;
+
+namespace base {
+class OneShotTimer;
+class RepeatingTimer;
+}
 
 namespace net {
 class HttpResponseHeaders;
@@ -44,7 +49,8 @@ class BraveStatsUpdater {
 
   PrefService* pref_service_;
   std::unique_ptr<network::SimpleURLLoader> simple_url_loader_;
-  std::unique_ptr<base::RepeatingTimer> server_ping_timer_;
+  std::unique_ptr<base::OneShotTimer> server_ping_startup_timer_;
+  std::unique_ptr<base::RepeatingTimer> server_ping_periodic_timer_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveStatsUpdater);
 };

--- a/browser/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats_updater_browsertest.cc
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_stats_updater.h"
+#include "brave/common/pref_names.h"
+#include "brave/components/brave_referrals/browser/brave_referrals_service.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/testing_pref_service.h"
+#include "net/test/embedded_test_server/http_response.h"
+
+namespace {
+
+// Request handler for stats updates. The response this returns doesn't
+// represent a valid update server response, but it's sufficient for
+// testing purposes as we're not interested in the contents of the
+// response.
+std::unique_ptr<net::test_server::HttpResponse> HandleRequestForStats(
+    const net::test_server::HttpRequest& request) {
+  std::unique_ptr<net::test_server::BasicHttpResponse> http_response(
+      new net::test_server::BasicHttpResponse());
+  http_response->set_code(net::HTTP_OK);
+  http_response->set_content_type("text/html");
+  http_response->set_content("<html><head></head></html>");
+  return std::move(http_response);
+}
+
+}  // anonymous namespace
+
+class BraveStatsUpdaterBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    brave::RegisterPrefsForBraveStatsUpdater(testing_local_state_.registry());
+    brave::RegisterPrefsForBraveReferralsService(testing_local_state_.registry());
+    InitEmbeddedTestServer();
+  }
+
+  void InitEmbeddedTestServer() {
+    embedded_test_server()->RegisterRequestHandler(
+        base::Bind(&HandleRequestForStats));
+    ASSERT_TRUE(embedded_test_server()->Start());
+  }
+
+  PrefService* GetLocalState() { return &testing_local_state_; }
+
+  void SetBaseUpdateURLForTest(const GURL& base_update_url) {
+    brave::BraveStatsUpdater::SetBaseUpdateURLForTest(base_update_url);
+  }
+
+  void StatsUpdated() {
+    was_called_ = true;
+    wait_for_callback_loop_->Quit();
+  }
+
+  void WaitForStatsUpdatedCallback() {
+    if (was_called_)
+      return;
+    wait_for_callback_loop_.reset(new base::RunLoop);
+    wait_for_callback_loop_->Run();
+  }
+
+ private:
+  TestingPrefServiceSimple testing_local_state_;
+  std::unique_ptr<base::RunLoop> wait_for_callback_loop_;
+  bool was_called_ = false;
+};
+
+// Run the stats updater and verify that it sets the first check preference
+IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest, StatsUpdaterSetsFirstCheckPreference) {
+  GURL base_update_url = embedded_test_server()->GetURL("/1/usage/brave-core");
+  SetBaseUpdateURLForTest(base_update_url);
+
+  brave::BraveStatsUpdater stats_updater(GetLocalState());
+  stats_updater.SetStatsUpdatedCallback(base::BindRepeating(
+      &BraveStatsUpdaterBrowserTest::StatsUpdated, base::Unretained(this)));
+
+  // Ensure that first check preference is false
+  ASSERT_FALSE(GetLocalState()->GetBoolean(kFirstCheckMade));
+
+  // Start the stats updater, wait for it to perform its startup ping,
+  // and then shut it down
+  stats_updater.Start();
+  WaitForStatsUpdatedCallback();
+  stats_updater.Stop();
+
+  // First check preference should now be true
+  EXPECT_TRUE(GetLocalState()->GetBoolean(kFirstCheckMade));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -226,6 +226,7 @@ test("brave_browser_tests") {
     "//brave/browser/brave_features_browsertest.cc",
     "//brave/browser/brave_profile_prefs_browsertest.cc",
     "//brave/browser/brave_resources_browsertest.cc",
+    "//brave/browser/brave_stats_updater_browsertest.cc",
     "//brave/browser/devtools/brave_devtools_ui_bindings_browsertest.cc",
     "//brave/browser/extensions/brave_tor_client_updater_browsertest.cc",
     "//brave/browser/extensions/api/brave_shields_api_browsertest.cc",


### PR DESCRIPTION
Fixes brave/brave-browser#2188

We ping the stats server once an hour while the browser is running,
but we must also ping the server immediately upon startup as well. In
addition, this startup ping should occur 3 seconds after startup to
match the timing of our referral initialization ping.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source