### PR TITLE
Count blocked items at most once per load

### DIFF
--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -160,12 +160,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByDefaultBlocker) {
   ASSERT_TRUE(content::WaitForLoadStop(contents));
   EXPECT_EQ(url, contents->GetURL());
 
-  bool img_loaded;
+  bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(
       contents,
-      "addElement('ad_banner.png')",
-      &img_loaded));
-  EXPECT_FALSE(img_loaded);
+      "setExpectations(0, 1, 0, 0);"
+      "addImage('ad_banner.png')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
@@ -183,12 +184,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NotAdsDoNotGetBlockedByDefaultBlocker
   ASSERT_TRUE(content::WaitForLoadStop(contents));
   EXPECT_EQ(url, contents->GetURL());
 
-  bool img_loaded;
+  bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(
       contents,
-      "addElement('logo.png')",
-      &img_loaded));
-  EXPECT_TRUE(img_loaded);
+      "setExpectations(1, 0, 0, 0);"
+      "addImage('logo.png')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
 
@@ -212,12 +214,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByRegionalBlocker) {
   ASSERT_TRUE(content::WaitForLoadStop(contents));
   EXPECT_EQ(url, contents->GetURL());
 
-  bool img_loaded;
+  bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(
       contents,
-      "addElement('ad_fr.png')",
-      &img_loaded));
-  EXPECT_FALSE(img_loaded);
+      "setExpectations(0, 1, 0, 0);"
+      "addImage('ad_fr.png')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
@@ -241,12 +244,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NotAdsDoNotGetBlockedByRegionalBlocke
   ASSERT_TRUE(content::WaitForLoadStop(contents));
   EXPECT_EQ(url, contents->GetURL());
 
-  bool img_loaded;
+  bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(
       contents,
-      "addElement('logo.png')",
-      &img_loaded));
-  EXPECT_TRUE(img_loaded);
+      "setExpectations(1, 0, 0, 0);"
+      "addImage('logo.png')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
 
@@ -275,11 +279,103 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedAfterDataFileVersionUpgr
   ASSERT_TRUE(content::WaitForLoadStop(contents));
   EXPECT_EQ(url, contents->GetURL());
 
-  bool img_loaded;
+  bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(
       contents,
-      "addElement('v4_specific_banner.png')",
-      &img_loaded));
-  EXPECT_FALSE(img_loaded);
+      "setExpectations(0, 1, 0, 0);"
+      "addImage('v4_specific_banner.png')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+}
+
+// Load a page with several of the same adblocked xhr requests, it should only count 1.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TwoSameAdsGetCountedAsOne) {
+  SetDefaultComponentIdAndBase64PublicKeyForTest(
+      kDefaultAdBlockComponentTestId,
+      kDefaultAdBlockComponentTestBase64PublicKey);
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool as_expected = false;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "setExpectations(0, 0, 1, 2);"
+      "xhr('adbanner.js');"
+      "xhr('normal.js');"
+      "xhr('adbanner.js')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+}
+
+// Load a page with different adblocked xhr requests, it should count each.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TwoDiffAdsGetCountedAsTwo) {
+  SetDefaultComponentIdAndBase64PublicKeyForTest(
+      kDefaultAdBlockComponentTestId,
+      kDefaultAdBlockComponentTestBase64PublicKey);
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool as_expected = false;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "setExpectations(0, 0, 1, 2);"
+      "xhr('adbanner.js?1');"
+      "xhr('normal.js');"
+      "xhr('adbanner.js?2')",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+}
+
+// New tab continues to count blocking the same resource
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NewTabContinuesToBlock) {
+  SetDefaultComponentIdAndBase64PublicKeyForTest(
+      kDefaultAdBlockComponentTestId,
+      kDefaultAdBlockComponentTestBase64PublicKey);
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+  EXPECT_EQ(url, contents->GetURL());
+
+  bool as_expected = false;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "setExpectations(0, 0, 0, 1);"
+      "xhr('adbanner.js');",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+
+  ui_test_utils::NavigateToURL(browser(), url);
+  contents = browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+
+  as_expected = false;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+      contents,
+      "setExpectations(0, 0, 0, 1);"
+      "xhr('adbanner.js');",
+      &as_expected));
+  EXPECT_TRUE(as_expected);
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+
+  ui_test_utils::NavigateToURL(browser(), url);
 }

