### PR TITLE
Provide a switch to enable / disable WebTorrent in settings

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -330,6 +330,16 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <message name="IDS_SETTINGS_BRAVE_SYNC_LINK_LABEL" desc="Brave Sync link label">
         Access Sync via
       </message>
+      <!-- Brave Default Extensions -->
+      <message name="IDS_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_TITLE" desc="The title for Brave default extensions in settings">
+        Extensions
+      </message>
+      <message name="IDS_SETTINGS_WEBTORRENT_ENABLED_DESC" desc="The description for WebTorrent switch in settings">
+        Uses WebTorrent to display torrents directly in the browser. Supports torrent files and magnet links.
+      </message>
+      <message name="IDS_SETTINGS_MANAGE_EXTENSIONS_LABEL" desc="The label of manage extensions link in settings">
+        Manage Extensions
+      </message>
     </messages>
     <includes>
       <include name="IDR_BRAVE_TAG_SERVICES_POLYFILL" file="resources/js/tag_services_polyfill.js" type="BINDATA" />

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -37,6 +37,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(kHTTPSEVerywhereControlType, true);
   registry->RegisterBooleanPref(kNoScriptControlType, false);
 
+  // WebTorrent
+  registry->RegisterBooleanPref(kWebTorrentEnabled, true);
+
   // No sign into Brave functionality
   registry->SetDefaultPrefValue(prefs::kSigninAllowed, base::Value(false));
 

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -28,6 +28,8 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, MiscBravePrefs) {
       browser()->profile()->GetPrefs()->GetBoolean(kHTTPSEVerywhereControlType));
   EXPECT_FALSE(
       browser()->profile()->GetPrefs()->GetBoolean(kNoScriptControlType));
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(kWebTorrentEnabled));
 }
 
 IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DisableGoogleServicesByDefault) {

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -40,6 +40,9 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetWhitelistedKeys() {
   // appearance prefs
   (*s_brave_whitelist)[kLocationBarIsWide] =
     settings_api::PrefType::PREF_TYPE_BOOLEAN;
+  // WebTorrent pref
+  (*s_brave_whitelist)[kWebTorrentEnabled] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
   return *s_brave_whitelist;
 }
 

--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/extensions/brave_component_extension.h"
 #include "brave/common/brave_switches.h"
 #include "brave/common/extensions/extension_constants.h"
+#include "brave/common/pref_names.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/resources/extension/grit/brave_rewards_extension_resources.h"
 #include "brave/components/brave_webtorrent/grit/brave_webtorrent_resources.h"
@@ -100,7 +101,9 @@ void BraveComponentLoader::AddDefaultComponentExtensions(
   }
 #endif
 
-  if (!command_line.HasSwitch(switches::kDisableWebTorrentExtension)) {
+  if (!command_line.HasSwitch(switches::kDisableWebTorrentExtension) &&
+      (!profile_prefs_->FindPreference(kWebTorrentEnabled) ||
+      profile_prefs_->GetBoolean(kWebTorrentEnabled))) {
     base::FilePath brave_webtorrent_path(FILE_PATH_LITERAL(""));
     brave_webtorrent_path =
       brave_webtorrent_path.Append(FILE_PATH_LITERAL("brave_webtorrent"));

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_browser_proxy.html
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_browser_proxy.html
@@ -1,0 +1,2 @@
+<link rel="href" src="chrome://resources/html/cr.html">
+<script src="brave_default_extensions_browser_proxy.js"></script>

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_browser_proxy.js
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_browser_proxy.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+cr.define('settings', function() {
+  /** @interface */
+  class BraveDefaultExtensionsBrowserProxy {
+    /**
+     * @param {boolean} value name.
+     */
+    setWebTorrentEnabled(value) {}
+  }
+
+  /**
+   * @implements {settings.BraveDefaultExtensionsBrowserProxy}
+   */
+  class BraveDefaultExtensionsBrowserProxyImpl {
+    /** @override */
+    setWebTorrentEnabled(value) {
+      chrome.send('setWebTorrentEnabled', [value]);
+    }
+  }
+
+  cr.addSingletonGetter(BraveDefaultExtensionsBrowserProxyImpl);
+
+  return {
+    BraveDefaultExtensionsBrowserProxy,
+    BraveDefaultExtensionsBrowserProxyImpl
+  };
+});

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.html
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.html
@@ -1,0 +1,29 @@
+<link rel="import" href="chrome://resources/html/polymer.html">
+
+<link rel="import" href="chrome://resources/cr_elements/cr_link_row/cr_link_row.html">
+<link rel="import" href="chrome://resources/html/i18n_behavior.html">
+<link rel="import" href="brave_default_extensions_browser_proxy.html">
+<link rel="import" href="../settings_page/settings_section.html">
+<link rel="import" href="../settings_shared_css.html">
+<link rel="import" href="../settings_vars_css.html">
+
+<dom-module id="settings-brave-default-extensions-page">
+  <template>
+  <settings-section page-title="$i18n{braveDefaultExtensions}" section="braveDefaultExtensions">
+    <style include="settings-shared iron-flex">
+    </style>
+    <settings-toggle-button id="webTorrentEnabled"
+        pref="{{prefs.brave.webtorrent_enabled}}"
+        label="WebTorrent"
+        sub-label="$i18n{webTorrentEnabledDesc}"
+        on-settings-boolean-control-change="onWebTorrentEnabledChange_">
+    </settings-toggle-button>
+    <div class="settings-row continuation" id="manageExtensionsRow">
+      <cr-link-row class="first" icon-class="icon-external"
+        label="$i18n{manageExtensionsLabel}" on-click="openExtensionsPage_">
+      </cr-link-row>
+    </div>
+  </settings-section>
+  </template>
+  <script src="brave_default_extensions_page.js"></script>
+</dom-module>

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.js
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+'use strict';
+
+/**
+ * 'settings-brave-default-extensions-page' is the settings page containing
+ * brave's default extensions.
+ */
+Polymer({
+  is: 'settings-brave-default-extensions-page',
+
+  /** @private {?settings.BraveDefaultExtensionsBrowserProxy} */
+  browserProxy_: null,
+
+  /** @override */
+  created: function() {
+    this.browserProxy_ = settings.BraveDefaultExtensionsBrowserProxyImpl.getInstance();
+  },
+
+  /** @override */
+  ready: function() {
+    this.onWebTorrentEnabledChange_ = this.onWebTorrentEnabledChange_.bind(this)
+    this.openExtensionsPage_ = this.openExtensionsPage_.bind(this)
+  },
+
+  onWebTorrentEnabledChange_: function() {
+    this.browserProxy_.setWebTorrentEnabled(this.$.webTorrentEnabled.checked);
+  },
+
+  openExtensionsPage_: function() {
+    window.open("chrome://extensions", "_self");
+  },
+});
+})();

--- a/browser/resources/settings/settings_resources.grd
+++ b/browser/resources/settings/settings_resources.grd
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!--This file is created by l10nUtil.js. Do not edit manually.-->
 <grit latest_public_release="0" current_release="1" output_all_resource_defines="false">
   <outputs>
     <output filename="grit/brave_settings_resources.h" type="rc_header">
@@ -29,6 +28,10 @@
       <structure name="IDR_SETTINGS_BRAVE_SYNC_BROWSER_PROXY_JS" file="brave_sync_page/brave_sync_browser_proxy.js" type="chrome_html" preprocess="true" />
       <structure name="IDR_SETTINGS_BRAVE_SYNC_PAGE_JS" file="brave_sync_page/brave_sync_page.js" type="chrome_html" preprocess="true" />
       <structure name="IDR_SETTINGS_BRAVE_SYNC_PAGE_HTML" file="brave_sync_page/brave_sync_page.html" type="chrome_html" preprocess="true" allowexternalscript="true" />
+      <structure name="IDR_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_BROWSER_PROXY_HTML" file="brave_default_extensions_page/brave_default_extensions_browser_proxy.html" type="chrome_html" />
+      <structure name="IDR_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_BROWSER_PROXY_JS" file="brave_default_extensions_page/brave_default_extensions_browser_proxy.js" type="chrome_html" preprocess="true" />
+      <structure name="IDR_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_PAGE_JS" file="brave_default_extensions_page/brave_default_extensions_page.js" type="chrome_html" preprocess="true" />
+      <structure name="IDR_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_PAGE_HTML" file="brave_default_extensions_page/brave_default_extensions_page.html" type="chrome_html" preprocess="true" allowexternalscript="true" />
     </structures>
     <includes>
       <include name="IDR_SETTINGS_BRAVE_STAMP" file="brave_unpack.stamp" type="BINDATA" />

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -81,6 +81,8 @@ source_set("ui") {
     "webui/settings/default_brave_shields_handler.h",
     "webui/sync/sync_ui.cc",
     "webui/sync/sync_ui.h",
+    "webui/settings/brave_default_extensions_handler.cc",
+    "webui/settings/brave_default_extensions_handler.h",
   ]
 
   if (enable_widevine_cdm_component) {

--- a/browser/ui/webui/brave_md_settings_ui.cc
+++ b/browser/ui/webui/brave_md_settings_ui.cc
@@ -8,6 +8,7 @@
 #include "brave/browser/extensions/brave_component_loader.h"
 #include "brave/browser/resources/grit/brave_settings_resources.h"
 #include "brave/browser/resources/grit/brave_settings_resources_map.h"
+#include "brave/browser/ui/webui/settings/brave_default_extensions_handler.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/browser/ui/webui/settings/default_brave_shields_handler.h"
 #include "brave/common/brave_switches.h"
@@ -25,11 +26,11 @@ BraveMdSettingsUI::BraveMdSettingsUI(content::WebUI* web_ui,
   web_ui->AddMessageHandler(std::make_unique<settings::MetricsReportingHandler>());
   web_ui->AddMessageHandler(std::make_unique<BravePrivacyHandler>());
   web_ui->AddMessageHandler(std::make_unique<DefaultBraveShieldsHandler>());
-
-  #if defined(OS_MACOSX)
+  web_ui->AddMessageHandler(std::make_unique<BraveDefaultExtensionsHandler>());
+#if defined(OS_MACOSX)
   // Use sparkle's relaunch api for browser relaunch on update.
   web_ui->AddMessageHandler(std::make_unique<BraveRelaunchHandler>());
-  #endif
+#endif
 }
 
 BraveMdSettingsUI::~BraveMdSettingsUI() {

--- a/browser/ui/webui/settings/brave_default_extensions_handler.cc
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.cc
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/settings/brave_default_extensions_handler.h"
+
+#include <string>
+
+#include "base/bind.h"
+#include "base/values.h"
+#include "brave/common/extensions/extension_constants.h"
+#include "brave/components/brave_webtorrent/grit/brave_webtorrent_resources.h"
+#include "chrome/browser/extensions/component_loader.h"
+#include "chrome/browser/extensions/extension_service.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/web_ui.h"
+#include "extensions/browser/extension_system.h"
+
+void BraveDefaultExtensionsHandler::RegisterMessages() {
+  profile_ = Profile::FromWebUI(web_ui());
+  web_ui()->RegisterMessageCallback(
+      "setWebTorrentEnabled",
+      base::BindRepeating(&BraveDefaultExtensionsHandler::SetWebTorrentEnabled,
+                          base::Unretained(this)));
+}
+
+void BraveDefaultExtensionsHandler::SetWebTorrentEnabled(
+    const base::ListValue* args) {
+  CHECK_EQ(args->GetSize(), 1U);
+  CHECK(profile_);
+  bool value;
+  args->GetBoolean(0, &value);
+
+  extensions::ExtensionService* service =
+    extensions::ExtensionSystem::Get(profile_)->extension_service();
+  extensions::ComponentLoader* loader = service->component_loader();
+
+  if (value) {
+    if (!loader->Exists(brave_webtorrent_extension_id)) {
+      base::FilePath brave_webtorrent_path(FILE_PATH_LITERAL(""));
+      brave_webtorrent_path =
+        brave_webtorrent_path.Append(FILE_PATH_LITERAL("brave_webtorrent"));
+      loader->Add(IDR_BRAVE_WEBTORRENT, brave_webtorrent_path);
+    }
+    service->EnableExtension(brave_webtorrent_extension_id);
+  } else {
+    service->DisableExtension(brave_webtorrent_extension_id,
+        extensions::disable_reason::DisableReason::DISABLE_BLOCKED_BY_POLICY);
+  }
+}

--- a/browser/ui/webui/settings/brave_default_extensions_handler.h
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.h
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_HANDLER_H_
+
+#include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
+
+class Profile;
+
+class BraveDefaultExtensionsHandler : public settings::SettingsPageUIHandler {
+ public:
+  BraveDefaultExtensionsHandler() = default;
+  ~BraveDefaultExtensionsHandler() override = default;
+
+ private:
+  // SettingsPageUIHandler overrides:
+  void RegisterMessages() override;
+  void OnJavascriptAllowed() override {}
+  void OnJavascriptDisallowed() override {}
+
+  void SetWebTorrentEnabled(const base::ListValue* args);
+
+  Profile* profile_ = nullptr;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveDefaultExtensionsHandler);
+};
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_HANDLER_H_

--- a/chromium_src/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
@@ -80,7 +80,13 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
     {"braveSync",
       IDS_SETTINGS_BRAVE_SYNC_TITLE},
     {"braveSyncLabel",
-      IDS_SETTINGS_BRAVE_SYNC_LINK_LABEL}
+      IDS_SETTINGS_BRAVE_SYNC_LINK_LABEL},
+    {"braveDefaultExtensions",
+      IDS_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_TITLE},
+    {"webTorrentEnabledDesc",
+      IDS_SETTINGS_WEBTORRENT_ENABLED_DESC},
+    {"manageExtensionsLabel",
+      IDS_SETTINGS_MANAGE_EXTENSIONS_LABEL}
   };
   AddLocalizedStringsBulk(html_source, localized_strings,
                           arraysize(localized_strings));

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -42,3 +42,4 @@ const char kRewardsUserHasFunded[] = "brave.rewards.user_has_funded";
 const char kRewardsAddFundsNotification[] = "brave.rewards.add_funds_notification";
 const char kMigratedMuonProfile[] = "brave.muon.migrated_profile";
 const char kBravePaymentsPinnedItemCount[] = "brave.muon.import_pinned_item_count";
