### PR TITLE
Remove partial skip_signing patch from 0.61.x

### DIFF
--- a/patches/chrome-installer-mini_installer-BUILD.gn.patch
+++ b/patches/chrome-installer-mini_installer-BUILD.gn.patch
@@ -1,23 +1,12 @@
 diff --git a/chrome/installer/mini_installer/BUILD.gn b/chrome/installer/mini_installer/BUILD.gn
-index 8d19c74ebe9d96a6e53a0b8cd228626bfc3d78b6..72c4b1a8c00683df0fb82365a46a23b6323f3d3f 100644
+index 8d19c74ebe9d96a6e53a0b8cd228626bfc3d78b6..f0a76a96de3dc584415ae37ca4fd6fa189c97a18 100644
 --- a/chrome/installer/mini_installer/BUILD.gn
 +++ b/chrome/installer/mini_installer/BUILD.gn
-@@ -11,6 +11,9 @@ import("//third_party/icu/config.gni")
- import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
- import("//ui/base/ui_features.gni")
- import("//v8/gni/v8.gni")
-+if (brave_chromium_build) {
-+  import("//brave/build/config.gni")
-+}
- 
- declare_args() {
-   # The Chrome archive is compressed in official builds to reduce the size of
-@@ -182,6 +185,22 @@ template("generate_mini_installer") {
+@@ -182,6 +182,21 @@ template("generate_mini_installer") {
        "//third_party/icu:icudata",
        chrome_dll_target,
      ]
 +    if (brave_chromium_build) {
-+      if (skip_signing) { args += [ "--skip_signing" ] }
 +      inputs -= [
 +        "$root_out_dir/chrome.exe",
 +      ]


### PR DESCRIPTION
It was only merged to 0.62.x. So, It shouldn't be inserted to 0.61.x

F/U PR for #1651
Issue: [brave/brave-browser#3313](https://github.com/brave/brave-browser/issues/3313)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source