### PR TITLE
Fixes tipping report inconsistencies

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -606,6 +606,7 @@ void RewardsServiceImpl::OnGrantFinish(ledger::Result result,
                                   grant.probi);
   }
 
+  GetCurrentBalanceReport();
   TriggerOnGrantFinish(result, grant);
 }
 
@@ -624,6 +625,7 @@ void RewardsServiceImpl::OnReconcileComplete(ledger::Result result,
         GetCurrentTimestamp());
   }
 
+  GetCurrentBalanceReport();
   for (auto& observer : observers_)
     observer.OnReconcileComplete(this,
                                  result,

--- a/components/brave_rewards/resources/ui/actions/rewards_actions.ts
+++ b/components/brave_rewards/resources/ui/actions/rewards_actions.ts
@@ -93,6 +93,8 @@ export const onBalanceReports = (reports: Record<string, Rewards.Report>) => act
   reports
 })
 
+export const getCurrentReport = () => action(types.GET_CURRENT_REPORT, {})
+
 export const excludePublisher = (publisherKey: string) => action(types.ON_EXCLUDE_PUBLISHER, {
   publisherKey
 })

--- a/components/brave_rewards/resources/ui/components/settingsPage.tsx
+++ b/components/brave_rewards/resources/ui/components/settingsPage.tsx
@@ -52,6 +52,7 @@ class SettingsPage extends React.Component<Props, {}> {
     this.actions.getContributeList()
     this.actions.checkImported()
     this.actions.getAdsData()
+    this.actions.getCurrentReport()
   }
 
   componentWillUnmount () {

--- a/components/brave_rewards/resources/ui/constants/rewards_types.ts
+++ b/components/brave_rewards/resources/ui/constants/rewards_types.ts
@@ -46,5 +46,6 @@ export const enum types {
   ON_IMPORTED_CHECK = '@@rewards/ON_IMPORTED_CHECK',
   GET_ADS_DATA = '@@rewards/GET_ADS_DATA',
   ON_ADS_DATA = '@@rewards/ON_ADS_DATA',
-  ON_ADS_SETTING_SAVE = '@@rewards/ON_ADS_SETTING_SAVE'
+  ON_ADS_SETTING_SAVE = '@@rewards/ON_ADS_SETTING_SAVE',
+  GET_CURRENT_REPORT = '@@rewards/GET_CURRENT_REPORT'
 }

--- a/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
+++ b/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
@@ -170,6 +170,11 @@ const walletReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State,
         }
         break
       }
+    case types.GET_CURRENT_REPORT:
+      {
+        chrome.send('brave_rewards.getBalanceReports')
+        break
+      }
     case types.ON_BALANCE_REPORTS:
       {
         state = { ...state }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2273
Fixes: https://github.com/brave/brave-browser/issues/2332

Issue was that the call to fetch currentBalanceReport for these views was only happening on component mount, so if expected data to a bit to resolve, there was no retry. That was the primary issue with #2273

It makes sense that reports should be updated in sync with wallet props. Doing so resolves both of the above issues without any client side changes.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Defined in #2273 and #2332
 
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source