### PR TITLE
Update 0.58.x to brave-ui for 0.58.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,12 +2087,12 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#5c2d8a0f669af2e9a68ce0fe38d49a116bc52315",
-      "from": "github:brave/brave-ui#5c2d8a0f669af2e9a68ce0fe38d49a116bc52315",
+      "version": "github:brave/brave-ui#861153d09e025ca98d6fae11bb51aa458c4d8519",
+      "from": "github:brave/brave-ui#861153d09e025ca98d6fae11bb51aa458c4d8519",
       "dev": true,
       "requires": {
-        "emptykit.css": "1.0.1",
-        "styled-components": "3.4.5"
+        "emptykit.css": "^1.0.1",
+        "styled-components": "^3.2.5"
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.24.1",
-    "brave-ui": "brave/brave-ui#5c2d8a0f669af2e9a68ce0fe38d49a116bc52315",
+    "brave-ui": "brave/brave-ui#861153d09e025ca98d6fae11bb51aa458c4d8519",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
_Does not require uplift approval since all these PRs had uplift approval in brave-ui (probably, this new process was introduced mid-way)_

Fix brave/brave-browser#2439 - Clock AM / PM font size
Use brave-ui welcome images instead of brave-core

Changes: https://github.com/brave/brave-ui/compare/5c2d8a0f669af2e9a68ce0fe38d49a116bc52315..861153d09e025ca98d6fae11bb51aa458c4d8519

```
* 861153d - (21 hours ago) Merge pull request #247 from brave/c71-clock-period — Pete Miller (HEAD -> brave-core-0.58.x, origin/brave-core-0.58.x)
*   4195647 - (2 hours ago) Merge pull request #316 from brave/sync-revert-58 — Pete Miller
|\
| * cad6678 - (2 hours ago) Revert "sync v2" — Cezar Augusto
| * d134401 - (2 hours ago) Revert "Merge pull request #308 from brave/sync_img" — Cezar Augusto
| * 52aef38 - (2 hours ago) Revert "allow string type for some siteBanner props" — Cezar Augusto
|/
* 5f4a8b1 - (3 hours ago) allow string type for some siteBanner props auditor: @ryanml - currentAmout, onAmountSelection and onDonate accept strings as well this is a temp fix only included in 0.58.x — Cezar Augusto
* f0569c8 - (4 days ago) do not count first letter if space in textareaclipboard — Cezar Augusto
* 69ef8be - (5 days ago) Merge pull request #308 from brave/sync_img — Cezar Augusto
* 854d181 - (3 weeks ago) sync v2 — Cezar Augusto
* b35662c - (4 days ago) update snapshot for walletSummary — Cezar Augusto
* a85206d - (5 days ago) Merge pull request #309 from brave/welcome_img — Pete Miller
```

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Run web-uis

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source