### PR TITLE
Issue 1985: Properly show the widevine absence prompt.

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -15,6 +15,8 @@ source_set("browser_process") {
     "brave_browser_main_parts_mac.h",
     "brave_browser_process_impl.cc",
     "brave_browser_process_impl.h",
+    "brave_drm_tab_helper.cc",
+    "brave_drm_tab_helper.h",
     "brave_local_state_prefs.cc",
     "brave_local_state_prefs.h",
     "brave_profile_prefs.cc",

--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_drm_tab_helper.h"
+
+#include "brave/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/browser/navigation_handle.h"
+
+BraveDrmTabHelper::BraveDrmTabHelper(content::WebContents* contents)
+    : WebContentsObserver(contents), bindings_(contents, this) {}
+
+BraveDrmTabHelper::~BraveDrmTabHelper() {}
+
+bool BraveDrmTabHelper::ShouldShowWidevineOptIn() const {
+  // If the user already opted in, don't offer it.
+  PrefService* prefs = ProfileManager::GetActiveUserProfile()->GetPrefs();
+  if (prefs->GetBoolean(kWidevineOptedIn)) {
+    return false;
+  }
+
+  return is_widevine_requested_;
+}
+
+void BraveDrmTabHelper::DidStartNavigation(
+    content::NavigationHandle* navigation_handle) {
+  if (!navigation_handle->IsInMainFrame() ||
+      navigation_handle->IsSameDocument()) {
+    return;
+  }
+  is_widevine_requested_ = false;
+}
+
+void BraveDrmTabHelper::OnWidevineKeySystemAccessRequest() {
+  is_widevine_requested_ = true;
+
+  Browser* browser = chrome::FindBrowserWithWebContents(web_contents());
+  browser->window()->UpdateToolbar(web_contents());
+}

--- a/browser/brave_drm_tab_helper.h
+++ b/browser/brave_drm_tab_helper.h
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_DRM_TAB_HELPER_H_
+#define BRAVE_BROWSER_DRM_TAB_HELPER_H_
+
+#include "content/public/browser/web_contents_binding_set.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/browser/web_contents_user_data.h"
+#include "brave/third_party/blink/public/platform/brave_drm.mojom.h"
+
+// Reacts to DRM content detected on the renderer side.
+class BraveDrmTabHelper final
+    : public content::WebContentsObserver,
+      public content::WebContentsUserData<BraveDrmTabHelper>,
+      public blink::mojom::BraveDRM {
+ public:
+  BraveDrmTabHelper(content::WebContents* contents);
+  ~BraveDrmTabHelper() override;
+
+  bool ShouldShowWidevineOptIn() const;
+
+  // content::WebContentsObserver
+  void DidStartNavigation(
+      content::NavigationHandle* navigation_handle) override;
+
+  // blink::mojom::BraveDRM
+  void OnWidevineKeySystemAccessRequest() override;
+
+ private:
+  content::WebContentsFrameBindingSet<blink::mojom::BraveDRM> bindings_;
+
+  // True if we are notified that a page requested widevine availability.
+  bool is_widevine_requested_ = false;
+};
+
+#endif  // BRAVE_BROWSER_DRM_TAB_HELPER_H_

--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -4,6 +4,7 @@
 
 #include "brave/browser/brave_tab_helpers.h"
 
+#include "brave/browser/brave_drm_tab_helper.h"
 #include "brave/components/brave_ads/browser/ads_tab_helper.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "content/public/browser/web_contents.h"
@@ -26,6 +27,7 @@ void AttachTabHelpers(content::WebContents* web_contents) {
   brave_rewards::RewardsHelper::CreateForWebContents(web_contents);
 #endif
   // Add tab helpers here unless they are intended for android too
+  BraveDrmTabHelper::CreateForWebContents(web_contents);
 #endif
 
   brave_ads::AdsTabHelper::CreateForWebContents(web_contents);

--- a/browser/ui/content_settings/brave_content_setting_image_models.cc
+++ b/browser/ui/content_settings/brave_content_setting_image_models.cc
@@ -15,6 +15,9 @@ void BraveGenerateContentSettingImageModels(
     std::vector<std::unique_ptr<ContentSettingImageModel>>& result) {
   // Remove the cookies content setting image model
   // https://github.com/brave/brave-browser/issues/1197
+  // TODO(iefremov): This changes break internal image models ordering which is
+  // based on enum values. This breaks tests and probably should be fixed
+  // (by adding more diff of course).
   for (size_t i = 0; i < result.size(); i++) {
     if (result[i]->image_type() ==
         ContentSettingImageModel::ImageType::COOKIES) {

--- a/browser/ui/content_settings/brave_widevine_blocked_image_model.cc
+++ b/browser/ui/content_settings/brave_widevine_blocked_image_model.cc
@@ -4,16 +4,13 @@
 
 #include "brave/browser/ui/content_settings/brave_widevine_blocked_image_model.h"
 
-#include "brave/common/pref_names.h"
 #include "brave/common/shield_exceptions.h"
+#include "brave/browser/brave_drm_tab_helper.h"
 #include "brave/browser/ui/content_settings/brave_widevine_content_setting_bubble_model.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/profiles/profile_manager.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
-#include "components/prefs/pref_service.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/gfx/paint_vector_icon.h"
@@ -31,16 +28,9 @@ void BraveWidevineBlockedImageModel::UpdateFromWebContents(
   if (!web_contents)
     return;
 
-  // If the user alraedy opted in, don't show more UI
-  PrefService* prefs = ProfileManager::GetActiveUserProfile()->GetPrefs();
-  if (prefs->GetBoolean(kWidevineOptedIn)) {
-    return;
-  }
-
-  // If the URL isn't one that we whitelist as a site that gets UI for
-  // Widevine to be installable, then don't show naything.
-  GURL url = web_contents->GetURL();
-  if (!brave::IsWidevineInstallableURL(url)) {
+  BraveDrmTabHelper* drm_helper =
+      BraveDrmTabHelper::FromWebContents(web_contents);
+  if (!drm_helper->ShouldShowWidevineOptIn()) {
     return;
   }
 

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -109,6 +109,12 @@ void BraveLocationBarView::ChildPreferredSizeChanged(views::View* child) {
   Layout();
 }
 
+ContentSettingImageView*
+BraveLocationBarView::GetContentSettingsImageViewForTesting(size_t idx) {
+  DCHECK(idx < content_setting_views_.size());
+  return content_setting_views_[idx];
+}
+
 // Provide base class implementation for Update override that has been added to
 // header via a patch. This should never be called as the only instantiated
 // implementation should be our |BraveLocationBarView|.

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -25,6 +25,8 @@ class BraveLocationBarView : public LocationBarView {
     void OnThemeChanged() override;
     void ChildPreferredSizeChanged(views::View* child) override;
 
+    ContentSettingImageView* GetContentSettingsImageViewForTesting(size_t idx);
+
   private:
     void UpdateBookmarkStarVisibility() override;
     OmniboxTint GetTint() override;

--- a/chromium_src/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
+++ b/chromium_src/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
@@ -1,0 +1,41 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+namespace blink {
+class LocalFrame;
+
+namespace {
+class MediaKeySystemAccessInitializer;
+
+void MaybeOnWidevineRequest(MediaKeySystemAccessInitializer* initializer,
+                            LocalFrame* frame);
+}  // namespace
+}  // namespace blink
+
+#include "../../../../../../../third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc"
+
+#include "brave/third_party/blink/public/platform/brave_drm.mojom-blink.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+#include "third_party/blink/renderer/core/frame/local_frame_client.h"
+#include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"
+
+namespace blink {
+namespace {
+
+// Notifies Brave about the widevine availability request.
+void MaybeOnWidevineRequest(MediaKeySystemAccessInitializer* initializer,
+                            LocalFrame* frame) {
+  if (initializer->KeySystem() == "com.widevine.alpha") {
+    if (frame->Client()->GetRemoteNavigationAssociatedInterfaces()) {
+      mojom::blink::BraveDRMAssociatedPtr brave_drm_binding;
+      frame->Client()->GetRemoteNavigationAssociatedInterfaces()->GetInterface(
+          &brave_drm_binding);
+      DCHECK(brave_drm_binding.is_bound());
+      brave_drm_binding->OnWidevineKeySystemAccessRequest();
+    }
+  }
+}
+
+}  // namespace
+}  // namespace blink

--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -124,21 +124,4 @@ bool IsWhitelistedCookieExeption(const GURL& firstPartyOrigin,
       });
 }
 
-bool IsWidevineInstallableURL(const GURL& url) {
-  static std::vector<URLPattern> patterns({
-    URLPattern(URLPattern::SCHEME_ALL, "https://www.netflix.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://bitmovin.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://www.primevideo.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://www.spotify.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://shaka-player-demo.appspot.com/*"),
-    URLPattern(URLPattern::SCHEME_ALL, "https://*.hulu.com/*"),
-    // Used for tests
-    URLPattern(URLPattern::SCHEME_ALL, "http://www.netflix.com:*/*")
-  });
-  return std::any_of(patterns.begin(), patterns.end(),
-    [&url](URLPattern pattern){
-      return pattern.MatchesURL(url);
-    });
-}
-
 }

--- a/common/shield_exceptions.h
+++ b/common/shield_exceptions.h
@@ -13,6 +13,5 @@ bool IsWhitelistedCookieExeption(const GURL& firstPartyOrigin,
                                  const GURL& subresourceUrl);
 bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
                            const GURL& subresourceUrl);
-bool IsWidevineInstallableURL(const GURL& url);
 
 }  // namespace brave

--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -12,37 +12,6 @@ namespace {
 typedef testing::Test BraveShieldsExceptionsTest;
 using brave::IsWhitelistedReferrer;
 
-TEST_F(BraveShieldsExceptionsTest, WidevineInstallableURL) {
-  std::vector<GURL> urls({
-    GURL("https://www.netflix.com/"),
-    GURL("https://bitmovin.com/"),
-    GURL("https://www.primevideo.com/"),
-    GURL("https://www.spotify.com/"),
-    GURL("https://shaka-player-demo.appspot.com"),
-    GURL("https://www.netflix.com/subdir"),
-    GURL("https://bitmovin.com/subdir"),
-    GURL("https://www.primevideo.com/subdir"),
-    GURL("https://www.spotify.com/subdir"),
-    GURL("https://shaka-player-demo.appspot.com/subdir"),
-    GURL("https://hulu.com/watch/bf77880c-2f2e-4e09-b26d-5c7cc1de47ce")
-  });
-  std::for_each(urls.begin(), urls.end(),
-      [this](GURL url){
-    EXPECT_TRUE(brave::IsWidevineInstallableURL(url));
-  });
-}
-
-TEST_F(BraveShieldsExceptionsTest, NotWidevineInstallableURL) {
-  std::vector<GURL> urls({
-    GURL("https://www.brave.com/"),
-    GURL("https://widevine.com/")
-  });
-  std::for_each(urls.begin(), urls.end(),
-      [this](GURL url){
-    EXPECT_FALSE(brave::IsWidevineInstallableURL(url));
-  });
-}
-
 TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
   // *.fbcdn.net not allowed on some other URL
   EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://test.com"),

--- a/patches/third_party-blink-public-BUILD.gn.patch
+++ b/patches/third_party-blink-public-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/public/BUILD.gn b/third_party/blink/public/BUILD.gn
+index d7e025324889bb94136d05fe4d25e445eb85c1e9..0d12694524112ecd2d52b168febdd568f9a2c47b 100644
+--- a/third_party/blink/public/BUILD.gn
++++ b/third_party/blink/public/BUILD.gn
+@@ -671,6 +671,7 @@ mojom("mojo_bindings") {
+   visibility_blink =
+       [ "//third_party/blink/renderer/platform:blink_platform_public_deps" ]
+   sources = [
++    "../../../brave/third_party/blink/public/platform/brave_drm.mojom",
+     "platform/autoplay.mojom",
+     "platform/content_security_policy.mojom",
+     "platform/dedicated_worker_factory.mojom",

--- a/patches/third_party-blink-renderer-modules-encryptedmedia-navigator_request_media_key_system_access.cc.patch
+++ b/patches/third_party-blink-renderer-modules-encryptedmedia-navigator_request_media_key_system_access.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc b/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
+index 9f9702555d52ca094fcb982371e3b74a4c9bc3e5..de428db2aac07340f5b1f9eca4a84a2fa5caa24a 100644
+--- a/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
++++ b/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
+@@ -368,6 +368,9 @@ ScriptPromise NavigatorRequestMediaKeySystemAccess::requestMediaKeySystemAccess(
+   media_client->RequestMediaKeySystemAccess(
+       WebEncryptedMediaRequest(initializer));
+ 
++  // Notify Brave about the widevine availability request.
++  MaybeOnWidevineRequest(initializer, document->GetFrame());
++
+   // 7. Return promise.
+   return promise;
+ }

--- a/third_party/blink/public/platform/brave_drm.mojom
+++ b/third_party/blink/public/platform/brave_drm.mojom
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module blink.mojom;
+
+// Receives notifications about DRM presence.
+interface BraveDRM {
+  OnWidevineKeySystemAccessRequest();
+};
+


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1985
Replacing a set of hardcoded urls with a blink hook and a corresponding
tab helper that updates the widevine content settings icon.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source