### PR TITLE
Apply inox-patchset-0009 to disable Google IPv6 probes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,6 +19,10 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Alternatively, this code may be distributed or
 otherwise used under the terms of GPL v3
 
+Incorporating code from ungoogled-chromium,
+https://github.com/Eloston/ungoogled-chromium
+Licensed BSD-3-Clause License
+
 Text of Mozilla Public License Version 2.0
 ==========================================
 

--- a/patches/inox-patchset-0009-disable-google-ipv6-probes.patch
+++ b/patches/inox-patchset-0009-disable-google-ipv6-probes.patch
@@ -1,0 +1,16 @@
+--- a/net/dns/host_resolver_impl.cc
++++ b/net/dns/host_resolver_impl.cc
+@@ -115,10 +115,10 @@ const unsigned kMinimumTTLSeconds = kCac
+ // cached.
+ const int kIPv6ProbePeriodMs = 1000;
+ 
+-// Google DNS address used for IPv6 probes.
++/* RIPE NCC k.root-servers.net. 2001:7fd::1 (anycasted) */
+ const uint8_t kIPv6ProbeAddress[] =
+-    { 0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0x00, 0x00,
+-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x88 };
++    { 0x20, 0x01, 0x07, 0xfd, 0x00, 0x00, 0x00, 0x00,
++      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
+ 
+ // We use a separate histogram name for each platform to facilitate the
+ // display of error codes by their symbolic name (since each platform has


### PR DESCRIPTION
This fixes https://github.com/brave/brave-browser/issues/2324.
Based on https://github.com/gcarq/inox-patchset/blob/master/0009-disable-google-ipv6-probes.patch.
Patch updated to be from https://github.com/Eloston/ungoogled-chromium/commit/ecb7b49e1a030fab78a664070e6d3ac2fa7f2098 (at least at 70).

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source