### PR TITLE
Fixes weights in normalize process

### DIFF
--- a/vendor/bat-native-ledger/src/bat_publishers.cc
+++ b/vendor/bat-native-ledger/src/bat_publishers.cc
@@ -543,15 +543,17 @@ void BatPublishers::synopsisNormalizerInternal(
   std::vector<double> roundoffs;
   unsigned int totalPercents = 0;
   for (size_t i = 0; i < list.size(); i++) {
-    realPercents.push_back((double)list[i].score / (double)totalScores * 100.0);
-    percents.push_back((unsigned int)std::lround(realPercents[realPercents.size() - 1]));
-    double roundoff = percents[percents.size() - 1] - realPercents[realPercents.size() - 1];
+    double floatNumber = (list[i].score / totalScores) * 100.0;
+    double roundNumber = (unsigned int)std::lround(floatNumber);
+    realPercents.push_back(floatNumber);
+    percents.push_back(roundNumber);
+    double roundoff = roundNumber - floatNumber;
     if (roundoff < 0.0) {
       roundoff *= -1.0;
     }
     roundoffs.push_back(roundoff);
-    totalPercents += percents[percents.size() - 1];
-    weights.push_back((double)list[i].score / (double)list.size() * 100.0);
+    totalPercents += roundNumber;
+    weights.push_back(floatNumber);
   }
   while (totalPercents != 100) {
     size_t valueToChange = 0;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3163

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- clean profile
- enable rewards
- visit one site
- make sure that you see it in ac table
- open publisher db
 - make sure that weight in activity_info table is 100

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source