### PR TITLE
Fix create_dist fail with widevine cdm library

### DIFF
--- a/patches/chrome-installer-linux-common-installer.include.patch
+++ b/patches/chrome-installer-linux-common-installer.include.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.include b/chrome/installer/linux/common/installer.include
-index 58b80612445aa0616462805f464bcae0b3ee1c3e..8ee1615b31e93caf6259d91e68b1c856c0ac5a70 100644
+index 58b80612445aa0616462805f464bcae0b3ee1c3e..e0551eed012e437aa1109ae47d40d5fcd52c0650 100644
 --- a/chrome/installer/linux/common/installer.include
 +++ b/chrome/installer/linux/common/installer.include
 @@ -75,6 +75,7 @@ process_template() (
@@ -52,7 +52,7 @@ index 58b80612445aa0616462805f464bcae0b3ee1c3e..8ee1615b31e93caf6259d91e68b1c856
      fi
    fi
    LOGO_RESOURCES_PNG=$(find "${BUILDDIR}/installer/theme/" \
-@@ -381,7 +403,7 @@ stage_install_common() {
+@@ -381,12 +403,14 @@ stage_install_common() {
          exit 1
        fi
        local expected_perms=777
@@ -61,3 +61,10 @@ index 58b80612445aa0616462805f464bcae0b3ee1c3e..8ee1615b31e93caf6259d91e68b1c856
        local expected_perms=4755
      elif [[ "${base_name}" = "nacl_irt_"*".nexe" ]]; then
        local expected_perms=644
+     elif [[ "${file_type}" = *"shell script"* ]]; then
+       local expected_perms=755
++    elif [[ "${base_name}" = "libwidevinecdm.so" ]]; then
++      local expected_perms=${actual_perms}
+     elif [[ "${file_type}" = ELF* ]]; then
+       if [[ "${base_name}" = *".so" ]]; then
+         local expected_perms=${SHLIB_PERMS}


### PR DESCRIPTION
We use fake libwidevinecdm.so is used only for building.
During the packaging, file permission is checked by file type(ELF) and
extension. but our fake file is just empty file. So, handling it
explicitly.

This is f/u PR of https://github.com/brave/brave-core/pull/1606.

Issue: [brave/brave-browser#413](https://github.com/brave/brave-browser/issues/413)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn create_dist Release` and then check rpm and deb files are created w/o error.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source