### PR TITLE
Fixes crash reporting not working on Windows 7.

### DIFF
--- a/chromium_src/third_party/crashpad/crashpad/util/net/http_transport_win.cc
+++ b/chromium_src/third_party/crashpad/crashpad/util/net/http_transport_win.cc
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <windows.h>
+#include <versionhelpers.h>
+#include <winhttp.h>
+
+#include "base/logging.h"
+
+// Forward declaration.
+namespace crashpad {
+namespace {
+std::string WinHttpMessage(const char* extra);
+}
+}
+
+namespace {
+
+void BraveSetSessionOptions(HINTERNET hSession) {
+  // Windows 8.1+ already have TLS 1.1 and 1.2 available by default.
+  if (IsWindows8Point1OrGreater())
+    return;
+
+  // Use TLS 1.0, 1.1, or 1.2.
+  unsigned long secure_protocols = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1 |
+                                   WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_1 |
+                                   WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
+
+  // Set protocols and log an error if we can't. Bailing out on the session due
+  // to an error here is not necessary since if TLS 1.1 or 1.2 is required to
+  // connect then the connection will fail anyway.
+  if (!WinHttpSetOption(hSession, WINHTTP_OPTION_SECURE_PROTOCOLS,
+                        &secure_protocols, sizeof(secure_protocols))) {
+    LOG(ERROR) << crashpad::WinHttpMessage("WinHttpSetOption");
+  }
+}
+
+}  // namespace
+
+// The original file is patched to call the above function.
+#include "../../../../../../../third_party/crashpad/crashpad/util/net/http_transport_win.cc"
+

--- a/patches/third_party-crashpad-crashpad-util-net-http_transport_win.cc.patch
+++ b/patches/third_party-crashpad-crashpad-util-net-http_transport_win.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/crashpad/crashpad/util/net/http_transport_win.cc b/third_party/crashpad/crashpad/util/net/http_transport_win.cc
+index 2919bc11d0ba4bf84a11e146bf2961b830db35fe..56811eb3e2879e76404c836e6791f8c0ed317595 100644
+--- a/third_party/crashpad/crashpad/util/net/http_transport_win.cc
++++ b/third_party/crashpad/crashpad/util/net/http_transport_win.cc
+@@ -153,6 +153,8 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
+     return false;
+   }
+ 
++  BraveSetSessionOptions(session.get());
++
+   int timeout_in_ms = static_cast<int>(timeout() * 1000);
+   if (!WinHttpSetTimeouts(session.get(),
+                           timeout_in_ms,


### PR DESCRIPTION
Gives crashpad an option to use TLS 1.1 and 1.2 on Windows 7 and 8.0
in addition to TLS 1.0 used by WinHttp by default.

Fixes brave/brave-browser#1188

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Test on Windows 7 SP1 or on Windows 8;
2. Start Brave browser with a fresh profile;
3. Navigate to brave://settings, click on Advanced, then toggle `Automatically send crash reports to Brave` in the `Privacy and security` section to ON and click the `Relaunch` button that should have appeared next to the toggle;
4. Wait for the browser to relaunch;
5. Navigate to brave://crashe**s** and verify that there are no crashes in the list;
6. Open a new tab, in it navigate to brave://crash and wait for the "Aw, snap!" message on the page;
7. Go back to the brave://crashe**s** tab and reload it;
8. Verify an entry on the page that indicates that the crash was uploaded (Uploaded Crash Report ID xxxxxxxxxx, as opposed to just Local Crash ID).

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [x] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source