### PR TITLE
move RewardsNotificationServceImpl logic out of RewardsServiceImpl

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -105,6 +105,7 @@ class RewardsDOMHandler : public WebUIMessageHandler,
   void OnReconcileComplete(brave_rewards::RewardsService* rewards_service,
                            unsigned int result,
                            const std::string& viewing_id,
+                           const std::string& category,
                            const std::string& probi) override;
   void OnRecurringDonationUpdated(brave_rewards::RewardsService* rewards_service,
                                   brave_rewards::ContentSiteList) override;
@@ -617,10 +618,12 @@ void RewardsDOMHandler::GetContributionAmount(const base::ListValue* args) {
   }
 }
 
-void RewardsDOMHandler::OnReconcileComplete(brave_rewards::RewardsService* rewards_service,
-  unsigned int result,
-  const std::string& viewing_id,
-  const std::string& probi) {
+void RewardsDOMHandler::OnReconcileComplete(
+    brave_rewards::RewardsService* rewards_service,
+    unsigned int result,
+    const std::string& viewing_id,
+    const std::string& category,
+    const std::string& probi) {
   GetAllBalanceReports();
   OnContentSiteUpdated(rewards_service);
   GetReconcileStamp(nullptr);

--- a/components/brave_rewards/browser/rewards_notification_service_impl.h
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "brave/components/brave_rewards/browser/rewards_notification_service.h"
+#include "brave/components/brave_rewards/browser/rewards_service_observer.h"
 #include "extensions/buildflags/buildflags.h"
 
 class Profile;
@@ -19,6 +20,7 @@ class ExtensionRewardsNotificationServiceObserver;
 
 class RewardsNotificationServiceImpl
     : public RewardsNotificationService,
+      public RewardsServiceObserver,
       public base::SupportsWeakPtr<RewardsNotificationServiceImpl> {
  public:
   RewardsNotificationServiceImpl(Profile* profile);
@@ -36,6 +38,19 @@ class RewardsNotificationServiceImpl
   void StoreRewardsNotifications() override;
 
  private:
+  // RewardsServiceObserver impl
+  void OnGrant(RewardsService* rewards_service,
+               unsigned int error_code,
+               Grant properties) override;
+  void OnGrantFinish(RewardsService* rewards_service,
+                     unsigned int result,
+                     brave_rewards::Grant grant) override;
+  void OnReconcileComplete(RewardsService* rewards_service,
+                           unsigned int result,
+                           const std::string& viewing_id,
+                           const std::string& category,
+                           const std::string& probi) override;
+
   void TriggerOnNotificationAdded(
       const RewardsNotification& rewards_notification);
   void TriggerOnNotificationDeleted(

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -57,7 +57,7 @@ class Profile;
 namespace brave_rewards {
 
 class PublisherInfoDatabase;
-class RewardsNotificationService;
+class RewardsNotificationServiceImpl;
 
 class RewardsServiceImpl : public RewardsService,
                             public ledger::LedgerClient,
@@ -294,7 +294,7 @@ class RewardsServiceImpl : public RewardsService,
   const base::FilePath publisher_info_db_path_;
   const base::FilePath publisher_list_path_;
   std::unique_ptr<PublisherInfoDatabase> publisher_info_backend_;
-  std::unique_ptr<RewardsNotificationService> notification_service_;
+  std::unique_ptr<RewardsNotificationServiceImpl> notification_service_;
   base::ObserverList<RewardsServicePrivateObserver> private_observers_;
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   std::unique_ptr<ExtensionRewardsServiceObserver> private_observer_;

--- a/components/brave_rewards/browser/rewards_service_impl_unittest.cc
+++ b/components/brave_rewards/browser/rewards_service_impl_unittest.cc
@@ -25,18 +25,34 @@ class MockRewardsServiceObserver : public RewardsServiceObserver {
  public:
   MockRewardsServiceObserver() {}
   MOCK_METHOD2(OnWalletInitialized, void(RewardsService*, int));
-  MOCK_METHOD3(OnWalletProperties, void(RewardsService*, int, std::unique_ptr<brave_rewards::WalletProperties>));
-  MOCK_METHOD3(OnGrant, void(RewardsService*, unsigned int, brave_rewards::Grant));
-  MOCK_METHOD3(OnGrantCaptcha, void(RewardsService*, std::string, std::string));
-  MOCK_METHOD4(OnRecoverWallet, void(RewardsService*, unsigned int, double, std::vector<brave_rewards::Grant>));
-  MOCK_METHOD3(OnGrantFinish, void(RewardsService*, unsigned int, brave_rewards::Grant));
+  MOCK_METHOD3(OnWalletProperties, void(RewardsService*,
+      int,
+      std::unique_ptr<brave_rewards::WalletProperties>));
+  MOCK_METHOD3(OnGrant,
+      void(RewardsService*, unsigned int, brave_rewards::Grant));
+  MOCK_METHOD3(OnGrantCaptcha,
+      void(RewardsService*, std::string, std::string));
+  MOCK_METHOD4(OnRecoverWallet, void(RewardsService*,
+                                     unsigned int,
+                                     double,
+                                     std::vector<brave_rewards::Grant>));
+  MOCK_METHOD3(OnGrantFinish,
+      void(RewardsService*, unsigned int, brave_rewards::Grant));
   MOCK_METHOD1(OnContentSiteUpdated, void(RewardsService*));
   MOCK_METHOD2(OnExcludedSitesChanged, void(RewardsService*, std::string));
-  MOCK_METHOD4(OnReconcileComplete, void(RewardsService*, unsigned int, const std::string&, const std::string&));
-  MOCK_METHOD2(OnRecurringDonationUpdated, void(RewardsService*, brave_rewards::ContentSiteList));
-  MOCK_METHOD2(OnCurrentTips, void(RewardsService*, brave_rewards::ContentSiteList));
-  MOCK_METHOD2(OnPublisherBanner, void(RewardsService*, const brave_rewards::PublisherBanner));
-  MOCK_METHOD4(OnGetPublisherActivityFromUrl, void(RewardsService*, int, ledger::PublisherInfo*, uint64_t));
+  MOCK_METHOD5(OnReconcileComplete, void(RewardsService*,
+                                         unsigned int,
+                                         const std::string&,
+                                         const std::string&,
+                                         const std::string&));
+  MOCK_METHOD2(OnRecurringDonationUpdated,
+      void(RewardsService*, brave_rewards::ContentSiteList));
+  MOCK_METHOD2(OnCurrentTips,
+      void(RewardsService*, brave_rewards::ContentSiteList));
+  MOCK_METHOD2(OnPublisherBanner,
+      void(RewardsService*, const brave_rewards::PublisherBanner));
+  MOCK_METHOD4(OnGetPublisherActivityFromUrl,
+      void(RewardsService*, int, ledger::PublisherInfo*, uint64_t));
 };
 
 class RewardsServiceTest : public testing::Test {

--- a/components/brave_rewards/browser/rewards_service_observer.h
+++ b/components/brave_rewards/browser/rewards_service_observer.h
@@ -44,6 +44,7 @@ class RewardsServiceObserver : public base::CheckedObserver {
   virtual void OnReconcileComplete(RewardsService* rewards_service,
                                    unsigned int result,
                                    const std::string& viewing_id,
+                                   const std::string& category,
                                    const std::string& probi) {};
   virtual void OnRecurringDonationUpdated(RewardsService* rewards_service,
                                           brave_rewards::ContentSiteList) {};


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2582

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source