### PR TITLE
Avoid crashing utility process if user denies keychain access

### DIFF
--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -1,5 +1,5 @@
 diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
-index 2a55469312c3cd9d1827be84a20135d0379c94a5..b846eb802d7334241f598029435d46ab57c0915d 100644
+index 2a55469312c3cd9d1827be84a20135d0379c94a5..bfa358d03730f28a035ef872fb900196e9cc7f9b 100644
 --- a/components/os_crypt/keychain_password_mac.mm
 +++ b/components/os_crypt/keychain_password_mac.mm
 @@ -7,6 +7,7 @@
@@ -49,3 +49,16 @@ index 2a55469312c3cd9d1827be84a20135d0379c94a5..b846eb802d7334241f598029435d46ab
    UInt32 password_length = 0;
    void* password_data = NULL;
    OSStatus error = keychain_.FindGenericPassword(
+@@ -96,7 +110,11 @@ std::string KeychainPassword::GetPassword() const {
+     return password;
+   }
+ 
+-  key_creation_util_->OnKeychainLookupFailed();
++  // If we're in the importer utility process, key_creation_util_ is nullptr
++  // because it requires a PrefService and therefore can only be created in the
++  // browser process; do not dereference.
++  if (key_creation_util_)
++    key_creation_util_->OnKeychainLookupFailed();
+   OSSTATUS_DLOG(ERROR, error) << "Keychain lookup failed";
+   return std::string();
+ }


### PR DESCRIPTION
Resolves brave/brave-browser#2513.

#886 maintained our ability to use os_crypt in the importer utility process by ignoring the empty/irrelevant EncryptionKeyCreationUtil; however, during testing we failed to check the case where the user denies access to the keychain entry by clicking **Deny** when the keychain prompt is shown. 

If the user denies keychain access, the status returned from `keychain_.FindGenericPassword` is errSecUserCanceled (see SecKeychainFindGenericPassword API [docs](https://developer.apple.com/documentation/security/1397301-seckeychainfindgenericpassword?language=objc)), which is not handled by any of the subsequent conditionals in `KeychainPassword::GetPassword`. Execution continues to the end of the function, where `key_creation_util_->OnKeychainLookupFailed()` is called; unfortunately, in the importer utility process, this was never initialized, so a nullptr is dereferenced, crashing the importer utility process and preventing the remaining importer data types from being imported.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

See brave/brave-browser#2513 description.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source