### PR TITLE
CRLsets reintroduced

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -15,6 +15,12 @@ int OnBeforeURLRequest_StaticRedirectWork(
   GURL::Replacements replacements;
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS, kSafeBrowsingPrefix);
+  static URLPattern crlSet_pattern1(URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+    kCRLSetPrefix1);
+  static URLPattern crlSet_pattern2(URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+    kCRLSetPrefix2);
+  static URLPattern crxDownload_pattern(URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+    kCRXDownloadPrefix);
 
   if (geo_pattern.MatchesURL(ctx->request_url)) {
     ctx->new_url_spec = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY).spec();
@@ -23,6 +29,27 @@ int OnBeforeURLRequest_StaticRedirectWork(
 
   if (safeBrowsing_pattern.MatchesHost(ctx->request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crxDownload_pattern.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crxdownload.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern1.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets1.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern2.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets2.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
@@ -58,9 +85,16 @@ int OnBeforeURLRequest_StaticRedirectWork(
     URLPattern(URLPattern::SCHEME_HTTPS, "https://safebrowsing.brave.com/v4/*"),
     URLPattern(URLPattern::SCHEME_HTTPS, "https://ssl.gstatic.com/safebrowsing/*"),
 
+    //CRLSets
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets1.brave.com/*"),
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets2.brave.com/*"),
+
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crxdownload.brave.com/*"),
+
     // Will be removed when https://github.com/brave/brave-browser/issues/663 is fixed
     URLPattern(URLPattern::SCHEME_HTTPS, "https://www.gstatic.com/*"),
   });
+
   // Check to make sure the URL being requested matches at least one of the allowed patterns
   bool is_url_allowed = std::any_of(allowed_patterns.begin(), allowed_patterns.end(),
     [&gurl](URLPattern pattern) {

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -68,6 +68,70 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet1) {
+  net::TestDelegate test_delegate;
+  GURL url("https://dl.google.com/release2/chrome_component/AJ4r388iQSJq_4819/"
+    "4819_all_crl-set-5934829738003798040.data.crx3");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url("https://crlsets1.brave.com/release2/chrome_component/"
+    "AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret =
+      OnBeforeURLRequest_StaticRedirectWork(callback,
+                                            before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet2) {
+  net::TestDelegate test_delegate;
+  GURL url("https://r2---sn-8xgp1vo-qxoe.gvt1.com/edgedl/release2/chrome_compone"
+    "nt/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url("https://crlsets2.brave.com/edgedl/release2/chrome_compone"
+    "nt/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret =
+      OnBeforeURLRequest_StaticRedirectWork(callback,
+                                            before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRXDownload) {
+  net::TestDelegate test_delegate;
+  GURL url("https://clients2.googleusercontent.com/crx/blobs/QgAAAC6zw0qH2DJtn"
+    "Xe8Z7rUJP1RM6lX7kVcwkQ56ujmG3AWYOAkxoNnIdnEBUz_3z4keVhjzzAF10srsaL7lrntfB"
+    "IflcYIrTziwX3SUS9i_P-CAMZSmuV5tdQl-Roo6cnVC_GRzKsnZSKm1Q/extension_2_0_67"
+    "3_0.crx");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url("https://crxdownload.brave.com/crx/blobs/QgAAAC6"
+    "zw0qH2DJtnXe8Z7rUJP1RM6lX7kVcwkQ56ujmG3AWYOAkxoNnIdnEBUz_3z4keVhjzzAF10sr"
+    "saL7lrntfBIflcYIrTziwX3SUS9i_P-CAMZSmuV5tdQl-Roo6cnVC_GRzKsnZSKm1Q/extens"
+    "ion_2_0_673_0.crx");
+  int ret =
+      OnBeforeURLRequest_StaticRedirectWork(callback,
+                                            before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
   net::TestDelegate test_delegate;
   GURL url("https://safebrowsing.googleapis.com/v4/threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");

--- a/chromium_src/chrome/browser/component_updater/crl_set_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/crl_set_component_installer.cc
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define RegisterCRLSetComponent RegisterCRLSetComponent_ChromiumImpl
+#include "../../../../../chrome/browser/component_updater/crl_set_component_installer.cc"
+#undef  RegisterCRLSetComponent
+
+#include "brave/browser/extensions/brave_component_extension.h"
+#include "brave/common/extensions/extension_constants.h"
+#include "chrome/browser/browser_process.h"
+
+namespace component_updater {
+
+void OnCRLSetRegistered() {
+  ComponentsUI demand_updater;
+  demand_updater.OnDemandUpdate(g_browser_process->component_updater(),
+      crl_set_extension_id);
+}
+
+void RegisterCRLSetComponent(ComponentUpdateService* cus,
+                             const base::FilePath& user_data_dir) {
+  auto installer = base::MakeRefCounted<component_updater::ComponentInstaller>(
+      std::make_unique<CRLSetPolicy>());
+  installer->Register(g_browser_process->component_updater(),
+      base::Bind(&OnCRLSetRegistered));
+}
+
+}  // namespace component_updater

--- a/chromium_src/components/component_updater/configurator_impl.cc
+++ b/chromium_src/components/component_updater/configurator_impl.cc
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/component_updater/component_updater_url_constants.h"
+
+namespace component_updater {
+
+const char kBraveUpdaterDefaultUrl[] =
+    "https://componentupdater.brave.com/service/update2";
+
+const char kBraveUpdaterFallbackUrl[] =
+    "http://componentupdater.brave.com/service/update2";
+
+}  // namespace component_updater
+
+#define kUpdaterDefaultUrl kBraveUpdaterDefaultUrl
+#define kUpdaterFallbackUrl kBraveUpdaterFallbackUrl
+#include "../../../../components/component_updater/configurator_impl.cc"
+#undef kUpdaterDefaultUrl
+#undef kUpdaterFallbackUrl

--- a/common/extensions/extension_constants.cc
+++ b/common/extensions/extension_constants.cc
@@ -9,6 +9,7 @@ const char brave_rewards_extension_id[] = "jidkidbbcafjabdphckchenhfomhnfma";
 const char brave_webtorrent_extension_id[] = "lgjmpdmojkpocjcopdikifhejkkjglho";
 const char widevine_extension_id[] = "oimompecagnajdejgnnjijobebaeigek";
 const char brave_sync_extension_id[] = "nomlkjnggnifocmealianaaiobmebgil";
+const char crl_set_extension_id[] = "hfnkpimlhhgieaddgfemjhofmfblmnib";
 
 const char pdfjs_extension_id[] = "oemmndcbldboiebfnladdacbdfmadadm";
 const char pdfjs_extension_name[] = "PDF Viewer (PDF.js)";

--- a/common/extensions/extension_constants.h
+++ b/common/extensions/extension_constants.h
@@ -7,6 +7,7 @@ extern const char brave_rewards_extension_id[];
 extern const char brave_webtorrent_extension_id[];
 extern const char widevine_extension_id[];
 extern const char brave_sync_extension_id[];
+extern const char crl_set_extension_id[];
 
 extern const char pdfjs_extension_id[];
 extern const char pdfjs_extension_name[];

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -9,11 +9,14 @@ const char kBraveReferralsHeadersPath[] = "/promo/custom-headers";
 const char kBraveReferralsInitPath[] = "/promo/initialize/nonua";
 const char kBraveReferralsActivityPath[] = "/promo/activity";
 
+const char kCRXDownloadPrefix[] = "https://clients2.googleusercontent.com/crx/blobs/*crx*";
 const char kEmptyDataURI[] = "data:text/plain,";
 const char kEmptyImageDataURI[] = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 const char kJSDataURLPrefix[] = "data:application/javascript;base64,";
 const char kGeoLocationsPattern[] = "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kSafeBrowsingPrefix[] = "https://safebrowsing.googleapis.com/";
+const char kCRLSetPrefix1[] = "https://dl.google.com/release2/chrome_component/*crl-set*";
+const char kCRLSetPrefix2[] = "https://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
 const char kGoogleTagManagerPattern[] = "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] = "https://www.googletagservices.com/tag/js/gpt.js";
 const char kForbesPattern[] = "https://www.forbes.com/*";

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -8,6 +8,7 @@ extern const char kBraveReferralsHeadersPath[];
 extern const char kBraveReferralsInitPath[];
 extern const char kBraveReferralsActivityPath[];
 
+extern const char kCRXDownloadPrefix[];
 extern const char kEmptyDataURI[];
 extern const char kEmptyImageDataURI[];
 extern const char kJSDataURLPrefix[];
@@ -17,6 +18,8 @@ extern const char kGoogleTagServicesPattern[];
 extern const char kForbesPattern[];
 extern const char kForbesExtraCookies[];
 extern const char kSafeBrowsingPrefix[];
+extern const char kCRLSetPrefix1[];
+extern const char kCRLSetPrefix2[];
 extern const char kTwitterPattern[];
 extern const char kTwitterReferrer[];
 extern const char kTwitterRedirectURL[];


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/518
fix https://github.com/brave/brave-browser/issues/2160

CRLSets was reverted, this PR contains these changes:

1. https://github.com/brave/brave-core/pull/652
2. https://github.com/brave/brave-core/pull/920
3. Proxying requests for `update.googleapis.com` through `componentupdater.brave.com`
4. Proxying requests for `clients2.googleusercontent.com` through `crxdownload.brave.com`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
  1. Start Little Snitch or Fiddler and Brave
  2. Wait for ~2 mins and verify that there are no connections to *.gvt1.com, dl.google.com and update.googleapis.com, clients2.googleusercontent.com
  3. Navigate to `<data-dir>/CertificateRevocation/<dir>` and check if crl-sets are populated.
  4. On linux, windows - verify if revoked.badssl.com shows a certificate error.
  5. Reviewers only - Checkout `fix/network-audit-crlset` and run `npm run network-audit` to verify the audit passes.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source