### PR TITLE
Enables Ads on rewards opt-in via panel and welcome page

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -11,6 +11,8 @@
 #include "brave/common/extensions/api/brave_rewards.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
 #include "brave/components/brave_rewards/browser/rewards_service_factory.h"
+#include "brave/components/brave_ads/browser/ads_service.h"
+#include "brave/components/brave_ads/browser/ads_service_factory.h"
 #include "content/public/browser/web_contents.h"
 #include "chrome/browser/extensions/api/tabs/tabs_constants.h"
 #include "chrome/browser/extensions/extension_tab_util.h"
@@ -18,6 +20,8 @@
 
 using brave_rewards::RewardsService;
 using brave_rewards::RewardsServiceFactory;
+using brave_ads::AdsService;
+using brave_ads::AdsServiceFactory;
 
 namespace extensions {
 namespace api {
@@ -218,6 +222,21 @@ void BraveRewardsGetRewardsMainEnabledFunction::OnGetRewardsMainEnabled(
   Respond(OneArgument(std::make_unique<base::Value>(enabled)));
 }
 
+BraveRewardsSaveAdsSettingFunction::~BraveRewardsSaveAdsSettingFunction() {
+}
+
+ExtensionFunction::ResponseAction BraveRewardsSaveAdsSettingFunction::Run() {
+  std::unique_ptr<brave_rewards::SaveAdsSetting::Params> params(
+      brave_rewards::SaveAdsSetting::Params::Create(*args_));
+  Profile* profile = Profile::FromBrowserContext(browser_context());
+  AdsService* ads_service_ = AdsServiceFactory::GetForProfile(profile);
+  if (ads_service_) {
+    if (params->key == "adsEnabled") {
+      ads_service_->set_ads_enabled(params->value == "true");
+    }
+  }
+  return RespondNow(NoArguments());
+}
 
 }  // namespace api
 }  // namespace extensions

--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -127,6 +127,16 @@ class BraveRewardsGetRewardsMainEnabledFunction : public UIThreadExtensionFuncti
   void OnGetRewardsMainEnabled(bool enabled);
 };
 
+class BraveRewardsSaveAdsSettingFunction : public UIThreadExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("braveRewards.saveAdsSetting", UNKNOWN)
+
+ protected:
+  ~BraveRewardsSaveAdsSettingFunction() override;
+
+  ResponseAction Run() override;
+};
+
 }  // namespace api
 }  // namespace extensions
 

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -351,6 +351,21 @@
             ]
           }
         ]
+      },
+      {
+        "name": "saveAdsSetting",
+        "type": "function",
+        "description": "Updates settings related to ads service.",
+        "parameters": [
+          {
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
       }
     ]
   }

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -41,6 +41,7 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
     case types.ON_WALLET_CREATED:
       state = { ...state }
       state.walletCreated = true
+      chrome.braveRewards.saveAdsSetting('adsEnabled', 'true')
       chrome.storage.local.get(['is_dismissed'], function (result) {
         if (result && result['is_dismissed'] === 'false') {
           chrome.browserAction.setBadgeText({

--- a/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
+++ b/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
@@ -17,6 +17,7 @@ const createWallet = (state: Rewards.State) => {
 
   chrome.send('brave_rewards.getReconcileStamp')
   chrome.send('brave_rewards.getAddresses')
+  chrome.send('brave_rewards.saveAdsSetting', ['adsEnabled', 'true'])
 
   return state
 }

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -49,6 +49,7 @@ declare namespace chrome.braveRewards {
     addListener: (callback: (enabledMain: boolean) => void) => void
   }
   const getRewardsMainEnabled: (callback: (enabled: boolean) => void) => {}
+  const saveAdsSetting: (key: string, value: string) => {}
 }
 
 declare namespace chrome.rewardsNotifications {


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2877

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Run Brave from this PR with a clean profile
2. Navigate to `brave://rewards`, create wallet via the welcome page
3. Once the Rewards Settings page loads, confirm via the UI and console logs that Ads is fired up
4. Stop Brave, remove profile and run again
5. Enable Rewards via the panel
6. Navigate to `brave://rewards` and repeat step 3

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source