### PR TITLE
Brave ui update 0.59.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#4e1e2ab1c16e0e37f7d16fccca3e1266180503bc",
-      "from": "github:brave/brave-ui#4e1e2ab1c16e0e37f7d16fccca3e1266180503bc",
+      "version": "github:brave/brave-ui#df91eb673c84c3a4b5b422326d33e322fb991172",
+      "from": "github:brave/brave-ui#df91eb673c84c3a4b5b422326d33e322fb991172",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#4e1e2ab1c16e0e37f7d16fccca3e1266180503bc",
+    "brave-ui": "github:brave/brave-ui#df91eb673c84c3a4b5b422326d33e322fb991172",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Changes can be seen at https://github.com/brave/brave-ui/compare/4e1e2ab1c16e0e37f7d16fccca3e1266180503bc...df91eb673c84c3a4b5b422326d33e322fb991172
```
* df91eb6 - (2 weeks ago) Merge pull request #300 from brave/site-banner-icon — Ryan Lanese
```

All previously approved in brave-ui for uplift to 0.59.x


