### PR TITLE
pass no_compact_unwind in release builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -57,8 +57,18 @@ group("resources") {
   ]
 }
 
+config("rust_link") {
+  # https://bugzilla.mozilla.org/show_bug.cgi?id=1188030#c14
+  if (!is_component_build) {
+    ldflags = [ "-Wl,-no_compact_unwind" ]
+  }
+}
+
 if (is_mac) {
   group("framework_bundle_data") {
+    # this only seems to work correctly when applied to
+    # the chrome_framework target so we add it here
+    public_configs = [ ":rust_link" ]
     deps = [
       "vendor/brave-extension:brave_extension_framework_bundle_data",
       "components/brave_rewards/resources/extension:framework_bundle_data",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3214

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source