### PR TITLE
Strip de-duplicating suffix from stub installer filename

### DIFF
--- a/chromium_src/chrome/installer/mini_installer/brave_mini_installer_unittest.cc
+++ b/chromium_src/chrome/installer/mini_installer/brave_mini_installer_unittest.cc
@@ -1,0 +1,105 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/installer/mini_installer/mini_installer.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace mini_installer {
+
+class BraveMiniInstallerTest: public testing::Test {
+ public:
+  BraveMiniInstallerTest() {
+  }
+  ~BraveMiniInstallerTest() override {}
+};
+
+
+TEST_F(BraveMiniInstallerTest, HasNoReferralCode) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasStandardReferralCode) {
+  ReferralCodeString referral_code;
+  EXPECT_TRUE(ParseReferralCode(L"BraveBrowserSetup-FOO123.exe", referral_code));
+  EXPECT_STREQ(referral_code.get(), L"FOO123");
+}
+
+TEST_F(BraveMiniInstallerTest, HasStandardReferralCodeWithPath) {
+  ReferralCodeString referral_code;
+  EXPECT_TRUE(ParseReferralCode(L"c:/foo/bar/BraveBrowserSetup-FOO123.exe", referral_code));
+  EXPECT_STREQ(referral_code.get(), L"FOO123");
+}
+
+TEST_F(BraveMiniInstallerTest, HasStandardReferralCodeWithDeduplicatingSuffix) {
+  ReferralCodeString referral_code;
+  EXPECT_TRUE(ParseReferralCode(L"c:/foo/bar/BraveBrowserSetup-FOO123 (1).exe", referral_code));
+  EXPECT_STREQ(referral_code.get(), L"FOO123");
+}
+
+TEST_F(BraveMiniInstallerTest, HasStandardReferralCodeWithDeduplicatingSuffixNoSpaces) {
+  ReferralCodeString referral_code;
+  EXPECT_TRUE(ParseReferralCode(L"c:/foo/bar/BraveBrowserSetup-FOO123(1).exe", referral_code));
+  EXPECT_STREQ(referral_code.get(), L"FOO123");
+}
+
+TEST_F(BraveMiniInstallerTest, HasStandardReferralCodeWithDeduplicatingSuffixExtraSpaces) {
+  ReferralCodeString referral_code;
+  EXPECT_TRUE(ParseReferralCode(L"c:/foo/bar/BraveBrowserSetup-FOO123   (1).exe", referral_code));
+  EXPECT_STREQ(referral_code.get(), L"FOO123");
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeReversed) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-123FOO.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeNoDigits) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-FOO.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeNoLetters) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-123.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeTooManyDigits) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-FOO1234.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeTooFewDigits) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-FOO12.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeTooManyLetters) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-FOOO123.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidStandardReferralCodeTooFewLetters) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-FO123.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasExtendedReferralCode) {
+  ReferralCodeString referral_code;
+  EXPECT_TRUE(ParseReferralCode(L"BraveBrowserSetup-extended-code.exe", referral_code));
+  EXPECT_STREQ(referral_code.get(), L"extended-code");
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidExtendedReferralCodeNonAlphabeticCharacters) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-invalid-extended-c0de.exe", referral_code));
+}
+
+TEST_F(BraveMiniInstallerTest, HasInvalidExtendedReferralCodeTooFewWords) {
+  ReferralCodeString referral_code;
+  EXPECT_FALSE(ParseReferralCode(L"BraveBrowserSetup-invalidextendedcode.exe", referral_code));
+}
+
+}  // namespace mini_installer

