### PR TITLE
Prevent loading brave scheme url from javascript

### DIFF
--- a/browser/resources/settings/brave_sync_page/brave_sync_page.html
+++ b/browser/resources/settings/brave_sync_page/brave_sync_page.html
@@ -12,7 +12,7 @@
     </style>
     <div class="settings-box">
       <div class="start">
-        $i18n{braveSyncLabel} <a href="brave://sync" target="_blank">brave://sync</a>
+        $i18n{braveSyncLabel} <a href="chrome://sync" target="_blank">brave://sync</a>
       </div>
     </div>
   </template>

--- a/chromium_src/content/public/common/url_constants.cc
+++ b/chromium_src/content/public/common/url_constants.cc
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/net/brave_profile_network_delegate.h"
-#include "brave/common/url_constants.h"
+#include "../../../../../content/public/common/url_constants.cc"
 
-#include "../../../../../../chrome/browser/profiles/profile_io_data.cc"
+namespace content {
+const char kBraveUIScheme[] = "brave";
+}
+

--- a/chromium_src/content/public/common/url_constants.h
+++ b/chromium_src/content/public/common/url_constants.h
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/net/brave_profile_network_delegate.h"
-#include "brave/common/url_constants.h"
+#include "../../../../../content/public/common/url_constants.h"
 
-#include "../../../../../../chrome/browser/profiles/profile_io_data.cc"
+namespace content {
+CONTENT_EXPORT extern const char kBraveUIScheme[];
+}
+

