### PR TITLE
Remove Chrome repo erroneously added by brave-browser

### DIFF
--- a/patches/chrome-installer-linux-common-repo.cron.patch
+++ b/patches/chrome-installer-linux-common-repo.cron.patch
@@ -1,11 +1,20 @@
 diff --git a/chrome/installer/linux/common/repo.cron b/chrome/installer/linux/common/repo.cron
-index 2750e4924da6d0a723c1d649781637e7d08b3562..fbe7797e37633de174f4a83d7b11bf04b8813c1a 100755
+index 2750e4924da6d0a723c1d649781637e7d08b3562..2b9a3f3591a93a033a93e201b2b1a1d13ebbecd4 100755
 --- a/chrome/installer/linux/common/repo.cron
 +++ b/chrome/installer/linux/common/repo.cron
-@@ -17,6 +17,9 @@
+@@ -17,6 +17,18 @@
  # "false" as desired. An empty $DEFAULTS_FILE is the same as setting both values
  # to "false".
  
++# Remove Chrome repo if erroneously added (brave/brave-browser#2927)
++if [ -e "/etc/apt/sources.list.d/@@PACKAGE@@.list" ] ; then
++  if [ ! -e "/etc/apt/sources.list.d/google-chrome.list" -a ! -e "/etc/apt/sources.list.d/google-chrome-beta.list" -a ! -e "/etc/apt/sources.list.d/google-chrome-unstable.list" ] ; then
++    apt-key del D38B4796
++  fi
++  rm -f "/etc/default/@@PACKAGE@@"
++  rm "/etc/apt/sources.list.d/@@PACKAGE@@.list"
++fi
++
 +# Don't add the Chrome repo (brave/brave-browser#1084)
 +exit 0
 +

--- a/patches/chrome-installer-linux-common-rpmrepo.cron.patch
+++ b/patches/chrome-installer-linux-common-rpmrepo.cron.patch
@@ -1,11 +1,20 @@
 diff --git a/chrome/installer/linux/common/rpmrepo.cron b/chrome/installer/linux/common/rpmrepo.cron
-index f7fe2bcf7d7cbf95b23067f21f87422706c5e4d0..3541826a03009e2adb8dbd6c258d254d31247a77 100755
+index f7fe2bcf7d7cbf95b23067f21f87422706c5e4d0..3dbad7d3a412efb023f3d57707fe6723d5a78e66 100755
 --- a/chrome/installer/linux/common/rpmrepo.cron
 +++ b/chrome/installer/linux/common/rpmrepo.cron
-@@ -14,6 +14,9 @@
+@@ -14,6 +14,18 @@
  # setting "repo_add_once" to "true" or "false" as desired. An empty
  # $DEFAULTS_FILE is the same as setting the value to "false".
  
++# Remove Chrome repo if erroneously added (brave/brave-browser#2927)
++if [ -e "/etc/yum.repos.d/@@PACKAGE@@.repo" ] ; then
++  if [ ! -e "/etc/yum.repos.d/google-chrome.repo" -a ! -e "/etc/yum.repos.d/google-chrome-beta.repo" -a ! -e "/etc/yum.repos.d/google-chrome-unstable.repo" ] ; then
++    rpm -e gpg-pubkey-7fac5991-4615767f
++    rpm -e gpg-pubkey-d38b4796-570c8cd3
++  fi
++  rm "/etc/yum.repos.d/@@PACKAGE@@.repo"
++fi
++
 +# Don't add the Chrome repo (brave/brave-browser#1967)
 +exit 0
 +


### PR DESCRIPTION
Fixes brave/brave-browser#2927.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source