### PR TITLE
do not attempt to close `enter sync words` dialog when error is found

### DIFF
--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -58,7 +58,6 @@ export default class EnterSyncCodeModal extends React.PureComponent<Props, State
       )
     ) {
       this.setState({ willCreateNewSyncChainFromCode: false })
-      this.props.onClose()
       return
     }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2845

Test Plan (edited from https://github.com/brave/brave-browser/issues/2845)

1. launch brave (0.59.20 Chromium: 72.0.3626.28 in this instance)
2. open brave://sync and click on I Have a Sync Code
3. click on Confirm Sync Code without adding anything into the text field
4. should not close modal