### PR TITLE
Disable unified consent feature.

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -22,6 +22,7 @@
 #include "chrome/common/chrome_switches.h"
 #include "components/autofill/core/common/autofill_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
+#include "components/unified_consent/feature.h"
 #include "components/viz/common/features.h"
 #include "content/public/common/content_features.h"
 #include "extensions/common/extension_features.h"
@@ -136,7 +137,8 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
     << "," << features::kVizDisplayCompositor.name
     << "," << autofill::features::kAutofillSaveCardSignInAfterLocalSave.name
     << "," << features::kAudioServiceOutOfProcess.name
-    << "," << autofill::features::kAutofillServerCommunication.name;
+    << "," << autofill::features::kAutofillServerCommunication.name
+    << "," << unified_consent::kUnifiedConsent.name;
 
   command_line.AppendSwitchASCII(switches::kEnableFeatures,
       enabled_features.str());

--- a/browser/brave_features_browsertest.cc
+++ b/browser/brave_features_browsertest.cc
@@ -6,6 +6,7 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/autofill/core/common/autofill_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
+#include "components/unified_consent/feature.h"
 #include "content/public/common/content_features.h"
 
 using BraveFeaturesBrowserTest = InProcessBrowserTest;
@@ -22,4 +23,8 @@ IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, AutoFillServerCommunication) {
       autofill::features::kAutofillServerCommunication));
   EXPECT_FALSE(
     base::FeatureList::IsEnabled(features::kAudioServiceOutOfProcess));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, UnifiedConsent) {
+  EXPECT_FALSE(base::FeatureList::IsEnabled(unified_consent::kUnifiedConsent));
 }


### PR DESCRIPTION
Fixes brave/brave-browser#2242

Disabling this feature reverts the settings UI to not showing "Sync and
Brave services" item and placing other UI settings back to "Privacy and
security". It also generally disables unified consent feature - unified
sign-in into browser and google, which should be ok since we don't use
Google's sync service.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- Start Brave browser and navigate to brave://settings,
- Verify that the 'People' section doesn't have `Sync and Brave services` item,
- Scroll down and click on `Advanced`,
- Verify that the `Privacy and security` section looks exactly the same as in 0.56.x version.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source