### PR TITLE
Fix white flash on NTP

### DIFF
--- a/components/brave_new_tab_ui/brave_new_tab.html
+++ b/components/brave_new_tab_ui/brave_new_tab.html
@@ -14,6 +14,7 @@
 <script src="/strings.js"></script>
 <style>
   #root { height: 100%; }
+  body { background-color: #333639; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
Addresses: https://github.com/brave/brave-browser/issues/2568
Fixes: https://github.com/brave/brave-browser/issues/3362

From all the builds and different ways of surfacing the `body` background-color I tried, this is the only way I could get it to persist when opening a new webpage from NTP (and not show the white bar at the bottom). If the `CSS` is designated anywhere else the `background color` will load correctly but it won't fill the whole viewport when navigating away from NTP and the white strip surfaces at the bottom. 

This helps with the stark white bar being quite so apparent but a real fix for that problem is likely much more difficult and larger than just the scope of `NTP`. The background color helps that white flash before the images load as well. 

Video of the refresh: https://d.pr/i/JtzC4p
