### PR TITLE
Fix placeholder string is displayed twice in korean locale.

### DIFF
--- a/app/resources/brave_generated_resources_ko.xtb
+++ b/app/resources/brave_generated_resources_ko.xtb
@@ -4,7 +4,7 @@
 <translation id="3333887201479867589">Brave 리워드</translation>
 <translation id="7942180974165298215">Brave 광고 차단</translation>
 <translation id="6406506848690869874">Brave 동기화</translation>
-<translation id="120759863357279975"><ph name="EXTENSION_NAME">$1</ph> (extension ID "<ph name="EXTENSION_ID">$2<ex>abacabadabacabaeabacabadabacabaf</ex></ph>")은(는) Brave에서 허용되지 않습니다.</translation>
+<translation id="120759863357279975"><ph name="EXTENSION_NAME" /> (extension ID "<ph name="EXTENSION_ID" />")은(는) Brave에서 허용되지 않습니다.</translation>
 <translation id="7450557937477381864">Chrome 닫기</translation>
 <translation id="7008934821596358692">가져오기를 완료하려면 모든 Chrome 창을 닫아야 합니다.</translation>
 <translation id="5735465527556462863">Brave(구버전) 닫기</translation>
@@ -26,9 +26,9 @@
 <translation id="2240268017737062801">사이트가 언제 미디어를  자동재생하기를 원하는지 묻기</translation>
 <translation id="3371702087847741961">사이트가 언제 미디어를 자동재생하기를 원하는지 묻기(권장함)</translation>
 <translation id="3218385319396786393">이 페이지에서는 자동 재생이 차단되었습니다</translation>
-<translation id="4988333904713528597"><ph name="HOST">$1<ex>mail.google.com</ex></ph>에서 자동 재생 항상 허용하기</translation>
+<translation id="4988333904713528597"><ph name="HOST" />에서 자동 재생 항상 허용하기</translation>
 <translation id="4150684676757176434">계속해서 자동 재생 차단</translation>
-<translation id="7543906827780734027">Brave는 이 연장을 아직 검토하지 않았습니다 - 유언비어일 수도 있습니다. 그래도 "<ph name="EXTENSION_NAME">$1<ex>Gmail Checker</ex></ph>"을/를 추가할까요?</translation>
+<translation id="7543906827780734027">Brave는 이 연장을 아직 검토하지 않았습니다 - 유언비어일 수도 있습니다. 그래도 "<ph name="EXTENSION_NAME" />"을/를 추가할까요?</translation>
 <translation id="2044383478723007273">Brave 색상</translation>
 <translation id="5341901626640816374">넓은 위치 표시줄 사용</translation>
 <translation id="7965178729203412357">새로운 Tor 계정</translation>


### PR DESCRIPTION
This is fixed by removing <ex> tag in <ph>.
I'm not sure why this fixes.
When I checks upstream XX_ko.xtb files, it also doesn't use <ex> tag.

Fix https://github.com/brave/brave-browser/issues/2868

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. set locale to korean
2. trying to install any extensions from chrome web store
3. check extension name is not displayed twice

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source