### PR TITLE
Fixes brave browser tests duplicate symbols link error.

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -23,12 +23,11 @@
 #include "components/autofill/core/common/autofill_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
 #include "components/viz/common/features.h"
+#include "components/unified_consent/feature.h"
 #include "content/public/common/content_features.h"
 #include "extensions/common/extension_features.h"
 #include "gpu/config/gpu_finch_features.h"
 #include "ui/base/ui_base_features.h"
-
-#include "components/unified_consent/feature.cc"
 
 #if !defined(CHROME_MULTIPLE_DLL_BROWSER)
 base::LazyInstance<BraveContentRendererClient>::DestructorAtExit

--- a/patches/chrome-BUILD.gn.patch
+++ b/patches/chrome-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d75eb5687 100644
+index abbab2664254c9be1ec5074463722c1365590cd0..a114baddd2b52aa9deaf7ee15ea74e909c54522e 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -184,6 +184,10 @@ if (!is_android && !is_mac) {
@@ -13,7 +13,31 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
  
          deps += [
            ":chrome_dll",
-@@ -617,6 +621,11 @@ if (is_win) {
+@@ -260,6 +264,7 @@ if (!is_android && !is_mac) {
+ 
+           # Needed to use the master_preferences functions
+           "//chrome/installer/util:with_no_strings",
++          "//components/unified_consent",
+           "//content/public/app:both",
+           "//content/public/common:service_names",
+ 
+@@ -409,6 +414,7 @@ if (is_win) {
+       "//chrome_elf",
+       "//components/crash/content/app",
+       "//components/policy:generated",
++      "//components/unified_consent",
+       "//content/app/resources",
+       "//content/public/common:service_names",
+       "//crypto",
+@@ -514,6 +520,7 @@ if (is_win) {
+         "//chrome_elf",
+         "//components/browser_watcher:browser_watcher_client",
+         "//components/crash/content/app",
++        "//components/unified_consent",
+         "//content/public/app:child",
+         "//content/public/common:service_names",
+         "//headless:headless_shell_child_lib",
+@@ -617,6 +624,11 @@ if (is_win) {
      ]
    }
  
@@ -25,7 +49,7 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
    mac_app_bundle("chrome_app") {
      output_name = chrome_product_full_name
  
-@@ -653,6 +662,7 @@ if (is_win) {
+@@ -653,6 +665,7 @@ if (is_win) {
                    rebase_path("app/app.exports", root_build_dir) ]
      }
    }
@@ -33,7 +57,7 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
  
    compiled_action("chrome_app_strings") {
      tool = "//chrome/tools/build/mac:infoplist_strings_tool"
-@@ -682,7 +692,7 @@ if (is_win) {
+@@ -682,7 +695,7 @@ if (is_win) {
      args =
          [
            "-b",
@@ -42,7 +66,15 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
            "-v",
            rebase_path(chrome_version_file, root_build_dir),
            "-g",
-@@ -1274,6 +1284,10 @@ if (is_win) {
+@@ -1207,6 +1220,7 @@ if (is_win) {
+       "//components/policy:generated",
+       "//content/public/app:both",
+       "//content/public/common:service_names",
++      "//components/unified_consent",
+       "//headless:headless_shell_lib",
+       "//services/service_manager/embedder",
+       "//third_party/cld_3/src/src:cld_3",
+@@ -1274,6 +1288,10 @@ if (is_win) {
      if (is_chrome_branded) {
        deps += [ ":default_apps" ]
      }
@@ -53,7 +85,7 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
  
      ldflags = [
        "-Wl,-install_name,@executable_path/../Versions/$chrome_version_full/$chrome_framework_name.framework/$chrome_framework_name",
-@@ -1433,6 +1447,7 @@ if (is_win) {
+@@ -1433,6 +1451,7 @@ if (is_win) {
  
  group("browser_dependencies") {
    public_deps = [
@@ -61,7 +93,7 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
      "//chrome/browser",
      "//chrome/common",
      "//components/sync",
-@@ -1470,6 +1485,7 @@ group("browser_dependencies") {
+@@ -1470,6 +1489,7 @@ group("browser_dependencies") {
  
  group("child_dependencies") {
    public_deps = [
@@ -69,7 +101,7 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
      "//chrome/browser/devtools",
      "//chrome/child",
      "//chrome/common",
-@@ -1492,7 +1508,7 @@ group("child_dependencies") {
+@@ -1492,7 +1512,7 @@ group("child_dependencies") {
  if (is_win) {
    process_version_rc_template("chrome_exe_version") {
      sources = [
@@ -78,7 +110,7 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
      ]
      output = "$target_gen_dir/chrome_exe_version.rc"
    }
-@@ -1565,6 +1581,7 @@ group("resources") {
+@@ -1565,6 +1585,7 @@ group("resources") {
      "//chrome/browser:resources",
      "//chrome/common:resources",
      "//chrome/renderer:resources",
@@ -86,3 +118,11 @@ index abbab2664254c9be1ec5074463722c1365590cd0..65fd0676cc38f853ac93eba9ae8eb57d
    ]
  }
  
+@@ -1802,6 +1823,7 @@ if (is_android) {
+       "//components/safe_browsing/android:safe_browsing_mobile",
+       "//components/services/heap_profiling",
+       "//components/tracing",
++      "//components/unified_consent",
+       "//content/public/app:both",
+       "//content/public/common:service_names",
+       "//services/service_manager/embedder",

--- a/patches/chrome-app-BUILD.gn.patch
+++ b/patches/chrome-app-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/app/BUILD.gn b/chrome/app/BUILD.gn
-index 0f6308ea44ec5c8f8a76f9fd96e5387c79174db4..56ffd5f657170035ea5380e3ab0f4176f283ef87 100644
+index 0f6308ea44ec5c8f8a76f9fd96e5387c79174db4..e6248fd731aa4c6f8155fecae94b37fc483f4509 100644
 --- a/chrome/app/BUILD.gn
 +++ b/chrome/app/BUILD.gn
 @@ -251,7 +251,7 @@ grit("google_chrome_strings") {
@@ -11,7 +11,15 @@ index 0f6308ea44ec5c8f8a76f9fd96e5387c79174db4..56ffd5f657170035ea5380e3ab0f4176
    defines = chrome_grit_defines
    output_dir = "$root_gen_dir/chrome"
    outputs = [
-@@ -465,6 +465,7 @@ service_manifest("chrome_content_packaged_services_manifest_overlay") {
+@@ -335,6 +335,7 @@ static_library("test_support") {
+     "//components/nacl/common:buildflags",
+     "//components/startup_metric_utils/browser:lib",
+     "//components/tracing",
++    "//components/unified_consent",
+     "//content/public/app:both",
+     "//content/public/common",
+     "//content/public/common:service_names",
+@@ -465,6 +466,7 @@ service_manifest("chrome_content_packaged_services_manifest_overlay") {
        "//ui/accessibility:manifest",
      ]
    }


### PR DESCRIPTION
Removes inclusion of component/unified_consent/feature.cc from
brave/app/brave_main_delegate.cc and instead patches build files to
include dependency on component/unified_consent.

Fixes brave/brave-browser#2299

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source