### PR TITLE
Fix crash when brave wallet settings page is loading

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -330,6 +330,8 @@ void RewardsDOMHandler::OnWalletProperties(
         grants->Append(std::move(grant));
       }
       walletInfo->SetList("grants", std::move(grants));
+
+      result.SetDouble("monthlyAmount", wallet_properties->monthly_amount);
     }
 
     values.SetDictionary("ui", std::move(ui_values));
@@ -339,8 +341,6 @@ void RewardsDOMHandler::OnWalletProperties(
       "brave_rewards.initAutoContributeSettings", values);
 
     result.SetDictionary("wallet", std::move(walletInfo));
-    result.SetDouble("monthlyAmount", wallet_properties->monthly_amount);
-
 
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.walletProperties", result);
   }

--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -279,7 +279,6 @@ void RewardsDOMHandler::OnWalletProperties(
     brave_rewards::RewardsService* rewards_service,
     int error_code,
     std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) {
-
   if (web_ui()->CanCallJavascript()) {
     base::DictionaryValue values;
     values.SetBoolean("enabledContribute",

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -975,10 +975,11 @@ void RewardsServiceImpl::TriggerOnWalletProperties(int error_code,
 
         wallet_properties->grants.push_back(grant);
       }
-    }
 
-    // webui
-    observer.OnWalletProperties(this, error_code, std::move(wallet_properties));
+      // webui
+      observer.OnWalletProperties(
+          this, error_code, std::move(wallet_properties));
+    }
   }
 }
 

--- a/components/brave_rewards/browser/rewards_service_impl_unittest.cc
+++ b/components/brave_rewards/browser/rewards_service_impl_unittest.cc
@@ -158,8 +158,8 @@ TEST_F(RewardsServiceTest, HandleFlags) {
 
 TEST_F(RewardsServiceTest, OnWalletProperties) {
   // wallet properties are empty (no call should be made)
-  rewards_service()->OnWalletProperties(ledger::Result::LEDGER_OK, nullptr);
   EXPECT_CALL(*observer(), OnWalletProperties(_, _, _)).Times(0);
+  rewards_service()->OnWalletProperties(ledger::Result::LEDGER_OK, nullptr);
 }
 
 // add test for strange entries


### PR DESCRIPTION
|wallet_properties| could be null. All codes that references it should check
whether |error_code| is non-error and |wallet_properties| isn't null.

Still, I can't reproduce this but this pr could fix this null referencing crash as @iefremov suggested at https://github.com/brave/brave-browser/issues/2375#issuecomment-445771040

Fix https://github.com/brave/brave-browser/issues/2375

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_unit_tests --filter=RewardsServiceTest.OnWalletProperties`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source