### PR TITLE
Brave-ui update 0.58.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,46 +1237,12 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#56b99d7dd72da7cd2b0cb987a789c17120db5667",
-      "from": "github:brave/brave-ui#56b99d7dd72da7cd2b0cb987a789c17120db5667",
+      "version": "github:brave/brave-ui#4edb796376103e2f86bd24f181a5e56029f8bc7d",
+      "from": "github:brave/brave-ui#4edb796376103e2f86bd24f181a5e56029f8bc7d",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",
         "styled-components": "^3.2.5"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "styled-components": {
-          "version": "3.4.10",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
-          "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.0.3",
-            "css-to-react-native": "^2.0.3",
-            "fbjs": "^0.8.16",
-            "hoist-non-react-statics": "^2.5.0",
-            "prop-types": "^15.5.4",
-            "react-is": "^16.3.1",
-            "stylis": "^3.5.0",
-            "stylis-rule-sheet": "^0.0.10",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "brorand": {

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#56b99d7dd72da7cd2b0cb987a789c17120db5667",
+    "brave-ui": "github:brave/brave-ui#4edb796376103e2f86bd24f181a5e56029f8bc7d",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Changes can be seen at https://github.com/brave/brave-ui/compare/56b99d7dd72da7cd2b0cb987a789c17120db5667...4edb796376103e2f86bd24f181a5e56029f8bc7d
```
* 4edb796 - (2 weeks ago) Merge pull request #300 from brave/site-banner-icon — Ryan Lanese
```

All previously approved in brave-ui for uplift to 0.59.x