+const char kWebTorrentEnabled[] = "brave.webtorrent_enabled";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -39,5 +39,6 @@ extern const char kRewardsUserHasFunded[];
 extern const char kRewardsAddFundsNotification[];
 extern const char kMigratedMuonProfile[];
 extern const char kBravePaymentsPinnedItemCount[];
+extern const char kWebTorrentEnabled[];
 
 #endif  // BRAVE_COMMON_PREF_NAMES_H_

--- a/patches/chrome-browser-resources-settings-basic_page-basic_page.html.patch
+++ b/patches/chrome-browser-resources-settings-basic_page-basic_page.html.patch
@@ -1,17 +1,18 @@
 diff --git a/chrome/browser/resources/settings/basic_page/basic_page.html b/chrome/browser/resources/settings/basic_page/basic_page.html
-index a99337c3d25ac4681807a57874fa7bb20713c1a3..54372b9f7e94eb8468b3f1fbecf58c64c3866919 100644
+index a99337c3d25ac4681807a57874fa7bb20713c1a3..927e63519b7cdcfda770723ee100498acb8c5e6c 100644
 --- a/chrome/browser/resources/settings/basic_page/basic_page.html
 +++ b/chrome/browser/resources/settings/basic_page/basic_page.html
-@@ -27,6 +27,8 @@
+@@ -27,6 +27,9 @@
  
  <if expr="not chromeos">
  <link rel="import" href="../default_browser_page/default_browser_page.html">
 +<link rel="import" href="../default_brave_shields_page/default_brave_shields_page.html">
++<link rel="import" href="../brave_default_extensions_page/brave_default_extensions_page.html">
 +<link rel="import" href="../brave_sync_page/brave_sync_page.html">
  </if>
  
  <!-- TODO(michaelpg): Rename to something better than "basic" now that this page
-@@ -214,6 +216,19 @@
+@@ -214,6 +217,20 @@
            </settings-section>
          </template>
  </if>
@@ -28,6 +29,7 @@ index a99337c3d25ac4681807a57874fa7bb20713c1a3..54372b9f7e94eb8468b3f1fbecf58c64
 +            <settings-default-brave-shields-page  prefs="{{prefs}}"></settings-default-brave-shields-page>
 +          </settings-section>
 +        </template>
++        <settings-brave-default-extensions-page prefs="{{prefs}}"></settings-brave-default-extensions-page>
          <template is="dom-if" if="[[showPage_(pageVisibility.onStartup)]]"
              restamp>
            <settings-section page-title="$i18n{onStartup}" section="onStartup">


### PR DESCRIPTION
This is a PR credited to @yrliou 
I just rebased it and fixed up tests.

Fix https://github.com/brave/brave-browser/issues/897

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source