### PR TITLE
Sync ignore metadata changes

### DIFF
--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -1283,3 +1283,19 @@ TEST_F(BraveBookmarkChangeProcessorTest, IgnoreRapidCreateDelete) {
   EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS", _)).Times(0);
   change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
 }
+
+TEST_F(BraveBookmarkChangeProcessorTest, IgnoreMetadataSet) {
+  change_processor()->Start();
+
+  const auto* node_a = model()->AddURL(model()->other_node(), 0,
+                           base::ASCIIToUTF16("A.com - title"),
+                           GURL("https://a.com/"));
+
+  EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS", _)).Times(1);
+  change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
+
+  model()->SetNodeMetaInfo(node_a, "last_visited", "2019");
+  // Not interested in metadata changes, expecting no calls
+  EXPECT_CALL(*sync_client(), SendSyncRecords("BOOKMARKS", _)).Times(0);
+  change_processor()->SendUnsynced(base::TimeDelta::FromMinutes(10));
+}


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/3281 .
Do not send update record if metadata is changed. We are not interested in any metadata changes. Chromium changes bookmark metadata if url had been visited and this triggered unneeded send of UPDATE record.

## Submitter Checklist:

- [x] Submitted a [#3281](https://github.com/brave/brave-browser/issues/3281) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Taken from https://github.com/brave/brave-browser/issues/3281 .
1. Create chain brave-core1 <=> brave-core2
2. On brave-core1 visit duckduckgo.com, bookmark it and close the tab
3. Wait for this bookmark appear on brave-core2
4. On brave-core1 open chrome://inspect/#extensions => inspect link under `Brave Sync` => console
5. On brave-core1 open duckduckgo.com from bookmarks
6. No send record  in console with `"action":1` in ~ 1 minute


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source