### PR TITLE
Update devices each 1 second until chain is not created

### DIFF
--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -649,6 +649,10 @@ void BraveSyncServiceImpl::LoopProcThreadAligned() {
   RequestSyncData();
 }
 
+base::TimeDelta BraveSyncServiceImpl::GetLoopDelay() const {
+  return timer_->GetCurrentDelay();
+}
+
 void BraveSyncServiceImpl::NotifyLogMessage(const std::string& message) {
   DLOG(INFO) << message;
 }

--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -290,7 +290,9 @@ void BraveSyncServiceImpl::BackgroundSyncStarted(bool startup) {
   if (startup)
     bookmark_change_processor_->Start();
 
-  StartLoop();
+  const bool waiting_for_second_device =
+                            !sync_prefs_->GetSyncDevices()->has_second_device();
+  StartLoop(waiting_for_second_device);
 }
 
 void BraveSyncServiceImpl::BackgroundSyncStopped(bool shutdown) {
@@ -466,9 +468,10 @@ BraveSyncServiceImpl::PrepareResolvedPreferences(const RecordsList& records) {
 void BraveSyncServiceImpl::OnResolvedPreferences(const RecordsList& records) {
   const std::string this_device_id = sync_prefs_->GetThisDeviceId();
   bool this_device_deleted = false;
-  bool contains_only_one_device = false;
+  bool at_least_one_deleted = false;
 
   auto sync_devices = sync_prefs_->GetSyncDevices();
+  const bool waiting_for_second_device = !sync_devices->has_second_device();
   for (const auto &record : records) {
     DCHECK(record->has_device() || record->has_sitesetting());
     if (record->has_device()) {
@@ -484,18 +487,20 @@ void BraveSyncServiceImpl::OnResolvedPreferences(const RecordsList& records) {
         (record->deviceId == this_device_id &&
           record->action == jslib::SyncRecord::Action::A_DELETE &&
           actually_merged);
-      contains_only_one_device = sync_devices->size() < 2 &&
-        record->action == jslib::SyncRecord::Action::A_DELETE &&
-          actually_merged;
+      at_least_one_deleted = at_least_one_deleted ||
+          (record->action == jslib::SyncRecord::Action::A_DELETE &&
+          actually_merged);
     }
   } // for each device
 
   sync_prefs_->SetSyncDevices(*sync_devices);
-
-  if (this_device_deleted)
+  if (this_device_deleted ||
+                 (at_least_one_deleted && !sync_devices->has_second_device())) {
     ResetSyncInternal();
-  if (contains_only_one_device)
-    OnResetSync();
+  } else if (waiting_for_second_device && sync_devices->has_second_device()) {
+    // Restart loop with 30 sec interval
+    StartLoop(false);
+  }
 }
 
 void BraveSyncServiceImpl::OnSyncPrefsChanged(const std::string& pref) {
@@ -610,10 +615,14 @@ void BraveSyncServiceImpl::SendDeviceSyncRecord(
 }
 
 static const int64_t kCheckUpdatesIntervalSec = 60;
+static const int64_t kCheckInitialUpdatesIntervalSec = 1;
 
-void BraveSyncServiceImpl::StartLoop() {
+void BraveSyncServiceImpl::StartLoop(const bool use_initial_update_interval) {
   timer_->Start(FROM_HERE,
-                  base::TimeDelta::FromSeconds(kCheckUpdatesIntervalSec),
+                  base::TimeDelta::FromSeconds(
+                    use_initial_update_interval ?
+                        kCheckInitialUpdatesIntervalSec :
+                        kCheckUpdatesIntervalSec),
                   this,
                   &BraveSyncServiceImpl::LoopProc);
 }

--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -33,6 +33,7 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSyncReadyNewToSync);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnGetExistingObjects);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, BackgroundSyncStarted);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, BackgroundSyncStopped);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, LoopDelayVaries);
 
 class BraveSyncServiceTest;
 
@@ -110,6 +111,7 @@ class BraveSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnGetExistingObjects);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, BackgroundSyncStarted);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, BackgroundSyncStopped);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, LoopDelayVaries);
   friend class ::BraveSyncServiceTest;
 
   // SyncMessageHandler overrides
@@ -161,6 +163,7 @@ class BraveSyncServiceImpl
   void StopLoop();
   void LoopProc();
   void LoopProcThreadAligned();
+  base::TimeDelta GetLoopDelay() const;  // For tests only
 
   void GetExistingHistoryObjects(
     const RecordsList &records,

--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -157,7 +157,7 @@ class BraveSyncServiceImpl
     const std::string& deviceId,
     const std::string& objectId);
 
-  void StartLoop();
+  void StartLoop(const bool use_initial_update_interval);
   void StopLoop();
   void LoopProc();
   void LoopProcThreadAligned();

--- a/components/brave_sync/sync_devices.h
+++ b/components/brave_sync/sync_devices.h
@@ -43,6 +43,7 @@ public:
    std::unique_ptr<base::Value> ToValueArrOnly() const;
    std::string ToJson() const;
    size_t size() const { return devices_.size(); }
+   bool has_second_device() const { return size() >= 2; }
    void FromJson(const std::string &str_json);
    void Merge(const SyncDevice& device, int action, bool* actually_merged);
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/2742 , https://github.com/brave/brave-browser/issues/2782 .

Improves response time on sync creation. 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. On Device1 go to chrome://sync/
2. Press "Start new chain" => "Computer" => "Copy code"
3. On device 2 go to chrome://sync/
4. "Enter sync chain code" button
5. Paste the code
6. "Confirm sync code" button
7. Device1 gets created a sync chain not so late (<5 sec) after Device2

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source