### PR TITLE
Fix shields setting in private is weird

### DIFF
--- a/chromium_src/components/content_settings/core/browser/brave_content_settings_registry_browsertest.cc
+++ b/chromium_src/components/content_settings/core/browser/brave_content_settings_registry_browsertest.cc
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_shields/common/brave_shield_constants.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "components/content_settings/core/common/content_settings_pattern.h"
+
+const GURL kBraveURL("https://www.brave.com");
+
+class BraveContentSettingsRegistryBrowserTest : public InProcessBrowserTest {
+ public:
+  using InProcessBrowserTest::InProcessBrowserTest;
+
+  HostContentSettingsMap* content_settings() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  HostContentSettingsMap* private_content_settings() {
+    return HostContentSettingsMapFactory::GetForProfile(
+        browser()->profile()->GetOffTheRecordProfile());
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(BraveContentSettingsRegistryBrowserTest);
+};
+
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsRegistryBrowserTest,
+                       WithWildcardContentSetting) {
+  content_settings()->SetContentSettingCustomScope(
+      ContentSettingsPattern::Wildcard(),
+      ContentSettingsPattern::Wildcard(),
+      CONTENT_SETTINGS_TYPE_PLUGINS,
+      brave_shields::kBraveShields,
+      CONTENT_SETTING_ALLOW);
+
+  ContentSetting brave_url_shields_setting =
+      content_settings()->GetContentSetting(
+          kBraveURL, kBraveURL, CONTENT_SETTINGS_TYPE_PLUGINS,
+          brave_shields::kBraveShields);
+  EXPECT_EQ(CONTENT_SETTING_ALLOW, brave_url_shields_setting);
+
+  ContentSetting brave_url_shields_setting_private =
+      private_content_settings()->GetContentSetting(
+          kBraveURL, kBraveURL, CONTENT_SETTINGS_TYPE_PLUGINS,
+          brave_shields::kBraveShields);
+  EXPECT_EQ(CONTENT_SETTING_ALLOW, brave_url_shields_setting_private);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsRegistryBrowserTest,
+                       WithoutWildcardContentSetting) {
+  ContentSetting brave_url_shields_setting =
+      content_settings()->GetContentSetting(
+          kBraveURL, kBraveURL, CONTENT_SETTINGS_TYPE_PLUGINS,
+          brave_shields::kBraveShields);
+  EXPECT_EQ(CONTENT_SETTING_DEFAULT, brave_url_shields_setting);
+
+  ContentSetting brave_url_shields_setting_private =
+      private_content_settings()->GetContentSetting(
+          kBraveURL, kBraveURL, CONTENT_SETTINGS_TYPE_PLUGINS,
+          brave_shields::kBraveShields);
+  EXPECT_EQ(CONTENT_SETTING_DEFAULT, brave_url_shields_setting_private);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsRegistryBrowserTest,
+                       WithBraveShieldsContentSetting) {
+  ContentSettingsPattern brave_url_pattern =
+      ContentSettingsPattern::FromURL(kBraveURL);
+
+  content_settings()->SetContentSettingCustomScope(
+      brave_url_pattern,
+      brave_url_pattern,
+      CONTENT_SETTINGS_TYPE_PLUGINS,
+      brave_shields::kBraveShields,
+      CONTENT_SETTING_ALLOW);
+
+  ContentSetting brave_url_shields_setting =
+      content_settings()->GetContentSetting(
+          kBraveURL, kBraveURL, CONTENT_SETTINGS_TYPE_PLUGINS,
+          brave_shields::kBraveShields);
+  EXPECT_EQ(CONTENT_SETTING_ALLOW, brave_url_shields_setting);
+
+  ContentSetting brave_url_shields_setting_private =
+      private_content_settings()->GetContentSetting(
+          kBraveURL, kBraveURL, CONTENT_SETTINGS_TYPE_PLUGINS,
+          brave_shields::kBraveShields);
+  EXPECT_EQ(CONTENT_SETTING_ALLOW, brave_url_shields_setting_private);
+}

--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -29,7 +29,7 @@ void ContentSettingsRegistry::BraveInit() {
                     CONTENT_SETTING_DETECT_IMPORTANT_CONTENT),
       WebsiteSettingsInfo::SINGLE_ORIGIN_WITH_EMBEDDED_EXCEPTIONS_SCOPE,
       WebsiteSettingsRegistry::DESKTOP,
-      ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE,
+      ContentSettingsInfo::INHERIT_IN_INCOGNITO,
       ContentSettingsInfo::EPHEMERAL,
       ContentSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -232,6 +232,7 @@ test("brave_browser_tests") {
     "//brave/app/sharedarraybuffer_disabledtest.cc",
     "//brave/browser/autocomplete/brave_autocomplete_provider_client_browsertest.cc",
     "//brave/chromium_src/chrome/browser/google/chrome_google_url_tracker_client_browsertest.cc",
+    "//brave/chromium_src/components/content_settings/core/browser/brave_content_settings_registry_browsertest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/credentialmanager/credentials_containertest.cc",


### PR DESCRIPTION
When content setting's IncognitoBehavior is INHERIT_IF_LESS_PERMISSIVE,
normal profiles setting is modified when incognito profile's content settings
are initialized. Because of this behavior, sometimes shields are off and shields's
default configurations are different with normal window.
With INHERIT_IN_INCOGNITO, private windows uses normal windows' configuration w/o
modification.

Fix https://github.com/brave/brave-browser/issues/1373
Fix https://github.com/brave/brave-browser/issues/1897

Below is the reason why some users have private window with shields is always off.
Some times ago, the way of brave's default content settings is refactored.(https://github.com/brave/brave-core/pull/622)
Before this refactoring, shields content setting is stored to prefs like this.
```
void BraveHostContentSettingsMap::InitializeBraveShieldsContentSetting() {	
  SetContentSettingCustomScope(	
      ContentSettingsPattern::Wildcard(),	
      ContentSettingsPattern::Wildcard(),	
      CONTENT_SETTINGS_TYPE_PLUGINS,	
      brave_shields::kBraveShields,	
      CONTENT_SETTING_ALLOW);	
}
```
With this, user data stores allow value for brave shields with wildcard in `./BraveSoftware/Brave-browser/Default/Preferences` file. When private windows are open with this normal windows' value, private window changes it from allow to block. If prefs doesn't have that value, private window uses it w/o modification. So, user can see shields is on in private window with clean profile.

Why private window modifies when normal windows' prefs is inherited? The reason is plugins content setting's incognito behavior is `INHERIT_IF_LESS_PERMISSIVE`. When normal window has stored content setting value, it is modified by `ProcessIncognitoInheritanceBehavior()` in `host_content_settings_map.cc`. If there is no value in prefs, private window uses default value.
We can see brave's default plugin value by `GetDefaultFromResourceIdentifier()` in `brave_shields_util.cc`

So, we can expect below scenario for plugins type of `kBraveShields`.

|       | normal window | private window |
|-------|---------------|----------------|
| empty | ALLOW         | ALLOW          |
| ALLOW | ALLOW         | BLOCK          |
| BLOCK | BLOCK         | BLOCK          |

Above table can explain current behavior.

In conclusion, deleting default wildcard rule can't solve current issue because when user changes shields settings, its value is stored in user data explicitly. In this case, private window will get block setting. So, I think changing to `INHERIT_IN_INCOGNITO` is the solution.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveContentSettingsRegistryBrowserTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source