### PR TITLE
Fix SiteRemovalNotification is always visible when reloading

### DIFF
--- a/components/brave_new_tab_ui/components/app.tsx
+++ b/components/brave_new_tab_ui/components/app.tsx
@@ -33,6 +33,12 @@ interface Props {
 }
 
 class NewTabPage extends React.Component<Props, {}> {
+  constructor (props: Props) {
+    super(props)
+    // Makes NTP start w/o SiteRemovalNotification.
+    this.onHideSiteRemovalNotification()
+  }
+
   get actions () {
     return this.props.actions
   }


### PR DESCRIPTION
SiteRemovalNotification in NTP should be hidden after reloading or
restart.
To fix this, ctor of NewTabPage component hides it.

Fix https://github.com/brave/brave-browser/issues/2772

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Remove thumb in NTP
2. Reloading, creating new tab instance and browser restart
3. Check thumb removed notification isn't visible

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source