### PR TITLE
Fixes custom publisher tipping amounts

### DIFF
--- a/components/brave_rewards/resources/donate/components/siteBanner.tsx
+++ b/components/brave_rewards/resources/donate/components/siteBanner.tsx
@@ -47,8 +47,8 @@ class Banner extends React.Component<Props, State> {
 
     let amounts = [1, 5, 10]
 
-    if (publisher && publisher.amount) {
-      amounts = publisher.amount
+    if (publisher && publisher.amounts && publisher.amounts.length) {
+      amounts = publisher.amounts
     }
 
     return amounts.map((value: number) => {

--- a/components/definitions/rewardsDonate.d.ts
+++ b/components/definitions/rewardsDonate.d.ts
@@ -23,7 +23,7 @@ declare namespace RewardsDonate {
     description: string
     background: string
     logo: string
-    amount: number[],
+    amounts: number[],
     provider: string
     social: Record<string, string>
   }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2645

Turns out this already worked, just needed to change from `amount` -> `amounts` in the donate state enum.

Also updated the check to look for `amounts.length`, as if there are no custom amounts, we just get an empty list back.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Enable Rewards
2. Navigate to https://kjozwiak.github.io/
3. Open panel, hit 'Send Tip' to bring up site banner
4. Ensure that the donation amount choices reflect the customizations made to the publisher banner

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source