### PR TITLE
WebTorrent styling

### DIFF
--- a/components/brave_webtorrent/extension/components/app.tsx
+++ b/components/brave_webtorrent/extension/components/app.tsx
@@ -11,7 +11,13 @@ import MediaViewer from './mediaViewer'
 import TorrentViewer from './torrentViewer'
 
 // Constants
-import { TorrentObj, TorrentState, ApplicationState, getTorrentObj, getTorrentState } from '../constants/webtorrentState'
+import {
+  TorrentObj,
+  TorrentState,
+  ApplicationState,
+  getTorrentObj,
+  getTorrentState
+} from '../constants/webtorrentState'
 
 // Utils
 import * as torrentActions from '../actions/webtorrent_actions'
@@ -37,12 +43,8 @@ export class BraveWebtorrentPage extends React.Component<Props, {}> {
 
     if (!torrentState) return null
 
-    if (torrentObj && typeof(torrentState.ix) === 'number') {
-      return (
-        <MediaViewer
-          torrent={torrentObj}
-          ix={torrentState.ix}
-        />)
+    if (torrentObj && typeof torrentState.ix === 'number') {
+      return <MediaViewer torrent={torrentObj} ix={torrentState.ix} />
     }
 
     return (
@@ -53,13 +55,19 @@ export class BraveWebtorrentPage extends React.Component<Props, {}> {
         errorMsg={torrentState.errorMsg}
         torrent={torrentObj}
         tabId={torrentState.tabId}
-      />)
+      />
+    )
   }
 }
 
