### PR TITLE
WIP: Prototype of User Tipping on twitter.com

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/BUILD.gn
+++ b/components/brave_rewards/resources/extension/brave_rewards/BUILD.gn
@@ -24,12 +24,16 @@ transpile_web_ui("brave_rewards_panel") {
     "components/app.tsx",
     "components/panel.tsx",
     "constants/rewards_panel_types.ts",
+    "content-scripts/twitter.ts",
+    "user-tip/userTipDialog.tsx",
+    "user-tip/userTipDialogContent.tsx",
     "utils.ts",
   ]
 
   entry_points = [
     ["brave_rewards_panel", rebase_path("brave_rewards_panel.tsx")],
-    ["brave_rewards_panel_background", rebase_path("background.ts")]
+    ["brave_rewards_panel_background", rebase_path("background.ts")],
+    ["brave_rewards_content_twitter", rebase_path("content-scripts/twitter.ts")]
   ]
 
   resource_name = "brave_rewards_panel"

--- a/components/brave_rewards/resources/extension/brave_rewards/background.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background.ts
@@ -41,3 +41,48 @@ chrome.runtime.onConnect.addListener(function () {
     }
   })
 })
+
+//
+// Detect User Tip requests via network calls
+//
+// Twitter
+//
+const requestFilter = {
+  urls: ['https://api.twitter.com/1.1/favorites/create.json']
+}
+
+const twitterContentScriptArgs = {
+  file: '/out/brave_rewards_content_twitter.bundle.js'
+}
+
+async function onTwitterFavoriteCreated (details: any) {
+  const logPrefix = 'USER_TIP [twitter]: '
+  if (details.method !== 'POST' || !details.requestBody || !details.requestBody.formData) {
+    console.error(`${logPrefix}Received a favorite request, but not a POST, was a `, details.method)
+    return
+  }
+  const { formData } = details.requestBody
+  if (!formData.id || !formData.id.length) {
+    console.error(`${logPrefix}Received a favorite request, but no item ID`, details.formData)
+    return
+  }
+  const tweetId = formData.id[0]
+  console.log(`${logPrefix}Tab [${details.tabId}] received a favorite request for tweet`, tweetId)
+  const tabMessagePayload = { userAction: 'USER_TIP', tweetId }
+  // If we've already added the content script send the message immediately
+  chrome.tabs.sendMessage(details.tabId, tabMessagePayload, (tabResponsePayload?: any) => {
+    // If the content script isn't loaded, then we won't get a payload back
+    // and chrome.runtime.lastError will inform us that there is no content script
+    // in the frame yet.
+    if (!tabResponsePayload || !tabResponsePayload.received) {
+      // Inject the content script for this tab frame
+      chrome.tabs.executeScript(details.tabId, twitterContentScriptArgs, () => {
+        // Content script loaded. Send the message again.
+        chrome.tabs.sendMessage(details.tabId, tabMessagePayload)
+      })
+    }
+  })
+}
+
+// onBeforeRequest is the only extension API we can access req / res body data
+chrome.webRequest.onBeforeRequest.addListener(onTwitterFavoriteCreated, requestFilter, ['requestBody'])

