### PR TITLE
Fixes for onion domain leaks

### DIFF
--- a/patches/chrome-browser-net-net_error_diagnostics_dialog.h.patch
+++ b/patches/chrome-browser-net-net_error_diagnostics_dialog.h.patch
@@ -1,0 +1,19 @@
+diff --git a/chrome/browser/net/net_error_diagnostics_dialog.h b/chrome/browser/net/net_error_diagnostics_dialog.h
+index 2d3089a5cef0b9bc89bdc64f3068b324197cfb38..6b2f88cba88b26f9f960812763012f1933c5260d 100644
+--- a/chrome/browser/net/net_error_diagnostics_dialog.h
++++ b/chrome/browser/net/net_error_diagnostics_dialog.h
+@@ -11,9 +11,11 @@ namespace content {
+ class WebContents;
+ }
+ 
+-// Returns true if the platform has a supported tool for diagnosing network
+-// errors encountered when requesting URLs.
+-bool CanShowNetworkDiagnosticsDialog();
++// Returns true if a tool for diagnosing network errors encountered when
++// requesting URLs can be shown for the provided WebContents. The ability to
++// show the diagnostic tool depends on the host platform, and whether the
++// WebContents is incognito.
++bool CanShowNetworkDiagnosticsDialog(content::WebContents* web_contents);
+ 
+ // Shows a dialog for investigating an error received when requesting
+ // |failed_url|.  May only be called when CanShowNetworkDiagnosticsDialog()

