### PR TITLE
Remove sync/sign in language from avatar menu.

### DIFF
--- a/browser/ui/views/profiles/brave_profile_chooser_view.cc
+++ b/browser/ui/views/profiles/brave_profile_chooser_view.cc
@@ -9,11 +9,16 @@
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/profiles/profiles_state.h"
 #include "chrome/browser/profiles/profile_window.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "chrome/browser/ui/views/hover_button.h"
+#include "chrome/browser/ui/views/profiles/badged_profile_photo.h"
+#include "chrome/grit/generated_resources.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/gfx/paint_vector_icon.h"
 #include "ui/views/controls/button/label_button.h"
+#include "ui/views/layout/box_layout.h"
 #include "ui/views/layout/grid_layout.h"
 
 namespace {
@@ -62,4 +67,36 @@ void BraveProfileChooserView::AddTorButton(views::GridLayout* layout) {
 void BraveProfileChooserView::ResetView() {
   ProfileChooserView::ResetView();
   tor_profile_button_ = nullptr;
+}
+
+views::View* BraveProfileChooserView::CreateDiceSyncErrorView(
+    const AvatarMenu::Item& avatar_item,
+    sync_ui_util::AvatarSyncErrorType error,
+    int button_string_id) {
+  ChromeLayoutProvider* provider = ChromeLayoutProvider::Get();
+  
+  views::View* view = new views::View();
+  int content_list_vert_spacing =
+      provider->GetDistanceMetric(DISTANCE_CONTENT_LIST_VERTICAL_SINGLE);
+  view->SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::kVertical, gfx::Insets(content_list_vert_spacing, 0),
+      0));
+
+  Profile* profile = browser_->profile();
+  auto current_profile_photo = std::make_unique<BadgedProfilePhoto>(
+      BadgedProfilePhoto::BADGE_TYPE_NONE, avatar_item.icon);
+  base::string16 profile_name = avatar_item.name;
+  if (profile_name.empty())
+    profile_name = profiles::GetAvatarNameForProfile(profile->GetPath());
+
+  HoverButton* profile_card = new HoverButton(
+      this, std::move(current_profile_photo), profile_name, base::string16());
+  current_profile_card_ = profile_card;
+  view->AddChildView(current_profile_card_);
+
+  current_profile_card_->SetAccessibleName(
+    l10n_util::GetStringFUTF16(
+      IDS_PROFILES_EDIT_PROFILE_ACCESSIBLE_NAME, profile_name));
+
+  return view;
 }

