### PR TITLE
Add referrer-spoofing exceptions for Google Accounts (fixes #1356)

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -76,11 +76,17 @@ bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
     }
   }
 
-  static std::map<GURL, std::vector<URLPattern> > whitelist_patterns_map = {{
+  static std::map<GURL, std::vector<URLPattern> > whitelist_patterns_map = {
+    {
       GURL("https://www.facebook.com/"), {
         URLPattern(URLPattern::SCHEME_HTTPS, "https://*.fbcdn.net/*"),
       }
-    }
+    },
+    {
+      GURL("https://accounts.google.com/"), {
+        URLPattern(URLPattern::SCHEME_HTTPS, "https://content.googleapis.com/*"),
+      }
+    },
   };
   std::map<GURL, std::vector<URLPattern> >::iterator i =
       whitelist_patterns_map.find(firstPartyOrigin);

--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -48,6 +48,11 @@ TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
   // not allowed with a different scheme
   EXPECT_FALSE(IsWhitelistedReferrer(GURL("http://binance.com"),
       GURL("http://api.geetest.com/")));
+  // Google Accounts only allows a specific hostname
+  EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://accounts.google.com"),
+      GURL("https://content.googleapis.com/cryptauth/v1/authzen/awaittx")));
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://accounts.google.com"),
+      GURL("https://ajax.googleapis.com/ajax/libs/d3js/5.7.0/d3.min.js")));
 }
 
 }  // namespace


### PR DESCRIPTION
Logging into Google Accounts with the Google Prompt 2FA mechanism
doesn't work unless we send the correct referrer as part of the
long-polling XHR to content.googleapis.com.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source