### PR TITLE
Update stats can undercount when laptop is suspended

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -23,6 +23,8 @@ source_set("browser_process") {
     "brave_stats_updater.h",
     "brave_stats_updater_params.cc",
     "brave_stats_updater_params.h",
+    "brave_stats_updater_util.cc",
+    "brave_stats_updater_util.h",
     "brave_tab_helpers.cc",
     "brave_tab_helpers.h",
     "brave_rewards/donations_dialog.cc",

--- a/browser/brave_stats_updater.h
+++ b/browser/brave_stats_updater.h
@@ -53,11 +53,8 @@ class BraveStatsUpdater {
       std::unique_ptr<brave::BraveStatsUpdaterParams> stats_updater_params,
       scoped_refptr<net::HttpResponseHeaders> headers);
 
-  // Invoked when server ping startup timer fires.
-  void OnServerPingStartupTimerFired();
-
-  // Invoked when server ping periodic timer fires.
-  void OnServerPingPeriodicTimerFired();
+  // Invoked when server ping timer fires.
+  void OnServerPingTimerFired();
 
   // Invoked when the specified referral preference changes.
   void OnReferralCheckedForPromoCodeFileChanged();

--- a/browser/brave_stats_updater_params.cc
+++ b/browser/brave_stats_updater_params.cc
@@ -6,9 +6,9 @@
 
 #include "brave/browser/brave_stats_updater_params.h"
 
-#include "base/strings/stringprintf.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
+#include "brave/browser/brave_stats_updater_util.h"
 #include "brave/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 
@@ -83,15 +83,8 @@ std::string BraveStatsUpdaterParams::BooleanToString(bool bool_value) const {
   return bool_value ? "true" : "false";
 }
 
-std::string BraveStatsUpdaterParams::GetDateAsYMD(const base::Time& time) const {
-  base::Time::Exploded exploded;
-  time.LocalExplode(&exploded);
-  return base::StringPrintf("%d-%02d-%02d", exploded.year, exploded.month,
-                            exploded.day_of_month);
-}
-
 std::string BraveStatsUpdaterParams::GetCurrentDateAsYMD() const {
-  return GetDateAsYMD(g_current_time);
+  return brave::GetDateAsYMD(g_current_time);
 }
 
 std::string BraveStatsUpdaterParams::GetLastMondayAsYMD() const {
@@ -104,7 +97,7 @@ std::string BraveStatsUpdaterParams::GetLastMondayAsYMD() const {
       now.ToJsTime() -
       ((exploded.day_of_week - 1) * base::Time::kMillisecondsPerDay));
 
-  return GetDateAsYMD(last_monday);
+  return brave::GetDateAsYMD(last_monday);
 }
 
 int BraveStatsUpdaterParams::GetCurrentMonth() const {

--- a/browser/brave_stats_updater_util.cc
+++ b/browser/brave_stats_updater_util.cc
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_stats_updater_util.h"
+
+#include "base/strings/stringprintf.h"
+
+namespace brave {
+
+std::string GetDateAsYMD(const base::Time& time) {
+  base::Time::Exploded exploded;
+  time.LocalExplode(&exploded);
+  return base::StringPrintf("%d-%02d-%02d", exploded.year, exploded.month,
+                            exploded.day_of_month);
+}
+
+}  // namespace brave

--- a/browser/brave_stats_updater_util.h
+++ b/browser/brave_stats_updater_util.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_STATS_UPDATER_UTIL_H_
+#define BRAVE_BROWSER_BRAVE_STATS_UPDATER_UTIL_H_
+
+#include <string>
+
+#include "base/time/time.h"
+
+namespace brave {
+
+std::string GetDateAsYMD(const base::Time& time);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_BRAVE_STATS_UPDATER_UTIL_H_


### PR DESCRIPTION
Fixes brave/brave-browser#2338

We were previously pinging the update server once an hour. However, that approach will undercount in the following scenario: a user's laptop sends a ping, the user closes the laptop, and the next day the
user runs Brave for less than one hour.

To remedy that, we'll instead check every five minutes and only send a ping if we haven't already done it for today.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Test 1 - Verifies that the startup ping is sent and no periodic pings are sent when a date change doesn't occur while running Brave

- Start with a clean profile on a laptop
- Launch Brave with verbose logging set to 1 (`npm run start -- --v=1`)
- Verify that the startup ping is sent by checking logs (looks like `Brave stats ping, url ...`)
- Close the laptop lid, putting the laptop into a suspended state
- Leave the laptop closed for > 10 minutes (this should be enough time for the periodic check to run twice, as it runs every 5 minutes)
- Open the laptop, resuming it
- Verify via logs that no further pings were sent to the stats server

Test 2 - Verifies that the startup ping is sent and one periodic ping is sent when a date change does occur while running Brave

- Set laptop time to 11:55pm
- Start with a clean profile again
- Launch Brave with verbose logging set to 1 (`npm run start -- --v=1`)
- Verify that the startup ping is sent by checking logs (looks like `Brave stats ping, url ...`)
- Close the laptop lid, putting the laptop into a suspended state
- Leave the laptop closed for > 10 minutes (this should be enough time for the periodic check to run twice, as it runs every 5 minutes and also ensures that the date changes)
- Open the laptop, resuming it
- Verify via logs that one additional ping was sent to the stats server

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source