### PR TITLE
Correct include path for GritResourceMap on android

### DIFF
--- a/browser/ui/webui/basic_ui.cc
+++ b/browser/ui/webui/basic_ui.cc
@@ -12,8 +12,11 @@
 #include "content/public/common/bindings_policy.h"
 // TODO: The following is being included purely to get the generated
 //        GritResourceMap definition. Replace with a better solution.
+#if !defined(OS_ANDROID)
 #include "brave/components/brave_new_tab/resources/grit/brave_new_tab_generated_map.h"
-
+#else
+#include "components/brave_rewards/settings/resources/grit/brave_rewards_settings_generated_map.h"
+#endif
 content::WebUIDataSource* CreateBasicUIHTMLSource(Profile* profile,
                                                   const std::string& name,
                                                   const GritResourceMap* resource_map,


### PR DESCRIPTION
In the android branch at https://github.com/brave/browser-android-tabs/pull/819, we want to re-use brave-core's WebUI base class,  `BasicUI`, instead of the copied version in the android browser. This PR allows us to do so.