### PR TITLE
use different tsconfig for linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "tslint --project tsconfig.json 'components/**/*.{ts,tsx}'",
+    "lint": "tslint --project tsconfig-lint.json 'components/**/*.{ts,tsx}'",
     "pep8": "pycodestyle --max-line-length 120 -r script",
     "web-ui-gen-grd": "node components/webpack/gen-webpack-grd",
     "web-ui": "webpack --config components/webpack/webpack.config.js --progress --colors",

--- a/tsconfig-lint.json
+++ b/tsconfig-lint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+    "./components/**/*"
+  ],
+  "exclude": [
+    "./components/brave_sync/extension"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,11 +33,6 @@
     "noUnusedLocals": true
   },
   "include": [
-    "./components/definitions/*",
-    "./components/**/*"
-  ],
-  "exclude": [
-    "./components/test/**/*",
-    "./components/brave_sync/extension"
+    "./components/definitions/*"
   ]
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2669

## test plan

### lint
1. Edit any file you know would break lint i.e. multiple line-breaks
2. Run `npm run lint` and watch it fail

### ts compiler
1. Edit any component-specific file to break ts (i.e. not in `components/definitions`
  - Make it break typescript, e.g. by using an unknown type or function name
2. Build brave-browser and watch it fail