### PR TITLE
Update to latest brave-ui master

### DIFF
--- a/components/brave_rewards/resources/donate/components/siteBanner.tsx
+++ b/components/brave_rewards/resources/donate/components/siteBanner.tsx
@@ -18,14 +18,14 @@ interface Props extends RewardsDonate.ComponentProps {
 }
 
 interface State {
-  currentAmount: number
+  currentAmount: string
 }
 
 class Banner extends React.Component<Props, State> {
   constructor (props: Props) {
     super(props)
     this.state = {
-      currentAmount: 0
+      currentAmount: '0'
     }
   }
 
@@ -60,17 +60,17 @@ class Banner extends React.Component<Props, State> {
     })
   }
 
-  onAmountSelection = (tokens: number) => {
+  onAmountSelection = (tokens: string) => {
     this.setState({
       currentAmount: tokens
     })
   }
 
-  onDonate = (amount: number, recurring: boolean) => {
+  onDonate = (amount: string, recurring: boolean) => {
     const { publisher, walletInfo } = this.props.rewardsDonateData
     const { balance } = walletInfo
 
-    if (publisher && publisher.publisherKey && balance >= parseInt(amount.toString(), 10)) {
+    if (publisher && publisher.publisherKey && balance >= parseInt(amount, 10)) {
       this.actions.onDonate(publisher.publisherKey, amount, recurring)
     } else {
       // TODO return error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,46 +1237,12 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
-      "from": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
+      "version": "github:brave/brave-ui#cee363dd33ec3c7499b7d239384a6f2eb601f981",
+      "from": "github:brave/brave-ui#cee363dd33ec3c7499b7d239384a6f2eb601f981",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",
         "styled-components": "^3.2.5"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "styled-components": {
-          "version": "3.4.10",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
-          "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.0.3",
-            "css-to-react-native": "^2.0.3",
-            "fbjs": "^0.8.16",
-            "hoist-non-react-statics": "^2.5.0",
-            "prop-types": "^15.5.4",
-            "react-is": "^16.3.1",
-            "stylis": "^3.5.0",
-            "stylis-rule-sheet": "^0.0.10",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
+    "brave-ui": "brave/brave-ui#cee363dd33ec3c7499b7d239384a6f2eb601f981",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2439
Fixes: https://github.com/brave/brave-browser/issues/2381
Partially address brave/brave-browser#1164
Many rewards on android fixes (no issues in brave-browser)


### Changes: https://github.com/brave/brave-ui/compare/9be9bee...cee363d
```
*   cee363d - (44 minutes ago) Merge pull request #314 from brave/revert-sync-master — Pete Miller (HEAD -> master, origin/master, origin/HEAD)
|\
| * 0ca4b73 - (56 minutes ago) Revert "sync v2" — Cezar Augusto
| * a479cea - (56 minutes ago) Revert "Merge pull request #308 from brave/sync_img" — Cezar Augusto
|/
*   dd46eab - (19 hours ago) Merge pull request #247 from brave/c71-clock-period — Pete Miller
|\
| * 20d2a61 - (7 weeks ago) Fix NTP clock for c71 — petemill (origin/c71-clock-period, c71-clock-period)
* |   69a3399 - (19 hours ago) Merge pull request #305 from ryanml/android-rewards-title-fix — Pete Miller
|\ \
| |/
|/|
| * d92ce8f - (7 days ago) Fixing rewards toggle for long translations — ryanml (ryanml/android-rewards-title-fix, android-rewards-title-fix)
|/
* 4692dfd - (25 hours ago) readme typos — Ross Moody
*   ca3e285 - (29 hours ago) Merge pull request #312 from emerick/rewards-backup-wallet-notification — Nejc Zdovc
|\
| * 4dda1bc - (4 days ago) Add support for backupWallet notification — Emerick Rogul
* | 0a5f56e - (4 days ago) Emoji Life — Ross Moody
* | be16816 - (4 days ago) Readme formatting — Ross Moody
* | 35b166d - (4 days ago) Brave UI Logo — Ross Moody
* |   fddeb8a - (4 days ago) Merge pull request #311 from brave/now-deploy-static — Cezar Augusto
|\ \
| * | 6685301 - (5 days ago) Use new static deploy config for now instead of docker — petemill (origin/now-deploy-static, now-deploy-static)
* | | eb49e8b - (4 days ago) remove list from README file — Cezar Augusto
* | | 59eae8d - (4 days ago) remove outdated docs — Cezar Augusto
* | | f04fecc - (4 days ago) do not count first letter if space in textareaclipboard — Cezar Augusto
| |/
|/|
* |   7ea9178 - (5 days ago) Merge pull request #308 from brave/sync_img — Cezar Augusto
|\ \
| * | 470233f - (6 days ago) make sync images exportable — Cezar Augusto
| |/
* |   aa520cf - (5 days ago) Merge pull request #309 from brave/welcome_img — Pete Miller
|\ \
| * | 870d3ba - (6 days ago) animation dial in — Ross Moody (origin/welcome_img, welcome_img)
| * | 1c2525b - (6 days ago) make welcome page images exportable — Cezar Augusto
| |/
* |   96ccb12 - (6 days ago) Merge pull request #307 from kirkins/patch-1 — Ryan Lanese
|\ \
| * | f98a665 - (6 days ago) small typo — Philip Kirkbride
* | | f3c38e1 - (6 days ago) v0.36.0 — ryanml (tag: v0.36.0)
|/ /
* |   46b3501 - (6 days ago) Merge pull request #304 from ryanml/disabled-panel — Nejc Zdovc
|\ \
| * | 6be56a3 - (7 days ago) Adding disabledPanel component — ryanml (ryanml/disabled-panel)
|/ /
* |   79b16fb - (6 days ago) Merge pull request #299 from ryanml/fix-298 — Nejc Zdovc
|\ \
| |/
|/|
| * c79530c - (12 days ago) Fixes #298, uses string type for amount/tokens — ryanml (ryanml/fix-298, fix-298)
* 6bf8054 - (8 days ago) v0.35.0 — Cezar Augusto (tag: v0.35.0, now-deploy-reliable)
* 3535427 - (3 weeks ago) sync v2 — Cezar Augusto
*   10f07c0 - (9 days ago) Merge pull request #300 from brave/site-banner-icon — Ryan Lanese
|\
| * da3cc4b - (11 days ago) Site banner icon update — Ross Moody
* 9064f12 - (9 days ago) Merge pull request #301 from emerick/rewards-insufficient-funds-notification — Ryan Lanese
* 5300262 - (11 days ago) Add support for insufficientFunds notification — Emerick Rogul
```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
All webuis

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source