### PR TITLE
Show sync setup error

### DIFF
--- a/browser/ui/webui/sync/sync_ui.cc
+++ b/browser/ui/webui/sync/sync_ui.cc
@@ -46,6 +46,8 @@ class SyncUIDOMHandler : public WebUIMessageHandler,
   void DeleteDevice(const base::ListValue* args);
   void ResetSync(const base::ListValue* args);
 
+  void OnSyncSetupError(brave_sync::BraveSyncService* sync_service,
+                        const std::string& error) override;
   void OnSyncStateChanged(brave_sync::BraveSyncService *sync_service) override;
   void OnHaveSyncWords(brave_sync::BraveSyncService *sync_service,
                        const std::string& sync_words) override;
@@ -192,6 +194,14 @@ void SyncUIDOMHandler::DeleteDevice(const base::ListValue* args) {
 
 void SyncUIDOMHandler::ResetSync(const base::ListValue* args) {
   sync_service_->OnResetSync();
+}
+
+void SyncUIDOMHandler::OnSyncSetupError(
+    brave_sync::BraveSyncService* sync_service,
+    const std::string& error) {
+
+  web_ui()->CallJavascriptFunctionUnsafe(
+      "sync_ui_exports.syncSetupError", base::Value(error));
 }
 
 void SyncUIDOMHandler::OnSyncStateChanged(

--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -182,6 +182,9 @@ void BraveSyncServiceImpl::OnSetupSyncNewToSync(
     return;
   }
 
+  sync_words_.clear();  // If the previous attempt was connect to sync chain
+                        // and failed to receive save-init-data
+
   sync_prefs_->SetThisDeviceName(device_name);
   initializing_ = true;
 
@@ -288,7 +291,7 @@ void BraveSyncServiceImpl::OnSyncSetupError(const std::string& error) {
   if (!sync_initialized_) {
     sync_prefs_->Clear();
   }
-  OnSyncDebug(error);
+  NotifySyncSetupError(error);
 }
 
 void BraveSyncServiceImpl::OnGetInitData(const std::string& sync_version) {
@@ -607,6 +610,12 @@ void BraveSyncServiceImpl::LoopProcThreadAligned() {
 
 void BraveSyncServiceImpl::NotifyLogMessage(const std::string& message) {
   DLOG(INFO) << message;
+}
+
+void BraveSyncServiceImpl::NotifySyncSetupError(const std::string& error) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  for (auto& observer : observers_)
+    observer.OnSyncSetupError(this, error);
 }
 
 void BraveSyncServiceImpl::NotifySyncStateChanged() {

--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -157,6 +157,7 @@ class BraveSyncServiceImpl : public BraveSyncService,
     const bool is_truncated );
 
   void NotifyLogMessage(const std::string& message);
+  void NotifySyncSetupError(const std::string& error);
   void NotifySyncStateChanged();
   void NotifyHaveSyncWords(const std::string& sync_words);
 

--- a/components/brave_sync/brave_sync_service_observer.h
+++ b/components/brave_sync/brave_sync_service_observer.h
@@ -13,6 +13,8 @@ class BraveSyncServiceObserver : public base::CheckedObserver {
  public:
   ~BraveSyncServiceObserver() override {}
 
+  virtual void OnSyncSetupError(BraveSyncService* sync_service,
+                                const std::string& error) {}
   virtual void OnSyncStateChanged(BraveSyncService* sync_service) {}
   virtual void OnHaveSyncWords(BraveSyncService* sync_service,
                                const std::string& sync_words) {}

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -92,6 +92,7 @@ class MockBraveSyncServiceObserver : public BraveSyncServiceObserver {
  public:
   MockBraveSyncServiceObserver() {}
 
+  MOCK_METHOD2(OnSyncSetupError, void(BraveSyncService*, const std::string&));
   MOCK_METHOD1(OnSyncStateChanged, void(BraveSyncService*));
   MOCK_METHOD2(OnHaveSyncWords, void(BraveSyncService*, const std::string&));
 };
@@ -294,6 +295,11 @@ TEST_F(BraveSyncServiceTest, GetSyncWords) {
   const std::string words = "word1 word2 word3";
   EXPECT_CALL(*observer(), OnHaveSyncWords(sync_service(), words)).Times(1);
   sync_service()->OnSyncWordsPrepared(words);
+}
+
+TEST_F(BraveSyncServiceTest, SyncSetupError) {
+  EXPECT_CALL(*observer(), OnSyncSetupError(sync_service(), _)).Times(1);
+  sync_service()->OnSetupSyncHaveCode("", "");
 }
 
 TEST_F(BraveSyncServiceTest, GetSeed) {

--- a/components/brave_sync/extension/background.js
+++ b/components/brave_sync/extension/background.js
@@ -249,7 +249,7 @@ class InjectedObject {
         chrome.braveSync.saveInitData(arg1/*seed*/, deviceId);
         break;
       case "sync-ready":
-        console.log(`"save-init-data"`);
+        console.log(`"sync-ready"`);
         chrome.braveSync.syncReady();
         break;
       case "get-existing-objects":

--- a/components/brave_sync/ui/brave_sync.tsx
+++ b/components/brave_sync/ui/brave_sync.tsx
@@ -60,12 +60,17 @@ window.cr.define('sync_ui_exports', function () {
     getActions().onLogMessage(message)
   }
 
+  function syncSetupError(error: string) {
+    alert('Sync setup error: ' + error)
+  }
+
   return {
     initialize,
     showSettings,
     haveSyncWords,
     haveSeedForQrCode,
-    logMessage
+    logMessage,
+    syncSetupError
   }
 })
 


### PR DESCRIPTION
Address https://github.com/brave/brave-browser/issues/2103 .

This is PR for https://github.com/brave/brave-browser/issues/2103 and for `Expected results pt2` for https://github.com/brave/brave-browser/issues/2130 .
Contains required native-code changes, but does not close the issue entirely.
Issue still require to proper implement of 
```
function syncSetupError(error: string) {
    alert('Sync setup error: ' + error)
  }
```
in `components/brave_sync/ui/brave_sync.tsx`

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Take code words and make the last word to be wrong
2. Connect to existing sync chain with words from pt1
3. Should appear the  message `wrong code words`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source