### PR TITLE
Sync folder structure not kept

### DIFF
--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -13,6 +13,8 @@ source_set("js_sync_lib_impl") {
     "client/brave_sync_client_impl.h",
     "client/bookmark_change_processor.cc",
     "client/bookmark_change_processor.h",
+    "client/bookmark_node.cc",
+    "client/bookmark_node.h",
     "client/client_ext_impl_data.cc",
     "client/client_ext_impl_data.h",
     "client/client_data.cc",

--- a/components/brave_sync/client/bookmark_change_processor.cc
+++ b/components/brave_sync/client/bookmark_change_processor.cc
@@ -6,6 +6,7 @@
 
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_sync/bookmark_order_util.h"
+#include "brave/components/brave_sync/client/bookmark_node.h"
 #include "brave/components/brave_sync/jslib_const.h"
 #include "brave/components/brave_sync/jslib_messages.h"
 #include "brave/components/brave_sync/tools.h"
@@ -41,9 +42,9 @@ class ScopedPauseObserver {
 const char kDeletedBookmarksTitle[] = "Deleted Bookmarks";
 const char kPendingBookmarksTitle[] = "Pending Bookmarks";
 
-std::unique_ptr<bookmarks::BookmarkPermanentNode>
+std::unique_ptr<brave_sync::BraveBookmarkPermanentNode>
     MakePermanentNode(const std::string& title, int64_t* next_node_id) {
-  auto node = std::make_unique<bookmarks::BookmarkPermanentNode>(*next_node_id);
+  auto node = std::make_unique<brave_sync::BraveBookmarkPermanentNode>(*next_node_id);
   (*next_node_id)++;
   node->set_type(bookmarks::BookmarkNode::FOLDER);
   node->set_visible(false);
@@ -533,8 +534,6 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
         const BookmarkNode* bookmark_bar = bookmark_model_->bookmark_bar_node();
         bool bookmark_bar_was_empty = bookmark_bar->empty();
 
-        // TODO(alexeyb): use manual add node/folder to avoid model's observers
-        // invocation leading "Pending bookmarks" to be shown
         if (bookmark_record.isFolder) {
           node = bookmark_model_->AddFolder(
                           parent_node,
@@ -604,8 +603,6 @@ void BookmarkChangeProcessor::CompletePendingNodesMove(
     const auto& order = std::get<1>(move_info);
     int64_t index = GetIndexByOrder(created_folder_node, order);
 
-    // TODO(alexeyb): use manual move to avoid model observer invocation
-    // leading "Pending bookmarks" to get shown
     bookmark_model_->Move(node, created_folder_node, index);
     // Now we dont need "parent_object_id" metainfo on node, because node
     // is attached to proper parent. Note that parent can still be a child

--- a/components/brave_sync/client/bookmark_change_processor.h
+++ b/components/brave_sync/client/bookmark_change_processor.h
@@ -80,6 +80,7 @@ class BookmarkChangeProcessor : public ChangeProcessor,
   std::unique_ptr<jslib::SyncRecord> BookmarkNodeToSyncBookmark(
       const bookmarks::BookmarkNode* node);
   bookmarks::BookmarkNode* GetDeletedNodeRoot();
+  bookmarks::BookmarkNode* GetPendingNodeRoot();
   void CloneBookmarkNodeForDeleteImpl(
       const bookmarks::BookmarkNodeData::Element& element,
       bookmarks::BookmarkNode* parent,
@@ -92,12 +93,16 @@ class BookmarkChangeProcessor : public ChangeProcessor,
   // "Other Bookmarks" so we need to explicitly delete children
   void DeleteSelfAndChildren(const bookmarks::BookmarkNode* node);
 
+  void CompletePendingNodesMove(const bookmarks::BookmarkNode* folder_node,
+      const std::string& object_id);
+
   BraveSyncClient* sync_client_;  // not owned
   prefs::Prefs* sync_prefs_;  // not owned
   Profile* profile_; // not owned
   bookmarks::BookmarkModel* bookmark_model_;  // not owned
 
   bookmarks::BookmarkNode* deleted_node_root_;
+  bookmarks::BookmarkNode* pending_node_root_;
 
   DISALLOW_COPY_AND_ASSIGN(BookmarkChangeProcessor);
 };

--- a/components/brave_sync/client/bookmark_change_processor.h
+++ b/components/brave_sync/client/bookmark_change_processor.h
@@ -93,8 +93,9 @@ class BookmarkChangeProcessor : public ChangeProcessor,
   // "Other Bookmarks" so we need to explicitly delete children
   void DeleteSelfAndChildren(const bookmarks::BookmarkNode* node);
 
-  void CompletePendingNodesMove(const bookmarks::BookmarkNode* folder_node,
-      const std::string& object_id);
+  void CompletePendingNodesMove(
+      const bookmarks::BookmarkNode* created_folder_node,
+      const std::string& created_folder_object_id);
 
   BraveSyncClient* sync_client_;  // not owned
   prefs::Prefs* sync_prefs_;  // not owned

--- a/components/brave_sync/client/bookmark_change_processor.h
+++ b/components/brave_sync/client/bookmark_change_processor.h
@@ -17,6 +17,8 @@
 #include "components/bookmarks/browser/bookmark_node.h"
 #include "components/bookmarks/browser/bookmark_node_data.h"
 
+class BraveBookmarkChangeProcessorTest;
+
 namespace brave_sync {
 
 class BookmarkChangeProcessor : public ChangeProcessor,
@@ -40,6 +42,8 @@ class BookmarkChangeProcessor : public ChangeProcessor,
   void InitialSync() override;
 
  private:
+  friend class ::BraveBookmarkChangeProcessorTest;
+
   BookmarkChangeProcessor(Profile* profile,
                           BraveSyncClient* sync_client,
                           prefs::Prefs* sync_prefs);

--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -978,3 +978,178 @@ TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolderAgressive) {
   const auto* node_b = folder3->GetChild(1);
   EXPECT_EQ(node_b->url().spec(), "https://b.com/");
 }
+
+TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolderRequireStrictSorting) {
+  // Send these:
+  // Other
+  // +--0-1.com              1.1.1.1
+  // +--Folder1              1.1.1.2
+  // |  +--1-1.com           1.1.1.2.1
+  // |  +--Folder2           1.1.1.2.2
+  // |  |  +--2-1.com        1.1.1.2.2.1
+  // |  |  +--Folder3        1.1.1.2.2.2
+  // |  |  |  +--a.com       1.1.1.2.2.2.1
+  // |  |  |  +--b.com       1.1.1.2.2.2.2
+  // |  |  +--2-2.com        1.1.1.2.2.3
+  // |  |  +--2-3.com        1.1.1.2.2.4
+  // |  +--1-2.com           1.1.1.2.3
+  // +--0-2.com              1.1.1.3
+  //
+  // In an order:
+  //    Folder2, 2-1.com, Folder3, a.com, b.com
+  //    2-3.com, 2-2.com, 1-2.com
+  //    Folder1, 0-1.com, 0-2.com, 1-1.com
+  // Then verify in a model
+
+  change_processor()->Start();
+
+  auto folder1_record = SimpleFolderSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "Folder1",
+      "1.1.1.2",
+      "", true, "");
+
+  auto folder2_record = SimpleFolderSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "Folder2",
+      "1.1.1.2.2",
+      folder1_record->objectId,
+      true, "");
+
+  auto folder3_record = SimpleFolderSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "Folder3",
+      "1.1.1.2.2.2",
+      folder2_record->objectId,
+      true, "");
+
+  auto _0_1_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://0-1.com/",
+      "0-1.com - title",
+      "1.1.1.1",
+      "");
+  auto _0_2_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://0-2.com/",
+      "0-2.com - title",
+      "1.1.1.3",
+      "");
+
+  auto _1_1_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://1-1.com/",
+      "1-1.com - title",
+      "1.1.1.2.1",
+      folder1_record->objectId);
+  auto _1_2_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://1-2.com/",
+      "1-2.com - title",
+      "1.1.1.2.3",
+      folder1_record->objectId);
+
+  auto _2_1_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://2-1.com/",
+      "2-1.com - title",
+      "1.1.1.2.2.1",
+      folder2_record->objectId);
+  auto _2_2_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://2-2.com/",
+      "2-2.com - title",
+      "1.1.1.2.2.3",
+      folder2_record->objectId);
+  auto _2_3_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://2-3.com/",
+      "2-3.com - title",
+      "1.1.1.2.2.4",
+      folder2_record->objectId);
+
+  auto a_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://a.com/",
+      "A.com - title",
+      "1.1.1.1.1.1.1",
+      folder3_record->objectId);
+
+  auto b_record = SimpleBookmarkSyncRecord(
+      jslib::SyncRecord::Action::A_CREATE,
+      "",
+      "https://b.com/",
+      "B.com - title",
+      "1.1.1.1.1.1.2",
+      folder3_record->objectId);
+
+  // Send in an order
+  {
+    RecordsList records1;
+    records1.push_back(std::move(folder2_record));
+    records1.push_back(std::move(_2_1_record));
+    records1.push_back(std::move(folder3_record));
+    records1.push_back(std::move(a_record));
+    records1.push_back(std::move(b_record));
+    change_processor()->ApplyChangesFromSyncModel(records1);
+  }
+
+  {
+    RecordsList records2;
+    // 2-3 before 2-2 is important
+    records2.push_back(std::move(_2_3_record));
+    records2.push_back(std::move(_2_2_record));
+    records2.push_back(std::move(_1_2_record));
+    change_processor()->ApplyChangesFromSyncModel(records2);
+  }
+
+  {
+    RecordsList records3;
+    records3.push_back(std::move(folder1_record));
+    records3.push_back(std::move(_0_1_record));
+    records3.push_back(std::move(_0_2_record));
+    records3.push_back(std::move(_1_1_record));
+
+    change_processor()->ApplyChangesFromSyncModel(records3);
+  }
+
+  // Verify now all is as expected
+  ASSERT_EQ(model()->other_node()->child_count(), 3);
+  const auto* node_0_1 = model()->other_node()->GetChild(0);
+  EXPECT_EQ(node_0_1->url().spec(), "https://0-1.com/");
+  const auto* folder1 = model()->other_node()->GetChild(1);
+  EXPECT_EQ(base::UTF16ToUTF8(folder1->GetTitle()), "Folder1");
+  const auto* node_0_2 = model()->other_node()->GetChild(2);
+  EXPECT_EQ(node_0_2->url().spec(), "https://0-2.com/");
+
+  ASSERT_EQ(folder1->child_count(), 3);
+  const auto* node_1_1 = folder1->GetChild(0);
+  EXPECT_EQ(node_1_1->url().spec(), "https://1-1.com/");
+  const auto* folder2 = folder1->GetChild(1);
+  EXPECT_EQ(base::UTF16ToUTF8(folder2->GetTitle()), "Folder2");
+  const auto* node_1_2 = folder1->GetChild(2);
+  EXPECT_EQ(node_1_2->url().spec(), "https://1-2.com/");
+
+  ASSERT_EQ(folder2->child_count(), 4);
+  const auto* node_2_1 = folder2->GetChild(0);
+  EXPECT_EQ(node_2_1->url().spec(), "https://2-1.com/");
+  const auto* folder3 = folder2->GetChild(1);
+  EXPECT_EQ(base::UTF16ToUTF8(folder3->GetTitle()), "Folder3");
+  // Below fails if GetIndex uses tree iteartor
+  const auto* node_2_2 = folder2->GetChild(2);
+  EXPECT_EQ(node_2_2->url().spec(), "https://2-2.com/");
+
+  ASSERT_EQ(folder3->child_count(), 2);
+  const auto* node_a = folder3->GetChild(0);
+  EXPECT_EQ(node_a->url().spec(), "https://a.com/");
+  const auto* node_b = folder3->GetChild(1);
+  EXPECT_EQ(node_b->url().spec(), "https://b.com/");
+}

