### PR TITLE
Handle stale lockfiles in Muon browser profile

### DIFF
--- a/browser/importer/brave_external_process_importer_host.cc
+++ b/browser/importer/brave_external_process_importer_host.cc
@@ -106,6 +106,7 @@ bool BraveExternalProcessImporterHost::CheckForChromeOrBraveLock() {
     browser_lock_.reset(new BraveProfileLock(source_profile_.source_path));
   }
 
+  browser_lock_->Lock();
   if (browser_lock_->HasAcquired())
     return true;
 

--- a/browser/importer/brave_profile_lock.h
+++ b/browser/importer/brave_profile_lock.h
@@ -12,6 +12,8 @@ class BraveProfileLock : public ChromeProfileLock {
  public:
   explicit BraveProfileLock(const base::FilePath& user_data_dir);
   ~BraveProfileLock() override;
+
+  void Lock() override;
 };
 
 #endif  // BRAVE_BROWSER_IMPORTER_BRAVE_PROFILE_LOCK_H__

--- a/browser/importer/chrome_profile_lock.cc
+++ b/browser/importer/chrome_profile_lock.cc
@@ -6,17 +6,17 @@
 
 #include "base/bind.h"
 #include "base/bind_helpers.h"
+#include "base/logging.h"
 #include "base/threading/thread_restrictions.h"
+#include "chrome/browser/process_singleton.h"
 
 ChromeProfileLock::ChromeProfileLock(
     const base::FilePath& user_data_dir)
     : lock_acquired_(false),
-      user_data_dir_(user_data_dir),
       process_singleton_(new ProcessSingleton(user_data_dir,
-                         base::Bind(&ChromeProfileLock::NotificationCallback,
-                                    base::Unretained(this)))) {
-  Lock();
-}
+          base::Bind(&ChromeProfileLock::NotificationCallback,
+                     base::Unretained(this)))),
+      user_data_dir_(user_data_dir) {}
 
 ChromeProfileLock::~ChromeProfileLock() {
   Unlock();

--- a/browser/importer/chrome_profile_lock.h
+++ b/browser/importer/chrome_profile_lock.h
@@ -22,11 +22,12 @@ class ChromeProfileLock : public BrowserProfileLock {
   // Returns true if we lock the profile successfully.
   bool HasAcquired() override;
 
- private:
+ protected:
   bool lock_acquired_;
-  base::FilePath user_data_dir_;
   std::unique_ptr<ProcessSingleton> process_singleton_;
 
+ private:
+  base::FilePath user_data_dir_;
   bool NotificationCallback(const base::CommandLine& command_line,
                             const base::FilePath& current_directory);
 

--- a/browser/importer/chrome_profile_lock_unittest.cc
+++ b/browser/importer/chrome_profile_lock_unittest.cc
@@ -75,6 +75,7 @@ void ChromeProfileLockTest::LockFileExists(bool expect) {
 
 TEST_F(ChromeProfileLockTest, LockTest) {
   ChromeProfileLock lock(user_data_path_);
+  lock.Lock();
   ASSERT_TRUE(lock.HasAcquired());
   lock.Unlock();
   ASSERT_FALSE(lock.HasAcquired());
@@ -89,6 +90,7 @@ TEST_F(ChromeProfileLockTest, ProfileLock) {
   EXPECT_EQ(static_cast<ChromeProfileLock*>(NULL), lock.get());
   LockFileExists(false);
   lock.reset(new ChromeProfileLock(user_data_path_));
+  lock->Lock();
   EXPECT_TRUE(lock->HasAcquired());
   LockFileExists(true);
   lock->Unlock();


### PR DESCRIPTION
Resolves brave/brave-browser#2503.

If the initial attempt to create the ProcessSingleton fails, it may be the case that there are stale lockfiles or an unresponsive process holding lockfiles for Muon's user data directory. This PR will retry acquiring the browser profile lock with `ProcessSingleton::NotifyOtherProcessOrCreatte`, which attempts to [handle](https://cs.chromium.org/chromium/src/chrome/browser/process_singleton_posix.cc?l=822-827&rcl=87cce52e1898d568f6aa5439e6183d96e7bbb914) those edge cases.

Tested and confirmed to work on macOS; waiting on builds to confirm this approach also works on Windows and Linux.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Muon
2. Verify that this creates several new files, `Singleton{Cookie,Lock,Socket}`, in Muon's user data directory, e.g. on macOS: `ls -l ~/Library/Application\ Support/brave/Singleton*`
3. Extract Muon's PID from `SingletonLock`, e.g. on macOS: `readlink ~/Library/Application\ Support/brave/SingletonLock | awk -F- '{print $NF}'`
4. Terminate the Muon process (with extreme prejudice), e.g. on macOS: `kill -9 <muon PID>`
5. Verify that the Singleton files remain in the user data directory. They should not be cleaned up automatically, as they would be if Muon had exited cleanly.
6. Launch Brave Core and try to import from Muon; allow keychain access if/when prompted.

Importing all data types from Muon should be successful. You should not see the "Close Brave (old)" dialog.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source