### PR TITLE
Reject referral promo header names unless whitelisted

### DIFF
--- a/browser/net/brave_referrals_network_delegate_helper.cc
+++ b/browser/net/brave_referrals_network_delegate_helper.cc
@@ -6,6 +6,7 @@
 
 #include "base/values.h"
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
+#include "brave/common/network_constants.h"
 #include "chrome/browser/browser_process.h"
 #include "content/public/browser/browser_thread.h"
 #include "extensions/common/url_pattern.h"
@@ -27,7 +28,9 @@ int OnBeforeStartTransaction_ReferralsWork(
           *ctx->referral_headers_list, &request_headers_dict, request->url()))
     return net::OK;
   for (const auto& it : request_headers_dict->DictItems()) {
-    headers->SetHeader(it.first, it.second.GetString());
+    if (it.first == kBravePartnerHeader) {
+      headers->SetHeader(it.first, it.second.GetString());
+    }
   }
   return net::OK;
 }

--- a/browser/net/brave_referrals_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_referrals_network_delegate_helper_unittest.cc
@@ -21,7 +21,8 @@ const char kTestReferralHeaders[] = R"(
          "barrons.com"
       ],
       "headers": {
-         "X-Brave-Partner":"dowjones"
+         "X-Brave-Partner":"dowjones",
+         "X-Invalid": "test"
       },
       "cookieNames": [
       ],
@@ -88,6 +89,10 @@ TEST_F(BraveReferralsNetworkDelegateHelperTest, ReplaceHeadersForMatchingDomain)
   std::string partner_header;
   headers.GetHeader("X-Brave-Partner", &partner_header);
   EXPECT_EQ(partner_header, "dowjones");
+
+  std::string invalid_partner_header;
+  EXPECT_EQ(headers.GetHeader("X-Invalid", &invalid_partner_header), false);
+  EXPECT_EQ(invalid_partner_header, "");
 
   EXPECT_EQ(ret, net::OK);
 }

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -26,6 +26,7 @@ const char kCookieHeader[] = "Cookie";
 // Intentional misspelling on referrer to match HTTP spec
 const char kRefererHeader[] = "Referer";
 const char kUserAgentHeader[] = "User-Agent";
+const char kBravePartnerHeader[] = "X-Brave-Partner";
 
 const char kBittorrentMimeType[] = "application/x-bittorrent";
 const char kOctetStreamMimeType[] = "application/octet-stream";

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -24,6 +24,7 @@ extern const char kTwitterRedirectURL[];
 extern const char kCookieHeader[];
 extern const char kRefererHeader[];
 extern const char kUserAgentHeader[];
+extern const char kBravePartnerHeader[];
 
 extern const char kBittorrentMimeType[];
 extern const char kOctetStreamMimeType[];


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3301

Currently the only whitelisted header is 'X-Brave-Partner'.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source