--- a/components/brave_rewards/resources/extension/brave_rewards/content-scripts/twitter.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/content-scripts/twitter.ts
@@ -1,0 +1,72 @@
+import renderTipDialog from '../user-tip/userTipDialog'
+
+// Receive message from background script
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  const { userAction, tweetId }: { userAction: string, tweetId: string } = request
+  // Tell the background script we're here
+  // so that it doesn't add this content script to the frame again.
+  sendResponse({ received: true })
+  if (userAction === 'USER_TIP') {
+    if (!tweetId) {
+      console.error('Received a USER_TIP but no tweetId')
+      return
+    }
+    console.log(`Received a USER_TIP for tweet ${tweetId}`)
+    detectShowUserTip(tweetId)
+  }
+})
+
+function detectShowUserTip (tweetId: string) {
+  console.log('onUserTip', tweetId)
+  const tweetItems = document.querySelectorAll(`[data-retweet-id="${tweetId}"], [data-tweet-id="${tweetId}"]`)
+  // TODO: work out which one was clicked
+  if (tweetItems.length) {
+    const currentActionElement = tweetItems[0].querySelector('.js-actionFavorite')
+    if (currentActionElement) {
+      const stableActionElement = currentActionElement.parentElement
+      if (stableActionElement) {
+        window.requestAnimationFrame(() => {
+          offerUserTip(stableActionElement)
+        })
+        return
+      }
+    }
+  }
+  // const anchorElement = document.querySelector(`[aria-describedby="profile-tweet-action-favorite-count-aria-${tweetId}"]`)
+  console.log('onUserTip: could not get anchor element', tweetItems)
+}
+
+let dialogEl: HTMLElement | null
+
+async function offerUserTip (anchorElement: Element) {
+  console.log('offerUserTip', anchorElement)
+  removeDialog()
+  dialogEl = document.createElement('div')
+  const anchorElementRect = anchorElement.getBoundingClientRect()
+  // TODO: Show bottom / top and left / right
+  // according to viewport space available.
+  const dialogPosition = {
+    x: anchorElementRect.left + window.scrollX,
+    y: anchorElementRect.bottom + window.scrollY + 10
+  }
+  dialogEl.style.position = 'absolute'
+  dialogEl.style.left = `${dialogPosition.x}px`
+  dialogEl.style.top = `${dialogPosition.y}px`
+  renderTipDialog(dialogEl, 'topLeft')
+  document.body.appendChild(dialogEl)
+  document.body.addEventListener('click', onDocumentDialogBackgroundClick)
+}
+
+function onDocumentDialogBackgroundClick () {
+  console.log('onDocumentDialogBackgroundClick')
+  document.body.removeEventListener('click', onDocumentDialogBackgroundClick)
+  removeDialog()
+}
+
+function removeDialog () {
+  if (dialogEl) {
+    dialogEl.remove()
+    dialogEl = null
+  }
+}
+// get heart button: '[aria-describedby="profile-tweet-action-favorite-count-aria-853292140620730369"]'

