### PR TITLE
Fix build error comes from brave_plugin_registry_impl.o

### DIFF
--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -1,8 +1,0 @@
-source_set("browser") {
-  visibility = [ "//content/browser" ]
-
-  sources = [
-    "renderer_host/brave_plugin_registry_impl.cc",
-    "renderer_host/brave_plugin_registry_impl.h",
-  ]
-}

--- a/patches/content-browser-BUILD.gn.patch
+++ b/patches/content-browser-BUILD.gn.patch
@@ -1,13 +1,17 @@
 diff --git a/content/browser/BUILD.gn b/content/browser/BUILD.gn
-index b9925142f676f2a66fb50c7679e28ab91f81031b..edd962d8b9354b3bc11fc96a9341f7dbd5228409 100644
+index b9925142f676f2a66fb50c7679e28ab91f81031b..e1300c0319123545c5767a8fa3cbfaa78742df49 100644
 --- a/content/browser/BUILD.gn
 +++ b/content/browser/BUILD.gn
-@@ -1864,6 +1864,8 @@ jumbo_source_set("browser") {
-     "webui/web_ui_url_loader_factory_internal.h",
-   ]
- 
-+  deps += [ "//brave/content/browser" ]
-+
-   if (toolkit_views) {
-     deps += [ "//ui/events" ]
-   }
+@@ -2105,6 +2105,12 @@ jumbo_source_set("browser") {
+       "//ppapi/proxy:ipc",
+       "//ppapi/shared_impl",
+     ]
++    if (brave_chromium_build) {
++      sources += [
++        "//brave/content/browser/renderer_host/brave_plugin_registry_impl.cc",
++        "//brave/content/browser/renderer_host/brave_plugin_registry_impl.h",
++      ]
++    }
+     if (use_ozone) {
+       sources += [ "renderer_host/pepper/pepper_truetype_font_list_ozone.cc" ]
+     }


### PR DESCRIPTION
To fix compile/link error, adding brave sources directly to content/browser source list is
most simple and cleaner way. If not, we need more number of patches
and can meet content/public/common dependency cycle.

Fix https://github.com/brave/brave-browser/issues/2222

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source