### PR TITLE
Use VLOG (instead of LOG) to report failure to send usage stats

### DIFF
--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -138,10 +138,10 @@ void BraveStatsUpdater::OnSimpleLoaderComplete(
     response_code = headers->response_code();
   if (simple_url_loader_->NetError() != net::OK || response_code < 200 ||
       response_code > 299) {
-    LOG(ERROR) << "Failed to send usage stats to update server"
-               << ", error: " << simple_url_loader_->NetError()
-               << ", response code: " << response_code
-               << ", url: " << final_url.spec();
+    VLOG(1) << "Failed to send usage stats to update server"
+            << ", error: " << simple_url_loader_->NetError()
+            << ", response code: " << response_code
+            << ", url: " << final_url.spec();
     return;
   }
 


### PR DESCRIPTION
Use VLOG (not LOG) when reporting failure to send usage stats. Failure message looks like this:

```
[22244:22244:1127/142107.494241:ERROR:brave_stats_updater.cc(108)] Failed to send usage stats to update server, error: -2, response code: 400, url: https://laptop-updates.brave.com/1/usage/brave-core?platform=linux-bc&channel=unknown&version=0.56.15&daily=true&weekly=true&monthly=true&first=true&woi=2018-11-26&ref=none"
```

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source