### PR TITLE
Add support for Google Hangouts / Google Meet

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -337,6 +337,9 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <message name="IDS_SETTINGS_WEBTORRENT_ENABLED_DESC" desc="The description for WebTorrent switch in settings">
         Uses WebTorrent to display torrents directly in the browser. Supports torrent files and magnet links.
       </message>
+     <message name="IDS_SETTINGS_HANGOUTS_ENABLED_DESC" desc="The description for Hangouts switch in settings">
+        Uses Hangouts component to enable screen sharing and other features in the browser.
+      </message>
       <message name="IDS_SETTINGS_MANAGE_EXTENSIONS_LABEL" desc="The label of manage extensions link in settings">
         Manage Extensions
       </message>

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -40,6 +40,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // WebTorrent
   registry->RegisterBooleanPref(kWebTorrentEnabled, true);
 
+  // Hangouts
+  registry->RegisterBooleanPref(kHangoutsEnabled, true);
+
   // No sign into Brave functionality
   registry->SetDefaultPrefValue(prefs::kSigninAllowed, base::Value(false));
 

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -30,6 +30,8 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, MiscBravePrefs) {
       browser()->profile()->GetPrefs()->GetBoolean(kNoScriptControlType));
   EXPECT_TRUE(
       browser()->profile()->GetPrefs()->GetBoolean(kWebTorrentEnabled));
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(kHangoutsEnabled));
 }
 
 IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DisableGoogleServicesByDefault) {

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -43,6 +43,9 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetWhitelistedKeys() {
   // WebTorrent pref
   (*s_brave_whitelist)[kWebTorrentEnabled] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
+  // Hangouts pref
+  (*s_brave_whitelist)[kHangoutsEnabled] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
   return *s_brave_whitelist;
 }
 

--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -73,6 +73,13 @@ void BraveComponentLoader::AddExtension(const std::string& extension_id,
         base::Unretained(this), extension_id, true));
 }
 
