### PR TITLE
Broken favicons in a-c list #990

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -33,6 +33,8 @@
 #include "components/brave_rewards/settings/resources/grit/brave_rewards_settings_generated_map.h"
 #include "components/grit/components_resources.h"
 #include "components/grit/components_scaled_resources.h"
+#include "content/public/browser/url_data_source.h"
+#include "chrome/browser/ui/webui/favicon_source.h"
 #endif
 
 
@@ -147,6 +149,14 @@ RewardsDOMHandler::~RewardsDOMHandler() {
 }
 
 void RewardsDOMHandler::RegisterMessages() {
+
+#if defined(OS_ANDROID)
+  // Create our favicon data source.
+  Profile* profile = Profile::FromWebUI(web_ui());
+  content::URLDataSource::Add(profile,
+                              std::make_unique<FaviconSource>(profile));
+#endif
+
   web_ui()->RegisterMessageCallback("brave_rewards.createWalletRequested",
       base::BindRepeating(&RewardsDOMHandler::HandleCreateWalletRequested,
                           base::Unretained(this)));


### PR DESCRIPTION
It fixes issue: https://github.com/brave/browser-android-tabs/issues/990 and supposed to be merged with branch 'android'.
It duplicates PR: https://github.com/brave/brave-core/pull/961 for branch 'master'. 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source