### PR TITLE
Update 0.59.x to latest brave-ui 0.59.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,46 +1237,12 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
-      "from": "github:brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
+      "version": "github:brave/brave-ui#4e07f892a38e588d9dbca8dfa9d39fe06642183f",
+      "from": "github:brave/brave-ui#4e07f892a38e588d9dbca8dfa9d39fe06642183f",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",
         "styled-components": "^3.2.5"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "styled-components": {
-          "version": "3.4.10",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
-          "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.0.3",
-            "css-to-react-native": "^2.0.3",
-            "fbjs": "^0.8.16",
-            "hoist-non-react-statics": "^2.5.0",
-            "prop-types": "^15.5.4",
-            "react-is": "^16.3.1",
-            "stylis": "^3.5.0",
-            "stylis-rule-sheet": "^0.0.10",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "brave/brave-ui#9be9bee9764c6a1fd329acbe348f91b85142dc33",
+    "brave-ui": "brave/brave-ui#4e07f892a38e588d9dbca8dfa9d39fe06642183f",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
_Does not require uplift approval since all these PRs had uplift approval in brave-ui_

0.59.x for https://github.com/brave/brave-core/pull/1062
Fix brave/brave-browser#2439 - Clock AM / PM font size
Use brave-ui welcome images instead of brave-core

```
*   4e07f89 - (59 minutes ago) Merge pull request #315 from brave/revert-sync-59 — Pete Miller (HEAD -> brave-core-0.59.x, origin/brave-core-0.59.x)
|\
| * fb7deb8 - (69 minutes ago) Revert "sync v2" — Cezar Augusto
| * c5e16c7 - (69 minutes ago) Revert "Merge pull request #308 from brave/sync_img" — Cezar Augusto
|/
* c4694e2 - (20 hours ago) Merge pull request #247 from brave/c71-clock-period — Pete Miller
* a2443d8 - (4 days ago) do not count first letter if space in textareaclipboard — Cezar Augusto
* 2c16ae2 - (5 days ago) Merge pull request #308 from brave/sync_img — Cezar Augusto
* 7d9811c - (3 weeks ago) sync v2 — Cezar Augusto
* 3e3be2f - (4 days ago) update snapshot from walletSummary — Cezar Augusto
* a4c4dbd - (5 days ago) Merge pull request #309 from brave/welcome_img — Pete Miller
```
