### PR TITLE
Remove redundant GetSSID from Ads 0.59.x

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ deps = {
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
   "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@56a0fe1510a31f7b26710ff7409f0ab79a67db4d",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@7e391cec6975106fa9f686016f494cb8a782afcd",
-  "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@96e452545aa49b410a0f96fd264db8d8820e145b",
+  "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@fd6d9859a8327975aec0c11091066b0d3387bf4f",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
 }
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -816,26 +816,6 @@ const std::string AdsServiceImpl::GenerateUUID() const {
   return base::GenerateGUID();
 }
 
-const std::string AdsServiceImpl::GetSSID() const {
-    std::string ssid;
-#if defined(OS_WIN) || defined(OS_MACOSX)
-  std::unique_ptr<wifi::WiFiService> wifi_service(wifi::WiFiService::Create());
-  wifi_service->Initialize(nullptr);
-  std::string error;
-  wifi_service->GetConnectedNetworkSSID(&ssid, &error);
-  if (!error.empty())
-    return std::string();
-#elif defined(OS_LINUX)
-  ssid = net::GetWifiSSID();
-#elif defined(OS_ANDROID)
-  ssid = net::android::GetWifiSSID();
-#endif
-  // TODO: Handle non UTF8 SSIDs.
-  if (!base::IsStringUTF8(ssid))
-    return std::string();
-  return ssid;
-}
-
 const std::vector<std::string> AdsServiceImpl::GetLocales() const {
   std::vector<std::string> locales;
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -102,7 +102,6 @@ class AdsServiceImpl : public AdsService,
   void GetClientInfo(ads::ClientInfo* info) const override;
   const std::vector<std::string> GetLocales() const override;
   const std::string GenerateUUID() const override;
-  const std::string GetSSID() const override;
   void ShowNotification(
       std::unique_ptr<ads::NotificationInfo> info) override;
   uint32_t SetTimer(const uint64_t time_offset) override;

--- a/components/services/bat_ads/bat_ads_client_mojo_bridge.cc
+++ b/components/services/bat_ads/bat_ads_client_mojo_bridge.cc
@@ -139,15 +139,6 @@ const std::string BatAdsClientMojoBridge::GenerateUUID() const {
   return uuid;
 }
 
-const std::string BatAdsClientMojoBridge::GetSSID() const {
-  if (!connected())
-    return "";
-
-  std::string ssid;
-  bat_ads_client_->GetSSID(&ssid);
-  return ssid;
-}
-
 void BatAdsClientMojoBridge::ShowNotification(
     std::unique_ptr<ads::NotificationInfo> info) {
   if (!connected())

--- a/components/services/bat_ads/bat_ads_client_mojo_bridge.h
+++ b/components/services/bat_ads/bat_ads_client_mojo_bridge.h
@@ -28,7 +28,6 @@ class BatAdsClientMojoBridge : public ads::AdsClient {
   void GetClientInfo(ads::ClientInfo* info) const override;
   const std::vector<std::string> GetLocales() const override;
   const std::string GenerateUUID() const override;
-  const std::string GetSSID() const override;
   void ShowNotification(
       std::unique_ptr<ads::NotificationInfo> info) override;
   uint32_t SetTimer(const uint64_t time_offset) override;

--- a/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.cc
+++ b/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.cc
@@ -105,15 +105,6 @@ void AdsClientMojoBridge::GenerateUUID(GenerateUUIDCallback callback) {
   std::move(callback).Run(ads_client_->GenerateUUID());
 }
 
-bool AdsClientMojoBridge::GetSSID(std::string* out_ssid) {
-  *out_ssid = ads_client_->GetSSID();
-  return true;
-}
-
-void AdsClientMojoBridge::GetSSID(GetSSIDCallback callback) {
-  std::move(callback).Run(ads_client_->GetSSID());
-}
-
 bool AdsClientMojoBridge::IsNotificationsAvailable(bool* out_available) {
   *out_available = ads_client_->IsNotificationsAvailable();
   return true;

--- a/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.h
+++ b/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.h
@@ -39,8 +39,6 @@ class AdsClientMojoBridge : public mojom::BatAdsClient,
       IsNetworkConnectionAvailableCallback callback) override;
   bool GenerateUUID(std::string* out_uuid) override;
   void GenerateUUID(GenerateUUIDCallback callback) override;
-  bool GetSSID(std::string* out_ssid) override;
-  void GetSSID(GetSSIDCallback callback) override;
   bool IsNotificationsAvailable(bool* out_available) override;
   void IsNotificationsAvailable(
       IsNotificationsAvailableCallback callback) override;

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -28,8 +28,6 @@ interface BatAdsClient {
   [Sync]
   GenerateUUID() => (string uuid);
   [Sync]
-  GetSSID() => (string ssid);
-  [Sync]
   IsNotificationsAvailable() => (bool available);
   [Sync]
   SetTimer(uint64 time_offset) => (uint32 timer_id);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2923
this is an uplift request for https://github.com/brave/brave-core/pull/1298
