### PR TITLE
WIP: Prevents grant notifications if imported muon profile has claimed grants

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -133,7 +133,10 @@ ExtensionFunction::ResponseAction BraveRewardsGetGrantFunction::Run() {
   RewardsService* rewards_service_ =
     RewardsServiceFactory::GetForProfile(profile);
   if (rewards_service_) {
-    rewards_service_->FetchGrant(std::string(), std::string());
+    bool should_prevent = rewards_service_->GetPreventGrant();
+    if (!should_prevent) {
+      rewards_service_->FetchGrant(std::string(), std::string());
+    }
   }
   return RespondNow(NoArguments());
 }

--- a/browser/importer/brave_profile_writer.cc
+++ b/browser/importer/brave_profile_writer.cc
@@ -239,6 +239,10 @@ void BraveProfileWriter::SetWalletProperties(brave_rewards::RewardsService*
     rewards_service->ExcludePublisher(publisher_key);
   }
 
+  if (ledger_.grants_claimed) {
+    rewards_service->SetPreventGrant(true);
+  }
+
   // Set the recurring tips (formerly known as pinned sites)
   int sum_of_monthly_tips = 0;
   pinned_item_count_ = 0;

--- a/common/importer/brave_ledger.h
+++ b/common/importer/brave_ledger.h
@@ -45,6 +45,7 @@ struct BraveLedger {
   std::string passphrase;
   std::vector<std::string> excluded_publishers;
   std::vector<BravePublisher> pinned_publishers;
+  bool grants_claimed;
   SessionStoreSettings settings;
 };
 

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -113,6 +113,8 @@ class RewardsService : public KeyedService {
   virtual RewardsNotificationService* GetNotificationService() const = 0;
   virtual bool CheckImported() = 0;
   virtual void SetLedgerClient(std::unique_ptr<ledger::Ledger> new_ledger) = 0;
+  virtual void SetPreventGrant(bool should_prevent) = 0;
+  virtual bool GetPreventGrant() = 0;
   virtual void SetBackupCompleted() = 0;
 
   void AddObserver(RewardsServiceObserver* observer);

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -301,7 +301,8 @@ RewardsServiceImpl::RewardsServiceImpl(Profile* profile)
       private_observer_(
           std::make_unique<ExtensionRewardsServiceObserver>(profile_)),
 #endif
-      next_timer_id_(0) {
+      next_timer_id_(0),
+      prevent_grant_(false) {
   // Environment
   #if defined(OFFICIAL_BUILD)
     ledger::is_production = true;
@@ -1027,7 +1028,9 @@ void RewardsServiceImpl::FetchWalletProperties() {
 
 void RewardsServiceImpl::FetchGrant(const std::string& lang,
     const std::string& payment_id) {
-  ledger_->FetchGrant(lang, payment_id);
+  if (!prevent_grant_) {
+    ledger_->FetchGrant(lang, payment_id);
+  }
 }
 
 void RewardsServiceImpl::TriggerOnGrant(ledger::Result result,
@@ -1210,6 +1213,14 @@ void RewardsServiceImpl::SetTimer(uint64_t time_offset,
       base::TimeDelta::FromSeconds(time_offset),
       base::BindOnce(
           &RewardsServiceImpl::OnTimer, AsWeakPtr(), next_timer_id_));
+}
+
+void RewardsServiceImpl::SetPreventGrant(bool should_prevent) {
+  prevent_grant_ = should_prevent;
+}
+
+bool RewardsServiceImpl::GetPreventGrant() {
+  return prevent_grant_;
 }
 
 void RewardsServiceImpl::OnTimer(uint32_t timer_id) {

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -137,6 +137,8 @@ class RewardsServiceImpl : public RewardsService,
   void OnDonate(const std::string& publisher_key, int amount, bool recurring,
       std::unique_ptr<brave_rewards::ContentSite> site) override;
   void SetLedgerClient(std::unique_ptr<ledger::Ledger> new_ledger) override;
+  void SetPreventGrant(bool should_prevent) override;
+  bool GetPreventGrant() override;
 
  private:
   friend void RunIOTaskCallback(
@@ -322,6 +324,7 @@ class RewardsServiceImpl : public RewardsService,
   std::unique_ptr<base::RepeatingTimer> notification_periodic_timer_;
 
   uint32_t next_timer_id_;
+  bool prevent_grant_;
 
   DISALLOW_COPY_AND_ASSIGN(RewardsServiceImpl);
 };

--- a/utility/importer/brave_importer.cc
+++ b/utility/importer/brave_importer.cc
@@ -574,6 +574,22 @@ bool ends_with(const std::string &input, const std::string &test) {
   return false;
 }
 
+bool ParseClaimedGrants(BraveLedger& ledger,
+  const base::Value& session_store_json) {
+  const base::Value* grants = session_store_json.FindPathOfType(
+      {"ledger", "info", "grants"}, base::Value::Type::LIST);
+
+  if (!grants) {
+    LOG(ERROR)
+      << "\"ledger\".\"info\".\"grants\" not found in session-store-1";
+    return false;    
+  }
+
+  ledger.grants_claimed = (grants->GetList().size() > 0);
+
+  return true;
+}
+
 bool ParsePinnedSites(BraveLedger& ledger,
   const base::Value& session_store_json) {
   const base::Value* publishers = session_store_json.FindPathOfType(
@@ -660,6 +676,11 @@ bool BraveImporter::ImportLedger() {
   if (!ParsePinnedSites(ledger, *session_store_json)) {
     LOG(ERROR) << "Failed to parse list of pinned sites for Brave Payments";
     return false;
+  }
+
+  if (!ParseClaimedGrants(ledger, *session_store_json)) {
+    LOG(ERROR) << "Failed to parse list of grants for Brave Payments";
+    return false;    
   }
 
   bridge_->UpdateLedger(ledger);


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2394

In the case that grants have been accepted in a muon imported profile,
this PR does two things:

1. Prevents the GetGrant function from executing in the reward settings page
2. Prevents the grant notification from being added to the rewards panel

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Defined in issue.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source