### PR TITLE
Make Cargo download check more reliable 0.61.x

### DIFF
--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -15,7 +15,8 @@ import deps
 from rust_deps_config import RUST_DEPS_PACKAGES_URL, RUST_DEPS_PACKAGE_VERSION
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-RUSTUP_DIR = os.path.join(SOURCE_ROOT, 'build', 'rustup', RUST_DEPS_PACKAGE_VERSION)
+RUSTUP_DIR = os.path.join(SOURCE_ROOT, 'build', 'rustup')
+RUST_DEPS_DIR = os.path.join(RUSTUP_DIR, RUST_DEPS_PACKAGE_VERSION)
 
 
 def GetUrl(platform):
@@ -34,7 +35,7 @@ def GetUrl(platform):
 
 
 def AlreadyUpToDate():
-    if not os.path.exists(RUSTUP_DIR):
+    if not os.path.exists(RUST_DEPS_DIR):
         return False
 
     return True
@@ -49,7 +50,7 @@ def DownloadAndUnpackRustDeps(platform):
     try:
         deps.DownloadAndUnpack(url, RUSTUP_DIR)
     except urllib2.URLError:
-        print 'Failed to download Rust deps %s' % rust_deps_url
+        print 'Failed to download Rust deps %s' % url
         print 'Exiting.'
         sys.exit(1)
 

--- a/script/rust_deps_config.py
+++ b/script/rust_deps_config.py
@@ -5,4 +5,4 @@
 
 # Version number and URL for pre-configured rust dependency package, e.g. rust_deps_mac_0.1.0.gz
 RUST_DEPS_PACKAGES_URL = "https://s3-us-west-2.amazonaws.com/rust-pkg-brave-core"
-RUST_DEPS_PACKAGE_VERSION = "0.1.0"
+RUST_DEPS_PACKAGE_VERSION = "0.1.1"


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2925

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source