### PR TITLE
Adds action to Backup Wallet text in backup notification

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -185,6 +185,10 @@
     "message": "You have a grant waiting for you.",
     "description": "Description for new grant notification"
   },
+  "backupNow": {
+    "message": "Backup Now",
+    "description": "Notification button text when we ask user to backup wallet"
+  },
   "backupWalletTitle": {
     "message": "Backup Wallet",
     "description": "Notification title when we ask user to backup wallet"

--- a/components/brave_rewards/resources/extension/brave_rewards/background/api/locale_api.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/api/locale_api.ts
@@ -22,6 +22,7 @@ export const getMessage = (message: string, substitutions?: string[]): string =>
 
 export const getUIMessages = (): Record<string, string> => {
   const strings = [
+    'backupNow',
     'backupWalletNotification',
     'backupWalletTitle',
     'braveAdsTitle',

--- a/components/brave_rewards/resources/ui/components/pageWallet.tsx
+++ b/components/brave_rewards/resources/ui/components/pageWallet.tsx
@@ -53,9 +53,13 @@ class PageWallet extends React.Component<Props, State> {
 
   componentDidMount () {
     this.isAddFundsUrl()
+    this.isBackupUrl()
   }
 
   onModalBackupClose = () => {
+    if (this.urlHashIs('#backup-restore')) {
+      window.location.hash = ''
+    }
     this.actions.onModalBackupClose()
   }
 
@@ -171,8 +175,17 @@ class PageWallet extends React.Component<Props, State> {
     })
   }
 
+  urlHashIs = (hash: string) => {
+    return (
+      window &&
+      window.location &&
+      window.location.hash &&
+      window.location.hash === hash
+    )
+  }
+
   isAddFundsUrl = () => {
-    if (window && window.location && window.location.hash && window.location.hash === '#add-funds') {
+    if (this.urlHashIs('#add-funds')) {
       this.setState({
         modalAddFunds: true
       })
@@ -183,8 +196,14 @@ class PageWallet extends React.Component<Props, State> {
     }
   }
 
+  isBackupUrl = () => {
+    if (this.urlHashIs('#backup-restore')) {
+      this.onModalBackupOpen()
+    }
+  }
+
   closeModalAddFunds = () => {
-    if (window && window.location && window.location.hash && window.location.hash === '#add-funds') {
+    if (this.urlHashIs('#add-funds')) {
       window.location.hash = ''
     }
     this.onModalAddFundsToggle()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,8 +1319,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#0ef65019be62562e701090de4c09b68afc1963f9",
-      "from": "github:brave/brave-ui#0ef65019be62562e701090de4c09b68afc1963f9",
+      "version": "github:brave/brave-ui#9d1f75c7cc4e413c53f7f313ac519887ce3eba1b",
+      "from": "github:brave/brave-ui#9d1f75c7cc4e413c53f7f313ac519887ce3eba1b",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#0ef65019be62562e701090de4c09b68afc1963f9",
+    "brave-ui": "github:brave/brave-ui#9d1f75c7cc4e413c53f7f313ac519887ce3eba1b",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2739
UI: https://github.com/brave/brave-ui/pull/374

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- `brave.rewards.backup_notification_frequency` & `brave.rewards.notification_timer_interval`
can be adjusted in your profiles `Preferences` file to shorten the notification frequency and timer interval from 7 days and 15 minutes to something shorter.

1. Enable Rewards, fund wallet
2. Wait for Backup Wallet notification
3. Click the 'Backup Wallet' text
4. Ensure that a tab is opened with `brave://rewards#backup-restore`
5. Ensure that the backup modal is open

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source