### PR TITLE
Add rewards notification for insufficient funds

### DIFF
--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -39,5 +39,6 @@ const char kRewardsBackupNotificationInterval[] =
     "brave.rewards.backup_notification_interval";
 const char kRewardsBackupSucceeded[] = "brave.rewards.backup_succeeded";
 const char kRewardsUserHasFunded[] = "brave.rewards.user_has_funded";
+const char kRewardsAddFundsNotification[] = "brave.rewards.add_funds_notification";
 const char kMigratedMuonProfile[] = "brave.muon.migrated_profile";
 const char kBravePaymentsPinnedItemCount[] = "brave.muon.import_pinned_item_count";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -36,6 +36,7 @@ extern const char kRewardsBackupNotificationFrequency[];
 extern const char kRewardsBackupNotificationInterval[];
 extern const char kRewardsBackupSucceeded[];
 extern const char kRewardsUserHasFunded[];
+extern const char kRewardsAddFundsNotification[];
 extern const char kMigratedMuonProfile[];
 extern const char kBravePaymentsPinnedItemCount[];
 

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -50,6 +50,7 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
                                   base::TimeDelta::FromDays(7));
   registry->RegisterBooleanPref(kRewardsBackupSucceeded, false);
   registry->RegisterBooleanPref(kRewardsUserHasFunded, false);
+  registry->RegisterTimePref(kRewardsAddFundsNotification, base::Time());
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -202,6 +202,7 @@ class RewardsServiceImpl : public RewardsService,
       std::unique_ptr<ledger::PublisherInfo> info,
       uint64_t windowId);
   void MaybeShowBackupNotification();
+  void MaybeShowAddFundsNotification();
 
   // ledger::LedgerClient
   std::string GenerateGUID() const override;
@@ -289,6 +290,10 @@ class RewardsServiceImpl : public RewardsService,
   void StartNotificationTimers();
   void StopNotificationTimers();
   void OnNotificationTimerFired();
+
+  bool HasSufficientBalanceToReconcile() const;
+  bool ShouldShowNotificationAddFunds() const;
+  void ShowNotificationAddFunds();
 
   Profile* profile_;  // NOT OWNED
   std::unique_ptr<ledger::Ledger> ledger_;

--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -189,6 +189,14 @@
     "message": "Please backup your Brave wallet.",
     "description": "Description for backup wallet notification"
   },
+  "insufficientFundsNotification": {
+    "message": "Your Brave Payments account is waiting for a deposit.",
+    "description": "Description for new insufficient funds notification"
+  },
+  "insufficientFunds": {
+    "message": "Insufficient Funds",
+    "description": "Title for insufficient funds notification"
+  },
   "braveRewardsCreatingText": {
     "message": "Creating wallet",
     "description": "Used in a button displaying wallet creation process"

--- a/components/brave_rewards/resources/extension/brave_rewards/background/api/locale_api.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/api/locale_api.ts
@@ -36,6 +36,8 @@ export const getUIMessages = (): Record<string, string> => {
     'for',
     'grants',
     'includeInAuto',
+    'insufficientFunds',
+    'insufficientFundsNotification',
     'monthApr',
     'monthAug',
     'monthDec',

--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -9,6 +9,7 @@ import { WalletAddIcon, BatColorIcon } from 'brave-ui/components/icons'
 import { WalletWrapper, WalletSummary, WalletSummarySlider, WalletPanel } from 'brave-ui/features/rewards'
 import { Provider } from 'brave-ui/features/rewards/profile'
 import { NotificationType } from 'brave-ui/features/rewards/walletWrapper'
+import { RewardsNotificationType } from '../constants/rewards_panel_types'
 import { Type as AlertType } from 'brave-ui/features/rewards/alert'
 
 // Utils
@@ -192,18 +193,6 @@ export class Panel extends React.Component<Props, State> {
 
     const notification: RewardsExtension.Notification = notifications[currentNotification]
 
-    // Note: This declaration must match the RewardsNotificationType enum in
-    // brave/components/brave_rewards/browser/rewards_notification_service.h
-    enum RewardsNotificationType {
-      REWARDS_NOTIFICATION_INVALID = 0,
-      REWARDS_NOTIFICATION_AUTO_CONTRIBUTE,
-      REWARDS_NOTIFICATION_GRANT,
-      REWARDS_NOTIFICATION_FAILED_CONTRIBUTION,
-      REWARDS_NOTIFICATION_IMPENDING_CONTRIBUTION,
-      REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS,
-      REWARDS_NOTIFICATION_BACKUP_WALLET,
-    }
-
     let type: NotificationType = ''
     let text = ''
     let isAlert = ''
@@ -247,6 +236,10 @@ export class Panel extends React.Component<Props, State> {
       case RewardsNotificationType.REWARDS_NOTIFICATION_BACKUP_WALLET:
         type = 'backupWallet'
         text = getMessage('backupWalletNotification')
+        break
+      case RewardsNotificationType.REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS:
+        type = 'insufficientFunds'
+        text = getMessage('insufficientFundsNotification')
         break
       default:
         type = ''

--- a/components/brave_rewards/resources/extension/brave_rewards/constants/rewards_panel_types.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/constants/rewards_panel_types.ts
@@ -19,3 +19,15 @@ export const enum types {
   INCLUDE_IN_AUTO_CONTRIBUTION = '@@rewards_panel/INCLUDE_IN_AUTO_CONTRIBUTION',
   GET_GRANT = '@@rewards_panel/GET_GRANT'
 }
+
+// Note: This declaration must match the RewardsNotificationType enum in
+// brave/components/brave_rewards/browser/rewards_notification_service.h
+export const enum RewardsNotificationType {
+  REWARDS_NOTIFICATION_INVALID = 0,
+  REWARDS_NOTIFICATION_AUTO_CONTRIBUTE,
+  REWARDS_NOTIFICATION_GRANT,
+  REWARDS_NOTIFICATION_FAILED_CONTRIBUTION,
+  REWARDS_NOTIFICATION_IMPENDING_CONTRIBUTION,
+  REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS,
+  REWARDS_NOTIFICATION_BACKUP_WALLET,
+}


### PR DESCRIPTION
Fixes brave/brave-browser#1479
Requires brave/brave-ui#301

Notify the user about upcoming contribution when they don't have
enough funds to cover the donations. The notification occurs 3 days
before the contribution will be made.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Delete any existing profile
- Launch Brave
- Enable Rewards
- Ensure that existing balance is less than contribution amount
- Wait > 1 day (every day, we check if notifications need to be displayed)
- Rewards icon should be badged and should contain a notification like this:

![image](https://user-images.githubusercontent.com/5033691/49309907-c6b26d80-f4aa-11e8-878d-d92dcbb3a8a2.png)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source