### PR TITLE
Fixes padding in Rewards Panel

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -299,8 +299,7 @@ export class Panel extends React.Component<Props, State> {
         >
           {
             publisher && publisher.publisher_key
-            ? <>
-              <WalletPanel
+            ? <WalletPanel
               id={'wallet-panel'}
               platform={publisher.provider as Provider}
               publisherName={publisher.name}
@@ -315,11 +314,6 @@ export class Panel extends React.Component<Props, State> {
               onAmountChange={this.doNothing}
               onIncludeInAuto={this.switchAutoContribute}
               />
-              <div
-              style={{ height: '48px' }}
-              data-description='Temporary Platform Tipping Placeholder'
-              />
-              </>
             : null
           }
           <WalletSummary compact={true} {...this.getWalletSummary()}/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#c31aafc0d7186296f48d871be41df45a785d3467",
-      "from": "github:brave/brave-ui#c31aafc0d7186296f48d871be41df45a785d3467",
+      "version": "github:brave/brave-ui#c29dcb4de6e8b6ddea4abcc778b2f30b8fb7b456",
+      "from": "github:brave/brave-ui#c29dcb4de6e8b6ddea4abcc778b2f30b8fb7b456",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#c31aafc0d7186296f48d871be41df45a785d3467",
+    "brave-ui": "github:brave/brave-ui#c29dcb4de6e8b6ddea4abcc778b2f30b8fb7b456",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2590
Also Reverts https://github.com/brave/brave-core/pull/1072

This is meant to be a hardened fix for the rewards panel padding issue, the fix should persist beyond implementing the toggle tips component.

**Reviewer note: Do not merge. This must be additionally uplifted in brave-ui upon uplift approval in core. The ui hash will be finalized then.**

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Defined in issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source