### PR TITLE
Always fetch referral headers on startup

### DIFF
--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -91,7 +91,10 @@ void BraveReferralsService::Start() {
                          base::Bind(&BraveReferralsService::GetFirstRunTime,
                                     base::Unretained(this)));
 
-  // Periodically fetch referral headers.
+  // Fetch the referral headers on startup.
+  FetchReferralHeaders();
+
+  // Also, periodically fetch the referral headers.
   DCHECK(!fetch_referral_headers_timer_);
   fetch_referral_headers_timer_ = std::make_unique<base::RepeatingTimer>();
   fetch_referral_headers_timer_->Start(
@@ -113,8 +116,6 @@ void BraveReferralsService::Start() {
                    base::Unretained(this)),
         base::Bind(&BraveReferralsService::OnReadPromoCodeComplete,
                    weak_factory_.GetWeakPtr()));
-  else
-    FetchReferralHeaders();
 
   initialized_ = true;
 }


### PR DESCRIPTION
Fixes brave/brave-browser#3143

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source