### PR TITLE
Upgrade brave-ui to 0.34.4 and include required new definitions

### DIFF
--- a/components/common/typescript.gni
+++ b/components/common/typescript.gni
@@ -5,6 +5,7 @@ brave_common_typescript_includes = [
   rebase_path("dns.ts"),
   rebase_path("debounce.ts"),
   rebase_path("locale.ts"),
+  rebase_path("../definitions/non-js-loaders.d.ts"),
 ]
 
 # Runs webpack for the specified entry point(s) and outputs a GRD file

--- a/components/definitions/non-js-loaders.d.ts
+++ b/components/definitions/non-js-loaders.d.ts
@@ -1,0 +1,24 @@
+declare module '*.svg' {
+  const url: any
+  export default url
+}
+declare module '*.png' {
+  const url: any
+  export default url
+}
+declare module '*.jpg' {
+  const url: any
+  export default url
+}
+declare module '*.gif' {
+  const url: any
+  export default url
+}
+declare module '*.woff2' {
+  const url: any
+  export default url
+}
+declare module '*.css' {
+  const url: any
+  export default url
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,13 +2087,13 @@
       }
     },
     "brave-ui": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.34.1.tgz",
-      "integrity": "sha512-euqiYT4HCvL6lk3BgQt7Psz2im8E+fzQVxBaPbRsLDp71sCKNZ2cPNxk/VM1xIKunhjS990lKU0jCF/hfvqjpA==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.34.4.tgz",
+      "integrity": "sha512-AGRGh3JNzmyVC0F0owgEb9KWv91KezaLqjE7iggM/BYssa12ZdBCJbffUo9/wMGERo5f31xzGPdwPiuDrdYFMg==",
       "dev": true,
       "requires": {
-        "emptykit.css": "1.0.1",
-        "styled-components": "3.4.5"
+        "emptykit.css": "^1.0.1",
+        "styled-components": "^3.2.5"
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.24.1",
-    "brave-ui": "^0.34.1",
+    "brave-ui": "^0.34.4",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Proposed replacement for https://github.com/brave/brave-core/pull/956. This simple upgrade seems to work fine: tests pass and builds are fine.

All webui builds can be tested by touching (saving) the components/webpack/webpack.config.js file and then running a build. This invalidates all the webui targets, forcing a rebuild of them.