### PR TITLE
Block URL requests in Tor windows if Tor is not set up right.

### DIFF
--- a/browser/net/brave_tor_network_delegate_helper.cc
+++ b/browser/net/brave_tor_network_delegate_helper.cc
@@ -1,8 +1,11 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/net/brave_tor_network_delegate_helper.h"
+
+#include <memory>
 
 #include "brave/browser/renderer_host/brave_navigation_ui_data.h"
 #include "brave/browser/tor/tor_profile_service.h"

--- a/browser/net/brave_tor_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_tor_network_delegate_helper_unittest.cc
@@ -1,8 +1,13 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/net/brave_tor_network_delegate_helper.h"
+
+#include <memory>
+#include <string>
+#include <utility>
 
 #include "base/files/file_path.h"
 #include "base/files/scoped_temp_dir.h"
@@ -59,6 +64,7 @@ class BraveTorNetworkDelegateHelperTest: public testing::Test {
   content::MockResourceContext* resource_context() {
     return resource_context_.get();
   }
+
  protected:
   // The path to temporary directory used to contain the test operations.
   base::ScopedTempDir temp_dir_;
@@ -79,7 +85,8 @@ TEST_F(BraveTorNetworkDelegateHelperTest, NotTorProfile) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
@@ -118,7 +125,8 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfile) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
@@ -164,7 +172,8 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockFile) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
@@ -199,7 +208,8 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockIfHosed) {
                              TRAFFIC_ANNOTATION_FOR_TESTS);
   std::shared_ptr<brave::BraveRequestInfo>
       before_url_context(new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
   brave::ResponseCallback callback;
 
   std::unique_ptr<BraveNavigationUIData> navigation_ui_data =

--- a/browser/net/brave_tor_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_tor_network_delegate_helper_unittest.cc
@@ -11,6 +11,7 @@
 #include "brave/browser/profiles/tor_unittest_profile_manager.h"
 #include "brave/browser/renderer_host/brave_navigation_ui_data.h"
 #include "brave/browser/tor/mock_tor_profile_service_factory.h"
+#include "brave/common/tor/tor_common.h"
 #include "brave/common/tor/tor_test_constants.h"
 #include "chrome/test/base/chrome_render_view_host_test_harness.h"
 #include "chrome/test/base/scoped_testing_local_state.h"
@@ -182,4 +183,51 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockFile) {
                                       before_url_context);
   EXPECT_TRUE(before_url_context->new_url_spec.empty());
   EXPECT_EQ(ret, net::ERR_DISALLOWED_URL_SCHEME);
