### PR TITLE
Merge pull request #1179 from brave/sync-bookmarks-reducer

### DIFF
--- a/patches/chrome-browser-resources-md_bookmarks-reducers.js.patch
+++ b/patches/chrome-browser-resources-md_bookmarks-reducers.js.patch
@@ -1,0 +1,23 @@
+diff --git a/chrome/browser/resources/md_bookmarks/reducers.js b/chrome/browser/resources/md_bookmarks/reducers.js
+index 17ca9e18c8f4635aac2db849cb77886a4c7390dc..184e2f993812d6da4e09890336b2815e86d563f0 100644
+--- a/chrome/browser/resources/md_bookmarks/reducers.js
++++ b/chrome/browser/resources/md_bookmarks/reducers.js
+@@ -240,6 +240,9 @@ cr.define('bookmarks', function() {
+   NodeState.moveBookmark = function(nodes, action) {
+     const nodeModifications = {};
+     const id = action.id;
++    // Skip when new/old parent is invisible (Pending Bookmarks)
++    if (!nodes[action.oldParentId] || !nodes[action.parentId])
++      return nodes;
+ 
+     // Change node's parent.
+     nodeModifications[id] =
+@@ -414,7 +417,7 @@ cr.define('bookmarks', function() {
+         return FolderOpenState.openFolderAndAncestors(
+             folderOpenState, nodes[action.id].parentId, nodes);
+       case 'move-bookmark':
+-        if (!nodes[action.id].children)
++        if (!nodes[action.id] || !nodes[action.id].children)
+           return folderOpenState;
+ 
+         return FolderOpenState.openFolderAndAncestors(


### PR DESCRIPTION
Handle invisible nodes (Nodes under Pending Bookmarks and itself) in bookmarks reducer

this is needed by Sync but only made up to 0.60.x. ref https://github.com/brave/brave-core/pull/1179#issuecomment-449527342