--- a/components/brave_welcome_ui/components/app.tsx
+++ b/components/brave_welcome_ui/components/app.tsx
@@ -63,15 +63,15 @@ export class WelcomePage extends React.Component<Props, State> {
   }
 
   onClickConfirmDefaultSearchEngine = () => {
-    this.props.actions.goToTabRequested('brave://settings/search', '_blank')
+    this.props.actions.goToTabRequested('chrome://settings/search', '_blank')
   }
 
   onClickChooseYourTheme = () => {
-    this.props.actions.goToTabRequested('brave://settings/appearance', '_blank')
+    this.props.actions.goToTabRequested('chrome://settings/appearance', '_blank')
   }
 
   onClickRewardsGetStarted = () => {
-    this.props.actions.goToTabRequested('brave://rewards', '_blank')
+    this.props.actions.goToTabRequested('chrome://rewards', '_blank')
   }
 
   onClickSlideBullet = (nextScreen: number) => {
@@ -83,11 +83,11 @@ export class WelcomePage extends React.Component<Props, State> {
   }
 
   onClickDone = () => {
-    this.props.actions.goToTabRequested('brave://newtab', '_self')
+    this.props.actions.goToTabRequested('chrome://newtab', '_self')
   }
 
   onClickSkip = () => {
-    this.props.actions.goToTabRequested('brave://newtab', '_self')
+    this.props.actions.goToTabRequested('chrome://newtab', '_self')
   }
 
   render () {

--- a/patches/chrome-browser-profiles-profile_io_data.cc.patch
+++ b/patches/chrome-browser-profiles-profile_io_data.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/profiles/profile_io_data.cc b/chrome/browser/profiles/profile_io_data.cc
-index 5664ba395badcea25fdbb33a274b522747b7b2cf..d3f5e852b0d0ff5909da6cc0760e51142115d7bc 100644
+index 5664ba395badcea25fdbb33a274b522747b7b2cf..b14d6e5150c2bab6c15acaf164cd4b4ad139122c 100644
 --- a/chrome/browser/profiles/profile_io_data.cc
 +++ b/chrome/browser/profiles/profile_io_data.cc
 @@ -25,6 +25,7 @@
@@ -10,7 +10,17 @@ index 5664ba395badcea25fdbb33a274b522747b7b2cf..d3f5e852b0d0ff5909da6cc0760e5114
  #include "build/build_config.h"
  #include "chrome/browser/browser_process.h"
  #include "chrome/browser/chrome_notification_types.h"
-@@ -966,7 +967,7 @@ void ProfileIOData::Init(
+@@ -657,6 +658,9 @@ bool ProfileIOData::IsHandledProtocol(const std::string& scheme) {
+     extensions::kExtensionScheme,
+ #endif
+     content::kChromeUIScheme,
++#if defined(BRAVE_CHROMIUM_BUILD)
++    kBraveUIScheme,
++#endif
+     url::kDataScheme,
+ #if defined(OS_CHROMEOS)
+     content::kExternalFileScheme,
+@@ -966,7 +970,7 @@ void ProfileIOData::Init(
          std::make_unique<network::URLRequestContextBuilderMojo>();
  
      std::unique_ptr<ChromeNetworkDelegate> chrome_network_delegate(

--- a/patches/content-browser-child_process_security_policy_impl.cc.patch
+++ b/patches/content-browser-child_process_security_policy_impl.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/content/browser/child_process_security_policy_impl.cc b/content/browser/child_process_security_policy_impl.cc
+index 65abcbd4bb87a0a3e9661c97e8fd38556ee19f8b..06adc3f5b231e863d7a2ceaa43a227ac5c046ed3 100644
+--- a/content/browser/child_process_security_policy_impl.cc
++++ b/content/browser/child_process_security_policy_impl.cc
+@@ -691,6 +691,9 @@ void ChildProcessSecurityPolicyImpl::GrantWebUIBindings(int child_id,
+ 
+   // Web UI bindings need the ability to request chrome: URLs.
+   state->second->GrantRequestScheme(kChromeUIScheme);
++#if defined(BRAVE_CHROMIUM_BUILD)
++  state->second->GrantRequestScheme(kBraveUIScheme);
++#endif
+ 
+   // Web UI pages can contain links to file:// URLs.
+   state->second->GrantRequestScheme(url::kFileScheme);

--- a/patches/content-renderer-render_thread_impl.cc.patch
+++ b/patches/content-renderer-render_thread_impl.cc.patch
@@ -1,0 +1,19 @@
+diff --git a/content/renderer/render_thread_impl.cc b/content/renderer/render_thread_impl.cc
+index 68682fd876dd8a07d2548e32a0ce453ca41a339b..4fb31f452139df4043fc0b8816b2a2bd42fcc27b 100644
+--- a/content/renderer/render_thread_impl.cc
++++ b/content/renderer/render_thread_impl.cc
+@@ -1246,6 +1246,14 @@ void RenderThreadImpl::InitializeWebKit(
+ }
+ 
+ void RenderThreadImpl::RegisterSchemes() {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  // brave:
++  WebString brave_scheme(WebString::FromASCII(kBraveUIScheme));
++  WebSecurityPolicy::RegisterURLSchemeAsDisplayIsolated(brave_scheme);
++  WebSecurityPolicy::RegisterURLSchemeAsNotAllowingJavascriptURLs(
++      brave_scheme);
++#endif
++
+   // chrome:
+   WebString chrome_scheme(WebString::FromASCII(kChromeUIScheme));
+   WebSecurityPolicy::RegisterURLSchemeAsDisplayIsolated(chrome_scheme);


### PR DESCRIPTION
To fix this, brave scheme is registered to WebSecurityPolicy and
RequestScheme of ChildProcessSecurityPolicy::SecurityState.
Also, makes ProfileIOData::IsHandledProtocol consider brave scheme.

As brave scheme can be loaded only from brave scheme,
it should use chrome scheme instead of brave scheme in anchor tag..
Otherwise, that brave webui loading is prevented in brave webui from renderer.

Fix https://github.com/brave/brave-browser/issues/2861
Fix https://github.com/brave/brave-browser/issues/2849

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Test 1.
  1. Navigate to https://world_languages.gitlab.io/bravepoc/
  2. Click link
  3. Check brave://settings is not loaded in new tab.

Test 2.
  1. Navigate to brave://welcome
  2. Move to `Change your search engine` page in welcome page
  3. Click `Settings` button
  4. Check settings page is opened in new tab
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source