--- a/components/brave_shields/browser/brave_shields_web_contents_observer.cc
+++ b/components/brave_shields/browser/brave_shields_web_contents_observer.cc
@@ -182,6 +182,17 @@ GURL BraveShieldsWebContentsObserver::GetTabURLFromRenderFrameInfo(
   return GURL();
 }
 
+bool BraveShieldsWebContentsObserver::IsBlockedSubresource(
+    const std::string& subresource) {
+  return blocked_url_paths_.find(subresource) != blocked_url_paths_.end();
+}
+
+void BraveShieldsWebContentsObserver::AddBlockedSubresource(
+    const std::string& subresource) {
+  blocked_url_paths_.insert(subresource);
+}
+
+// static
 void BraveShieldsWebContentsObserver::DispatchBlockedEvent(
     std::string block_type,
     std::string subresource,
@@ -195,28 +206,35 @@ void BraveShieldsWebContentsObserver::DispatchBlockedEvent(
   DispatchBlockedEventForWebContents(block_type, subresource, web_contents);
 
   if (web_contents) {
-    PrefService* prefs = Profile::FromBrowserContext(
-        web_contents->GetBrowserContext())->
-        GetOriginalProfile()->
-        GetPrefs();
+    BraveShieldsWebContentsObserver* observer =
+        BraveShieldsWebContentsObserver::FromWebContents(web_contents);
+    if (observer &&
+        !observer->IsBlockedSubresource(subresource)) {
+      observer->AddBlockedSubresource(subresource);
+      PrefService* prefs = Profile::FromBrowserContext(
+          web_contents->GetBrowserContext())->
+          GetOriginalProfile()->
+          GetPrefs();
 
-    if (block_type == kAds) {
-      prefs->SetUint64(kAdsBlocked, prefs->GetUint64(kAdsBlocked) + 1);
-    } else if (block_type == kTrackers) {
-      prefs->SetUint64(kTrackersBlocked,
-          prefs->GetUint64(kTrackersBlocked) + 1);
-    } else if (block_type == kHTTPUpgradableResources) {
-      prefs->SetUint64(kHttpsUpgrades, prefs->GetUint64(kHttpsUpgrades) + 1);
-    } else if (block_type == kJavaScript) {
-      prefs->SetUint64(kJavascriptBlocked,
-          prefs->GetUint64(kJavascriptBlocked) + 1);
-    } else if (block_type == kFingerprinting) {
-      prefs->SetUint64(kFingerprintingBlocked,
-          prefs->GetUint64(kFingerprintingBlocked) + 1);
+      if (block_type == kAds) {
+        prefs->SetUint64(kAdsBlocked, prefs->GetUint64(kAdsBlocked) + 1);
+      } else if (block_type == kTrackers) {
+        prefs->SetUint64(kTrackersBlocked,
+            prefs->GetUint64(kTrackersBlocked) + 1);
+      } else if (block_type == kHTTPUpgradableResources) {
+        prefs->SetUint64(kHttpsUpgrades, prefs->GetUint64(kHttpsUpgrades) + 1);
+      } else if (block_type == kJavaScript) {
+        prefs->SetUint64(kJavascriptBlocked,
+            prefs->GetUint64(kJavascriptBlocked) + 1);
+      } else if (block_type == kFingerprinting) {
+        prefs->SetUint64(kFingerprintingBlocked,
+            prefs->GetUint64(kFingerprintingBlocked) + 1);
+      }
     }
   }
 }
 
+// static
 void BraveShieldsWebContentsObserver::DispatchBlockedEventForWebContents(
     const std::string& block_type, const std::string& subresource,
     WebContents* web_contents) {
@@ -295,9 +313,11 @@ void BraveShieldsWebContentsObserver::ReadyToCommitNavigation(
     content::NavigationHandle* navigation_handle) {
   // when the main frame navigate away
   if (navigation_handle->IsInMainFrame() &&
-      !navigation_handle->IsSameDocument() &&
-      navigation_handle->GetReloadType() == content::ReloadType::NONE) {
+      !navigation_handle->IsSameDocument()) {
     allowed_script_origins_.clear();
+    if (navigation_handle->GetReloadType() == content::ReloadType::NONE) {
+      blocked_url_paths_.clear();
+    }
   }
 
   navigation_handle->GetWebContents()->SendToAllFrames(

--- a/components/brave_shields/browser/brave_shields_web_contents_observer.h
+++ b/components/brave_shields/browser/brave_shields_web_contents_observer.h
@@ -38,6 +38,8 @@ class BraveShieldsWebContentsObserver : public content::WebContentsObserver,
   static GURL GetTabURLFromRenderFrameInfo(int render_process_id, int render_frame_id);
   void AllowScriptsOnce(const std::vector<std::string>& origins,
                         content::WebContents* web_contents);
+  bool IsBlockedSubresource(const std::string& subresource);
+  void AddBlockedSubresource(const std::string& subresource);
 
  protected:
     // A set of identifiers that uniquely identifies a RenderFrame.
@@ -78,9 +80,12 @@ class BraveShieldsWebContentsObserver : public content::WebContentsObserver,
   // UI thread and read on the IO thread.
   static base::Lock frame_data_map_lock_;
 
-  private:
-    friend class content::WebContentsUserData<BraveShieldsWebContentsObserver>;
-    std::vector<std::string> allowed_script_origins_;
+ private:
+  friend class content::WebContentsUserData<BraveShieldsWebContentsObserver>;
+  std::vector<std::string> allowed_script_origins_;
+  // We keep a set of the current page's blocked URLs in case the page
+  // continually tries to load the same blocked URLs.
+  std::set<std::string> blocked_url_paths_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveShieldsWebContentsObserver);
 };

--- a/test/data/adbanner.js
+++ b/test/data/adbanner.js
@@ -1,0 +1,1 @@
+console.log('adbanner.js loaded!')

--- a/test/data/blocking.html
+++ b/test/data/blocking.html
@@ -1,20 +1,73 @@
 <html>
 <head>
 <script>
-function addElement(src) {
+let expectedImgLoaded = 0
+let expectedImgBlocked = 0
+let expectedXHRLoaded = 0
+let expectedXHRBlocked = 0
+let numXHRLoaded = 0
+let numXHRBlocked = 0
+
+// Performs an XHR for the specified src
+function xhr(src) {
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', src, true);
+  xhr.onload = function(e) {
+    if (xhr.response.length !== 0)
+      numXHRLoaded++
+    else
+      numXHRBlocked++
+    onLoad()
+  }
+  xhr.onerror = function(e) {
+    numXHRBlocked++
+    onLoad()
+  }
+  xhr.send();
+}
+
+// Adds an image to the DOM with the specified src
+function addImage(src) {
   const img = document.createElement('img')
-  img.id = 'adImage'
   img.src = src
-  img.addEventListener('load', imgLoaded)
+  img.className = 'adImage'
+  img.addEventListener('load', onLoad)
   document.body.appendChild(img)
 }
 
-function imgLoaded() {
-  const adImage = document.querySelector('#adImage')
+// Sets the expectation for the number of images and XHR loaded and blocked
+function setExpectations(numImgLoaded, numImgBlocked, numXHRLoaded, numXHRBlocked) {
+  expectedImgLoaded = numImgLoaded
+  expectedImgBlocked = numImgBlocked
+  expectedXHRLoaded = numXHRLoaded
+  expectedXHRBlocked = numXHRBlocked
+}
+
+function onLoad() {
+  const adImages = Array.from(document.querySelectorAll('.adImage'))
+  if (adImages.length !== expectedImgLoaded + expectedImgBlocked ||
+      numXHRLoaded + numXHRBlocked !== expectedXHRLoaded + expectedXHRBlocked) {
+    return;
+  }
+
   // Blocked image should be a 1x1 stub
-  window.domAutomationController.send(adImage.complete &&
-    (adImage.naturalHeight !== 1 ||
-    adImage.naturalWidth !== 1))
+  const numImgLoaded = adImages.reduce((total, adImage) => {
+    if (adImage.complete &&
+        (adImage.naturalHeight !== 1 || adImage.naturalWidth !== 1)) {
+      return total + 1
+    }
+    return total
+  }, 0);
+
+  const numImgBlocked = adImages.length - numImgLoaded
+  const result = numImgLoaded == expectedImgLoaded &&
+      expectedImgBlocked == numImgBlocked &&
+      numXHRLoaded === expectedXHRLoaded &&
+      numXHRBlocked === expectedXHRBlocked
+  // For debugging:
+  // console.log('sending: ' + JSON.stringify({result, expectedImgLoaded, expectedImgBlocked, numImgBlocked,
+  //    numXHRLoaded, expectedXHRLoaded, numXHRBlocked, expectedXHRBlocked}))
+  window.domAutomationController.send(result)
 }
 </script>
 </head>

--- a/test/data/normal.js
+++ b/test/data/normal.js
@@ -1,0 +1,1 @@
+console.log('normal loaded!')


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1311

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source