### PR TITLE
fix misalignment in all sync title modals

### DIFF
--- a/components/brave_sync/ui/components/modals/addNewChainCameraOption.tsx
+++ b/components/brave_sync/ui/components/modals/addNewChainCameraOption.tsx
@@ -24,9 +24,6 @@ import ScanCodeModal from './scanCode'
 // Utils
 import { getLocale } from '../../../../common/locale'
 
-// Images
-import { SyncAddIcon } from 'brave-ui/features/sync/images'
-
 interface Props {
   fromMobileScreen?: boolean
   syncData: Sync.State
@@ -66,7 +63,6 @@ export default class AddNewChainCameraOptionModal extends React.PureComponent<Pr
             : null
         }
         <ModalHeader>
-          <SyncAddIcon />
           <div>
             <ModalTitle level={1}>
               {

--- a/components/brave_sync/ui/components/modals/addNewChainNoCamera.tsx
+++ b/components/brave_sync/ui/components/modals/addNewChainNoCamera.tsx
@@ -20,9 +20,6 @@ import {
 // Utils
 import { getLocale } from '../../../../common/locale'
 
-// Images
-import { SyncAddIcon } from 'brave-ui/features/sync/images'
-
 interface Props {
   syncData: Sync.State
   actions: any
@@ -40,7 +37,6 @@ export default class AddNewChainNoCameraModal extends React.PureComponent<Props,
     return (
       <Modal id='addNewChainNoCameraModal' onClose={onClose} size='small'>
         <ModalHeader>
-          <SyncAddIcon />
           <div>
             <ModalTitle level={1}>{getLocale('enterThisCode')}</ModalTitle>
             <ModalSubTitle>{getLocale('syncChainCodeHowTo')}</ModalSubTitle>

--- a/components/brave_sync/ui/components/modals/deviceType.tsx
+++ b/components/brave_sync/ui/components/modals/deviceType.tsx
@@ -27,9 +27,7 @@ import { getLocale } from '../../../../common/locale'
 import { getDefaultDeviceName } from '../../helpers'
 
 // Images
-import { SyncAddIcon } from 'brave-ui/features/sync/images'
-import { SyncMobileIcon } from 'brave-ui/features/sync/images'
-import { SyncDesktopIcon } from 'brave-ui/features/sync/images'
+import { SyncDesktopIcon, SyncMobileIcon } from 'brave-ui/features/sync/images'
 
 interface Props {
   syncData: Sync.State
@@ -105,9 +103,8 @@ export default class DeviceTypeModal extends React.PureComponent<Props, State> {
             : null
         }
         <ModalHeader>
-          <SyncAddIcon />
           <div>
-            <ModalTitle level={1}>{getLocale('letsSync')}<br />“{getDefaultDeviceName()}”.</ModalTitle>
+            <ModalTitle level={1}>{getLocale('letsSync')} “{getDefaultDeviceName()}”.</ModalTitle>
             <ModalSubTitle>{getLocale('chooseDeviceType')}</ModalSubTitle>
           </div>
         </ModalHeader>

--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -23,9 +23,6 @@ import {
 import { getLocale } from '../../../../common/locale'
 import { getDefaultDeviceName } from '../../helpers'
 
-// Images
-import { SyncDefaultIcon } from 'brave-ui/features/sync/images'
-
 interface Props {
   syncData: Sync.State
   actions: any
@@ -105,7 +102,6 @@ interface Props {
           : null
         }
         <ModalHeader>
-          <SyncDefaultIcon />
           <div>
             <ModalTitle level={1}>{getLocale('enterSyncCode')}</ModalTitle>
             <ModalSubTitle>{getLocale('enterSyncCodeDescription')}</ModalSubTitle>

--- a/components/brave_sync/ui/components/modals/removeDevice.tsx
+++ b/components/brave_sync/ui/components/modals/removeDevice.tsx
@@ -20,9 +20,6 @@ import {
 // Utils
 import { getLocale } from '../../../../common/locale'
 
-// Images
-import { SyncRemoveIcon } from 'brave-ui/features/sync/images'
-
 interface Props {
   onClose: (event?: React.MouseEvent<HTMLButtonElement>) => void
   actions: any
@@ -43,7 +40,6 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, {}
     return (
       <Modal id='removeMainDeviceModal' onClose={onClose} size='small'>
         <ModalHeader>
-          <SyncRemoveIcon />
           <ModalTitle level={1}>{getLocale('remove')} “{deviceName}” {getLocale('thisSyncChain')}?</ModalTitle>
         </ModalHeader>
         <ModalContent>

--- a/components/brave_sync/ui/components/modals/resetSync.tsx
+++ b/components/brave_sync/ui/components/modals/resetSync.tsx
@@ -22,9 +22,6 @@ import {
 // Utils
 import { getLocale } from '../../../../common/locale'
 
-// Images
-import { SyncRemoveIcon } from 'brave-ui/features/sync/images'
-
 interface Props {
   syncData: Sync.State
   actions: any
@@ -74,7 +71,6 @@ export default class ResetSyncModal extends React.PureComponent<Props, State> {
           : null
         }
         <ModalHeader>
-          <SyncRemoveIcon />
           <div>
             <ModalSubTitle highlight={true}>{getLocale('warning')}</ModalSubTitle>
             <ModalTitle level={1}>{getLocale('removing')} “{syncData.thisDeviceName}” {getLocale('deleteSyncChain')}</ModalTitle>

--- a/components/brave_sync/ui/components/modals/scanCode.tsx
+++ b/components/brave_sync/ui/components/modals/scanCode.tsx
@@ -13,7 +13,6 @@ import {
   ModalTitle,
   ModalSubTitle,
   ScanGrid,
-  QRCodeContainer,
   ThreeColumnButtonGrid,
   ThreeColumnButtonGridCol1,
   ThreeColumnButtonGridCol2
@@ -26,7 +25,7 @@ import AddNewChainCameraOptionModal from './addNewChainCameraOption'
 import { getLocale } from '../../../../common/locale'
 
 // Images
-import { SyncAddIcon, SyncMobilePicture, QRCode } from 'brave-ui/features/sync/images'
+import { SyncMobilePicture, QRCode } from 'brave-ui/features/sync/images'
 
 interface Props {
   syncData: Sync.State
@@ -65,7 +64,6 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
             : null
         }
         <ModalHeader>
-          <SyncAddIcon />
           <div>
             <ModalTitle level={1}>{getLocale('scanThisCode')}</ModalTitle>
             <ModalSubTitle>{getLocale('scanThisCodeHowTo')}</ModalSubTitle>
@@ -73,7 +71,7 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
         </ModalHeader>
         <ScanGrid>
           <div><SyncMobilePicture /></div>
-          <QRCodeContainer><QRCode size='normal' src={syncData.seedQRImageSource} /></QRCodeContainer>
+          <QRCode size='normal' src={syncData.seedQRImageSource} />
         </ScanGrid>
         <ThreeColumnButtonGrid>
           <ThreeColumnButtonGridCol1>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2526

should match last changes from @rossmoody in brave-ui

<img width="689" alt="screen shot 2018-12-13 at 9 39 49 pm" src="https://user-images.githubusercontent.com/4672033/49974293-a5786500-ff1f-11e8-89e9-c2d3471b91f9.png">
<img width="692" alt="screen shot 2018-12-13 at 9 39 36 pm" src="https://user-images.githubusercontent.com/4672033/49974294-a5786500-ff1f-11e8-9928-423d6ebb8a99.png">
![Uploading Screen Shot 2018-12-13 at 9.39.29 PM.png…]()
<img width="703" alt="screen shot 2018-12-13 at 9 39 25 pm" src="https://user-images.githubusercontent.com/4672033/49974297-a5786500-ff1f-11e8-8c36-8ed1ecfed6a1.png">
<img width="693" alt="screen shot 2018-12-13 at 9 39 20 pm" src="https://user-images.githubusercontent.com/4672033/49974298-a610fb80-ff1f-11e8-84bb-7f78f33d02b2.png">
<img width="715" alt="screen shot 2018-12-13 at 9 39 11 pm" src="https://user-images.githubusercontent.com/4672033/49974299-a610fb80-ff1f-11e8-8e01-c309352ffaad.png">
<img width="695" alt="screen shot 2018-12-13 at 9 13 44 pm" src="https://user-images.githubusercontent.com/4672033/49974301-a610fb80-ff1f-11e8-889a-029aa6b92d37.png">
