### PR TITLE
Merge pull request #1188 from brave/sync_frequent_initial_update

### DIFF
--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -33,6 +33,7 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSyncReadyNewToSync);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnGetExistingObjects);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, BackgroundSyncStarted);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, BackgroundSyncStopped);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, LoopDelayVaries);
 
 class BraveSyncServiceTest;
 
@@ -110,6 +111,7 @@ class BraveSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnGetExistingObjects);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, BackgroundSyncStarted);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, BackgroundSyncStopped);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, LoopDelayVaries);
   friend class ::BraveSyncServiceTest;
 
   // SyncMessageHandler overrides
@@ -157,10 +159,11 @@ class BraveSyncServiceImpl
     const std::string& deviceId,
     const std::string& objectId);
 
-  void StartLoop();
+  void StartLoop(const bool use_initial_update_interval);
   void StopLoop();
   void LoopProc();
   void LoopProcThreadAligned();
+  base::TimeDelta GetLoopDelay() const;  // For tests only
 
   void GetExistingHistoryObjects(
     const RecordsList &records,

--- a/components/brave_sync/sync_devices.h
+++ b/components/brave_sync/sync_devices.h
@@ -43,6 +43,7 @@ public:
    std::unique_ptr<base::Value> ToValueArrOnly() const;
    std::string ToJson() const;
    size_t size() const { return devices_.size(); }
+   bool has_second_device() const { return size() >= 2; }
    void FromJson(const std::string &str_json);
    void Merge(const SyncDevice& device, int action, bool* actually_merged);
 


### PR DESCRIPTION
Update devices each 1 second until chain is not created

Fixes https://github.com/brave/brave-browser/issues/2742 .
Fixes https://github.com/brave/brave-browser/issues/2782 .

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. On Device1 go to chrome://sync/
2. Press "Start new chain" => "Computer" => "Copy code"
3. On device 2 go to chrome://sync/
4. "Enter sync chain code" button
5. Paste the code
6. "Confirm sync code" button
7. Device1 gets created a sync chain not so late (<5 sec) after Device2


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source