### PR TITLE
Externalize HTML/JS changes to extensions item_list.html/js.

### DIFF
--- a/brave_paks.gni
+++ b/brave_paks.gni
@@ -56,6 +56,7 @@ template("brave_extra_paks") {
     sources = [
       "$root_gen_dir/brave/brave_generated_resources.pak",
       "$root_gen_dir/brave/brave_unscaled_resources.pak",
+      "$root_gen_dir/brave/browser/resources/brave_extensions_resources.pak",
       "$root_gen_dir/brave/browser/resources/brave_settings_resources.pak",
       "$root_gen_dir/components/brave_components_resources.pak",
       "$root_gen_dir/brave/components/brave_ads/resources/brave_ads_resources.pak",
@@ -76,6 +77,7 @@ template("brave_extra_paks") {
       "//brave/components/brave_webtorrent:resources",
       "//brave/components/resources",
       "//brave/components/resources:strings",
+      "//brave/browser/resources:brave_extensions_resources",
       "//brave/browser/resources:brave_settings_resources",
       "//brave/common/extensions/api",
       "//brave/components/brave_sync:resources",

--- a/browser/resources/BUILD.gn
+++ b/browser/resources/BUILD.gn
@@ -18,10 +18,27 @@ grit("brave_settings_resources") {
   resource_ids = "resource_ids"
 }
 
+grit("brave_extensions_resources") {
+  source = "md_extensions/extensions_resources.grd"
+
+  source_is_generated = optimize_webui
+
+  outputs = [
+    "grit/brave_extensions_resources.h",
+    "grit/brave_extensions_resources_map.cc",
+    "grit/brave_extensions_resources_map.h",
+    "brave_extensions_resources.pak",
+  ]
+
+  output_dir = "$root_gen_dir/brave/browser/resources"
+  resource_ids = "resource_ids"
+}
+
 if (optimize_webui) {
   group("unpak") {
     deps = [
       ":unpak_settings_resources",
+      ":unpak_extensions_resources",
     ]
   }
 
@@ -41,6 +58,32 @@ if (optimize_webui) {
 
     deps = [
       ":brave_settings_resources",
+    ]
+
+    args = [
+      "--out_folder",
+      rebase_path(out_folder, root_build_dir),
+      "--pak_file",
+      rebase_path("$target_gen_dir/${pak_file}", root_build_dir),
+    ]
+  }
+
+  action("unpak_extensions_resources") {
+    script = "//chrome/browser/resources/unpack_pak.py"
+
+    pak_file = "brave_extensions_resources.pak"
+    out_folder = "$root_gen_dir/chrome/browser/resources/md_extensions/extensions_resources.unpak"
+
+    inputs = [
+      "$target_gen_dir/brave_extensions_resources.pak",
+    ]
+
+    outputs = [
+      "${out_folder}/brave_unpack.stamp",
+    ]
+
+    deps = [
+      ":brave_extensions_resources",
     ]
 
     args = [

--- a/browser/resources/md_extensions/brave_item_list_more_items.html
+++ b/browser/resources/md_extensions/brave_item_list_more_items.html
@@ -1,0 +1,29 @@
+<link rel="import" href="chrome://resources/html/polymer.html">
+
+<link rel="import" href="chrome://resources/cr_elements/cr_container_shadow_behavior.html">
+<link rel="import" href="chrome://resources/cr_elements/shared_style_css.html">
+<link rel="import" href="chrome://resources/html/cr.html">
+<link rel="import" href="chrome://resources/html/i18n_behavior.html">
+<link rel="import" href="chrome://resources/polymer/v1_0/iron-a11y-announcer/iron-a11y-announcer.html">
+
+<dom-module id="extensions-brave-item-list-more-items">
+  <template>
+    <style include="cr-shared-style">
+      .more-items-message {
+        color: #6e6e6e;
+        font-size: 123%; /* Should be 16px when 100% is 13px. */
+        font-weight: 500;
+        margin-top: 32px;
+        text-align: center;
+      }
+    </style>
+    <div id="more-items" class="more-items-message"
+         hidden$="[[!shouldShowMoreItemsMessage_(
+             apps.length, extensions.length)]]">
+      <span>
+        $i18nRaw{noExtensionsOrApps}
+      </span>
+    </div>
+  </template>
+  <script src="brave_item_list_more_items.js"></script>
+</dom-module>

--- a/browser/resources/md_extensions/brave_item_list_more_items.js
+++ b/browser/resources/md_extensions/brave_item_list_more_items.js
@@ -1,0 +1,29 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+cr.define('extensions', function() {
+  'use strict';
+
+  const MoreItems = Polymer({
+    is: 'extensions-brave-item-list-more-items',
+
+    properties: {
+      /** @type {!Array<!chrome.developerPrivate.ExtensionInfo>} */
+      apps: Array,
+
+      /** @type {!Array<!chrome.developerPrivate.ExtensionInfo>} */
+      extensions: Array,
+    },
+
+    shouldShowMoreItemsMessage_: function() {
+      if (!this.apps || !this.extensions)
+        return;
+
+      return this.apps.length !== 0 || this.extensions.length !== 0;
+    },
+  });
+
+  return {MoreItems: MoreItems};
+});

--- a/browser/resources/md_extensions/extensions_resources.grd
+++ b/browser/resources/md_extensions/extensions_resources.grd
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<grit latest_public_release="0" current_release="1" output_all_resource_defines="false">
+  <outputs>
+    <output filename="grit/brave_extensions_resources.h" type="rc_header">
+      <emit emit_type="prepend" />
+    </output>
+    <output filename="grit/brave_extensions_resources_map.cc" type="resource_file_map_source" />
+    <output filename="grit/brave_extensions_resources_map.h" type="resource_map_header" />
+    <output filename="brave_extensions_resources.pak" type="data_package" />
+  </outputs>
+  <release seq="1">
+    <structures>
+      <structure name="IDR_EXTENSIONS_BRAVE_ITEM_LIST_MORE_ITEMS_JS" file="brave_item_list_more_items.js" type="chrome_html" preprocess="true" />
+      <structure name="IDR_EXTENSIONS_BRAVE_ITEM_LIST_MORE_ITEMS_HTML" file="brave_item_list_more_items.html" type="chrome_html" preprocess="true" allowexternalscript="true" />
+    </structures>
+    <includes>
+      <include name="IDR_EXTENSIONS_BRAVE_STAMP" file="brave_unpack.stamp" type="BINDATA" />
+    </includes>
+  </release>
+</grit>

--- a/browser/resources/resource_ids
+++ b/browser/resources/resource_ids
@@ -80,4 +80,8 @@
     "includes": [41000],
     "structures": [42000],
   },
+  "brave/browser/resources/md_extensions/extensions_resources.grd": {
+    "structures": [43000],
+    "includes": [43500],
+  },
 }

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -135,6 +135,7 @@ source_set("ui") {
     "//brave/components/brave_welcome_ui:generated_resources",
     "//brave/browser/devtools",
     "//brave/browser/tor",
+    "//brave/browser/resources:brave_extensions_resources",
     "//brave/browser/resources:brave_settings_resources",
     "//chrome/app:command_ids",
     "//chrome/common",

--- a/chromium_src/chrome/browser/ui/webui/extensions/extensions_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/extensions/extensions_ui.cc
@@ -1,10 +1,33 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/resources/grit/brave_extensions_resources.h"
+#include "brave/browser/resources/grit/brave_extensions_resources_map.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "chrome/common/buildflags.h"
 #include "chrome/grit/generated_resources.h"
 #include "content/public/browser/web_ui_data_source.h"
+
+namespace extensions {
+
+namespace {
+
+// Called from the original extension_ui.cc's CreateMdExtensionsSource via a
+// patch.
+void BraveAddExtensionsResources(content::WebUIDataSource* source) {
+#if !BUILDFLAG(OPTIMIZE_WEBUI)
+  for (size_t i = 0; i < kBraveExtensionsResourcesSize; ++i) {
+    source->AddResourcePath(kBraveExtensionsResources[i].name,
+                            kBraveExtensionsResources[i].value);
+  }
+#endif
+}
+
+}  // namespace
+
+}  // namespace extensions
 
 // These are defined in generated_resources.h, but since we are including it
 // here the original extensions_ui.cc shouldn't include it again and the
@@ -16,4 +39,4 @@
 #define IDS_MD_EXTENSIONS_ITEM_SOURCE_WEBSTORE \
   IDS_MD_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE
 
-#include "../../../../../../chrome/browser/ui/webui/extensions/extensions_ui.cc"
+#include "../../../../../../chrome/browser/ui/webui/extensions/extensions_ui.cc"  // NOLINT

--- a/patches/chrome-browser-resources-md_extensions-item_list.html.patch
+++ b/patches/chrome-browser-resources-md_extensions-item_list.html.patch
@@ -1,18 +1,20 @@
 diff --git a/chrome/browser/resources/md_extensions/item_list.html b/chrome/browser/resources/md_extensions/item_list.html
-index 71766b65bc271a903e60f9c4838eb119406fb3e3..fa6dc6977f4d4f0c9493409226392678cc7e53b7 100644
+index 71766b65bc271a903e60f9c4838eb119406fb3e3..c0635f2ef405e56b3f1ef1ce9910ec9bdf106bad 100644
 --- a/chrome/browser/resources/md_extensions/item_list.html
 +++ b/chrome/browser/resources/md_extensions/item_list.html
-@@ -122,6 +122,13 @@
+@@ -7,6 +7,7 @@
+ <link rel="import" href="chrome://resources/html/i18n_behavior.html">
+ <link rel="import" href="chrome://resources/polymer/v1_0/iron-a11y-announcer/iron-a11y-announcer.html">
+ <link rel="import" href="item.html">
++<link rel="import" href="brave_item_list_more_items.html">
+ 
+ <dom-module id="extensions-item-list">
+   <template>
+@@ -122,6 +123,7 @@
              </template>
            </div>
          </div>
-+        <div id="more-items" class="empty-list-message" style="margin-top: 32px;"
-+            hidden$="[[shouldShowEmptyItemsMessage_(
-+                apps.length, extensions.length)]]">
-+          <span>
-+            $i18nRaw{noExtensionsOrApps}
-+          </span>
-+        </div>
++        <extensions-brave-item-list-more-items apps="{{apps}}" extensions="{{extensions}}" />
        </div>
      </div>
    </template>

