### PR TITLE
Do not attempt to clean non-existant previous webpack build

### DIFF
--- a/script/transpile-web-ui.py
+++ b/script/transpile-web-ui.py
@@ -46,10 +46,10 @@ def parse_args():
 
 def clean_target_dir(target_dir, env=None):
     try:
-        shutil.rmtree(target_dir)
+        if os.path.exists(target_dir):
+            shutil.rmtree(target_dir)
     except Exception as e:
-        raise Exception(
-            "Error removing previous webpack target dir: {0} - {1}".format(e.filename, e.strerror), e)
+        raise Exception("Error removing previous webpack target dir", e)
 
 
 def transpile_web_uis(production, target_gen_dir, entry_points, env=None):


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2189

> **Build error "Error removing previous webpack target dir" "No such file or directory"**
> If there has not been a previous output for a webpack target, the python script will error complaining that the directory does not exist. This is because it attempts to delete the previous webpack build's output, but does not first check to see if the directory it is attempting to delete errors. When this was first developed we were catching Exceptions, so the issue was not a problem. However, in review of that PR, we decided that we would like to throw exceptions to account for possible deletion errors (on Windows) and thus introduced this issue.