--- a/patches/chrome-installer-mini_installer-mini_installer.cc.patch
+++ b/patches/chrome-installer-mini_installer-mini_installer.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mini_installer/mini_installer.cc b/chrome/installer/mini_installer/mini_installer.cc
-index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e795b1a07ca 100644
+index 1f39abbeb2579098a54fa82612199f0307ea03b4..5909709a6f51428abf261f8384fb78aba0575c42 100644
 --- a/chrome/installer/mini_installer/mini_installer.cc
 +++ b/chrome/installer/mini_installer/mini_installer.cc
 @@ -61,7 +61,7 @@ struct Context {
@@ -11,7 +11,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e79
  // Opens the Google Update ClientState key. If |binaries| is false, opens the
  // key for Google Chrome or Chrome SxS (canary). If |binaries| is true and an
  // existing multi-install Chrome is being updated, opens the key for the
-@@ -142,6 +142,122 @@ void SetInstallerFlags(const Configuration& configuration) {
+@@ -142,6 +142,140 @@ void SetInstallerFlags(const Configuration& configuration) {
  }
  #endif  // GOOGLE_CHROME_BUILD
  
@@ -103,6 +103,24 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e79
 +  if (*scan == L'.')
 +    filename.truncate_at(scan - filename.get());
 +
++  // Strip any de-duplicating suffix from filename, e.g. "(1)".
++  scan = filename.get() + filename.length() - 1;
++  if (*scan == L')') {
++    --scan;
++    while (scan != filename.get() && *scan >= '0' && *scan <= '9')
++      --scan;
++    if (*scan == L'(')
++      filename.truncate_at(scan - filename.get());
++  }
++
++  // Strip trailing spaces from filename.
++  scan = filename.get() + filename.length() - 1;
++  while (scan != filename.get() && *scan == L' ')
++    --scan;
++
++  if (scan != filename.get() && (scan != filename.get() + filename.length()))
++    filename.truncate_at(scan - filename.get() + 1);
++
 +  // First check for 6-character standard referral code XXXDDD, where
 +  // X is an alphabetic character and D is a numeric character. If not
 +  // found, check for an alphabetic referral code of any length in the
@@ -134,7 +152,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e79
  // Gets the setup.exe path from Registry by looking at the value of Uninstall
  // string.  |size| is measured in wchar_t units.
  ProcessExitResult GetSetupExePathForAppGuid(bool system_level,
-@@ -526,6 +642,21 @@ ProcessExitResult RunSetup(const Configuration& configuration,
+@@ -526,6 +660,21 @@ ProcessExitResult RunSetup(const Configuration& configuration,
    // on to setup.exe
    AppendCommandLineFlags(configuration.command_line(), &cmd_line);
  
@@ -156,7 +174,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e79
    return RunProcessAndWait(setup_exe.get(), cmd_line.get(),
                             RUN_SETUP_FAILED_FILE_NOT_FOUND,
                             RUN_SETUP_FAILED_PATH_NOT_FOUND,
-@@ -873,7 +1004,7 @@ ProcessExitResult WMain(HMODULE module) {
+@@ -873,7 +1022,7 @@ ProcessExitResult WMain(HMODULE module) {
    if (!GetWorkDir(module, &base_path, &exit_code))
      return exit_code;
  
@@ -165,7 +183,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..80095fc3ab546770adc098a36bef9e79
    // Set the magic suffix in registry to try full installer next time. We ignore
    // any errors here and we try to set the suffix for user level unless
    // GoogleUpdateIsMachine=1 is present in the environment or --system-level is
-@@ -898,7 +1029,7 @@ ProcessExitResult WMain(HMODULE module) {
+@@ -898,7 +1047,7 @@ ProcessExitResult WMain(HMODULE module) {
    if (ShouldDeleteExtractedFiles())
      DeleteExtractedFiles(base_path.get(), archive_path.get(), setup_path.get());
  

--- a/patches/chrome-installer-mini_installer-mini_installer.cc.patch
+++ b/patches/chrome-installer-mini_installer-mini_installer.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mini_installer/mini_installer.cc b/chrome/installer/mini_installer/mini_installer.cc
-index 1f39abbeb2579098a54fa82612199f0307ea03b4..5909709a6f51428abf261f8384fb78aba0575c42 100644
+index 1f39abbeb2579098a54fa82612199f0307ea03b4..6f31bf299b3de9da2ba3a4f41a6e21ee07ddd298 100644
 --- a/chrome/installer/mini_installer/mini_installer.cc
 +++ b/chrome/installer/mini_installer/mini_installer.cc
 @@ -61,7 +61,7 @@ struct Context {
@@ -11,13 +11,11 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..5909709a6f51428abf261f8384fb78ab
  // Opens the Google Update ClientState key. If |binaries| is false, opens the
  // key for Google Chrome or Chrome SxS (canary). If |binaries| is true and an
  // existing multi-install Chrome is being updated, opens the key for the
-@@ -142,6 +142,140 @@ void SetInstallerFlags(const Configuration& configuration) {
+@@ -142,6 +142,138 @@ void SetInstallerFlags(const Configuration& configuration) {
  }
  #endif  // GOOGLE_CHROME_BUILD
  
 +#if defined(BRAVE_CHROMIUM_BUILD)
-+typedef StackString<128> ReferralCodeString;
-+
 +bool ParseStandardReferralCode(const wchar_t* filename, ReferralCodeString& referral_code) {
 +  // Scan backwards for last dash in filename.
 +  const wchar_t* scan = filename + lstrlen(filename) - 1;
@@ -152,7 +150,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..5909709a6f51428abf261f8384fb78ab
  // Gets the setup.exe path from Registry by looking at the value of Uninstall
  // string.  |size| is measured in wchar_t units.
  ProcessExitResult GetSetupExePathForAppGuid(bool system_level,
-@@ -526,6 +660,21 @@ ProcessExitResult RunSetup(const Configuration& configuration,
+@@ -526,6 +658,21 @@ ProcessExitResult RunSetup(const Configuration& configuration,
    // on to setup.exe
    AppendCommandLineFlags(configuration.command_line(), &cmd_line);
  
@@ -174,7 +172,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..5909709a6f51428abf261f8384fb78ab
    return RunProcessAndWait(setup_exe.get(), cmd_line.get(),
                             RUN_SETUP_FAILED_FILE_NOT_FOUND,
                             RUN_SETUP_FAILED_PATH_NOT_FOUND,
-@@ -873,7 +1022,7 @@ ProcessExitResult WMain(HMODULE module) {
+@@ -873,7 +1020,7 @@ ProcessExitResult WMain(HMODULE module) {
    if (!GetWorkDir(module, &base_path, &exit_code))
      return exit_code;
  
@@ -183,7 +181,7 @@ index 1f39abbeb2579098a54fa82612199f0307ea03b4..5909709a6f51428abf261f8384fb78ab
    // Set the magic suffix in registry to try full installer next time. We ignore
    // any errors here and we try to set the suffix for user level unless
    // GoogleUpdateIsMachine=1 is present in the environment or --system-level is
-@@ -898,7 +1047,7 @@ ProcessExitResult WMain(HMODULE module) {
+@@ -898,7 +1045,7 @@ ProcessExitResult WMain(HMODULE module) {
    if (ShouldDeleteExtractedFiles())
      DeleteExtractedFiles(base_path.get(), archive_path.get(), setup_path.get());
  

--- a/patches/chrome-installer-mini_installer-mini_installer.h.patch
+++ b/patches/chrome-installer-mini_installer-mini_installer.h.patch
@@ -1,0 +1,21 @@
+diff --git a/chrome/installer/mini_installer/mini_installer.h b/chrome/installer/mini_installer/mini_installer.h
+index 7f8f1ff21e45c67c617c376be26e49d2134b6bca..85da9aadb552d193a3d15097f4d85d0ea83698e2 100644
+--- a/chrome/installer/mini_installer/mini_installer.h
++++ b/chrome/installer/mini_installer/mini_installer.h
+@@ -50,6 +50,16 @@ void AppendCommandLineFlags(const wchar_t* command_line, CommandString* buffer);
+ // of differential updates.
+ ProcessExitResult WMain(HMODULE module);
+ 
++#if defined(BRAVE_CHROMIUM_BUILD)
++typedef StackString<128> ReferralCodeString;
++
++// Populates |referral_code| with a Brave referral code if one is
++// present in the installer filename. This may be a standard or an
++// extended referral code.
++bool ParseReferralCode(const wchar_t* installer_filename,
++                       ReferralCodeString& referral_code);
++#endif
++
+ }  // namespace mini_installer
+ 
+ #endif  // CHROME_INSTALLER_MINI_INSTALLER_MINI_INSTALLER_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -171,6 +171,7 @@ test("brave_unit_tests") {
       "//brave/chromium_src/chrome/install_static/brave_install_util_unittest.cc",
       "//brave/chromium_src/chrome/install_static/brave_product_install_details_unittest.cc",
       "//brave/chromium_src/chrome/install_static/brave_user_data_dir_win_unittest.cc",
+      "//brave/chromium_src/chrome/installer/mini_installer/brave_mini_installer_unittest.cc",
     ]
     include_dirs += [ "$target_gen_dir" ]
     deps += [
@@ -179,6 +180,8 @@ test("brave_unit_tests") {
       "//base/test:test_support",
       "//chrome/install_static:install_static_util",
       "//chrome/install_static/test:test_support",
+      "//chrome/installer/mini_installer:lib",
+      "//chrome/installer/mini_installer:mini_installer",
       "//testing/gmock",
       "//testing/gtest",
     ]


### PR DESCRIPTION
If a user downloads the stub installer multiple times, it may have a
de-duplicating suffix added to it: e.g., "BraveBrowserSetup-FOO123 (1).exe"

As part of processing the filename, we should strip that suffix along with any trailing spaces, so that we'll still correctly find the promo code in this scenario.

Fixes brave/brave-browser#1839

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source