--- a/patches/chrome-browser-ui-webui-extensions-extensions_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-extensions-extensions_ui.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/webui/extensions/extensions_ui.cc b/chrome/browser/ui/webui/extensions/extensions_ui.cc
+index e30570e55a7a6edd7153fae5d99f4aae28c00a34..d3164662ac2697026340876d87be1b3367e84af2 100644
+--- a/chrome/browser/ui/webui/extensions/extensions_ui.cc
++++ b/chrome/browser/ui/webui/extensions/extensions_ui.cc
+@@ -338,6 +338,8 @@ content::WebUIDataSource* CreateMdExtensionsSource(Profile* profile,
+   source->SetDefaultResource(IDR_MD_EXTENSIONS_EXTENSIONS_HTML);
+ #endif
+ 
++  BraveAddExtensionsResources(source);
++
+   return source;
+ }
+ 


### PR DESCRIPTION
- Minimizes patch of extensions' page item_list.html/js by externalizing our changes into a separate dom-module,
- Adds brave_extensions_resources.pak.

Fixes brave/brave-browser#3012

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Copied from #1358:
- Start Brave with a fresh profile
- Navigate to brave://extensions
- Verify that the page shows text `Find extensions and themes in the [Web Store]`
- Verify that clicking on the link takes you to the Chrome Web Store
- Add one or more extensions
- Return to brave://extensions page
- Verify that the page shows text `Find extensions and themes in the [Web Store]`,
- Verify that clicking on the text takes you to the Chrome Web Store
- Return to brave://extensions page
- Click on Details button for any extension installed from Chrome Web Store
- On the details page, verify that the Source shows text `Web Extensions Store`

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source