### PR TITLE
Rewards publisher list is now updated every 24 hours

### DIFF
--- a/vendor/bat-native-ledger/src/static_values.h
+++ b/vendor/bat-native-ledger/src/static_values.h
@@ -89,7 +89,7 @@ static const unsigned int _twitch_events_array_size = 8;
 static const std::string _twitch_events[] = {"buffer-empty", "buffer-refill", "video_end",
   "minute-watched", "video_pause", "player_click_vod_seek", "video-play", "video_error"};
 
-static const uint64_t _publishers_list_load_interval = 48 * 60 * 60; // 48 hours in seconds
+static const uint64_t _publishers_list_load_interval = 24 * 60 * 60; // 24 hours in seconds
 static const uint64_t _reconcile_default_interval = 30 * 24 * 60 * 60; // 30 days in seconds
 static const uint64_t _grant_load_interval = 24 * 60 * 60; // 1 day in seconds
 


### PR DESCRIPTION
Fixes brave/brave-browser#3171

Previously was updated every 48 hours.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave and enable rewards
2. Quit Brave and open publisher_state file
3. set `pubs_load_timestamp` to a value more than 24 hours in advance and save file
4. Restart Brave and use terminal to ensure publisher list is updated
5. Open publisher_state and ensure `pubs_load_timestamp` has been updated.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source