### PR TITLE
Make brave download url to variable

### DIFF
--- a/chromium_src/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/common/url_constants.h"  // for kDownloadBraveUrl
+
+#include "../../../../../../chrome/browser/ui/views/outdated_upgrade_bubble_view.cc"

--- a/common/url_constants.h
+++ b/common/url_constants.h
@@ -11,4 +11,11 @@ extern const char kMagnetScheme[];
 extern const char kWidevineMoreInfoURL[];
 extern const char kWidevineTOS[];
 
+// This is introduced to replace |kDownloadChromeUrl| in
+// outdated_upgrade_bubble_view.cc"
+// |kDownloadChromeUrl| couldn't be replaced with char array because array
+// should be initialized with initialize list or string literal.
+// So, this macro is used.
+#define kDownloadBraveUrl "https://www.brave.com/download"
+
 #endif  // BRAVE_COMMON_URL_CONSTANTS_H_

--- a/patches/chrome-browser-ui-views-outdated_upgrade_bubble_view.cc.patch
+++ b/patches/chrome-browser-ui-views-outdated_upgrade_bubble_view.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc b/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
-index f5d3be5bc95769b682080c53c7be08cb9ab2dfe2..0a6e86850cb40767b093f399c4eb717ec051c544 100644
+index f5d3be5bc95769b682080c53c7be08cb9ab2dfe2..83ddc64b25ffa1cab9d1ab2254e3b7d723054a12 100644
 --- a/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
 +++ b/chrome/browser/ui/views/outdated_upgrade_bubble_view.cc
 @@ -31,8 +31,12 @@ namespace {
@@ -7,7 +7,7 @@ index f5d3be5bc95769b682080c53c7be08cb9ab2dfe2..0a6e86850cb40767b093f399c4eb717e
  // The URL to be used to re-install Chrome when auto-update failed for too long.
  constexpr char kDownloadChromeUrl[] =
 +#if defined(BRAVE_CHROMIUM_BUILD)
-+    "https://www.brave.com/download";
++    kDownloadBraveUrl;
 +#else
      "https://www.google.com/chrome/?&brand=CHWL"
      "&utm_campaign=en&utm_source=en-et-na-us-chrome-bubble&utm_medium=et";


### PR DESCRIPTION
With this, this url can be reused and we don't need to touch patch file
when url is updated.

Fix https://github.com/brave/brave-browser/issues/2942

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source