### PR TITLE
Fix brave_installer.exe fail on x86

### DIFF
--- a/patches/chrome-installer-mini_installer-mini_installer.cc.patch
+++ b/patches/chrome-installer-mini_installer-mini_installer.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mini_installer/mini_installer.cc b/chrome/installer/mini_installer/mini_installer.cc
-index 1f39abbeb2579098a54fa82612199f0307ea03b4..6aa317767ed09e31296c5c9af187481aecc0eeaf 100644
+index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e795b1a07ca 100644
 --- a/chrome/installer/mini_installer/mini_installer.cc
 +++ b/chrome/installer/mini_installer/mini_installer.cc
 @@ -61,7 +61,7 @@ struct Context {
@@ -11,7 +11,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..6aa317767ed09e31296c5c9af187481a
  // Opens the Google Update ClientState key. If |binaries| is false, opens the
  // key for Google Chrome or Chrome SxS (canary). If |binaries| is true and an
  // existing multi-install Chrome is being updated, opens the key for the
-@@ -142,6 +142,119 @@ void SetInstallerFlags(const Configuration& configuration) {
+@@ -142,6 +142,122 @@ void SetInstallerFlags(const Configuration& configuration) {
  }
  #endif  // GOOGLE_CHROME_BUILD
  
@@ -116,14 +116,17 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..6aa317767ed09e31296c5c9af187481a
 +}
 +
 +bool GetStubInstallerFilename(PathString& installer_filename) {
-+  wchar_t value[MAX_PATH];
-+  if (RegKey::ReadSZValue(HKEY_CURRENT_USER, L"Software\\BraveSoftware\\Promo",
-+                          L"StubInstallerPath", value, _countof(value)) &&
-+      value[0] == L'0') {
-+    return false;
-+  }
++  wchar_t value[MAX_PATH] = {0,};
++  const bool result =
++      RegKey::ReadSZValue(HKEY_CURRENT_USER, L"Software\\BraveSoftware\\Promo",
++                          L"StubInstallerPath", value, _countof(value)) ;
 +
-+  installer_filename.assign(value);
++  if (!result)
++    return false;
++
++  if (!installer_filename.assign(value) || installer_filename.length() == 0)
++    return false;
++
 +  return true;
 +}
 +#endif  // BRAVE_CHROMIUM_BUILD
@@ -131,7 +134,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..6aa317767ed09e31296c5c9af187481a
  // Gets the setup.exe path from Registry by looking at the value of Uninstall
  // string.  |size| is measured in wchar_t units.
  ProcessExitResult GetSetupExePathForAppGuid(bool system_level,
-@@ -526,6 +639,21 @@ ProcessExitResult RunSetup(const Configuration& configuration,
+@@ -526,6 +642,21 @@ ProcessExitResult RunSetup(const Configuration& configuration,
    // on to setup.exe
    AppendCommandLineFlags(configuration.command_line(), &cmd_line);
  
@@ -153,7 +156,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..6aa317767ed09e31296c5c9af187481a
    return RunProcessAndWait(setup_exe.get(), cmd_line.get(),
                             RUN_SETUP_FAILED_FILE_NOT_FOUND,
                             RUN_SETUP_FAILED_PATH_NOT_FOUND,
-@@ -873,7 +1001,7 @@ ProcessExitResult WMain(HMODULE module) {
+@@ -873,7 +1004,7 @@ ProcessExitResult WMain(HMODULE module) {
    if (!GetWorkDir(module, &base_path, &exit_code))
      return exit_code;
  
@@ -162,7 +165,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..6aa317767ed09e31296c5c9af187481a
    // Set the magic suffix in registry to try full installer next time. We ignore
    // any errors here and we try to set the suffix for user level unless
    // GoogleUpdateIsMachine=1 is present in the environment or --system-level is
-@@ -898,7 +1026,7 @@ ProcessExitResult WMain(HMODULE module) {
+@@ -898,7 +1029,7 @@ ProcessExitResult WMain(HMODULE module) {
    if (ShouldDeleteExtractedFiles())
      DeleteExtractedFiles(base_path.get(), archive_path.get(), setup_path.get());
  


### PR DESCRIPTION
When RegKey::ReadSZValue() returns false, GetStubInstallerFilename()
should return false, too.

Fix https://github.com/brave/brave-browser/issues/1695

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Build 32bit `brave_installer.exe` by `yarn create_dist Release` and runs it on x86 windows platform.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source