### PR TITLE
[WIP] Adds functionality to monthly contribution dropdown (Panel) (#2)

### DIFF
--- a/components/brave_rewards/browser/extension_rewards_service_observer.h
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.h
@@ -21,6 +21,7 @@ class RewardsService;
 class ExtensionRewardsServiceObserver : public RewardsServiceObserver,
                                         public RewardsServicePrivateObserver {
  public:
+  ExtensionRewardsServiceObserver() {}
   ExtensionRewardsServiceObserver(Profile* profile);
   ~ExtensionRewardsServiceObserver() override;
 

--- a/components/brave_rewards/browser/extension_rewards_service_observer_browsertest.cc
+++ b/components/brave_rewards/browser/extension_rewards_service_observer_browsertest.cc
@@ -9,12 +9,13 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "content/public/test/browser_test_utils.h"
+#include "brave/components/brave_rewards/browser/content_site.h"
 
 using namespace brave_rewards;
 
 class ExtensionRewardsServiceObserverBrowserTest
     : public InProcessBrowserTest,
-      public RewardsServiceObserver {
+      public ExtensionRewardsServiceObserver {
   public:
 
   void SetUpOnMainThread() override {
@@ -28,11 +29,10 @@ class ExtensionRewardsServiceObserverBrowserTest
 
   void OnRecurringDonations(
       RewardsService* rewards_service,
-      const ledger::PublisherInfoList& list) override {
+      brave_rewards::ContentSiteList list) override {
 
-    ledger::PublisherInfo firstPublisher = list.front();
-    EXPECT_STREQ(firstPublisher.id.c_str(), "brave.com");
-    EXPECT_STREQ(std::to_string(firstPublisher.weight).c_str(), "10");
+    EXPECT_STREQ(list.front().id.c_str(), "brave.com");
+    EXPECT_STREQ(std::to_string(list.front().weight).c_str(), "10");
 
     on_recurring_notifications_callback_was_called_ = true;
   }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2245

The brunt of the work for this was adding extension functions to support:

Adding a recurring contribution
Removing a recurring contribution
Retrieving recurring contributions

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
   1. Enable Brave Rewards
   2. Navigate to a site such as `brave.com`
   3. Bring up the wallet panel.
   4. Change monthly contribution amount to '5.0'
   5. Close and re-open panel
   6. Confirm that the value '5.0' persists
   7. Confirm that the change is reflected in the donation table
 
   The above six steps should be tried in different ways with different values. Ex: Ensuring that the data persists across tabs with the same site open

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source