### PR TITLE
only call Stop when DistillerPageWebContents::CreateNewWebContents is…

### DIFF
--- a/patches/components-dom_distiller-content-browser-distiller_page_web_contents.cc.patch
+++ b/patches/components-dom_distiller-content-browser-distiller_page_web_contents.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/components/dom_distiller/content/browser/distiller_page_web_contents.cc b/components/dom_distiller/content/browser/distiller_page_web_contents.cc
+index 9dd3a81fea2797c06db85868f0da94612b2a362d..9de2e23743c44deffafa96c7a2bdaabda046de87 100644
+--- a/components/dom_distiller/content/browser/distiller_page_web_contents.cc
++++ b/components/dom_distiller/content/browser/distiller_page_web_contents.cc
+@@ -182,7 +182,9 @@ void DistillerPageWebContents::ExecuteJavaScript() {
+   content::WebContentsObserver::Observe(nullptr);
+   // Stop any pending navigation since the intent is to distill the current
+   // page.
++  if (source_page_handle_->web_contents()->GetDelegate() == this)
+   source_page_handle_->web_contents()->Stop();
++
+   DVLOG(1) << "Beginning distillation";
+   RunIsolatedJavaScript(
+       frame, script_,


### PR DESCRIPTION
… called. This maintains the original behavior from https://chromium.googlesource.com/chromium/src/+/fb688daf52cef3bb041634888583ee2c28c8af66%5E%21/components/dom_distiller/content/distiller_page_web_contents.cc without breaking sites that use the original webcontents

Fix https://github.com/brave/brave-browser/issues/2991
Fix https://github.com/brave/brave-browser/issues/2901

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source