--- a/browser/ui/views/profiles/brave_profile_chooser_view.h
+++ b/browser/ui/views/profiles/brave_profile_chooser_view.h
@@ -23,6 +23,10 @@ class BraveProfileChooserView : public ProfileChooserView {
 
   void ResetView() override;
 
+  views::View* CreateDiceSyncErrorView(const AvatarMenu::Item& avatar_item,
+    sync_ui_util::AvatarSyncErrorType error,
+    int button_string_id) override;
+
   void AddTorButton(views::GridLayout* layout);
 
   views::LabelButton* tor_profile_button_;

--- a/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc
+++ b/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/profiles/brave_profile_chooser_view.h"
+
+#include "chrome/browser/profiles/avatar_menu.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "ui/events/base_event_utils.h"
+#include "ui/events/event.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/views/controls/button/button.h"
+#include "ui/views/controls/button/label_button.h"
+
+class BraveProfileChooserViewTest : public InProcessBrowserTest {
+ public:
+  BraveProfileChooserViewTest() = default;
+  ~BraveProfileChooserViewTest() override = default;
+
+protected:
+  void OpenProfileChooserView(Browser* browser) {
+    BrowserView* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
+    views::View* button = browser_view->toolbar()->avatar_button();
+    DCHECK(button);
+
+    ui::MouseEvent e(ui::ET_MOUSE_PRESSED, gfx::Point(), gfx::Point(),
+      ui::EventTimeForNow(), ui::EF_LEFT_MOUSE_BUTTON, 0);
+    button->OnMousePressed(e);
+  }
+
+  AvatarMenu* avatar_menu() {
+    return ProfileChooserView::profile_bubble_->avatar_menu_.get();
+  }
+
+  views::LabelButton* current_profile_card() {
+    return ProfileChooserView::profile_bubble_->current_profile_card_;
+  }
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(BraveProfileChooserViewTest);
+};
+
+IN_PROC_BROWSER_TEST_F(BraveProfileChooserViewTest, TestCurrentProfileView) {
+  OpenProfileChooserView(browser());
+
+  EXPECT_EQ(1u, avatar_menu()->GetNumberOfItems());
+  ASSERT_EQ(avatar_menu()->GetItemAt(0).name,
+            current_profile_card()->accessible_name());
+}

--- a/patches/chrome-browser-ui-views-profiles-profile_chooser_view.h.patch
+++ b/patches/chrome-browser-ui-views-profiles-profile_chooser_view.h.patch
@@ -1,16 +1,17 @@
 diff --git a/chrome/browser/ui/views/profiles/profile_chooser_view.h b/chrome/browser/ui/views/profiles/profile_chooser_view.h
-index 83709a31644e43fad0a3754a37db181d7ce7b9f6..e0bf4ca6d80713b5830fa0f0dd7d1080a849968f 100644
+index 83709a31644e43fad0a3754a37db181d7ce7b9f6..3f9b08b74a1a17c8e3bc4872b7069416f92d2cd8 100644
 --- a/chrome/browser/ui/views/profiles/profile_chooser_view.h
 +++ b/chrome/browser/ui/views/profiles/profile_chooser_view.h
-@@ -71,6 +71,7 @@ class ProfileChooserView : public content::WebContentsDelegate,
+@@ -71,6 +71,8 @@ class ProfileChooserView : public content::WebContentsDelegate,
    const Browser* browser() const { return browser_; }
  
   private:
 +  friend class BraveProfileChooserView;
++  friend class BraveProfileChooserViewTest;
    friend class ProfileChooserViewExtensionsTest;
  
    typedef std::vector<size_t> Indexes;
-@@ -120,7 +121,7 @@ class ProfileChooserView : public content::WebContentsDelegate,
+@@ -120,7 +122,7 @@ class ProfileChooserView : public content::WebContentsDelegate,
    // Tests set this to "false" for more consistent operation.
    static bool close_on_deactivate_for_testing_;
  
@@ -19,3 +20,11 @@ index 83709a31644e43fad0a3754a37db181d7ce7b9f6..e0bf4ca6d80713b5830fa0f0dd7d1080
  
    // Shows the bubble with the |view_to_display|.
    void ShowView(profiles::BubbleViewMode view_to_display,
+@@ -168,6 +170,7 @@ class ProfileChooserView : public content::WebContentsDelegate,
+ 
+   // Creates a view showing the profile associated with |avatar_item| and an
+   // error button below.
++  virtual
+   views::View* CreateDiceSyncErrorView(const AvatarMenu::Item& avatar_item,
+                                        sync_ui_util::AvatarSyncErrorType error,
+                                        int button_string_id);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -247,6 +247,7 @@ test("brave_browser_tests") {
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
+    "//brave/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_service_browsertest.cc",


### PR DESCRIPTION
Fixes brave/brave-browser#2234

This fix modifies the current profile's button in the avatar popup menu.
It removes the sync overlay from the profile icon and replaces "Sync
disabled"/"Not signed in" labels with the profile's name.

Adds a browser test to verify that the button shows profile name.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
**Automated test:**
`npm run test -- brave_browser_tests --filter=BraveProfileChooserViewTest.TestCurrentProfileView`

**Manual test:**
- Start Brave browser,
- Click on the avatar menu button in the toolbar,
- Verify that the first button in the menu shows profile avatar with no overlays and the text is the name of the profile.
- Click on the button - this should result in profile settings page showing up,
- In the profile settings page change the profile name,
- Click on the avatar menu button again,
- Verify that the profile button shows the new name.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source