-export const mapStateToProps = (state: ApplicationState, ownProps: { tabId: number }) => {
-  return { torrentState: getTorrentState(state.torrentsData, ownProps.tabId),
-    torrentObj: getTorrentObj(state.torrentsData, ownProps.tabId) }
+export const mapStateToProps = (
+  state: ApplicationState,
+  ownProps: { tabId: number }
+) => {
+  return {
+    torrentState: getTorrentState(state.torrentsData, ownProps.tabId),
+    torrentObj: getTorrentObj(state.torrentsData, ownProps.tabId)
+  }
 }
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/components/brave_webtorrent/extension/components/mediaViewer.tsx
+++ b/components/brave_webtorrent/extension/components/mediaViewer.tsx
@@ -7,22 +7,9 @@ import * as React from 'react'
 // Constants
 import { TorrentObj } from '../constants/webtorrentState'
 
-const SUPPORTED_VIDEO_EXTENSIONS = [
-  'm4v',
-  'mkv',
-  'mov',
-  'mp4',
-  'ogv',
-  'webm'
-]
+const SUPPORTED_VIDEO_EXTENSIONS = ['m4v', 'mkv', 'mov', 'mp4', 'ogv', 'webm']
 
-const SUPPORTED_AUDIO_EXTENSIONS = [
-  'aac',
-  'mp3',
-  'ogg',
-  'wav',
-  'm4a'
-]
+const SUPPORTED_AUDIO_EXTENSIONS = ['aac', 'mp3', 'ogg', 'wav', 'm4a']
 
 // Given 'foo.txt', returns 'txt'
 // Given eg. null, undefined, '', or 'README', returns null
@@ -43,19 +30,27 @@ export default class MediaViewer extends React.PureComponent<Props, {}> {
     const { torrent, ix } = this.props
 
     const file = torrent.files ? torrent.files[ix] : undefined
-    const fileURL = torrent.serverURL && (torrent.serverURL + '/' + ix)
+    const fileURL = torrent.serverURL && torrent.serverURL + '/' + ix
 
     const fileExt = file && getExtension(file.name)
-    const isVideo = fileExt ? SUPPORTED_VIDEO_EXTENSIONS.includes(fileExt) : false
-    const isAudio = fileExt ? SUPPORTED_AUDIO_EXTENSIONS.includes(fileExt) : false
+    const isVideo = fileExt
+      ? SUPPORTED_VIDEO_EXTENSIONS.includes(fileExt)
+      : false
+    const isAudio = fileExt
+      ? SUPPORTED_AUDIO_EXTENSIONS.includes(fileExt)
+      : false
 
     let content
     if (!file || !torrent.serverURL) {
       content = <div className='loading'>Loading Media</div>
     } else if (isVideo) {
-      content = <video id='video' src={fileURL} autoPlay={true} controls={true} />
+      content = (
+        <video id='video' src={fileURL} autoPlay={true} controls={true} />
+      )
     } else if (isAudio) {
-      content = <audio id='audio' src={fileURL} autoPlay={true} controls={true} />
+      content = (
+        <audio id='audio' src={fileURL} autoPlay={true} controls={true} />
+      )
     } else {
       // For security, sandbox and disallow scripts.
       // We need allow-same-origin so that the iframe can load from
@@ -63,10 +58,6 @@ export default class MediaViewer extends React.PureComponent<Props, {}> {
       content = <iframe id='other' src={fileURL} sandbox='allow-same-origin' />
     }
 
-    return (
-      <div className='mediaViewer'>
-        {content}
-      </div>
-    )
+    return <div className='mediaViewer'>{content}</div>
   }
 }

--- a/components/brave_webtorrent/extension/components/torrentFileList.tsx
+++ b/components/brave_webtorrent/extension/components/torrentFileList.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react'
 import { Table } from 'brave-ui/components'
 import { Cell, Row } from 'brave-ui/components/dataTables/table/index'
-import { Heading } from 'brave-ui/old'
+import { LoaderIcon } from 'brave-ui/components/icons'
 
 // Constants
 import { File, TorrentObj } from '../constants/webtorrentState'
@@ -20,8 +20,11 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
     const { torrent } = this.props
     if (!torrent || !torrent.files) {
       return (
-        <div>
-          Click "Start Torrent" to load the torrent file list
+        <div className='torrentSubhead'>
+          <p>
+            Click "Start Torrent" to begin your download. WebTorrent can be
+            disabled from the extensions panel in Settings.
+          </p>
         </div>
       )
     }
@@ -47,23 +50,30 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
       if (isDownload) {
         if (torrent.serverURL) {
           const url = torrent.serverURL + '/' + ix
-          return (<a href={url} download={file.name}>⇩</a>)
+          return (
+            <a href={url} download={file.name}>
+              ⇩
+            </a>
+          )
         } else {
-          return (<div />) // No download links until the server is ready
+          return <div /> // No download links until the server is ready
         }
       } else {
         // use # for .torrent links, since query params might cause the remote
         // server to return 404
-        const suffix = /^https?:/.test(torrentId)
-          ? '#ix=' + ix
-          : '&ix=' + ix
+        const suffix = /^https?:/.test(torrentId) ? '#ix=' + ix : '&ix=' + ix
         const href = torrentId + suffix
-        return (<a href={href} target='_blank'> {file.name} </a>)
+        return (
+          <a href={href} target='_blank'>
+            {' '}
+            {file.name}{' '}
+          </a>
+        )
       }
     }
 
     const rows: Row[] = torrent.files.map((file: File, index: number) => {
-      return ({
+      return {
         content: [
           {
             content: index + 1
@@ -78,20 +88,18 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
             content: file.length
           }
         ]
-      })
+      }
     })
 
     return (
       <div>
-        <Heading
-          text='Files'
-          level={3}
-        />
-        <Table
-          header={header}
-          rows={rows}
-        >
-        'Loading the torrent file list...'
+        <Table header={header} rows={rows}>
+          <div className='loadingContainer'>
+            <div className='__icon'>
+              <LoaderIcon />
+            </div>
+            Loading the torrent file list
+          </div>
         </Table>
       </div>
     )

--- a/components/brave_webtorrent/extension/components/torrentStatus.tsx
+++ b/components/brave_webtorrent/extension/components/torrentStatus.tsx
@@ -4,8 +4,7 @@
 
 import * as React from 'react'
 import * as prettierBytes from 'prettier-bytes'
-import { Column, Grid } from 'brave-ui/components'
-import { Heading } from 'brave-ui/old'
+import { Column, Grid, Heading } from 'brave-ui/components'
 
 // Constants
 import { TorrentObj } from '../constants/webtorrentState'
