### PR TITLE
Prevent duplicate nodes from reconnect and refine reset to make sure deleted record is sent

### DIFF
--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -14,6 +14,7 @@ namespace prefs {
 
 const char kSyncDeviceId[] = "brave_sync.device_id";
 const char kSyncSeed[] = "brave_sync.seed";
+const char kSyncPrevSeed[] = "brave_sync.previous_seed";
 const char kSyncDeviceName[] = "brave_sync.device_name";
 const char kSyncBookmarksBaseOrder[] = "brave_sync.bookmarks_base_order";
 const char kSyncEnabled[] = "brave_sync.enabled";
@@ -34,6 +35,14 @@ std::string Prefs::GetSeed() const {
 void Prefs::SetSeed(const std::string& seed) {
   DCHECK(!seed.empty());
   pref_service_->SetString(kSyncSeed, seed);
+}
+
+std::string Prefs::GetPrevSeed() const {
+  return pref_service_->GetString(kSyncPrevSeed);
+}
+
+void Prefs::SetPrevSeed(const std::string& seed) {
+  pref_service_->SetString(kSyncPrevSeed, seed);
 }
 
 std::string Prefs::GetThisDeviceId() const {

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -28,6 +28,8 @@ extern const char kSyncDeviceId[];
 // String of 32 comma separated bytes
 // like "145,58,125,111,85,164,236,38,204,67,40,31,182,114,14,152,242,..."
 extern const char kSyncSeed[];
+// For storing previous seed after reset. It won't be cleared by Clear()
+extern const char kSyncPrevSeed[];
 // String of current device namefor sync
 extern const char kSyncDeviceName[];
 // The initial bookmarks order, in a format of
@@ -57,6 +59,8 @@ public:
 
   std::string GetSeed() const;
   void SetSeed(const std::string& seed);
+  std::string GetPrevSeed() const;
+  void SetPrevSeed(const std::string& seed);
   std::string GetThisDeviceId() const;
   void SetThisDeviceId(const std::string& device_id);
   std::string GetThisDeviceName() const;

--- a/components/brave_sync/brave_sync_service_factory.cc
+++ b/components/brave_sync/brave_sync_service_factory.cc
@@ -51,6 +51,7 @@ void BraveSyncServiceFactory::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterStringPref(prefs::kSyncDeviceId, std::string());
   registry->RegisterStringPref(prefs::kSyncSeed, std::string());
+  registry->RegisterStringPref(prefs::kSyncPrevSeed, std::string());
   registry->RegisterStringPref(prefs::kSyncDeviceName, std::string());
   registry->RegisterStringPref(prefs::kSyncBookmarksBaseOrder, std::string());
 

--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -172,6 +172,8 @@ class BraveSyncServiceImpl
   void NotifySyncStateChanged();
   void NotifyHaveSyncWords(const std::string& sync_words);
 
+  void ResetSyncInternal();
+
   std::unique_ptr<BraveSyncClient> sync_client_;
 
   // True when is in active sync chain
@@ -182,6 +184,8 @@ class BraveSyncServiceImpl
   // Prevent two sequential calls OnSetupSyncHaveCode or OnSetupSyncNewToSync
   // while being initializing
   bool initializing_ = false;
+
+  bool reseting_ = false;
 
   std::string sync_words_;
 

--- a/components/brave_sync/client/bookmark_change_processor.cc
+++ b/components/brave_sync/client/bookmark_change_processor.cc
@@ -405,12 +405,12 @@ void BookmarkChangeProcessor::BookmarkNodeChildrenReordered(
   // this should be safe to ignore as it's only called for managed bookmarks
 }
 
-void BookmarkChangeProcessor::Reset() {
+void BookmarkChangeProcessor::Reset(bool clear_meta_info) {
   ui::TreeNodeIterator<const bookmarks::BookmarkNode>
       iterator(bookmark_model_->root_node());
   bookmark_model_->BeginExtensiveChanges();
 
-  {
+  if (clear_meta_info) {
     ScopedPauseObserver pause(this);
     while (iterator.has_next()) {
       const bookmarks::BookmarkNode* node = iterator.Next();
@@ -425,6 +425,9 @@ void BookmarkChangeProcessor::Reset() {
   auto* deleted_node = GetDeletedNodeRoot();
   CHECK(deleted_node);
   deleted_node->DeleteAll();
+  auto* pending_node = GetPendingNodeRoot();
+  CHECK(pending_node);
+  pending_node->DeleteAll();
   bookmark_model_->EndExtensiveChanges();
 }
 

--- a/components/brave_sync/client/bookmark_change_processor.h
+++ b/components/brave_sync/client/bookmark_change_processor.h
@@ -35,7 +35,7 @@ class BookmarkChangeProcessor : public ChangeProcessor,
   // ChangeProcessor implementation
   void Start() override;
   void Stop() override;
-  void Reset() override;
+  void Reset(bool clear_meta_info) override;
   void ApplyChangesFromSyncModel(const RecordsList &records) override;
   void GetAllSyncData(
       const std::vector<std::unique_ptr<jslib::SyncRecord>>& records,

--- a/components/brave_sync/model/change_processor.h
+++ b/components/brave_sync/model/change_processor.h
@@ -21,7 +21,10 @@ class ChangeProcessor {
   virtual void Stop() = 0;
 
   // reset all sync data, but do not delete local records
-  virtual void Reset() = 0;
+  // with clear_meta_info == false, we perserve meta info for reconnecting to
+  // previous sync chain and only clear permanent nodes managed by sync.
+  // If we want to connect/create to new sync chain, we should clear meta info.
+  virtual void Reset(bool clear_meta_info) = 0;
 
   // setup permanent nodes
   virtual void InitialSync() = 0;


### PR DESCRIPTION
`kSyncPrevSeed` is saved when reset and then will be clear during OnSaveInitData for create/connect sync chain
`ResetSyncInternal` is introduced for making sure the final delete record is sent and resolved.

fix https://github.com/brave/brave-browser/issues/2443
fix https://github.com/brave/brave-browser/issues/2527 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Create sync chain from device A and create bookmarks like this
 ```
f1 -|
     |- f2
     |- b1
```   
2. Connect to the sync chain from device B and device C
3. Wait for devices list and bookmarks synced on all devices
4. Remove device C on device C by click "x" or "leave sync chain" (self deleted)
5. Make sure device C get deleted on device A and device B
6. Delete b1 from device A
7. Connect device C to the sync chain which contains device A and device B again
8. Make sure device C has bookmarks like this
 ```
f1 -|
     |- f2
```   
9. Add b2 to device C to prove it is syncing with the sync chain like this
 ```
f1 -|
     |- f2
     |- b2
```   
10. Make sure all devices have bookmarks like above structure
11. Remove device C on device C by click "x" or "leave sync chain" (self deleted)
12. Make sure device C get deleted on device A and device B
13. Create sync chain on device C and connect device D to it /create sync chain on device D and connect device C to it (Connect/Create different chain)
14. Make sure device D has bookmarks like this
 ```
f1 -|
     |- f2
     |- b2
```  

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source