### PR TITLE
Merge pull request #1560 from brave/sync_dont_double_reset (0.60.x)

### DIFF
--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -1,6 +1,7 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Copyright 2016 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/files/scoped_temp_dir.h"
 #include "base/strings/utf_string_conversions.h"
@@ -87,11 +88,17 @@
 //                           | BraveSyncServiceTest.OnResetSync
 // OnSyncPrefsChanged        | +
 
-using testing::_;
-using testing::AtLeast;
-using namespace brave_sync;
+using brave_sync::BraveSyncService;
+using brave_sync::BraveSyncServiceImpl;
+using brave_sync::BraveSyncServiceObserver;
+using brave_sync::jslib::SyncRecord;
+using brave_sync::MockBraveSyncClient;
+using brave_sync::RecordsList;
+using brave_sync::SimpleDeviceRecord;
 using network::TestNetworkConnectionTracker;
 using network::mojom::ConnectionType;
+using testing::_;
+using testing::AtLeast;
 
 class MockBraveSyncServiceObserver : public BraveSyncServiceObserver {
  public:
@@ -114,20 +121,22 @@ class BraveSyncServiceTest
     EXPECT_TRUE(temp_dir_.CreateUniqueTempDir());
     // register the factory
 
-    profile_ = CreateBraveSyncProfile(temp_dir_.GetPath());
+    profile_ = brave_sync::CreateBraveSyncProfile(temp_dir_.GetPath());
     EXPECT_TRUE(profile_.get() != NULL);
 
     // TODO(bridiver) - this is temporary until some changes are made to
     // to bookmark_change_processor to allow `set_for_testing` like
     // BraveSyncClient
     BookmarkModelFactory::GetInstance()->SetTestingFactory(
-       profile(), base::BindRepeating(&BuildFakeBookmarkModelForTests));
+       profile(),
+       base::BindRepeating(&brave_sync::BuildFakeBookmarkModelForTests));
 
-    BraveSyncClientImpl::set_for_testing(
+    brave_sync::BraveSyncClientImpl::set_for_testing(
         new MockBraveSyncClient());
 
     sync_service_ = static_cast<BraveSyncServiceImpl*>(
-        BraveSyncServiceFactory::GetInstance()->GetForProfile(profile()));
+        brave_sync::BraveSyncServiceFactory::GetInstance()->GetForProfile(
+            profile()));
 
     sync_client_ =
         static_cast<MockBraveSyncClient*>(sync_service_->GetSyncClient());
@@ -219,7 +228,8 @@ void BraveSyncServiceTest::BookmarkAddedImpl() {
   // Invoke BraveSyncService::BookmarkAdded
   // Expect BraveSyncClient::SendSyncRecords invoked
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(AtLeast(1));
+  EXPECT_CALL(*observer(),
+      OnSyncStateChanged(sync_service())).Times(AtLeast(1));
   sync_service()->OnSetupSyncNewToSync("UnitTestBookmarkAdded");
   sync_service()->BackgroundSyncStarted(true/*startup*/);
 
@@ -228,7 +238,7 @@ void BraveSyncServiceTest::BookmarkAddedImpl() {
                                  GURL("https://a.com"),
                                  base::ASCIIToUTF16("A.com - title"));
   // Force service send bookmarks and fire the mock
-  EXPECT_CALL(*sync_client(), SendSyncRecords(_,_)).Times(1);
+  EXPECT_CALL(*sync_client(), SendSyncRecords(_, _)).Times(1);
   sync_service()->OnResolvedSyncRecords(brave_sync::jslib_const::kBookmarks,
     std::make_unique<RecordsList>());
 }
@@ -246,7 +256,8 @@ TEST_F(BraveSyncServiceTest, BookmarkDeleted) {
   bookmarks::GetMostRecentlyAddedEntries(bookmark_model, 1, &nodes);
   ASSERT_EQ(nodes.size(), 1u);
   ASSERT_NE(nodes.at(0), nullptr);
-  EXPECT_CALL(*sync_client(), SendSyncRecords(_,_)).Times(1); // TODO, AB: preciece with mock expect filter
+  // TODO(alexeyb): preciece with mock expect filter
+  EXPECT_CALL(*sync_client(), SendSyncRecords(_, _)).Times(1);
   bookmark_model->Remove(nodes.at(0));
   // record->action = jslib::SyncRecord::Action::A_DELETE;
   // <= BookmarkNodeToSyncBookmark <= BookmarkChangeProcessor::SendUnsynced
@@ -347,8 +358,8 @@ TEST_F(BraveSyncServiceTest, GetSettingsAndDevices) {
             EXPECT_FALSE(settings->sync_settings_);
             EXPECT_FALSE(settings->sync_history_);
             EXPECT_EQ(devices->size(), 0u);
-        }
-  );
+        });
+
   sync_service()->GetSettingsAndDevices(callback1);
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged);
   // Expecting sync state changed twice: for enabled state and for device name
@@ -362,8 +373,7 @@ TEST_F(BraveSyncServiceTest, GetSettingsAndDevices) {
           // Other fields may be switched later
           EXPECT_EQ(settings->this_device_name_, "test_device");
           EXPECT_TRUE(settings->sync_this_device_);
-      }
-  );
+      });
   sync_service()->GetSettingsAndDevices(callback2);
 }
 
