### PR TITLE
Accept empty field for device name in Sync existing code modal

### DIFF
--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -142,8 +142,8 @@ void BraveSyncServiceImpl::Shutdown() {
 void BraveSyncServiceImpl::OnSetupSyncHaveCode(const std::string& sync_words,
     const std::string& device_name) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  if (sync_words.empty() || device_name.empty()) {
-    OnSyncSetupError("missing sync words or device name");
+  if (sync_words.empty()) {
+    OnSyncSetupError("missing sync words");
     return;
   }
 
@@ -167,10 +167,6 @@ void BraveSyncServiceImpl::OnSetupSyncHaveCode(const std::string& sync_words,
 void BraveSyncServiceImpl::OnSetupSyncNewToSync(
     const std::string& device_name) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  if (device_name.empty()) {
-    OnSyncSetupError("missing device name");
-    return;
-  }
 
   if (initializing_) {
     NotifyLogMessage("currently initializing");

--- a/components/brave_sync/ui/components/modals/existingSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/existingSyncCode.tsx
@@ -32,8 +32,11 @@ class ExistingSyncCodeModal extends React.PureComponent<ExistingSyncCodeModalPro
       syncWords: ''
     }
   }
-  get defaultDeviceName () {
-    return getDefaultDeviceName()
+
+  get deviceName () {
+    return this.state.deviceName === ''
+      ? getDefaultDeviceName()
+      : this.state.deviceName
   }
 
   getUserInputDeviceName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,8 +48,8 @@ class ExistingSyncCodeModal extends React.PureComponent<ExistingSyncCodeModalPro
   }
 
   onSetupSyncHaveCode = () => {
-    const { deviceName, syncWords } = this.state
-    this.props.actions.onSetupSyncHaveCode(syncWords, deviceName)
+    const { syncWords } = this.state
+    this.props.actions.onSetupSyncHaveCode(syncWords, this.deviceName)
   }
 
   render () {
@@ -61,7 +64,7 @@ class ExistingSyncCodeModal extends React.PureComponent<ExistingSyncCodeModalPro
         <Label>{getLocale('enterAnOptionalName')}</Label>
         <SectionBlock>
           <Input
-            placeholder={this.defaultDeviceName}
+            placeholder={getDefaultDeviceName()}
             onChange={this.getUserInputDeviceName}
           />
         </SectionBlock>

--- a/components/brave_sync/ui/reducers/sync_reducer.ts
+++ b/components/brave_sync/ui/reducers/sync_reducer.ts
@@ -123,9 +123,6 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
 
     case types.SYNC_SETUP_SYNC_HAVE_CODE:
       const wordsAsArray = payload.syncWords.split(' ')
-      if (payload.deviceName.length === 0) {
-        window.alert('device name is required')
-      }
       if (wordsAsArray.length !== 24) {
         window.alert('Invalid input code')
         break


### PR DESCRIPTION
## Dear reviewer: This PR is blocked as it conflicts with https://github.com/brave/brave-browser/issues/2103. Please wait it to be merged before checking out these changes.

fix https://github.com/brave/brave-browser/issues/2256

## Test Plan:

1. Enable Sync via flag;
2. Go to brave://bravesync, ensure it is disabled;
3. Click "I have an existing Sync code:"
4. Paste this code `word tuna gym prosper business double clump baby about slim mosquito this there awesome behind sniff injury duck mercy discover sick carbon govern month double`
5. Leave the `Enter a name for this device:` field emtpy
6. You should see devices connected.