### PR TITLE
Use gethostname to setup default device name

### DIFF
--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -33,6 +33,7 @@ source_set("js_sync_lib_impl") {
     "//content/public/browser",
     "//extensions/browser",
     "//services/network/public/cpp",
+    "//net",
     "//ui/base",
   ]
 }

--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -22,6 +22,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "components/bookmarks/browser/bookmark_model.h"
 #include "content/public/browser/network_service_instance.h"
+#include "net/base/network_interfaces.h"
 
 namespace brave_sync {
 
@@ -166,11 +167,6 @@ void BraveSyncServiceImpl::OnSetupSyncHaveCode(const std::string& sync_words,
     return;
   }
 
-  if (device_name.empty()) {
-    OnSyncSetupError("ERR_SYNC_NO_DEVICE_NAME");
-    return;
-  }
-
   if (initializing_) {
     NotifyLogMessage("currently initializing");
     return;
@@ -181,7 +177,7 @@ void BraveSyncServiceImpl::OnSetupSyncHaveCode(const std::string& sync_words,
     return;
   }
 
-  sync_prefs_->SetThisDeviceName(device_name);
+  SetDeviceName(device_name);
   initializing_ = true;
 
   sync_prefs_->SetSyncEnabled(true);
@@ -193,11 +189,6 @@ void BraveSyncServiceImpl::OnSetupSyncNewToSync(
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   if (content::GetNetworkConnectionTracker()->IsOffline()) {
     OnSyncSetupError("ERR_SYNC_NO_INTERNET");
-    return;
-  }
-
-  if (device_name.empty()) {
-    OnSyncSetupError("ERR_SYNC_NO_DEVICE_NAME");
     return;
   }
 
@@ -213,8 +204,7 @@ void BraveSyncServiceImpl::OnSetupSyncNewToSync(
 
   sync_words_.clear();  // If the previous attempt was connect to sync chain
                         // and failed to receive save-init-data
-
-  sync_prefs_->SetThisDeviceName(device_name);
+  SetDeviceName(device_name);
   initializing_ = true;
 
   sync_prefs_->SetSyncEnabled(true);
@@ -684,6 +674,24 @@ void BraveSyncServiceImpl::ResetSyncInternal() {
   sync_initialized_ = false;
 
   sync_prefs_->SetSyncEnabled(false);
+}
+
+void BraveSyncServiceImpl::SetDeviceName(const std::string& name) {
+  if (name.empty()) {
+    std::string hostname = net::GetHostName();
+    if (hostname.empty()) {
+#if defined(OS_MACOSX)
+      hostname = std::string("Mac Desktop");
+#elif defined(OS_LINUX)
+      hostname = std::string("Linux Desktop");
+#elif defined(OS_WIN)
+      hostname = std::string("Windows Desktop");
+#endif
+    }
+    sync_prefs_->SetThisDeviceName(hostname);
+  } else {
+    sync_prefs_->SetThisDeviceName(name);
+  }
 }
 
 } // namespace brave_sync

--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -174,6 +174,8 @@ class BraveSyncServiceImpl
 
   void ResetSyncInternal();
 
+  void SetDeviceName(const std::string& name);
+
   std::unique_ptr<BraveSyncClient> sync_client_;
 
   // True when is in active sync chain

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -25,6 +25,7 @@
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/test/test_browser_thread_bundle.h"
 #include "services/network/test/test_network_connection_tracker.h"
+#include "net/base/network_interfaces.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -263,6 +264,17 @@ TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCode) {
        brave_sync::prefs::kSyncEnabled));
 }
 
+TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCode_EmptyDeviceName) {
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged);
+  // Expecting sync state changed twice: for enabled state and for device name
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(2);
+  sync_service()->OnSetupSyncHaveCode("word1 word2 word3", "");
+  EXPECT_TRUE(profile()->GetPrefs()->GetBoolean(
+       brave_sync::prefs::kSyncEnabled));
+  EXPECT_EQ(profile()->GetPrefs()->GetString(
+      brave_sync::prefs::kSyncDeviceName), net::GetHostName());
+}
+
 TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCode_Offline) {
   TestNetworkConnectionTracker* tracker =
     TestNetworkConnectionTracker::GetInstance();
@@ -294,6 +306,17 @@ TEST_F(BraveSyncServiceTest, OnSetupSyncNewToSync_Offline) {
        brave_sync::prefs::kSyncEnabled));
   // Restore network connection
   tracker->SetConnectionType(ConnectionType::CONNECTION_UNKNOWN);
