### PR TITLE
don't classify pages from restored sessions

### DIFF
--- a/components/brave_ads/browser/ads_tab_helper.cc
+++ b/components/brave_ads/browser/ads_tab_helper.cc
@@ -64,7 +64,9 @@ void AdsTabHelper::DidFinishNavigation(
             "cache-control", "private")) {
       run_distiller_ = false;
     } else {
-      run_distiller_ = true;
+      bool was_restored =
+          navigation_handle->GetRestoreType() != content::RestoreType::NONE;
+      run_distiller_ = !was_restored;
     }
   }
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2632

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [x] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source