### PR TITLE
Enabling CRLSets; Capping the maximum component updates per request to go-updater to 1

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -42,6 +42,8 @@ source_set("browser_process") {
     "component_updater/brave_component_installer.h",
     "component_updater/brave_component_updater_configurator.cc",
     "component_updater/brave_component_updater_configurator.h",
+    "component_updater/brave_crx_update_service.cc",
+    "component_updater/brave_crx_update_service.h",
     "geolocation/brave_geolocation_permission_context.cc",
     "geolocation/brave_geolocation_permission_context.h",
     "mac/sparkle_glue.mm",

--- a/browser/component_updater/brave_crx_update_service.cc
+++ b/browser/component_updater/brave_crx_update_service.cc
@@ -1,0 +1,139 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "brave/browser/component_updater/brave_crx_update_service.h"
+#include "brave/browser/extensions/brave_extension_provider.h"
+#include "components/component_updater/update_scheduler.h"
+#include "components/update_client/configurator.h"
+#include "components/update_client/task_update.h"
+#include "components/update_client/update_client_internal.h"
+#include "components/update_client/update_engine.h"
+#include "components/update_client/utils.h"
+
+namespace component_updater {
+
+BraveCrxUpdateService::BraveCrxUpdateService(
+    scoped_refptr<Configurator> config,
+    std::unique_ptr<UpdateScheduler> scheduler,
+    scoped_refptr<UpdateClient> update_client)
+    : CrxUpdateService(config, std::move(scheduler), update_client) {}
+
+void BraveCrxUpdateService::Start() {
+  DCHECK(thread_checker_.CalledOnValidThread());
+  scheduler_->Schedule(
+      base::TimeDelta::FromSeconds(config_->InitialDelay()),
+      base::TimeDelta::FromSeconds(config_->NextCheckDelay()),
+      base::Bind(base::IgnoreResult(&BraveCrxUpdateService::CheckForUpdates),
+                 base::Unretained(this)),
+      base::DoNothing());
+}
+
+bool BraveCrxUpdateService::RegisterComponent(const CrxComponent& component) {
+  DCHECK(thread_checker_.CalledOnValidThread());
+  if (component.pk_hash.empty() || !component.version.IsValid() ||
+      !component.installer) {
+    return false;
+  }
+
+  // Update the registration data if the component has been registered before.
+  const std::string id(GetCrxComponentID(component));
+  auto it = components_.find(id);
+  if (it != components_.end()) {
+    it->second = component;
+    return true;
+  }
+
+  components_.insert(std::make_pair(id, component));
+  components_order_.push_back(id);
+  for (const auto& mime_type : component.handled_mime_types)
+    component_ids_by_mime_type_[mime_type] = id;
+
+  // Create an initial state for this component. The state is mutated in
+  // response to events from the UpdateClient instance.
+  CrxUpdateItem item;
+  item.id = id;
+  item.component = component;
+  const auto inserted = component_states_.insert(std::make_pair(id, item));
+  DCHECK(inserted.second);
+
+  // Start the timer if this is the first component registered. The first timer
+  // event occurs after an interval defined by the component update
+  // configurator. The subsequent timer events are repeated with a period
+  // defined by the same configurator.
+  if (components_.size() == 1)
+    Start();
+
+  return true;
+}
+
+bool BraveCrxUpdateService::CheckForUpdates(
+    UpdateScheduler::OnFinishedCallback on_finished) {
+  DCHECK(thread_checker_.CalledOnValidThread());
+
+  std::vector<std::string> secure_ids;    // Requires HTTPS for update checks.
+  std::vector<std::string> unsecure_ids;  // Can fallback to HTTP.
+  for (const auto id : components_order_) {
+    DCHECK(components_.find(id) != components_.end());
+    if (!extensions::BraveExtensionProvider::IsVetted(id)) {
+          continue;
+    }
+
+    const auto component = GetComponent(id);
+    if (!component || component->requires_network_encryption)
+      secure_ids.push_back(id);
+    else
+      unsecure_ids.push_back(id);
+  }
+
+  if (unsecure_ids.empty() && secure_ids.empty()) {
+    base::ThreadTaskRunnerHandle::Get()->PostTask(FROM_HERE,
+                                                  std::move(on_finished));
+    return true;
+  }
+
+  Callback on_finished_callback = base::BindOnce(
+      [](UpdateScheduler::OnFinishedCallback on_finished,
+         update_client::Error error) { std::move(on_finished).Run(); },
+      std::move(on_finished));
+
+  if (!unsecure_ids.empty()) {
+    for (auto id : unsecure_ids) {
+      update_client_->Update(
+          {id},
+          base::BindOnce(&CrxUpdateService::GetCrxComponents,
+                         base::Unretained(this)),
+          false,
+          base::BindOnce(&CrxUpdateService::OnUpdateComplete,
+                         base::Unretained(this),
+                         secure_ids.empty() && (id == unsecure_ids.back())
+                             ? std::move(on_finished_callback)
+                             : Callback(),
+                         base::TimeTicks::Now()));
+    }
+  }
+
+  if (!secure_ids.empty()) {
+    for (auto id : secure_ids) {
+      update_client_->Update(
+          {id},
+          base::BindOnce(&CrxUpdateService::GetCrxComponents,
+                         base::Unretained(this)),
+          false,
+          base::BindOnce(
+              &CrxUpdateService::OnUpdateComplete, base::Unretained(this),
+              (id == secure_ids.back()) ? std::move(on_finished_callback)
+                                        : Callback(),
+              base::TimeTicks::Now()));
+    }
+  }
+
+  return true;
+}
+
+}  // namespace component_updater

--- a/browser/component_updater/brave_crx_update_service.h
+++ b/browser/component_updater/brave_crx_update_service.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_COMPONENT_UPDATER_BRAVE_CRX_UPDATE_SERVICE_H_
+#define BRAVE_BROWSER_COMPONENT_UPDATER_BRAVE_CRX_UPDATE_SERVICE_H_
+
+#include <memory>
+
+#include "components/component_updater/component_updater_service.h"
+#include "components/component_updater/component_updater_service_internal.h"
+
+namespace component_updater {
+
+using CrxInstaller = update_client::CrxInstaller;
+using UpdateClient = update_client::UpdateClient;
+
+class BraveCrxUpdateService : public CrxUpdateService {
+ public:
+  using CrxUpdateService::CrxUpdateService;
+  BraveCrxUpdateService(scoped_refptr<Configurator> config,
+                        std::unique_ptr<UpdateScheduler> scheduler,
+                        scoped_refptr<UpdateClient> update_client);
+
+  bool RegisterComponent(const CrxComponent& component) override;
+  ~BraveCrxUpdateService() override{};
+
+ private:
+  bool CheckForUpdates(UpdateScheduler::OnFinishedCallback on_finished);
+  void Start();
+
+  DISALLOW_COPY_AND_ASSIGN(BraveCrxUpdateService);
+};
+}  // namespace component_updater
+
+#endif  // BRAVE_BROWSER_COMPONENT_UPDATER_BRAVE_CRX_UPDATE_SERVICE_H_

--- a/browser/extensions/brave_extension_provider.cc
+++ b/browser/extensions/brave_extension_provider.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/brave_browser_process_impl.h"
 #include "brave/common/extensions/extension_constants.h"
 #include "brave/components/brave_shields/browser/extension_whitelist_service.h"
+#include "brave/components/brave_shields/browser/local_data_files_service.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -60,6 +61,7 @@ bool BraveExtensionProvider::IsVetted(const std::string id) {
       pdfjs_extension_id,
       hangouts_extension_id,
       widevine_extension_id,
+      brave_shields::kLocalDataFilesComponentId,
       // Web Store
       "ahfgeienlihckogmohjhadlkjgocpleb",
       // Brave Automation Extension

--- a/browser/extensions/brave_extension_provider.cc
+++ b/browser/extensions/brave_extension_provider.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -21,20 +22,19 @@ bool IsBlacklisted(const extensions::Extension* extension) {
   // This is a hardcoded list of extensions to block.
   // Don't add new extensions to this list. Add them to
   // the files managed by the extension whitelist service.
-  static std::vector<std::string> blacklisted_extensions({
-    // Used for tests, corresponds to
-    // brave/test/data/should-be-blocked-extension.
-    "mlklomjnahgiddgfdgjhibinlfibfffc",
-    // Chromium PDF Viewer.
-    "mhjfbmdgcfjbbpaeojofohoefgiehjai"
-  });
+  static std::vector<std::string> blacklisted_extensions(
+      {// Used for tests, corresponds to
+       // brave/test/data/should-be-blocked-extension.
+       "mlklomjnahgiddgfdgjhibinlfibfffc",
+       // Chromium PDF Viewer.
+       "mhjfbmdgcfjbbpaeojofohoefgiehjai"});
 
   if (std::find(blacklisted_extensions.begin(), blacklisted_extensions.end(),
-      extension->id()) != blacklisted_extensions.end())
+                extension->id()) != blacklisted_extensions.end())
     return true;
 
   return g_brave_browser_process->extension_whitelist_service()->IsBlacklisted(
-    extension->id());
+      extension->id());
 }
 
 }  // namespace
