### PR TITLE
set only 1 row for bookmarks in sync data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#576efc57a18d183f2ebd7346716399a24c299a15",
-      "from": "github:brave/brave-ui#576efc57a18d183f2ebd7346716399a24c299a15",
+      "version": "github:brave/brave-ui#c00db2cf0313abb631abbef5274e2ccd9f52471b",
+      "from": "github:brave/brave-ui#c00db2cf0313abb631abbef5274e2ccd9f52471b",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#576efc57a18d183f2ebd7346716399a24c299a15",
+    "brave-ui": "github:brave/brave-ui#c00db2cf0313abb631abbef5274e2ccd9f52471b",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2676
brave-ui commit sha https://github.com/brave/brave-ui/commit/c00db2cf0313abb631abbef5274e2ccd9f52471b

Test Plan:

1. Have sync enabled
2. Inspect the `bookmarks` section and ensure it has only one row

<img width="606" alt="screen shot 2018-12-20 at 9 11 09 pm" src="https://user-images.githubusercontent.com/4672033/50315934-cef33c80-049b-11e9-8fe3-e5cf9e8c3831.png">
