### PR TITLE
Hardening is_enabled check for Ads Service

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -610,22 +610,7 @@ void RewardsDOMHandler::SaveSetting(const base::ListValue* args) {
     args->GetString(1, &value);
 
     if (key == "enabledMain") {
-      bool rewards_enabled = (value == "true");
-
-      if (ads_service_) {
-        if (rewards_enabled) {
-          // When Rewards are enabled, set Ads enabled to whatever UI value is
-          bool ads_ui_enabled = ads_service_->is_ui_enabled();
-          ads_service_->set_ads_enabled(ads_ui_enabled);
-        } else {
-          // When Rewards are disabled, cache UI value and disable Ads
-          bool ads_enabled = ads_service_->is_enabled();
-          ads_service_->set_ads_ui_enabled(ads_enabled);
-          ads_service_->set_ads_enabled(rewards_enabled);
-        }
-      }
-
-      rewards_service_->SetRewardsMainEnabled(rewards_enabled);
+      rewards_service_->SetRewardsMainEnabled(value == "true");
     }
 
     if (key == "contributionMonthly") {
@@ -824,7 +809,7 @@ void RewardsDOMHandler::GetAdsData(const base::ListValue *args) {
     base::DictionaryValue adsData;
 
     bool ads_ui_enabled;
-    bool ads_enabled = ads_service_->is_ui_enabled();
+    bool ads_enabled = ads_service_->is_enabled();
     int ads_per_hour = ads_service_->ads_per_hour();
 
     #if BUILDFLAG(BRAVE_ADS_ENABLED)
@@ -850,7 +835,6 @@ void RewardsDOMHandler::SaveAdsSetting(const base::ListValue* args) {
 
     if (key == "adsEnabled") {
       ads_service_->set_ads_enabled(value == "true");
-      ads_service_->set_ads_ui_enabled(value == "true");
     }
 
     if (key == "adsPerHour") {

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -31,17 +31,7 @@ const char kReferralHeaders[] = "brave.referral.headers";
 const char kReferralCheckedForPromoCodeFile[] = "brave.referral.checked_for_promo_code_file";
 const char kHTTPSEVerywhereControlType[] = "brave.https_everywhere_default";
 const char kNoScriptControlType[] = "brave.no_script_default";
-const char kRewardsNotifications[] = "brave.rewards.notifications";
-const char kRewardsNotificationTimerInterval[] = "brave.rewards.notification_timer_interval";
-const char kRewardsBackupNotificationFrequency[] =
-    "brave.rewards.backup_notification_frequency";
-const char kRewardsBackupNotificationInterval[] =
-    "brave.rewards.backup_notification_interval";
-const char kRewardsBackupSucceeded[] = "brave.rewards.backup_succeeded";
-const char kRewardsUserHasFunded[] = "brave.rewards.user_has_funded";
-const char kRewardsAddFundsNotification[] = "brave.rewards.add_funds_notification";
 const char kMigratedMuonProfile[] = "brave.muon.migrated_profile";
 const char kBravePaymentsPinnedItemCount[] = "brave.muon.import_pinned_item_count";
 const char kWebTorrentEnabled[] = "brave.webtorrent_enabled";
 const char kHangoutsEnabled[] = "brave.hangouts_enabled";
-const char kBraveRewardsEnabled[] = "brave.rewards.enabled";

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -44,3 +44,4 @@ const char kMigratedMuonProfile[] = "brave.muon.migrated_profile";
 const char kBravePaymentsPinnedItemCount[] = "brave.muon.import_pinned_item_count";
 const char kWebTorrentEnabled[] = "brave.webtorrent_enabled";
 const char kHangoutsEnabled[] = "brave.hangouts_enabled";
+const char kBraveRewardsEnabled[] = "brave.rewards.enabled";

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -41,5 +41,6 @@ extern const char kMigratedMuonProfile[];
 extern const char kBravePaymentsPinnedItemCount[];
 extern const char kWebTorrentEnabled[];
 extern const char kHangoutsEnabled[];
+extern const char kBraveRewardsEnabled[];
 
 #endif  // BRAVE_COMMON_PREF_NAMES_H_

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -30,17 +30,9 @@ extern const char kReferralHeaders[];
 extern const char kReferralCheckedForPromoCodeFile[];
 extern const char kHTTPSEVerywhereControlType[];
 extern const char kNoScriptControlType[];
-extern const char kRewardsNotifications[];
-extern const char kRewardsNotificationTimerInterval[];
-extern const char kRewardsBackupNotificationFrequency[];
-extern const char kRewardsBackupNotificationInterval[];
-extern const char kRewardsBackupSucceeded[];
-extern const char kRewardsUserHasFunded[];
-extern const char kRewardsAddFundsNotification[];
 extern const char kMigratedMuonProfile[];
 extern const char kBravePaymentsPinnedItemCount[];
 extern const char kWebTorrentEnabled[];
 extern const char kHangoutsEnabled[];
-extern const char kBraveRewardsEnabled[];
 
 #endif  // BRAVE_COMMON_PREF_NAMES_H_

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -16,6 +16,7 @@ source_set("browser") {
   deps = [
     "//base",
     "//brave/components/brave_ads/common",
+    "//brave/components/brave_rewards/common",
     "//components/dom_distiller/content/browser",
     "//components/dom_distiller/core",
     "//components/keyed_service/content",

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -17,6 +17,7 @@ source_set("browser") {
     "//base",
     "//brave/components/brave_ads/common",
     "//brave/components/brave_rewards/common",
+    "//brave/components/brave_rewards/browser",
     "//components/dom_distiller/content/browser",
     "//components/dom_distiller/core",
     "//components/keyed_service/content",

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -18,11 +18,9 @@ class AdsService : public KeyedService {
   AdsService() = default;
 
   virtual bool is_enabled() const = 0;
-  virtual bool is_ui_enabled() const = 0;
   virtual uint64_t ads_per_hour() const = 0;
 
   virtual void set_ads_enabled(bool enabled) = 0;
-  virtual void set_ads_ui_enabled(bool enabled) = 0;
   virtual void set_ads_per_hour(int ads_per_hour) = 0;
 
   // ads::Ads proxy

--- a/components/brave_ads/browser/ads_service_factory.cc
+++ b/components/brave_ads/browser/ads_service_factory.cc
@@ -16,6 +16,7 @@
 #include "brave/components/brave_ads/browser/ads_service_impl.h"
 #include "chrome/browser/dom_distiller/dom_distiller_service_factory.h"
 #include "chrome/browser/notifications/notification_display_service_factory.h"
+#include "brave/components/brave_rewards/browser/rewards_service_factory.h"
 #endif
 
 namespace brave_ads {
@@ -42,6 +43,7 @@ AdsServiceFactory::AdsServiceFactory()
 #if BUILDFLAG(BRAVE_ADS_ENABLED)
   DependsOn(NotificationDisplayServiceFactory::GetInstance());
   DependsOn(dom_distiller::DomDistillerServiceFactory::GetInstance());
+  DependsOn(brave_rewards::RewardsServiceFactory::GetInstance());
 #endif
 }
 

--- a/components/brave_ads/browser/ads_service_factory.cc
+++ b/components/brave_ads/browser/ads_service_factory.cc
@@ -77,7 +77,6 @@ bool AdsServiceFactory::ServiceIsNULLWhileTesting() const {
 void AdsServiceFactory::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(prefs::kBraveAdsEnabled, false);
-  registry->RegisterBooleanPref(prefs::kBraveAdsUIEnabled, false);
   registry->RegisterUint64Pref(prefs::kBraveAdsPerHour, 2);
   registry->RegisterUint64Pref(prefs::kBraveAdsPerDay, 6);
   registry->RegisterIntegerPref(prefs::kBraveAdsIdleThreshold, 15);

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -20,8 +20,8 @@
 #include "bat/ads/resources/grit/bat_ads_resources.h"
 #include "brave/components/brave_ads/browser/ad_notification.h"
 #include "brave/components/brave_ads/browser/bundle_state_database.h"
-#include "brave/common/pref_names.h"
 #include "brave/components/brave_ads/common/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_ads/common/switches.h"
 #include "brave/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.h"
 #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
@@ -268,7 +268,7 @@ AdsServiceImpl::AdsServiceImpl(Profile* profile) :
       base::Bind(&AdsServiceImpl::OnPrefsChanged,
                  base::Unretained(this)));
   profile_pref_change_registrar_.Add(
-      kBraveRewardsEnabled,
+      brave_rewards::prefs::kBraveRewardsEnabled,
       base::Bind(&AdsServiceImpl::OnPrefsChanged,
                  base::Unretained(this)));
   profile_pref_change_registrar_.Add(
@@ -435,7 +435,7 @@ void AdsServiceImpl::Shutdown() {
 
 void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
   if (pref == prefs::kBraveAdsEnabled ||
-      pref == kBraveRewardsEnabled) {
+      pref == brave_rewards::prefs::kBraveRewardsEnabled) {
     if (is_enabled()) {
       Start();
     } else if (!is_enabled()) {
@@ -448,7 +448,7 @@ void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
 
 bool AdsServiceImpl::is_enabled() const {
   bool ads_enabled = profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
-  bool rewards_enabled = profile_->GetPrefs()->GetBoolean(kBraveRewardsEnabled);
+  bool rewards_enabled = profile_->GetPrefs()->GetBoolean(brave_rewards::prefs::kBraveRewardsEnabled);
   return (ads_enabled && rewards_enabled);
 }
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -20,6 +20,7 @@
 #include "bat/ads/resources/grit/bat_ads_resources.h"
 #include "brave/components/brave_ads/browser/ad_notification.h"
 #include "brave/components/brave_ads/browser/bundle_state_database.h"
+#include "brave/common/pref_names.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_ads/common/switches.h"
 #include "brave/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.h"
@@ -267,6 +268,10 @@ AdsServiceImpl::AdsServiceImpl(Profile* profile) :
       base::Bind(&AdsServiceImpl::OnPrefsChanged,
                  base::Unretained(this)));
   profile_pref_change_registrar_.Add(
+      kBraveRewardsEnabled,
+      base::Bind(&AdsServiceImpl::OnPrefsChanged,
+                 base::Unretained(this)));
+  profile_pref_change_registrar_.Add(
       prefs::kBraveAdsIdleThreshold,
       base::Bind(&AdsServiceImpl::OnPrefsChanged,
                  base::Unretained(this)));
@@ -429,7 +434,8 @@ void AdsServiceImpl::Shutdown() {
 }
 
 void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
-  if (pref == prefs::kBraveAdsEnabled) {
+  if (pref == prefs::kBraveAdsEnabled ||
+      pref == kBraveRewardsEnabled) {
     if (is_enabled()) {
       Start();
     } else if (!is_enabled()) {
@@ -441,11 +447,9 @@ void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
 }
 
 bool AdsServiceImpl::is_enabled() const {
-  return profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
-}
-
-bool AdsServiceImpl::is_ui_enabled() const {
-  return profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsUIEnabled);
+  bool ads_enabled = profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
+  bool rewards_enabled = profile_->GetPrefs()->GetBoolean(kBraveRewardsEnabled);
+  return (ads_enabled && rewards_enabled);
 }
 
 bool AdsServiceImpl::IsAdsEnabled() const {
@@ -454,10 +458,6 @@ bool AdsServiceImpl::IsAdsEnabled() const {
 
 void AdsServiceImpl::set_ads_enabled(bool enabled) {
   profile_->GetPrefs()->SetBoolean(prefs::kBraveAdsEnabled, enabled);
-}
-
-void AdsServiceImpl::set_ads_ui_enabled(bool enabled) {
-  profile_->GetPrefs()->SetBoolean(prefs::kBraveAdsUIEnabled, enabled);
 }
 
 void AdsServiceImpl::set_ads_per_hour(int ads_per_hour) {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -52,11 +52,9 @@ class AdsServiceImpl : public AdsService,
 
   // AdsService implementation
   bool is_enabled() const override;
-  bool is_ui_enabled() const override;
   uint64_t ads_per_hour() const override;
 
   void set_ads_enabled(bool enabled) override;
-  void set_ads_ui_enabled(bool enabled) override;
   void set_ads_per_hour(int ads_per_hour) override;
 
   void TabUpdated(

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -8,7 +8,6 @@ namespace brave_ads {
 namespace prefs {
 
 const char kBraveAdsEnabled[] = "brave.brave_ads.enabled";
-const char kBraveAdsUIEnabled[] = "brave.brave_ads_ui_enabled";
 const char kBraveAdsPerHour[] = "brave.brave_ads.ads_per_hour";
 const char kBraveAdsPerDay[] = "brave.brave_ads.ads_per_day";
 const char kBraveAdsIdleThreshold[] = "brave.brave_ads.idle_threshold";

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -9,7 +9,6 @@ namespace brave_ads {
 namespace prefs {
 
 extern const char kBraveAdsEnabled[];
-extern const char kBraveAdsUIEnabled[];
 extern const char kBraveAdsPerHour[];
 extern const char kBraveAdsPerDay[];
 extern const char kBraveAdsIdleThreshold[];

--- a/components/brave_rewards/browser/BUILD.gn
+++ b/components/brave_rewards/browser/BUILD.gn
@@ -48,6 +48,7 @@ source_set("browser") {
 
   deps = [
     "//base",
+    "//brave/components/brave_rewards/common",
     "//components/keyed_service/content",
     "//components/keyed_service/core",
     "//components/sessions",

--- a/components/brave_rewards/browser/rewards_notification_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.cc
@@ -14,7 +14,7 @@
 #include "base/values.h"
 #include "bat/ledger/ledger_callback_handler.h"
 #include "bat/ledger/publisher_info.h"
-#include "brave/common/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service_observer.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/prefs/pref_service.h"
@@ -113,7 +113,7 @@ RewardsNotificationServiceImpl::GenerateRewardsNotificationTimestamp() const {
 }
 
 void RewardsNotificationServiceImpl::ReadRewardsNotificationsJSON() {
-  std::string json = profile_->GetPrefs()->GetString(kRewardsNotifications);
+  std::string json = profile_->GetPrefs()->GetString(prefs::kRewardsNotifications);
   if (json.empty())
     return;
   std::unique_ptr<base::DictionaryValue> dictionary =
@@ -227,7 +227,7 @@ void RewardsNotificationServiceImpl::StoreRewardsNotifications() {
     return;
   }
 
-  profile_->GetPrefs()->SetString(kRewardsNotifications, result);
+  profile_->GetPrefs()->SetString(prefs::kRewardsNotifications, result);
 }
 
 void RewardsNotificationServiceImpl::TriggerOnNotificationAdded(

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -52,6 +52,7 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(prefs::kRewardsUserHasFunded, false);
   registry->RegisterTimePref(prefs::kRewardsAddFundsNotification, base::Time());
   registry->RegisterBooleanPref(prefs::kBraveRewardsEnabled, false);
+  registry->RegisterBooleanPref(prefs::kBraveRewardsEnabledMigrated, false);
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -5,7 +5,7 @@
 
 #include "base/logging.h"
 #include "base/time/time.h"
-#include "brave/common/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service_impl.h"
 #include "brave/components/brave_rewards/browser/rewards_service_observer.h"
@@ -41,17 +41,17 @@ void RewardsService::RemoveObserver(RewardsServiceObserver* observer) {
 
 // static
 void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
-  registry->RegisterStringPref(kRewardsNotifications, "");
-  registry->RegisterTimeDeltaPref(kRewardsNotificationTimerInterval,
+  registry->RegisterStringPref(prefs::kRewardsNotifications, "");
+  registry->RegisterTimeDeltaPref(prefs::kRewardsNotificationTimerInterval,
                                   base::TimeDelta::FromDays(1));
-  registry->RegisterTimeDeltaPref(kRewardsBackupNotificationFrequency,
+  registry->RegisterTimeDeltaPref(prefs::kRewardsBackupNotificationFrequency,
                                   base::TimeDelta::FromDays(7));
-  registry->RegisterTimeDeltaPref(kRewardsBackupNotificationInterval,
+  registry->RegisterTimeDeltaPref(prefs::kRewardsBackupNotificationInterval,
                                   base::TimeDelta::FromDays(7));
-  registry->RegisterBooleanPref(kRewardsBackupSucceeded, false);
-  registry->RegisterBooleanPref(kRewardsUserHasFunded, false);
-  registry->RegisterTimePref(kRewardsAddFundsNotification, base::Time());
-  registry->RegisterBooleanPref(kBraveRewardsEnabled, false);
+  registry->RegisterBooleanPref(prefs::kRewardsBackupSucceeded, false);
+  registry->RegisterBooleanPref(prefs::kRewardsUserHasFunded, false);
+  registry->RegisterTimePref(prefs::kRewardsAddFundsNotification, base::Time());
+  registry->RegisterBooleanPref(prefs::kBraveRewardsEnabled, false);
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -51,6 +51,7 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kRewardsBackupSucceeded, false);
   registry->RegisterBooleanPref(kRewardsUserHasFunded, false);
   registry->RegisterTimePref(kRewardsAddFundsNotification, base::Time());
+  registry->RegisterBooleanPref(kBraveRewardsEnabled, false);
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -812,6 +812,9 @@ void RewardsServiceImpl::OnLedgerStateLoaded(
 
 void RewardsServiceImpl::LoadPublisherState(
     ledger::LedgerCallbackHandler* handler) {
+  bat_ledger_->GetRewardsMainEnabled(
+      base::BindOnce(&RewardsServiceImpl::SetRewardsMainEnabledPref,
+        AsWeakPtr()));
   base::PostTaskAndReplyWithResult(file_task_runner_.get(), FROM_HERE,
       base::Bind(&LoadStateOnFileTaskRunner, publisher_state_path_),
       base::Bind(&RewardsServiceImpl::OnPublisherStateLoaded,
@@ -1262,6 +1265,7 @@ void RewardsServiceImpl::SetRewardsMainEnabled(bool enabled) {
     return;
   }
 
+  SetRewardsMainEnabledPref(enabled);
   bat_ledger_->SetRewardsMainEnabled(enabled);
   TriggerOnRewardsMainEnabled(enabled);
 }
@@ -1273,6 +1277,10 @@ void RewardsServiceImpl::GetRewardsMainEnabled(
   }
 
   bat_ledger_->GetRewardsMainEnabled(callback);
+}
+
+void RewardsServiceImpl::SetRewardsMainEnabledPref(bool enabled) {
+  profile_->GetPrefs()->SetBoolean(kBraveRewardsEnabled, enabled);
 }
 
 void RewardsServiceImpl::GetPublisherMinVisitTime(

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -813,9 +813,11 @@ void RewardsServiceImpl::OnLedgerStateLoaded(
 
 void RewardsServiceImpl::LoadPublisherState(
     ledger::LedgerCallbackHandler* handler) {
-  bat_ledger_->GetRewardsMainEnabled(
-      base::BindOnce(&RewardsServiceImpl::SetRewardsMainEnabledPref,
-        AsWeakPtr()));
+  if (!profile_->GetPrefs()->GetBoolean(prefs::kBraveRewardsEnabledMigrated)) {
+    bat_ledger_->GetRewardsMainEnabled(
+        base::BindOnce(&RewardsServiceImpl::SetRewardsMainEnabledPref,
+          AsWeakPtr()));
+  }
   base::PostTaskAndReplyWithResult(file_task_runner_.get(), FROM_HERE,
       base::Bind(&LoadStateOnFileTaskRunner, publisher_state_path_),
       base::Bind(&RewardsServiceImpl::OnPublisherStateLoaded,
@@ -1282,6 +1284,11 @@ void RewardsServiceImpl::GetRewardsMainEnabled(
 
 void RewardsServiceImpl::SetRewardsMainEnabledPref(bool enabled) {
   profile_->GetPrefs()->SetBoolean(prefs::kBraveRewardsEnabled, enabled);
+  SetRewardsMainEnabledMigratedPref(true);
+}
+
+void RewardsServiceImpl::SetRewardsMainEnabledMigratedPref(bool enabled) {
+  profile_->GetPrefs()->SetBoolean(prefs::kBraveRewardsEnabledMigrated, enabled);
 }
 
 void RewardsServiceImpl::GetPublisherMinVisitTime(

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -344,6 +344,7 @@ class RewardsServiceImpl : public RewardsService,
       const GetAutoContributePropsCallback& callback,
       const std::string& json_props);
   void SetRewardsMainEnabledPref(bool enabled);
+  void SetRewardsMainEnabledMigratedPref(bool enabled);
 
   bool Connected() const;
   void ConnectionClosed();

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -343,6 +343,7 @@ class RewardsServiceImpl : public RewardsService,
   void OnGetAutoContributeProps(
       const GetAutoContributePropsCallback& callback,
       const std::string& json_props);
+  void SetRewardsMainEnabledPref(bool enabled);
 
   bool Connected() const;
   void ConnectionClosed();

--- a/components/brave_rewards/common/BUILD.gn
+++ b/components/brave_rewards/common/BUILD.gn
@@ -1,0 +1,6 @@
+source_set("common") {
+  sources = [
+    "pref_names.cc",
+    "pref_names.h"
+  ]
+}

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_rewards/common/pref_names.h"
+
+namespace brave_rewards {
+namespace prefs {
+
+const char kBraveRewardsEnabled[] = "brave.rewards.enabled";
+const char kRewardsNotifications[] = "brave.rewards.notifications";
+const char kRewardsNotificationTimerInterval[] = "brave.rewards.notification_timer_interval";
+const char kRewardsBackupNotificationFrequency[] =
+    "brave.rewards.backup_notification_frequency";
+const char kRewardsBackupNotificationInterval[] =
+    "brave.rewards.backup_notification_interval";
+const char kRewardsBackupSucceeded[] = "brave.rewards.backup_succeeded";
+const char kRewardsUserHasFunded[] = "brave.rewards.user_has_funded";
+const char kRewardsAddFundsNotification[] = "brave.rewards.add_funds_notification";
+
+}  // namespace prefs
+}  // namespace brave_rewards

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -8,6 +8,7 @@ namespace brave_rewards {
 namespace prefs {
 
 const char kBraveRewardsEnabled[] = "brave.rewards.enabled";
+const char kBraveRewardsEnabledMigrated[] = "brave.rewards.enabled_migrated";
 const char kRewardsNotifications[] = "brave.rewards.notifications";
 const char kRewardsNotificationTimerInterval[] = "brave.rewards.notification_timer_interval";
 const char kRewardsBackupNotificationFrequency[] =

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -9,6 +9,7 @@ namespace brave_rewards {
 namespace prefs {
 
 extern const char kBraveRewardsEnabled[];
+extern const char kBraveRewardsEnabledMigrated[];
 extern const char kRewardsNotifications[];
 extern const char kRewardsNotificationTimerInterval[];
 extern const char kRewardsBackupNotificationFrequency[];

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_REWARDS_COMMON_PREF_NAMES_H_
+#define BRAVE_COMPONENTS_BRAVE_REWARDS_COMMON_PREF_NAMES_H_
+
+namespace brave_rewards {
+namespace prefs {
+
+extern const char kBraveRewardsEnabled[];
+extern const char kRewardsNotifications[];
+extern const char kRewardsNotificationTimerInterval[];
+extern const char kRewardsBackupNotificationFrequency[];
+extern const char kRewardsBackupNotificationInterval[];
+extern const char kRewardsBackupSucceeded[];
+extern const char kRewardsUserHasFunded[];
+extern const char kRewardsAddFundsNotification[];
+
+}  // namespace prefs
+}  // namespace brave_rewards
+
+#endif  // BRAVE_COMPONENTS_BRAVE_REWARDS_COMMON_PREF_NAMES_H_


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2972
Undoes: https://github.com/brave/brave-core/pull/1337

This fix renders what was done in #1337 obsolete

Also migrates current rewards prefs in to their own namespace in `brave_rewards/common`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source