### PR TITLE
Allows to specify enabled/disabled features on command line.

### DIFF
--- a/app/brave_command_line_helper.cc
+++ b/app/brave_command_line_helper.cc
@@ -1,0 +1,95 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/app/brave_command_line_helper.h"
+
+#include <sstream>
+#include <vector>
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#include "base/strings/string_split.h"
+
+BraveCommandLineHelper::BraveCommandLineHelper(base::CommandLine* command_line)
+    : command_line_(*command_line) {
+  Parse();
+}
+
+const std::unordered_set<std::string>&
+BraveCommandLineHelper::enabled_features() const {
+  return enabled_features_;
+}
+
+const std::unordered_set<std::string>&
+BraveCommandLineHelper::disabled_features() const {
+  return disabled_features_;
+}
+
+void BraveCommandLineHelper::ParseCSV(
+    const std::string& value,
+    std::unordered_set<std::string>* dest) const {
+  DCHECK(dest);
+  if (value.empty())
+    return;
+  std::vector<std::string> values = base::SplitString(
+      value, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  dest->insert(std::make_move_iterator(values.begin()),
+               std::make_move_iterator(values.end()));
+}
+
+void BraveCommandLineHelper::Parse() {
+  ParseCSV(command_line_.GetSwitchValueASCII(switches::kEnableFeatures),
+           &enabled_features_);
+  ParseCSV(command_line_.GetSwitchValueASCII(switches::kDisableFeatures),
+           &disabled_features_);
+  // Remove enabled features that are also disabled. When processing
+  // features, if the same feature is enabled and disabled the latter takes
+  // precedence, so there is no point adding to enabled set.
+  auto it = enabled_features_.begin();
+  while (it != enabled_features_.end()) {
+    if (disabled_features_.find(*it) != disabled_features_.end())
+      it = enabled_features_.erase(it);
+    else
+      ++it;
+  }
+}
+
+void BraveCommandLineHelper::AppendSwitch(const char* switch_key) {
+  if (!command_line_.HasSwitch(switch_key))
+    command_line_.AppendSwitch(switch_key);
+}
+
+void BraveCommandLineHelper::AppendFeatures(
+    const std::unordered_set<const char*>& enabled,
+    const std::unordered_set<const char*>& disabled) {
+  // Assuming that the two passed in sets do not intersect, but in case they do
+  // process the disabled set first since disabled features take precedence.
+  // Add programmatically disabled features that aren't already enabled.
+  for (auto it = disabled.cbegin(); it != disabled.cend(); ++it) {
+    if (enabled_features_.find(*it) == enabled_features_.end())
+      disabled_features_.insert(*it);
+  }
+  // Add programmatically enabled features that aren't already disabled.
+  for (auto it = enabled.cbegin(); it != enabled.cend(); ++it) {
+    if (disabled_features_.find(*it) == disabled_features_.end())
+      enabled_features_.insert(*it);
+  }
+  if (!enabled_features_.empty())
+    AppendCSV(switches::kEnableFeatures, enabled_features_);
+  if (!disabled_features_.empty())
+    AppendCSV(switches::kDisableFeatures, disabled_features_);
+}
+
+void BraveCommandLineHelper::AppendCSV(
+    const char* switch_key,
+    const std::unordered_set<std::string>& values) {
+  std::stringstream ss;
+  for (auto it = values.cbegin(); it != values.cend(); ++it) {
+    if (it != values.cbegin())
+      ss << ",";
+    ss << *it;
+  }
+  command_line_.AppendSwitchASCII(switch_key, ss.str());
+}

--- a/app/brave_command_line_helper.h
+++ b/app/brave_command_line_helper.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_APP_BRAVE_COMMAND_LINE_HELPER_H_
+#define BRAVE_APP_BRAVE_COMMAND_LINE_HELPER_H_
+
+#include <string>
+#include <unordered_set>
+
+#include "base/macros.h"
+
+namespace base {
+class CommandLine;
+}
+
+class BraveCommandLineHelper {
+ public:
+  explicit BraveCommandLineHelper(base::CommandLine* command_line);
+  inline ~BraveCommandLineHelper() = default;
+
+  void AppendSwitch(const char* switch_key);
+  void AppendFeatures(const std::unordered_set<const char*>& enabled,
+                      const std::unordered_set<const char*>& disabled);
+
+  const std::unordered_set<std::string>& enabled_features() const;
+  const std::unordered_set<std::string>& disabled_features() const;
+
+ private:
+  void Parse();
+  void ParseCSV(const std::string& value,
+                std::unordered_set<std::string>* dest) const;
+  void AppendCSV(const char* switch_key,
+                 const std::unordered_set<std::string>& values);
+
+  base::CommandLine& command_line_;
+  std::unordered_set<std::string> enabled_features_;
+  std::unordered_set<std::string> disabled_features_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveCommandLineHelper);
+};
+
+#endif  // BRAVE_APP_BRAVE_COMMAND_LINE_HELPER_H_

