### PR TITLE
Revert rewards observer change

### DIFF
--- a/browser/importer/brave_profile_writer.cc
+++ b/browser/importer/brave_profile_writer.cc
@@ -131,7 +131,7 @@ void BraveProfileWriter::OnWalletBackupComplete(bool result) {
 void BraveProfileWriter::OnWalletProperties(
   brave_rewards::RewardsService* rewards_service,
   int error_code,
-  brave_rewards::WalletProperties* properties) {
+  std::unique_ptr<brave_rewards::WalletProperties> properties) {
   // Avoid overwriting Brave Rewards wallet if:
   // - it existed BEFORE import happened
   // - it has a non-zero balance

--- a/browser/importer/brave_profile_writer.h
+++ b/browser/importer/brave_profile_writer.h
@@ -34,9 +34,10 @@ class BraveProfileWriter : public ProfileWriter,
                        unsigned int result,
                        double balance,
                        std::vector<brave_rewards::Grant> grants) override;
-  void OnWalletProperties(brave_rewards::RewardsService* rewards_service,
-                          int error_code,
-                          brave_rewards::WalletProperties* properties) override;
+  void OnWalletProperties(
+      brave_rewards::RewardsService* rewards_service,
+      int error_code,
+      std::unique_ptr<brave_rewards::WalletProperties> properties) override;
 
  protected:
   friend class base::RefCountedThreadSafe<BraveProfileWriter>;

--- a/browser/ui/webui/brave_donate_ui.cc
+++ b/browser/ui/webui/brave_donate_ui.cc
@@ -8,7 +8,6 @@
 #include "brave/browser/ui/webui/basic_ui.h"
 #include "brave/common/pref_names.h"
 #include "brave/common/webui_url_constants.h"
-#include "brave/components/brave_rewards/browser/wallet_properties.h"
 #include "brave/components/brave_rewards/resources/grit/brave_rewards_resources.h"
 #include "brave/components/brave_rewards/resources/grit/brave_donate_generated_map.h"
 #include "chrome/browser/profiles/profile.h"
@@ -49,10 +48,9 @@ private:
   void GetRecurringDonations(const base::ListValue* args);
 
   // RewardsServiceObserver implementation
-  void OnWalletProperties(
-      brave_rewards::RewardsService* rewards_service,
+  void OnWalletProperties(brave_rewards::RewardsService* rewards_service,
       int error_code,
-      brave_rewards::WalletProperties* wallet_properties) override;
+      std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) override;
   void OnRecurringDonationUpdated(brave_rewards::RewardsService* rewards_service,
                                   brave_rewards::ContentSiteList) override;
   void OnPublisherBanner(brave_rewards::RewardsService* rewards_service,
@@ -107,7 +105,7 @@ void RewardsDonateDOMHandler::GetWalletProperties(const base::ListValue* args) {
 void RewardsDonateDOMHandler::OnWalletProperties(
     brave_rewards::RewardsService* rewards_service,
     int error_code,
-    brave_rewards::WalletProperties* wallet_properties) {
+    std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) {
 
   if (!web_ui()->CanCallJavascript()) {
     return;

--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -76,10 +76,9 @@ class RewardsDOMHandler : public WebUIMessageHandler,
   // RewardsServiceObserver implementation
   void OnWalletInitialized(brave_rewards::RewardsService* rewards_service,
                        int error_code) override;
-  void OnWalletProperties(
-      brave_rewards::RewardsService* rewards_service,
+  void OnWalletProperties(brave_rewards::RewardsService* rewards_service,
       int error_code,
-      brave_rewards::WalletProperties* wallet_properties) override;
+      std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) override;
   void OnGrant(brave_rewards::RewardsService* rewards_service,
                    unsigned int error_code,
                    brave_rewards::Grant result) override;
@@ -258,7 +257,7 @@ void RewardsDOMHandler::OnWalletInitialized(
 void RewardsDOMHandler::OnWalletProperties(
     brave_rewards::RewardsService* rewards_service,
     int error_code,
-    brave_rewards::WalletProperties* wallet_properties) {
+    std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) {
 
   if (web_ui()->CanCallJavascript()) {
     base::DictionaryValue result;

--- a/components/brave_rewards/browser/extension_rewards_service_observer.cc
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.cc
@@ -4,10 +4,8 @@
 
 #include "brave/components/brave_rewards/browser/extension_rewards_service_observer.h"
 
-#include "bat/ledger/publisher_info.h"
 #include "brave/common/extensions/api/brave_rewards.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
-#include "brave/components/brave_rewards/browser/wallet_properties.h"
 #include "chrome/browser/profiles/profile.h"
 #include "extensions/browser/event_router.h"
 
@@ -39,7 +37,7 @@ void ExtensionRewardsServiceObserver::OnWalletInitialized(
 void ExtensionRewardsServiceObserver::OnWalletProperties(
     RewardsService* rewards_service,
     int error_code,
-    brave_rewards::WalletProperties* wallet_properties) {
+    std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) {
   extensions::EventRouter* event_router =
       extensions::EventRouter::Get(profile_);
   if (event_router && wallet_properties) {
@@ -107,7 +105,7 @@ void ExtensionRewardsServiceObserver::OnGetCurrentBalanceReport(
 void ExtensionRewardsServiceObserver::OnGetPublisherActivityFromUrl(
     RewardsService* rewards_service,
     int error_code,
-    ledger::PublisherInfo* info,
+    std::unique_ptr<ledger::PublisherInfo> info,
     uint64_t windowId) {
   extensions::EventRouter* event_router =
       extensions::EventRouter::Get(profile_);
@@ -116,6 +114,11 @@ void ExtensionRewardsServiceObserver::OnGetPublisherActivityFromUrl(
   }
 
   extensions::api::brave_rewards::OnPublisherData::Publisher publisher;
+
+  if (!info.get()) {
+    info.reset(new ledger::PublisherInfo());
+    info->id = "";
+  }
 
   publisher.percentage = info->percent;
   publisher.verified = info->verified;

--- a/components/brave_rewards/browser/extension_rewards_service_observer.h
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.h
@@ -26,18 +26,19 @@ class ExtensionRewardsServiceObserver : public RewardsServiceObserver,
   // RewardsServiceObserver implementation
   void OnWalletInitialized(RewardsService* rewards_service,
                            int error_code) override;
-  void OnWalletProperties(
-      RewardsService* rewards_service,
-      int error_code,
-      brave_rewards::WalletProperties* wallet_properties) override;
-  void OnGetPublisherActivityFromUrl(RewardsService* rewards_service,
-                                     int error_code,
-                                     ledger::PublisherInfo* info,
-                                     uint64_t windowId) override;
+  void OnWalletProperties(RewardsService* rewards_service,
+                          int error_code,
+                          std::unique_ptr<brave_rewards::WalletProperties>
+                              wallet_properties) override;
 
   // RewardsServicePrivateObserver implementation
   void OnGetCurrentBalanceReport(RewardsService* rewards_service,
                                  const BalanceReport& balance_report) override;
+  void OnGetPublisherActivityFromUrl(
+      RewardsService* rewards_service,
+      int error_code,
+      std::unique_ptr<ledger::PublisherInfo> info,
+      uint64_t windowId) override;
 
  private:
   Profile* profile_;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -951,7 +951,7 @@ void RewardsServiceImpl::TriggerOnWalletProperties(int error_code,
     }
 
     // webui
-    observer.OnWalletProperties(this, error_code, wallet_properties.get());
+    observer.OnWalletProperties(this, error_code, std::move(wallet_properties));
   }
 }
 
@@ -1561,12 +1561,9 @@ void RewardsServiceImpl::TriggerOnGetPublisherActivityFromUrl(
     ledger::Result result,
     std::unique_ptr<ledger::PublisherInfo> info,
     uint64_t windowId) {
-  if (!info) {
-    info.reset(new ledger::PublisherInfo());
-    info->id = "";
-  }
-  for (auto& observer : observers_)
-    observer.OnGetPublisherActivityFromUrl(this, result, info.get(), windowId);
+  for (auto& observer : private_observers_)
+    observer.OnGetPublisherActivityFromUrl(this, result, std::move(info),
+                                           windowId);
 }
 
 void RewardsServiceImpl::SetContributionAutoInclude(std::string publisher_key,

--- a/components/brave_rewards/browser/rewards_service_impl_unittest.cc
+++ b/components/brave_rewards/browser/rewards_service_impl_unittest.cc
@@ -20,7 +20,7 @@ class MockRewardsServiceObserver : public RewardsServiceObserver {
  public:
   MockRewardsServiceObserver() {}
   MOCK_METHOD2(OnWalletInitialized, void(RewardsService*, int));
-  MOCK_METHOD3(OnWalletProperties, void(RewardsService*, int, brave_rewards::WalletProperties*));
+  MOCK_METHOD3(OnWalletProperties, void(RewardsService*, int, std::unique_ptr<brave_rewards::WalletProperties>));
   MOCK_METHOD3(OnGrant, void(RewardsService*, unsigned int, brave_rewards::Grant));
   MOCK_METHOD3(OnGrantCaptcha, void(RewardsService*, std::string, std::string));
   MOCK_METHOD4(OnRecoverWallet, void(RewardsService*, unsigned int, double, std::vector<brave_rewards::Grant>));

--- a/components/brave_rewards/browser/rewards_service_observer.h
+++ b/components/brave_rewards/browser/rewards_service_observer.h
@@ -2,22 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_REWARDS_SERVICE_OBSERVER_H_
-#define BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_REWARDS_SERVICE_OBSERVER_H_
+#ifndef BRAVE_BROWSER_PAYMENTS_PAYMENTS_SERVICE_OBSERVER_H_
+#define BRAVE_BROWSER_PAYMENTS_PAYMENTS_SERVICE_OBSERVER_H_
 
 #include "base/observer_list_types.h"
 #include "brave/components/brave_rewards/browser/content_site.h"
 #include "brave/components/brave_rewards/browser/grant.h"
 #include "brave/components/brave_rewards/browser/publisher_banner.h"
-
-namespace ledger {
-struct PublisherInfo;
-}
+#include "brave/components/brave_rewards/browser/wallet_properties.h"
 
 namespace brave_rewards {
 
 class RewardsService;
-struct WalletProperties;
 
 class RewardsServiceObserver : public base::CheckedObserver {
  public:
@@ -28,7 +24,7 @@ class RewardsServiceObserver : public base::CheckedObserver {
   virtual void OnWalletProperties(
       RewardsService* rewards_service,
       int error_code,
-      brave_rewards::WalletProperties* properties) {};
+      std::unique_ptr<brave_rewards::WalletProperties> properties) {};
   virtual void OnGrant(RewardsService* rewards_service,
                            unsigned int error_code,
                            brave_rewards::Grant properties) {};
@@ -54,13 +50,8 @@ class RewardsServiceObserver : public base::CheckedObserver {
                              brave_rewards::ContentSiteList) {};
   virtual void OnPublisherBanner(brave_rewards::RewardsService* rewards_service,
                                  const brave_rewards::PublisherBanner banner) {};
-  virtual void OnGetPublisherActivityFromUrl(
-      brave_rewards::RewardsService* rewards_service,
-      int error_code,
-      ledger::PublisherInfo* info,
-      uint64_t windowId) {};
 };
 
 }  // namespace brave_rewards
 
-#endif  // BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_REWARDS_SERVICE_OBSERVER_H_
+#endif  // BRAVE_BROWSER_PAYMENTS_PAYMENTS_SERVICE_OBSERVER_H_

--- a/components/brave_rewards/browser/rewards_service_private_observer.h
+++ b/components/brave_rewards/browser/rewards_service_private_observer.h
@@ -6,6 +6,7 @@
 #define BRAVE_BROWSER_PAYMENTS_PAYMENTS_SERVICE_PRIVATE_OBSERVER_H_
 
 #include "base/observer_list_types.h"
+#include "bat/ledger/publisher_info.h"
 
 namespace brave_rewards {
 
@@ -18,6 +19,11 @@ class RewardsServicePrivateObserver : public base::CheckedObserver {
 
   virtual void OnGetCurrentBalanceReport(RewardsService* rewards_service,
                                          const BalanceReport& balance_report) {}
+  virtual void OnGetPublisherActivityFromUrl(
+      RewardsService* rewards_service,
+      int error_code,
+      std::unique_ptr<ledger::PublisherInfo> info,
+      uint64_t windowId) {}
 };
 
 }  // namespace brave_rewards


### PR DESCRIPTION
This reverts a recent change that moved `OnGetPublisherActivityFromUrl` from a private observer into a public observer. Although Android needs access to that function, we can't expose ledger types in the Rewards public API.

Associated with brave/brave-browser#2019

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source