### PR TITLE
Handle Brave Payment import failures properly

### DIFF
--- a/utility/importer/brave_importer.h
+++ b/utility/importer/brave_importer.h
@@ -33,7 +33,7 @@ class BraveImporter : public ChromeImporter {
   void ImportBookmarks() override;
   void ImportHistory() override;
   void ImportStats();
-  void ImportLedger();
+  bool ImportLedger();
   void ImportWindows();
   void ImportReferral();
 


### PR DESCRIPTION
- if session-store-1 and ledger-state.json are missing, skip import
- if rewards is disabled, skip import
- if passphrase or other key fields are missing, skip import

In each of these cases, an error is still logged (to console). But it won't hang the import anymore.

Fixes https://github.com/brave/brave-browser/issues/2337

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Run through steps to reproduce here: https://github.com/brave/brave-browser/issues/2337

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source