### PR TITLE
Rename `Brave Sync` to `Sync` in settings

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -127,7 +127,7 @@
         Brave Ad Block
       </message>
       <message name="IDS_SHOW_BRAVE_SYNC" desc="The show brave sync menu in the app menu">
-        Brave Sync
+        Sync
       </message>
       <message name="IDS_EXTENSION_CANT_INSTALL_ON_BRAVE" desc="Error message when user tries to install an extension that is not allowed in Brave.">
         <ph name="EXTENSION_NAME">$1</ph> (extension ID "<ph name="EXTENSION_ID">$2<ex>abacabadabacabaeabacabadabacabaf</ex></ph>") is not allowed in Brave.
@@ -322,10 +322,10 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       </message>
       <!-- Brave Sync Settings -->
       <message name="IDS_SETTINGS_BRAVE_SYNC_TITLE" desc="The title for Brave Sync in settings">
-        Brave Sync
+        Sync
       </message>
       <message name="IDS_SETTINGS_BRAVE_SYNC_LINK_LABEL" desc="Brave Sync link label">
-        Access Brave Sync via
+        Access Sync via
       </message>
     </messages>
     <includes>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2592

Test Plan

1. Go to brave://settings
2. Ensure Sync is shown as `Sync` and not `Brave Sync`