### PR TITLE
protect unsafe multithreaded access to httpse cache

### DIFF
--- a/components/brave_shields/browser/https_everywhere_recently_used_cache.h
+++ b/components/brave_shields/browser/https_everywhere_recently_used_cache.h
@@ -1,57 +1,85 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2016 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <unordered_map>
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_HTTPS_EVERYWHERE_RECENTLY_USED_CACHE_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_HTTPS_EVERYWHERE_RECENTLY_USED_CACHE_H_
+
 #include <string>
+#include <unordered_map>
 #include <vector>
 
-template <class T> class RingBuffer
-{
-private:
-    int currentIdx = 0;
-    int count;
-    std::vector<T> data;
-public:
-    RingBuffer(int fixedSize) : count(fixedSize), data(count) {}
+#include "base/synchronization/lock.h"
 
-    const T& at(int i) {
-        return data[(currentIdx - (i % count) + count) % count];
-    }
+template <class T> class RingBuffer {
+ public:
+  explicit RingBuffer(int fixedSize) : count(fixedSize), data(count) {}
 
-    void add(const T& newValue) {
-        currentIdx = (currentIdx + 1) % count;
-        data[currentIdx] = newValue;
-    }
+  const T& at(int i) {
+    return data[(currentIdx - (i % count) + count) % count];
+  }
 
-    T oldest() {
-        return data[(currentIdx + 1) % count];
-    }
+  void add(const T& newValue) {
+    currentIdx = (currentIdx + 1) % count;
+    data[currentIdx] = newValue;
+  }
 
-    void clear() {
-        data = std::vector<T>(count);
-    }
+  T oldest() {
+    return data[(currentIdx + 1) % count];
+  }
+
+  void clear() {
+    data = std::vector<T>(count);
+  }
+
+ private:
+  int currentIdx = 0;
+  int count;
+  std::vector<T> data;
 };
 
-template <class T> class HTTPSERecentlyUsedCache
-{
-private:
-    RingBuffer<T> keysByAge;
-public:
-    std::unordered_map<std::string, T> data;
+template <class T> class HTTPSERecentlyUsedCache {
+ public:
+  explicit HTTPSERecentlyUsedCache(unsigned int size = 100) : keysByAge(size) {}
 
-    HTTPSERecentlyUsedCache(unsigned int size = 100) : keysByAge(size) {}
+  void add(const std::string& key, const T& value) {
+    base::AutoLock create(lock_);
 
-    void add(const std::string& key, const T& value) {
-        std::string old = keysByAge.oldest();
-        if (!old.empty()) {
-            keysByAge.data.erase(old);
-        }
-        keysByAge[key] = value;
+    data_[key] = value;
+    // https://github.com/brave/brave-browser/issues/3193
+    // std::string old = keysByAge.oldest();
+    // if (!old.empty()) {
+    //   keysByAge.data.erase(old);
+    // }
+    // keysByAge[key] = value;
+  }
+
+  bool get(const std::string& key, T* value) {
+    base::AutoLock create(lock_);
+
+    auto search = data_.find(key);
+    if (search != data_.end()) {
+      *value = search->second;
+      return true;
     }
+    return false;
+  }
 
-    void clear() {
-        data.clear();
-        keysByAge.clear();
-    }
+  void remove(const std::string& key) {
+    data_.erase(key);
+  }
+
+  void clear() {
+    data_.clear();
+    // https://github.com/brave/brave-browser/issues/3193
+    // keysByAge.clear();
+  }
+
+ private:
+  std::unordered_map<std::string, T> data_;
+  base::Lock lock_;
+  RingBuffer<T> keysByAge;
 };
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_HTTPS_EVERYWHERE_RECENTLY_USED_CACHE_H_


### PR DESCRIPTION
original PR https://github.com/brave/brave-core/pull/1546
protect unsafe multithreaded access to httpse cache

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source