### PR TITLE
Use os.listdir vs. os.walk to avoid descending into subdirs

### DIFF
--- a/script/upload.py
+++ b/script/upload.py
@@ -121,8 +121,8 @@ def get_brave_packages(dir, channel, version):
         return file_desired_path
 
     channel_capitalized = channel.capitalize()
-    for _, _, files in os.walk(dir):
-        for file in files:
+    for file in os.listdir(dir):
+        if os.path.isfile(os.path.join(dir, file)):
             file_path = os.path.join(dir, file)
             if PLATFORM == 'darwin':
                 if channel_capitalized == 'Release':


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/1569

Fixes https://github.com/brave/brave-browser/issues/3165

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source