### PR TITLE
Fixes summary being displayed before enabled

### DIFF
--- a/components/brave_rewards/browser/extension_rewards_service_observer.cc
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.cc
@@ -25,7 +25,7 @@ void ExtensionRewardsServiceObserver::OnWalletInitialized(
     int error_code) {
   extensions::EventRouter* event_router =
       extensions::EventRouter::Get(profile_);
-  if (event_router) {
+  if (event_router && error_code == 0) {
     std::unique_ptr<base::ListValue> args(new base::ListValue());
     std::unique_ptr<extensions::Event> event(new extensions::Event(
         extensions::events::BRAVE_WALLET_CREATED,


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2962

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source