--- a/app/brave_command_line_helper_unittest.cc
+++ b/app/brave_command_line_helper_unittest.cc
@@ -1,0 +1,131 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/app/brave_command_line_helper.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#include "base/strings/string_split.h"
+#include "base/strings/utf_string_conversions.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+int CountA(const base::CommandLine::StringVector& sv) {
+  int count = 0;
+  for (const auto& argv : sv) {
+    std::string value;
+#if defined(OS_WIN)
+    value = base::UTF16ToASCII(argv);
+#else
+    value = argv;
+#endif
+    if (value == "--a")
+      count++;
+  }
+  return count;
+}
+
+std::set<std::string> FeaturesToSet(const std::string& features) {
+  std::set<std::string> result;
+  std::vector<std::string> values = base::SplitString(
+      features, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  result.insert(std::make_move_iterator(values.begin()),
+                std::make_move_iterator(values.end()));
+  return result;
+}
+
+void CheckEnabledFeatures(base::CommandLine& command_line,
+                          const std::string& expected) {
+  EXPECT_EQ(FeaturesToSet(
+                command_line.GetSwitchValueASCII(switches::kEnableFeatures)),
+            FeaturesToSet(expected));
+}
+
+void CheckDisabledFeatures(base::CommandLine& command_line,
+                           const std::string& expected) {
+  EXPECT_EQ(FeaturesToSet(
+                command_line.GetSwitchValueASCII(switches::kDisableFeatures)),
+            FeaturesToSet(expected));
+}
+
+}  // namespace
+
+TEST(BraveCommandLineHelperUnitTest, TestAppendSwitch) {
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+  BraveCommandLineHelper helper(&command_line);
+  // Test that append switch works.
+  helper.AppendSwitch("a");
+  ASSERT_TRUE(command_line.HasSwitch("a"));
+  ASSERT_EQ(1, CountA(command_line.argv()));
+
+  // Chromium's AppendSwtich always adds to argv even if the switch
+  // has already been added.
+  command_line.AppendSwitch("a");
+  ASSERT_EQ(2, CountA(command_line.argv()));
+
+  // Test that multiple attempts to append the same switch doesn't append
+  // more than once.
+  helper.AppendSwitch("a");
+  ASSERT_EQ(2, CountA(command_line.argv()));
+}
+
+TEST(BraveCommandLineHelperUnitTest, TestParseFeatures) {
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+  command_line.AppendSwitchASCII(switches::kEnableFeatures, "a,b,x");
+  command_line.AppendSwitchASCII(switches::kDisableFeatures, "x,y,z");
+  BraveCommandLineHelper helper(&command_line);
+  // Test that intersecting enabled and disabled features have been removed from
+  // enabled set.
+  const std::unordered_set<std::string>& enabled = helper.enabled_features();
+  ASSERT_EQ(std::set<std::string>(enabled.begin(), enabled.end()),
+            FeaturesToSet("a,b"));
+  const std::unordered_set<std::string>& disabled = helper.disabled_features();
+  ASSERT_EQ(std::set<std::string>(disabled.begin(), disabled.end()),
+            FeaturesToSet("x,y,z"));
+}
+
+TEST(BraveCommandLineHelperUnitTest, TestAppendFeatures) {
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+  BraveCommandLineHelper helper(&command_line);
+  // Test enabled features: none on command line.
+  helper.AppendFeatures({"a"}, {});
+  CheckEnabledFeatures(command_line, "a");
+  CheckDisabledFeatures(command_line, "");
+
+  // Test enabled features: merge with existing.
+  helper.AppendFeatures({"a", "b", "c"}, {});
+  CheckEnabledFeatures(command_line, "a,b,c");
+  CheckDisabledFeatures(command_line, "");
+
+  // Test disabled features: none on command line.
+  helper.AppendFeatures({}, {"e", "f"});
+  CheckEnabledFeatures(command_line, "a,b,c");
+  CheckDisabledFeatures(command_line, "e,f");
+
+  // Test disabled features: merge with existing.
+  helper.AppendFeatures({}, {"e", "f", "g", "h"});
+  CheckEnabledFeatures(command_line, "a,b,c");
+  CheckDisabledFeatures(command_line, "e,f,g,h");
+
+  // Test enabled features: intersects disabled.
+  helper.AppendFeatures({"d", "x"}, {"x"});
+  CheckEnabledFeatures(command_line, "a,b,c,d");
+  CheckDisabledFeatures(command_line, "e,f,g,h,x");
+
+  // Test disabled features: intersects with enabled.
+  helper.AppendFeatures({}, {"c", "d", "i"});
+  CheckEnabledFeatures(command_line, "a,b,c,d");
+  CheckDisabledFeatures(command_line, "e,f,g,h,x,i");
+
+  // Append same to enabled and disabled.
+  helper.AppendFeatures({"v", "w"}, {"v", "w"});
+  CheckEnabledFeatures(command_line, "a,b,c,d");
+  CheckDisabledFeatures(command_line, "e,f,g,h,x,i,v,w");
+}

