### PR TITLE
Fix wrong python script indentation

### DIFF
--- a/script/create-signed-installer.py
+++ b/script/create-signed-installer.py
@@ -27,7 +27,7 @@ def create_signed_installer(root_out_dir, brave_installer_exe, skip_signing, env
     shutil.copyfile(os.path.join(root_out_dir, 'mini_installer.exe'),
                     installer_file)
     if not skip_signing:
-      sign_binary(installer_file)
+        sign_binary(installer_file)
     # Copy signed installer to version appended name
     installer_file_with_version = os.path.join(root_out_dir,
                                                brave_installer_exe)


### PR DESCRIPTION
Change it to multiple of four.

Fix https://github.com/brave/brave-browser/issues/3169

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source