### PR TITLE
Fix crash during the sync page loading in tor(guest) window

### DIFF
--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -56,7 +56,9 @@ void BraveRenderViewContextMenu::AppendBraveLinkItems() {
 bool BraveRenderViewContextMenu::IsCommandIdEnabled(int id) const {
   switch (id) {
     case IDC_CONTENT_CONTEXT_OPENLINKTOR:
-      return params_.link_url.is_valid() && !browser_context_->IsTorProfile();
+      return params_.link_url.is_valid() &&
+             IsURLAllowedInIncognito(params_.link_url, browser_context_) &&
+             !browser_context_->IsTorProfile();
     default:
       return RenderViewContextMenu_Chromium::IsCommandIdEnabled(id);
   }

--- a/components/brave_sync/brave_sync_service.cc
+++ b/components/brave_sync/brave_sync_service.cc
@@ -24,10 +24,7 @@ void BraveSyncService::RemoveObserver(BraveSyncServiceObserver* observer) {
 bool BraveSyncService::is_enabled() {
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
-  if (command_line.HasSwitch(switches::kDisableBraveSync))
-    return false;
-  else
-    return true;
+  return !command_line.HasSwitch(switches::kDisableBraveSync);
 }
 
 }  // namespace brave_sync

--- a/components/brave_sync/resources.grd
+++ b/components/brave_sync/resources.grd
@@ -18,6 +18,7 @@
       <include name="IDR_BRAVE_SYNC_EXTENSION_BUNDLE_JS" file="brave_sync/extension/brave-sync/bundles/bundle.js" type="BINDATA" />
       <include name="IDR_BRAVE_SYNC_EXTENSION_CRYPTO_JS" file="brave_sync/extension/brave-crypto/browser/crypto.js" type="BINDATA" />
       <include name="IDR_BRAVE_SYNC_HTML" file="brave_sync/ui/brave_sync.html" type="BINDATA" />
+      <include name="IDR_BRAVE_SYNC_DISABLED_HTML" file="brave_sync/ui/brave_sync_disabled.html" type="BINDATA" />
     </includes>
   </release>
 </grit>

--- a/components/brave_sync/ui/brave_sync_disabled.html
+++ b/components/brave_sync/ui/brave_sync_disabled.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Sync(Disabled)</title>
+  </head>
+  <body>
+    Sync in tor(guest) window is disabled.
+  </body>
+</html>


### PR DESCRIPTION
Sync page should be disabled for now because BraveSyncService isn't
instantiated for OTR profile.
Instead, sync is disabled page is loaded.

Fix https://github.com/brave/brave-browser/issues/3003

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Please refer STR in https://github.com/brave/brave-browser/issues/3003

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source