--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -6,13 +6,14 @@
 #include "brave/app/brave_main_delegate.h"
 
 #include <memory>
-#include <sstream>
+#include <unordered_set>
 
 #include "base/base_switches.h"
 #include "base/lazy_instance.h"
 #include "base/path_service.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
+#include "brave/app/brave_command_line_helper.h"
 #include "brave/browser/brave_content_browser_client.h"
 #include "brave/common/brave_switches.h"
 #include "brave/common/resource_bundle_helper.h"
@@ -123,8 +124,7 @@ void BraveMainDelegate::PreSandboxStartup() {
 }
 
 bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
-  base::CommandLine& command_line =
-      *base::CommandLine::ForCurrentProcess();
+  BraveCommandLineHelper command_line(base::CommandLine::ForCurrentProcess());
 #if BUILDFLAG(BRAVE_ADS_ENABLED)
   command_line.AppendSwitch(switches::kEnableDomDistiller);
 #endif
@@ -132,23 +132,25 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
   command_line.AppendSwitch(switches::kDisableChromeGoogleURLTrackingClient);
   command_line.AppendSwitch(switches::kNoPings);
 
-  std::stringstream enabled_features;
-  enabled_features << features::kDesktopPWAWindowing.name
-    << "," << password_manager::features::kFillOnAccountSelect.name
-    << "," << extensions_features::kNewExtensionUpdaterService.name;
+  // Enabled features.
+  const std::unordered_set<const char*> enabled_features = {
+      extensions_features::kNewExtensionUpdaterService.name,
+      features::kDesktopPWAWindowing.name,
+      password_manager::features::kFillOnAccountSelect.name,
+  };
 
-  std::stringstream disabled_features;
-  disabled_features << features::kSharedArrayBuffer.name
-    << "," << features::kDefaultEnableOopRasterization.name
-    << "," << autofill::features::kAutofillSaveCardSignInAfterLocalSave.name
-    << "," << features::kAudioServiceOutOfProcess.name
-    << "," << autofill::features::kAutofillServerCommunication.name
-    << "," << unified_consent::kUnifiedConsent.name;
+  // Disabled features.
+  const std::unordered_set<const char*> disabled_features = {
+      autofill::features::kAutofillSaveCardSignInAfterLocalSave.name,
+      autofill::features::kAutofillServerCommunication.name,
+      features::kAudioServiceOutOfProcess.name,
+      features::kDefaultEnableOopRasterization.name,
+      features::kSharedArrayBuffer.name,
+      unified_consent::kUnifiedConsent.name,
+  };
 
-  command_line.AppendSwitchASCII(switches::kEnableFeatures,
-      enabled_features.str());
-  command_line.AppendSwitchASCII(switches::kDisableFeatures,
-      disabled_features.str());
+  command_line.AppendFeatures(enabled_features, disabled_features);
+
 
   bool ret = ChromeMainDelegate::BasicStartupComplete(exit_code);
 

--- a/chromium_src/chrome/app/chrome_main_delegate.cc
+++ b/chromium_src/chrome/app/chrome_main_delegate.cc
@@ -1,7 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// This chormium_src override allows us to skip a lot of patching to chrome/BUILD.gn
-#include "brave/app/brave_main_delegate.cc"
-#include "../../../../chrome/app/chrome_main_delegate.cc"
+// This chormium_src override allows us to skip a lot of patching to
+// chrome/BUILD.gn
+#include "brave/app/brave_command_line_helper.cc"  // NOLINT
+#include "brave/app/brave_main_delegate.cc"  // NOLINT
+#include "../../../../chrome/app/chrome_main_delegate.cc"  // NOLINT

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -29,6 +29,7 @@ static_library("brave_test_support_unit") {
 
 test("brave_unit_tests") {
   sources = [
+    "//brave/app/brave_command_line_helper_unittest.cc",
     "//brave/browser/autocomplete/brave_autocomplete_provider_client_unittest.cc",
     "//brave/browser/autoplay/autoplay_permission_context_unittest.cc",
     "//brave/browser/brave_resources_util_unittest.cc",


### PR DESCRIPTION
Fixes brave/brave-browser#3209

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
**Automated testing**
`npm run test -- brave_unit_tests --filter=BraveCommandLineHelperUnitTest.TestAppendSwitch`
`npm run test -- brave_unit_tests --filter=BraveCommandLineHelperUnitTest.TestParseFeatures`
`npm run test -- brave_unit_tests --filter=BraveCommandLineHelperUnitTest.TestAppendFeatures`

**Manual testing**
1. Start Brave and navigate to brave://process-internals/#general,
2. Verify that the `Site Isolation mode:` is set to `Site Per Process`,
3. Exit Brave,
4. Start Brave on command line with switch `--disable-features=IsolateOrigins,site-per-process`,
5. Navigate to brave://process-internals/#general,
6. Verify that the `Site Isolation mode:` is set to `Disabled`.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source