### PR TITLE
Update DEPS for Omaha to fix stats ping when downloading/running stub

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
-  "vendor/omaha":  "https://github.com/brave/omaha.git@079c2f24e51c25da80abce4aaea7d1b6d533483c",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@8df5e4b07bf37a9f48eedc9df0c15b615cb889b3",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",


### PR DESCRIPTION
Fix brave/brave-browser#2917
Uplift request from #1330

Update DEPS for Omaha to fix stats ping when downloading/running stub installer.