@@ -386,25 +396,26 @@ TEST_F(BraveSyncServiceTest, SyncSetupError) {
 
 TEST_F(BraveSyncServiceTest, GetSeed) {
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged);
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(AtLeast(2));
+  EXPECT_CALL(*observer(),
+      OnSyncStateChanged(sync_service())).Times(AtLeast(2));
   sync_service()->OnSetupSyncNewToSync("test_device");
   EXPECT_TRUE(profile()->GetPrefs()->GetBoolean(
        brave_sync::prefs::kSyncEnabled));
 
   // Service gets seed from client via BraveSyncServiceImpl::OnSaveInitData
-  const auto binary_seed = Uint8Array(16, 77);
+  const auto binary_seed = brave_sync::Uint8Array(16, 77);
 
   EXPECT_TRUE(sync_service()->sync_prefs_->GetPrevSeed().empty());
   sync_service()->OnSaveInitData(binary_seed, {0});
-  std::string expected_seed = StrFromUint8Array(binary_seed);
+  std::string expected_seed = brave_sync::StrFromUint8Array(binary_seed);
   EXPECT_EQ(sync_service()->GetSeed(), expected_seed);
   EXPECT_TRUE(sync_service()->sync_prefs_->GetPrevSeed().empty());
 }
 
-bool DevicesContains(SyncDevices* devices, const std::string& id,
+bool DevicesContains(brave_sync::SyncDevices* devices, const std::string& id,
     const std::string& name) {
   DCHECK(devices);
-  for (const SyncDevice &device : devices->devices_) {
+  for (const auto& device : devices->devices_) {
     if (device.device_id_ == id && device.name_ == name) {
       return true;
     }
@@ -429,13 +440,13 @@ MATCHER_P2(ContainsDeviceRecord, action, name,
 TEST_F(BraveSyncServiceTest, OnDeleteDevice) {
   RecordsList records;
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "1", "device1"));
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "2", "device2"));
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "3", "device3"));
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnResolvedPreferences(records);
@@ -447,14 +458,13 @@ TEST_F(BraveSyncServiceTest, OnDeleteDevice) {
   EXPECT_TRUE(DevicesContains(devices.get(), "2", "device2"));
   EXPECT_TRUE(DevicesContains(devices.get(), "3", "device3"));
 
-  using brave_sync::jslib::SyncRecord;
   EXPECT_CALL(*sync_client(), SendSyncRecords("PREFERENCES",
       ContainsDeviceRecord(SyncRecord::Action::A_DELETE, "device3"))).Times(1);
   sync_service()->OnDeleteDevice("3");
 
   RecordsList resolved_records;
   auto resolved_record = SyncRecord::Clone(*records.at(2));
-  resolved_record->action = jslib::SyncRecord::Action::A_DELETE;
+  resolved_record->action = SyncRecord::Action::A_DELETE;
   resolved_records.push_back(std::move(resolved_record));
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnResolvedPreferences(resolved_records);
@@ -469,10 +479,10 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenOneDevice) {
   sync_service()->sync_prefs_->SetThisDeviceId("1");
   RecordsList records;
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "1", "device1"));
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "2", "device2"));
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnResolvedPreferences(records);
@@ -482,21 +492,36 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenOneDevice) {
   EXPECT_TRUE(DevicesContains(devices.get(), "1", "device1"));
   EXPECT_TRUE(DevicesContains(devices.get(), "2", "device2"));
 
-  using brave_sync::jslib::SyncRecord;
   EXPECT_CALL(*sync_client(), SendSyncRecords).Times(1);
   sync_service()->OnDeleteDevice("2");
 
   RecordsList resolved_records;
   auto resolved_record = SyncRecord::Clone(*records.at(1));
-  resolved_record->action = jslib::SyncRecord::Action::A_DELETE;
+  resolved_record->action = SyncRecord::Action::A_DELETE;
   resolved_records.push_back(std::move(resolved_record));
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(3);
+  // Expecting to be called one time to set the new devices list
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
+
+  EXPECT_CALL(*sync_client(), SendSyncRecords).Times(1);
+
   sync_service()->OnResolvedPreferences(resolved_records);
+
+  auto devices_semi_final = sync_service()->sync_prefs_->GetSyncDevices();
+  EXPECT_FALSE(DevicesContains(devices_semi_final.get(), "2", "device2"));
+  EXPECT_TRUE(DevicesContains(devices_semi_final.get(), "1", "device1"));
+
+  // Emulate sending DELETE for this device
+  RecordsList resolved_records2;
+  auto resolved_record2 = SyncRecord::Clone(*records.at(0));
+  resolved_record2->action = SyncRecord::Action::A_DELETE;
+  resolved_records2.push_back(std::move(resolved_record2));
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(3);
+
+  sync_service()->OnResolvedPreferences(resolved_records2);
 
   auto devices_final = sync_service()->sync_prefs_->GetSyncDevices();
   EXPECT_FALSE(DevicesContains(devices_final.get(), "1", "device1"));
   EXPECT_FALSE(DevicesContains(devices_final.get(), "2", "device2"));
-
   EXPECT_FALSE(sync_service()->IsSyncConfigured());
 }
 
