### PR TITLE
Sync mobile bookmarks on toolbar

### DIFF
--- a/components/brave_sync/client/bookmark_change_processor.cc
+++ b/components/brave_sync/client/bookmark_change_processor.cc
@@ -173,17 +173,15 @@ const bookmarks::BookmarkNode* FindParent(bookmarks::BookmarkModel* model,
   auto* parent_node = FindByObjectId(model, bookmark.parentFolderObjectId);
 
   if (!parent_node) {
-    if (!bookmark.order.empty() &&
-        bookmark.order.at(0) == '2') {
-      // mobile generated bookmarks go in the mobile folder so they don't
-      // get so we don't get m.xxx.xxx domains in the normal bookmarks
-      parent_node = model->mobile_node();
-    } else if (!bookmark.hideInToolbar) {
-      // this flag is a bit odd, but if the node doesn't have a parent and
-      // hideInToolbar is false, then this bookmark should go in the
-      // toolbar root. We don't care about this flag for records with
-      // a parent id because they will be inserted into the correct
-      // parent folder
+    if (
+        // this flag is a bit odd, but if the node doesn't have a parent and
+        // hideInToolbar is false, then this bookmark should go in the
+        // toolbar root. We don't care about this flag for records with
+        // a parent id because they will be inserted into the correct
+        // parent folder
+        !bookmark.hideInToolbar ||
+        // mobile generated bookmarks go also in bookmark bar
+        (!bookmark.order.empty() && bookmark.order.at(0) == '2')) {
       parent_node = model->bookmark_bar_node();
     } else {
       parent_node = model->other_node();

--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -592,8 +592,9 @@ TEST_F(BraveBookmarkChangeProcessorTest, ChildrenOfPermanentNodesFromSync) {
       "", false, ""));
   ASSERT_EQ(model()->mobile_node()->child_count(), 0);
   change_processor()->ApplyChangesFromSyncModel(records);
-  ASSERT_EQ(model()->mobile_node()->child_count(), 1);
-  const auto* folder2 = model()->mobile_node()->GetChild(0);
+  ASSERT_EQ(model()->mobile_node()->child_count(), 0);
+  ASSERT_EQ(model()->bookmark_bar_node()->child_count(), 2);
+  const auto* folder2 = model()->bookmark_bar_node()->GetChild(1);
   EXPECT_EQ(base::UTF16ToUTF8(folder2->GetTitle()), "Folder2");
 
   records.clear();
@@ -779,4 +780,25 @@ TEST_F(BraveBookmarkChangeProcessorTest, TitleCustomTitle) {
   ASSERT_EQ(folder1->child_count(), 1);
   const auto* folder2 = folder1->GetChild(0);
   EXPECT_EQ(base::UTF16ToUTF8(folder2->GetTitle()), "Folder2");
+}
+
+TEST_F(BraveBookmarkChangeProcessorTest, BookmarkFromMobileGoesToToolbar) {
+  change_processor()->Start();
+  auto a_record = SimpleBookmarkSyncRecord(
+    jslib::SyncRecord::Action::A_CREATE,
+    "",
+    "https://a.com/",
+    "A.com - title",
+    "2.1.1",
+    "");
+  RecordsList records;
+  records.push_back(std::move(a_record));
+  change_processor()->ApplyChangesFromSyncModel(records);
+  // Verify the model, now we should find the folder and the nodes
+  EXPECT_EQ(model()->other_node()->child_count(), 0);
+  EXPECT_EQ(model()->mobile_node()->child_count(), 0);
+  ASSERT_EQ(model()->bookmark_bar_node()->child_count(), 1);
+
+  const auto* node_a = model()->bookmark_bar_node()->GetChild(0);
+  EXPECT_EQ(node_a->url().spec(), "https://a.com/");
 }


### PR DESCRIPTION
## Submitter Checklist:

Fixes https://github.com/brave/brave-browser/issues/2127 . Mobile bookmarks go to `Bookmarks bar` folder.

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Specified in issue https://github.com/brave/brave-browser/issues/2127 .
Auto test:
`npm run test -- brave_unit_tests --filter=BraveBookmarkChangeProcessorTest.ChildrenOfPermanentNodesFromSync:BraveBookmarkChangeProcessorTest.BookmarkFromMobileGoesToToolbar`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source