### PR TITLE
Check key_creation_util_ in importer utility process

### DIFF
--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -1,5 +1,5 @@
 diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
-index 00fe8402c3357e08e69336752133aeb69bbc027b..0a3cf99e489abf003729e110f39bb4056d270ba5 100644
+index 00fe8402c3357e08e69336752133aeb69bbc027b..a1f97f815179ee89b864b41e71f86a71ee460d8b 100644
 --- a/components/os_crypt/keychain_password_mac.mm
 +++ b/components/os_crypt/keychain_password_mac.mm
 @@ -7,6 +7,7 @@
@@ -21,7 +21,7 @@ index 00fe8402c3357e08e69336752133aeb69bbc027b..0a3cf99e489abf003729e110f39bb405
  #endif
  
  KeychainPassword::KeychainPassword(
-@@ -62,8 +63,20 @@ KeychainPassword::KeychainPassword(
+@@ -62,30 +63,48 @@ KeychainPassword::KeychainPassword(
  KeychainPassword::~KeychainPassword() = default;
  
  std::string KeychainPassword::GetPassword() const {
@@ -44,14 +44,32 @@ index 00fe8402c3357e08e69336752133aeb69bbc027b..0a3cf99e489abf003729e110f39bb405
    UInt32 password_length = 0;
    void* password_data = NULL;
    OSStatus error = keychain_.FindGenericPassword(
-@@ -85,7 +98,11 @@ std::string KeychainPassword::GetPassword() const {
+       strlen(service_name), service_name, strlen(account_name), account_name,
+       &password_length, &password_data, NULL);
+ 
++  // If we're in the importer utility process, key_creation_util_ is nullptr
++  // because it requires a PrefService and therefore can only be created in the
++  // browser process; do not dereference.
+   if (error == noErr) {
+     std::string password =
+         std::string(static_cast<char*>(password_data), password_length);
+     keychain_.ItemFreeContent(password_data);
+-    key_creation_util_->OnKeyWasFound();
++    if (key_creation_util_)
++      key_creation_util_->OnKeyWasFound();
+     return password;
+   }
+ 
+   if (error == errSecItemNotFound) {
+     std::string password =
+         AddRandomPasswordToKeychain(keychain_, service_name, account_name);
+-    key_creation_util_->OnKeyNotFound(!password.empty());
++    if (key_creation_util_)
++      key_creation_util_->OnKeyNotFound(!password.empty());
      return password;
    }
  
 -  key_creation_util_->OnKeychainLookupFailed();
-+  // If we're in the importer utility process, key_creation_util_ is nullptr
-+  // because it requires a PrefService and therefore can only be created in the
-+  // browser process; do not dereference.
 +  if (key_creation_util_)
 +    key_creation_util_->OnKeychainLookupFailed();
    OSSTATUS_DLOG(ERROR, error) << "Keychain lookup failed";


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3112

Upstream commit:
```
commit f1ab93849fe9436e27b27ad76d59369a6ad40ce9
Author: Vasilii Sukhanov <vasilii@chromium.org>
Date:   Thu Nov 22 15:54:53 2018 +0000

    Delete kPreventEncryptionKeyOverwrites feature.

    The feature is not to be launched and the associated code is
    removed.
    The metrics collection should be running.
```
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source