### PR TITLE
dismiss all errors at sync start

### DIFF
--- a/components/brave_sync/ui/components/app.tsx
+++ b/components/brave_sync/ui/components/app.tsx
@@ -26,7 +26,7 @@ interface Props {
 export class SyncPage extends React.PureComponent<Props, {}> {
   componentDidMount () {
     // Inform the back-end that Sync can be loaded
-    syncActions.onPageLoaded()
+    this.props.actions.onPageLoaded()
   }
 
   render () {

--- a/components/brave_sync/ui/reducers/sync_reducer.ts
+++ b/components/brave_sync/ui/reducers/sync_reducer.ts
@@ -23,6 +23,10 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
     // inform SyncUIImpl we can start requesting sync settings data
     case types.SYNC_ON_PAGE_LOADED:
       chrome.send('pageLoaded')
+      // if there are errors coming from previous views, reset.
+      if (typeof state.error !== 'undefined') {
+        state = { ...state, error: undefined }
+      }
       break
 
     case types.SYNC_ON_SHOW_SETTINGS:

--- a/components/test/brave_sync_ui/components/app_test.tsx
+++ b/components/test/brave_sync_ui/components/app_test.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 import { shallow } from 'enzyme'
 import { types } from '../../../brave_sync/ui/constants/sync_types'
 import { syncInitialState } from '../../testData'
+import * as actions from '../../../brave_sync/ui/actions/sync_actions'
 import {
   SyncPage,
   mapStateToProps,
@@ -44,7 +45,7 @@ describe('sync page component', () => {
     it('renders the component', () => {
       const wrapper = shallow(
         <SyncPage
-          actions={{}}
+          actions={actions}
           syncData={syncInitialState.syncData as Sync.State}
         />
       )


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2484

Test Plan:

1. Disconnect device from network
2. Open brave://bravesync and click on `Enter a sync chain code`
3. Click `Confirm Sync code`, shows error message
4. Close browser without dismissing the popup notification
5. Restart browser and open sync page and click on `Enter a sync chain code`. No message should be shown
6. Click `Confirm Sync code`, shows error message as expected