### PR TITLE
Maintains Ads UI preference

### DIFF
--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -18,9 +18,11 @@ class AdsService : public KeyedService {
   AdsService() = default;
 
   virtual bool is_enabled() const = 0;
+  virtual bool is_ui_enabled() const = 0;
   virtual uint64_t ads_per_hour() const = 0;
 
   virtual void set_ads_enabled(bool enabled) = 0;
+  virtual void set_ads_ui_enabled(bool enabled) = 0;
   virtual void set_ads_per_hour(int ads_per_hour) = 0;
 
   // ads::Ads proxy

--- a/components/brave_ads/browser/ads_service_factory.cc
+++ b/components/brave_ads/browser/ads_service_factory.cc
@@ -75,6 +75,7 @@ bool AdsServiceFactory::ServiceIsNULLWhileTesting() const {
 void AdsServiceFactory::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(prefs::kBraveAdsEnabled, false);
+  registry->RegisterBooleanPref(prefs::kBraveAdsUIEnabled, false);
   registry->RegisterUint64Pref(prefs::kBraveAdsPerHour, 2);
   registry->RegisterUint64Pref(prefs::kBraveAdsPerDay, 6);
   registry->RegisterIntegerPref(prefs::kBraveAdsIdleThreshold, 15);

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -444,12 +444,20 @@ bool AdsServiceImpl::is_enabled() const {
   return profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
 }
 
+bool AdsServiceImpl::is_ui_enabled() const {
+  return profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsUIEnabled);
+}
+
 bool AdsServiceImpl::IsAdsEnabled() const {
   return is_enabled();
 }
 
 void AdsServiceImpl::set_ads_enabled(bool enabled) {
   profile_->GetPrefs()->SetBoolean(prefs::kBraveAdsEnabled, enabled);
+}
+
+void AdsServiceImpl::set_ads_ui_enabled(bool enabled) {
+  profile_->GetPrefs()->SetBoolean(prefs::kBraveAdsUIEnabled, enabled);
 }
 
 void AdsServiceImpl::set_ads_per_hour(int ads_per_hour) {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -52,9 +52,11 @@ class AdsServiceImpl : public AdsService,
 
   // AdsService implementation
   bool is_enabled() const override;
+  bool is_ui_enabled() const override;
   uint64_t ads_per_hour() const override;
 
   void set_ads_enabled(bool enabled) override;
+  void set_ads_ui_enabled(bool enabled) override;
   void set_ads_per_hour(int ads_per_hour) override;
 
   void TabUpdated(

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -8,6 +8,7 @@ namespace brave_ads {
 namespace prefs {
 
 const char kBraveAdsEnabled[] = "brave.brave_ads.enabled";
+const char kBraveAdsUIEnabled[] = "brave.brave_ads_ui_enabled";
 const char kBraveAdsPerHour[] = "brave.brave_ads.ads_per_hour";
 const char kBraveAdsPerDay[] = "brave.brave_ads.ads_per_day";
 const char kBraveAdsIdleThreshold[] = "brave.brave_ads.idle_threshold";

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -9,6 +9,7 @@ namespace brave_ads {
 namespace prefs {
 
 extern const char kBraveAdsEnabled[];
+extern const char kBraveAdsUIEnabled[];
 extern const char kBraveAdsPerHour[];
 extern const char kBraveAdsPerDay[];
 extern const char kBraveAdsIdleThreshold[];


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2888

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Launch from clean profile and enable Brave Rewards
2. From `brave://rewards`, disable Ads via the settings box
3. Disable Rewards from the main toggle
4. Re-enable Rewards from the main toggle
5. Confirm that Ads does not re-enable and ad service is shut down
6. Enable Ads
7. Disable Rewards from the main toggle
8. Re-enable Rewards from the main toggle
9. Confirm that Ads comes back on in UI and ad service is started

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source