### PR TITLE
Fix for crash reporting on Linux.

### DIFF
--- a/patches/chrome-app-chrome_crash_reporter_client.cc.patch
+++ b/patches/chrome-app-chrome_crash_reporter_client.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/app/chrome_crash_reporter_client.cc b/chrome/app/chrome_crash_reporter_client.cc
+index 941caaa910906af473915f444fbbd2b4a9abe4d1..9606df6b5f8bb76acd4b8cf0cea6c58215ffb779 100644
+--- a/chrome/app/chrome_crash_reporter_client.cc
++++ b/chrome/app/chrome_crash_reporter_client.cc
+@@ -110,7 +110,7 @@ bool ChromeCrashReporterClient::IsRunningUnattended() {
+ }
+ 
+ bool ChromeCrashReporterClient::GetCollectStatsConsent() {
+-#if defined(GOOGLE_CHROME_BUILD)
++#if defined(GOOGLE_CHROME_BUILD) || (defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD))
+   bool is_official_chrome_build = true;
+ #else
+   bool is_official_chrome_build = false;

--- a/patches/components-crash-content-app-breakpad_linux.cc.patch
+++ b/patches/components-crash-content-app-breakpad_linux.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/components/crash/content/app/breakpad_linux.cc b/components/crash/content/app/breakpad_linux.cc
+index a7378204ffaa5586be9789a552de0f2a951ad208..9044ab8c9bb148edba86cad6b9781c726ad6dfed 100644
+--- a/components/crash/content/app/breakpad_linux.cc
++++ b/components/crash/content/app/breakpad_linux.cc
+@@ -88,8 +88,12 @@ namespace breakpad {
+ namespace {
+ 
+ #if !defined(OS_CHROMEOS)
++#if defined(BRAVE_CHROMIUM_BUILD)
++const char kUploadURL[] = "https://laptop-updates.brave.com/1/bc-crashes";
++#else
+ const char kUploadURL[] = "https://clients2.google.com/cr/report";
+ #endif
++#endif
+ 
+ bool g_is_crash_reporter_enabled = false;
+ uint64_t g_process_start_time = 0;


### PR DESCRIPTION
- Patches ChromeCrashReporterClient::GetCollectStatsConsent to check for
  BRAVE_CHROMIUM_BUILD in addition to GOOGLE_CHROME_BUILD.
- Patches breakpad Linux implementation with Brave's crash reporting upload
  endpoint.

Fixes brave/brave-browser#1251

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
**On Linux**
1. Start Brave browser with a fresh profile and navigate to brave://crashes.
2. Verify that the page indicates the crash reporting is disabled.
3. Navigate to brave://settings, scroll down and click on Advanced.
4. In the `Privacy and security` section toggle `Automatically send crash reports to Brave` to ON.
5. Click Relaunch button and wait for the browser to restart.
6. Navigate to brave://crashes and verify that there are 0 crashes.
7. In a new tab navigate to brave://crash and wait for the tab to show the "Aw, snap!" message.
8. Go back to the brave://crashes tab and reload it.
9. Verify that there is a crash entry there and text similar to `Uploaded Crash Report ID <hexadecimals>`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source