### PR TITLE
Displaying sync in setting according to sync enable/disable status

### DIFF
--- a/browser/resources/settings/brave_page_visibility.js
+++ b/browser/resources/settings/brave_page_visibility.js
@@ -35,6 +35,11 @@ cr.define('settings', function() {
     get: function(obj, prop) {
       if (prop === 'appearance') return new Proxy({}, appearanceHandler);
       if (prop === 'braveShieldsDefaults') return new Proxy({}, braveShieldsDefaultsHandler);
+      if (prop === 'braveSync') {
+        if (loadTimeData.getBoolean('isSyncDisabled'))
+          return false;
+        return true;
+      }
       if (prop === 'privacy') return new Proxy({}, privacyHandler);
       return prop === 'a11y' ? false : true;
     }

--- a/browser/ui/webui/brave_md_settings_ui.cc
+++ b/browser/ui/webui/brave_md_settings_ui.cc
@@ -4,11 +4,13 @@
 
 #include "brave/browser/ui/webui/brave_md_settings_ui.h"
 
+#include "base/command_line.h"
 #include "brave/browser/extensions/brave_component_loader.h"
 #include "brave/browser/resources/grit/brave_settings_resources.h"
 #include "brave/browser/resources/grit/brave_settings_resources_map.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/browser/ui/webui/settings/default_brave_shields_handler.h"
+#include "brave/common/brave_switches.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
 #include "content/public/browser/web_ui_data_source.h"
@@ -43,4 +45,8 @@ void BraveMdSettingsUI::AddResources(content::WebUIDataSource* html_source,
 
   html_source->AddBoolean("isPdfjsDisabled",
                           extensions::BraveComponentLoader::IsPdfjsDisabled());
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  html_source->AddBoolean("isSyncDisabled",
+                          command_line.HasSwitch(switches::kDisableBraveSync));
 }

--- a/patches/chrome-browser-resources-settings-basic_page-basic_page.html.patch
+++ b/patches/chrome-browser-resources-settings-basic_page-basic_page.html.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/resources/settings/basic_page/basic_page.html b/chrome/browser/resources/settings/basic_page/basic_page.html
-index a99337c3d25ac4681807a57874fa7bb20713c1a3..3c233c45a8f375a9261a4a4a67fd34144d4d2345 100644
+index a99337c3d25ac4681807a57874fa7bb20713c1a3..54372b9f7e94eb8468b3f1fbecf58c64c3866919 100644
 --- a/chrome/browser/resources/settings/basic_page/basic_page.html
 +++ b/chrome/browser/resources/settings/basic_page/basic_page.html
 @@ -27,6 +27,8 @@
@@ -11,13 +11,16 @@ index a99337c3d25ac4681807a57874fa7bb20713c1a3..3c233c45a8f375a9261a4a4a67fd3414
  </if>
  
  <!-- TODO(michaelpg): Rename to something better than "basic" now that this page
-@@ -214,6 +216,16 @@
+@@ -214,6 +216,19 @@
            </settings-section>
          </template>
  </if>
-+        <settings-section page-title="$i18n{braveSync}" section="braveSync">
-+          <settings-brave-sync-page prefs="{{prefs}}"></settings-brave-sync-page>
-+        </settings-section>
++        <template is="dom-if" if="[[showPage_(pageVisibility.braveSync)]]"
++            restamp>
++          <settings-section page-title="$i18n{braveSync}" section="braveSync">
++            <settings-brave-sync-page prefs="{{prefs}}"></settings-brave-sync-page>
++          </settings-section>
++        </template>
 +        <template is="dom-if" if="[[showPage_(pageVisibility.braveShieldsDefaults)]]"
 +            restamp>
 +          <settings-section page-title="$i18n{braveShieldsDefaults}"


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2650

## Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
### sync disabled
1. Launch Brave with `--disable-brave-sync`
2. Go to `chrome://settings/`
3. There should not be "Brave Sync" section

### sync enabled

1. Launch Brave without `--disable-brave-sync`
2. Go to `chrome://settings/`
3. You should see "Brave Sync" section

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source