### PR TITLE
Avoid crashing importer utility process if Muon bookmarks data is malformed

### DIFF
--- a/utility/importer/brave_importer.cc
+++ b/utility/importer/brave_importer.cc
@@ -238,19 +238,30 @@ void BraveImporter::RecursiveReadBookmarksFolder(
   if (!bookmark_order)
     return;
 
-  for (const auto& entry : bookmark_order->GetList()) {
-    auto& type = entry.FindKeyOfType("type",
-      base::Value::Type::STRING)->GetString();
-    auto& key = entry.FindKeyOfType("key",
-      base::Value::Type::STRING)->GetString();
+  for (auto& entry : bookmark_order->GetList()) {
+    base::Value* typeValue = entry.FindKeyOfType("type",
+        base::Value::Type::STRING);
+    base::Value* keyValue = entry.FindKeyOfType("key",
+        base::Value::Type::STRING);
+    if (!(typeValue && keyValue))
+      continue;
 
-     if (type == "bookmark-folder") {
+    auto type = typeValue->GetString();
+    auto key = keyValue->GetString();
+
+    if (type == "bookmark-folder") {
       base::Value* bookmark_folder =
         bookmark_folders_dict->FindKeyOfType(key,
           base::Value::Type::DICTIONARY);
-      auto& title =
-        bookmark_folder->FindKeyOfType("title",
-          base::Value::Type::STRING)->GetString();
+      if (!bookmark_folder)
+        continue;
+
+      base::Value* titleValue = bookmark_folder->FindKeyOfType("title",
+          base::Value::Type::STRING);
+      if (!titleValue)
+        continue;
+
+      auto title = titleValue->GetString();
 
       // Empty folders don't have a corresponding entry in bookmark_order_dict,
       // which provides an easy way to test whether a folder is empty.
@@ -282,12 +293,18 @@ void BraveImporter::RecursiveReadBookmarksFolder(
     } else if (type == "bookmark") {
       base::Value* bookmark =
         bookmarks_dict->FindKeyOfType(key, base::Value::Type::DICTIONARY);
-      auto& title =
-        bookmark->FindKeyOfType("title",
-          base::Value::Type::STRING)->GetString();
-      auto& location =
-        bookmark->FindKeyOfType("location",
-          base::Value::Type::STRING)->GetString();
+      if (!bookmark)
+        continue;
+
+      base::Value* titleValue = bookmark->FindKeyOfType("title",
+          base::Value::Type::STRING);
+      base::Value* locationValue = bookmark->FindKeyOfType("location",
+          base::Value::Type::STRING);
+      if (!(titleValue && locationValue))
+        continue;
+
+      auto title = titleValue->GetString();
+      auto location = locationValue->GetString();
 
       ImportedBookmarkEntry imported_bookmark;
       imported_bookmark.is_folder = false;


### PR DESCRIPTION
Resolves brave/brave-browser#2517.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:



## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source