### PR TITLE
Shows grant notification only once

### DIFF
--- a/components/brave_rewards/browser/rewards_notification_service.h
+++ b/components/brave_rewards/browser/rewards_notification_service.h
@@ -51,13 +51,14 @@ class RewardsNotificationService {
 
   virtual void AddNotification(RewardsNotificationType type,
                                RewardsNotificationArgs args,
-                               RewardsNotificationID id = "") = 0;
+                               RewardsNotificationID id = "",
+                               bool only_once = false) = 0;
   virtual void DeleteNotification(RewardsNotificationID id) = 0;
   virtual void DeleteAllNotifications() = 0;
   virtual void GetNotification(RewardsNotificationID id) = 0;
   virtual void GetAllNotifications() = 0;
 
-  virtual void ReadRewardsNotifications() = 0;
+  virtual void ReadRewardsNotificationsJSON() = 0;
   virtual void StoreRewardsNotifications() = 0;
 
   void AddObserver(RewardsNotificationServiceObserver* observer);

--- a/components/brave_rewards/browser/rewards_notification_service_impl.h
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/values.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service.h"
 #include "brave/components/brave_rewards/browser/rewards_service_observer.h"
 #include "extensions/buildflags/buildflags.h"
@@ -28,13 +29,15 @@ class RewardsNotificationServiceImpl
 
   void AddNotification(RewardsNotificationType type,
                        RewardsNotificationArgs args,
-                       RewardsNotificationID id = "") override;
+                       RewardsNotificationID id = "",
+                       bool only_once = false) override;
   void DeleteNotification(RewardsNotificationID id) override;
   void DeleteAllNotifications() override;
   void GetNotification(RewardsNotificationID id) override;
   void GetAllNotifications() override;
 
-  void ReadRewardsNotifications() override;
+  void ReadRewardsNotificationsJSON() override;
+  void ReadRewardsNotifications(std::unique_ptr<base::ListValue>);
   void StoreRewardsNotifications() override;
 
  private:
@@ -73,6 +76,7 @@ class RewardsNotificationServiceImpl
 
   Profile* profile_;
   std::map<RewardsNotificationID, RewardsNotification> rewards_notifications_;
+  std::vector<RewardsNotificationID> rewards_notifications_displayed_;
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   std::unique_ptr<ExtensionRewardsNotificationServiceObserver>
       extension_rewards_notification_service_observer_;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2454

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- clean profile
- open panel
- enable rewards
- make sure that you see grant notification
- click on X
- close panel
- open panel again and make sure that you don't see notification again

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source