@@ -47,43 +47,48 @@ bool BraveExtensionProvider::IsVetted(const Extension* extension) {
   // unit tests.
   // Don't add new extensions to this list. Add them to
   // the files managed by the extension whitelist service.
+  return BraveExtensionProvider::IsVetted(extension->id());
+}
+
+bool BraveExtensionProvider::IsVetted(const std::string id) {
   static std::vector<std::string> vetted_extensions({
-    brave_extension_id,
-    brave_rewards_extension_id,
-    brave_sync_extension_id,
-    brave_webtorrent_extension_id,
-    pdfjs_extension_id,
-    // Web Store
-    "ahfgeienlihckogmohjhadlkjgocpleb",
-    // Brave Automation Extension
-    "aapnijgdinlhnhlmodcfapnahmbfebeb",
-    // Test ID: Brave Default Ad Block Updater
-    "naccapggpomhlhoifnlebfoocegenbol",
-    // Test ID: Brave Regional Ad Block Updater
-    // (9852EFC4-99E4-4F2D-A915-9C3196C7A1DE)
-    "dlpmaigjliompnelofkljgcmlenklieh",
-    // Test ID: Brave Tracking Protection Updater
-    "eclbkhjphkhalklhipiicaldjbnhdfkc",
-    // Test ID: PDFJS
-    "kpbdcmcgkedhpbcpfndimofjnefgjidd",
-    // Test ID: Brave HTTPS Everywhere Updater
-    "bhlmpjhncoojbkemjkeppfahkglffilp",
-    // Test ID: Brave Tor Client Updater
-    "ngicbhhaldfdgmjhilmnleppfpmkgbbk",
+      brave_extension_id,
+      brave_rewards_extension_id,
+      brave_sync_extension_id,
+      brave_webtorrent_extension_id,
+      crl_set_extension_id,
+      pdfjs_extension_id,
+      hangouts_extension_id,
+      widevine_extension_id,
+      // Web Store
+      "ahfgeienlihckogmohjhadlkjgocpleb",
+      // Brave Automation Extension
+      "aapnijgdinlhnhlmodcfapnahmbfebeb",
+      // Test ID: Brave Default Ad Block Updater
+      "naccapggpomhlhoifnlebfoocegenbol",
+      // Test ID: Brave Regional Ad Block Updater
+      // (9852EFC4-99E4-4F2D-A915-9C3196C7A1DE)
+      "dlpmaigjliompnelofkljgcmlenklieh",
+      // Test ID: Brave Tracking Protection Updater
+      "eclbkhjphkhalklhipiicaldjbnhdfkc",
+      // Test ID: PDFJS
+      "kpbdcmcgkedhpbcpfndimofjnefgjidd",
+      // Test ID: Brave HTTPS Everywhere Updater
+      "bhlmpjhncoojbkemjkeppfahkglffilp",
+      // Test ID: Brave Tor Client Updater
+      "ngicbhhaldfdgmjhilmnleppfpmkgbbk",
   });
-  if (std::find(vetted_extensions.begin(), vetted_extensions.end(),
-                extension->id()) != vetted_extensions.end())
+  if (std::find(vetted_extensions.begin(), vetted_extensions.end(), id) !=
+      vetted_extensions.end())
     return true;
 
   return g_brave_browser_process->extension_whitelist_service()->IsWhitelisted(
-    extension->id());
+      id);
 }
 
-BraveExtensionProvider::BraveExtensionProvider() {
-}
+BraveExtensionProvider::BraveExtensionProvider() {}
 