--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -135,6 +135,14 @@ class BraveBookmarkChangeProcessorTest : public testing::Test {
   brave_sync::BookmarkChangeProcessor* change_processor() {
     return change_processor_.get();
   }
+  const bookmarks::BookmarkPermanentNode* GetDeletedNodeRoot() {
+    return static_cast<const bookmarks::BookmarkPermanentNode*>(
+              change_processor_->GetDeletedNodeRoot());
+  }
+  const bookmarks::BookmarkPermanentNode* GetPendingNodeRoot() {
+    return static_cast<const bookmarks::BookmarkPermanentNode*>(
+              change_processor_->GetPendingNodeRoot());
+  }
 
   void BookmarkAddedImpl();
   void BookmarkCreatedFromSyncImpl();
@@ -296,6 +304,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, BookmarkDeleted) {
       ContainsRecord(SyncRecord::Action::A_DELETE, "https://a.com/"))).Times(1);
   model()->Remove(nodes.at(0));
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
+  EXPECT_FALSE(GetDeletedNodeRoot()->IsVisible());
 }
 
 TEST_F(BraveBookmarkChangeProcessorTest, BookmarkModified) {
@@ -862,6 +871,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolder) {
   EXPECT_EQ(node_a->url().spec(), "https://a.com/");
   const auto* node_b = folder1->GetChild(1);
   EXPECT_EQ(node_b->url().spec(), "https://b.com/");
+  EXPECT_FALSE(GetPendingNodeRoot()->IsVisible());
 }
 
 TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolderAgressive) {
@@ -977,6 +987,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolderAgressive) {
   EXPECT_EQ(node_a->url().spec(), "https://a.com/");
   const auto* node_b = folder3->GetChild(1);
   EXPECT_EQ(node_b->url().spec(), "https://b.com/");
+  EXPECT_FALSE(GetPendingNodeRoot()->IsVisible());
 }
 
 TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolderRequireStrictSorting) {
@@ -1152,4 +1163,5 @@ TEST_F(BraveBookmarkChangeProcessorTest, ItemAheadOfFolderRequireStrictSorting) 
   EXPECT_EQ(node_a->url().spec(), "https://a.com/");
   const auto* node_b = folder3->GetChild(1);
   EXPECT_EQ(node_b->url().spec(), "https://b.com/");
+  EXPECT_FALSE(GetPendingNodeRoot()->IsVisible());
 }

