### PR TITLE
Adds support for different watch youtube urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /components/brave_sync/extension/brave-sync/
 /dist/
 /out/
-/vendor
+/vendor/*
 !/vendor/bat-native-ledger
 node_modules/
 *.xcodeproj

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -85,6 +85,7 @@ test("brave_unit_tests") {
 
   if (brave_rewards_enabled) {
     sources += [
+      "//brave/vendor/bat-native-ledger/src/bat_get_media_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/test/niceware_partial_unittest.cc",
       "//brave/vendor/bat-native-usermodel/test/usermodel_unittest.cc",
       "//brave/components/brave_rewards/browser/rewards_service_impl_unittest.cc",

--- a/vendor/bat-native-ledger/src/bat_get_media.cc
+++ b/vendor/bat-native-ledger/src/bat_get_media.cc
@@ -7,6 +7,7 @@
 
 #include <sstream>
 #include <cmath>
+#include <vector>
 
 #include "bat_get_media.h"
 #include "bat_helper.h"
@@ -735,11 +736,28 @@ std::string BatGetMedia::parseChannelId(const std::string& data) {
   return id;
 }
 
+// static
 std::string BatGetMedia::getYoutubeMediaIdFromUrl(const ledger::VisitData& visit_data) {
-  std::vector<std::string> m_url =
-    braveledger_bat_helper::split(visit_data.url, '=');
-  if (m_url.size() > 1) {
-    return m_url[1];
+  std::vector<std::string> first_split =
+    braveledger_bat_helper::split(visit_data.url, '?');
+
+  if (first_split.size() < 2) {
+    return std::string();
+  }
+
+  std::vector<std::string> and_split =
+    braveledger_bat_helper::split(first_split[1], '&');
+
+  for (const auto& item : and_split) {
+    std::vector<std::string> m_url = braveledger_bat_helper::split(item, '=');
+
+    if (m_url.size() < 2) {
+      continue;
+    }
+
+    if (m_url[0] == "v") {
+      return m_url[1];
+    }
   }
 
   return std::string();

--- a/vendor/bat-native-ledger/src/bat_get_media.h
+++ b/vendor/bat-native-ledger/src/bat_get_media.h
@@ -44,6 +44,8 @@ class BatGetMedia {
                                const ledger::VisitData& visit_data,
                                const std::string& providerType);
 
+  static std::string getYoutubeMediaIdFromUrl(const ledger::VisitData& visit_data);
+
  private:
   std::string getMediaURL(const std::string& mediaId, const std::string& providerName);
   void getPublisherFromMediaPropsCallback(const uint64_t& duration,
@@ -169,8 +171,6 @@ class BatGetMedia {
   std::string parseFavIconUrl(const std::string& data);
 
   std::string parseChannelId(const std::string& data);
-
-  std::string getYoutubeMediaIdFromUrl(const ledger::VisitData& visit_data);
 
   std::string getYoutubeMediaKeyFromUrl(const std::string& provider_type, const std::string& media_id);
 

--- a/vendor/bat-native-ledger/src/bat_get_media_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat_get_media_unittest.cc
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/vendor/bat-native-ledger/include/bat/ledger/ledger.h"
+#include "brave/vendor/bat-native-ledger/src/bat_get_media.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(BatGetMediaTest, GetYoutubeMediaIdFromUrl) {
+  //BatGetMedia media = new BatGetMedia(nullptr);
+
+  // missing video id
+  ledger::VisitData data;
+  data.url = "https://www.youtube.com/watch";
+
+  std::string media =
+      braveledger_bat_get_media::BatGetMedia::getYoutubeMediaIdFromUrl(data);
+
+  ASSERT_EQ(media, "");
+
+  // single element in the url
+  data.url = "https://www.youtube.com/watch?v=44444444";
+
+  media =
+      braveledger_bat_get_media::BatGetMedia::getYoutubeMediaIdFromUrl(data);
+
+  ASSERT_EQ(media, "44444444");
+
+  // single element in the url with & appended
+  data.url = "https://www.youtube.com/watch?v=44444444&";
+
+  media =
+      braveledger_bat_get_media::BatGetMedia::getYoutubeMediaIdFromUrl(data);
+
+  ASSERT_EQ(media, "44444444");
+
+  // multiple elements in the url (id first)
+  data.url = "https://www.youtube.com/watch?v=44444444&time_continue=580";
+
+  media =
+      braveledger_bat_get_media::BatGetMedia::getYoutubeMediaIdFromUrl(data);
+
+  ASSERT_EQ(media, "44444444");
+
+  // multiple elements in the url
+  data.url = "https://www.youtube.com/watch?time_continue=580&v=44444444";
+
+  media =
+      braveledger_bat_get_media::BatGetMedia::getYoutubeMediaIdFromUrl(data);
+
+  ASSERT_EQ(media, "44444444");
+}


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2820

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- enable rewards
- open https://www.youtube.com/watch?time_continue=580&v=Zp9ZJiFFBnU
- open rewards panel and try to tip

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source