@@ -504,10 +529,10 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
   sync_service()->sync_prefs_->SetThisDeviceId("1");
   RecordsList records;
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "1", "device1"));
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "2", "device2"));
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnResolvedPreferences(records);
@@ -517,16 +542,16 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
   EXPECT_TRUE(DevicesContains(devices.get(), "1", "device1"));
   EXPECT_TRUE(DevicesContains(devices.get(), "2", "device2"));
 
-  using brave_sync::jslib::SyncRecord;
   EXPECT_CALL(*sync_client(), SendSyncRecords("PREFERENCES",
       ContainsDeviceRecord(SyncRecord::Action::A_DELETE, "device1"))).Times(1);
   sync_service()->OnDeleteDevice("1");
 
   RecordsList resolved_records;
   auto resolved_record = SyncRecord::Clone(*records.at(0));
-  resolved_record->action = jslib::SyncRecord::Action::A_DELETE;
+  resolved_record->action = SyncRecord::Action::A_DELETE;
   resolved_records.push_back(std::move(resolved_record));
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(5);
+  // If you have to modify .Times(3) to another value, double re-check
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(3);
   sync_service()->OnResolvedPreferences(resolved_records);
 
   auto devices_final = sync_service()->sync_prefs_->GetSyncDevices();
@@ -538,7 +563,8 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
 
 TEST_F(BraveSyncServiceTest, OnResetSync) {
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(AtLeast(1));
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(AtLeast(3));
+  EXPECT_CALL(*observer(),
+      OnSyncStateChanged(sync_service())).Times(AtLeast(3));
   sync_service()->OnSetupSyncNewToSync("this_device");
   EXPECT_TRUE(profile()->GetPrefs()->GetBoolean(
        brave_sync::prefs::kSyncEnabled));
@@ -546,10 +572,10 @@ TEST_F(BraveSyncServiceTest, OnResetSync) {
 
   RecordsList records;
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "0", "this_device"));
   records.push_back(SimpleDeviceRecord(
-      jslib::SyncRecord::Action::A_CREATE,
+      SyncRecord::Action::A_CREATE,
       "1", "device1"));
 
   sync_service()->OnResolvedPreferences(records);
@@ -561,8 +587,8 @@ TEST_F(BraveSyncServiceTest, OnResetSync) {
 
   sync_service()->OnResetSync();
   RecordsList resolved_records;
-  auto resolved_record = jslib::SyncRecord::Clone(*records.at(0));
-  resolved_record->action = jslib::SyncRecord::Action::A_DELETE;
+  auto resolved_record = SyncRecord::Clone(*records.at(0));
+  resolved_record->action = SyncRecord::Action::A_DELETE;
   resolved_records.push_back(std::move(resolved_record));
   sync_service()->OnResolvedPreferences(resolved_records);
 
@@ -683,7 +709,7 @@ TEST_F(BraveSyncServiceTest, OnGetExistingObjects) {
   EXPECT_CALL(*sync_client(), SendResolveSyncRecords).Times(1);
 
   auto records = std::make_unique<RecordsList>();
-  sync_service()->OnGetExistingObjects(jslib_const::kBookmarks,
+  sync_service()->OnGetExistingObjects(brave_sync::jslib_const::kBookmarks,
       std::move(records),
       base::Time(),
       false);


### PR DESCRIPTION
Sync don't do double reset

Fix https://github.com/brave/brave-browser/issues/3188 .
Fix https://github.com/brave/brave-browser/issues/3225 .

This is a PR for 0.60.x (beta)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
 Taken from https://github.com/brave/brave-browser/issues/3188 

**Devices**
Device 1: Samsung Tab running 1.0.76
Device 2: Pixel 3XL running 1.0.76
Device 3: Linux running 0.59.34 profile 1 (Sync already created and reset)
Device 4: Linux running 0.59.34 profile 2

**Steps to Reproduce**

1. Create bookmarks and folders on device 1
2. Create sync chain on Device 1 and scan QR code on device 2, ensure all bookmarks are sync'd on device2
3. Reset existing sync on device 3 which has existing bookmarks
4. Enter code words from device 1 and join device 3 on the sync chain, bookmarks from device 1 sync on device 3
5. Existing bookmarks from device 3 isn't sync'd to device 1 or device 2
6. Create bookmarks on device 4 and join the sync chain using code words
7. Once device is listed, device 4 sync's all bookmarks from device 1, similarly device 1,2 & 3 sync's all bookmarks from device 4

Taken from https://github.com/brave/brave-browser/issues/3225

**Steps to Reproduce**

1. Create sync chain brave-core device1
2. Connect to sync chain brave-core device2
3. Create bookmark on device1 and ensure it is synced to device2
4. On device1 press `View sync code` -> `View QR code`, do the screenshot of QR code
5. On device2 press `Leave Sync Chain`
6. Wait until both devices will get sync turned off
7. With the Android device connect to existing sync chain with QR at pt 4

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source