### PR TITLE
Sync clear orders map

### DIFF
--- a/browser/extensions/api/brave_sync_event_router.cc
+++ b/browser/extensions/api/brave_sync_event_router.cc
@@ -142,4 +142,13 @@ void BraveSyncEventRouter::LoadClient() {
   event_router_->BroadcastEvent(std::move(event));
 }
 
+void BraveSyncEventRouter::ClearOrderMap() {
+  auto args = std::make_unique<base::ListValue>();
+  std::unique_ptr<Event> event(
+     new Event(extensions::events::FOR_TEST,
+       extensions::api::brave_sync::OnClearOrderMap::kEventName,
+       std::move(args)));
+  event_router_->BroadcastEvent(std::move(event));
+}
+
 } // namespace extensions

--- a/browser/extensions/api/brave_sync_event_router.h
+++ b/browser/extensions/api/brave_sync_event_router.h
@@ -57,6 +57,8 @@ class BraveSyncEventRouter {
 
   void NeedSyncWords(const std::string& seed);
 
+  void ClearOrderMap();
+
   void LoadClient();
 
 private:

--- a/common/extensions/api/brave_sync.json
+++ b/common/extensions/api/brave_sync.json
@@ -288,6 +288,11 @@
         "type": "function",
         "description": "Browser informs extension page to load js sync library.",
         "parameters": []
+      },
+      {
+        "name": "onClearOrderMap",
+        "type": "function",
+        "description": "Browser informs extension page all portions of bookmarks are sent, so it is time to clear the order map"
       }
     ],
     "functions": [

--- a/components/brave_sync/client/bookmark_change_processor.cc
+++ b/components/brave_sync/client/bookmark_change_processor.cc
@@ -827,6 +827,7 @@ void BookmarkChangeProcessor::SendUnsynced(
       jslib_const::SyncRecordType_BOOKMARKS, records);
     records.clear();
   }
+  sync_client_->ClearOrderMap();
 }
 
 void BookmarkChangeProcessor::InitialSync() {}

--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -253,6 +253,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, ResetClearMeta) {
   AddSimpleHierarchy(&folder1, &node_a, &node_b, &node_c);
 
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS", _)).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 
   EXPECT_TRUE(HasAnySyncMetaInfo(folder1));
@@ -291,6 +292,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, ResetPreserveMeta) {
   AddSimpleHierarchy(&folder1, &node_a, &node_b, &node_c);
 
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS", _)).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 
   EXPECT_TRUE(HasAnySyncMetaInfo(folder1));
@@ -333,6 +335,7 @@ void BraveBookmarkChangeProcessorTest::BookmarkAddedImpl() {
   using brave_sync::jslib::SyncRecord;
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS",
       ContainsRecord(SyncRecord::Action::A_CREATE, "https://a.com/"))).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 }
 
@@ -353,6 +356,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, BookmarkDeleted) {
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS",
       ContainsRecord(SyncRecord::Action::A_DELETE, "https://a.com/"))).Times(1);
   model()->Remove(nodes.at(0));
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
   EXPECT_FALSE(GetDeletedNodeRoot()->IsVisible());
 }
@@ -370,6 +374,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, BookmarkModified) {
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS",
       ContainsRecord(SyncRecord::Action::A_UPDATE, "https://a-m.com/"))).Times(1);
   model()->SetURL(nodes.at(0), GURL("https://a-m.com/"));
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 }
 
@@ -390,6 +395,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, BookmarkMovedInFolder) {
   EXPECT_EQ(intex_c, 2);
 
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS", _)).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 
   EXPECT_TRUE(HasAnySyncMetaInfo(folder1));
@@ -414,6 +420,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, BookmarkMovedInFolder) {
   // BookmarkNodeMoved does not reset "last_send_time" so SendUnsynced
   // ignores order change untill unsynced_send_interval passes,
   // so here below unsynced_send_interval is 0
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(0));
 }
 
