### PR TITLE
Upgrade from Chromium 72.0.3626.28 to 72.0.3626.53 

### DIFF
--- a/app/settings_strings.grdp
+++ b/app/settings_strings.grdp
@@ -3590,6 +3590,9 @@
     <message name="IDS_SETTINGS_SYNC_WILL_START" desc="The message to tell users that sync will start once they leave the sync setup page.">
       Sync will start once you leave this page
     </message>
+    <message name="IDS_SETTINGS_SYNC_WILL_START_UNITY" desc="The message to tell users that sync will start once they leave the sync setup page when unified consent is enabled.">
+      Sync will start once you leave sync settings
+    </message>
     <message name="IDS_SETTINGS_SYNC_SETTINGS_CANCEL_SYNC" desc="The label of button that allows user to cancel sync.">
       Cancel sync
     </message>

--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,11 +1,11 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index 9c67f2c949285ed02aa16e176d4719b9849841c7..bc23412c2654aa5f32004b78a78204acb3acb3ee 100644
+index e303dbbc9c1d5b75bea7374bbc4c2fc43a55996e..bc23412c2654aa5f32004b78a78204acb3acb3ee 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@
  MAJOR=72
  MINOR=0
 -BUILD=3626
--PATCH=28
+-PATCH=53
 +BUILD=59
 +PATCH=21

--- a/patches/chrome-browser-media-webrtc-webrtc_log_uploader.cc.patch
+++ b/patches/chrome-browser-media-webrtc-webrtc_log_uploader.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/media/webrtc/webrtc_log_uploader.cc b/chrome/browser/media/webrtc/webrtc_log_uploader.cc
-index a892aa2d548f291f05c703787eafcbf98084ba8c..07c3aad9ec9fd04e4f9d7004523bf744ccb8cb1a 100644
+index 0b1436923d72995593da289f9f552472acfb4fd0..137ea8f0c5929cc585a8d29de86a7a474ee063c2 100644
 --- a/chrome/browser/media/webrtc/webrtc_log_uploader.cc
 +++ b/chrome/browser/media/webrtc/webrtc_log_uploader.cc
-@@ -472,6 +472,7 @@ void WebRtcLogUploader::ResizeForNextOutput(std::string* compressed_log,
+@@ -476,6 +476,7 @@ void WebRtcLogUploader::ResizeForNextOutput(std::string* compressed_log,
  void WebRtcLogUploader::UploadCompressedLog(
      const WebRtcLogUploadDoneData& upload_done_data,
      std::unique_ptr<std::string> post_data) {

--- a/patches/chrome-browser-profiles-profile_io_data.cc.patch
+++ b/patches/chrome-browser-profiles-profile_io_data.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/profiles/profile_io_data.cc b/chrome/browser/profiles/profile_io_data.cc
-index 5664ba395badcea25fdbb33a274b522747b7b2cf..b14d6e5150c2bab6c15acaf164cd4b4ad139122c 100644
+index d2ae5365fa439f06603226e096b3a19d7778ccc4..d615044b0a7b54af64ddacab2fd93b46adda14ef 100644
 --- a/chrome/browser/profiles/profile_io_data.cc
 +++ b/chrome/browser/profiles/profile_io_data.cc
 @@ -25,6 +25,7 @@
@@ -10,7 +10,7 @@ index 5664ba395badcea25fdbb33a274b522747b7b2cf..b14d6e5150c2bab6c15acaf164cd4b4a
  #include "build/build_config.h"
  #include "chrome/browser/browser_process.h"
  #include "chrome/browser/chrome_notification_types.h"
-@@ -657,6 +658,9 @@ bool ProfileIOData::IsHandledProtocol(const std::string& scheme) {
+@@ -660,6 +661,9 @@ bool ProfileIOData::IsHandledProtocol(const std::string& scheme) {
      extensions::kExtensionScheme,
  #endif
      content::kChromeUIScheme,
@@ -20,7 +20,7 @@ index 5664ba395badcea25fdbb33a274b522747b7b2cf..b14d6e5150c2bab6c15acaf164cd4b4a
      url::kDataScheme,
  #if defined(OS_CHROMEOS)
      content::kExternalFileScheme,
-@@ -966,7 +970,7 @@ void ProfileIOData::Init(
+@@ -969,7 +973,7 @@ void ProfileIOData::Init(
          std::make_unique<network::URLRequestContextBuilderMojo>();
  
      std::unique_ptr<ChromeNetworkDelegate> chrome_network_delegate(

--- a/patches/chrome-browser-resources-settings-people_page-people_page.html.patch
+++ b/patches/chrome-browser-resources-settings-people_page-people_page.html.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/resources/settings/people_page/people_page.html b/chrome/browser/resources/settings/people_page/people_page.html
-index ccbbfb55030cea37ff8a4d8e26901dd5d531c35c..c5a371f731c9f99615bafa2ae26e0ce6ce96e8fd 100644
+index 118ab0e242757ed83b114674328efc9222da94b3..dd812ba337339b304c0f0f6ab5f25a74f8a9bd62 100644
 --- a/chrome/browser/resources/settings/people_page/people_page.html
 +++ b/chrome/browser/resources/settings/people_page/people_page.html
 @@ -173,6 +173,7 @@

--- a/patches/chrome-browser-ui-webui-settings-md_settings_localized_strings_provider.cc.patch
+++ b/patches/chrome-browser-ui-webui-settings-md_settings_localized_strings_provider.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc b/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
-index 3b7bc8ed32d188b30471e5ac888c31cdc449786a..b522c39a3fb1810c0df07de085a1c0b8e7f4d72e 100644
+index ab6b01e39cf0d930f61638ba55ba7e988291326f..167ba4f015c10be03d6795e0be8cdd52bb973a2e 100644
 --- a/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/md_settings_localized_strings_provider.cc
-@@ -2794,6 +2794,7 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source,
+@@ -2796,6 +2796,7 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source,
  #endif
    policy_indicator::AddLocalizedStrings(html_source);
  

--- a/patches/third_party-blink-renderer-modules-peerconnection-rtc_peer_connection.cc.patch
+++ b/patches/third_party-blink-renderer-modules-peerconnection-rtc_peer_connection.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
-index 7fc27898124c9ddcf992c232bbfbdf8a8aed8267..53ccedb086e498004079cca2b8a14e8ff41875c0 100644
+index e21602e3d2adebaf675841cc941a583d82d97543..1951ac0585808fea9c049ae490b23ad02e6242d7 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
 @@ -38,6 +38,7 @@

--- a/patches/third_party-blink-renderer-modules-webgl-webgl_rendering_context_base.cc.patch
+++ b/patches/third_party-blink-renderer-modules-webgl-webgl_rendering_context_base.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
-index 53ccbf3ba38282c861e9780459a2d20fc5b41f68..4cd5554e8071627380c7ecee2c7e53c059058e78 100644
+index 9fd9c417aa781335f34465da5974b203e84a0a25..9a16bc2a306002806304c11d10db5a53cfae28de 100644
 --- a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
 +++ b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
 @@ -28,6 +28,7 @@


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2932
Uplift request for: https://github.com/brave/brave-core/pull/1314 (but excludes 1 commit relating to Rust which is not in 0.59.x)
Must be merged with https://github.com/brave/brave-browser/pull/2935