+}
+
+TEST_F(BraveSyncServiceTest, OnSetupSyncNewToSync_EmptyDeviceName) {
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged);
+  // Expecting sync state changed twice: for enabled state and for device name
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(2);
+  sync_service()->OnSetupSyncNewToSync("");
+  EXPECT_TRUE(profile()->GetPrefs()->GetBoolean(
+       brave_sync::prefs::kSyncEnabled));
+  EXPECT_EQ(profile()->GetPrefs()->GetString(
+      brave_sync::prefs::kSyncDeviceName), net::GetHostName());
 }
 
 TEST_F(BraveSyncServiceTest, OnConnectionChanged_After_OnSetupSyncNewToSync) {

--- a/components/brave_sync/ui/components/modals/deviceType.tsx
+++ b/components/brave_sync/ui/components/modals/deviceType.tsx
@@ -24,7 +24,6 @@ import ScanCodeModal from './scanCode'
 
 // Utils
 import { getLocale } from '../../../../common/locale'
-import { getDefaultDeviceName } from '../../helpers'
 
 // Images
 import { SyncDesktopIcon, SyncMobileIcon } from 'brave-ui/features/sync/images'
@@ -54,7 +53,7 @@ export default class DeviceTypeModal extends React.PureComponent<Props, State> {
     // this allow us to request the qr code and sync words immediately
     const { thisDeviceName } = this.props.syncData
     if (thisDeviceName === '') {
-       this.props.actions.onSetupNewToSync(getDefaultDeviceName())
+       this.props.actions.onSetupNewToSync('')
     }
   }
 
@@ -117,7 +116,7 @@ export default class DeviceTypeModal extends React.PureComponent<Props, State> {
         }
         <ModalHeader>
           <div>
-            <ModalTitle level={1}>{getLocale('letsSync')} “{getDefaultDeviceName()}”.</ModalTitle>
+            <ModalTitle level={1}>{getLocale('letsSync')} “{syncData.thisDeviceName}”.</ModalTitle>
             <ModalSubTitle>{getLocale('chooseDeviceType')}</ModalSubTitle>
           </div>
         </ModalHeader>

--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -21,7 +21,6 @@ import {
 
 // Utils
 import { getLocale } from '../../../../common/locale'
-import { getDefaultDeviceName } from '../../helpers'
 
 interface Props {
   syncData: Sync.State
@@ -53,8 +52,7 @@ interface Props {
       return
     }
     const { passphrase } = this.state
-    const deviceName = getDefaultDeviceName()
-    this.props.actions.onSetupSyncHaveCode(passphrase, deviceName)
+    this.props.actions.onSetupSyncHaveCode(passphrase, '')
   }
 
   render () {

--- a/components/brave_sync/ui/helpers.ts
+++ b/components/brave_sync/ui/helpers.ts
@@ -38,31 +38,3 @@ export const generateQRCodeImageSource = (seed: string) => {
     console.error('[SYNC] QR image error:', error.toString())
   }
 }
-
-/**
- * Gets the user's operating system name to ne ised as a default device name
- * @returns {string} - A string including the OS + the desktop suffix
- */
-export const getDefaultDeviceName = () => {
-  const userAgent = window.navigator.userAgent
-  const currentPlatform = window.navigator.platform
-  const macosVariants = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K']
-  const windowsVariants = ['Win32', 'Win64', 'Windows', 'WinCE']
-  const iOSVariants = ['iPhone', 'iPad', 'iPod']
-  const androidVariants = ['Android']
-
-  let system
-
-  if (macosVariants.includes(currentPlatform)) {
-    system = 'Mac'
-  } else if (windowsVariants.includes(currentPlatform)) {
-    system = 'Windows'
-  } else if (iOSVariants.includes(currentPlatform)) {
-    system = 'iOS'
-  } else if (androidVariants.includes(userAgent)) {
-    system = 'Android'
-  } else {
-    system = 'Linux'
-  }
-  return `${system} Desktop`
-}

--- a/components/brave_sync/ui/reducers/sync_reducer.ts
+++ b/components/brave_sync/ui/reducers/sync_reducer.ts
@@ -80,9 +80,6 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
       break
 
     case types.SYNC_ON_SETUP_NEW_TO_SYNC:
-      if (!payload.thisDeviceName) {
-        break
-      }
       chrome.send('setupSyncNewToSync', [payload.thisDeviceName])
       break
 

--- a/components/definitions/sync.d.ts
+++ b/components/definitions/sync.d.ts
@@ -27,7 +27,6 @@ export type SetupErrorType =
   'ERR_SYNC_NO_INTERNET' |
   'ERR_SYNC_MISSING_WORDS' |
   'ERR_SYNC_WRONG_WORDS' |
-  'ERR_SYNC_NO_DEVICE_NAME' |
   'ERR_SYNC_INIT_FAILED' |
   undefined
 


### PR DESCRIPTION
Use `gethostname` to setup default device name

this is needed by Sync but only made up to 0.60.x. ref https://github.com/brave/brave-core/pull/1136#issuecomment-448826804