### PR TITLE
Update brave-extension dep for 0.60.x

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ deps = {
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@e67738e656244f7ab6e0ed9815071ca744f5468f",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@4b55fe39bb25bb0d8b11a43d547d75f00c6c46fb",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@9be5c63b14e094156e00c8b28f205e7794f0b92c",
-  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@70550a1619139459119f472c18a03dc12c3ed5f2",
+  "vendor/brave-extension": "https://github.com/brave/brave-extension.git@4280db3a46823ba11c9236c181614ee1e8e22319",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3262 for security issue in `sinon -> just-extend`

Only change from previous version of brave-extension on this brave-core branch is to include https://github.com/brave/brave-extension/pull/92

Related master version of PR https://github.com/brave/brave-core/pull/1611

## Test Plan:
`npm run test-security` from brave-browser

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source