### PR TITLE
WIP: Allow downloading PDFs instead of opening them in Brave.

### DIFF
--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -7,6 +7,7 @@
 
 #include "base/files/file_path.h"
 #include "chrome/browser/extensions/component_loader.h"
+#include "components/prefs/pref_change_registrar.h"
 
 namespace extensions {
 
@@ -32,8 +33,17 @@ class BraveComponentLoader : public ComponentLoader {
   void AddExtension(const std::string& id,
       const std::string& name, const std::string& public_key);
  
+  static bool IsPdfjsDisabled();
+
  private:
+   void ObserveOpenPdfExternallySetting();
+   // Callback for changes to the AlwaysOpenPdfExternally setting.
+   void UpdatePdfExtension(const std::string& pref_name);
+
   Profile* profile_;
+  PrefService* profile_prefs_;
+  PrefChangeRegistrar registrar_;
+  bool always_open_pdf_externally_;
   DISALLOW_COPY_AND_ASSIGN(BraveComponentLoader);
 };
 

--- a/browser/ui/webui/brave_md_settings_ui.cc
+++ b/browser/ui/webui/brave_md_settings_ui.cc
@@ -4,6 +4,7 @@
 
 #include "brave/browser/ui/webui/brave_md_settings_ui.h"
 
+#include "brave/browser/extensions/brave_component_loader.h"
 #include "brave/browser/resources/grit/brave_settings_resources.h"
 #include "brave/browser/resources/grit/brave_settings_resources_map.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
@@ -26,8 +27,11 @@ BraveMdSettingsUI::~BraveMdSettingsUI() {
 // static
 void BraveMdSettingsUI::AddResources(content::WebUIDataSource* html_source,
                                 Profile* profile) {
-for (size_t i = 0; i < kBraveSettingsResourcesSize; ++i) {
+  for (size_t i = 0; i < kBraveSettingsResourcesSize; ++i) {
     html_source->AddResourcePath(kBraveSettingsResources[i].name,
                                  kBraveSettingsResources[i].value);
   }
+
+  html_source->AddBoolean("isPdfjsDisabled",
+                          extensions::BraveComponentLoader::IsPdfjsDisabled());
 }

--- a/patches/chrome-browser-resources-settings-site_settings-pdf_documents.js.patch
+++ b/patches/chrome-browser-resources-settings-site_settings-pdf_documents.js.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/resources/settings/site_settings/pdf_documents.js b/chrome/browser/resources/settings/site_settings/pdf_documents.js
+index 66f61a6db59bc5a549db3ec505518462f72b5cb7..dc96ac708d68be5f82972aa3273e38ce687b61ab 100644
+--- a/chrome/browser/resources/settings/site_settings/pdf_documents.js
++++ b/chrome/browser/resources/settings/site_settings/pdf_documents.js
+@@ -17,4 +17,12 @@ Polymer({
+       notify: true,
+     },
+   },
++
++  /** @override */
++  ready: function () {
++    if (loadTimeData.getBoolean('isPdfjsDisabled')) {
++      this.$.toggle.disabled = true;
++      this.$.toggle.checked = true;
++    }
++  },
+ });


### PR DESCRIPTION
Fixes brave/brave-browser#1531

The fix does the following:

1. Makes the initial decision on whether to load PDFJS extension based
on the value of kPluginsAlwaysOpenPdfExternally profile preference.

2. Watches profile preference value kPluginsAlwaysOpenPdfExternally and
adds/removes PDFJS extension when the value changes.

3. Modifies js behind the chrome://settings/content/pdfDocuments so that
if the PDFJS extension is disabled from the command line the option to
download PDF files instead of opening them in Brave is set to ON and the
toggle is disabled.

Note, that this fix doesn't address being able to turn off opening PDFs
in Brave in Guest/Tor profiles. The web ui setting to do so is not
available in these profiles.

The command line switch to not load PDFJS already applies to all profile
types.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source