### PR TITLE
Issue 2554: Replace data urls with HTTP 200 OK in adblocker.

### DIFF
--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -288,8 +288,15 @@ void BraveNetworkDelegateBase::RunNextCallback(
         IsRequestIdentifierValid(ctx->request_identifier)) {
       *ctx->new_url = GURL(ctx->new_url_spec);
     }
+    if (ctx->blocked_by == brave::kAdBlocked ||
+        ctx->blocked_by == brave::kTrackerBlocked) {
+      // We are going to intercept this request and block it later in the
+      // network stack.
+      request->SetExtraRequestHeaderByName("X-Brave-Block", "", true);
+    }
     rv = ChromeNetworkDelegate::OnBeforeURLRequest(request,
-        std::move(wrapped_callback), ctx->new_url);
+                                                   std::move(wrapped_callback),
+                                                   ctx->new_url);
   } else if (ctx->event_type == brave::kOnBeforeStartTransaction) {
     rv = ChromeNetworkDelegate::OnBeforeStartTransaction(request,
         std::move(wrapped_callback), ctx->headers);

--- a/content/browser/adblock_interceptor.cc
+++ b/content/browser/adblock_interceptor.cc
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/content/browser/adblock_interceptor.h"
+
+#include "base/bind.h"
+#include "base/compiler_specific.h"
+#include "base/location.h"
+#include "base/single_thread_task_runner.h"
+#include "base/threading/thread_task_runner_handle.h"
+#include "base/memory/weak_ptr.h"
+#include "net/url_request/url_request_job.h"
+#include "net/http/http_response_info.h"
+#include "net/http/http_response_headers.h"
+#include "net/http/http_util.h"
+
+namespace brave {
+namespace content {
+
+class Http200OkJob : public net::URLRequestJob {
+ public:
+  Http200OkJob(net::URLRequest* request,
+               net::NetworkDelegate* network_delegate);
+
+  // URLRequestJob:
+  void Start() override;
+  void Kill() override;
+  bool GetMimeType(std::string* mime_type) const override;
+  void GetResponseInfo(net::HttpResponseInfo* info) override;
+
+ private:
+  ~Http200OkJob() override;
+  void StartAsync();
+
+  base::WeakPtrFactory<Http200OkJob> weak_factory_;
+};
+
+Http200OkJob::Http200OkJob(net::URLRequest* request,
+                           net::NetworkDelegate* network_delegate)
+    : net::URLRequestJob(request, network_delegate), weak_factory_(this) {}
+
+void Http200OkJob::Start()  {
+  // Start reading asynchronously so that all error reporting and data
+  // callbacks happen as they would for network requests.
+  base::ThreadTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE, base::BindOnce(&Http200OkJob::StartAsync,
+                                weak_factory_.GetWeakPtr()));
+}
+
+void Http200OkJob::Kill() {
+  weak_factory_.InvalidateWeakPtrs();
+  URLRequestJob::Kill();
+}
+
+bool Http200OkJob::GetMimeType(std::string* mime_type) const {
+  *mime_type = "text/html";
+  return true;
+}
+
+void Http200OkJob::GetResponseInfo(net::HttpResponseInfo* info) {
+  net::HttpResponseInfo new_info;
+  // TODO(iefremov): Allowing any origins still breaks some CORS requests.
+  // Maybe we can provide something smarter here.
+  std::string raw_headers =
+      "HTTP/1.1 200 OK\r\n"
+      "Access-Control-Allow-Origin: *\r\n";;
+  new_info.headers = new net::HttpResponseHeaders(
+      net::HttpUtil::AssembleRawHeaders(raw_headers.c_str(),
+                                        raw_headers.size()));
+  *info = new_info;
+}
+
+Http200OkJob::~Http200OkJob() {}
+
+void Http200OkJob::StartAsync() {
+  NotifyHeadersComplete();
+}
+
+AdBlockInterceptor::AdBlockInterceptor() {}
+AdBlockInterceptor::~AdBlockInterceptor() {}
+
+net::URLRequestJob* AdBlockInterceptor::MaybeInterceptRequest(
+    net::URLRequest* request,
+    net::NetworkDelegate* network_delegate) const {
+  std::string header;
+  if (request->extra_request_headers().GetHeader("X-Brave-Block", &header)) {
+    VLOG(1) << "Intercepting request: " << request->url().spec();
+    return new Http200OkJob(request, network_delegate);
+  }
+  return nullptr;
+}
+
+}  // namespace brave
+}  // namespace content

