### PR TITLE
Ad user model can now classify pages with certain common caching directives

### DIFF
--- a/components/brave_ads/browser/ads_tab_helper.cc
+++ b/components/brave_ads/browser/ads_tab_helper.cc
@@ -59,9 +59,7 @@ void AdsTabHelper::DidFinishNavigation(
   if (navigation_handle->IsInMainFrame() &&
       navigation_handle->GetResponseHeaders()) {
     if (navigation_handle->GetResponseHeaders()->HasHeaderValue(
-            "cache-control", "no-store") ||
-        navigation_handle->GetResponseHeaders()->HasHeaderValue(
-            "cache-control", "private")) {
+            "cache-control", "no-store")) {
       run_distiller_ = false;
     } else {
       bool was_restored =


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/2819

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Confirm pages that have the `private` common caching directive, i.e. cnet.com, reddit.com and mashable.com can be classified


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source