### PR TITLE
Added brave-ads-staging command-line switch to Brave Ads

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ deps = {
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
   "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@d926cfb84e3f644ab14d0908608025c19c753f4b",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@7e391cec6975106fa9f686016f494cb8a782afcd",
-  "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@ebad9519a0a6adaff38dce39475bf535da4ec10a",
+  "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@b7ce146f1bc3de4a806a7a364523f6b32bd21620",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
 }
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -333,6 +333,9 @@ void AdsServiceImpl::Start() {
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
 
+  if (command_line.HasSwitch(switches::kStaging)) {
+    is_production = false;
+  }
   if (command_line.HasSwitch(switches::kProduction)) {
     is_production = true;
   }

--- a/components/brave_ads/common/switches.cc
+++ b/components/brave_ads/common/switches.cc
@@ -6,6 +6,7 @@
 
 namespace brave_ads {
 namespace switches {
+const char kStaging[] = "brave-ads-staging";
 const char kProduction[] = "brave-ads-production";
 const char kDebug[] = "brave-ads-debug";
 const char kTesting[] = "brave-ads-testing";

--- a/components/brave_ads/common/switches.h
+++ b/components/brave_ads/common/switches.h
@@ -7,6 +7,7 @@
 
 namespace brave_ads {
 namespace switches {
+extern const char kStaging[];
 extern const char kProduction[];
 extern const char kDebug[];
 extern const char kTesting[];


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2487

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Confirm that switch uses Staging Ads Serve instead of Production Ads Serve

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source