### PR TITLE
Add Rust as a dep and automate building of Challenge Bypass Ristretto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ npm-debug.log
 CMakeLists.txt
 cmake-build-debug/
 coverage/
+/build/rustup/

--- a/DEPS
+++ b/DEPS
@@ -19,6 +19,7 @@ deps = {
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@7e391cec6975106fa9f686016f494cb8a782afcd",
   "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@96e452545aa49b410a0f96fd264db8d8820e145b",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
+  "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@7d0fdeb137e32bcbcf90ebb6c5b0b878e9a6f02e",
 }
 
 hooks = [

--- a/DEPS
+++ b/DEPS
@@ -43,6 +43,12 @@ hooks = [
     'action': ['python', 'src/brave/script/init-brave-extension.py'],
   },
   {
+    # Download rust deps if necessary
+    'name': 'download_rust_deps',
+    'pattern': '.',
+    'action': ['python', 'src/brave/script/download_rust_deps.py'],
+  },
+  {
     # Build brave-sync
     'name': 'build_brave_sync',
     'pattern': '.',

--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@ deps = {
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@7e391cec6975106fa9f686016f494cb8a782afcd",
   "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@96e452545aa49b410a0f96fd264db8d8820e145b",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
-  "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@7d0fdeb137e32bcbcf90ebb6c5b0b878e9a6f02e",
+  "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@0a9320a061b77f7682261eb7303ddfa4fc734595",
 }
 
 hooks = [

--- a/build/cargo.gni
+++ b/build/cargo.gni
@@ -1,0 +1,23 @@
+# Runs a script to compile a local Cargo package and all of its dependencies
+template("cargo_build") {
+  action(target_name) {
+    rust_deps_version = "0.1.0"
+
+    script = "//brave/script/cargo.py"
+
+    # make sure rebuilds when files change
+    forward_variables_from(invoker, "*")
+
+    outputs = [output]
+
+    args = [
+      "--rustup_bin=" + rebase_path("//brave/build/rustup/" + rust_deps_version + "/bin", root_build_dir),
+      "--rustup_home=" + rebase_path("//brave/build/rustup/" + rust_deps_version, root_build_dir),
+      "--cargo_home=" + rebase_path("//brave/build/rustup/" + rust_deps_version, root_build_dir),
+      "--manifest_path=" + rebase_path(manifest_path, root_build_dir),
+      "--build_path=" + rebase_path(build_path, root_build_dir),
+      "--platform=" + platform,
+      "--is_debug=$is_debug"
+    ]
+  }
+}

--- a/build/cargo.gni
+++ b/build/cargo.gni
@@ -17,7 +17,7 @@ template("cargo_build") {
       "--cargo_home=" + rebase_path("//brave/build/rustup/", root_build_dir),
       "--manifest_path=" + rebase_path(manifest_path, root_build_dir),
       "--build_path=" + rebase_path(build_path, root_build_dir),
-      "--platform=" + platform,
+      "--target=" + target,
       "--is_debug=$is_debug"
     ]
   }

--- a/build/cargo.gni
+++ b/build/cargo.gni
@@ -1,8 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Runs a script to compile a local Cargo package and all of its dependencies
 template("cargo_build") {
   action(target_name) {
-    rust_deps_version = "0.1.0"
-
     script = "//brave/script/cargo.py"
 
     # make sure rebuilds when files change
@@ -11,9 +13,8 @@ template("cargo_build") {
     outputs = [output]
 
     args = [
-      "--rustup_bin=" + rebase_path("//brave/build/rustup/" + rust_deps_version + "/bin", root_build_dir),
-      "--rustup_home=" + rebase_path("//brave/build/rustup/" + rust_deps_version, root_build_dir),
-      "--cargo_home=" + rebase_path("//brave/build/rustup/" + rust_deps_version, root_build_dir),
+      "--rustup_home=" + rebase_path("//brave/build/rustup/", root_build_dir),
+      "--cargo_home=" + rebase_path("//brave/build/rustup/", root_build_dir),
       "--manifest_path=" + rebase_path(manifest_path, root_build_dir),
       "--build_path=" + rebase_path(build_path, root_build_dir),
       "--platform=" + platform,

--- a/script/cargo.py
+++ b/script/cargo.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
 import os
@@ -6,11 +9,12 @@ import sys
 import subprocess
 import shutil
 
+from rust_deps_config import RUST_DEPS_PACKAGE_VERSION
+
 
 def main():
     args = parse_args()
 
-    rustup_bin = args.rustup_bin[0]
     rustup_home = args.rustup_home[0]
     cargo_home = args.cargo_home[0]
     manifest_path = args.manifest_path[0]
@@ -18,13 +22,12 @@ def main():
     platform = args.platform[0]
     is_debug = args.is_debug[0]
 
-    build(rustup_bin, rustup_home, cargo_home, manifest_path, build_path, platform, is_debug)
+    build(rustup_home, cargo_home, manifest_path, build_path, platform, is_debug)
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Cargo')
 
-    parser.add_argument('--rustup_bin', nargs=1)
     parser.add_argument('--rustup_home', nargs=1)
     parser.add_argument('--cargo_home', nargs=1)
     parser.add_argument('--manifest_path', nargs=1)
@@ -33,12 +36,6 @@ def parse_args():
     parser.add_argument('--is_debug', nargs=1)
 
     args = parser.parse_args()
-
-    # Validate rustup_bin args
-    if (args.rustup_bin is None or
-        len(args.rustup_bin) is not 1 or
-            len(args.rustup_bin[0]) is 0):
-        raise Exception("rustup_bin argument was not specified correctly")
 
     # Validate rustup_home args
     if (args.rustup_home is None or
@@ -86,7 +83,7 @@ def parse_args():
     return args
 
 
-def build(rustup_bin, rustup_home, cargo_home, manifest_path, build_path, platform, is_debug):
+def build(rustup_home, cargo_home, manifest_path, build_path, platform, is_debug):
     targets = []
 
     if platform == "Windows x86":
@@ -112,9 +109,15 @@ def build(rustup_bin, rustup_home, cargo_home, manifest_path, build_path, platfo
 
     # Set environment variables for rustup
     env = os.environ.copy()
-    env['PATH'] = rustup_bin + os.pathsep + env['PATH']
+
+    rustup_home = os.path.join(rustup_home, RUST_DEPS_PACKAGE_VERSION)
     env['RUSTUP_HOME'] = rustup_home
+
+    cargo_home = os.path.join(cargo_home, RUST_DEPS_PACKAGE_VERSION)
     env['CARGO_HOME'] = cargo_home
+
+    rustup_bin = os.path.join(rustup_home, 'bin')
+    env['PATH'] = rustup_bin + os.pathsep + env['PATH']
 
     # Set environment variables for Challenge Bypass Ristretto FFI
     env['NO_CXXEXCEPTIONS'] = "1"

--- a/script/cargo.py
+++ b/script/cargo.py
@@ -19,10 +19,10 @@ def main():
     cargo_home = args.cargo_home[0]
     manifest_path = args.manifest_path[0]
     build_path = args.build_path[0]
-    platform = args.platform[0]
+    target = args.target[0]
     is_debug = args.is_debug[0]
 
-    build(rustup_home, cargo_home, manifest_path, build_path, platform, is_debug)
+    build(rustup_home, cargo_home, manifest_path, build_path, target, is_debug)
 
 
 def parse_args():
@@ -32,7 +32,7 @@ def parse_args():
     parser.add_argument('--cargo_home', nargs=1)
     parser.add_argument('--manifest_path', nargs=1)
     parser.add_argument('--build_path', nargs=1)
-    parser.add_argument('--platform', nargs=1)
+    parser.add_argument('--target', nargs=1)
     parser.add_argument('--is_debug', nargs=1)
 
     args = parser.parse_args()
@@ -64,11 +64,11 @@ def parse_args():
     if "out" not in args.build_path[0]:
         raise Exception("build_path did not contain 'out'")
 
-    # Validate platform args
-    if (args.platform is None or
-        len(args.platform) is not 1 or
-            len(args.platform[0]) is 0):
-        raise Exception("platform argument was not specified correctly")
+    # Validate target args
+    if (args.target is None or
+        len(args.target) is not 1 or
+            len(args.target[0]) is 0):
+        raise Exception("target argument was not specified correctly")
 
     # Validate is_debug args
     if (args.is_debug is None or
@@ -83,30 +83,7 @@ def parse_args():
     return args
 
 
-def build(rustup_home, cargo_home, manifest_path, build_path, platform, is_debug):
-    targets = []
-
-    if platform == "Windows x86":
-        targets = ["i686-pc-windows-msvc"]
-    elif platform == "Windows x64":
-        targets = ["x86_64-pc-windows-msvc"]
-    elif platform == "macOS x64":
-        targets = ["x86_64-apple-darwin"]
-    elif platform == "Linux x64":
-        targets = ["x86_64-unknown-linux-gnu"]
-    elif platform == "Android arm":
-        targets = ["arm-linux-androideabi"]
-    elif platform == "Android arm64":
-        targets = ["aarch64-linux-android"]
-    elif platform == "Android x86":
-        targets = ["i686-linux-android"]
-    elif platform == "Android x64":
-        targets = ["x86_64-linux-android"]
-    elif platform == "iOS":
-        targets = ["aarch64-apple-ios", "x86_64-apple-ios"]
-    else:
-        raise ValueError('Cannot build due to unknown platform')
-
+def build(rustup_home, cargo_home, manifest_path, build_path, target, is_debug):
     # Set environment variables for rustup
     env = os.environ.copy()
 
@@ -125,21 +102,20 @@ def build(rustup_home, cargo_home, manifest_path, build_path, platform, is_debug
         env['NDEBUG'] = "1"
 
     # Build targets
-    for target in targets:
-        args = []
-        args.append("cargo")
-        args.append("build")
-        if is_debug == "false":
-            args.append("--release")
-        args.append("--manifest-path=" + manifest_path)
-        args.append("--target-dir=" + build_path)
-        args.append("--target=" + target)
+    args = []
+    args.append("cargo")
+    args.append("build")
+    if is_debug == "false":
+        args.append("--release")
+    args.append("--manifest-path=" + manifest_path)
+    args.append("--target-dir=" + build_path)
+    args.append("--target=" + target)
 
-        try:
-            subprocess.check_call(args, env=env)
-        except subprocess.CalledProcessError as e:
-            print e.output
-            raise e
+    try:
+        subprocess.check_call(args, env=env)
+    except subprocess.CalledProcessError as e:
+        print e.output
+        raise e
 
 
 if __name__ == '__main__':

--- a/script/cargo.py
+++ b/script/cargo.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+import subprocess
+import shutil
+
+
+def main():
+    args = parse_args()
+
+    rustup_bin = args.rustup_bin[0]
+    rustup_home = args.rustup_home[0]
+    cargo_home = args.cargo_home[0]
+    manifest_path = args.manifest_path[0]
+    build_path = args.build_path[0]
+    platform = args.platform[0]
+    is_debug = args.is_debug[0]
+
+    build(rustup_bin, rustup_home, cargo_home, manifest_path, build_path, platform, is_debug)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Cargo')
+
+    parser.add_argument('--rustup_bin', nargs=1)
+    parser.add_argument('--rustup_home', nargs=1)
+    parser.add_argument('--cargo_home', nargs=1)
+    parser.add_argument('--manifest_path', nargs=1)
+    parser.add_argument('--build_path', nargs=1)
+    parser.add_argument('--platform', nargs=1)
+    parser.add_argument('--is_debug', nargs=1)
+
+    args = parser.parse_args()
+
+    # Validate rustup_bin args
+    if (args.rustup_bin is None or
+        len(args.rustup_bin) is not 1 or
+            len(args.rustup_bin[0]) is 0):
+        raise Exception("rustup_bin argument was not specified correctly")
+
+    # Validate rustup_home args
+    if (args.rustup_home is None or
+        len(args.rustup_home) is not 1 or
+            len(args.rustup_home[0]) is 0):
+        raise Exception("rustup_home argument was not specified correctly")
+
+    # Validate cargo_home args
+    if (args.cargo_home is None or
+        len(args.cargo_home) is not 1 or
+            len(args.cargo_home[0]) is 0):
+        raise Exception("cargo_home argument was not specified correctly")
+
+    # Validate manifest_path args
+    if (args.manifest_path is None or
+        len(args.manifest_path) is not 1 or
+            len(args.manifest_path[0]) is 0):
+        raise Exception("manifest_path argument was not specified correctly")
+
+    # Validate build_path args
+    if (args.build_path is None or
+        len(args.build_path) is not 1 or
+            len(args.build_path[0]) is 0):
+        raise Exception("build_path argument was not specified correctly")
+
+    if "out" not in args.build_path[0]:
+        raise Exception("build_path did not contain 'out'")
+
+    # Validate platform args
+    if (args.platform is None or
+        len(args.platform) is not 1 or
+            len(args.platform[0]) is 0):
+        raise Exception("platform argument was not specified correctly")
+
+    # Validate is_debug args
+    if (args.is_debug is None or
+        len(args.is_debug) is not 1 or
+            len(args.is_debug[0]) is 0):
+        raise Exception("is_debug argument was not specified correctly")
+
+    if (args.is_debug[0] != "false" and args.is_debug[0] != "true"):
+        raise Exception("is_debug argument was not specified correctly")
+
+    # args are valid
+    return args
+
+
+def build(rustup_bin, rustup_home, cargo_home, manifest_path, build_path, platform, is_debug):
+    targets = []
+
+    if platform == "Windows x86":
+        targets = ["i686-pc-windows-msvc"]
+    elif platform == "Windows x64":
+        targets = ["x86_64-pc-windows-msvc"]
+    elif platform == "macOS x64":
+        targets = ["x86_64-apple-darwin"]
+    elif platform == "Linux x64":
+        targets = ["x86_64-unknown-linux-gnu"]
+    elif platform == "Android arm":
+        targets = ["arm-linux-androideabi"]
+    elif platform == "Android arm64":
+        targets = ["aarch64-linux-android"]
+    elif platform == "Android x86":
+        targets = ["i686-linux-android"]
+    elif platform == "Android x64":
+        targets = ["x86_64-linux-android"]
+    elif platform == "iOS":
+        targets = ["aarch64-apple-ios", "x86_64-apple-ios"]
+    else:
+        raise ValueError('Cannot build due to unknown platform')
+
+    # Set environment variables for rustup
+    env = os.environ.copy()
+    env['PATH'] = rustup_bin + os.pathsep + env['PATH']
+    env['RUSTUP_HOME'] = rustup_home
+    env['CARGO_HOME'] = cargo_home
+
+    # Set environment variables for Challenge Bypass Ristretto FFI
+    env['NO_CXXEXCEPTIONS'] = "1"
+    if is_debug == "false":
+        env['NDEBUG'] = "1"
+
+    # Build targets
+    for target in targets:
+        args = []
+        args.append("cargo")
+        args.append("build")
+        if is_debug == "false":
+            args.append("--release")
+        args.append("--manifest-path=" + manifest_path)
+        args.append("--target-dir=" + build_path)
+        args.append("--target=" + target)
+
+        try:
+            subprocess.check_call(args, env=env)
+        except subprocess.CalledProcessError as e:
+            print e.output
+            raise e
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/script/deps.py
+++ b/script/deps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""This script is used to download deps."""
+
+import argparse
+import os
+import sys
+import tarfile
+import tempfile
+import time
+import urllib2
+import zipfile
+
+
+def DownloadUrl(url, output_file):
+    """Download url into output_file."""
+    CHUNK_SIZE = 4096
+    TOTAL_DOTS = 10
+    num_retries = 3
+    retry_wait_s = 5  # Doubled at each retry.
+
+    while True:
+        try:
+            sys.stdout.write('Downloading %s ' % url)
+            sys.stdout.flush()
+            response = urllib2.urlopen(url)
+            total_size = int(response.info().getheader('Content-Length').strip())
+            bytes_done = 0
+            dots_printed = 0
+            while True:
+                chunk = response.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                output_file.write(chunk)
+                bytes_done += len(chunk)
+                num_dots = TOTAL_DOTS * bytes_done / total_size
+                sys.stdout.write('.' * (num_dots - dots_printed))
+                sys.stdout.flush()
+                dots_printed = num_dots
+            if bytes_done != total_size:
+                raise urllib2.URLError("only got %d of %d bytes" % (bytes_done, total_size))
+            print ' Done.'
+            return
+        except urllib2.URLError as e:
+            sys.stdout.write('\n')
+            print e
+            if num_retries == 0 or isinstance(e, urllib2.HTTPError) and e.code == 404:
+                raise e
+            num_retries -= 1
+            print 'Retrying in %d s ...' % retry_wait_s
+            time.sleep(retry_wait_s)
+            retry_wait_s *= 2
+
+
+def EnsureDirExists(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+
+def DownloadAndUnpack(url, output_dir, path_prefix=None):
+    """Download an archive from url and extract into output_dir. If path_prefix is not
+        None, only extract files whose paths within the archive start with path_prefix."""
+    with tempfile.TemporaryFile() as f:
+        DownloadUrl(url, f)
+        f.seek(0)
+        EnsureDirExists(output_dir)
+        if url.endswith('.zip'):
+            assert path_prefix is None
+            zipfile.ZipFile(f).extractall(path=output_dir)
+        else:
+            t = tarfile.open(mode='r:gz', fileobj=f)
+            members = None
+            if path_prefix is not None:
+                members = [m for m in t.getmembers() if m.name.startswith(path_prefix)]
+            t.extractall(path=output_dir, members=members)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Script to download rust_deps."""
+
+import os
+import re
+import subprocess
+import sys
+import urllib2
+
+import deps
+from rust_deps_config import RUST_DEPS_PACKAGES_URL, RUST_DEPS_PACKAGE_VERSION
+
+SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+RUSTUP_DIR = os.path.join(SOURCE_ROOT, 'build', 'rustup', RUST_DEPS_PACKAGE_VERSION)
+
+
+def GetUrl(platform):
+    if platform == "win32" or platform == "cygwin":
+        filename = "rust_deps_win_" + RUST_DEPS_PACKAGE_VERSION + ".zip"
+    elif platform == 'darwin':
+        filename = "rust_deps_mac_" + RUST_DEPS_PACKAGE_VERSION + ".gz"
+    elif platform.startswith('linux'):
+        filename = "rust_deps_linux_" + RUST_DEPS_PACKAGE_VERSION + ".gz"
+    else:
+        print 'Invalid platform for Rust deps %s' % platform
+        print 'Exiting.'
+        sys.exit(1)
+
+    return RUST_DEPS_PACKAGES_URL + "/" + filename
+
+
+def AlreadyUpToDate():
+    if not os.path.exists(RUSTUP_DIR):
+        return False
+
+    return True
+
+
+def DownloadAndUnpackRustDeps(platform):
+    if AlreadyUpToDate():
+        return 0
+
+    url = GetUrl(platform)
+
+    try:
+        deps.DownloadAndUnpack(url, RUSTUP_DIR)
+    except urllib2.URLError:
+        print 'Failed to download Rust deps %s' % rust_deps_url
+        print 'Exiting.'
+        sys.exit(1)
+
+
+def main():
+    DownloadAndUnpackRustDeps(sys.platform)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/script/rust_deps_config.py
+++ b/script/rust_deps_config.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Version number and URL for pre-configured rust dependency package, e.g. rust_deps_mac_0.1.0.gz
+RUST_DEPS_PACKAGES_URL = "https://s3-us-west-2.amazonaws.com/rust-pkg-brave-core"
+RUST_DEPS_PACKAGE_VERSION = "0.1.0"

--- a/vendor/bat-native-ledger/BUILD.gn
+++ b/vendor/bat-native-ledger/BUILD.gn
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_ads/browser/buildflags/buildflags.gni")
+
 if (is_android) {
   import("//build/config/android/rules.gni")
 }
@@ -81,4 +83,9 @@ source_set("ledger") {
     rebase_path("bat-native-tweetnacl:tweetnacl", dep_base),
     rebase_path("bat-native-rapidjson", dep_base),
   ]
+
+  if (brave_ads_enabled && !is_linux) {
+    # TODO(bridiver): Required for all platforms once Brave Ads is building on Linux
+    deps += [ rebase_path("challenge_bypass_ristretto_ffi", dep_base) ]
+  }
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2796
requires https://github.com/brave-intl/challenge-bypass-ristretto-ffi/pull/23

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source