### PR TITLE
Fixes on boarding boxes for rewards

### DIFF
--- a/components/brave_rewards/resources/ui/components/adsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/adsBox.tsx
@@ -90,7 +90,7 @@ class AdsBox extends React.Component<Props, State> {
   render () {
     let adsEnabled = false
     let adsUIEnabled = false
-    const { adsData, enabledMain } = this.props.rewardsData
+    const { adsData, enabledMain, firstLoad } = this.props.rewardsData
 
     if (adsData) {
       adsEnabled = adsData.adsEnabled
@@ -98,6 +98,7 @@ class AdsBox extends React.Component<Props, State> {
     }
 
     const toggle = !(!enabledMain || !adsUIEnabled)
+    const showDisabled = firstLoad !== false || !toggle || !adsEnabled
 
     return (
       <Box
@@ -108,7 +109,7 @@ class AdsBox extends React.Component<Props, State> {
         checked={adsEnabled}
         settingsChild={this.adsSettings(adsEnabled && enabledMain)}
         testId={'braveAdsSettings'}
-        disabledContent={this.adsDisabled()}
+        disabledContent={showDisabled ? this.adsDisabled() : null}
         onToggle={this.onAdsSettingChange.bind(this, 'adsEnabled', '')}
         settingsOpened={this.state.settings}
         onSettingsClick={this.onSettingsToggle}

--- a/components/brave_rewards/resources/ui/components/contributeBox.tsx
+++ b/components/brave_rewards/resources/ui/components/contributeBox.tsx
@@ -183,22 +183,22 @@ class ContributeBox extends React.Component<Props, State> {
       numExcludedSites,
       autoContributeList
     } = this.props.rewardsData
-    const toggleOn = !(firstLoad !== false || !enabledMain)
     const monthlyList: MonthlyChoice[] = utils.generateContributionMonthly(walletInfo.choices, walletInfo.rates)
     const contributeRows = this.getContributeRows(autoContributeList)
     const topRows = contributeRows.slice(0, 5)
     const numRows = contributeRows && contributeRows.length
     const allSites = !(numRows > 5)
+    const showDisabled = firstLoad !== false || !enabledMain || !enabledContribute
 
     return (
       <Box
         title={getLocale('contributionTitle')}
         type={'contribute'}
         description={getLocale('contributionDesc')}
-        toggle={toggleOn}
-        checked={toggleOn ? enabledContribute : false}
+        toggle={enabledMain}
+        checked={enabledMain ? enabledContribute : false}
         settingsChild={this.contributeSettings(monthlyList)}
-        disabledContent={this.contributeDisabled()}
+        disabledContent={showDisabled ? this.contributeDisabled() : null}
         onToggle={this.onToggleContribution}
         testId={'autoContribution'}
         settingsOpened={this.state.settings}

--- a/components/brave_rewards/resources/ui/components/settingsPage.tsx
+++ b/components/brave_rewards/resources/ui/components/settingsPage.tsx
@@ -55,8 +55,10 @@ class SettingsPage extends React.Component<Props, {}> {
       this.actions.getWalletProperties()
     }, 60000)
 
-    this.refreshActions()
-    this.actions.getAdsData()
+    if (this.props.rewardsData.firstLoad === false) {
+      this.refreshActions()
+      this.actions.getAdsData()
+    }
     this.actions.checkImported()
     this.actions.getGrant()
 
@@ -78,7 +80,8 @@ class SettingsPage extends React.Component<Props, {}> {
   componentDidUpdate (prevProps: Props) {
     if (
       !prevProps.rewardsData.enabledMain &&
-      this.props.rewardsData.enabledMain
+      this.props.rewardsData.enabledMain &&
+      this.props.rewardsData.firstLoad === false
     ) {
       this.refreshActions()
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#77f9fc79cc2e771ccf35c39f67b5491b3da75f2c",
-      "from": "github:brave/brave-ui#77f9fc79cc2e771ccf35c39f67b5491b3da75f2c",
+      "version": "github:brave/brave-ui#cb256411ff36a5b80b9f744080091fad60a8ff13",
+      "from": "github:brave/brave-ui#cb256411ff36a5b80b9f744080091fad60a8ff13",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#77f9fc79cc2e771ccf35c39f67b5491b3da75f2c",
+    "brave-ui": "github:brave/brave-ui#cb256411ff36a5b80b9f744080091fad60a8ff13",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3123

UI implementation: https://github.com/brave/brave-ui/pull/366

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
plan 1
- clean profile
- go to settings page
- enable rewards
- make sure that you see this
![image](https://user-images.githubusercontent.com/9574457/52260545-b1ccdd00-2926-11e9-9e66-cfd18278c7f9.png)

plan 2
- clean profile
- go to settings page
- enable rewards
- reload page
- make sure that you see regular boxes (with tables)
- disable ads and ac boxes and make sure that you see disabled content

plan 3
- clean profile
- go to settings page
- enable rewards
- reload page
- disabled rewards
- make sure that you see this
![image](https://user-images.githubusercontent.com/9574457/52260586-de80f480-2926-11e9-9539-8982c130e509.png)



## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source