### PR TITLE
Updates settings page data when re-enabling rewards

### DIFF
--- a/components/brave_rewards/resources/ui/components/settingsPage.tsx
+++ b/components/brave_rewards/resources/ui/components/settingsPage.tsx
@@ -32,6 +32,14 @@ class SettingsPage extends React.Component<Props, {}> {
     return this.props.actions
   }
 
+  refreshActions () {
+    this.actions.getCurrentReport()
+    this.actions.getDonationTable()
+    this.actions.getContributeList()
+    this.actions.getPendingContributionsTotal()
+    this.actions.getReconcileStamp()
+  }
+
   componentDidMount () {
     if (this.props.rewardsData.firstLoad === null) {
       // First load ever
@@ -47,19 +55,32 @@ class SettingsPage extends React.Component<Props, {}> {
       this.actions.getWalletProperties()
     }, 60000)
 
-    this.actions.getCurrentReport()
-    this.actions.getDonationTable()
-    this.actions.getContributeList()
+    this.refreshActions()
     this.actions.getAdsData()
     this.actions.checkImported()
-    this.actions.getReconcileStamp()
     this.actions.getGrant()
-    this.actions.getPendingContributionsTotal()
 
     // one time check (legacy fix)
     // more info here https://github.com/brave/brave-browser/issues/2172
     if (!this.props.rewardsData.ui.addressCheck) {
       this.actions.getAddresses()
+    }
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    if (
+      !prevProps.rewardsData.enabledMain &&
+      this.props.rewardsData.enabledMain
+    ) {
+      this.refreshActions()
+    }
+
+    if (
+      !prevProps.rewardsData.enabledContribute &&
+      this.props.rewardsData.enabledContribute
+    ) {
+      this.actions.getContributeList()
+      this.actions.getReconcileStamp()
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/2892

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Clean profile
- Run Brave with flag --rewards=staging=true,reconcile-interval=2
- Enable rewards brave://rewards and claim the grant
- Open kjozwiakstaging.github.io in a new tab and stay on it for 10s to add it to a-c table
- Disable rewards
- Wait till the reconcile-interval is passed (2 minutes)
- Enable rewards
- Make sure that ac table is cleared

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source