### PR TITLE
Revert "Fix #2608: Brave Ads notifications disappear without user input"

### DIFF
--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -98,9 +98,6 @@ def Main(argv):
   # Explicitly disable profiling
   plist['SUEnableSystemProfiling'] = False
 
-  # Explicitly force user notification style to use alerts
-  plist['NSUserNotificationAlertStyle'] = "alert"
-
   # Now that all keys have been mutated, rewrite the file.
   with tempfile.NamedTemporaryFile() as temp_info_plist:
     plistlib.writePlist(plist, temp_info_plist.name)


### PR DESCRIPTION
Reverts brave/brave-core#1137