### PR TITLE
Use brave downloads url in outdated update install dialog

### DIFF
--- a/patches/chrome-browser-ui-views-outdated_upgrade_bubble_view.cc.patch
+++ b/patches/chrome-browser-ui-views-outdated_upgrade_bubble_view.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc b/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
+index f5d3be5bc95769b682080c53c7be08cb9ab2dfe2..0a6e86850cb40767b093f399c4eb717ec051c544 100644
+--- a/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
++++ b/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
+@@ -31,8 +31,12 @@ namespace {
+ 
+ // The URL to be used to re-install Chrome when auto-update failed for too long.
+ constexpr char kDownloadChromeUrl[] =
++#if defined(BRAVE_CHROMIUM_BUILD)
++    "https://www.brave.com/download";
++#else
+     "https://www.google.com/chrome/?&brand=CHWL"
+     "&utm_campaign=en&utm_source=en-et-na-us-chrome-bubble&utm_medium=et";
++#endif
+ 
+ // The maximum number of ignored bubble we track in the NumLaterPerReinstall
+ // histogram.


### PR DESCRIPTION
When user tries to install via outdated update dialog, brave install
page should be visible.

Fix https://github.com/brave/brave-browser/issues/2942

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
See STR in https://github.com/brave/brave-browser/issues/2942

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source