### PR TITLE
Issue 3258: Using BraveUpdateClientConfig to send requests for extension update in XML and disable CUP signing

### DIFF
--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -36,6 +36,8 @@ source_set("extensions") {
     "brave_theme_event_router.h",
     "brave_tor_client_updater.cc",
     "brave_tor_client_updater.h",
+    "updater/brave_update_client_config.cc",
+    "updater/brave_update_client_config.h"
   ]
 
   deps = [

--- a/browser/extensions/updater/brave_update_client_config.cc
+++ b/browser/extensions/updater/brave_update_client_config.cc
@@ -1,0 +1,242 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+
+#include "brave/browser/extensions/updater/brave_update_client_config.h"
+
+#include <algorithm>
+
+#include "base/command_line.h"
+#include "base/containers/flat_map.h"
+#include "base/no_destructor.h"
+#include "base/version.h"
+#include "chrome/browser/component_updater/component_updater_utils.h"
+#include "chrome/browser/extensions/updater/extension_update_client_command_line_config_policy.h"
+#include "chrome/browser/google/google_brand.h"
+#include "chrome/browser/update_client/chrome_update_query_params_delegate.h"
+#include "chrome/common/channel_info.h"
+#include "components/prefs/pref_service.h"
+#include "components/update_client/activity_data_service.h"
+#include "components/update_client/protocol_handler.h"
+#include "components/update_client/update_query_params.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/storage_partition.h"
+#include "content/public/common/service_manager_connection.h"
+#include "extensions/browser/extension_prefs.h"
+#include "services/service_manager/public/cpp/connector.h"
+
+namespace extensions {
+
+namespace {
+
+using FactoryCallback = BraveUpdateClientConfig::FactoryCallback;
+
+// static
+static FactoryCallback& GetFactoryCallback() {
+  static base::NoDestructor<FactoryCallback> factory;
+  return *factory;
+}
+
+class ExtensionActivityDataService final
+    : public update_client::ActivityDataService {
+ public:
+  explicit ExtensionActivityDataService(ExtensionPrefs* extension_prefs);
+  ~ExtensionActivityDataService() override {}
+
+  // update_client::ActivityDataService:
+  bool GetActiveBit(const std::string& id) const override;
+  int GetDaysSinceLastActive(const std::string& id) const override;
+  int GetDaysSinceLastRollCall(const std::string& id) const override;
+  void ClearActiveBit(const std::string& id) override;
+
+ private:
+  // This member is not owned by this class, it's owned by a profile keyed
+  // service.
+  ExtensionPrefs* extension_prefs_;
+
+  DISALLOW_COPY_AND_ASSIGN(ExtensionActivityDataService);
+};
+
+// Calculates the value to use for the ping days parameter.
+int CalculatePingDays(const base::Time& last_ping_day) {
+  return last_ping_day.is_null()
+             ? update_client::kDaysFirstTime
+             : std::max((base::Time::Now() - last_ping_day).InDays(), 0);
+}
+
+ExtensionActivityDataService::ExtensionActivityDataService(
+    ExtensionPrefs* extension_prefs)
+    : extension_prefs_(extension_prefs) {
+  DCHECK(extension_prefs_);
+}
+
+bool ExtensionActivityDataService::GetActiveBit(const std::string& id) const {
+  return extension_prefs_->GetActiveBit(id);
+}
+
+int ExtensionActivityDataService::GetDaysSinceLastActive(
+    const std::string& id) const {
+  return CalculatePingDays(extension_prefs_->LastActivePingDay(id));
+}
+
+int ExtensionActivityDataService::GetDaysSinceLastRollCall(
+    const std::string& id) const {
+  return CalculatePingDays(extension_prefs_->LastPingDay(id));
+}
+
+void ExtensionActivityDataService::ClearActiveBit(const std::string& id) {
+  extension_prefs_->SetActiveBit(id, false);
+}
+
+}  // namespace
+
+// For privacy reasons, requires encryption of the component updater
+// communication with the update backend.
+BraveUpdateClientConfig::BraveUpdateClientConfig(
+    content::BrowserContext* context)
+    : context_(context),
+      impl_(ExtensionUpdateClientCommandLineConfigPolicy(
+                base::CommandLine::ForCurrentProcess()),
+            /*require_encryption=*/true),
+      pref_service_(ExtensionPrefs::Get(context)->pref_service()),
+      activity_data_service_(std::make_unique<ExtensionActivityDataService>(
+          ExtensionPrefs::Get(context))) {
+  DCHECK(pref_service_);
+}
+
+int BraveUpdateClientConfig::InitialDelay() const {
+  return impl_.InitialDelay();
+}
+
+int BraveUpdateClientConfig::NextCheckDelay() const {
+  return impl_.NextCheckDelay();
+}
+
+int BraveUpdateClientConfig::OnDemandDelay() const {
+  return impl_.OnDemandDelay();
+}
+
+int BraveUpdateClientConfig::UpdateDelay() const {
+  return impl_.UpdateDelay();
+}
+
+std::vector<GURL> BraveUpdateClientConfig::UpdateUrl() const {
+  return impl_.UpdateUrl();
+}
+
+std::vector<GURL> BraveUpdateClientConfig::PingUrl() const {
+  return impl_.PingUrl();
+}
+
+std::string BraveUpdateClientConfig::GetProdId() const {
+  return update_client::UpdateQueryParams::GetProdIdString(
+      update_client::UpdateQueryParams::ProdId::CRX);
+}
+
+base::Version BraveUpdateClientConfig::GetBrowserVersion() const {
+  return impl_.GetBrowserVersion();
+}
+
+std::string BraveUpdateClientConfig::GetChannel() const {
+  return std::string("stable");;
+}
+
+std::string BraveUpdateClientConfig::GetBrand() const {
+  std::string brand;
+  google_brand::GetBrand(&brand);
+  return brand;
+}
+
+std::string BraveUpdateClientConfig::GetLang() const {
+  return ChromeUpdateQueryParamsDelegate::GetLang();
+}
+
+std::string BraveUpdateClientConfig::GetOSLongName() const {
+  return impl_.GetOSLongName();
+}
+
+base::flat_map<std::string, std::string>
+BraveUpdateClientConfig::ExtraRequestParams() const {
+  return impl_.ExtraRequestParams();
+}
+
+std::string BraveUpdateClientConfig::GetDownloadPreference() const {
+  return std::string();
+}
+
+scoped_refptr<network::SharedURLLoaderFactory>
+BraveUpdateClientConfig::URLLoaderFactory() const {
+  return content::BrowserContext::GetDefaultStoragePartition(context_)
+      ->GetURLLoaderFactoryForBrowserProcess();
+}
+
+std::unique_ptr<service_manager::Connector>
+BraveUpdateClientConfig::CreateServiceManagerConnector() const {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  return content::ServiceManagerConnection::GetForProcess()
+      ->GetConnector()
+      ->Clone();
+}
+
+bool BraveUpdateClientConfig::EnabledDeltas() const {
+  return impl_.EnabledDeltas();
+}
+
+bool BraveUpdateClientConfig::EnabledComponentUpdates() const {
+  return impl_.EnabledComponentUpdates();
+}
+
+bool BraveUpdateClientConfig::EnabledBackgroundDownloader() const {
+  return impl_.EnabledBackgroundDownloader();
+}
+
+// Disabling cup signing
+bool BraveUpdateClientConfig::EnabledCupSigning() const {
+  return false;
+}
+
+PrefService* BraveUpdateClientConfig::GetPrefService() const {
+  return pref_service_;
+}
+
+update_client::ActivityDataService*
+BraveUpdateClientConfig::GetActivityDataService() const {
+  return activity_data_service_.get();
+}
+
+bool BraveUpdateClientConfig::IsPerUserInstall() const {
+  return component_updater::IsPerUserInstall();
+}
+
+std::vector<uint8_t> BraveUpdateClientConfig::GetRunActionKeyHash() const {
+  return impl_.GetRunActionKeyHash();
+}
+
+std::string BraveUpdateClientConfig::GetAppGuid() const {
+  return impl_.GetAppGuid();
+}
+
+// Always use XML ProtocolHandler
+std::unique_ptr<update_client::ProtocolHandlerFactory>
+BraveUpdateClientConfig::GetProtocolHandlerFactory() const {
+  return std::make_unique<update_client::ProtocolHandlerFactoryXml>();
+}
+
+BraveUpdateClientConfig::~BraveUpdateClientConfig() {}
+
+// static
+scoped_refptr<BraveUpdateClientConfig> BraveUpdateClientConfig::Create(
+    content::BrowserContext* context) {
+  FactoryCallback& factory = GetFactoryCallback();
+  return factory.is_null() ? scoped_refptr<BraveUpdateClientConfig>(
+                                 new BraveUpdateClientConfig(context))
+                           : factory.Run(context);
+}
+
+// static
+void BraveUpdateClientConfig::SetBraveUpdateClientConfigFactoryForTesting(
+    FactoryCallback factory) {
+  DCHECK(!factory.is_null());
+  GetFactoryCallback() = factory;
+}
+
+}  // namespace extensions

--- a/browser/extensions/updater/brave_update_client_config.h
+++ b/browser/extensions/updater/brave_update_client_config.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+
+#ifndef BRAVE_BROWSER_EXTENSIONS_UPDATER_BRAVE_UPDATE_CLIENT_CONFIG_H_
+#define BRAVE_BROWSER_EXTENSIONS_UPDATER_BRAVE_UPDATE_CLIENT_CONFIG_H_
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "base/macros.h"
+#include "base/memory/ref_counted.h"
+#include "components/component_updater/configurator_impl.h"
+#include "components/update_client/configurator.h"
+
+namespace content {
+class BrowserContext;
+}
+
+namespace update_client {
+class ActivityDataService;
+class ProtocolHandlerFactory;
+}
+
+namespace extensions {
+
+class ExtensionUpdateClientBaseTest;
+
+class BraveUpdateClientConfig : public update_client::Configurator {
+ public:
+  using FactoryCallback =
+      base::RepeatingCallback<scoped_refptr<BraveUpdateClientConfig>(
+          content::BrowserContext* context)>;
+
+  static scoped_refptr<BraveUpdateClientConfig> Create(
+      content::BrowserContext* context);
+
+  int InitialDelay() const override;
+  int NextCheckDelay() const override;
+  int OnDemandDelay() const override;
+  int UpdateDelay() const override;
+  std::vector<GURL> UpdateUrl() const override;
+  std::vector<GURL> PingUrl() const override;
+  std::string GetProdId() const override;
+  base::Version GetBrowserVersion() const override;
+  std::string GetChannel() const override;
+  std::string GetBrand() const override;
+  std::string GetLang() const override;
+  std::string GetOSLongName() const override;
+  base::flat_map<std::string, std::string> ExtraRequestParams() const override;
+  std::string GetDownloadPreference() const override;
+  scoped_refptr<network::SharedURLLoaderFactory> URLLoaderFactory()
+      const override;
+  std::unique_ptr<service_manager::Connector> CreateServiceManagerConnector()
+      const override;
+  bool EnabledDeltas() const override;
+  bool EnabledComponentUpdates() const override;
+  bool EnabledBackgroundDownloader() const override;
+  bool EnabledCupSigning() const override;
+  PrefService* GetPrefService() const override;
+  update_client::ActivityDataService* GetActivityDataService() const override;
+  bool IsPerUserInstall() const override;
+  std::vector<uint8_t> GetRunActionKeyHash() const override;
+  std::string GetAppGuid() const override;
+  std::unique_ptr<update_client::ProtocolHandlerFactory>
+  GetProtocolHandlerFactory() const override;
+
+ protected:
+  friend class base::RefCountedThreadSafe<BraveUpdateClientConfig>;
+  friend class ExtensionUpdateClientBaseTest;
+
+  explicit BraveUpdateClientConfig(content::BrowserContext* context);
+  ~BraveUpdateClientConfig() override;
+
+  // Injects a new client config by changing the creation factory.
+  // Should be used for tests only.
+  static void SetBraveUpdateClientConfigFactoryForTesting(
+      FactoryCallback factory);
+
+ private:
+  content::BrowserContext* context_ = nullptr;
+  component_updater::ConfiguratorImpl impl_;
+  PrefService* pref_service_;
+  std::unique_ptr<update_client::ActivityDataService> activity_data_service_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveUpdateClientConfig);
+};
+
+}  // namespace extensions
+
+#endif  // BRAVE_BROWSER_EXTENSIONS_UPDATER_BRAVE_UPDATE_CLIENT_CONFIG_H_

--- a/chromium_src/chrome/browser/extensions/chrome_extensions_browser_client.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_extensions_browser_client.cc
@@ -1,0 +1,9 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+
+#include "brave/browser/extensions/updater/brave_update_client_config.h"
+#include "chrome/browser/extensions/chrome_extensions_browser_client.h"
+#include "chrome/browser/extensions/updater/chrome_update_client_config.h"
+
+#define ChromeUpdateClientConfig BraveUpdateClientConfig
+#include "../../../../../chrome/browser/extensions/chrome_extensions_browser_client.cc"  // NOLINT
+#undef ChromeUpdateClientConfig


### PR DESCRIPTION
Uplift request for [brave/brave-browser#3258](https://github.com/brave/brave-browser/issues/3258)
Original PR: #1602

Reason: Extension updates fail without this change

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Specified here: #1602

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source