### PR TITLE
Disable safebrowsing by default

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -56,6 +56,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // Disable spell check service
   registry->SetDefaultPrefValue(spellcheck::prefs::kSpellCheckUseSpellingService, base::Value(false));
 
+  // Disable safebrowsing
+  registry->SetDefaultPrefValue(prefs::kSafeBrowsingEnabled, base::Value(false));
+
   // Disable safebrowsing reporting
   registry->SetDefaultPrefValue(prefs::kSafeBrowsingExtendedReportingOptInAllowed, base::Value(false));
 


### PR DESCRIPTION
## Submitter Checklist:

This is a subset of inox-patchset-0006 (see https://github.com/brave/brave-browser/issues/1431#issuecomment-442246164, https://github.com/Eloston/ungoogled-chromium/blob/master/patches/inox-patchset/0006-modify-default-prefs.patch#L207), which prevents from contacting google server for resolving potentially malicious urls.
See also https://ungoogled-software.github.io/ungoogled-chromium-wiki/faq#why-is-safe-browsing-disabled, https://github.com/Eloston/ungoogled-chromium/issues/50.

The risks stated above do not apply to brave-browser because the functionality is already covered by the built-in client-side [ad-block engine](https://github.com/brave/ad-block) (via https://github.com/brave/ad-block/blob/master/lists/malware.h), while ungoogled-chromium doesn't have uBlock Origin (with malware domains enabled) installed by default.

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source