### PR TITLE
Autocomplete to chrome://sync and not chrome://sync-internals

### DIFF
--- a/browser/autocomplete/brave_autocomplete_provider_client.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client.cc
@@ -4,8 +4,11 @@
 
 #include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
 
+#include "base/strings/utf_string_conversions.h"
+#include "brave/common/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/common/webui_url_constants.h"
 
 BraveAutocompleteProviderClient::BraveAutocompleteProviderClient(
     Profile* profile)
@@ -23,4 +26,16 @@ TemplateURLService* BraveAutocompleteProviderClient::GetTemplateURLService() {
 const TemplateURLService*
 BraveAutocompleteProviderClient::GetTemplateURLService() const {
   return TemplateURLServiceFactory::GetForProfile(profile_);
+}
+
+std::vector<base::string16> BraveAutocompleteProviderClient::GetBuiltinURLs() {
+  std::vector<base::string16> v =
+      ChromeAutocompleteProviderClient::GetBuiltinURLs();
+  auto it = std::find(v.begin(), v.end(),
+      base::ASCIIToUTF16(chrome::kChromeUISyncInternalsHost));
+  DCHECK(it != v.end());
+  if (it != v.end()) {
+    *it = base::ASCIIToUTF16(kBraveUISyncHost);
+  }
+  return v;
 }

--- a/browser/autocomplete/brave_autocomplete_provider_client.h
+++ b/browser/autocomplete/brave_autocomplete_provider_client.h
@@ -33,6 +33,7 @@ class BraveAutocompleteProviderClient
 
   TemplateURLService* GetTemplateURLService() override;
   const TemplateURLService* GetTemplateURLService() const override;
+  std::vector<base::string16> GetBuiltinURLs() override;
 
  private:
   Profile* profile_;

--- a/browser/autocomplete/brave_autocomplete_provider_client_unittest.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client_unittest.cc
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+
+#include "base/strings/utf_string_conversions.h"
+#include "brave/common/webui_url_constants.h"
+#include "chrome/common/webui_url_constants.h"
+#include "chrome/test/base/testing_profile.h"
+#include "content/public/test/fake_service_worker_context.h"
+#include "content/public/test/test_browser_thread_bundle.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class BraveAutocompleteProviderClientUnitTest : public testing::Test {
+ public:
+  void SetUp() override {
+    profile_ = std::make_unique<TestingProfile>();
+    client_ =
+        std::make_unique<BraveAutocompleteProviderClient>(profile_.get());
+  }
+
+  bool BuiltinExists(const base::string16& builtin) {
+    std::vector<base::string16> v = client_->GetBuiltinURLs();
+    auto it = std::find(v.begin(), v.end(), builtin);
+    return it != v.end();
+  }
+
+ protected:
+  content::TestBrowserThreadBundle test_browser_thread_bundle_;
+  std::unique_ptr<TestingProfile> profile_;
+  std::unique_ptr<BraveAutocompleteProviderClient> client_;
+};
+
+TEST_F(BraveAutocompleteProviderClientUnitTest,
+       SyncURLSuggestedNotSyncInternal) {
+  ASSERT_FALSE(BuiltinExists(base::ASCIIToUTF16(chrome::kChromeUISyncInternalsHost)));
+  ASSERT_TRUE(BuiltinExists(base::ASCIIToUTF16(kBraveUISyncHost)));
+}

--- a/chromium_src/chrome/browser/ui/omnibox/chrome_omnibox_client.cc
+++ b/chromium_src/chrome/browser/ui/omnibox/chrome_omnibox_client.cc
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+
+#define ChromeAutocompleteProviderClient BraveAutocompleteProviderClient
+#include "../../../../../../chrome/browser/ui/omnibox/chrome_omnibox_client.cc"
+#undef ChromeAutocompleteProviderClient
+

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -29,6 +29,7 @@ static_library("brave_test_support_unit") {
 
 test("brave_unit_tests") {
   sources = [
+    "//brave/browser/autocomplete/brave_autocomplete_provider_client_unittest.cc",
     "//brave/browser/autoplay/autoplay_permission_context_unittest.cc",
     "//brave/browser/brave_resources_util_unittest.cc",
     "//brave/browser/brave_stats_updater_unittest.cc",


### PR DESCRIPTION
Uplift request for: https://github.com/brave/brave-core/pull/1341
Fix brave/brave-browser#2603