### PR TITLE
Fixes cherry-pick problem with rewards

### DIFF
--- a/vendor/bat-native-ledger/src/bat_publishers.cc
+++ b/vendor/bat-native-ledger/src/bat_publishers.cc
@@ -230,6 +230,8 @@ void BatPublishers::saveVisitInternal(
     return;
   }
 
+  bool verified = isVerified(publisher_id);
+
   bool new_visit = false;
   if (!publisher_info.get()) {
     new_visit = true;
@@ -267,7 +269,7 @@ void BatPublishers::saveVisitInternal(
     }
   }
   publisher_info->score += concaveScore(duration);
-  publisher_info->verified = isVerified(publisher_info->id);
+  publisher_info->verified = verified;
   publisher_info->reconcile_stamp = ledger_->GetReconcileStamp();
 
   auto media_info = std::make_unique<ledger::PublisherInfo>(*publisher_info);


### PR DESCRIPTION
This one fixes crash for 0.59

```
18:06:21 FAILED: obj/brave/vendor/bat-native-ledger/ledger/bat_publishers.o 
18:06:21 /Users/jenkins/jenkins/workspace/brave-browser-build-darwin/src/brave/script/redirect-cc.py ../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/brave/vendor/bat-native-ledger/ledger/bat_publishers.o.d -DBRAVE_CHROMIUM_BUILD -DV8_DEPRECATION_WARNINGS -DNO_TCMALLOC -DFULL_SAFE_BROWSING -DSAFE_BROWSING_CSD -DSAFE_BROWSING_DB_LOCAL -DOFFICIAL_BUILD -DCHROMIUM_BUILD -DFIELDTRIAL_TESTING_ENABLED -D_LIBCPP_HAS_NO_ALIGNED_ALLOCATION -DCR_XCODE_VERSION=0920 -DCR_CLANG_REVISION=\"346388-5\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORE=0 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DLEVELDB_PLATFORM_CHROMIUM=1 -DLEVELDB_PLATFORM_CHROMIUM=1 -DRELIC_LIBRARY -DARCH=X64 -DALIGN=16 -DOPSYS=MACOSX -DSHLIB=OFF -DALLOC=AUTO -DCOLOR=OFF -DSEED=UDEV -DWITH=\"BN\;DV\;FP\;FPX\;EP\;EPX\;PP\;MD\" -DBN_PRECI=256 -DBN_MAGNI=DOUBLE -DBENCH=100 -DTESTS=0 -DTIMER=NONE -DOVERH=0 -DUSE_NUM_NONE -DUSE_FIELD_10X26 -DUSE_FIELD_INV_BUILTIN -DUSE_SCALAR_8X32 -DUSE_SCALAR_INV_BUILTIN -DENABLE_MODULE_GENERATOR -DENABLE_MODULE_RANGEPROOF -DENABLE_MODULE_ECDH -DENABLE_MODULE_SURJECTIONPROOF -I../../brave/chromium_src -I../.. -Igen -I../../brave/vendor/bat-native-ledger/src -I../../brave/vendor/bat-native-ledger/include -I../../third_party/boringssl/src/include -I../../third_party/leveldatabase -I../../third_party/leveldatabase/src -I../../third_party/leveldatabase/src/include -I../../brave/vendor/bat-native-anonize -I../../brave/vendor/bat-native-anonize/anon/macos_include -I../../brave/vendor/bat-native-anonize/relic/include -I../../brave/vendor/bat-native-anonize/relic/include/low -I../../brave/vendor/bip39wally-core-native/include -I../../brave/vendor/bip39wally-core-native/src/secp256k1/include -I../../brave/vendor/bip39wally-core-native/src/secp256k1/src -I../../brave/vendor/bat-native-tweetnacl -I../../brave/vendor/bat-native-rapidjson/include -fno-strict-aliasing -fstack-protector -fcolor-diagnostics -fmerge-all-constants -Xclang -mllvm -Xclang -instcombine-lower-dbg-declare=0 -no-canonical-prefixes -arch x86_64 -Wall -Werror -Wextra -Wimplicit-fallthrough -Wthread-safety -Wunguarded-availability -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wno-null-pointer-arithmetic -Wno-ignored-pragma-optimize -O2 -fno-omit-frame-pointer -gdwarf-2 -fno-standalone-debug -isysroot ../../../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -fvisibility=hidden -Xclang -load -Xclang ../../third_party/llvm-build/Release+Asserts/lib/libFindBadConstructs.dylib -Xclang -add-plugin -Xclang find-bad-constructs -Xclang -plugin-arg-find-bad-constructs -Xclang enforce-in-thirdparty-webkit -Xclang -plugin-arg-find-bad-constructs -Xclang check-enum-max-value -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -std=c++14 -stdlib=libc++ -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../brave/vendor/bat-native-ledger/src/bat_publishers.cc -o obj/brave/vendor/bat-native-ledger/ledger/bat_publishers.o
18:06:21 ../../brave/vendor/bat-native-ledger/src/bat_publishers.cc:246:7: error: use of undeclared identifier 'verified'
18:06:21   if (verified && fav_icon.length() > 0) {
18:06:21       ^
18:06:21 1 error generated.
```