--- a/components/brave_sync/client/bookmark_node.cc
+++ b/components/brave_sync/client/bookmark_node.cc
@@ -1,0 +1,14 @@
+#include "brave/components/brave_sync/client/bookmark_node.h"
+
+namespace brave_sync {
+
+BraveBookmarkPermanentNode::BraveBookmarkPermanentNode(int64_t id)
+    : bookmarks::BookmarkPermanentNode(id) {}
+
+BraveBookmarkPermanentNode::~BraveBookmarkPermanentNode() = default;
+
+bool BraveBookmarkPermanentNode::IsVisible() const {
+  return visible_;
+}
+
+}  // namespace brave_sync

--- a/components/brave_sync/client/bookmark_node.h
+++ b/components/brave_sync/client/bookmark_node.h
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_CLIENT_BOOKMARK_NODE_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_CLIENT_BOOKMARK_NODE_H_
+
+#include "components/bookmarks/browser/bookmark_node.h"
+
+namespace brave_sync {
+
+// Sync Managed PerrmanentNode
+class BraveBookmarkPermanentNode : public bookmarks::BookmarkPermanentNode {
+ public:
+  explicit BraveBookmarkPermanentNode(int64_t id);
+  ~BraveBookmarkPermanentNode() override;
+
+  void set_visible(bool value) { visible_ = value; }
+
+  // BookmarkNode overrides:
+  bool IsVisible() const override;
+
+ private:
+  bool visible_ = false;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveBookmarkPermanentNode);
+};
+
+}  // namespace brave_sync
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_CLIENT_BOOKMARK_NODE_H_

