### PR TITLE
Updates state.excluded in reducer when publisher exclusion is updated

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ deps = {
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
   "vendor/omaha":  "https://github.com/brave/omaha.git@e4263050ed24e92f4d3ed0b6874538f811011c5b",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
-  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@c07de55c1f8cb8ea4259f1ff01c0ef3c0dc39150",
+  "vendor/bat-native-ledger": "https://github.com/brave-intl/bat-native-ledger@ab50d0edf4cb5975e1690085feab67459e052d6c",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@adeff3254bb90ccdc9699040d5a4e1cd6b8393b7",

--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -93,7 +93,8 @@ class RewardsDOMHandler : public WebUIMessageHandler,
                        unsigned int result,
                        brave_rewards::Grant grant) override;
   void OnContentSiteUpdated(brave_rewards::RewardsService* rewards_service) override;
-  void OnExcludedSitesChanged(brave_rewards::RewardsService* rewards_service) override;
+  void OnExcludedSitesChanged(brave_rewards::RewardsService* rewards_service,
+                              std::string publisher_id) override;
   void OnReconcileComplete(brave_rewards::RewardsService* rewards_service,
                            unsigned int result,
                            const std::string& viewing_id,
@@ -462,10 +463,16 @@ void RewardsDOMHandler::OnContentSiteUpdated(brave_rewards::RewardsService* rewa
       base::Bind(&RewardsDOMHandler::OnGetContentSiteList, weak_factory_.GetWeakPtr()));
 }
 