@@ -20,9 +19,7 @@ export default class TorrentStatus extends React.PureComponent<Props, {}> {
     const { torrent, errorMsg } = this.props
 
     if (errorMsg) {
-      return (
-        <div> {errorMsg} </div>
-      )
+      return <div> {errorMsg} </div>
     }
 
     if (!torrent) {
@@ -31,41 +28,57 @@ export default class TorrentStatus extends React.PureComponent<Props, {}> {
 
     const renderStatus = () => {
       const status = torrent.progress < 1 ? 'Downloading' : 'Seeding'
-      return (<Column size={2}> {status} </Column>)
+      return <Column size={2}> {status} </Column>
     }
 
     const renderPercentage = () => {
-      const percentage = (torrent.progress < 1) ?
-        (torrent.progress * 100).toFixed(1) : '100'
-      return (<Column size={2}> {percentage} </Column>)
+      const percentage =
+        torrent.progress < 1 ? (torrent.progress * 100).toFixed(1) : '100'
+      return <Column size={2}> {percentage} </Column>
     }
 
     const renderSpeeds = () => {
       let str = ''
-      if (torrent.downloadSpeed > 0) str += ' ↓ ' + prettierBytes(torrent.downloadSpeed) + '/s'
-      if (torrent.uploadSpeed > 0) str += ' ↑ ' + prettierBytes(torrent.uploadSpeed) + '/s'
+      if (torrent.downloadSpeed > 0) {
+        str += ' ↓ ' + prettierBytes(torrent.downloadSpeed) + '/s'
+      }
+      if (torrent.uploadSpeed > 0) {
+        str += ' ↑ ' + prettierBytes(torrent.uploadSpeed) + '/s'
+      }
       if (str === '') return
-      return (<Column size={2}> {str} </Column>)
+      return <Column size={2}> {str} </Column>
     }
 
     const renderTotalProgress = () => {
       const downloaded = prettierBytes(torrent.downloaded)
       const total = prettierBytes(torrent.length || 0)
       if (downloaded === total) {
-        return (<Column size={2}> {downloaded} </Column>)
+        return <Column size={2}> {downloaded} </Column>
       } else {
-        return (<Column size={2}> {downloaded} / {total} </Column>)
+        return (
+          <Column size={2}>
+            {' '}
+            {downloaded} / {total}{' '}
+          </Column>
+        )
       }
     }
 
     const renderPeers = () => {
       if (torrent.numPeers === 0) return
       const count = torrent.numPeers === 1 ? 'peer' : 'peers'
-      return (<Column size={2}> {torrent.numPeers} {count} </Column>)
+      return (
+        <Column size={2}>
+          {' '}
+          {torrent.numPeers} {count}{' '}
+        </Column>
+      )
     }
 
     const renderEta = () => {
-      if (torrent.timeRemaining === 0 || torrent.timeRemaining === Infinity) return // Zero download speed
+      if (torrent.timeRemaining === 0 || torrent.timeRemaining === Infinity) {
+        return
+      } // Zero download speed
       if (torrent.downloaded === torrent.length) return // Already done
 
       const rawEta = torrent.timeRemaining / 1000
@@ -76,19 +89,20 @@ export default class TorrentStatus extends React.PureComponent<Props, {}> {
       // Only display hours and minutes if they are greater than 0 but always
       // display minutes if hours is being displayed
       const hoursStr = hours ? hours + 'h' : ''
-      const minutesStr = (hours || minutes) ? minutes + 'm' : ''
+      const minutesStr = hours || minutes ? minutes + 'm' : ''
       const secondsStr = seconds + 's'
 
-      return (<Column size={2}> {hoursStr} {minutesStr} {secondsStr} remaining </Column>)
+      return (
+        <div className='__column'>
+          {hoursStr} {minutesStr} {secondsStr} remaining
+        </div>
+      )
     }
 
     return (
-      <div>
-        <Heading
-          text='Torrent Status'
-          level={3}
-        />
-        <Grid>
+      <div className='torrentSubhead'>
+        <Heading children='Torrent Status' level={3} />
+        <Grid className='gridFix'>
           {renderStatus()}
           {renderPercentage()}
           {renderSpeeds()}

--- a/components/brave_webtorrent/extension/components/torrentViewer.tsx
+++ b/components/brave_webtorrent/extension/components/torrentViewer.tsx
@@ -36,17 +36,9 @@ export default class TorrentViewer extends React.PureComponent<Props, {}> {
           onStartTorrent={actions.startTorrent}
           onStopDownload={actions.stopDownload}
         />
-        <TorrentStatus
-          torrent={torrent}
-          errorMsg={errorMsg}
-        />
-        <TorrentFileList
-          torrentId={torrentId}
-          torrent={torrent}
-        />
-        <TorrentViewerFooter
-          torrent={torrent}
-        />
+        <TorrentStatus torrent={torrent} errorMsg={errorMsg} />
+        <TorrentFileList torrentId={torrentId} torrent={torrent} />
+        <TorrentViewerFooter torrent={torrent} />
       </div>
     )
   }

--- a/components/brave_webtorrent/extension/components/torrentViewerFooter.tsx
+++ b/components/brave_webtorrent/extension/components/torrentViewerFooter.tsx
@@ -3,45 +3,40 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import { Anchor, Heading, Paragraph } from 'brave-ui/old'
+import { Anchor } from 'brave-ui/old'
 
 // Constants
 import { TorrentObj } from '../constants/webtorrentState'
 
 // Themes
-import { theme } from '../constants/theme'
+// import { theme } from '../constants/theme'
 
 interface Props {
   torrent?: TorrentObj
 }
 
-export default class TorrentViewerFooter extends React.PureComponent<Props, {}> {
+export default class TorrentViewerFooter extends React.PureComponent<
+  Props,
+  {}
+> {
   render () {
     const { torrent } = this.props
-    const privacyNotice = 'When you click "Start Torrent", Brave will download pieces of the torrent file from other users and upload pieces to them in turn. This will share the fact that you\'re downloading this file: other people will know what you\'re downloading, and they may also have access to your public IP address.'
 
-    return (
-      torrent ?
-      (
-        <Anchor
-          href='https://webtorrent.io'
-          text='Powered By WebTorrent'
-          target='_blank'
-        />
-      )
-      :
-      (
-        <div className='privacy-warning'>
-          <Heading
-            text='Privacy Warning:'
-            level={4}
-          />
-        <Paragraph
-          text={privacyNotice}
-          customStyle={theme.privacyNoticeBody}
-        />
-        </div>
-      )
+    return torrent ? (
+      <Anchor
+        href='https://webtorrent.io'
+        text='Powered By WebTorrent'
+        target='_blank'
+        id='webTorrentCredit'
+      />
+    ) : (
+      <div className='privacyNotice'>
+        Privacy Warning: When you click "Start Torrent" Brave will beging
+        downloading pieces of the torrent file from other users and uploading to
+        them in turn. This action will share that you're downloading this file.
+        Others may be able to see what you're downloading and/or determine your
+        public IP address.
+      </div>
     )
   }
 }

--- a/components/brave_webtorrent/extension/components/torrentViewerHeader.tsx
+++ b/components/brave_webtorrent/extension/components/torrentViewerHeader.tsx
@@ -3,14 +3,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import { Button, Column, Grid } from 'brave-ui/components'
-import { TitleHeading } from 'brave-ui/old'
+import { Button, Heading } from 'brave-ui/components'
 
 // Constants
 import { TorrentObj } from '../constants/webtorrentState'
-
-// Themes
-import { theme } from '../constants/theme'
 
 let clipboardCopy = require('clipboard-copy')
 
@@ -23,7 +19,10 @@ interface Props {
   onStopDownload: (tabId: number) => void
 }
 
-export default class TorrentViewerHeader extends React.PureComponent<Props, {}> {
+export default class TorrentViewerHeader extends React.PureComponent<
+  Props,
+  {}
+> {
   onClick = () => {
     this.props.torrent
       ? this.props.onStopDownload(this.props.tabId)
@@ -43,42 +42,41 @@ export default class TorrentViewerHeader extends React.PureComponent<Props, {}> 
 
   render () {
     const { torrent } = this.props
-    const name = typeof(this.props.name) === 'object'
-      ? this.props.name[0]
-      : this.props.name
+    const name =
+      typeof this.props.name === 'object'
+        ? this.props.name[0]
+        : this.props.name
     const title = torrent
       ? name
       : name
-        ? `Start Torrenting ${name}?`
-        : 'Loading torrent information...'
-    const mainButtonText = torrent ? 'Stop Download' : 'Start Torrent'
+      ? `${name}`
+      : 'Loading torrent information...'
+    const mainButtonText = torrent ? 'Stop Torrent' : 'Start Torrent'
     const copyButtonText = this.props.torrentId.startsWith('magnet:')
       ? 'Copy Magnet Link'
-      : 'Save Torrent File'
+      : 'Save File'
 
     return (
-      <Grid>
-        <Column size={9} customStyle={theme.headerColumnLeft}>
-          <TitleHeading
-            text={title}
+      <div className='headerContainer'>
+        <div className='__column'>
+          <Heading children={title} className='__torrentTitle' />
+        </div>
+        <div className='__column'>
+          <Button
+            type='accent'
+            text={mainButtonText}
+            onClick={this.onClick}
+            className='__button'
           />
-        </Column>
-        <Column size={3} customStyle={theme.headerColumnRight}>
-          <div style={theme.buttonContainer}>
-            <Button
-              type='accent'
-              text={mainButtonText}
-              onClick={this.onClick}
-            />
-            <Button
-              type='accent'
-              level='secondary'
-              text={copyButtonText}
-              onClick={this.onCopyClick}
-            />
-          </div>
-        </Column>
-      </Grid>
+          <Button
+            type='accent'
+            level='secondary'
+            text={copyButtonText}
+            onClick={this.onCopyClick}
+            className='__button'
+          />
+        </div>
+      </div>
     )
   }
 }

--- a/components/brave_webtorrent/extension/constants/theme.ts
+++ b/components/brave_webtorrent/extension/constants/theme.ts
@@ -3,22 +3,4 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export const theme = {
-  headerColumnLeft: {
-    alignItems: 'center',
-    justifyContent: 'flex-start'
-  },
-  headerColumnRight: {
-    alignItems: 'center',
-    justifyContent: 'flex-end'
-  },
-  privacyNoticeBody: {
-    fontSize: '12px'
-  },
-  buttonContainer: {
-    display: 'grid',
-    height: '100%',
-    gridTemplateColumns: '1fr 1fr',
-    gridTemplateRows: '1fr',
-    gridGap: '15px'
-  }
 }

--- a/components/styles/webtorrent.less
+++ b/components/styles/webtorrent.less
@@ -1,20 +1,72 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+// Color variables
+@bravePrimary: #fb542b;
+@silverBase: #c8c8d5;
+@silverDarken10: darken(@silverBase, 10%);
 
 body {
-  padding: 20px
-}
-
-h3 {
-  color: rgb(255, 80, 0);
+  padding: 100px;
+  font-family: Muli, sans-serif;
 }
 
 a {
   text-decoration: none;
-  color: #686978;
+  color: @bravePrimary;
 }
 
-.mediaViewer, .torrent-viewer {
-  font-family: Muli, sans-serif;
+.headerContainer {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 0 18px;
+  .__column {
+    justify-content: center;
+    align-items: center;
+    display: flex;
+    .__torrentTitle {
+      font-size: 24px;
+      font-weight: 500;
+      line-height: 36px;
+    }
+    .__button {
+      white-space: nowrap;
+      margin: 12px;
+    }
+  }
+}
+
+.torrentSubhead {
+  padding: 18px 0;
+  border-top: solid 1px @silverBase;
+  p {
+    font-size: 18px;
+  }
+  h3 {
+    font-size: 20px;
+    margin: 24px 0;
+    font-weight: 500;
+    color: @bravePrimary;
+  }
+}
+
+.privacyNotice {
+  padding: 18px 0;
+  border-top: solid 1px @silverBase;
+  color: @silverDarken10;
+  line-height: 24px;
+}
+
+#webTorrentCredit {
+  color: @silverBase;
+}
+
+.gridFix {
+  grid-template-columns: repeat(auto-fill, 50px);
+}
+
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  .__icon {
+    height: 32px;
+    margin: 0 0 18px;
+  }
 }

--- a/components/test/brave_webtorrent/components/torrentViewerFooter_test.tsx
+++ b/components/test/brave_webtorrent/components/torrentViewerFooter_test.tsx
@@ -24,7 +24,7 @@ describe('torrentViewerFooter component', () => {
       const wrapper = shallow(
         <TorrentViewerFooter />
       )
-      const assertion = wrapper.find('.privacy-warning')
+      const assertion = wrapper.find('.privacyNotice')
       expect(assertion.length).toBe(1)
     })
   })

--- a/components/test/brave_webtorrent/components/torrentViewerHeader_test.tsx
+++ b/components/test/brave_webtorrent/components/torrentViewerHeader_test.tsx
@@ -41,7 +41,7 @@ describe('torrentViewerHeader component', () => {
           />
         </TestThemeProvider>
       )
-      expect(wrapper.html()).toEqual(expect.stringContaining('Stop Download'))
+      expect(wrapper.html()).toEqual(expect.stringContaining('Stop Torrent'))
     })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/3034

This PR is meant to serve as very base formatting update to address only the breaking parts of this page in lieu of a proper spec. The main updates:

1. Made page generally responsive so it doesn't break when sized down or when a long torrent title is surfaced.
2. Added copy to make the user aware there is a way to disable this feature in settings. 
3. Small copy tweaks and amendments where `'` elements were being pulled in.
4. Added an animated loading icon

## Before
<img width="1021" alt="screen shot 2019-01-21 at 11 30 40 am" src="https://user-images.githubusercontent.com/29072694/51495478-5b31a180-1d71-11e9-85a6-8255b2fae263.png">


## After
<img width="909" alt="screen shot 2019-01-21 at 11 32 45 am" src="https://user-images.githubusercontent.com/29072694/51495473-579e1a80-1d71-11e9-83e9-b61fc2b3b62c.png">

## Test plan
1. Visit https://webtorrent.io/free-torrents
2. Open one of the demo URLs (the torrent link)
3. `Start torrenting` page shows
4. Resize the page a bit; make sure it responds properly