-BraveExtensionProvider::~BraveExtensionProvider() {
-}
+BraveExtensionProvider::~BraveExtensionProvider() {}
 
 std::string BraveExtensionProvider::GetDebugPolicyProviderName() const {
 #if defined(NDEBUG)
@@ -98,14 +103,13 @@ bool BraveExtensionProvider::UserMayLoad(const Extension* extension,
                                          base::string16* error) const {
   if (IsBlacklisted(extension)) {
     if (error) {
-      *error =
-        l10n_util::GetStringFUTF16(IDS_EXTENSION_CANT_INSTALL_ON_BRAVE,
-                                   base::UTF8ToUTF16(extension->name()),
-                                   base::UTF8ToUTF16(extension->id()));
+      *error = l10n_util::GetStringFUTF16(IDS_EXTENSION_CANT_INSTALL_ON_BRAVE,
+                                          base::UTF8ToUTF16(extension->name()),
+                                          base::UTF8ToUTF16(extension->id()));
     }
     DVLOG(1) << "Extension will not install "
-      << " ID: " << base::UTF8ToUTF16(extension->id()) << ", "
-      << " Name: " << base::UTF8ToUTF16(extension->name());
+             << " ID: " << base::UTF8ToUTF16(extension->id()) << ", "
+             << " Name: " << base::UTF8ToUTF16(extension->name());
     return false;
   }
   return true;
@@ -114,8 +118,8 @@ bool BraveExtensionProvider::UserMayLoad(const Extension* extension,
 bool BraveExtensionProvider::MustRemainInstalled(const Extension* extension,
                                                  base::string16* error) const {
   return extension->id() == brave_extension_id ||
-    extension->id() == brave_rewards_extension_id ||
-    extension->id() == brave_sync_extension_id;
+         extension->id() == brave_rewards_extension_id ||
+         extension->id() == brave_sync_extension_id;
 }
 
 }  // namespace extensions

--- a/browser/extensions/brave_extension_provider.h
+++ b/browser/extensions/brave_extension_provider.h
@@ -1,9 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_EXTENSIONS_BROWSER_MANAGEMENT_POLICY_H_
-#define BRAVE_EXTENSIONS_BROWSER_MANAGEMENT_POLICY_H_
+#ifndef BRAVE_BROWSER_EXTENSIONS_BRAVE_EXTENSION_PROVIDER_H_
+#define BRAVE_BROWSER_EXTENSIONS_BRAVE_EXTENSION_PROVIDER_H_
+
+#include <string>
 
 #include "extensions/browser/management_policy.h"
 
@@ -19,10 +22,11 @@ class BraveExtensionProvider : public ManagementPolicy::Provider {
   bool MustRemainInstalled(const Extension* extension,
                            base::string16* error) const override;
   static bool IsVetted(const extensions::Extension* extension);
+  static bool IsVetted(const std::string id);
  private:
   DISALLOW_COPY_AND_ASSIGN(BraveExtensionProvider);
 };
 
 }  // namespace extensions
 
-#endif
+#endif  // BRAVE_BROWSER_EXTENSIONS_BRAVE_EXTENSION_PROVIDER_H_

--- a/browser/net/brave_common_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper.cc
@@ -14,16 +14,17 @@ namespace brave {
 // Update server checks happen from the profile context for admin policy installed extensions.
 // Update server checks happen from the system context for normal update operations.
 bool IsUpdaterURL(const GURL& gurl) {
-  static std::vector<URLPattern> updater_patterns({
-      URLPattern(URLPattern::SCHEME_HTTPS, std::string(component_updater::kUpdaterDefaultUrl) + "*"),
-      URLPattern(URLPattern::SCHEME_HTTP, std::string(component_updater::kUpdaterFallbackUrl) + "*"),
-      URLPattern(URLPattern::SCHEME_HTTPS, std::string(extension_urls::kChromeWebstoreUpdateURL) + "*")
-  });
-  bool braveRedirect = gurl.query().find("braveRedirect=true") != std::string::npos;
-  return std::any_of(updater_patterns.begin(), updater_patterns.end(),
-      [&gurl, braveRedirect](URLPattern pattern) {
-        return !braveRedirect && pattern.MatchesURL(gurl);
-      });
+  static std::vector<URLPattern> updater_patterns(
+      {URLPattern(URLPattern::SCHEME_HTTPS,
+                  std::string(component_updater::kUpdaterDefaultUrl) + "*"),
+       URLPattern(URLPattern::SCHEME_HTTP,
+                  std::string(component_updater::kUpdaterFallbackUrl) + "*"),
+       URLPattern(
+           URLPattern::SCHEME_HTTPS,
+           std::string(extension_urls::kChromeWebstoreUpdateURL) + "*")});
+  return std::any_of(
+      updater_patterns.begin(), updater_patterns.end(),
+      [&gurl](URLPattern pattern) { return pattern.MatchesURL(gurl); });
 }
 
 int OnBeforeURLRequest_CommonStaticRedirectWork(

--- a/browser/net/brave_common_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper.cc
@@ -1,8 +1,13 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/net/brave_common_static_redirect_network_delegate_helper.h"
+
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "brave/common/network_constants.h"
 #include "components/component_updater/component_updater_url_constants.h"
@@ -11,8 +16,9 @@
 
 namespace brave {
 
-// Update server checks happen from the profile context for admin policy installed extensions.
-// Update server checks happen from the system context for normal update operations.
+// Update server checks happen from the profile context for admin policy
+// installed extensions. Update server checks happen from the system context for
+// normal update operations.
 bool IsUpdaterURL(const GURL& gurl) {
   static std::vector<URLPattern> updater_patterns(
       {URLPattern(URLPattern::SCHEME_HTTPS,
@@ -33,7 +39,9 @@ int OnBeforeURLRequest_CommonStaticRedirectWork(
   GURL::Replacements replacements;
   if (IsUpdaterURL(ctx->request_url)) {
     replacements.SetQueryStr(ctx->request_url.query_piece());
-    ctx->new_url_spec = GURL(kBraveUpdatesExtensionsEndpoint).ReplaceComponents(replacements).spec();
+    ctx->new_url_spec = GURL(kBraveUpdatesExtensionsEndpoint)
+                            .ReplaceComponents(replacements)
+                            .spec();
     return net::OK;
   }
   return net::OK;

--- a/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
@@ -1,8 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/net/brave_common_static_redirect_network_delegate_helper.h"
+
+#include <memory>
+#include <string>
 
 #include "brave/browser/net/url_context.h"
 #include "brave/common/network_constants.h"
@@ -13,21 +17,18 @@
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
-
 namespace {
 
 const char kComponentUpdaterProxy[] = "https://componentupdater.brave.com";
 
-class BraveCommonStaticRedirectNetworkDelegateHelperTest: public testing::Test {
+class BraveCommonStaticRedirectNetworkDelegateHelperTest
+    : public testing::Test {
  public:
   BraveCommonStaticRedirectNetworkDelegateHelperTest()
       : thread_bundle_(content::TestBrowserThreadBundle::IO_MAINLOOP),
-        context_(new net::TestURLRequestContext(true)) {
-  }
+        context_(new net::TestURLRequestContext(true)) {}
   ~BraveCommonStaticRedirectNetworkDelegateHelperTest() override {}
-  void SetUp() override {
-    context_->Init();
-  }
+  void SetUp() override { context_->Init(); }
   net::TestURLRequestContext* context() { return context_.get(); }
 
  private:
@@ -40,14 +41,15 @@ TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest,
   net::TestDelegate test_delegate;
   std::string query_string("?foo=bar");
   GURL url(std::string(component_updater::kUpdaterDefaultUrl) + query_string);
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
-  GURL expected_url(std::string(kBraveUpdatesExtensionsEndpoint + query_string));
+  GURL expected_url(
+      std::string(kBraveUpdatesExtensionsEndpoint + query_string));
   int ret =
       OnBeforeURLRequest_CommonStaticRedirectWork(callback, before_url_context);
   EXPECT_EQ(GURL(before_url_context->new_url_spec), expected_url);

--- a/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc
@@ -16,6 +16,8 @@
 
 namespace {
 
+const char kComponentUpdaterProxy[] = "https://componentupdater.brave.com";
+
 class BraveCommonStaticRedirectNetworkDelegateHelperTest: public testing::Test {
  public:
   BraveCommonStaticRedirectNetworkDelegateHelperTest()
@@ -33,7 +35,8 @@ class BraveCommonStaticRedirectNetworkDelegateHelperTest: public testing::Test {
   std::unique_ptr<net::TestURLRequestContext> context_;
 };
 
-TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, ModifyComponentUpdaterURL) {
+TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest,
+       ModifyComponentUpdaterURL) {
   net::TestDelegate test_delegate;
   std::string query_string("?foo=bar");
   GURL url(std::string(component_updater::kUpdaterDefaultUrl) + query_string);
@@ -51,16 +54,16 @@ TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, ModifyComponentUpdate
   EXPECT_EQ(ret, net::OK);
 }
 
-TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest, NoModifyComponentUpdaterURL) {
+TEST_F(BraveCommonStaticRedirectNetworkDelegateHelperTest,
+       NoModifyComponentUpdaterURL) {
   net::TestDelegate test_delegate;
-  std::string query_string("?braveRedirect=true");
-  GURL url(std::string(component_updater::kUpdaterDefaultUrl) + query_string);
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  GURL url(kComponentUpdaterProxy);
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
   GURL expected_url;
   int ret =

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -1,8 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/net/brave_static_redirect_network_delegate_helper.h"
+
+#include <memory>
+#include <vector>
 
 #include "brave/common/network_constants.h"
 #include "extensions/common/url_pattern.h"
@@ -14,7 +18,8 @@ int OnBeforeURLRequest_StaticRedirectWork(
     std::shared_ptr<BraveRequestInfo> ctx) {
   GURL::Replacements replacements;
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
-  static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS, kSafeBrowsingPrefix);
+  static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS,
+                                         kSafeBrowsingPrefix);
   static URLPattern crlSet_pattern1(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix1);
   static URLPattern crlSet_pattern2(
@@ -66,56 +71,74 @@ int OnBeforeURLRequest_StaticRedirectWork(
 #if !defined(NDEBUG)
   GURL gurl = ctx->request_url;
   static std::vector<URLPattern> allowed_patterns({
-    // Brave updates
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://go-updater.brave.com/*"),
-    // Brave promo referrals, production and staging (laptop-updates
-    // proxies to promo-services)
-    // TODO: In the future, we may want to specify the value of the
-    // BRAVE_REFERRALS_SERVER environment variable rather than
-    // hardcoding the server name here
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://laptop-updates.brave.com/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://laptop-updates-staging.herokuapp.com/*"),
-    // CRX file download
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://brave-core-ext.s3.brave.com/release/*"),
-    // Safe Browsing and other files
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://static.brave.com/*"),
-    // We do allow redirects to the Google update server for extensions we don't support
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://update.googleapis.com/service/update2"),
+      // Brave updates
+      URLPattern(URLPattern::SCHEME_HTTPS, "https://go-updater.brave.com/*"),
+      // Brave promo referrals, production and staging (laptop-updates
+      // proxies to promo-services)
+      // TODO(@emerick): In the future, we may want to specify the value of the
+      // BRAVE_REFERRALS_SERVER environment variable rather than
+      // hardcoding the server name here
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://laptop-updates.brave.com/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://laptop-updates-staging.herokuapp.com/*"),
+      // CRX file download
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://brave-core-ext.s3.brave.com/release/*"),
+      // Safe Browsing and other files
+      URLPattern(URLPattern::SCHEME_HTTPS, "https://static.brave.com/*"),
+      // We do allow redirects to the Google update server for extensions we
+      // don't support
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://update.googleapis.com/service/update2"),
 
-    // Rewards URLs
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://ledger.mercury.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://balance.mercury.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://publishers.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://publishers-distro.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://ledger-staging.mercury.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://balance-staging.mercury.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://publishers-staging.basicattentiontoken.org/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://publishers-staging-distro.basicattentiontoken.org/*"),
+      // Rewards URLs
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://ledger.mercury.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://balance.mercury.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://publishers.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://publishers-distro.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://ledger-staging.mercury.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://balance-staging.mercury.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://publishers-staging.basicattentiontoken.org/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://publishers-staging-distro.basicattentiontoken.org/*"),
 
-    // Safe browsing
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://safebrowsing.brave.com/v4/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://ssl.gstatic.com/safebrowsing/*"),
+      // Safe browsing
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://safebrowsing.brave.com/v4/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://ssl.gstatic.com/safebrowsing/*"),
 
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets.brave.com/*"),
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://crxdownload.brave.com/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets.brave.com/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS, "https://crxdownload.brave.com/*"),
   });
 
-  // Check to make sure the URL being requested matches at least one of the allowed patterns
-  bool is_url_allowed = std::any_of(allowed_patterns.begin(), allowed_patterns.end(),
-    [&gurl](URLPattern pattern) {
-      if (pattern.MatchesURL(gurl)) {
-        return true;
-      }
-      return false;
-    });
+  // Check to make sure the URL being requested matches at least one of the
+  // allowed patterns
+  bool is_url_allowed =
+      std::any_of(allowed_patterns.begin(), allowed_patterns.end(),
+                  [&gurl](URLPattern pattern) {
+                    if (pattern.MatchesURL(gurl)) {
+                      return true;
+                    }
+                    return false;
+                  });
   if (!is_url_allowed) {
     LOG(ERROR) << "URL not allowed from system network delegate: " << gurl;
   }
-  // TODO: Before we can turn this into DCHECK we have to find a way to allow these, I think they are for Chrome Cast
+  // TODO(@bbondy): Before we can turn this into DCHECK we have to find a way to
+  // allow these, I think they are for Chrome Cast
   // http://192.168.0.13:8008/ssdp/device-desc.xml
   // http://192.168.0.27:60000/upnp/dev/e16bf493-ed87-5798-ffff-ffffeb4f1c34/desc
-  // And also I don't know where they're from, but there's always 3 requests similar to this:
-  // http://vijscbncpv/
+  // And also I don't know where they're from, but there's always 3 requests
+  // similar to this: http://vijscbncpv/
 #endif
 
   return net::OK;

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -15,6 +15,14 @@ int OnBeforeURLRequest_StaticRedirectWork(
   GURL::Replacements replacements;
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS, kSafeBrowsingPrefix);
+  static URLPattern crlSet_pattern1(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix1);
+  static URLPattern crlSet_pattern2(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix2);
+  static URLPattern crlSet_pattern3(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix3);
+  static URLPattern crxDownload_pattern(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRXDownloadPrefix);
 
   if (geo_pattern.MatchesURL(ctx->request_url)) {
     ctx->new_url_spec = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY).spec();
@@ -23,6 +31,34 @@ int OnBeforeURLRequest_StaticRedirectWork(
 
   if (safeBrowsing_pattern.MatchesHost(ctx->request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crxDownload_pattern.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crxdownload.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern1.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern2.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern3.MatchesHost(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
@@ -60,9 +96,10 @@ int OnBeforeURLRequest_StaticRedirectWork(
     URLPattern(URLPattern::SCHEME_HTTPS, "https://safebrowsing.brave.com/v4/*"),
     URLPattern(URLPattern::SCHEME_HTTPS, "https://ssl.gstatic.com/safebrowsing/*"),
 
-    // Will be removed when https://github.com/brave/brave-browser/issues/663 is fixed
-    URLPattern(URLPattern::SCHEME_HTTPS, "https://www.gstatic.com/*"),
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crlsets.brave.com/*"),
+    URLPattern(URLPattern::SCHEME_HTTPS, "https://crxdownload.brave.com/*"),
   });
+
   // Check to make sure the URL being requested matches at least one of the allowed patterns
   bool is_url_allowed = std::any_of(allowed_patterns.begin(), allowed_patterns.end(),
     [&gurl](URLPattern pattern) {

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -40,28 +40,28 @@ int OnBeforeURLRequest_StaticRedirectWork(
     return net::OK;
   }
 
-  if (crxDownload_pattern.MatchesHost(ctx->request_url)) {
+  if (crxDownload_pattern.MatchesURL(ctx->request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr("crxdownload.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
 
-  if (crlSet_pattern1.MatchesHost(ctx->request_url)) {
+  if (crlSet_pattern1.MatchesURL(ctx->request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr("crlsets.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
 
-  if (crlSet_pattern2.MatchesHost(ctx->request_url)) {
+  if (crlSet_pattern2.MatchesURL(ctx->request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr("crlsets.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
 
-  if (crlSet_pattern3.MatchesHost(ctx->request_url)) {
+  if (crlSet_pattern3.MatchesURL(ctx->request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr("crlsets.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -68,6 +68,95 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet1) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "https://dl.google.com/release2/chrome_component/AJ4r388iQSJq_4819/"
+      "4819_all_crl-set-5934829738003798040.data.crx3");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crlsets.brave.com/release2/chrome_component/"
+      "AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet2) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "https://r2---sn-8xgp1vo-qxoe.gvt1.com/edgedl/release2/"
+      "chrome_component/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040"
+      ".data.crx3");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crlsets.brave.com/edgedl/release2/chrome_compone"
+      "nt/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet3) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "https://www.google.com/dl/release2/chrome_component/LLjIBPPmveI_4988/"
+      "4988_all_crl-set-6296993568184466307.data.crx3");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crlsets.brave.com/dl/release2/chrome_component/LLjIBPPmveI_4988/"
+      "4988_all_crl-set-6296993568184466307.data.crx3");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRXDownload) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "https://clients2.googleusercontent.com/crx/blobs/QgAAAC6zw0qH2DJtn"
+      "Xe8Z7rUJP1RM6lX7kVcwkQ56ujmG3AWYOAkxoNnIdnEBUz_"
+      "3z4keVhjzzAF10srsaL7lrntfB"
+      "IflcYIrTziwX3SUS9i_P-CAMZSmuV5tdQl-Roo6cnVC_GRzKsnZSKm1Q/"
+      "extension_2_0_67"
+      "3_0.crx");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crxdownload.brave.com/crx/blobs/QgAAAC6"
+      "zw0qH2DJtnXe8Z7rUJP1RM6lX7kVcwkQ56ujmG3AWYOAkxoNnIdnEBUz_"
+      "3z4keVhjzzAF10sr"
+      "saL7lrntfBIflcYIrTziwX3SUS9i_P-CAMZSmuV5tdQl-Roo6cnVC_GRzKsnZSKm1Q/"
+      "extens"
+      "ion_2_0_673_0.crx");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
   net::TestDelegate test_delegate;
   GURL url("https://safebrowsing.googleapis.com/v4/threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -1,8 +1,11 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/net/brave_static_redirect_network_delegate_helper.h"
+
+#include <memory>
 
 #include "brave/browser/net/url_context.h"
 #include "brave/common/network_constants.h"
@@ -13,19 +16,15 @@
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
-
 namespace {
 
-class BraveStaticRedirectNetworkDelegateHelperTest: public testing::Test {
+class BraveStaticRedirectNetworkDelegateHelperTest : public testing::Test {
  public:
   BraveStaticRedirectNetworkDelegateHelperTest()
       : thread_bundle_(content::TestBrowserThreadBundle::IO_MAINLOOP),
-        context_(new net::TestURLRequestContext(true)) {
-  }
+        context_(new net::TestURLRequestContext(true)) {}
   ~BraveStaticRedirectNetworkDelegateHelperTest() override {}
-  void SetUp() override {
-    context_->Init();
-  }
+  void SetUp() override { context_->Init(); }
   net::TestURLRequestContext* context() { return context_.get(); }
 
  private:
@@ -36,16 +35,14 @@ class BraveStaticRedirectNetworkDelegateHelperTest: public testing::Test {
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
   net::TestDelegate test_delegate;
   GURL url("https://bradhatesprimes.brave.com/composite_numbers_ftw");
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
-  int ret =
-    OnBeforeURLRequest_StaticRedirectWork(callback,
-        before_url_context);
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
   EXPECT_TRUE(before_url_context->new_url_spec.empty());
   EXPECT_EQ(ret, net::OK);
 }
@@ -53,17 +50,15 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, NoModifyTypicalURL) {
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGeoURL) {
   net::TestDelegate test_delegate;
   GURL url("https://www.googleapis.com/geolocation/v1/geolocate?key=2_3_5_7");
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
   GURL expected_url(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY);
-  int ret =
-      OnBeforeURLRequest_StaticRedirectWork(callback,
-                                            before_url_context);
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
   EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
@@ -159,40 +154,40 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRXDownload) {
 
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
   net::TestDelegate test_delegate;
-  GURL url("https://safebrowsing.googleapis.com/v4/threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  GURL url(
+      "https://safebrowsing.googleapis.com/v4/"
+      "threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
   GURL::Replacements replacements;
   replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
   GURL expected_url(url.ReplaceComponents(replacements));
-  int ret =
-      OnBeforeURLRequest_StaticRedirectWork(callback,
-                                            before_url_context);
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
   EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
 
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
   net::TestDelegate test_delegate;
-  GURL url("https://safebrowsing.googleapis.com/v5/threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");
-  std::unique_ptr<net::URLRequest> request =
-      context()->CreateRequest(url, net::IDLE, &test_delegate,
-                             TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo>
-      before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  GURL url(
+      "https://safebrowsing.googleapis.com/v5/"
+      "threatListUpdates:fetch?$req=ChkKCGNocm9taXVtEg02Ni");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
   GURL::Replacements replacements;
   replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
   GURL expected_url(url.ReplaceComponents(replacements));
-  int ret =
-      OnBeforeURLRequest_StaticRedirectWork(callback,
-                                            before_url_context);
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
   EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -152,6 +152,95 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRXDownload) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet1_http) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "http://dl.google.com/release2/chrome_component/AJ4r388iQSJq_4819/"
+      "4819_all_crl-set-5934829738003798040.data.crx3");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crlsets.brave.com/release2/chrome_component/"
+      "AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet2_http) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "http://r2---sn-8xgp1vo-qxoe.gvt1.com/edgedl/release2/"
+      "chrome_component/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040"
+      ".data.crx3");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crlsets.brave.com/edgedl/release2/chrome_compone"
+      "nt/AJ4r388iQSJq_4819/4819_all_crl-set-5934829738003798040.data.crx3");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRLSet3_http) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "http://www.google.com/dl/release2/chrome_component/LLjIBPPmveI_4988/"
+      "4988_all_crl-set-6296993568184466307.data.crx3");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crlsets.brave.com/dl/release2/chrome_component/LLjIBPPmveI_4988/"
+      "4988_all_crl-set-6296993568184466307.data.crx3");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifyCRXDownload_http) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "http://clients2.googleusercontent.com/crx/blobs/QgAAAC6zw0qH2DJtn"
+      "Xe8Z7rUJP1RM6lX7kVcwkQ56ujmG3AWYOAkxoNnIdnEBUz_"
+      "3z4keVhjzzAF10srsaL7lrntfB"
+      "IflcYIrTziwX3SUS9i_P-CAMZSmuV5tdQl-Roo6cnVC_GRzKsnZSKm1Q/"
+      "extension_2_0_67"
+      "3_0.crx");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://crxdownload.brave.com/crx/blobs/QgAAAC6"
+      "zw0qH2DJtnXe8Z7rUJP1RM6lX7kVcwkQ56ujmG3AWYOAkxoNnIdnEBUz_"
+      "3z4keVhjzzAF10sr"
+      "saL7lrntfBIflcYIrTziwX3SUS9i_P-CAMZSmuV5tdQl-Roo6cnVC_GRzKsnZSKm1Q/"
+      "extens"
+      "ion_2_0_673_0.crx");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV4) {
   net::TestDelegate test_delegate;
   GURL url(

--- a/chromium_src/chrome/browser/component_updater/crl_set_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/crl_set_component_installer.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define RegisterCRLSetComponent RegisterCRLSetComponent_ChromiumImpl
+#include "../../../../../chrome/browser/component_updater/crl_set_component_installer.cc"  // NOLINT
+#undef RegisterCRLSetComponent
+
+#include "brave/browser/extensions/brave_component_extension.h"
+#include "brave/common/extensions/extension_constants.h"
+#include "chrome/browser/browser_process.h"
+
+namespace component_updater {
+
+void OnCRLSetRegistered() {
+  ComponentsUI demand_updater;
+  demand_updater.OnDemandUpdate(g_browser_process->component_updater(),
+                                crl_set_extension_id);
+}
+
+void RegisterCRLSetComponent(ComponentUpdateService* cus,
+                             const base::FilePath& user_data_dir) {
+  auto installer = base::MakeRefCounted<component_updater::ComponentInstaller>(
+      std::make_unique<CRLSetPolicy>());
+  installer->Register(g_browser_process->component_updater(),
+                      base::Bind(&OnCRLSetRegistered));
+}
+
+}  // namespace component_updater

--- a/chromium_src/components/component_updater/component_updater_service.cc
+++ b/chromium_src/components/component_updater/component_updater_service.cc
@@ -1,0 +1,37 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/component_updater/component_updater_service.h"
+
+#include "brave/browser/component_updater/brave_crx_update_service.h"
+#include "components/update_client/crx_downloader.h"
+#include "components/update_client/ping_manager.h"
+#include "components/update_client/update_checker.h"
+#include "components/update_client/update_client_internal.h"
+
+#define ComponentUpdateServiceFactory ComponentUpdateServiceFactory_ChromiumImpl
+#include "../../../../components/component_updater/component_updater_service.cc"  // NOLINT
+#undef ComponentUpdateServiceFactory
+
+using update_client::CrxDownloader;
+using update_client::PingManager;
+using update_client::UpdateChecker;
+using update_client::UpdateClientImpl;
+
+namespace component_updater {
+
+std::unique_ptr<ComponentUpdateService> ComponentUpdateServiceFactory(
+    scoped_refptr<Configurator> config,
+    std::unique_ptr<UpdateScheduler> scheduler) {
+  DCHECK(config);
+  DCHECK(scheduler);
+  auto update_client = base::MakeRefCounted<UpdateClientImpl>(
+      config, base::MakeRefCounted<PingManager>(config), &UpdateChecker::Create,
+      &CrxDownloader::Create);
+  return std::make_unique<BraveCrxUpdateService>(config, std::move(scheduler),
+                                                 std::move(update_client));
+}
+
+}  // namespace component_updater

--- a/common/extensions/extension_constants.cc
+++ b/common/extensions/extension_constants.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -14,5 +15,10 @@ const char crl_set_extension_id[] = "hfnkpimlhhgieaddgfemjhofmfblmnib";
 
 const char pdfjs_extension_id[] = "oemmndcbldboiebfnladdacbdfmadadm";
 const char pdfjs_extension_name[] = "PDF Viewer (PDF.js)";
-const char pdfjs_extension_public_key[] = "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDb5PIb8ayK6vHvEIY1nJKRSCDE8iJ1T43qFN+5dvCVQrmyEkgqB9ZuZNT24Lwot96HV51VoITHKRNIVKI2Nrbfn0M49t7qtaP34g/GXJ7mAIbSzsY4+i+Wsz8EL2SNEIw6uH8RmXG7nZ29NJ7sk7jn17QmMsO2UJ01UT8hfOOOEQIDAQAB";
-const char pdfjs_extension_origin[] = "chrome-extension://oemmndcbldboiebfnladdacbdfmadadm/";
+const char pdfjs_extension_public_key[] =
+    "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDb5PIb8ayK6vHvEIY1nJKRSCDE8iJ1T43qFN"
+    "+5dvCVQrmyEkgqB9ZuZNT24Lwot96HV51VoITHKRNIVKI2Nrbfn0M49t7qtaP34g/"
+    "GXJ7mAIbSzsY4+i+"
+    "Wsz8EL2SNEIw6uH8RmXG7nZ29NJ7sk7jn17QmMsO2UJ01UT8hfOOOEQIDAQAB";
+const char pdfjs_extension_origin[] =
+    "chrome-extension://oemmndcbldboiebfnladdacbdfmadadm/";

--- a/common/extensions/extension_constants.cc
+++ b/common/extensions/extension_constants.cc
@@ -10,6 +10,7 @@ const char brave_webtorrent_extension_id[] = "lgjmpdmojkpocjcopdikifhejkkjglho";
 const char hangouts_extension_id[] = "nkeimhogjdpnpccoofpliimaahmaaome";
 const char widevine_extension_id[] = "oimompecagnajdejgnnjijobebaeigek";
 const char brave_sync_extension_id[] = "nomlkjnggnifocmealianaaiobmebgil";
+const char crl_set_extension_id[] = "hfnkpimlhhgieaddgfemjhofmfblmnib";
 
 const char pdfjs_extension_id[] = "oemmndcbldboiebfnladdacbdfmadadm";
 const char pdfjs_extension_name[] = "PDF Viewer (PDF.js)";

--- a/common/extensions/extension_constants.h
+++ b/common/extensions/extension_constants.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/common/extensions/extension_constants.h
+++ b/common/extensions/extension_constants.h
@@ -2,14 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#ifndef BRAVE_COMMON_EXTENSIONS_EXTENSION_CONSTANTS_H_
+#define BRAVE_COMMON_EXTENSIONS_EXTENSION_CONSTANTS_H_
+
 extern const char brave_extension_id[];
 extern const char brave_rewards_extension_id[];
 extern const char brave_webtorrent_extension_id[];
 extern const char hangouts_extension_id[];
 extern const char widevine_extension_id[];
 extern const char brave_sync_extension_id[];
+extern const char crl_set_extension_id[];
 
 extern const char pdfjs_extension_id[];
 extern const char pdfjs_extension_name[];
 extern const char pdfjs_extension_public_key[];
 extern const char pdfjs_extension_origin[];
+
+#endif  // BRAVE_COMMON_EXTENSIONS_EXTENSION_CONSTANTS_H_

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -19,9 +19,12 @@ const char kBraveReferralsActivityPath[] = "/promo/activity";
 const char kCRXDownloadPrefix[] =
     "https://clients2.googleusercontent.com/crx/blobs/*crx*";
 const char kEmptyDataURI[] = "data:text/plain,";
-const char kEmptyImageDataURI[] = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+const char kEmptyImageDataURI[] =
+    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///"
+    "yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 const char kJSDataURLPrefix[] = "data:application/javascript;base64,";
-const char kGeoLocationsPattern[] = "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
+const char kGeoLocationsPattern[] =
+    "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kSafeBrowsingPrefix[] = "https://safebrowsing.googleapis.com/";
 const char kCRLSetPrefix1[] =
     "https://dl.google.com/release2/chrome_component/*crl-set*";
@@ -29,10 +32,14 @@ const char kCRLSetPrefix2[] =
     "https://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
 const char kCRLSetPrefix3[] =
     "https://www.google.com/dl/release2/chrome_component/*crl-set*";
-const char kGoogleTagManagerPattern[] = "https://www.googletagmanager.com/gtm.js";
-const char kGoogleTagServicesPattern[] = "https://www.googletagservices.com/tag/js/gpt.js";
+const char kGoogleTagManagerPattern[] =
+    "https://www.googletagmanager.com/gtm.js";
+const char kGoogleTagServicesPattern[] =
+    "https://www.googletagservices.com/tag/js/gpt.js";
 const char kForbesPattern[] = "https://www.forbes.com/*";
-const char kForbesExtraCookies[] = "forbes_ab=true; welcomeAd=true; adblock_session=Off; dailyWelcomeCookie=true";
+const char kForbesExtraCookies[] =
+    "forbes_ab=true; welcomeAd=true; adblock_session=Off; "
+    "dailyWelcomeCookie=true";
 const char kTwitterPattern[] = "https://*.twitter.com/*";
 const char kTwitterReferrer[] = "https://twitter.com/*";
 const char kTwitterRedirectURL[] = "https://mobile.twitter.com/i/nojs_router*";

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -17,7 +17,7 @@ const char kBraveReferralsInitPath[] = "/promo/initialize/nonua";
 const char kBraveReferralsActivityPath[] = "/promo/activity";
 
 const char kCRXDownloadPrefix[] =
-    "https://clients2.googleusercontent.com/crx/blobs/*crx*";
+    "*://clients2.googleusercontent.com/crx/blobs/*crx*";
 const char kEmptyDataURI[] = "data:text/plain,";
 const char kEmptyImageDataURI[] =
     "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///"
@@ -27,11 +27,11 @@ const char kGeoLocationsPattern[] =
     "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kSafeBrowsingPrefix[] = "https://safebrowsing.googleapis.com/";
 const char kCRLSetPrefix1[] =
-    "https://dl.google.com/release2/chrome_component/*crl-set*";
+    "*://dl.google.com/release2/chrome_component/*crl-set*";
 const char kCRLSetPrefix2[] =
-    "https://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
+    "*://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
 const char kCRLSetPrefix3[] =
-    "https://www.google.com/dl/release2/chrome_component/*crl-set*";
+    "*://www.google.com/dl/release2/chrome_component/*crl-set*";
 const char kGoogleTagManagerPattern[] =
     "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] =

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -1,19 +1,34 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #include "brave/common/network_constants.h"
 
-const char kBraveUpdatesExtensionsEndpoint[] = "https://go-updater.brave.com/extensions";
+// const char kBraveUpdatesExtensionsEndpoint[] =
+//    "https://go-updater.brave.com/extensions";
 // For debgugging:
-// const char kBraveUpdatesExtensionsEndpoint[] = "http://localhost:8192/extensions";
+const char kBraveUpdatesExtensionsEndpoint[] =
+    "http://18.191.178.76/extensions";
 
 const char kBraveReferralsServer[] = "laptop-updates.brave.com";
 const char kBraveReferralsHeadersPath[] = "/promo/custom-headers";
 const char kBraveReferralsInitPath[] = "/promo/initialize/nonua";
 const char kBraveReferralsActivityPath[] = "/promo/activity";
 
+const char kCRXDownloadPrefix[] =
+    "https://clients2.googleusercontent.com/crx/blobs/*crx*";
 const char kEmptyDataURI[] = "data:text/plain,";
 const char kEmptyImageDataURI[] = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 const char kJSDataURLPrefix[] = "data:application/javascript;base64,";
 const char kGeoLocationsPattern[] = "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kSafeBrowsingPrefix[] = "https://safebrowsing.googleapis.com/";
+const char kCRLSetPrefix1[] =
+    "https://dl.google.com/release2/chrome_component/*crl-set*";
+const char kCRLSetPrefix2[] =
+    "https://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
+const char kCRLSetPrefix3[] =
+    "https://www.google.com/dl/release2/chrome_component/*crl-set*";
 const char kGoogleTagManagerPattern[] = "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] = "https://www.googletagservices.com/tag/js/gpt.js";
 const char kForbesPattern[] = "https://www.forbes.com/*";

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -5,11 +5,11 @@
 
 #include "brave/common/network_constants.h"
 
-// const char kBraveUpdatesExtensionsEndpoint[] =
-//    "https://go-updater.brave.com/extensions";
-// For debgugging:
 const char kBraveUpdatesExtensionsEndpoint[] =
-    "http://18.191.178.76/extensions";
+    "https://go-updater.brave.com/extensions";
+// For debgugging:
+// const char kBraveUpdatesExtensionsEndpoint[] =
+// "http://localhost:8192/extensions";
 
 const char kBraveReferralsServer[] = "laptop-updates.brave.com";
 const char kBraveReferralsHeadersPath[] = "/promo/custom-headers";

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -1,3 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #ifndef BRAVE_COMMON_NETWORK_CONSTANTS_H_
 #define BRAVE_COMMON_NETWORK_CONSTANTS_H_
 
@@ -8,6 +13,7 @@ extern const char kBraveReferralsHeadersPath[];
 extern const char kBraveReferralsInitPath[];
 extern const char kBraveReferralsActivityPath[];
 
+extern const char kCRXDownloadPrefix[];
 extern const char kEmptyDataURI[];
 extern const char kEmptyImageDataURI[];
 extern const char kJSDataURLPrefix[];
@@ -17,6 +23,9 @@ extern const char kGoogleTagServicesPattern[];
 extern const char kForbesPattern[];
 extern const char kForbesExtraCookies[];
 extern const char kSafeBrowsingPrefix[];
+extern const char kCRLSetPrefix1[];
+extern const char kCRLSetPrefix2[];
+extern const char kCRLSetPrefix3[];
 extern const char kTwitterPattern[];
 extern const char kTwitterReferrer[];
 extern const char kTwitterRedirectURL[];

--- a/patches/components-component_updater-component_updater_service_internal.h.patch
+++ b/patches/components-component_updater-component_updater_service_internal.h.patch
@@ -1,0 +1,20 @@
+diff --git a/components/component_updater/component_updater_service_internal.h b/components/component_updater/component_updater_service_internal.h
+index 341fbf78a96bb1b0b8e10bf9579dea9b930bec13..5d1d80b412cc8669c0acfd3b707651af27b62809 100644
+--- a/components/component_updater/component_updater_service_internal.h
++++ b/components/component_updater/component_updater_service_internal.h
+@@ -26,6 +26,7 @@ enum class Error;
+ 
+ namespace component_updater {
+ 
++class BraveCrxUpdateService;
+ class OnDemandUpdater;
+ 
+ using CrxInstaller = update_client::CrxInstaller;
+@@ -66,6 +67,7 @@ class CrxUpdateService : public ComponentUpdateService,
+                       Callback callback) override;
+ 
+  private:
++  friend class BraveCrxUpdateService;
+   void Start();
+   void Stop();
+ 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/518
fix https://github.com/brave/brave-browser/issues/2160
fix https://github.com/brave/brave-browser/issues/3615

## Description:

Revoked certificates don't show certificate error on all platforms. This PR enables CRLSets, a component managed by Google to show certificate errors for domains with revoked certificates.

Since, CRLSets is maintained by Google we will be proxying requests for CRLSets through crlsets[n].brave.com, crxdownload.brave.com (resources) and componentupdater.brave.com (component updates)

This PR also caps the maximum component updates per request to `go-updater` to 1, since `go-updater` cannot handle an update request with both Google and Brave components.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

### For CRLSets

1. Open Brave with a fresh profile
2. No connections are initiated to google domains. (use fiddler or little snitch to verify)
3. CRLSets should be available in `<Data-Dir>/CertificateRevocation/<CRLSET_ID>`
4. CRLSet ID can be verified via chrome://components (should NOT be 0.0.0.0)
5. Navigate to revoked.badssl.com - Should show a certificate error

### For Component Updates 
1. Restart Brave Browser
2. Wait for 8 mins, and verify that no components show `Update Error`
3. Verify only `MEI Preload` | `Brave Local Data Updater` | `Brave Ad Block Updater` | `Brave Tor Client Updater (OS)` |  `CRLSet` | `PDF Viewer (PDF.js) ` and `Brave HTTPS Everywhere Updater` have non-zero version numbers by default

**For QA**

On `macOS` the system uses the system CRLSets, so to verify this is working verify that the `CertificateRevocation` directory has the correct CRLSet version.

Please verify that `revoked.badssl.com` does not show error on Windows/Linux.

**For devs:**

Please use: https://github.com/brave/brave-browser/pull/3452/ to verify the network audit passes. The changes to the go-updater are still in dev. Will be transitioned to prod once QA sign-off is received.

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source