### PR TITLE
Fixes ads build error

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ deps = {
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
   "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@50a886b08c96b29d1b5c5f1c98f09b80de8a8182",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@7e391cec6975106fa9f686016f494cb8a782afcd",
-  "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@89298f3fae8b9a81ced5092f0d7d6fa29b3a0f34",
+  "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@57fee72cb39c4a40d3d9fd8abbfa8f8cd2f35e39",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
 }
 

--- a/components/services/bat_ads/bat_ads_impl.cc
+++ b/components/services/bat_ads/bat_ads_impl.cc
@@ -57,7 +57,6 @@ void BatAdsImpl::OnIdle() {
 void OnSaveCachedInfo(const ads::Result result) {}
 
 void BatAdsImpl::SaveCachedInfo(SaveCachedInfoCallback callback) {
-  ads_->SaveCachedInfo(std::bind(&OnSaveCachedInfo, _1));
   std::move(callback).Run();
 }
 


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2442

`bat-native-ads` is now upgraded to latest hash and deprecated method `SaveCachedInfo` has been removed.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source