--- a/content/browser/adblock_interceptor.h
+++ b/content/browser/adblock_interceptor.h
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CONTENT_BROWSER_ADBLOCK_INTERCEPTOR_H_
+#define BRAVE_CONTENT_BROWSER_ADBLOCK_INTERCEPTOR_H_
+
+#include "base/macros.h"
+#include "content/common/content_export.h"
+#include "net/url_request/url_request_interceptor.h"
+
+namespace brave {
+namespace content {
+
+// Intercepts certain requests and blocks them by silently returning 200 OK
+// and not allowing them to hit the network.
+class CONTENT_EXPORT AdBlockInterceptor : public net::URLRequestInterceptor {
+ public:
+  AdBlockInterceptor();
+  ~AdBlockInterceptor() override;
+
+protected:
+  // net::URLRequestInterceptor:
+  net::URLRequestJob* MaybeInterceptRequest(
+      net::URLRequest* request,
+      net::NetworkDelegate* network_delegate) const override;
+};
+
+}  // namespace brave
+}  // namespace content
+
+#endif  // BRAVE_CONTENT_BROWSER_ADBLOCK_INTERCEPTOR_H_

--- a/patches/content-browser-BUILD.gn.patch
+++ b/patches/content-browser-BUILD.gn.patch
@@ -1,13 +1,15 @@
 diff --git a/content/browser/BUILD.gn b/content/browser/BUILD.gn
-index c89b65d27a7e0d639f9cc1468aca4083303860a3..cf3a9cfa10c608f1d7493d34206d34d206a3710a 100644
+index c89b65d27a7e0d639f9cc1468aca4083303860a3..5db63fc03ccf7f1f8d1d72743f23c537f377fa78 100644
 --- a/content/browser/BUILD.gn
 +++ b/content/browser/BUILD.gn
-@@ -2122,6 +2122,12 @@ jumbo_source_set("browser") {
+@@ -2122,6 +2122,14 @@ jumbo_source_set("browser") {
        "//ppapi/proxy:ipc",
        "//ppapi/shared_impl",
      ]
 +    if (brave_chromium_build) {
 +      sources += [
++        "//brave/content/browser/adblock_interceptor.cc",
++        "//brave/content/browser/adblock_interceptor.h",
 +        "//brave/content/browser/renderer_host/brave_plugin_registry_impl.cc",
 +        "//brave/content/browser/renderer_host/brave_plugin_registry_impl.h",
 +      ]

--- a/patches/content-browser-storage_partition_impl_map.cc.patch
+++ b/patches/content-browser-storage_partition_impl_map.cc.patch
@@ -1,0 +1,21 @@
+diff --git a/content/browser/storage_partition_impl_map.cc b/content/browser/storage_partition_impl_map.cc
+index 871ab0738802d4d8d9b01b68489548cec19a53ee..c8b60e4e877e20443cecb416a72f3e242cf766fc 100644
+--- a/content/browser/storage_partition_impl_map.cc
++++ b/content/browser/storage_partition_impl_map.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <utility>
+ 
++#include "../brave/content/browser/adblock_interceptor.h"
+ #include "base/bind.h"
+ #include "base/callback.h"
+ #include "base/command_line.h"
+@@ -417,6 +418,8 @@ StoragePartitionImpl* StoragePartitionImplMap::Get(
+   request_interceptors.push_back(ServiceWorkerRequestHandler::CreateInterceptor(
+       browser_context_->GetResourceContext()));
+   request_interceptors.push_back(std::make_unique<AppCacheInterceptor>());
++  request_interceptors.push_back(
++      std::make_unique<brave::content::AdBlockInterceptor>());
+ 
+   // These calls must happen after StoragePartitionImpl::Create().
+   if (partition_domain.empty()) {

--- a/test/data/blocking.html
+++ b/test/data/blocking.html
@@ -7,6 +7,7 @@ let expectedXHRLoaded = 0
 let expectedXHRBlocked = 0
 let numXHRLoaded = 0
 let numXHRBlocked = 0
+let numImgBlocked = 0
 
 // Performs an XHR for the specified src
 function xhr(src) {
@@ -32,6 +33,7 @@ function addImage(src) {
   img.src = src
   img.className = 'adImage'
   img.addEventListener('load', onLoad)
+  img.addEventListener('error', function(e) {numImgBlocked++; onLoad();})
   document.body.appendChild(img)
 }
 
@@ -50,17 +52,17 @@ function onLoad() {
     return;
   }
 
-  // Blocked image should be a 1x1 stub
+  // Blocked image should have zero size
   const numImgLoaded = adImages.reduce((total, adImage) => {
     if (adImage.complete &&
-        (adImage.naturalHeight !== 1 || adImage.naturalWidth !== 1)) {
+        (adImage.naturalHeight !== 0 || adImage.naturalWidth !== 0)) {
       return total + 1
     }
     return total
   }, 0);
 
-  const numImgBlocked = adImages.length - numImgLoaded
-  const result = numImgLoaded == expectedImgLoaded &&
+  const result = numImgBlocked == expectedImgBlocked
+      numImgLoaded == expectedImgLoaded
       expectedImgBlocked == numImgBlocked &&
       numXHRLoaded === expectedXHRLoaded &&
       numXHRBlocked === expectedXHRBlocked


### PR DESCRIPTION
To better maintain web compatibility we want to get rid of returning data
urls with emtpy content, because they cause CORS errors and return 200 OK
instead. This cannot be done using the current NetworkDelegate infra, so
the URLRequestInterceptor is utilized, allowing us to easily block unwanted
requests.

Fix https://github.com/brave/a-browser/issues/2554

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source