@@ -444,6 +451,7 @@ TEST_F(BraveBookmarkChangeProcessorTest, DISABLED_MoveNodesBetweenDirs) {
   // Send all created objects
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS",
       RecordsNumber(4))).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 }
 
@@ -466,10 +474,12 @@ TEST_F(BraveBookmarkChangeProcessorTest, DeleteFolderWithNodes) {
 
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS",
       RecordsNumber(4))).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 
   model()->Remove(folder1);
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS",_)).Times(1);
+  EXPECT_CALL(*sync_client(), ClearOrderMap()).Times(1);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 }
 

--- a/components/brave_sync/client/brave_sync_client.h
+++ b/components/brave_sync/client/brave_sync_client.h
@@ -85,6 +85,8 @@ class BraveSyncClient {
   virtual void OnExtensionInitialized() = 0;
 
   virtual void OnSyncEnabledChanged() = 0;
+
+  virtual void ClearOrderMap() = 0;
 };
 
 } // namespace brave_sync

--- a/components/brave_sync/client/brave_sync_client_impl.cc
+++ b/components/brave_sync/client/brave_sync_client_impl.cc
@@ -191,4 +191,9 @@ void BraveSyncClientImpl::OnExtensionSystemReady() {
   }
 };
 
+void BraveSyncClientImpl::ClearOrderMap() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  brave_sync_event_router_->ClearOrderMap();
+}
+
 } // namespace brave_sync

--- a/components/brave_sync/client/brave_sync_client_impl.h
+++ b/components/brave_sync/client/brave_sync_client_impl.h
@@ -78,6 +78,8 @@ class BraveSyncClientImpl : public BraveSyncClient,
   void LoadOrUnloadExtension(bool load);
   void OnExtensionSystemReady();
 
+  void ClearOrderMap() override;
+
   SyncMessageHandler* handler_;  // not owned
   Profile* profile_;  // not owned
   std::unique_ptr<brave_sync::prefs::Prefs> sync_prefs_;

--- a/components/brave_sync/extension/background.js
+++ b/components/brave_sync/extension/background.js
@@ -60,7 +60,6 @@ chrome.braveSync.onSendSyncRecords.addListener(function(category_name, records) 
   if (category_name == 'BOOKMARKS') {
     fixupSyncRecordsArrayExtensionToBrowser(records);
     chrome.braveSync.resolvedSyncRecords(category_name, records);
-    orderMap = {};
   }
 });
 
@@ -82,6 +81,10 @@ chrome.braveSync.onLoadClient.addListener(function() {
   LoadJsLibScript();
 });
 
+chrome.braveSync.onClearOrderMap.addListener(function() {
+  orderMap = {};
+});
+
 chrome.braveSync.extensionInitialized();
 console.log("chrome.braveSync.extensionInitialized");
 
@@ -96,6 +99,7 @@ function getOrder(record) {
           orderMap[record.objectId] = order;
         getBookmarkOrderCallback = null;
       }
+
       var prevOrder = record.bookmark.prevOrder;
       var parentOrder = record.bookmark.parentOrder;
       if (!prevOrder && orderMap[record.bookmark.prevObjectId])

--- a/components/brave_sync/test_util.h
+++ b/components/brave_sync/test_util.h
@@ -51,6 +51,7 @@ class MockBraveSyncClient : public BraveSyncClient {
   MOCK_METHOD1(NeedBytesFromSyncWords, void(const std::string& words));
   MOCK_METHOD0(OnExtensionInitialized, void());
   MOCK_METHOD0(OnSyncEnabledChanged, void());
+  MOCK_METHOD0(ClearOrderMap, void());
 };
 
 std::unique_ptr<Profile> CreateBraveSyncProfile(const base::FilePath& path);


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/2367 .


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Create sync chain on device 1
2. Join device 2 and add a bookmark on device 2, gets sync'd to device 1
3. Import 5000 bookmark HTML file on device 1, wait for a really long time to sync bookmarks into device 2 
4. Expand the very nested folder in bookmarks on device 2, see some bookmarks at a wrong position compare to device 1


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source