### PR TITLE
make sure nothing gets interpreted as an extra command when EXTRA_FLA…

### DIFF
--- a/build/mac/sign_app.sh
+++ b/build/mac/sign_app.sh
@@ -14,11 +14,6 @@ MAC_SIGNING_KEYCHAIN="${4}"
 MAC_SIGNING_IDENTIFIER="${5}"
 MAC_PROVISIONING_PROFILE="${6}"
 MAC_ENTITLEMENTS_PLIST="${7}"
-if [[ ${#} -eq 8 ]]; then
-EXTRA_FLAGS="${8}"
-else
-EXTRA_FLAGS=""
-fi
 
 function check_exit() {
     return=$?;
@@ -42,6 +37,11 @@ mkdir -p "$tmpdir"
 
 cp -a "$SOURCE" "$DEST"
 
+if [[ ${#} -eq 8 ]]; then
+EXTRA_FLAGS="${8}"
 "${PKG_DIR}/sign_versioned_dir.sh" "$DEST" "$MAC_SIGNING_KEYCHAIN" "$MAC_SIGNING_IDENTIFIER" "$EXTRA_FLAGS"
-
 "${PKG_DIR}/sign_app.sh" "$DEST" "$MAC_SIGNING_KEYCHAIN" "$MAC_SIGNING_IDENTIFIER" "$MAC_PROVISIONING_PROFILE" "${MAC_ENTITLEMENTS_PLIST}" "$EXTRA_FLAGS"
+else
+"${PKG_DIR}/sign_versioned_dir.sh" "$DEST" "$MAC_SIGNING_KEYCHAIN" "$MAC_SIGNING_IDENTIFIER"
+"${PKG_DIR}/sign_app.sh" "$DEST" "$MAC_SIGNING_KEYCHAIN" "$MAC_SIGNING_IDENTIFIER" "$MAC_PROVISIONING_PROFILE" "${MAC_ENTITLEMENTS_PLIST}"
+fi


### PR DESCRIPTION
…GS is not supplied

maybe fixes https://github.com/brave/brave-browser/issues/2860

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source