### PR TITLE
Change link text on extensions page.

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -340,6 +340,19 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <message name="IDS_SETTINGS_MANAGE_EXTENSIONS_LABEL" desc="The label of manage extensions link in settings">
         Manage Extensions
       </message>
+      <!-- Extensions page strings -->
+      <message name="IDS_MD_EXTENSIONS_BRAVE_MORE_EXTENSIONS" desc="The message shown to the user on the Extensions settings page under the list of installed extensions.">
+        <ph name="BEGIN_LINK">&lt;a target="_blank" href="https://chrome.google.com/webstore/category/extensions"&gt;</ph>Looking for even more extensions?<ph name="END_LINK">&lt;/a&gt;<ex>&lt;/a&gt;</ex></ph>
+      </message>
+      <message name="IDS_MD_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE" desc="The text to indicate that an extension is from the Web Extensions Store.">
+        Web Extensions Store
+      </message>
+      <message name="IDS_MD_EXTENSIONS_BRAVE_ITEM_CHROME_WEB_STORE" desc="Label for button to visit the Web Extensions Store.">
+        View in Web Extensions Store
+      </message>
+      <message name="IDS_MD_EXTENSIONS_BRAVE_NO_INSTALLED_ITEMS" desc="The message shown to the user on the Extensions settings page when there are no extensions or apps installed.">
+        You don't have any extensions yet. Would you like to <ph name="BEGIN_LINK">&lt;a target="_blank" href="https://chrome.google.com/webstore/category/extensions"&gt;</ph>install some<ph name="END_LINK">&lt;/a&gt;<ex>&lt;/a&gt;</ex></ph>?
+      </message>
     </messages>
     <includes>
       <include name="IDR_BRAVE_TAG_SERVICES_POLYFILL" file="resources/js/tag_services_polyfill.js" type="BINDATA" />

--- a/chromium_src/chrome/browser/ui/webui/extensions/extensions_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/extensions/extensions_ui.cc
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/grit/generated_resources.h"
+#include "content/public/browser/web_ui_data_source.h"
+
+// These are defined in generated_resources.h, but since we are including it
+// here the original extensions_ui.cc shouldn't include it again and the
+// redefined values will be used.
+#undef IDS_MD_EXTENSIONS_ITEM_CHROME_WEB_STORE
+#define IDS_MD_EXTENSIONS_ITEM_CHROME_WEB_STORE \
+  IDS_MD_EXTENSIONS_BRAVE_ITEM_CHROME_WEB_STORE
+#undef IDS_MD_EXTENSIONS_ITEM_SOURCE_WEBSTORE
+#define IDS_MD_EXTENSIONS_ITEM_SOURCE_WEBSTORE \
+  IDS_MD_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE
+#undef IDS_MD_EXTENSIONS_NO_INSTALLED_ITEMS
+#define IDS_MD_EXTENSIONS_NO_INSTALLED_ITEMS \
+  IDS_MD_EXTENSIONS_BRAVE_NO_INSTALLED_ITEMS
+
+// Forward declarations needed due to extensions_ui.cc being patched with this
+// function name.
+namespace extensions {
+namespace {
+void BraveAddLocalizedStrings(content::WebUIDataSource* html_source);
+} // namespace
+} // namespace extensions
+
+#include "../../../../../../chrome/browser/ui/webui/extensions/extensions_ui.cc"
+
+namespace extensions {
+
+namespace {
+
+void BraveAddLocalizedStrings(content::WebUIDataSource* html_source) {
+  html_source->AddLocalizedString("moreExtensions",
+                                  IDS_MD_EXTENSIONS_BRAVE_MORE_EXTENSIONS);
+}
+
+} // namespace
+
+} // namespace extensions

--- a/patches/chrome-browser-resources-md_extensions-item_list.html.patch
+++ b/patches/chrome-browser-resources-md_extensions-item_list.html.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/browser/resources/md_extensions/item_list.html b/chrome/browser/resources/md_extensions/item_list.html
+index 90244de120cf8fda71002f535810619b1e8aeb3e..84450aca34abf7b55e1289b8716b81d5323e6ec0 100644
+--- a/chrome/browser/resources/md_extensions/item_list.html
++++ b/chrome/browser/resources/md_extensions/item_list.html
+@@ -106,6 +106,13 @@
+             </template>
+           </div>
+         </div>
++        <div id="more-items" class="empty-list-message" style="margin-top: 32px;"
++            hidden$="[[shouldShowEmptyItemsMessage_(
++                apps.length, extensions.length)]]">
++          <span>
++            $i18nRaw{moreExtensions}
++          </span>
++        </div>
+       </div>
+     </div>
+   </template>

--- a/patches/chrome-browser-ui-webui-extensions-extensions_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-extensions-extensions_ui.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/webui/extensions/extensions_ui.cc b/chrome/browser/ui/webui/extensions/extensions_ui.cc
+index 1b7560672a3608c7331799ce516d63066bf4d068..c3480b2cdcdf6950a6a8c136f3a8dabde5e4a615 100644
+--- a/chrome/browser/ui/webui/extensions/extensions_ui.cc
++++ b/chrome/browser/ui/webui/extensions/extensions_ui.cc
+@@ -285,6 +285,8 @@ content::WebUIDataSource* CreateMdExtensionsSource(bool in_dev_mode) {
+   AddLocalizedStringsBulk(source, localized_strings,
+                           base::size(localized_strings));
+ 
++  BraveAddLocalizedStrings(source);
++
+   source->AddString("errorLinesNotShownSingular",
+                     l10n_util::GetPluralStringFUTF16(
+                         IDS_MD_EXTENSIONS_ERROR_LINES_NOT_SHOWN, 1));


### PR DESCRIPTION
Updates extensions store link language on the extensions page. Adds
link to the store even if there are installed extensions.

Fixes brave/brave-browser#2497
Fixes brave/brave-browser#1013

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- Start Brave with a fresh profile,
- Navigate to brave://extensions,
- Verify that the page shows text `You don't have any extensions yet. Would you like to [install some]`?,
- Verify that clicking on `install some` takes you to the Chrome Web Store,
- Add one or more extensions,
- Return to brave://extensions page,
- Verify that the page shows text `Looking for even more extensions?`,
- Verify that clicking on the text takes you to the Chrome Web Store,
- Return to brave://extensions page,
- Click on Details button for any extension installed from Chrome Web Store,
- On the details page, verify that the Source shows text `Web Extensions Store`.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source