### PR TITLE
Fixes whitespace when doing restore

### DIFF
--- a/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
+++ b/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
@@ -78,20 +78,25 @@ const walletReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State,
       }
       break
     case types.RECOVER_WALLET:
-      if (!action.payload.key || action.payload.key.length === 0) {
-        let ui = state.ui
-        ui.walletRecoverySuccess = false
+      {
+        let key = action.payload.key
+        key = key.trim()
 
-        state = {
-          ...state,
-          ui
+        if (!key || key.length === 0) {
+          let ui = state.ui
+          ui.walletRecoverySuccess = false
+
+          state = {
+            ...state,
+            ui
+          }
+
+          break
         }
 
+        chrome.send('brave_rewards.recoverWallet', [key])
         break
       }
-
-      chrome.send('brave_rewards.recoverWallet', [action.payload.key])
-      break
     case types.ON_RECOVER_WALLET_DATA:
       {
         state = { ...state }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2665

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- open restore modal
- past recovery key and add some spaces at the beginning and the end
- make sure that restore is successful

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source