### PR TITLE
Only accept the full GPG key ID when signing linux packages

### DIFF
--- a/script/upload_to_aptly
+++ b/script/upload_to_aptly
@@ -16,6 +16,12 @@ set -exu
 ### The first argument is the S3 bucket, the second is the GPG key fingerprint
 OPTION=${1:-brave-browser-apt-staging-nightly}
 GPG_KEY_ID=${2:-E85FFA8E2E90B40B33ED39274FE13824E3FFC656} # Defaults to New Brave Software signing key
+
+if [[ $2 == 0x* ]]; then
+    echo "Error: Please pass the Full GPG KEY ID to sign with! (i.e. '9228DBCE20DDE5EC46488DE90B31DBA06A8A26F9')"
+    exit 1
+fi
+
 if [ "$GPG_KEY_ID" = "E85FFA8E2E90B40B33ED39274FE13824E3FFC656" ]; then
   KEY_NAME=brave-core.asc
 else

--- a/script/upload_to_rpm_repo
+++ b/script/upload_to_rpm_repo
@@ -16,6 +16,12 @@ set -exu
 BUCKET=${1:-brave-browser-rpm-staging-nightly}
 GPG_KEY_ID=${2:-E85FFA8E2E90B40B33ED39274FE13824E3FFC656} # Defaults to New Brave Software signing key
 GPG_KEY_SHORT_ID=${GPG_KEY_ID:(-8)}
+
+if [[ $2 == 0x* ]]; then
+    echo "Error: Please pass the Full GPG KEY ID to sign with! (i.e. '9228DBCE20DDE5EC46488DE90B31DBA06A8A26F9')"
+    exit 1
+fi
+
 if [ "$GPG_KEY_ID" = "E85FFA8E2E90B40B33ED39274FE13824E3FFC656" ]; then
   KEY_NAME=brave-core.asc
 else


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/3107

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source