### PR TITLE
Use faster loading page for browsertest CanLoadChromeURL

### DIFF
--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -81,11 +81,11 @@ class BraveContentBrowserClientTest : public InProcessBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadChromeURL) {
-  GURL chrome_settings_url("chrome://settings/");
+  GURL chrome_settings_url("chrome://about/");
   std::vector<GURL> urls {
     chrome_settings_url,
-    GURL("about:settings/"),
-    GURL("brave://settings/")
+    GURL("about:about/"),
+    GURL("brave://about/")
   };
   std::for_each(urls.begin(), urls.end(), [this, &chrome_settings_url](const GURL& url) {
     content::WebContents* contents = browser()->tab_strip_model()->GetActiveWebContents();


### PR DESCRIPTION
Sometimes on my Windows VM this test times out. 
This uses a faster loading page.

Fix https://github.com/brave/brave-browser/issues/2322


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source