### PR TITLE
Fix public asset path for webpack-generated assets in extensions

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/BUILD.gn
+++ b/components/brave_rewards/resources/extension/brave_rewards/BUILD.gn
@@ -37,4 +37,6 @@ transpile_web_ui("brave_rewards_panel") {
   # Must match the relative path from the static GRD to the manifest.json
   # plus any other relative path we want these files to live in the extension
   extra_relative_path = "/brave_rewards/out"
+
+  public_asset_path = "/out/"
 }

--- a/components/brave_webtorrent/extension/BUILD.gn
+++ b/components/brave_webtorrent/extension/BUILD.gn
@@ -45,4 +45,6 @@ transpile_web_ui("generate_brave_webtorrent") {
   # Must match the relative path from the static GRD to the manifest.json
   # plus any other relative path we want these files to live in the extension
   extra_relative_path = "/brave_webtorrent/extension/out"
+
+  public_asset_path = "/out/"
 }

--- a/components/common/typescript.gni
+++ b/components/common/typescript.gni
@@ -56,6 +56,18 @@ template("transpile_web_ui") {
       ]
     }
 
+    # Support a different URL path to access generated resources at.
+    # Webpack's default is '/' and we'll want to keep that most of the time,
+    # but if we're specifying extra_relative_path then normally a portion of
+    # that will need to be involved in the public_asset_path.
+    # For extensions, this is the relative path from where the manifest is to
+    # where the extra_relative_path ends.
+    if (defined(invoker.public_asset_path)) {
+      args += [
+        "--public_asset_path=" + invoker.public_asset_path
+      ]
+    }
+
     args += [
       "--target_gen_dir=$gen_dir",
       "--resource_name=$resource_name"

--- a/script/transpile-web-ui.py
+++ b/script/transpile-web-ui.py
@@ -16,7 +16,8 @@ def main():
     webpack_gen_dir = args.target_gen_dir[0]
     if args.extra_relative_path is not None:
         webpack_gen_dir = webpack_gen_dir + args.extra_relative_path
-    transpile_web_uis(args.production, webpack_gen_dir, args.entry)
+    transpile_web_uis(args.production, webpack_gen_dir,
+                      args.entry, args.public_asset_path)
     generate_grd(args.target_gen_dir[0], args.resource_name[0])
 
 
@@ -32,6 +33,7 @@ def parse_args():
     parser.add_argument('--target_gen_dir', nargs=1)
     parser.add_argument('--resource_name', nargs=1)
     parser.add_argument('--extra_relative_path', nargs='?')
+    parser.add_argument('--public_asset_path', nargs='?')
     args = parser.parse_args()
     # validate args
     if (args.target_gen_dir is None or
@@ -52,7 +54,8 @@ def clean_target_dir(target_dir, env=None):
         raise Exception("Error removing previous webpack target dir", e)
 
 
-def transpile_web_uis(production, target_gen_dir, entry_points, env=None):
+def transpile_web_uis(production, target_gen_dir,
+                      entry_points, public_asset_path=None, env=None):
     if env is None:
         env = os.environ.copy()
 
@@ -62,6 +65,9 @@ def transpile_web_uis(production, target_gen_dir, entry_points, env=None):
         args.append("--mode=production")
     else:
         args.append("--mode=development")
+
+    if public_asset_path is not None:
+        args.append("--output-public-path=" + public_asset_path)
 
     # entrypoints
     for entry in entry_points:


### PR DESCRIPTION
For external assets e.g. an .svg file, webpack emits the file in the fs at the path specified by target_gen_dir or target_gen_dir + extra_relative_path. webpack also outputs a relative URL to access these assets. By default this relative URL is '/' but if we do specify an extra relative path, then we need to specify a new public relative url to access those resources. In the case of extensions, this needs to be the portion of the extra_relative_path that is deeper than where the manifest.json lives. This is because chromium matches the extension resources with ones that have the same fs path prefix as the manifest.json path.

This regressed in https://github.com/brave/brave-core/pull/919

Fix https://github.com/brave/brave-browser/issues/2259

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source