### PR TITLE
Ties Ads UI to BRAVE_ADS_ENABLED

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -9,6 +9,7 @@
 
 #include "brave/components/brave_ads/browser/ads_service.h"
 #include "brave/components/brave_ads/browser/ads_service_factory.h"
+#include "brave/components/brave_ads/browser/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
 #include "brave/components/brave_rewards/browser/wallet_properties.h"
 #include "brave/components/brave_rewards/browser/balance_report.h"
@@ -708,11 +709,20 @@ void RewardsDOMHandler::CheckImported(const base::ListValue *args) {
 void RewardsDOMHandler::GetAdsData(const base::ListValue *args) {
   if (ads_service_ && web_ui()->CanCallJavascript()) {
     base::DictionaryValue adsData;
+
+    bool ads_ui_enabled;
     bool ads_enabled = ads_service_->is_enabled();
     int ads_per_hour = ads_service_->ads_per_hour();
 
+    #if BUILDFLAG(BRAVE_ADS_ENABLED)
+      ads_ui_enabled = true;
+    #else
+      ads_ui_enabled = false;
+    #endif
+
     adsData.SetBoolean("adsEnabled", ads_enabled);
     adsData.SetInteger("adsPerHour", ads_per_hour);
+    adsData.SetBoolean("adsUIEnabled", ads_ui_enabled);
 
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.adsData", adsData);
   }

--- a/components/brave_rewards/resources/ui/components/adsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/adsBox.tsx
@@ -77,13 +77,13 @@ class AdsBox extends React.Component<Props, {}> {
   }
 
   render () {
-    let adsEnabled
+    let adsEnabled = false
+    let adsUIEnabled = false
     const { adsData } = this.props.rewardsData
 
-    if (!adsData) {
-      adsEnabled = false
-    } else {
-      adsEnabled = this.props.rewardsData.adsData.adsEnabled
+    if (adsData) {
+      adsEnabled = adsData.adsEnabled
+      adsUIEnabled = adsData.adsUIEnabled
     }
 
     return (
@@ -91,7 +91,7 @@ class AdsBox extends React.Component<Props, {}> {
         title={getLocale('adsTitle')}
         type={'ads'}
         description={getLocale('adsDesc')}
-        toggle={true}
+        toggle={adsUIEnabled}
         checked={adsEnabled}
         settingsChild={this.adsSettings(adsEnabled)}
         testId={'braveAdsSettings'}

--- a/components/brave_rewards/resources/ui/storage.ts
+++ b/components/brave_rewards/resources/ui/storage.ts
@@ -49,7 +49,8 @@ export const defaultState: Rewards.State = {
   excluded: [],
   adsData: {
     adsEnabled: false,
-    adsPerHour: 0
+    adsPerHour: 0,
+    adsUIEnabled: false
   }
 }
 

--- a/components/definitions/rewards.d.ts
+++ b/components/definitions/rewards.d.ts
@@ -139,5 +139,6 @@ declare namespace Rewards {
   export interface AdsData {
     adsEnabled: boolean
     adsPerHour: number
+    adsUIEnabled: boolean
   }
 }


### PR DESCRIPTION
Also disables the flag on linux

Fixes: https://github.com/brave/brave-browser/issues/2456 and https://github.com/brave/brave-browser/issues/2455

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source