-void RewardsDOMHandler::OnExcludedSitesChanged(brave_rewards::RewardsService* rewards_service) {
+void RewardsDOMHandler::OnExcludedSitesChanged(brave_rewards::RewardsService* rewards_service,
+                                               std::string publisher_id) {
   if (rewards_service_ && web_ui()->CanCallJavascript()) {
-    int num = (int)rewards_service_->GetNumExcludedSites();
-    web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.numExcludedSites", base::Value(num));
+    base::DictionaryValue excludedSitesInfo;
+    int num = rewards_service_->GetNumExcludedSites();
+
+    excludedSitesInfo.SetString("num", std::to_string(num));
+    excludedSitesInfo.SetString("publisherKey", publisher_id);
+
+    web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.numExcludedSites", excludedSitesInfo);
   }
 }
 

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1288,9 +1288,9 @@ void RewardsServiceImpl::GetPublisherActivityFromUrl(uint64_t windowId,
   ledger_->GetPublisherActivityFromUrl(windowId, visitData);
 }
 
-void RewardsServiceImpl::OnExcludedSitesChanged() {
+void RewardsServiceImpl::OnExcludedSitesChanged(const std::string& publisher_id) {
   for (auto& observer : observers_)
-    observer.OnExcludedSitesChanged(this);
+    observer.OnExcludedSitesChanged(this, publisher_id);
 }
 
 void RewardsServiceImpl::OnPublisherActivity(ledger::Result result,

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -254,7 +254,7 @@ class RewardsServiceImpl : public RewardsService,
   void SetContributionAmount(double amount) const override;
   void SetUserChangedContribution() const override;
   void SetAutoContribute(bool enabled) const override;
-  void OnExcludedSitesChanged() override;
+  void OnExcludedSitesChanged(const std::string& publisher_id) override;
   void OnPublisherActivity(ledger::Result result,
                           std::unique_ptr<ledger::PublisherInfo> info,
                           uint64_t windowId) override;

--- a/components/brave_rewards/browser/rewards_service_impl_unittest.cc
+++ b/components/brave_rewards/browser/rewards_service_impl_unittest.cc
@@ -31,7 +31,7 @@ class MockRewardsServiceObserver : public RewardsServiceObserver {
   MOCK_METHOD4(OnRecoverWallet, void(RewardsService*, unsigned int, double, std::vector<brave_rewards::Grant>));
   MOCK_METHOD3(OnGrantFinish, void(RewardsService*, unsigned int, brave_rewards::Grant));
   MOCK_METHOD1(OnContentSiteUpdated, void(RewardsService*));
-  MOCK_METHOD1(OnExcludedSitesChanged, void(RewardsService*));
+  MOCK_METHOD2(OnExcludedSitesChanged, void(RewardsService*, std::string));
   MOCK_METHOD4(OnReconcileComplete, void(RewardsService*, unsigned int, const std::string&, const std::string&));
   MOCK_METHOD2(OnRecurringDonationUpdated, void(RewardsService*, brave_rewards::ContentSiteList));
   MOCK_METHOD2(OnCurrentTips, void(RewardsService*, brave_rewards::ContentSiteList));

--- a/components/brave_rewards/browser/rewards_service_observer.h
+++ b/components/brave_rewards/browser/rewards_service_observer.h
@@ -39,7 +39,8 @@ class RewardsServiceObserver : public base::CheckedObserver {
                                  unsigned int result,
                                  brave_rewards::Grant grant) {};
   virtual void OnContentSiteUpdated(RewardsService* rewards_service) {};
-  virtual void OnExcludedSitesChanged(RewardsService* rewards_service) {};
+  virtual void OnExcludedSitesChanged(RewardsService* rewards_service,
+                                      std::string publisher_id) {};
   virtual void OnReconcileComplete(RewardsService* rewards_service,
                                    unsigned int result,
                                    const std::string& viewing_id,

--- a/components/brave_rewards/resources/ui/actions/rewards_actions.ts
+++ b/components/brave_rewards/resources/ui/actions/rewards_actions.ts
@@ -105,8 +105,8 @@ export const onWalletExists = (exists: boolean) => action(types.ON_WALLET_EXISTS
 
 export const restorePublishers = () => action(types.ON_RESTORE_PUBLISHERS)
 
-export const onNumExcludedSites = (num: string) => action(types.ON_NUM_EXCLUDED_SITES, {
-  num
+export const onNumExcludedSites = (excludedSitesInfo: {num: string, publisherKey: string}) => action(types.ON_NUM_EXCLUDED_SITES, {
+  excludedSitesInfo
 })
 
 export const onContributionAmount = (amount: number) => action(types.ON_CONTRIBUTION_AMOUNT, {

--- a/components/brave_rewards/resources/ui/brave_rewards.tsx
+++ b/components/brave_rewards/resources/ui/brave_rewards.tsx
@@ -93,8 +93,8 @@ window.cr.define('brave_rewards', function () {
     getActions().onContributeList(list)
   }
 
-  function numExcludedSites (num: string) {
-    getActions().onNumExcludedSites(num)
+  function numExcludedSites (excludedSitesInfo: {num: string, publisherKey: string}) {
+    getActions().onNumExcludedSites(excludedSitesInfo)
   }
 
   function balanceReports (reports: Record<string, Rewards.Report>) {

--- a/components/test/brave_rewards/ui/reducers/publishers_reducer_test.ts
+++ b/components/test/brave_rewards/ui/reducers/publishers_reducer_test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global chrome */
+
+import reducers from '../../../../brave_rewards/resources/ui/reducers/index'
+import * as actions from '../../../../brave_rewards/resources/ui/actions/rewards_actions'
+import { types } from '../../../../brave_rewards/resources/ui/constants/rewards_types'
+import { defaultState } from '../../../../brave_rewards/resources/ui/storage'
+
+describe('publishers reducer', () => {
+  describe('ON_CONTRIBUTE_LIST', () => {
+    it('does not include excluded publishers in auto-contribute list', () => {
+      const initialState = reducers(defaultState, {
+        type: types.ON_NUM_EXCLUDED_SITES,
+        payload: {
+          excludedSitesInfo: {
+            num: 1,
+            publisherKey: 'brave.com'
+          }
+        }
+      })
+
+      const assertion = reducers(initialState, {
+        type: types.ON_CONTRIBUTE_LIST,
+        payload: {
+          list: [
+            {publisherKey: 'brave.com', percentage: 0, verified: true, excluded: 0, url: 'https://brave.com', name: 'brave.com', id: 'brave.com', provider: '', favicon: ''},
+            {publisherKey: 'test.com', percentage: 0, verified: true, excluded: 0, url: 'https://test.com', name: 'test.com', id: 'test.com', provider: '', favicon: ''},
+            {publisherKey: 'test2.com', percentage: 0, verified: true, excluded: 0, url: 'https://test2.com', name: 'test2.com', id: 'test2.com', provider: '', favicon: ''}
+          ]
+        }
+      })
+
+      const expectedState: Rewards.State = { ...defaultState }
+      expectedState.numExcludedSites = 1
+      expectedState.excluded = ['brave.com']
+      expectedState.contributeLoad = true
+      expectedState.autoContributeList = [
+        {publisherKey: 'test.com', percentage: 0, verified: true, excluded: 0, url: 'https://test.com', name: 'test.com', id: 'test.com', provider: '', favicon: ''},
+        {publisherKey: 'test2.com', percentage: 0, verified: true, excluded: 0, url: 'https://test2.com', name: 'test2.com', id: 'test2.com', provider: '', favicon: ''}
+      ]
+
+      expect(assertion).toEqual({
+        rewardsData: expectedState
+      })
+    })
+  })
+
+  describe('ON_NUM_EXCLUDED_SITES', () => {
+    it('adds a recently excluded publisher to state.excluded', () => {
+      const assertion = reducers(undefined, {
+        type: types.ON_NUM_EXCLUDED_SITES,
+        payload: {
+          excludedSitesInfo: {
+            num: 1,
+            publisherKey: 'brave.com'
+          }
+        }
+      })
+
+      const expectedState: Rewards.State = { ...defaultState }
+      expectedState.numExcludedSites = 1
+      expectedState.excluded = ['brave.com']
+
+      expect(assertion).toEqual({
+        rewardsData: expectedState
+      })
+    })
+
+    it('removes a recently restored publisher from state.excluded', () => {
+      let testState = reducers(defaultState, {
+        type: types.ON_NUM_EXCLUDED_SITES,
+        payload: {
+          excludedSitesInfo: {
+            num: 1,
+            publisherKey: 'test.com'
+          }
+        }
+      })
+
+      testState = reducers(testState, {
+        type: types.ON_NUM_EXCLUDED_SITES,
+        payload: {
+          excludedSitesInfo: {
+            num: 2,
+            publisherKey: 'brave.com'
+          }
+        }
+      })
+
+      testState = reducers(testState, {
+        type: types.ON_NUM_EXCLUDED_SITES,
+        payload: {
+          excludedSitesInfo: {
+            num: 1,
+            publisherKey: 'test.com'
+          }
+        }
+      })
+
+      const expectedState: Rewards.State = { ...defaultState }
+      expectedState.numExcludedSites = 1
+      expectedState.excluded = ['brave.com']
+
+      expect(testState).toEqual({
+        rewardsData: expectedState
+      })
+    })
+
+    it('does not modify state when excludedSitesInfo is null', () => {
+      const assertion = reducers(undefined, {
+        type: types.ON_NUM_EXCLUDED_SITES,
+        payload: {
+          excludedSitesInfo: null
+        }
+      })
+
+      const expectedState: Rewards.State = { ...defaultState }
+
+      expect(assertion).toEqual({
+        rewardsData: expectedState
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2340
Native ledger PR: https://github.com/brave-intl/bat-native-ledger/pull/194

Previously, state.excluded was only set when a publisher exclude action was triggered (by clicking on 'excluded' in the -ac table). https://github.com/brave/brave-core/blob/master/components/brave_rewards/resources/ui/reducers/publishers_reducer.ts#L27

With muon import, excluded publishers are handled directly via this call: https://github.com/brave/brave-core/blob/dcc6e31fdcd5dd66e57a0235aba6a36741fa20f0/components/brave_rewards/browser/rewards_service_impl.cc#L511-L513

Because of the direct call, the above reducer wasn't getting hit, therefore state was not reflected.

This adds the publisherKey of the updated publisher to the callback that feeds in to `ON_NUM_EXCLUDED_SITES`, which is triggered whenever there is an exclusion update. The publisherKey is then added or removed from state.excluded depending on what their new status is.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
  1. Launch Brave with rewards enabled.
  2. Visit some sites to add them to the a-c table.
  3. Ensure publisher exclusion works correctly.
  4. Ensure that publisher restoration works correctly.
  5. Ensure that publishers can be re-excluded after a restore.
  6. Confirm that `state.excluded` is updated appropriately.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source