### PR TITLE
Fix relaunch fail after update on mac

### DIFF
--- a/browser/mac/sparkle_glue.h
+++ b/browser/mac/sparkle_glue.h
@@ -53,6 +53,8 @@ extern NSString* const kBraveAutoupdateStatusErrorMessages;
 
 - (void)checkForUpdates;
 
+- (void)relaunch;
+
 - (AutoupdateStatus)recentStatus;
 - (NSNotification*)recentNotification;
 

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -225,6 +225,11 @@ NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
   [su_updater_ checkForUpdatesInBackground];
 }
 
+- (void)relaunch {
+  [su_updater_.driver installWithToolAndRelaunch:YES
+                         displayingUserInterface:NO];
+}
+
 - (void)checkForUpdatesInBackground {
   DCHECK(registered_);
   [su_updater_ checkForUpdatesInBackground];

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -147,6 +147,8 @@ NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
   if ([self isOnReadOnlyFilesystem])
     return NO;
 
+  DCHECK(!su_updater_);
+
   NSString* sparkle_path =
       [[base::mac::FrameworkBundle() privateFrameworksPath]
           stringByAppendingPathComponent:@"Sparkle.framework"];
@@ -164,6 +166,11 @@ NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
 }
 
 - (void)registerWithSparkle {
+  // This can be called by BraveBrowserMainPartsMac::PreMainMessageLoopStart()
+  // again when browser is relaunched.
+  if (registered_)
+    return;
+
   DCHECK(brave::UpdateEnabled());
   DCHECK(su_updater_);
 

--- a/browser/mac/su_updater.h
+++ b/browser/mac/su_updater.h
@@ -7,7 +7,16 @@
 
 #import <Foundation/Foundation.h>
 
+@interface SUUpdateDriver;
+
+- (void)installWithToolAndRelaunch:(BOOL)relaunch displayingUserInterface
+                                  :(BOOL)showUI;
+
+@end
+
 @interface SUUpdater : NSObject
+
+@property (strong) SUUpdateDriver *driver;
 
 + (SUUpdater *)sharedUpdater;
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -73,6 +73,8 @@ source_set("ui") {
     "webui/brave_welcome_ui.h",
     "webui/settings/brave_privacy_handler.cc",
     "webui/settings/brave_privacy_handler.h",
+    "webui/settings/brave_relaunch_handler_mac.mm",
+    "webui/settings/brave_relaunch_handler_mac.h",
     "webui/settings/default_brave_shields_handler.cc",
     "webui/settings/default_brave_shields_handler.h",
     "webui/sync/sync_ui.cc",

--- a/browser/ui/webui/brave_md_settings_ui.cc
+++ b/browser/ui/webui/brave_md_settings_ui.cc
@@ -12,12 +12,21 @@
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
 #include "content/public/browser/web_ui_data_source.h"
 
+#if defined(OS_MACOSX)
+#include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
+#endif
+
 BraveMdSettingsUI::BraveMdSettingsUI(content::WebUI* web_ui,
                                      const std::string& host)
     : MdSettingsUI(web_ui) {
   web_ui->AddMessageHandler(std::make_unique<settings::MetricsReportingHandler>());
   web_ui->AddMessageHandler(std::make_unique<BravePrivacyHandler>());
   web_ui->AddMessageHandler(std::make_unique<DefaultBraveShieldsHandler>());
+
+  #if defined(OS_MACOSX)
+  // Use sparkle's relaunch api for browser relaunch on update.
+  web_ui->AddMessageHandler(std::make_unique<BraveRelaunchHandler>());
+  #endif
 }
 
 BraveMdSettingsUI::~BraveMdSettingsUI() {

--- a/browser/ui/webui/settings/brave_relaunch_handler_mac.h
+++ b/browser/ui/webui/settings/brave_relaunch_handler_mac.h
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_RELAUNCH_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_RELAUNCH_HANDLER_H_
+
+#include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
+
+class Profile;
+
+class BraveRelaunchHandler : public settings::SettingsPageUIHandler {
+ public:
+  BraveRelaunchHandler() = default;
+  ~BraveRelaunchHandler() override = default;
+
+ private:
+  // SettingsPageUIHandler overrides:
+  void RegisterMessages() override;
+  void OnJavascriptAllowed() override {}
+  void OnJavascriptDisallowed() override {}
+
+  void Relaunch(const base::ListValue* args);
+
+  DISALLOW_COPY_AND_ASSIGN(BraveRelaunchHandler);
+};
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_RELAUNCH_HANDLER_H_

--- a/browser/ui/webui/settings/brave_relaunch_handler_mac.mm
+++ b/browser/ui/webui/settings/brave_relaunch_handler_mac.mm
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
+
+#include "base/bind.h"
+#import "brave/browser/mac/sparkle_glue.h"
+
+void BraveRelaunchHandler::RegisterMessages() {
+  web_ui()->RegisterMessageCallback(
+      "relaunchOnMac",
+      base::BindRepeating(&BraveRelaunchHandler::Relaunch,
+                          base::Unretained(this)));
+}
+
+void BraveRelaunchHandler::Relaunch(const base::ListValue* args) {
+  [[SparkleGlue sharedSparkleGlue] relaunch];
+}

--- a/patches/chrome-browser-resources-settings-about_page-about_page.js.patch
+++ b/patches/chrome-browser-resources-settings-about_page-about_page.js.patch
@@ -1,0 +1,19 @@
+diff --git a/chrome/browser/resources/settings/about_page/about_page.js b/chrome/browser/resources/settings/about_page/about_page.js
+index 70e53fcf3166560520b31ecaa906120f44e3315a..6f31f72f1d0ffe8e8add29ebe1f0027bfc7be2dc 100644
+--- a/chrome/browser/resources/settings/about_page/about_page.js
++++ b/chrome/browser/resources/settings/about_page/about_page.js
+@@ -271,7 +271,14 @@ Polymer({
+ 
+   /** @private */
+   onRelaunchTap_: function() {
++    // <if expr="is_macosx">
++    // Sparkle framework's relaunch api is used.
++    this.lifetimeBrowserProxy_.relaunchOnMac();
++    // </if>
++
++    // <if expr="not is_macosx">
+     this.lifetimeBrowserProxy_.relaunch();
++    // </if>
+   },
+ 
+   /** @private */

--- a/patches/chrome-browser-resources-settings-lifetime_browser_proxy.js.patch
+++ b/patches/chrome-browser-resources-settings-lifetime_browser_proxy.js.patch
@@ -1,0 +1,32 @@
+diff --git a/chrome/browser/resources/settings/lifetime_browser_proxy.js b/chrome/browser/resources/settings/lifetime_browser_proxy.js
+index 396539708ffed08cc0fc084fde54bba2496598fe..afa73c21c35d4ab6d54797b63a96eec993d93f73 100644
+--- a/chrome/browser/resources/settings/lifetime_browser_proxy.js
++++ b/chrome/browser/resources/settings/lifetime_browser_proxy.js
+@@ -11,6 +11,13 @@ cr.define('settings', function() {
+     // Triggers a browser relaunch.
+     relaunch() {}
+ 
++    // <if expr="is_macosx">
++    // Use separate api for relaunch after update on Mac.
++    // Chromium's relaunch api isn't compatible with sparkle framework.
++    // So, sparkle framework's relaunch api is used on Mac.
++    relaunchOnMac() {}
++    // </if>
++
+     // <if expr="chromeos">
+     // First signs out current user and then performs a restart.
+     signOutAndRestart() {}
+@@ -39,6 +46,13 @@ cr.define('settings', function() {
+       chrome.send('relaunch');
+     }
+ 
++    // <if expr="is_macosx">
++    /** @override */
++    relaunchOnMac() {
++      chrome.send('relaunchOnMac');
++    }
++    // </if>
++
+     // <if expr="chromeos">
+     /** @override */
+     signOutAndRestart() {


### PR DESCRIPTION
First commit is cleanup.
Second commit is fix for relaunch fail after update.
Sparkle framework's relaunch api is used instead of using chromium's relaunch api.

This change will not affect other platforms(linux and win).

Fix https://github.com/brave/brave-browser/issues/977
Fix https://github.com/brave/brave-browser/issues/2339

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Modify version in source tree to lower than released stable version for update test
    Ex, change 55.1 in `package.json` and `chrome/VERSION`.
2. Build master release mode
3. Start browser with update enabled mode 
    `yarn start Release --enable_brave_update`
4. Open help page and waiting to finish update and push relaunch button
5. Check relaunch is done

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source