+void BraveComponentLoader::AddHangoutServicesExtension() {
+  if (!profile_prefs_->FindPreference(kHangoutsEnabled) ||
+      profile_prefs_->GetBoolean(kHangoutsEnabled)) {
+    ComponentLoader::AddHangoutServicesExtension();
+  }
+}
+
 void BraveComponentLoader::AddDefaultComponentExtensions(
     bool skip_session_components) {
   ComponentLoader::AddDefaultComponentExtensions(skip_session_components);

--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -76,8 +76,12 @@ void BraveComponentLoader::AddExtension(const std::string& extension_id,
 void BraveComponentLoader::AddHangoutServicesExtension() {
   if (!profile_prefs_->FindPreference(kHangoutsEnabled) ||
       profile_prefs_->GetBoolean(kHangoutsEnabled)) {
-    ComponentLoader::AddHangoutServicesExtension();
+    ForceAddHangoutServicesExtension();
   }
+}
+
+void BraveComponentLoader::ForceAddHangoutServicesExtension() {
+  ComponentLoader::AddHangoutServicesExtension();
 }
 
 void BraveComponentLoader::AddDefaultComponentExtensions(

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -39,6 +39,7 @@ class BraveComponentLoader : public ComponentLoader {
 
  private:
   friend class ::BravePDFExtensionTest;
+  void AddHangoutServicesExtension() override;
   void ObserveOpenPdfExternallySetting();
   // Callback for changes to the AlwaysOpenPdfExternally setting.
   void UpdatePdfExtension(const std::string& pref_name);

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -34,12 +34,13 @@ class BraveComponentLoader : public ComponentLoader {
     const std::string& manifest);
   void AddExtension(const std::string& id,
       const std::string& name, const std::string& public_key);
+  void ForceAddHangoutServicesExtension();
  
   static bool IsPdfjsDisabled();
 
  private:
-  friend class ::BravePDFExtensionTest;
   void AddHangoutServicesExtension() override;
+  friend class ::BravePDFExtensionTest;
   void ObserveOpenPdfExternallySetting();
   // Callback for changes to the AlwaysOpenPdfExternally setting.
   void UpdatePdfExtension(const std::string& pref_name);

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_browser_proxy.js
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_browser_proxy.js
@@ -9,6 +9,7 @@ cr.define('settings', function() {
      * @param {boolean} value name.
      */
     setWebTorrentEnabled(value) {}
+    setHangoutsEnabled(value) {}
   }
 
   /**
@@ -18,6 +19,9 @@ cr.define('settings', function() {
     /** @override */
     setWebTorrentEnabled(value) {
       chrome.send('setWebTorrentEnabled', [value]);
+    }
+    setHangoutsEnabled(value) {
+      chrome.send('setHangoutsEnabled', [value]);
     }
   }
 

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.html
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.html
@@ -18,6 +18,12 @@
         sub-label="$i18n{webTorrentEnabledDesc}"
         on-settings-boolean-control-change="onWebTorrentEnabledChange_">
     </settings-toggle-button>
+    <settings-toggle-button id="hangoutsEnabled"
+        pref="{{prefs.brave.hangouts_enabled}}"
+        label="Hangouts"
+        sub-label="$i18n{hangoutsEnabledDesc}"
+        on-settings-boolean-control-change="onHangoutsEnabledChange_">
+    </settings-toggle-button>
     <div class="settings-row continuation" id="manageExtensionsRow">
       <cr-link-row class="first" icon-class="icon-external"
         label="$i18n{manageExtensionsLabel}" on-click="openExtensionsPage_">

--- a/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.js
+++ b/browser/resources/settings/brave_default_extensions_page/brave_default_extensions_page.js
@@ -23,11 +23,16 @@ Polymer({
   /** @override */
   ready: function() {
     this.onWebTorrentEnabledChange_ = this.onWebTorrentEnabledChange_.bind(this)
+    this.onHangoutsEnabledChange_ = this.onHangoutsEnabledChange_.bind(this)
     this.openExtensionsPage_ = this.openExtensionsPage_.bind(this)
   },
 
   onWebTorrentEnabledChange_: function() {
     this.browserProxy_.setWebTorrentEnabled(this.$.webTorrentEnabled.checked);
+  },
+
+  onHangoutsEnabledChange_: function() {
+    this.browserProxy_.setHangoutsEnabled(this.$.hangoutsEnabled.checked);
   },
 
   openExtensionsPage_: function() {

--- a/browser/ui/webui/settings/brave_default_extensions_handler.h
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.h
@@ -21,6 +21,7 @@ class BraveDefaultExtensionsHandler : public settings::SettingsPageUIHandler {
   void OnJavascriptDisallowed() override {}
 
   void SetWebTorrentEnabled(const base::ListValue* args);
+  void SetHangoutsEnabled(const base::ListValue* args);
 
   Profile* profile_ = nullptr;
 

--- a/chromium_src/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
@@ -85,6 +85,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       IDS_SETTINGS_BRAVE_DEFAULT_EXTENSIONS_TITLE},
     {"webTorrentEnabledDesc",
       IDS_SETTINGS_WEBTORRENT_ENABLED_DESC},
+    {"hangoutsEnabledDesc",
+      IDS_SETTINGS_HANGOUTS_ENABLED_DESC},
     {"manageExtensionsLabel",
       IDS_SETTINGS_MANAGE_EXTENSIONS_LABEL}
   };

--- a/common/extensions/extension_constants.cc
+++ b/common/extensions/extension_constants.cc
@@ -7,6 +7,7 @@
 const char brave_extension_id[] = "mnojpmjdmbbfmejpflffifhffcmidifd";
 const char brave_rewards_extension_id[] = "jidkidbbcafjabdphckchenhfomhnfma";
 const char brave_webtorrent_extension_id[] = "lgjmpdmojkpocjcopdikifhejkkjglho";
+const char hangouts_extension_id[] = "nkeimhogjdpnpccoofpliimaahmaaome";
 const char widevine_extension_id[] = "oimompecagnajdejgnnjijobebaeigek";
 const char brave_sync_extension_id[] = "nomlkjnggnifocmealianaaiobmebgil";
 

--- a/common/extensions/extension_constants.h
+++ b/common/extensions/extension_constants.h
@@ -5,6 +5,7 @@
 extern const char brave_extension_id[];
 extern const char brave_rewards_extension_id[];
 extern const char brave_webtorrent_extension_id[];
+extern const char hangouts_extension_id[];
 extern const char widevine_extension_id[];
 extern const char brave_sync_extension_id[];
 

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -43,3 +43,4 @@ const char kRewardsAddFundsNotification[] = "brave.rewards.add_funds_notificatio
 const char kMigratedMuonProfile[] = "brave.muon.migrated_profile";
 const char kBravePaymentsPinnedItemCount[] = "brave.muon.import_pinned_item_count";
 const char kWebTorrentEnabled[] = "brave.webtorrent_enabled";
+const char kHangoutsEnabled[] = "brave.hangouts_enabled";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -40,5 +40,6 @@ extern const char kRewardsAddFundsNotification[];
 extern const char kMigratedMuonProfile[];
 extern const char kBravePaymentsPinnedItemCount[];
 extern const char kWebTorrentEnabled[];
+extern const char kHangoutsEnabled[];
 
 #endif  // BRAVE_COMMON_PREF_NAMES_H_

--- a/patches/chrome-browser-extensions-component_loader.h.patch
+++ b/patches/chrome-browser-extensions-component_loader.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/component_loader.h b/chrome/browser/extensions/component_loader.h
-index 8a78a56e2425adf937754bd0b202549744597bd0..54badd2618b872ecdafff1457e0e955fdc057729 100644
+index 8a78a56e2425adf937754bd0b202549744597bd0..52a2735a5bf944e8f39e61ba8294d70ee3034a7f 100644
 --- a/chrome/browser/extensions/component_loader.h
 +++ b/chrome/browser/extensions/component_loader.h
 @@ -83,7 +83,7 @@ class ComponentLoader {
@@ -11,3 +11,19 @@ index 8a78a56e2425adf937754bd0b202549744597bd0..54badd2618b872ecdafff1457e0e955f
  
    // Similar to above but adds the default component extensions for kiosk mode.
    void AddDefaultComponentExtensionsForKioskMode(bool skip_session_components);
+@@ -118,6 +118,7 @@ class ComponentLoader {
+   }
+ 
+  private:
++  friend class BraveComponentLoader;
+   FRIEND_TEST_ALL_PREFIXES(ComponentLoaderTest, ParseManifest);
+ 
+   // Information about a registered component extension.
+@@ -166,6 +167,7 @@ class ComponentLoader {
+   void AddAudioPlayerExtension();
+   void AddGalleryExtension();
+   void AddZipArchiverExtension();
++  virtual
+   void AddHangoutServicesExtension();
+   void AddImageLoaderExtension();
+   void AddNetworkSpeechSynthesisExtension();

--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -268,6 +268,8 @@ bool BraveContentSettingsObserver::AllowAutoplay(bool default_value) {
       "[*.]pandora.com",
       "[*.]periscope.tv",
       "[*.]pscp.tv",
+      "[*.]hangouts.google.com",
+      "[*.]meet.google.com",
   };
   for (const auto& pattern : kWhitelistPatterns) {
     if (ContentSettingsPattern::FromString(pattern).Matches(primary_url))


### PR DESCRIPTION
This fixes screen share feature and probably other things for Google Hangouts and Google Meet.

Fix https://github.com/brave/brave-browser/issues/1982
Requires: https://github.com/brave/brave-browser/pull/1983

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source