### PR TITLE
Fixes broken browser test

### DIFF
--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -234,7 +234,7 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, ToggleAutoContribute) {
 
   // toggle auto contribute off
   content::EvalJsResult toggleOffResult = EvalJs(contents(),
-    "document.querySelector(\"[data-test-id2='autoContribution']\").click();"
+    "let toggleClicked = false;"
     "new Promise((resolve) => {"
     "var count = 10;"
     "var interval = setInterval(function() {"
@@ -245,9 +245,14 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, ToggleAutoContribute) {
     "    count -= 1;"
     "  }"
     "  if (document.querySelector(\"[data-test-id2='autoContribution']\")) {"
-    "    clearInterval(interval);"
-    "    resolve(document.querySelector(\"[data-test-id2='autoContribution']\")"
-    "      .getAttribute(\"data-toggled\") === 'false');"
+    "    if (!toggleClicked) {"
+    "      toggleClicked = true;"
+    "      document.querySelector(\"[data-test-id2='autoContribution']\").click();"
+    "    } else {"
+    "      clearInterval(interval);"
+    "      resolve(document.querySelector(\"[data-test-id2='autoContribution']\")"
+    "        .getAttribute(\"data-toggled\") === 'false');"
+    "    }"
     "  }"
     "}, 500);});",
     content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,


### PR DESCRIPTION
Fixes brave/brave-browser#1284

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Run `npm run test brave_browser_test -- --filter=BraveRewardsBrowserTest.ToggleAutoContribute` and ensure test passes


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source