### PR TITLE
Fixes compilation and link error.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ deps = {
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/omaha":  "https://github.com/brave/omaha.git@e4263050ed24e92f4d3ed0b6874538f811011c5b",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@807e0d9594a605e4378adaad9e139a18185b0313",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@16bfe91269ee2d97af25d2b32509915f0686d041",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -22,12 +22,13 @@
 #include "chrome/common/chrome_switches.h"
 #include "components/autofill/core/common/autofill_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
-#include "components/unified_consent/feature.h"
 #include "components/viz/common/features.h"
 #include "content/public/common/content_features.h"
 #include "extensions/common/extension_features.h"
 #include "gpu/config/gpu_finch_features.h"
 #include "ui/base/ui_base_features.h"
+
+#include "components/unified_consent/feature.cc"
 
 #if !defined(CHROME_MULTIPLE_DLL_BROWSER)
 base::LazyInstance<BraveContentRendererClient>::DestructorAtExit


### PR DESCRIPTION
Added components/unified_consent/feature.cc as an include to
brave_main_delegate.cc. This is done because beave_main_delegate.cc is
pulled into chrome_main_delegate.cc via chromium_src and adding
dependency on /components/unified_conset everywhere
chrome_main_delegate.cc is used would introduce a lot of patches to the
build files.

Also updated DEPS for bat-native-ledger to incorporate brave-intl/bat-native-ledger#189

Fixes brave/brave-browser#2299

This is the same fix as brave/brave-core#990 for 0.57.x, but this one is meant for master/0.58.x/0.59.x.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source