### PR TITLE
Remove dl.google.com repository from Linux packages

### DIFF
--- a/patches/chrome-installer-linux-common-repo.cron.patch
+++ b/patches/chrome-installer-linux-common-repo.cron.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/installer/linux/common/repo.cron b/chrome/installer/linux/common/repo.cron
+index 2750e4924da6d0a723c1d649781637e7d08b3562..fbe7797e37633de174f4a83d7b11bf04b8813c1a 100755
+--- a/chrome/installer/linux/common/repo.cron
++++ b/chrome/installer/linux/common/repo.cron
+@@ -17,6 +17,9 @@
+ # "false" as desired. An empty $DEFAULTS_FILE is the same as setting both values
+ # to "false".
+ 
++# Don't add the Chrome repo (brave/brave-browser#1084)
++exit 0
++
+ @@include@@apt.include
+ 
+ ## MAIN ##

--- a/patches/chrome-installer-linux-common-rpmrepo.cron.patch
+++ b/patches/chrome-installer-linux-common-rpmrepo.cron.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/installer/linux/common/rpmrepo.cron b/chrome/installer/linux/common/rpmrepo.cron
+index f7fe2bcf7d7cbf95b23067f21f87422706c5e4d0..3541826a03009e2adb8dbd6c258d254d31247a77 100755
+--- a/chrome/installer/linux/common/rpmrepo.cron
++++ b/chrome/installer/linux/common/rpmrepo.cron
+@@ -14,6 +14,9 @@
+ # setting "repo_add_once" to "true" or "false" as desired. An empty
+ # $DEFAULTS_FILE is the same as setting the value to "false".
+ 
++# Don't add the Chrome repo (brave/brave-browser#1967)
++exit 0
++
+ @@include@@rpm.include
+ 
+ ## MAIN ##

--- a/patches/chrome-installer-linux-rpm-chrome.spec.template.patch
+++ b/patches/chrome-installer-linux-rpm-chrome.spec.template.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/installer/linux/rpm/chrome.spec.template b/chrome/installer/linux/rpm/chrome.spec.template
+index 55a35677b9c46a2038cea9ac8dedf40d31a679f4..210f7c15ab98449f2ce121d5e7d8a7f632f5e94f 100644
+--- a/chrome/installer/linux/rpm/chrome.spec.template
++++ b/chrome/installer/linux/rpm/chrome.spec.template
+@@ -127,7 +127,8 @@ if [ ! -e "$DEFAULTS_FILE" ]; then
+   echo 'repo_add_once="true"' > "$DEFAULTS_FILE"
+ fi
+ 
+-. "$DEFAULTS_FILE"
++# Don't install the Chrome repo (brave/brave-browser#1967)
++#. "$DEFAULTS_FILE"
+ 
+ if [ "$repo_add_once" = "true" ]; then
+   determine_rpm_package_manager


### PR DESCRIPTION
This disables the cronjob that gets installed by the RPM and DEB packages in
order to forcefully add (or re-add) the Google Chrome package repository and
signing key.

This fixes brave/brave-browser#1084 and fixes brave/brave-browser#1967.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source