### PR TITLE
Show media publishers images only when verified

### DIFF
--- a/browser/ui/webui/brave_donate_ui.cc
+++ b/browser/ui/webui/brave_donate_ui.cc
@@ -203,6 +203,7 @@ void RewardsDonateDOMHandler::OnPublisherBanner(brave_rewards::RewardsService* r
   result.SetString("background", banner.background);
   result.SetString("logo", banner.logo);
   result.SetString("provider", banner.provider);
+  result.SetBoolean("verified", banner.verified);
 
   auto amounts = std::make_unique<base::ListValue>();
   for (int const& value : banner.amounts) {

--- a/components/brave_rewards/browser/publisher_banner.cc
+++ b/components/brave_rewards/browser/publisher_banner.cc
@@ -18,7 +18,8 @@ namespace brave_rewards {
     logo(""),
     amounts(std::vector<int>()),
     provider(""),
-    social(std::map<std::string, std::string>()) {}
+    social(std::map<std::string, std::string>()),
+    verified(false) {}
 
   PublisherBanner::~PublisherBanner() { }
 
@@ -32,6 +33,7 @@ namespace brave_rewards {
     amounts = properties.amounts;
     provider = properties.provider;
     social = properties.social;
+    verified = properties.verified;
   }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/publisher_banner.h
+++ b/components/brave_rewards/browser/publisher_banner.h
@@ -24,6 +24,7 @@ namespace brave_rewards {
     std::vector<int> amounts;
     std::string provider;
     std::map<std::string, std::string> social;
+    bool verified;
   };
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1427,6 +1427,7 @@ void RewardsServiceImpl::OnPublisherBanner(std::unique_ptr<ledger::PublisherBann
   new_banner.amounts = banner->amounts;
   new_banner.social = banner->social;
   new_banner.provider = banner->provider;
+  new_banner.verified = banner->verified;
 
   for (auto& observer : observers_)
     observer.OnPublisherBanner(this, new_banner);

--- a/components/brave_rewards/resources/donate/components/siteBanner.tsx
+++ b/components/brave_rewards/resources/donate/components/siteBanner.tsx
@@ -126,6 +126,10 @@ class Banner extends React.Component<Props, State> {
       if (internalFavicon.test(publisher.logo)) {
         logo = `chrome://favicon/size/160@2x/${publisher.logo}`
       }
+
+      if (!publisher.verified) {
+        logo = ''
+      }
     }
 
     // TODO we need to use title and not publisherKey for domain for media publishers

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -89,7 +89,7 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
         if (publisher && !publisher.publisher_key) {
           delete publishers[id]
         } else {
-          publishers[id] = payload.publisher
+          publishers[id] = publisher
         }
 
         state = {

--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -293,7 +293,7 @@ export class Panel extends React.Component<Props, State> {
     let faviconUrl
     if (publisher && publisher.url) {
       faviconUrl = `chrome://favicon/size/48@2x/${publisher.url}`
-      if (publisher.favicon_url) {
+      if (publisher.favicon_url && publisher.verified) {
         faviconUrl = `chrome://favicon/size/48@2x/${publisher.favicon_url}`
       }
     }

--- a/components/brave_rewards/resources/ui/components/contributeBox.tsx
+++ b/components/brave_rewards/resources/ui/components/contributeBox.tsx
@@ -42,7 +42,7 @@ class ContributeBox extends React.Component<Props, State> {
   getContributeRows = (list: Rewards.Publisher[]) => {
     return list.map((item: Rewards.Publisher) => {
       let faviconUrl = `chrome://favicon/size/48@1x/${item.url}`
-      if (item.favIcon) {
+      if (item.favIcon && item.verified) {
         faviconUrl = `chrome://favicon/size/48@1x/${item.favIcon}`
       }
 

--- a/components/brave_rewards/resources/ui/components/donationsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/donationsBox.tsx
@@ -80,7 +80,7 @@ class DonationBox extends React.Component<Props, State> {
     if (recurringList) {
       recurring = recurringList.map((item: Rewards.Publisher) => {
         let faviconUrl = `chrome://favicon/size/48@1x/${item.url}`
-        if (item.favIcon) {
+        if (item.favIcon && item.verified) {
           faviconUrl = `chrome://favicon/size/48@1x/${item.favIcon}`
         }
 

--- a/components/definitions/rewardsDonate.d.ts
+++ b/components/definitions/rewardsDonate.d.ts
@@ -26,6 +26,7 @@ declare namespace RewardsDonate {
     amounts: number[],
     provider: string
     social: Record<string, string>
+    verified: boolean
   }
 
   export interface WalletProperties {

--- a/vendor/bat-native-ledger/include/bat/ledger/publisher_info.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/publisher_info.h
@@ -94,6 +94,7 @@ LEDGER_EXPORT struct PublisherBanner {
   std::vector<int> amounts;
   std::string provider;
   std::map<std::string, std::string> social;
+  bool verified;
 };
 
 LEDGER_EXPORT struct PublisherInfo {

--- a/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
@@ -116,7 +116,8 @@ PublisherBanner::PublisherBanner(const PublisherBanner& info) :
     logo(info.logo),
     amounts(info.amounts),
     provider(info.provider),
-    social(info.social) {}
+    social(info.social),
+    verified(info.verified) {}
 
 PublisherBanner::~PublisherBanner() {}
 

--- a/vendor/bat-native-ledger/src/bat_publishers.cc
+++ b/vendor/bat-native-ledger/src/bat_publishers.cc
@@ -928,6 +928,7 @@ void BatPublishers::onPublisherBanner(ledger::PublisherBannerCallback callback,
 
   new_banner->name = publisher_info->name;
   new_banner->provider = publisher_info->provider;
+  new_banner->verified = publisher_info->verified;
 
   if (new_banner->logo.empty()) {
     new_banner->logo = publisher_info->favicon_url;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2696

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- visit unverified youtube publisher
- make sure that in panel, site banner and ac table we show youtube image
- visit verified youtube publisher 
- make sure that in panel, site banner and ac table we show publisher image

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source