### PR TITLE
Rewrite chrome:// in edit URLs too (closes brave/brave-browser#1616)

### DIFF
--- a/components/omnibox/browser/brave_location_bar_model_impl.cc
+++ b/components/omnibox/browser/brave_location_bar_model_impl.cc
@@ -20,9 +20,7 @@ const base::string16 replacement_scheme_part =
 
 }
 
-base::string16 BraveLocationBarModelImpl::GetURLForDisplay() const {
-  base::string16 formatted_text = LocationBarModelImpl::GetURLForDisplay();
-
+base::string16 BraveLocationBarModelImpl::RewriteSchemes(base::string16 formatted_text) const {
   const GURL url(GetURL());
   // Only replace chrome:// with brave:// if scheme is "chrome" and
   // it has not been stripped from the display text
@@ -33,4 +31,12 @@ base::string16 BraveLocationBarModelImpl::GetURLForDisplay() const {
                             replacement_scheme_part);
   }
   return formatted_text;
+}
+
+base::string16 BraveLocationBarModelImpl::GetFormattedFullURL() const {
+  return RewriteSchemes(LocationBarModelImpl::GetFormattedFullURL());
+}
+
+base::string16 BraveLocationBarModelImpl::GetURLForDisplay() const {
+  return RewriteSchemes(LocationBarModelImpl::GetURLForDisplay());
 }

--- a/components/omnibox/browser/brave_location_bar_model_impl.h
+++ b/components/omnibox/browser/brave_location_bar_model_impl.h
@@ -10,9 +10,11 @@
 class BraveLocationBarModelImpl : public LocationBarModelImpl {
   public:
     using LocationBarModelImpl::LocationBarModelImpl;
+    base::string16 GetFormattedFullURL() const override;
     base::string16 GetURLForDisplay() const override;
   private:
     DISALLOW_COPY_AND_ASSIGN(BraveLocationBarModelImpl);
+    base::string16 RewriteSchemes(base::string16 formatted_text) const;
 };
 
 #endif


### PR DESCRIPTION
Both GetFormattedFullURL() and GetURLForDisplay() need to be overridden in
order for the URL to be displayed properly in the URL bar and to be copy/pasted
properly when editing the URL.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Open `brave://settings`.
2. Click on the URL bar to edit the URL.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source