### PR TITLE
Fixes ads being toggled on

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -100,7 +100,7 @@ class RewardsDOMHandler : public WebUIMessageHandler,
 
   // RewardsServiceObserver implementation
   void OnWalletInitialized(brave_rewards::RewardsService* rewards_service,
-                       int error_code) override;
+                       int result) override;
   void OnWalletProperties(brave_rewards::RewardsService* rewards_service,
       int error_code,
       std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) override;
@@ -306,13 +306,14 @@ void RewardsDOMHandler::GetWalletProperties(const base::ListValue* args) {
 
 void RewardsDOMHandler::OnWalletInitialized(
     brave_rewards::RewardsService* rewards_service,
-    int error_code) {
+    int result) {
   if (!web_ui()->CanCallJavascript())
     return;
 
-  if (error_code == 0) {
+  // ledger::Result::WALLET_CREATED
+  if (result == 12) {
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.walletCreated");
-  } else if (error_code != 3) {
+  } else if (result != 3 && result != 0) {
     // Report back all errors except when ledger_state is missing
     web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.walletCreateFailed");
   }

--- a/components/brave_rewards/browser/extension_rewards_service_observer.h
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.h
@@ -25,7 +25,7 @@ class ExtensionRewardsServiceObserver : public RewardsServiceObserver,
 
   // RewardsServiceObserver implementation
   void OnWalletInitialized(RewardsService* rewards_service,
-                           int error_code) override;
+                           int result) override;
   void OnWalletProperties(RewardsService* rewards_service,
                           int error_code,
                           std::unique_ptr<brave_rewards::WalletProperties>

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -718,7 +718,6 @@ void RewardsServiceImpl::OnWalletInitialized(ledger::Result result) {
     SetRewardsMainEnabled(true);
     SetAutoContribute(true);
     StartNotificationTimers(true);
-    result = ledger::Result::LEDGER_OK;
   }
 
   TriggerOnWalletInitialized(result);
@@ -1165,9 +1164,9 @@ void RewardsServiceImpl::OnURLFetchComplete(
   callback(response_code == 200, body, headers);
 }
 
-void RewardsServiceImpl::TriggerOnWalletInitialized(int error_code) {
+void RewardsServiceImpl::TriggerOnWalletInitialized(int result) {
   for (auto& observer : observers_)
-    observer.OnWalletInitialized(this, error_code);
+    observer.OnWalletInitialized(this, result);
 }
 
 void RewardsServiceImpl::TriggerOnWalletProperties(int error_code,

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -193,7 +193,7 @@ class RewardsServiceImpl : public RewardsService,
                              bool success);
   void OnPublisherStateLoaded(ledger::LedgerCallbackHandler* handler,
                               const std::string& data);
-  void TriggerOnWalletInitialized(int error_code);
+  void TriggerOnWalletInitialized(int result);
   void TriggerOnWalletProperties(int error_code,
                                  std::unique_ptr<ledger::WalletInfo> result);
   void TriggerOnGrant(ledger::Result result, const ledger::Grant& grant);

--- a/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
+++ b/components/brave_rewards/resources/ui/reducers/wallet_reducer.ts
@@ -17,7 +17,6 @@ const createWallet = (state: Rewards.State) => {
 
   chrome.send('brave_rewards.getReconcileStamp')
   chrome.send('brave_rewards.getAddresses')
-  chrome.send('brave_rewards.saveAdsSetting', ['adsEnabled', 'true'])
 
   return state
 }
@@ -33,6 +32,7 @@ const walletReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State,
     case types.WALLET_CREATED:
       state = { ...state }
       state = createWallet(state)
+      chrome.send('brave_rewards.saveAdsSetting', ['adsEnabled', 'true'])
       break
     case types.WALLET_CREATE_FAILED:
       state = { ...state }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2986

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
pre-requirement
1. go to 0.59
2. clean profile
3. enable rewards via panel
4. close the bowser
5. rename profile to development

Test plan
1. go to this PR
2. start the browser
3. go to rewards settings page
4. make sure that ads are off


Plan 2 (no need for pre-requirement)
1. clean profile on this PR
2. create wallet in the panel
3. make sure that settings page is updated as well / create it via settings page and make sure that panel is enabled / open multiple rewards windows and enable it in one and make sure that all opdate

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source