### PR TITLE
Defer initial load of imported tabs

### DIFF
--- a/browser/importer/brave_profile_writer.cc
+++ b/browser/importer/brave_profile_writer.cc
@@ -25,6 +25,7 @@
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_navigator.h"
 #include "chrome/browser/ui/browser_navigator_params.h"
+#include "chrome/browser/ui/browser_tabrestore.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "content/public/browser/browser_context.h"
@@ -377,12 +378,19 @@ void OpenImportedBrowserTabs(Browser* browser,
     const std::vector<ImportedBrowserTab>& tabs,
     bool pinned) {
   for (const auto tab : tabs) {
-    NavigateParams params(browser, tab.location,
-                          ui::PAGE_TRANSITION_AUTO_TOPLEVEL);
-    params.disposition = WindowOpenDisposition::NEW_BACKGROUND_TAB;
-    params.tabstrip_add_types = pinned ? TabStripModel::ADD_PINNED
-                                       : TabStripModel::ADD_FORCE_INDEX;
-    Navigate(&params);
+    std::vector<sessions::SerializedNavigationEntry> e;
+    sessions::SerializedNavigationEntry entry;
+    entry.set_virtual_url(tab.location);
+    entry.set_original_request_url(tab.location);
+    entry.set_is_restored(true);
+    e.push_back(entry);
+
+    chrome::AddRestoredTab(
+        browser, e, browser->tab_strip_model()->count(), 0,
+        "", false, pinned, true,
+        base::TimeTicks::UnixEpoch(), nullptr,
+        "", true /* from_session_restore */);
+
   }
 }
 


### PR DESCRIPTION
Resolves brave/brave-browser#2374.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Follow brave/brave-browser#2374 STR.

Expected result:
1. All windows/tabs are recreated in the background.
2. Only the active tab in each imported window is initially loaded.
3. Other tabs are present but deferred. They should initially load once the user activates them.
4. The browser should remain responsive during and immediately after import. There should not be a huge increase in CPU or memory use.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source