### PR TITLE
Unifies text for grants in rewards summary

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -128,7 +128,7 @@
     "description": "Month"
   },
   "tokenGrant": {
-    "message": "Token Grant",
+    "message": "Token Grants Claimed",
     "description": "Title for grant section in wallet summary"
   },
   "earningsAds": {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2637

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- claim grant
- make sure that text in rewards summary is the same on settings page and the panel

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source