### PR TITLE
Fixes summary being displayed before enabled

### DIFF
--- a/components/brave_rewards/browser/extension_rewards_service_observer.cc
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.cc
@@ -25,7 +25,7 @@ void ExtensionRewardsServiceObserver::OnWalletInitialized(
     int error_code) {
   extensions::EventRouter* event_router =
       extensions::EventRouter::Get(profile_);
-  if (event_router) {
+  if (event_router && error_code == 0) {
     std::unique_ptr<base::ListValue> args(new base::ListValue());
     std::unique_ptr<extensions::Event> event(new extensions::Event(
         extensions::events::BRAVE_WALLET_CREATED,


### PR DESCRIPTION
Original PR: #1386

Resolves brave/brave-browser#2962