### PR TITLE
Set sync to default enabled and provide "disable-brave-sync" switch

### DIFF
--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -29,9 +29,8 @@ const char kDisableTorClientUpdaterExtension[] = "disable-tor-client-updater-ext
 // Allows disabling the WebTorrent extension.
 const char kDisableWebTorrentExtension[] = "disable-webtorrent-extension";
 
-// Enables Brave Sync. For now it is targeted to staging for QA tests, so
-// is disabled by default for a while.
-const char kEnableBraveSync[] = "enable-brave-sync";
+// Allows disabling Brave Sync.
+const char kDisableBraveSync[] = "disable-brave-sync";
 
 // Specifies which server should we use for rewards
 // Valid values are: "stag" | "prod".

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -23,7 +23,7 @@ extern const char kDisableTorClientUpdaterExtension[];
 
 extern const char kDisableWebTorrentExtension[];
 
-extern const char kEnableBraveSync[];
+extern const char kDisableBraveSync[];
 
 extern const char kRewardsEnv[];
 

--- a/components/brave_sync/brave_sync_service.cc
+++ b/components/brave_sync/brave_sync_service.cc
@@ -24,10 +24,10 @@ void BraveSyncService::RemoveObserver(BraveSyncServiceObserver* observer) {
 bool BraveSyncService::is_enabled() {
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
-  if (command_line.HasSwitch(switches::kEnableBraveSync))
-    return true;
-  else
+  if (command_line.HasSwitch(switches::kDisableBraveSync))
     return false;
+  else
+    return true;
 }
 
 }  // namespace brave_sync

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/command_line.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/strings/utf_string_conversions.h"
-#include "brave/common/brave_switches.h"
 #include "brave/components/brave_sync/client/bookmark_change_processor.h"
 #include "brave/components/brave_sync/client/brave_sync_client_impl.h"
 #include "brave/components/brave_sync/client/client_ext_impl_data.h"
@@ -255,8 +253,6 @@ TEST_F(BraveSyncServiceTest, OnSetupSyncNewToSync) {
 }
 
 TEST_F(BraveSyncServiceTest, GetSettingsAndDevices) {
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-        switches::kEnableBraveSync);
   // The test absorbs OnSetupSyncNewToSync test
   auto callback1 = base::BindRepeating(
       [](std::unique_ptr<brave_sync::Settings> settings,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2208

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. npm run test -- brave_unit_tests --filter=BraveSyncServiceTest.*
2. Sync should be accessible without any switches
3. Execute Brave with "disable-brave-sync", sync option shouldn't appear on menu and also sync extension is disabled

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source