### PR TITLE
Allow tipping to only verified publishers

### DIFF
--- a/components/brave_rewards/browser/publisher_info_database.cc
+++ b/components/brave_rewards/browser/publisher_info_database.cc
@@ -600,7 +600,8 @@ void PublisherInfoDatabase::GetRecurringDonations(ledger::PublisherInfoList* lis
       db_.GetUniqueStatement("SELECT pi.publisher_id, pi.name, pi.url, pi.favIcon, "
                              "rd.amount, rd.added_date, pi.verified, pi.provider "
                              "FROM recurring_donation as rd "
-                             "INNER JOIN publisher_info AS pi ON rd.publisher_id = pi.publisher_id "));
+                             "INNER JOIN publisher_info AS pi ON rd.publisher_id = pi.publisher_id "
+                             "WHERE pi.verified = 1"));
 
   while (info_sql.Step()) {
     std::string id(info_sql.ColumnString(0));

--- a/components/brave_rewards/resources/donate/components/siteBanner.tsx
+++ b/components/brave_rewards/resources/donate/components/siteBanner.tsx
@@ -30,6 +30,11 @@ class Banner extends React.Component<Props, State> {
   }
 
   componentDidMount () {
+    const { publisher } = this.props.rewardsDonateData
+    if (publisher && publisher.verified) {
+      this.onClose()
+    }
+
     this.actions.getWalletProperties()
     this.actions.getRecurringDonations()
   }

--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -281,10 +281,6 @@
     "message": "This grant is no longer available.",
     "description": "Error title when user missed a grant."
   },
-  "changeSettingsButton": {
-    "message": "Change Auto-Contribute settings",
-    "description": "CAT that user can do to open auto contribute settings"
-  },
   "unVerifiedPublisher": {
     "message": "Not yet verified",
     "description": "Status of the publisher shown in the panel"

--- a/components/brave_rewards/resources/extension/brave_rewards/background/api/locale_api.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/api/locale_api.ts
@@ -35,7 +35,6 @@ export const getUIMessages = (): Record<string, string> => {
     'captchaTarget',
     'captchaMissedTarget',
     'claim',
-    'changeSettingsButton',
     'donateMonthly',
     'donateNow',
     'earningsAds',

--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -291,12 +291,6 @@ export class Panel extends React.Component<Props, State> {
     }
   }
 
-  openSettings = () => {
-    chrome.tabs.create({
-      url: 'brave://rewards/#ac-settings'
-    })
-  }
-
   render () {
     const { grant } = this.props.rewardsPanelData
     const { balance, rates, grants } = this.props.rewardsPanelData.walletProperties
@@ -355,7 +349,7 @@ export class Panel extends React.Component<Props, State> {
               publisherImg={faviconUrl}
               monthlyAmount={'10.0'}
               isVerified={publisher.verified}
-              tipsEnabled={true}
+              tipsEnabled={publisher.verified}
               includeInAuto={!publisher.excluded}
               attentionScore={(publisher.percentage || 0).toString()}
               onToggleTips={this.doNothing}
@@ -363,9 +357,7 @@ export class Panel extends React.Component<Props, State> {
               onAmountChange={this.doNothing}
               onIncludeInAuto={this.switchAutoContribute}
               showUnVerified={!publisher.verified}
-              showChangeSetting={this.state.nonVerified}
               moreLink={'https://brave.com/faq-rewards/#unclaimed-funds'}
-              onChangeSetting={this.openSettings}
             />
             : null
           }

--- a/components/brave_rewards/resources/ui/components/contributeBox.tsx
+++ b/components/brave_rewards/resources/ui/components/contributeBox.tsx
@@ -41,10 +41,6 @@ class ContributeBox extends React.Component<Props, State> {
     }
   }
 
-  componentDidMount () {
-    this.isSettingsUrl()
-  }
-
   getContributeRows = (list: Rewards.Publisher[]) => {
     return list.map((item: Rewards.Publisher) => {
       let faviconUrl = `chrome://favicon/size/48@1x/${item.url}`
@@ -102,14 +98,6 @@ class ContributeBox extends React.Component<Props, State> {
 
   onCheckSettingChange = (key: string, selected: boolean) => {
     this.actions.onSettingSave(key, selected)
-  }
-
-  isSettingsUrl = () => {
-    if (window && window.location && window.location.hash && window.location.hash === '#ac-settings') {
-      this.setState({
-        settings: true
-      })
-    }
   }
 
   contributeSettings = (monthlyList: MonthlyChoice[]) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#0ef71e2127af947ff7f2e6e830cc61dfac360123",
-      "from": "github:brave/brave-ui#0ef71e2127af947ff7f2e6e830cc61dfac360123",
+      "version": "github:brave/brave-ui#33abaec75d79073d5e80721ae038b4bac0408c5b",
+      "from": "github:brave/brave-ui#33abaec75d79073d5e80721ae038b4bac0408c5b",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#0ef71e2127af947ff7f2e6e830cc61dfac360123",
+    "brave-ui": "github:brave/brave-ui#33abaec75d79073d5e80721ae038b4bac0408c5b",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2785

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
plan 1
- enable rewards
- claim grant
- go to verified site and youtube channel
- make sure that you can tip that site

plan 2
- enable rewards
- claim grant
- go to non-verified site and youtube channel
- make sure that you can't tip that site

plan 3
- start browser from the master
- add some verified and non verified sites/channels to monthly tip
- switch to this PR branch
- make sure that only verified sites/channel are in the tables
- wait for contribution to happen and make sure that it went out just to verified publishers

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source