### PR TITLE
Update background.ts

### DIFF
--- a/components/brave_new_tab_ui/constants/backgrounds.ts
+++ b/components/brave_new_tab_ui/constants/backgrounds.ts
@@ -4,7 +4,7 @@
 
 export const images: NewTab.Image[] = [
   {
-    'name': 'Tuolome Meadows',
+    'name': 'Tuolumne Meadows',
     'source': 'dksfoto1.jpg',
     'author': 'Darrell Sano',
     'link': 'https://dksfoto.smugmug.com'

--- a/components/brave_new_tab_ui/constants/backgrounds.ts
+++ b/components/brave_new_tab_ui/constants/backgrounds.ts
@@ -94,7 +94,7 @@ export const images: NewTab.Image[] = [
     'link': 'https://www.photoserge.com/'
   },
   {
-    'name': 'Paris: Conciergeri',
+    'name': 'Paris: Conciergerie',
     'source': 'Phoyoserge_ParisConciergeri.jpg',
     'author': 'Serge Ramelli',
     'link': 'https://www.photoserge.com/'


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/2320

- revised spelling of "Tuolumne Meadows" on NTP image
- update from "Paris: Conciergeri" to "Paris: Conciergerie"