### PR TITLE
Upgrading brave-ui -> 0.34.6

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -304,7 +304,7 @@ export class Panel extends React.Component<Props, State> {
               platform={publisher.provider as Provider}
               publisherName={publisher.name}
               publisherImg={faviconUrl}
-              monthlyAmount={10}
+              monthlyAmount={'10.0'}
               isVerified={publisher.verified}
               tipsEnabled={true}
               includeInAuto={!publisher.excluded}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,13 +2087,13 @@
       }
     },
     "brave-ui": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.34.4.tgz",
-      "integrity": "sha512-AGRGh3JNzmyVC0F0owgEb9KWv91KezaLqjE7iggM/BYssa12ZdBCJbffUo9/wMGERo5f31xzGPdwPiuDrdYFMg==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.34.6.tgz",
+      "integrity": "sha512-jjgh71Accmsuawr9FWe0pKHf96PMGPRxBaC79ZBH0biEy+C0wfUEthfmMuYnPYABF7oI+NvROwqhEbNPD8O4eg==",
       "dev": true,
       "requires": {
-        "emptykit.css": "^1.0.1",
-        "styled-components": "^3.2.5"
+        "emptykit.css": "1.0.1",
+        "styled-components": "3.4.5"
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.24.1",
-    "brave-ui": "^0.34.4",
+    "brave-ui": "^0.34.6",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
## Submitter Checklist:
Fixes: https://github.com/brave/brave-browser/issues/2277

Contains the following updates:
Fixes console error concerning use of `fill-rule`
Fixes missing data-test-id from welcome page opt-in button

It should be verified that browser tests are passing with this PR

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Checkout the branch
2. `rm -rf node_modules && npm i`
3. Fresh profile
4. Launch Brave
5. Visit brave://rewards
6. Inspect `Yes, I'm in!` button
7. Should have `data-test-id='optInAction'`

## Automated test plan
`npm run test brave_browser_tests`

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source