### PR TITLE
Fixes subdomain logging for rewards

### DIFF
--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -22,6 +22,7 @@ class Profile;
 
 namespace ledger {
 struct PublisherInfo;
+class Ledger;
 }
 
 namespace content {
@@ -111,6 +112,7 @@ class RewardsService : public KeyedService {
     std::string publisher_key, bool excluded, uint64_t windowId) = 0;
   virtual RewardsNotificationService* GetNotificationService() const = 0;
   virtual bool CheckImported() = 0;
+  virtual void SetLedgerClient(std::unique_ptr<ledger::Ledger> new_ledger) = 0;
 
   void AddObserver(RewardsServiceObserver* observer);
   void RemoveObserver(RewardsServiceObserver* observer);

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -381,6 +381,8 @@ void RewardsServiceImpl::OnLoad(SessionID tab_id, const GURL& url) {
   if (baseDomain == "")
     return;
 
+  const std::string publisher_url = origin.scheme() + "://" + baseDomain + "/";
+
   auto now = base::Time::Now();
   ledger::VisitData data(baseDomain,
                          origin.host(),
@@ -389,7 +391,7 @@ void RewardsServiceImpl::OnLoad(SessionID tab_id, const GURL& url) {
                          GetPublisherMonth(now),
                          GetPublisherYear(now),
                          baseDomain,
-                         origin.spec(),
+                         publisher_url,
                          "",
                          "");
   ledger_->OnLoad(data, GetCurrentTimestamp());

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1718,4 +1718,9 @@ void RewardsServiceImpl::OnDonate(
   OnDonate(publisher_key, amount, recurring, &info);
 }
 
+void RewardsServiceImpl::SetLedgerClient(
+    std::unique_ptr<ledger::Ledger> new_ledger) {
+  ledger_ = std::move(new_ledger);
+}
+
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -134,6 +134,7 @@ class RewardsServiceImpl : public RewardsService,
                           std::unique_ptr<ledger::WalletInfo> info) override;
   void OnDonate(const std::string& publisher_key, int amount, bool recurring,
       std::unique_ptr<brave_rewards::ContentSite> site) override;
+  void SetLedgerClient(std::unique_ptr<ledger::Ledger> new_ledger) override;
 
  private:
   friend void RunIOTaskCallback(

--- a/components/brave_rewards/browser/rewards_service_impl_unittest.cc
+++ b/components/brave_rewards/browser/rewards_service_impl_unittest.cc
@@ -14,12 +14,12 @@
 #include "content/public/test/test_browser_thread_bundle.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 // npm run test -- brave_unit_tests --filter=RewardsServiceTest.*
 
 using namespace brave_rewards;
 using ::testing::_;
-using ::testing::AtLeast;
 
 class MockRewardsServiceObserver : public RewardsServiceObserver {
  public:
@@ -55,6 +55,7 @@ class MockRewardsServiceObserver : public RewardsServiceObserver {
       void(RewardsService*, int, ledger::PublisherInfo*, uint64_t));
 };
 
+
 class RewardsServiceTest : public testing::Test {
  public:
   RewardsServiceTest() {}
@@ -71,6 +72,10 @@ class RewardsServiceTest : public testing::Test {
     ASSERT_TRUE(rewards_service() != NULL);
     observer_.reset(new MockRewardsServiceObserver);
     rewards_service_->AddObserver(observer_.get());
+
+    auto ledger_client = std::make_unique<MockLedgerClient>();
+    ledger_client_ = ledger_client.get();
+    rewards_service()->SetLedgerClient(std::move(ledger_client));
   }
 
   void TearDown() override {
@@ -81,6 +86,7 @@ class RewardsServiceTest : public testing::Test {
   Profile* profile() { return profile_.get(); }
   RewardsServiceImpl* rewards_service() { return rewards_service_; }
   MockRewardsServiceObserver* observer() { return observer_.get(); }
+  MockLedgerClient* ledger_client() { return ledger_client_; }
 
  private:
   // Need this as a very first member to run tests in UI thread
@@ -91,6 +97,7 @@ class RewardsServiceTest : public testing::Test {
   RewardsServiceImpl* rewards_service_;
   std::unique_ptr<MockRewardsServiceObserver> observer_;
   base::ScopedTempDir temp_dir_;
+  MockLedgerClient* ledger_client_; // not owned
 };
 
 TEST_F(RewardsServiceTest, HandleFlags) {
@@ -176,6 +183,12 @@ TEST_F(RewardsServiceTest, OnWalletProperties) {
   // We always need to call observer as we report errors back even when we have null pointer
   EXPECT_CALL(*observer(), OnWalletProperties(_, 1, _)).Times(1);
   rewards_service()->OnWalletProperties(ledger::Result::LEDGER_ERROR, nullptr);
+}
+
+TEST_F(RewardsServiceTest, OnLoad) {
+  EXPECT_CALL(*ledger_client(), OnLoad(_, _)).Times(1);
+  rewards_service()->OnLoad(SessionID::FromSerializedValue(1),
+                            GURL("https://brave.com"));
 }
 
 // add test for strange entries

--- a/components/brave_rewards/browser/test_util.cc
+++ b/components/brave_rewards/browser/test_util.cc
@@ -17,6 +17,10 @@
 
 namespace brave_rewards {
 
+MockLedgerClient::MockLedgerClient() {}
+
+MockLedgerClient::~MockLedgerClient() {}
+
 std::unique_ptr<Profile> CreateBraveRewardsProfile(const base::FilePath& path) {
   // Bitmap fetcher service needed for rewards service
   BitmapFetcherServiceFactory::GetInstance();

--- a/components/brave_rewards/browser/test_util.h
+++ b/components/brave_rewards/browser/test_util.h
@@ -5,14 +5,213 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_TEST_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_TEST_UTIL_H_
 
+#include <map>
 #include <memory>
+#include <string>
 
+#include "bat/ledger/ledger.h"
 #include "base/files/file_path.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
 
 class KeyedService;
 class Profile;
 
 namespace brave_rewards {
+
+class MockLedgerClient : public ledger::Ledger {
+ public:
+  MockLedgerClient();
+  ~MockLedgerClient() override;
+
+  MOCK_METHOD2(OnLoad, void(const ledger::VisitData& visit_data,
+                            const uint64_t& current_time));
+
+  MOCK_METHOD0(Initialize, void());
+
+  MOCK_METHOD0(CreateWallet, bool());
+
+  MOCK_METHOD1(MakePayment, void(const ledger::PaymentData& payment_data));
+
+  MOCK_METHOD2(AddRecurringPayment, void(const std::string& publisher_id,
+                                         const double& value));
+
+  MOCK_METHOD3(DoDirectDonation, void(const ledger::PublisherInfo& publisher,
+                                      const int amount,
+                                      const std::string& currency));
+
+  MOCK_METHOD2(OnUnload, void(uint32_t tab_id, const uint64_t& current_time));
+
+  MOCK_METHOD2(OnShow, void(uint32_t tab_id, const uint64_t& current_time));
+
+  MOCK_METHOD2(OnHide, void(uint32_t tab_id, const uint64_t& current_time));
+
+  MOCK_METHOD2(OnForeground, void(uint32_t tab_id,
+                                  const uint64_t& current_time));
+
+  MOCK_METHOD2(OnBackground, void(uint32_t tab_id,
+                                  const uint64_t& current_time));
+
+  MOCK_METHOD2(OnMediaStart, void(uint32_t tab_id,
+                                  const uint64_t& current_time));
+
+  MOCK_METHOD2(OnMediaStop, void(uint32_t tab_id,
+                                 const uint64_t& current_time));
+  MOCK_METHOD6(OnXHRLoad, void(
+      uint32_t tab_id,
+      const std::string& url,
+      const std::map<std::string, std::string>& parts,
+      const std::string& first_party_url,
+      const std::string& referrer,
+      const ledger::VisitData& visit_data));
+
+  MOCK_METHOD5(OnPostData, void(
+      const std::string& url,
+      const std::string& first_party_url,
+      const std::string& referrer,
+      const std::string& post_data,
+      const ledger::VisitData& visit_data));
+
+  MOCK_METHOD1(OnTimer, void(uint32_t timer_id));
+
+  MOCK_METHOD1(URIEncode, std::string(const std::string& value));
+
+  MOCK_METHOD2(SetPublisherInfo,
+      void(std::unique_ptr<ledger::PublisherInfo> publisher_info,
+           ledger::PublisherInfoCallback callback));
+
+  MOCK_METHOD2(GetPublisherInfo, void(const ledger::PublisherInfoFilter& filter,
+                                      ledger::PublisherInfoCallback callback));
+
+  MOCK_METHOD2(SetMediaPublisherInfo, void(const std::string& media_key,
+                                           const std::string& publisher_id));
+
+  MOCK_METHOD2(GetMediaPublisherInfo, void(
+      const std::string& media_key,
+      ledger::PublisherInfoCallback callback));
+
+  MOCK_METHOD0(GetRecurringDonationPublisherInfo,
+               std::vector<ledger::ContributionInfo>());
+
+  MOCK_METHOD4(GetPublisherInfoList, void(
+      uint32_t start,
+      uint32_t limit,
+      const ledger::PublisherInfoFilter& filter,
+      ledger::PublisherInfoListCallback callback));
+
+  MOCK_METHOD1(SetRewardsMainEnabled, void(bool enabled));
+
+  MOCK_METHOD1(SetPublisherMinVisitTime, void(uint64_t duration_in_seconds));
+
+  MOCK_METHOD1(SetPublisherMinVisits, void(unsigned int visits));
+
+  MOCK_METHOD1(SetPublisherAllowNonVerified, void(bool allow));
+
+  MOCK_METHOD1(SetPublisherAllowVideos, void(bool allow));
+
+  MOCK_METHOD1(SetContributionAmount, void(double amount));
+
+  MOCK_METHOD0(SetUserChangedContribution, void());
+
+  MOCK_METHOD1(SetAutoContribute, void(bool enabled));
+
+  MOCK_METHOD3(SetBalanceReport, void(
+      ledger::PUBLISHER_MONTH month,
+      int year,
+      const ledger::BalanceReportInfo& report_info));
+
+  MOCK_CONST_METHOD0(GetBATAddress, const std::string&());
+
+  MOCK_CONST_METHOD0(GetBTCAddress, const std::string&());
+
+  MOCK_CONST_METHOD0(GetETHAddress, const std::string&());
+
+  MOCK_CONST_METHOD0(GetLTCAddress, const std::string&());
+
+  MOCK_CONST_METHOD0(GetReconcileStamp, uint64_t());
+
+  MOCK_CONST_METHOD0(GetRewardsMainEnabled, bool());
+
+  MOCK_CONST_METHOD0(GetPublisherMinVisitTime, uint64_t());
+
+  MOCK_CONST_METHOD0(GetPublisherMinVisits, unsigned int());
+
+  MOCK_CONST_METHOD0(GetNumExcludedSites, unsigned int());
+
+  MOCK_CONST_METHOD0(GetPublisherAllowNonVerified, bool());
+
+  MOCK_CONST_METHOD0(GetPublisherAllowVideos, bool());
+
+  MOCK_CONST_METHOD0(GetContributionAmount, double());
+
+  MOCK_CONST_METHOD0(GetAutoContribute, bool());
+
+  MOCK_CONST_METHOD0(FetchWalletProperties, void());
+
+  MOCK_CONST_METHOD2(FetchGrant, void(const std::string& lang,
+                                const std::string& paymentId));
+
+  MOCK_CONST_METHOD1(SolveGrantCaptcha, void(const std::string& solution));
+
+  MOCK_CONST_METHOD0(GetGrantCaptcha, void());
+
+  MOCK_CONST_METHOD0(GetWalletPassphrase,  std::string());
+
+  MOCK_CONST_METHOD3(GetBalanceReport, bool(
+      ledger::PUBLISHER_MONTH month,
+      int year,
+      ledger::BalanceReportInfo* report_info));
+
+  MOCK_CONST_METHOD0(GetAllBalanceReports,
+      std::map<std::string, ledger::BalanceReportInfo>());
+
+  MOCK_CONST_METHOD1(RecoverWallet, void(const std::string& passPhrase));
+
+  MOCK_METHOD4(SaveMediaVisit, void(const std::string& publisher_id,
+                                    const ledger::VisitData& visit_data,
+                                    const uint64_t& duration,
+                                    const uint64_t window_id));
+
+  MOCK_METHOD2(SetPublisherExclude, void(
+      const std::string& publisher_id,
+      const ledger::PUBLISHER_EXCLUDE& exclude));
+
+  MOCK_METHOD3(SetPublisherPanelExclude, void(
+      const std::string& publisher_id,
+      const ledger::PUBLISHER_EXCLUDE& exclude,
+      uint64_t windowId));
+
+  MOCK_METHOD0(RestorePublishers, void());
+
+  MOCK_CONST_METHOD0(IsWalletCreated, bool());
+
+  MOCK_METHOD2(GetPublisherActivityFromUrl, void(
+      uint64_t windowId,
+      const ledger::VisitData& visit_data));
+
+  MOCK_METHOD4(SetBalanceReportItem, void(ledger::PUBLISHER_MONTH month,
+                                          int year,
+                                          ledger::ReportType type,
+                                          const std::string& probi));
+
+  MOCK_METHOD2(GetPublisherBanner, void(
+      const std::string& publisher_id,
+      ledger::PublisherBannerCallback callback));
+
+  MOCK_METHOD0(GetBalance, double());
+
+  MOCK_METHOD6(OnReconcileCompleteSuccess, void(
+      const std::string& viewing_id,
+      const ledger::PUBLISHER_CATEGORY category,
+      const std::string& probi,
+      const ledger::PUBLISHER_MONTH month,
+      const int year,
+      const uint32_t date));
+
+  MOCK_METHOD1(RemoveRecurring, void(const std::string& publisher_key));
+
+  MOCK_METHOD0(GetDefaultContributionAmount, double());
+};
 
 std::unique_ptr<Profile> CreateBraveRewardsProfile(const base::FilePath& path);
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -128,7 +128,6 @@ test("brave_unit_tests") {
   deps = [
     "//brave/components/brave_rewards/browser:testutil",
     "//brave/components/brave_sync:testutil",
-    "//brave/vendor/bat-native-ledger",
     "//brave/vendor/bat-native-usermodel",
     "//brave/vendor/bat-native-rapidjson",
     "//chrome:browser_dependencies",
@@ -144,6 +143,12 @@ test("brave_unit_tests") {
     "//components/sync_preferences",
     "//content/public/common",
   ]
+
+  if (brave_rewards_enabled) {
+    deps += [
+      "//brave/vendor/bat-native-ledger",
+    ]
+  }
 
   public_deps = [
     "//base",

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -89,7 +89,7 @@ class LEDGER_EXPORT Ledger {
   virtual void MakePayment(const PaymentData& payment_data) = 0;
   virtual void AddRecurringPayment(const std::string& publisher_id, const double& value) = 0;
   virtual void DoDirectDonation(const PublisherInfo& publisher, const int amount, const std::string& currency) = 0;
-  virtual void OnLoad(const VisitData& visit_data, const uint64_t& current_time) = 0;
+  virtual void OnLoad(const ledger::VisitData& visit_data, const uint64_t& current_time) = 0;
   virtual void OnUnload(uint32_t tab_id, const uint64_t& current_time) = 0;
   virtual void OnShow(uint32_t tab_id, const uint64_t& current_time) = 0;
   virtual void OnHide(uint32_t tab_id, const uint64_t& current_time) = 0;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2073

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- visit regular site (like clifton.io), wait 10s
- go to settings page and make sure that favicon is there and if you click on it clifton.io is opened
- visit stats.brave.com, wait 10s
- go to settings page and make sure that favicon is not there and if you click on it brave.com is opened
- visit brave.com, wait 10s
- go to settings page and make sure that favicon is now there

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source