### PR TITLE
Don't send startup usage ping until we've checked for referral code

### DIFF
--- a/browser/brave_stats_updater.h
+++ b/browser/brave_stats_updater.h
@@ -13,6 +13,7 @@
 #include "url/gurl.h"
 
 class BraveStatsUpdaterBrowserTest;
+class PrefChangeRegistrar;
 class PrefRegistrySimple;
 class PrefService;
 
@@ -41,7 +42,8 @@ class BraveStatsUpdater {
   void Start();
   void Stop();
 
-  using StatsUpdatedCallback = base::RepeatingCallback<void()>;
+  using StatsUpdatedCallback =
+      base::RepeatingCallback<void(const std::string& url)>;
 
   void SetStatsUpdatedCallback(StatsUpdatedCallback stats_updated_callback);
 
@@ -51,8 +53,17 @@ class BraveStatsUpdater {
       std::unique_ptr<brave::BraveStatsUpdaterParams> stats_updater_params,
       scoped_refptr<net::HttpResponseHeaders> headers);
 
-  // Invoked when server ping timer fires.
-  void OnServerPingTimerFired();
+  // Invoked when server ping startup timer fires.
+  void OnServerPingStartupTimerFired();
+
+  // Invoked when server ping periodic timer fires.
+  void OnServerPingPeriodicTimerFired();
+
+  // Invoked when the specified referral preference changes.
+  void OnReferralCheckedForPromoCodeFileChanged();
+
+  void StartServerPingStartupTimer();
+  void SendServerPing();
 
   friend class ::BraveStatsUpdaterBrowserTest;
   static void SetBaseUpdateURLForTest(const GURL& base_update_url);
@@ -63,6 +74,7 @@ class BraveStatsUpdater {
   std::unique_ptr<network::SimpleURLLoader> simple_url_loader_;
   std::unique_ptr<base::OneShotTimer> server_ping_startup_timer_;
   std::unique_ptr<base::RepeatingTimer> server_ping_periodic_timer_;
+  std::unique_ptr<PrefChangeRegistrar> pref_change_registrar_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveStatsUpdater);
 };

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -228,9 +228,6 @@ void BraveReferralsService::OnReferralInitLoadComplete(
   const base::Value* download_id = root->FindKey("download_id");
   pref_service_->SetString(kReferralDownloadID, download_id->GetString());
 
-  const base::Value* referral_code = root->FindKey("referral_code");
-  pref_service_->SetString(kReferralPromoCode, referral_code->GetString());
-
   const base::Value* offer_page_url = root->FindKey("offer_page_url");
   if (offer_page_url) {
     GURL gurl(offer_page_url->GetString());
@@ -287,8 +284,10 @@ void BraveReferralsService::OnReferralFinalizationCheckLoadComplete(
 
 void BraveReferralsService::OnReadPromoCodeComplete() {
   pref_service_->SetBoolean(kReferralCheckedForPromoCodeFile, true);
-  if (!promo_code_.empty())
+  if (!promo_code_.empty()) {
+    pref_service_->SetString(kReferralPromoCode, promo_code_);
     InitReferral();
+  }
 }
 
 void BraveReferralsService::GetFirstRunTime() {


### PR DESCRIPTION
Fixes brave/brave-browser#2258

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Download a stub installer with a referral promo
- Run the referral installer
- Launch Brave with verbose = 1 (`npm run --prefix $BRAVEDIR start -- --v=1`)
- Wait 10-15 seconds (the referral code check is performed 3 seconds after startup)
- Verify that the stats ping debug log message contains the expected referral code:

```
[20400:21652:1127/163727.937:VERBOSE1:brave_stats_updater.cc(147)] Brave stats ping, url: https://laptop-updates.brave.com/1/usage/brave-core?platform=winx64-bc&channel=release&version=0.59.1&daily=false&weekly=false&monthly=false&first=false&woi=2018-11-19&ref=FOO123
```

For timing reasons, we should run this test several times and verify that we never see `ref=none`.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source