### PR TITLE
Tab separator becomes 1dp wide

### DIFF
--- a/patches/chrome-browser-ui-views-tabs-tab_style.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab_style.cc.patch
@@ -1,16 +1,7 @@
 diff --git a/chrome/browser/ui/views/tabs/tab_style.cc b/chrome/browser/ui/views/tabs/tab_style.cc
-index 8f21aa7edbb3b0409c68e0d850541573710f993c..791e5dc1c2c161325990a43f0bb2d960d152e95a 100644
+index 8f21aa7edbb3b0409c68e0d850541573710f993c..c77782443be84d1980cc36e54a89ed872807454d 100644
 --- a/chrome/browser/ui/views/tabs/tab_style.cc
 +++ b/chrome/browser/ui/views/tabs/tab_style.cc
-@@ -128,7 +128,7 @@ class GM2TabStyle : public TabStyle {
- 
- // Thickness in DIPs of the separator painted on the left and right edges of
- // the tab.
--constexpr int kSeparatorThickness = 1;
-+constexpr int kSeparatorThickness = 2;
- 
- // Returns the radius of the outer corners of the tab shape.
- int GetCornerRadius() {
 @@ -144,7 +144,7 @@ int GetContentsHorizontalInsetSize() {
  
  // Returns the height of the separator between tabs.
@@ -37,11 +28,14 @@ index 8f21aa7edbb3b0409c68e0d850541573710f993c..791e5dc1c2c161325990a43f0bb2d960
                   separator_size.width(), separator_size.height());
  
    separator_bounds.trailing = separator_bounds.leading;
-@@ -696,12 +697,13 @@ void GM2TabStyle::PaintSeparators(gfx::Canvas* canvas) const {
+@@ -696,12 +697,16 @@ void GM2TabStyle::PaintSeparators(gfx::Canvas* canvas) const {
                                                     SK_AlphaOPAQUE));
    };
  
-+  const int separator_radius = separator_bounds.leading.width() / 2;
++  // Even if |separator_radius| becomes 1 native pixel the 'roundedness'
++  // will be approximated with color, although extremely subtle and
++  // likely only on screens >= 2x (i.e. separator width is 2+px)!
++  const int separator_radius =  separator_bounds.leading.width() / 2;
    cc::PaintFlags flags;
    flags.setAntiAlias(true);
    flags.setColor(separator_color(separator_opacities.left));


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3081

I kept the patch in for drawing the separators with _rounded_ rectangles because, although extremely subtle, it matches the similar strategy for other separators in Brave (e.g. brave actions bar in location bar).

![image](https://user-images.githubusercontent.com/741836/51713532-19aa2c00-1fe7-11e9-97fa-b9da9d5169c6.png)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- Open multiple tabs
- Tab separators should be 1dp thick (2px on most retina screens)
  - Take screenshot
  - Zoom in
  - Count pixels

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source