### PR TITLE
Enable --skip_signing subcommand of create_dist on Windows

### DIFF
--- a/build/win/BUILD.gn
+++ b/build/win/BUILD.gn
@@ -49,6 +49,9 @@ action("create_signed_installer") {
     "--root_out_dir=$out_dir",
     "--brave_installer_exe=$brave_installer_exe",
   ]
+
+  if (skip_signing) { args += [ "--skip_signing" ] }
+
   deps = [
     "//chrome/installer/mini_installer"
   ]

--- a/patches/chrome-installer-mini_installer-BUILD.gn.patch
+++ b/patches/chrome-installer-mini_installer-BUILD.gn.patch
@@ -1,12 +1,24 @@
 diff --git a/chrome/installer/mini_installer/BUILD.gn b/chrome/installer/mini_installer/BUILD.gn
-index 931761ff27de83f8ac6ce6b0211b7eaa1151c5cb..14fcfe917fbff1a7147135e4e7b96b2a9078d267 100644
+index 931761ff27de83f8ac6ce6b0211b7eaa1151c5cb..76b0b5884dee55ee6cbb22e999c921108ca597f2 100644
 --- a/chrome/installer/mini_installer/BUILD.gn
 +++ b/chrome/installer/mini_installer/BUILD.gn
-@@ -181,6 +181,21 @@ template("generate_mini_installer") {
+@@ -12,6 +12,10 @@ import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
+ import("//ui/base/ui_features.gni")
+ import("//v8/gni/v8.gni")
+ 
++if (brave_chromium_build) {
++  import("//brave/build/config.gni")
++}
++
+ declare_args() {
+   # The Chrome archive is compressed in official builds to reduce the size of
+   # the installer. By default: non-official or component builds, a build mode
+@@ -181,6 +185,22 @@ template("generate_mini_installer") {
        "//third_party/icu:icudata",
        chrome_dll_target,
      ]
 +    if (brave_chromium_build) {
++      if (skip_signing) { args += [ "--skip_signing" ] }
 +      inputs -= [
 +        "$root_out_dir/chrome.exe",
 +      ]

--- a/patches/chrome-tools-build-win-create_installer_archive.py.patch
+++ b/patches/chrome-tools-build-win-create_installer_archive.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/tools/build/win/create_installer_archive.py b/chrome/tools/build/win/create_installer_archive.py
-index 0e12f2a17d11bdde2470330b6437f3254e3d1be7..504b38c805c2fa4190a4d0088318374ba27dce69 100755
+index 0e12f2a17d11bdde2470330b6437f3254e3d1be7..b70f73cfb733e7fe3c4539c31743a478202bfd54 100755
 --- a/chrome/tools/build/win/create_installer_archive.py
 +++ b/chrome/tools/build/win/create_installer_archive.py
 @@ -109,6 +109,60 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
@@ -63,13 +63,23 @@ index 0e12f2a17d11bdde2470330b6437f3254e3d1be7..504b38c805c2fa4190a4d0088318374b
  
  def CopySectionFilesToStagingDir(config, section, staging_dir, src_dir):
    """Copies installer archive files specified in section from src_dir to
-@@ -557,6 +611,9 @@ def main(options):
+@@ -557,6 +611,10 @@ def main(options):
      version_numbers = prev_version.split('.')
      prev_build_number = version_numbers[2] + '.' + version_numbers[3]
  
-+  from sign_binaries import sign_binaries
-+  sign_binaries(staging_dir)
++  if not options.skip_signing:
++    from sign_binaries import sign_binaries
++    sign_binaries(staging_dir)
 +
    # Name of the archive file built (for example - chrome.7z or
    # patch-<old_version>-<new_version>.7z or patch-<new_version>.7z
    archive_file = CreateArchiveFile(options, staging_dir,
+@@ -625,6 +683,8 @@ def _ParseOptions():
+            'with the installer archive {x86|x64}.')
+   parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
+                     default=False)
++  parser.add_option('--skip_signing', default=False)
++
+ 
+   options, _ = parser.parse_args()
+   if not options.build_dir:

--- a/script/create-signed-installer.py
+++ b/script/create-signed-installer.py
@@ -11,21 +11,23 @@ def main():
         os.path.dirname(os.path.dirname(os.path.dirname(
             os.path.realpath(__file__)))),
         args.root_out_dir[0])
-    create_signed_installer(root_out_dir, args.brave_installer_exe[0])
+    create_signed_installer(root_out_dir, args.brave_installer_exe[0], args.skip_signing)
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Create signed installer')
     parser.add_argument('--root_out_dir', nargs=1)
     parser.add_argument('--brave_installer_exe', nargs=1)
+    parser.add_argument('--skip_signing', action='store_true')
     return parser.parse_args()
 
 
-def create_signed_installer(root_out_dir, brave_installer_exe, env=None):
+def create_signed_installer(root_out_dir, brave_installer_exe, skip_signing, env=None):
     installer_file = os.path.join(root_out_dir, 'brave_installer.exe')
     shutil.copyfile(os.path.join(root_out_dir, 'mini_installer.exe'),
                     installer_file)
-    sign_binary(installer_file)
+    if not skip_signing:
+      sign_binary(installer_file)
     # Copy signed installer to version appended name
     installer_file_with_version = os.path.join(root_out_dir,
                                                brave_installer_exe)


### PR DESCRIPTION
So far, some scripts should be modified to build installer on local
machine because it needs credentials during the signing.
For test purpose, signing is not needed.

Fix https://github.com/brave/brave-browser/issues/3149

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. run `yarn create_dist Release --skip_signing`
2. Check finished w/o script error

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source