### PR TITLE
Issue 2799: Fix tab crash while resizing the devtools window.

### DIFF
--- a/renderer/brave_content_settings_observer_helper.h
+++ b/renderer/brave_content_settings_observer_helper.h
@@ -12,7 +12,9 @@
 #include "third_party/blink/renderer/platform/bindings/script_state.h"
 
 static bool AllowFingerprinting(blink::LocalFrame* frame) {
-  if (!frame) return true;
+  if (!frame || !frame->GetContentSettingsClient()) {
+    return true;
+  }
   return frame->GetContentSettingsClient()->AllowFingerprinting(true);
 }
 


### PR DESCRIPTION
FrameContentClient of a given frame can obviously be null, lets check it.

Fix https://github.com/brave/brave-browser/issues/2799

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source