### PR TITLE
do not dismiss enter sync words modal when error occurs

### DIFF
--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -41,7 +41,6 @@ interface Props {
 
   onUserNoticedError = () => {
     this.props.actions.resetSyncSetupError()
-    this.props.onClose()
   }
 
   onEnterPassphrase = (event: React.ChangeEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2541

Test Plan:

1. Click Enter a sync chain code to join a sync chain
2. Do not enter any code words and click on Confirm sync code
3. Click Ok on the info modal, it should close the error dialog but not sync words modal