--- a/components/brave_rewards/resources/extension/brave_rewards/manifest.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/manifest.json
@@ -11,7 +11,10 @@
   "permissions": [
     "storage",
     "tabs",
-    "chrome://favicon/*"
+    "chrome://favicon/*",
+    "activeTab",
+    "webRequest",
+    "https://*.twitter.com/"
   ],
   "browser_action": {
     "default_popup": "brave_rewards_panel.html",

--- a/components/brave_rewards/resources/extension/brave_rewards/user-tip/userTipDialog.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/user-tip/userTipDialog.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { render } from 'react-dom'
+import defaultTheme from 'brave-ui/theme/brave-default'
+import { ThemeProvider } from 'brave-ui/theme'
+import { StyleSheetManager } from 'styled-components'
+import { initLocale } from 'brave-ui/helpers'
+import { getUIMessages } from '../background/api/locale_api'
+import TipDialogContent, { AnchorDirection } from './userTipDialogContent'
+
+console.log('init user tip dialog')
+initLocale(getUIMessages())
+
+export default function renderTipDialog (container: Element, anchorDirection?: AnchorDirection) {
+  // Keep everything contained to a closed shadow-dom
+  // so that host site cannot read or write our content.
+  const shadowElement = container.attachShadow({ mode: 'closed' })
+  const appContainer = document.createElement('div')
+  const stylesContainer = document.createElement('div')
+  shadowElement.appendChild(stylesContainer)
+  shadowElement.appendChild(appContainer)
+  render(
+    <StyleSheetManager target={stylesContainer}>
+      <ThemeProvider theme={defaultTheme}>
+        <TipDialogContent anchorDirection={anchorDirection} />
+      </ThemeProvider>
+    </StyleSheetManager>,
+    appContainer
+  )
+}

--- a/components/brave_rewards/resources/extension/brave_rewards/user-tip/userTipDialogContent.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/user-tip/userTipDialogContent.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+import { Tip } from 'brave-ui/features/rewards'
+
+export type AnchorDirection = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
+
+type TipDialogContentProps = {
+  anchorDirection: AnchorDirection
+}
+
+const donationAmounts = [
+  {
+    tokens: '1.0',
+    converted: '0.30',
+    selected: false
+  },
+  {
+    tokens: '5.0',
+    converted: '1.50',
+    selected: false
+  },
+  {
+    tokens: '10.0',
+    converted: '3.00',
+    selected: false
+  }
+]
+
+export default class TipDialogContent
+                extends React.PureComponent<TipDialogContentProps> {
+
+  static defaultProps = {
+    anchorDirection: 'topLeft'
+  }
+
+  onDonate = () => {
+    console.log('does nothing')
+  }
+
+  onClose = () => {
+    console.log('does nothing')
+  }
+
+  onAllow = () => {
+    console.log('does nothing')
+  }
+
+  onAmountSelection = () => {
+    console.log('does nothing')
+  }
+
+  render () {
+    // TODO: anchor arrow
+    return (
+      <Tip
+        donationAmounts={donationAmounts}
+        title='Bart Baker'
+        allow={true}
+        provider='YouTube'
+        balance='5'
+        onDonate={this.onDonate}
+        onClose={this.onClose}
+        onAllow={this.onAllow}
+        onAmountSelection={this.onAmountSelection}
+        currentAmount={5}
+      />
+    )
+  }
+}


### PR DESCRIPTION
## What
This is the beginning of the Brave Rewards feature which offers a Brave Rewards user to tip a specific user of a content platform's (such as Twitter) within a stream of content (such as a Twitter feed).

## Why like this?
After discussion, we decided to _start with_ an implementation in HTML despite a strong preference for this to ultimately be completely independent from the host DOM. This was to get a working version rapidly, flush out the UI requirements, and unblock some backend implementation and UX review.

## How does it work?
- Detects 'like' action via network requests
- Detects 'like' button position via DOM query
- Shows dialog via plain DIV injection
- Dialog content contained within Shadow DOM

Uses JS and HTML to create a dialog inside the host content document.
Security precautions:

- Does not expose any extension URLs to the host page (as would be the case with a src'ed iframe or XHR JS)


## Security
### Questions I asked myself:
- Can the host site know what we're doing?
  - Renders dialog content to a closed shadow DOM. ✅ 

- Can the host site interfere with what we're doing?
  - All execution is done within an isolated V8 content script. AFAIK the host site cannot modify global type prototypes to interfere with our DOM calls.  ✅ 
  - They could observe the shadow host element that is added to the DOM (which looks merely like `<div style="position: absolute;" />`) 🔴 
    _- With this, the host site could potentially remove our element if they could somehow detect it was not created by their code, or perhaps determine that their user is a Brave Rewards user._


Because of this last point, [I did do something (potentially) crazy in another branch](https://github.com/brave/brave-core/commit/20bad3c173a75a6b45b2e10a371cf30660092a65): instead of creating a new DOM element, this branch attaches a closed shadow to the `document.body` (which requires 0 visible DOM elements), and thus the source site will not be able to observe any DOM changes as a result of Brave Rewards showing the dialog.
See that branch diff here - https://github.com/brave/brave-core/commit/20bad3c173a75a6b45b2e10a371cf30660092a65

An alternative to the closed-shadow-dom security model could be a non-`src`ed iframe and rendering the dialog content in the `iFrame.documentWindow`. I'm not sure if this would provide any advantage though. The disadvantage would be that the iframe would be in the DOM 🤷‍♀️ 

## Why not native yet?
1. We do not yet have a rapid method of developing a native widget which can:
  - be displayed anchored to a position in the DOM or the viewport
  - whilst containing a webview
  - have transparent webview background _or_ allow clipping the webview to the widget's custom shape (e.g. rounded corners, anchor arrow)
2. Because I wanted to rule out this method first, which took me ~1 day to create.

Issue which describes native dialog approach, features of which we don't have yet: https://github.com/brave/brave-browser/issues/1221