### PR TITLE
Update brave-extension dep for master

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@e67738e656244f7ab6e0ed9815071ca744f5468f",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@4b55fe39bb25bb0d8b11a43d547d75f00c6c46fb",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@9be5c63b14e094156e00c8b28f205e7794f0b92c",
-  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@d1a956accdbb38a51bede5d463edb299012d0fe8",
+  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@385e580507125b7aa91b6e34fcb8e90c58b8c96a",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3262 for security issue in `sinon -> just-extend`

Only change from previous version of brave-extension on this brave-core branch is to include https://github.com/brave/brave-extension/pull/92


## Test Plan:
`npm run test-security` from brave-browser

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source