+}
+
+TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockIfHosed) {
+  ProfileManager* profile_manager = g_browser_process->profile_manager();
+  base::FilePath tor_path = BraveProfileManager::GetTorProfilePath();
+
+  Profile* profile = profile_manager->GetProfile(tor_path);
+  ASSERT_TRUE(profile);
+
+  net::TestDelegate test_delegate;
+  GURL url("https://check.torproject.org/");
+  std::unique_ptr<net::URLRequest> request =
+      context()->CreateRequest(url, net::IDLE, &test_delegate,
+                             TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo>
+      before_url_context(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(), before_url_context);
+  brave::ResponseCallback callback;
+
+  std::unique_ptr<BraveNavigationUIData> navigation_ui_data =
+    std::make_unique<BraveNavigationUIData>();
+  BraveNavigationUIData* navigation_ui_data_ptr = navigation_ui_data.get();
+  content::ResourceRequestInfo::AllocateForTesting(
+    request.get(), content::RESOURCE_TYPE_MAIN_FRAME, resource_context(),
+    kRenderProcessId, /*render_view_id=*/-1, kRenderFrameId,
+    /*is_main_frame=*/true, /*allow_download=*/false, /*is_async=*/true,
+    content::PREVIEWS_OFF, std::move(navigation_ui_data));
+
+  MockTorProfileServiceFactory::SetTorNavigationUIData(profile,
+                                                       navigation_ui_data_ptr);
+
+  // `Relaunch' tor with broken config.
+  {
+    auto* tor_profile_service = navigation_ui_data_ptr->GetTorProfileService();
+    base::FilePath path(tor::kTestBrokenTorPath);
+    std::string proxy(tor::kTestTorProxy);
+    tor_profile_service->ReLaunchTor(tor::TorConfig(path, proxy));
+  }
+
+  int ret =
+    brave::OnBeforeURLRequest_TorWork(callback,
+                                      before_url_context);
+  EXPECT_TRUE(before_url_context->new_url_spec.empty());
+  // TODO(riastradh): This is broken -- the sense should be reversed,
+  // with a marker to indicate expected failure.  But googletest
+  // apparently has no native way to express expected failures.
+  EXPECT_EQ(ret, net::OK);
 }

--- a/browser/net/brave_tor_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_tor_network_delegate_helper_unittest.cc
@@ -226,8 +226,5 @@ TEST_F(BraveTorNetworkDelegateHelperTest, TorProfileBlockIfHosed) {
     brave::OnBeforeURLRequest_TorWork(callback,
                                       before_url_context);
   EXPECT_TRUE(before_url_context->new_url_spec.empty());
-  // TODO(riastradh): This is broken -- the sense should be reversed,
-  // with a marker to indicate expected failure.  But googletest
-  // apparently has no native way to express expected failures.
-  EXPECT_EQ(ret, net::OK);
+  EXPECT_NE(ret, net::OK);
 }

--- a/browser/tor/mock_tor_profile_service_impl.cc
+++ b/browser/tor/mock_tor_profile_service_impl.cc
@@ -27,7 +27,9 @@ MockTorProfileServiceImpl::~MockTorProfileServiceImpl() {}
 
 void MockTorProfileServiceImpl::LaunchTor(const TorConfig& config) {}
 
-void MockTorProfileServiceImpl::ReLaunchTor(const TorConfig& config) {}
+void MockTorProfileServiceImpl::ReLaunchTor(const TorConfig& config) {
+  config_ = config;
+}
 
 
 void MockTorProfileServiceImpl::SetNewTorCircuit(const GURL& request_url,

--- a/browser/tor/mock_tor_profile_service_impl.cc
+++ b/browser/tor/mock_tor_profile_service_impl.cc
@@ -1,8 +1,11 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/tor/mock_tor_profile_service_impl.h"
+
+#include <string>
 
 #include "brave/browser/tor/tor_proxy_config_service.h"
 #include "brave/common/tor/tor_test_constants.h"

--- a/browser/tor/mock_tor_profile_service_impl.h
+++ b/browser/tor/mock_tor_profile_service_impl.h
@@ -1,9 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_TOR_MOCK_TOR_PROFILE_SERVICE_IMPL_
-#define BRAVE_BROWSER_TOR_MOCK_TOR_PROFILE_SERVICE_IMPL_
+#ifndef BRAVE_BROWSER_TOR_MOCK_TOR_PROFILE_SERVICE_IMPL_H_
+#define BRAVE_BROWSER_TOR_MOCK_TOR_PROFILE_SERVICE_IMPL_H_
 
 #include "brave/browser/tor/tor_profile_service.h"
 
@@ -13,7 +14,7 @@ namespace tor {
 
 class MockTorProfileServiceImpl : public TorProfileService {
  public:
-  MockTorProfileServiceImpl(Profile* profile);
+  explicit MockTorProfileServiceImpl(Profile* profile);
   ~MockTorProfileServiceImpl() override;
 
   // TorProfileService:
@@ -35,4 +36,4 @@ class MockTorProfileServiceImpl : public TorProfileService {
 
 }  // namespace tor
 
-#endif  // BRAVE_BROWSER_TOR_MOCK_TOR_PROFILE_SERVICE_IMPL_
+#endif  // BRAVE_BROWSER_TOR_MOCK_TOR_PROFILE_SERVICE_IMPL_H_

--- a/browser/tor/mock_tor_profile_service_impl.h
+++ b/browser/tor/mock_tor_profile_service_impl.h
@@ -23,8 +23,9 @@ class MockTorProfileServiceImpl : public TorProfileService {
   const TorConfig& GetTorConfig() override;
   int64_t GetTorPid() override;
 
-  void SetProxy(net::ProxyResolutionService*, const GURL& request_url,
-                bool new_circuit) override;
+  int SetProxy(net::ProxyResolutionService*,
+               const GURL& request_url,
+               bool new_circuit) override;
 
  private:
   Profile* profile_;  // NOT OWNED

--- a/browser/tor/tor_profile_service.h
+++ b/browser/tor/tor_profile_service.h
@@ -1,9 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_
-#define BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_
+#ifndef BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_H_
+#define BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_H_
 
 #include "base/macros.h"
 #include "base/observer_list.h"
@@ -56,4 +57,4 @@ class TorProfileService : public KeyedService {
 
 }  // namespace tor
 
-#endif  // BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_
+#endif  // BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_H_

--- a/browser/tor/tor_profile_service.h
+++ b/browser/tor/tor_profile_service.h
@@ -40,8 +40,9 @@ class TorProfileService : public KeyedService {
   virtual const TorConfig& GetTorConfig() = 0;
   virtual int64_t GetTorPid() = 0;
 
-  virtual void SetProxy(net::ProxyResolutionService*, const GURL& request_url,
-                        bool new_circuit) = 0;
+  virtual int SetProxy(net::ProxyResolutionService*,
+                       const GURL& request_url,
+                       bool new_circuit) = 0;
 
   void AddObserver(TorLauncherServiceObserver* observer);
   void RemoveObserver(TorLauncherServiceObserver* observer);

--- a/browser/tor/tor_profile_service_impl.cc
+++ b/browser/tor/tor_profile_service_impl.cc
@@ -92,17 +92,24 @@ int64_t TorProfileServiceImpl::GetTorPid() {
   return tor_launcher_factory_->GetTorPid();
 }
 
-void TorProfileServiceImpl::SetProxy(net::ProxyResolutionService* service,
-                                     const GURL& request_url,bool new_circuit) {
+int TorProfileServiceImpl::SetProxy(net::ProxyResolutionService* service,
+                                    const GURL& request_url,
+                                    bool new_circuit) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
   const TorConfig tor_config = tor_launcher_factory_->GetTorConfig();
   GURL url = SiteInstance::GetSiteForURL(profile_, request_url);
-  if (url.host().empty() || tor_config.empty())
-    return;
+  if (tor_config.empty()) {
+    // No tor config => we absolutely cannot talk to the network.
+    // This might mean that there was a problem trying to initialize
+    // Tor.
+    LOG(ERROR) << "Tor not configured -- blocking connection";
+    return net::ERR_SOCKS_CONNECTION_FAILED;
+  }
   base::PostTaskWithTraits(FROM_HERE, {BrowserThread::IO},
       base::Bind(&TorProxyConfigService::TorSetProxy,
       service, tor_config.proxy_string(),
       url.host(), &tor_proxy_map_, new_circuit));
+  return net::OK;
 }
 
 void TorProfileServiceImpl::KillTor() {

--- a/browser/tor/tor_profile_service_impl.cc
+++ b/browser/tor/tor_profile_service_impl.cc
@@ -1,8 +1,11 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/tor/tor_profile_service_impl.h"
+
+#include <string>
 
 #include "base/bind.h"
 #include "base/task/post_task.h"
@@ -81,7 +84,6 @@ void TorProfileServiceImpl::SetNewTorCircuit(const GURL& request_url,
                  base::WrapRefCounted(url_request_context_getter),
                  url.host()),
     callback);
-
 }
 
 const TorConfig& TorProfileServiceImpl::GetTorConfig() {

--- a/browser/tor/tor_profile_service_impl.h
+++ b/browser/tor/tor_profile_service_impl.h
@@ -35,8 +35,9 @@ class TorProfileServiceImpl : public TorProfileService,
   const TorConfig& GetTorConfig() override;
   int64_t GetTorPid() override;
 
-  void SetProxy(net::ProxyResolutionService*, const GURL& request_url,
-                bool new_circuit) override;
+  int SetProxy(net::ProxyResolutionService*,
+               const GURL& request_url,
+               bool new_circuit) override;
 
   void KillTor();
 

--- a/browser/tor/tor_profile_service_impl.h
+++ b/browser/tor/tor_profile_service_impl.h
@@ -1,11 +1,14 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_IMPL_
-#define BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_IMPL_
+#ifndef BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_IMPL_H_
+#define BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_IMPL_H_
 
 #include "brave/browser/tor/tor_profile_service.h"
+
+#include <string>
 
 #include "base/memory/scoped_refptr.h"
 #include "brave/browser/tor/tor_launcher_factory.h"
@@ -22,7 +25,7 @@ namespace tor {
 class TorProfileServiceImpl : public TorProfileService,
                               public base::CheckedObserver {
  public:
-  TorProfileServiceImpl(Profile* profile);
+  explicit TorProfileServiceImpl(Profile* profile);
   ~TorProfileServiceImpl() override;
 
   // KeyedService:
@@ -45,17 +48,17 @@ class TorProfileServiceImpl : public TorProfileService,
   void NotifyTorLauncherCrashed();
   void NotifyTorCrashed(int64_t pid);
   void NotifyTorLaunched(bool result, int64_t pid);
- private:
 
+ private:
   void SetNewTorCircuitOnIOThread(
       const scoped_refptr<net::URLRequestContextGetter>&, std::string);
 
   Profile* profile_;  // NOT OWNED
-  TorLauncherFactory* tor_launcher_factory_; // Singleton
+  TorLauncherFactory* tor_launcher_factory_;  // Singleton
   TorProxyConfigService::TorProxyMap tor_proxy_map_;
   DISALLOW_COPY_AND_ASSIGN(TorProfileServiceImpl);
 };
 
 }  // namespace tor
 
-#endif  // BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_IMPL_
+#endif  // BRAVE_BROWSER_TOR_TOR_PROFILE_SERVICE_IMPL_H_

--- a/common/tor/tor_test_constants.cc
+++ b/common/tor/tor_test_constants.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/common/tor/tor_test_constants.cc
+++ b/common/tor/tor_test_constants.cc
@@ -11,6 +11,6 @@ namespace tor {
 const char kTestTorProxy[] = "socks5://127.0.0.1:9999";
 const char kTestTorPacString[] = "SOCKS5 127.0.0.1:9999";
 const base::FilePath::CharType kTestTorPath[] = FPL(".");
-
+const base::FilePath::CharType kTestBrokenTorPath[] = FPL("");
 
 }  // namespace tor

--- a/common/tor/tor_test_constants.h
+++ b/common/tor/tor_test_constants.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/common/tor/tor_test_constants.h
+++ b/common/tor/tor_test_constants.h
@@ -12,6 +12,7 @@ namespace tor {
 extern const char kTestTorProxy[];
 extern const char kTestTorPacString[];
 extern const base::FilePath::CharType kTestTorPath[];
+extern const base::FilePath::CharType kTestBrokenTorPath[];
 
 }  // namespace tor
 


### PR DESCRIPTION
Not sure whether I should set QA/Yes or QA/No here: the steps to reproduce are kind of obscure, and the automatic test ought to cover this.  But I'm also a little nervous about keeping the copypasta in tor_profile_service_impl.cc and mock_tor_profile_service_impl.cc synchronized.

fix https://github.com/brave/brave-browser/issues/3058
fix https://github.com/brave/brave-browser/issues/3349

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. `npm test brave_unit_tests`
2. 1. Launch Brave, open a window with Tor, visit check.torproject.org, and quit Brave.  (This ensures the extension with the tor daemon executable is downloaded.)
   2. Find the `tor-<version>-<os>-brave-<revision>` file under the user data directory (~/.config/BraveSoftware/Brave-Browser-Dev or similar on Linux, ~/Library/Application Support/BraveSoftware/Brave-Browser-Dev or similar on macOS, %appdata%\BraveSoftware\Brave-Browser-Dev or similar on Windows).
   3. Change the permissions on that file to be nonexecutable and nonchangeable by your user id, e.g.: `chmod -x tor-<version>-<os>-brave-<revision> && sudo chown nobody tor-<version>-<os>-brave-<revision>`.
   4. Launch Brave, open a window with Tor (confirm the new tab page is as expected), and visit check.torproject.org.
   5. - If you get an error page, success.
      - If you get a page telling you you're not using Tor, failure.
      - If you get a page telling you you _are_ using Tor, you didn't screw things up in your user data directory badly enough; maybe try attacking it with a blowtorch or chainsaw instead, or let an airline baggage handler at it.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source