--- a/components/brave_sync/test_util.cc
+++ b/components/brave_sync/test_util.cc
@@ -17,6 +17,21 @@
 #include "components/sync_preferences/pref_service_mock_factory.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 
+namespace {
+
+using namespace bookmarks;
+
+void AddPermanentNode(BookmarkPermanentNodeList* extra_nodes, int64_t id,
+      const std::string& title) {
+  auto node = std::make_unique<BookmarkPermanentNode>(id);
+  node->set_type(bookmarks::BookmarkNode::FOLDER);
+  node->set_visible(false);
+  node->SetTitle(base::UTF8ToUTF16(title));
+  extra_nodes->push_back(std::move(node));
+}
+
+}  // namespace
+
 namespace brave_sync {
 
 MockBraveSyncClient::MockBraveSyncClient() {}
@@ -45,13 +60,10 @@ std::unique_ptr<KeyedService> BuildFakeBookmarkModelForTests(
   std::unique_ptr<TestBookmarkClient> client(new TestBookmarkClient());
   BookmarkPermanentNodeList extra_nodes;
 
-  auto node = std::make_unique<BookmarkPermanentNode>(0xDE1E7ED40DE);
-  node->set_type(bookmarks::BookmarkNode::FOLDER);
-  node->set_visible(false);
-  // This is hard-coded title and cannot be changed
-  node->SetTitle(base::UTF8ToUTF16("Deleted Bookmarks"));
+  // These hard-coded titles cannot be changed
+  AddPermanentNode(&extra_nodes, 0xDE1E7ED40DE, "Deleted Bookmarks");
+  AddPermanentNode(&extra_nodes, 0x9E7D17640DE, "Pending Bookmarks");
 
-  extra_nodes.push_back(std::move(node));
   client->SetExtraNodesToLoad(std::move(extra_nodes));
   std::unique_ptr<BookmarkModel> model(
       TestBookmarkClient::CreateModelWithClient(std::move(client)));
@@ -147,6 +159,5 @@ SyncRecordPtr SimpleDeviceRecord(
 
   return record;
 }
-
 
 }  // namespace

--- a/components/brave_sync/test_util.cc
+++ b/components/brave_sync/test_util.cc
@@ -7,6 +7,7 @@
 #include "base/files/file_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_sync/brave_sync_service_factory.h"
+#include "brave/components/brave_sync/client/bookmark_node.h"
 #include "brave/components/brave_sync/tools.h"
 #include "brave/components/brave_sync/values_conv.h"
 #include "chrome/browser/prefs/browser_prefs.h"
@@ -23,7 +24,7 @@ using namespace bookmarks;
 
 void AddPermanentNode(BookmarkPermanentNodeList* extra_nodes, int64_t id,
       const std::string& title) {
-  auto node = std::make_unique<BookmarkPermanentNode>(id);
+  auto node = std::make_unique<brave_sync::BraveBookmarkPermanentNode>(id);
   node->set_type(bookmarks::BookmarkNode::FOLDER);
   node->set_visible(false);
   node->SetTitle(base::UTF8ToUTF16(title));


### PR DESCRIPTION
Things done in PR:
1) Orphaned bookmarks are placed to `Pending Bookmarks` folder and moved into actual parent folder once it arrived;
2) `Pending Bookmarks` and `Deleted Bookmarks` folder is hidden by `BraveBookmarkPermanentNode`
3) Fixed sorting issue of bookmarks tree with a lot of mixed child items/folder;
4) Added unit tests.

Fixes https://github.com/brave/brave-browser/issues/2133

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Manual is described in https://github.com/brave/brave-browser/issues/2133 .
Auto tests: ``` npm run test -- brave_unit_tests --filter=BraveBookmarkChangeProcessorTest.ItemAheadOfFolder:BraveBookmarkChangeProcessorTest.ItemAheadOfFolderAgressive:BraveBookmarkChangeProcessorTest.ItemAheadOfFolderRequireStrictSorting```


## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source