### PR TITLE
Display device Added on by only date

### DIFF
--- a/components/brave_sync/ui/reducers/sync_reducer.ts
+++ b/components/brave_sync/ui/reducers/sync_reducer.ts
@@ -34,7 +34,7 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
         return {
           name: device.name,
           id: device.device_id,
-          lastActive: (new Date(device.last_active)).toString()
+          lastActive: (new Date(device.last_active)).toDateString()
         }
       })
 


### PR DESCRIPTION
Display device Added on by only date

this is needed by Sync but only made up to 0.60.x. ref #1136 (comment)