### PR TITLE
Travis: Disable sudo to enable container-based vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - npm --version
 
 install:
-  - npm i
+  - npm i --no-audit
 
 script:
   - npm run $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "node"
 
 dist: trusty
-sudo: required
+sudo: false
 
 branches:
   only:
@@ -15,17 +15,24 @@ cache:
     - $HOME/.npm
     - node_modules
 
-env:
-  - TEST_SUITE=lint
-  - TEST_SUITE=test-security
-  - TEST_SUITE=test-unit
-  - TEST_SUITE=pep8
+matrix:
+  include:
+    - env: TEST_SUITE=lint
+    - env: TEST_SUITE=test-security
+    - env: TEST_SUITE=test-unit
+    - language: python
+      env: TEST_SUITE=pep8
+      cache:
+        pip: true
+      before_install:
+        - pip install --upgrade pip
+        - pip install pycodestyle
+      install:
+        - echo
 
 before_install:
   - npm i -g npm
   - npm --version
-  - sudo pip install --upgrade pip
-  - sudo pip install pycodestyle
 
 install:
   - npm i


### PR DESCRIPTION
Container-based vm's have faster boot time (1-6s vs 20-50s with sudo enabled) [1].

[1] https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source