### PR TITLE
Fix domain typo in shield_exceptions_unittest

### DIFF
--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -20,7 +20,7 @@ TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
   EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.facebook.com"),
         GURL("https://video-zyz1-9.xy.fbcdn.net")));
   // Facebook doesn't allow just anything
-  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://www.facebook.com.com"),
+  EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://www.facebook.com"),
         GURL("https://test.com")));
   // Allowed for reddit.com
   EXPECT_TRUE(IsWhitelistedReferrer(GURL("https://www.reddit.com/"),


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source