### PR TITLE
Use git commit ref for brave-ui dependency instead of npm-published version

### DIFF
--- a/components/webpack/webpack.config.js
+++ b/components/webpack/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = (env, argv) => ({
     extensions: ['.js', '.tsx', '.ts', '.json'],
     alias: {
       'bittorrent-tracker': path.resolve(__dirname, '../../node_modules/bittorrent-tracker'),
+      'brave-ui': path.resolve(__dirname, '../../node_modules/brave-ui/src'),
       'dgram': 'chrome-dgram',
       'dns': path.resolve(__dirname, '../common/dns.ts'),
       'net': 'chrome-net',

--- a/package-lock.json
+++ b/package-lock.json
@@ -612,7 +612,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1237,9 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "0.34.7",
-      "resolved": "https://registry.npmjs.org/brave-ui/-/brave-ui-0.34.7.tgz",
-      "integrity": "sha512-bt818hmJm1oIEtuKw6xX1T2kNABFJ5qZxMNLRQ8KbtCEAHJLM6Qb8SxsP/JAGZswbZiQUp+fpx57wiaSOYMCAg==",
+      "version": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
+      "from": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",
@@ -8880,7 +8879,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -256,7 +256,9 @@
     ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|svg|ttf|woff|woff2)$": "<rootDir>/components/test/fileMock.ts",
-      "\\.(css|less)$": "identity-obj-proxy"
+      "\\.(css|less)$": "identity-obj-proxy",
+      "^brave-ui$": "<rootDir>/node_modules/brave-ui/src",
+      "^brave-ui\\/(.*)": "<rootDir>/node_modules/brave-ui/src/$1"
     }
   },
   "devDependencies": {
@@ -270,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "^0.34.7",
+    "brave-ui": "brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,11 @@
       "es2017"
     ],
     "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "brave-ui": ["node_modules/brave-ui/src"],
+      "brave-ui/*": ["node_modules/brave-ui/src/*"]
+    },
     "typeRoots": [
       "./node_modules/@types",
       "./components/definitions"


### PR DESCRIPTION
This is the minimum change necessary to have brave-ui go direct to a specific commit in github, rather than a specific version published to npm.
It clears the way for the branch strategy outlined in https://github.com/brave/brave-browser/issues/2315.

Addresses https://github.com/brave/brave-browser/issues/2315

## Test Plan:
- `npm install` in src/brave (don't remove node_modules first)
- check that it installed the commit-version of brave-ui via:
  - `cat ./node_modules/brave-ui/package.json | grep _from`. You should see `"_from": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",`
- Check that web unit tests work: `npm run test-unit`
- Check that webui builds work
  - Ensure all webuis re-build by simply re-saving the file at `"components/webpack/webpack.config.js`
  - run `npm run build` from brave-browser
  - should see no error
  - webuis should look ok

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source