--- a/patches/chrome-browser-net-net_error_diagnostics_dialog_posix.cc.patch
+++ b/patches/chrome-browser-net-net_error_diagnostics_dialog_posix.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/net/net_error_diagnostics_dialog_posix.cc b/chrome/browser/net/net_error_diagnostics_dialog_posix.cc
+index e2866f851389a1e645b133419834bab26c5f68dc..2c21794a89878b5921c8fe8cf0bc32620946aabe 100644
+--- a/chrome/browser/net/net_error_diagnostics_dialog_posix.cc
++++ b/chrome/browser/net/net_error_diagnostics_dialog_posix.cc
+@@ -6,7 +6,7 @@
+ 
+ #include "base/logging.h"
+ 
+-bool CanShowNetworkDiagnosticsDialog() {
++bool CanShowNetworkDiagnosticsDialog(content::WebContents* web_contents) {
+   return false;
+ }
+ 

--- a/patches/chrome-browser-net-net_error_diagnostics_dialog_win.cc.patch
+++ b/patches/chrome-browser-net-net_error_diagnostics_dialog_win.cc.patch
@@ -1,0 +1,33 @@
+diff --git a/chrome/browser/net/net_error_diagnostics_dialog_win.cc b/chrome/browser/net/net_error_diagnostics_dialog_win.cc
+index 4a3768f6b14d1f66482999366f85772073302e65..ea046e11d3aff8690f294831c98829de9b35b183 100644
+--- a/chrome/browser/net/net_error_diagnostics_dialog_win.cc
++++ b/chrome/browser/net/net_error_diagnostics_dialog_win.cc
+@@ -24,6 +24,7 @@
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/task_runner.h"
+ #include "base/threading/thread.h"
++#include "chrome/browser/profiles/profile.h"
+ #include "content/public/browser/web_contents.h"
+ #include "ui/gfx/native_widget_types.h"
+ #include "ui/shell_dialogs/base_shell_dialog_win.h"
+@@ -82,13 +83,17 @@ class NetErrorDiagnosticsDialog : public ui::BaseShellDialogImpl {
+ 
+ }  // namespace
+ 
+-bool CanShowNetworkDiagnosticsDialog() {
+-  return true;
++bool CanShowNetworkDiagnosticsDialog(content::WebContents* web_contents) {
++  Profile* profile =
++      Profile::FromBrowserContext(web_contents->GetBrowserContext());
++  // The Windows diagnostic tool logs URLs it's run with, so it shouldn't be
++  // used with incognito or guest profiles.  See https://crbug.com/929141
++  return !profile->IsOffTheRecord() && !profile->IsGuestSession();
+ }
+ 
+ void ShowNetworkDiagnosticsDialog(content::WebContents* web_contents,
+                                   const std::string& failed_url) {
+-  DCHECK(CanShowNetworkDiagnosticsDialog());
++  DCHECK(CanShowNetworkDiagnosticsDialog(web_contents));
+ 
+   NetErrorDiagnosticsDialog* dialog = new NetErrorDiagnosticsDialog();
+   dialog->Show(

--- a/patches/chrome-browser-net-net_error_tab_helper.cc.patch
+++ b/patches/chrome-browser-net-net_error_tab_helper.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/net/net_error_tab_helper.cc b/chrome/browser/net/net_error_tab_helper.cc
-index 0d094df161accd5740306543fc938ab6e58da296..91daf4ecf22ab5c1dbee3e6c2aa857d986e62dea 100644
+index 0d094df161accd5740306543fc938ab6e58da296..eede25d41103e85be7c9067ecd09667a6c0e97b3 100644
 --- a/chrome/browser/net/net_error_tab_helper.cc
 +++ b/chrome/browser/net/net_error_tab_helper.cc
 @@ -89,7 +89,8 @@ void NetErrorTabHelper::RenderFrameCreated(
@@ -12,7 +12,17 @@ index 0d094df161accd5740306543fc938ab6e58da296..91daf4ecf22ab5c1dbee3e6c2aa857d9
  }
  
  void NetErrorTabHelper::DidStartNavigation(
-@@ -293,6 +294,11 @@ void NetErrorTabHelper::RunNetworkDiagnostics(const GURL& url) {
+@@ -259,6 +260,9 @@ void NetErrorTabHelper::InitializePref(WebContents* contents) {
+ }
+ 
+ bool NetErrorTabHelper::ProbesAllowed() const {
++#if defined(BRAVE_CHROMIUM_BUILD)
++  return false;
++#endif
+   if (testing_state_ != TESTING_DEFAULT)
+     return testing_state_ == TESTING_FORCE_ENABLED;
+ 
+@@ -293,6 +297,11 @@ void NetErrorTabHelper::RunNetworkDiagnostics(const GURL& url) {
  
  void NetErrorTabHelper::RunNetworkDiagnosticsHelper(
      const std::string& sanitized_url) {

--- a/patches/chrome-browser-net-net_error_tab_helper.cc.patch
+++ b/patches/chrome-browser-net-net_error_tab_helper.cc.patch
@@ -1,0 +1,26 @@
+diff --git a/chrome/browser/net/net_error_tab_helper.cc b/chrome/browser/net/net_error_tab_helper.cc
+index 0d094df161accd5740306543fc938ab6e58da296..91daf4ecf22ab5c1dbee3e6c2aa857d986e62dea 100644
+--- a/chrome/browser/net/net_error_tab_helper.cc
++++ b/chrome/browser/net/net_error_tab_helper.cc
+@@ -89,7 +89,8 @@ void NetErrorTabHelper::RenderFrameCreated(
+ 
+   chrome::mojom::NetworkDiagnosticsClientAssociatedPtr client;
+   render_frame_host->GetRemoteAssociatedInterfaces()->GetInterface(&client);
+-  client->SetCanShowNetworkDiagnosticsDialog(CanShowNetworkDiagnosticsDialog());
++  client->SetCanShowNetworkDiagnosticsDialog(
++      CanShowNetworkDiagnosticsDialog(web_contents()));
+ }
+ 
+ void NetErrorTabHelper::DidStartNavigation(
+@@ -293,6 +294,11 @@ void NetErrorTabHelper::RunNetworkDiagnostics(const GURL& url) {
+ 
+ void NetErrorTabHelper::RunNetworkDiagnosticsHelper(
+     const std::string& sanitized_url) {
++  // The button shouldn't even be shown in this case, but still best to be safe,
++  // since the renderer isn't trusted.
++  if (!CanShowNetworkDiagnosticsDialog(web_contents()))
++    return;
++
+   if (network_diagnostics_bindings_.GetCurrentTargetFrame()
+           != web_contents()->GetMainFrame()) {
+     return;


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3249

1st commit - cherry-pick of the chromium fix for the main issue: https://chromium.googlesource.com/chromium/src.git/+/e005fff9c838a13ff1402b01617adca691187a6b%5E%21/. This should be reverted after we rebase on c74.

2nd commit - defense in depth by disabling DNS probing on error pages (which should be disabled already for the majority of Brave users anyway)

Test Plan (windows only):
* Go to a non-existent site like dklfjdkafjdkafj.com in a regular tab
* You should see a link that says 'Running Windows Network Diagnostics'
* Repeat in a private tab; you should not see this link
* Repeat in a tor tab; you should not see this link

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source