### PR TITLE
Fixes unable to clear notification

### DIFF
--- a/components/brave_rewards/browser/rewards_notification_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.cc
@@ -74,10 +74,19 @@ void RewardsNotificationServiceImpl::AddNotification(
 
 void RewardsNotificationServiceImpl::DeleteNotification(RewardsNotificationID id) {
   DCHECK(!id.empty());
-  if (rewards_notifications_.find(id) == rewards_notifications_.end())
-    return;
-  RewardsNotification rewards_notification = rewards_notifications_[id];
-  rewards_notifications_.erase(id);
+  RewardsNotification rewards_notification;
+  if (rewards_notifications_.find(id) == rewards_notifications_.end()) {
+    rewards_notification.id_ = id;
+    rewards_notification.type_ = RewardsNotificationType::REWARDS_NOTIFICATION_INVALID;
+
+    // clean up, so that we don't have long standing notifications
+    if (rewards_notifications_.size() == 1) {
+      rewards_notifications_.clear();
+    }
+  } else {
+    rewards_notification = rewards_notifications_[id];
+    rewards_notifications_.erase(id);
+  }
   OnNotificationDeleted(rewards_notification);
 }
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2883

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- wait for grant notification to appear
- open profile folder `Default/Preferences`
- search for `brave/rewards/notifications/notifications` object and rename notification id
- start browser again
- make sure that you can clear grant notification

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source