### PR TITLE
Foreground/Background notifications aren't implemented on Linux for Brave Ads

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -40,6 +40,8 @@ source_set("browser") {
       "ads_service_impl.h",
       "background_helper.cc",
       "background_helper.h",
+      "background_helper_linux.cc",
+      "background_helper_linux.h",
       "background_helper_mac.mm",
       "background_helper_mac.h",
       "background_helper_win.cc",

--- a/components/brave_ads/browser/background_helper.cc
+++ b/components/brave_ads/browser/background_helper.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -32,7 +33,7 @@ void BackgroundHelper::RemoveObserver(Observer* observer) {
   observers_.RemoveObserver(observer);
 }
 
-#if !defined(OS_MACOSX) && !defined(OS_WIN)
+#if !defined(OS_MACOSX) && !defined(OS_WIN) && !defined(OS_LINUX)
 BackgroundHelper* BackgroundHelper::GetInstance() {
   // just return a dummy background helper for all other platforms
   return base::Singleton<BackgroundHelper>::get();

--- a/components/brave_ads/browser/background_helper_linux.cc
+++ b/components/brave_ads/browser/background_helper_linux.cc
@@ -1,0 +1,70 @@
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/background_helper_linux.h"
+
+#include "base/bind.h"
+#include "base/threading/sequenced_task_runner_handle.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/x/x11_util.h"
+
+namespace brave_ads {
+
+BackgroundHelperLinux::BackgroundHelperLinux() {
+  BrowserList::AddObserver(this);
+  OnBrowserSetLastActive(BrowserList::GetInstance()->GetLastActive());
+}
+
+BackgroundHelperLinux::~BackgroundHelperLinux() {
+  BrowserList::RemoveObserver(this);
+}
+
+bool BackgroundHelperLinux::IsForeground() const {
+  XID xid = 0;
+  ui::GetXIDProperty(ui::GetX11RootWindow(), "_NET_ACTIVE_WINDOW", &xid);
+
+  for (auto* browser : *BrowserList::GetInstance()) {
+    auto window =
+        browser->window()->GetNativeWindow()->GetHost()->GetAcceleratedWidget();
+    if (xid == window)
+      return true;
+  }
+
+  return false;
+}
+
+void BackgroundHelperLinux::CheckState() {
+  if (IsForeground()) {
+    TriggerOnForeground();
+  } else {
+    TriggerOnBackground();
+  }
+}
+
+void BackgroundHelperLinux::OnBrowserSetLastActive(Browser* browser) {
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&BackgroundHelperLinux::TriggerOnForeground, AsWeakPtr()));
+}
+
+void BackgroundHelperLinux::OnBrowserNoLongerActive(Browser* browser) {
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&BackgroundHelperLinux::TriggerOnBackground, AsWeakPtr()));
+}
+
+BackgroundHelperLinux* BackgroundHelperLinux::GetInstance() {
+  return base::Singleton<BackgroundHelperLinux>::get();
+}
+
+BackgroundHelper* BackgroundHelper::GetInstance() {
+  return BackgroundHelperLinux::GetInstance();
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/browser/background_helper_linux.h
+++ b/components/brave_ads/browser/background_helper_linux.h
@@ -1,0 +1,44 @@
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_BACKGROUND_HELPER_LINUX_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_BACKGROUND_HELPER_LINUX_H_
+
+#include "base/macros.h"
+#include "base/memory/singleton.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/brave_ads/browser/background_helper.h"
+#include "chrome/browser/ui/browser_list_observer.h"
+
+namespace brave_ads {
+
+class BackgroundHelperLinux :
+    public BackgroundHelper,
+    public base::SupportsWeakPtr<BackgroundHelperLinux>,
+    public BrowserListObserver {
+ public:
+  BackgroundHelperLinux();
+  ~BackgroundHelperLinux() override;
+
+  static BackgroundHelperLinux* GetInstance();
+
+ private:
+  friend struct base::DefaultSingletonTraits<BackgroundHelperLinux>;
+
+  // BackgroundHelper impl
+  bool IsForeground() const override;
+
+  // BrowserListObserver overrides
+  void OnBrowserSetLastActive(Browser* browser) override;
+  void OnBrowserNoLongerActive(Browser* browser) override;
+
+  void CheckState();
+
+  DISALLOW_COPY_AND_ASSIGN(BackgroundHelperLinux);
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_BACKGROUND_HELPER_LINUX_H_

--- a/components/brave_ads/browser/buildflags/buildflags.gni
+++ b/components/brave_ads/browser/buildflags/buildflags.gni
@@ -1,5 +1,5 @@
 import("//build/config/features.gni")
 
 declare_args() {
-  brave_ads_enabled = true
+  brave_ads_enabled = !is_android
 }

--- a/components/services/bat_ads/manifest.json
+++ b/components/services/bat_ads/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "bat_ads",
+  "display_name": "Bat Ads Service",
+  "sandbox_type": "none",
+  "options" : {
+    "instance_sharing" : "shared_instance_across_users"
+  },
+  "interface_provider_specs": {
+    "service_manager:connector": {
+      "provides": {
+        "bat_ads": [ "bat_ads.mojom.BatAdsService" ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/2511

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Confirm AdsService Event Log is logged to console for "foreground" and "background" events. Launch browser from command-line with following arguments: `--enable-logging=stderr --vmodule=brave_ads=3`.


## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source