### PR TITLE
Hides sites with 0% attention from the A-C table

### DIFF
--- a/components/brave_rewards/browser/publisher_info_database.cc
+++ b/components/brave_rewards/browser/publisher_info_database.cc
@@ -483,6 +483,10 @@ std::string PublisherInfoDatabase::BuildClauses(int start,
     ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED)
     clauses += " AND pi.excluded != ?";
 
+  if (filter.percent > 0) {
+    clauses += " AND ai.percent >= ?";
+  }
+
   for (const auto& it : filter.order_by) {
     clauses += " ORDER BY " + it.first;
     clauses += (it.second ? " ASC" : " DESC");
@@ -528,6 +532,9 @@ void PublisherInfoDatabase::BindFilter(sql::Statement& statement,
   if (filter.excluded ==
     ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED)
     statement.BindInt(column++, ledger::PUBLISHER_EXCLUDE::EXCLUDED);
+
+  if (filter.percent > 0)
+    statement.BindInt(column++, filter.percent);
 }
 
 bool PublisherInfoDatabase::InsertContributionInfo(const brave_rewards::ContributionInfo& info) {

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -360,6 +360,7 @@ void RewardsServiceImpl::GetCurrentContributeList(
   filter.reconcile_stamp = ledger_->GetReconcileStamp();
   filter.excluded =
     ledger::PUBLISHER_EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED;
+  filter.percent = 1;
 
   ledger_->GetPublisherInfoList(
       start,

--- a/vendor/bat-native-ledger/include/bat/ledger/publisher_info.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/publisher_info.h
@@ -62,6 +62,7 @@ LEDGER_EXPORT struct PublisherInfoFilter {
   PUBLISHER_MONTH month;
   int year;
   PUBLISHER_EXCLUDE_FILTER excluded;
+  uint32_t percent;
   std::vector<std::pair<std::string, bool>> order_by;
   unsigned int min_duration;
   uint64_t reconcile_stamp;

--- a/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
@@ -88,6 +88,7 @@ PublisherInfoFilter::PublisherInfoFilter() :
     month(PUBLISHER_MONTH::ANY),
     year(-1),
     excluded(PUBLISHER_EXCLUDE_FILTER::FILTER_DEFAULT),
+    percent(0),
     min_duration(0),
     reconcile_stamp(0) {}
 PublisherInfoFilter::PublisherInfoFilter(const PublisherInfoFilter& filter) :
@@ -96,6 +97,7 @@ PublisherInfoFilter::PublisherInfoFilter(const PublisherInfoFilter& filter) :
     month(filter.month),
     year(filter.year),
     excluded(filter.excluded),
+    percent(filter.percent),
     order_by(filter.order_by),
     min_duration(filter.min_duration),
     reconcile_stamp(filter.reconcile_stamp) {}


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2365
Native-ledger: https://github.com/brave-intl/bat-native-ledger/pull/199

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Build from this branch and enable rewards
2. Acquire 0% attention publishers in the AC table (knowingly from an old profile is fine)
    * `publisher_info_db` can be edited directly to add some
3. Ensure that these 0% publishers do not show in the AC table

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source