### PR TITLE
Toggle "show bookmark bar" when bookmark bar was empty after adding bookmark from sync

### DIFF
--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -23,6 +23,7 @@ source_set("js_sync_lib_impl") {
     "//base",
     "//components/prefs",
     "//components/bookmarks/browser",
+    "//components/bookmarks/common",
     "//components/keyed_service/content",
     "//components/keyed_service/core",
     "//components/prefs",

--- a/components/brave_sync/client/bookmark_change_processor.h
+++ b/components/brave_sync/client/bookmark_change_processor.h
@@ -94,6 +94,7 @@ class BookmarkChangeProcessor : public ChangeProcessor,
 
   BraveSyncClient* sync_client_;  // not owned
   prefs::Prefs* sync_prefs_;  // not owned
+  Profile* profile_; // not owned
   bookmarks::BookmarkModel* bookmark_model_;  // not owned
 
   bookmarks::BookmarkNode* deleted_node_root_;

--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -17,7 +17,9 @@
 #include "chrome/browser/profiles/profile.h"
 #include "components/bookmarks/browser/bookmark_model.h"
 #include "components/bookmarks/browser/bookmark_utils.h"
+#include "components/bookmarks/common/bookmark_pref_names.h"
 #include "components/bookmarks/test/test_bookmark_client.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/test/test_browser_thread_bundle.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -457,6 +459,9 @@ void BraveBookmarkChangeProcessorTest::BookmarkCreatedFromSyncImpl() {
   EXPECT_NE(index_b, -1);
 
   EXPECT_LT(index_a, index_b);
+
+  EXPECT_TRUE(profile_->GetPrefs()->GetBoolean(
+                                      bookmarks::prefs::kShowBookmarkBar));
 }
 
 TEST_F(BraveBookmarkChangeProcessorTest, BookmarkCreatedFromSync) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2136

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
### Manual Test
- case a
1. Create sync chain with bookmark on Device A
2. Connect to sync chain from Device B with empty bookmark bar
3. Bookmark bar will show when bookmark sync complete
- case b
1. Create sync chain with bookmark on Device A
2. Connect to sync chain from Device B with non-empty bookmark bar
3. We respect original "Always Show Bookmark Bar" setting

### Unit Test
- npm run test -- brave_unit_tests --filter=BraveBookmarkChangeProcessorTest.*

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source