### PR TITLE
Fix webtorrent bundle access path

### DIFF
--- a/components/brave_webtorrent/extension/BUILD.gn
+++ b/components/brave_webtorrent/extension/BUILD.gn
@@ -46,5 +46,5 @@ transpile_web_ui("generate_brave_webtorrent") {
   # plus any other relative path we want these files to live in the extension
   extra_relative_path = "/brave_webtorrent/extension/out"
 
-  public_asset_path = "/out/"
+  public_asset_path = "/extension/out/"
 }

--- a/components/brave_webtorrent/extension/brave_webtorrent.html
+++ b/components/brave_webtorrent/extension/brave_webtorrent.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 <title>Webtorrent</title>
-<script src="/out/brave_webtorrent.bundle.js"></script>
+<script src="/extension/out/brave_webtorrent.bundle.js"></script>
 <style>
   #root { height: 100%; }
 </style>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2479
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source