### PR TITLE
Temporarily disable Windows network diagnostic button; permanently disable DNS diagnostic probes

### DIFF
--- a/patches/chrome-browser-net-net_error_diagnostics_dialog_win.cc.patch
+++ b/patches/chrome-browser-net-net_error_diagnostics_dialog_win.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/net/net_error_diagnostics_dialog_win.cc b/chrome/browser/net/net_error_diagnostics_dialog_win.cc
+index 4a3768f6b14d1f66482999366f85772073302e65..a433884fb320e998b20e34fb9f42088c46f71f42 100644
+--- a/chrome/browser/net/net_error_diagnostics_dialog_win.cc
++++ b/chrome/browser/net/net_error_diagnostics_dialog_win.cc
+@@ -83,6 +83,9 @@ class NetErrorDiagnosticsDialog : public ui::BaseShellDialogImpl {
+ }  // namespace
+ 
+ bool CanShowNetworkDiagnosticsDialog() {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  return false;
++#endif
+   return true;
+ }
+ 

--- a/patches/chrome-browser-net-net_error_tab_helper.cc.patch
+++ b/patches/chrome-browser-net-net_error_tab_helper.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/net/net_error_tab_helper.cc b/chrome/browser/net/net_error_tab_helper.cc
+index 0d094df161accd5740306543fc938ab6e58da296..7fe69647b81d9d2c40abe9096a736f16864b6003 100644
+--- a/chrome/browser/net/net_error_tab_helper.cc
++++ b/chrome/browser/net/net_error_tab_helper.cc
+@@ -259,6 +259,9 @@ void NetErrorTabHelper::InitializePref(WebContents* contents) {
+ }
+ 
+ bool NetErrorTabHelper::ProbesAllowed() const {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  return false;
++#endif
+   if (testing_state_ != TESTING_DEFAULT)
+     return testing_state_ == TESTING_FORCE_ENABLED;
+ 


### PR DESCRIPTION
1st commit:
quick fix for https://github.com/brave/brave-browser/issues/3249;
however this is fixed upstream in https://chromium.googlesource.com/chromium/src.git/+/e005fff9c838a13ff1402b01617adca691187a6b%5E%21/; we may just want to cherry-pick that commit? not sure if we have a procedure for doing that. I don't think we want to wait for Chromium 74 in order to get this fix out given the impact on Tor.

2nd commit:
defense in depth to ensure DNS probes are disabled

Test plan (windows only)
1. Go to a non-existent site like dklfjdkafjdkafj.com
2. You should no longer see a link that says 'Running Windows Network
   Diagnostics'

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source