### PR TITLE
Disable Ads (0.60)

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -447,9 +447,11 @@ void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
 }
 
 bool AdsServiceImpl::is_enabled() const {
-  bool ads_enabled = profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
-  bool rewards_enabled = profile_->GetPrefs()->GetBoolean(brave_rewards::prefs::kBraveRewardsEnabled);
-  return (ads_enabled && rewards_enabled);
+  // (Ads disabled on 0.60.x, this fix ensures backwards compliance)
+  // bool ads_enabled = profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
+  // bool rewards_enabled = profile_->GetPrefs()->GetBoolean(brave_rewards::prefs::kBraveRewardsEnabled);
+  // return (ads_enabled && rewards_enabled);
+  return false;
 }
 
 bool AdsServiceImpl::IsAdsEnabled() const {

--- a/components/brave_rewards/resources/ui/components/adsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/adsBox.tsx
@@ -104,7 +104,7 @@ class AdsBox extends React.Component<Props, State> {
         title={getLocale('adsTitle')}
         type={'ads'}
         description={getLocale('adsDesc')}
-        toggle={toggle}
+        toggle={false}
         checked={adsEnabled}
         settingsChild={this.adsSettings(adsEnabled && enabledMain)}
         testId={'braveAdsSettings'}


### PR DESCRIPTION
Related PR for (0.59): https://github.com/brave/brave-core/pull/1450
Related issue: https://github.com/brave/brave-browser/issues/3141

This should display the "Coming Soon!" message in the Ads box in Rewards settings, as well as ensure that the Ads service does not start in any case the where the user may have had them enabled before.

cc: @jsecretan @mandar-brave 