### PR TITLE
Repair Welcome Favico

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -93,6 +93,10 @@ void CustomizeWebUIHTMLSource(const std::string &name, content::WebUIDataSource*
         { "2c6f798a519beabb327149c349912f5f.svg", IDR_BRAVE_REWARDS_IMG_LTC },
       }
     }, {
+      std::string("welcome"), {
+        { "favicon.ico", IDR_BRAVE_WELCOME_PAGE_FAVICON }
+      }
+    }, {
       std::string("adblock"), {
       }
     }, {
@@ -184,7 +188,7 @@ void CustomizeWebUIHTMLSource(const std::string &name, content::WebUIDataSource*
         { "theme", IDS_BRAVE_WELCOME_PAGE_THEME_BUTTON },
         { "skipWelcomeTour", IDS_BRAVE_WELCOME_PAGE_SKIP_BUTTON },
         { "next", IDS_BRAVE_WELCOME_PAGE_NEXT_BUTTON },
-        { "done", IDS_BRAVE_WELCOME_PAGE_DONE_BUTTON }
+        { "done", IDS_BRAVE_WELCOME_PAGE_DONE_BUTTON },
       }
     }, {
       std::string("rewards"), {

--- a/components/brave_welcome_ui/brave_welcome.html
+++ b/components/brave_welcome_ui/brave_welcome.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
-<title>Welcome</title>
+<title>Welcome to Brave</title>
 <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
-<link rel="shortcut icon" href="/ecaefa14dcf65df518730a336430727e.ico" type="image/x-icon">
+<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 <link rel="import" href="chrome://resources/html/cr.html">
 <script src="chrome://resources/js/cr.js"></script>
 <script src="chrome://resources/js/load_time_data.js"></script>

--- a/components/resources/brave_components_resources.grd
+++ b/components/resources/brave_components_resources.grd
@@ -25,7 +25,7 @@
       <!-- WebUI welcome page resources -->
       <!-- TODO: move to brave_welcome_ui component -->
       <include name="IDR_BRAVE_WELCOME_HTML" file="../brave_welcome_ui/brave_welcome.html" type="BINDATA" />
-      <include name="IDR_BRAVE_WELCOME_FAVICON" file="../img/welcome/favicon.ico" type="BINDATA" />
+      <include name="IDR_BRAVE_WELCOME_PAGE_FAVICON" file="../img/welcome/favicon.ico" type="BINDATA" />
 
       <!-- WebUI newtab resources -->
       <!-- TODO: move to brave_new_tab_ui component -->


### PR DESCRIPTION
Had a revert where the Welcome page favicon went missing. This repairs it. 

Fixes https://github.com/brave/brave-browser/issues/2611