### PR TITLE
update brave-ui sha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#fd261169723db24c3850b4c205aa06c3e0dc791e",
-      "from": "github:brave/brave-ui#fd261169723db24c3850b4c205aa06c3e0dc791e",
+      "version": "github:brave/brave-ui#59bcd505c8a3105c9155b7fa6ba67e2c334e03df",
+      "from": "github:brave/brave-ui#59bcd505c8a3105c9155b7fa6ba67e2c334e03df",
       "dev": true,
       "requires": {
         "emptykit.css": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "@types/react-dom": "^16.0.7",
     "@types/react-redux": "6.0.4",
     "awesome-typescript-loader": "^5.2.0",
-    "brave-ui": "github:brave/brave-ui#fd261169723db24c3850b4c205aa06c3e0dc791e",
+    "brave-ui": "github:brave/brave-ui#59bcd505c8a3105c9155b7fa6ba67e2c334e03df",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "emptykit.css": "^1.0.1",


### PR DESCRIPTION
sibling pr https://github.com/brave/brave-core/pull/1664
reflects last brave-ui sha. ref: https://github.com/brave/brave-ui/commit/59bcd505c8a3105c9155b7fa6ba67e2c334e03df