### PR TITLE
fix PR builder to use branch naming convention

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
     options {
         disableConcurrentBuilds()
+        timeout(time: 4, unit: "HOURS")
         timestamps()
     }
     agent {
@@ -9,70 +10,49 @@ pipeline {
     environment {
         GITHUB_CREDENTIALS = credentials('brave-builds-github-token-for-pr-builder')
         BC_REPO = "https://${GITHUB_CREDENTIALS}@github.com/brave/brave-browser"
-        BC_BRANCH = "brave-core-${GIT_BRANCH}"
     }
     stages {
-        stage('checkout') {
+        stage('config') {
             steps {
                 sh """
                     if [ -d brave-browser ]; then
                         rm -rf brave-browser
                     fi
 
+                    echo "Cloning brave-browser..."
                     git clone -b ${CHANGE_TARGET} ${BC_REPO}
 
                     cd brave-browser
 
-                    if [ -z "`git ls-remote --heads ${BC_REPO} ${BC_BRANCH}`" ]; then
-                        git checkout -f -b ${BC_BRANCH}
-                    else
-                        git checkout -f ${BC_BRANCH}
+                    if [ -z "`git ls-remote --heads ${BC_REPO} ${CHANGE_BRANCH}`" ]; then
+                        git config user.name brave-builds
+                        git config user.email devops@brave.com
+                        git config push.default simple
+
+                        echo "Creating ${CHANGE_BRANCH} branch in brave-browser..."
+                        git checkout -f -b ${CHANGE_BRANCH}
+
+                        echo "Pinning brave-core to branch ${CHANGE_BRANCH}..."
+                        jq "del(.config.projects[\\"brave-core\\"].branch) | .config.projects[\\"brave-core\\"].branch=\\"${CHANGE_BRANCH}\\"" package.json > package.json.new
+                        mv package.json.new package.json
+
+                        echo "Pushing changes..."
+                        git commit -a -m "pin brave-core to branch ${CHANGE_BRANCH}"
+                        git push ${BC_REPO}
+
+                        echo "Sleeping 5m so new branch is discovered..."
+                        sleep 300
                     fi
                 """
             }
         }
-        stage('config') {
-            steps {
-                sh """
-                    git config -f brave-browser/.git/config user.name brave-builds
-                    git config -f brave-browser/.git/config user.email devops@brave.com
-                    git config -f brave-browser/.git/config push.default simple
-                """
-            }
-        }
-        stage('pin') {
-            steps {
-                sh """
-                    jq "del(.config.projects[\\"brave-core\\"].branch) | .config.projects[\\"brave-core\\"].commit=\\"${GIT_COMMIT}\\"" brave-browser/package.json > brave-browser/package.json.new
-                    mv brave-browser/package.json.new brave-browser/package.json
-                """
-            }
-        }
-        stage('push') {
-            steps {
-                sh """
-                    git -C brave-browser commit -a -m "pin brave-core to ${GIT_COMMIT} from ${GIT_BRANCH}"
-                    git -C brave-browser push ${BC_REPO}
-                """
-            }
-        }
-        stage('sleep') {
-            steps {
-                sleep time: 5, unit: 'MINUTES'
-            }
-        }        
         stage('build') {
             steps {
                 script {
-                    def buildResult = build(job: "brave-browser-build-pr/${BC_BRANCH}", propagate: false).result
-                    echo "Building browser result is ${buildResult}"
+                    def buildResult = build(job: "brave-browser-build-pr/${CHANGE_BRANCH}", propagate: false).result
+                    echo "Browser build ${buildResult} at ${JENKINS_URL}/job/brave-browser-build-pr/${CHANGE_BRANCH}"
                     if (buildResult == 'ABORTED') { currentBuild.result = 'FAILURE' } else { currentBuild.result = buildResult }
                 }
-            }
-        }
-        stage('clean') {
-            steps {
-                sh "git -C brave-browser push origin :${BC_BRANCH}"
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/brave/brave-browser/issues/3295

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source