### PR TITLE
do not attempt to close `enter sync words` dialog when error is found

### DIFF
--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -57,7 +57,6 @@ interface Props {
       )
     ) {
       this.setState({ willCreateNewSyncChainFromCode: false })
-      this.props.onClose()
       return
     }
 


### PR DESCRIPTION
https://github.com/brave/brave-core/pull/1357 version for 0.59.x