### PR TITLE
Fix some webui that doesn't allowed in private window is loaded in private window

### DIFF
--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -1,8 +1,28 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/renderer_host/brave_navigation_ui_data.h"
+#include "brave/common/webui_url_constants.h"
+#include "chrome/common/webui_url_constants.h"
+#include "url/gurl.h"
+
+namespace {
+bool IsHostAllowedInIncognitoBraveImpl(std::string* scheme,
+                                       const base::StringPiece& host) {
+  if (*scheme == "brave")
+    *scheme = content::kChromeUIScheme;
+
+  if (host == kRewardsHost ||
+      host == kBraveUISyncHost ||
+      host == chrome::kChromeUISyncInternalsHost) {
+    return false;
+  }
+
+  return true;
+}
+}
 
 #define ChromeNavigationUIData BraveNavigationUIData
 #include "../../../../chrome/browser/ui/browser_navigator.cc"

--- a/patches/chrome-browser-ui-browser_navigator.cc.patch
+++ b/patches/chrome-browser-ui-browser_navigator.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/ui/browser_navigator.cc b/chrome/browser/ui/browser_navigator.cc
+index 57cc96c276c1106079828b5e359a3d88e1c901ce..32d1e9d68577760d78345630204b30ae0bb1bfca 100644
+--- a/chrome/browser/ui/browser_navigator.cc
++++ b/chrome/browser/ui/browser_navigator.cc
+@@ -700,6 +700,9 @@ void Navigate(NavigateParams* params) {
+ bool IsHostAllowedInIncognito(const GURL& url) {
+   std::string scheme = url.scheme();
+   base::StringPiece host = url.host_piece();
++#if defined(BRAVE_CHROMIUM_BUILD)
++  if (!IsHostAllowedInIncognitoBraveImpl(&scheme, host)) return false;
++#endif
+   if (scheme == chrome::kChromeSearchScheme) {
+     return host != chrome::kChromeUIThumbnailHost &&
+            host != chrome::kChromeUIThumbnailHost2 &&


### PR DESCRIPTION
Some webui should not be loaded in private window.
Instead, they should be redirected to normal window.
This also fixes crash when user tries to load sync page in private window.
Sync page will be also redirected to normal window.

Fix https://github.com/brave/brave-browser/issues/2853
Fix https://github.com/brave/brave-browser/issues/2852

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`BraveSchemeLoadBrowserTest.*PageIsNotAllowedInPrivateWindow`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source