### PR TITLE
Add regions support and command-line switch to change region for testing geo targeted Ads 0.62.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -363,6 +363,12 @@ void AdsServiceImpl::Start() {
   if (command_line.HasSwitch(switches::kTesting)) {
     is_testing = true;
   }
+  if (command_line.HasSwitch(switches::kLocale)) {
+    std::string locale = command_line.GetSwitchValueASCII(switches::kLocale);
+    if (!locale.empty()) {
+      command_line_switch_ads_locale_ = locale;
+    }
+  }
 
   bat_ads_service_->SetProduction(is_production, base::NullCallback());
   bat_ads_service_->SetDebug(is_debug, base::NullCallback());
@@ -838,6 +844,10 @@ const std::vector<std::string> AdsServiceImpl::GetLocales() const {
 }
 
 const std::string AdsServiceImpl::GetAdsLocale() const {
+  if (!command_line_switch_ads_locale_.empty()) {
+    return command_line_switch_ads_locale_;
+  }
+
   return g_browser_process->GetApplicationLocale();
 }
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -200,6 +200,8 @@ class AdsServiceImpl : public AdsService,
   NotificationInfoMap notification_ids_;
   std::map<const net::URLFetcher*, ads::URLRequestCallback> fetchers_;
 
+  std::string command_line_switch_ads_locale_;
+
   DISALLOW_COPY_AND_ASSIGN(AdsServiceImpl);
 };
 

--- a/components/brave_ads/browser/bundle_state_database.cc
+++ b/components/brave_ads/browser/bundle_state_database.cc
@@ -340,20 +340,18 @@ bool BundleStateDatabase::GetAdsForCategory(const std::string& region,
       db_.GetUniqueStatement("SELECT ai.creative_set_id, ai.advertiser, "
                              "ai.notification_text, ai.notification_url, "
                              "ai.start_timestamp, ai.end_timestamp, "
-                             "ai.uuid, ai.campaign_id, ai.daily_cap, "
+                             "ai.uuid, ai.region, ai.campaign_id, ai.daily_cap, "
                              "ai.per_day, ai.total_max FROM ad_info AS ai "
                              "INNER JOIN ad_info_category AS aic "
                              "ON aic.ad_info_uuid = ai.uuid "
                              "WHERE aic.category_name = ? and "
-                             // TODO(tmancey) - use region in the query
-                             // "ai.region = ? and "
+                             "ai.region = ? and "
                              "ai.start_timestamp <= strftime('%Y-%m-%d %H:%M', "
                                "datetime('now','localtime')) and "
                              "ai.end_timestamp >= strftime('%Y-%m-%d %H:%M', "
                                "datetime('now','localtime'));"));
   info_sql.BindString(0, category);
-  // TODO(tmancey) - use region in the query
-  // info_sql.BindString(1, region);
+  info_sql.BindString(1, region);
 
   while (info_sql.Step()) {
     ads::AdInfo info;

--- a/components/brave_ads/common/switches.cc
+++ b/components/brave_ads/common/switches.cc
@@ -10,5 +10,6 @@ const char kStaging[] = "brave-ads-staging";
 const char kProduction[] = "brave-ads-production";
 const char kDebug[] = "brave-ads-debug";
 const char kTesting[] = "brave-ads-testing";
+const char kLocale[] = "brave-ads-locale";
 }  // namespace switches
 }  // namespace brave_ads

--- a/components/brave_ads/common/switches.h
+++ b/components/brave_ads/common/switches.h
@@ -11,6 +11,7 @@ extern const char kStaging[];
 extern const char kProduction[];
 extern const char kDebug[];
 extern const char kTesting[];
+extern const char kLocale[];
 }  // namespace switches
 }  // namespace apps
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2661

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Launch browser with --brave-ads-locale={locale} command-line argument, i.e. `--brave-ads-locale=en_US` and make sure Ads are only shown for the region(s) specified in the Ads catalog from the Ads Serve

- Launch browser without --brave-ads-locale command-line argument and make sure Ads are shown based upon the system locale

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source