### PR TITLE
Cleanup displaying sync & rewards items in app menu

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -75,14 +75,18 @@ bool BraveBrowserCommandController::UpdateCommandEnabled(int id, bool state) {
 }
 
 void BraveBrowserCommandController::InitBraveCommandState() {
+  // Sync & Rewards pages doesn't work on tor(guest) session.
+  // They also doesn't work on private window but they are redirected
+  // to normal window in this case.
+  if (!browser_->profile()->IsGuestSession()) {
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
-  UpdateCommandForBraveRewards();
+    UpdateCommandForBraveRewards();
 #endif
+    if (brave_sync::BraveSyncService::is_enabled())
+      UpdateCommandForBraveSync();
+  }
   UpdateCommandForBraveAdblock();
   UpdateCommandForTor();
-  if (brave_sync::BraveSyncService::is_enabled() &&
-      !browser_->profile()->IsOffTheRecord())
-    UpdateCommandForBraveSync();
 }
 
 void BraveBrowserCommandController::UpdateCommandForBraveRewards() {

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -27,10 +27,20 @@ void BraveAppMenuModel::Build() {
 }
 
 void BraveAppMenuModel::InsertBraveMenuItems() {
-  InsertItemWithStringIdAt(
-      GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
-      IDC_SHOW_BRAVE_REWARDS,
-      IDS_SHOW_BRAVE_REWARDS);
+  // Sync & Rewards pages are redirected to normal window when it is loaded in
+  // private window. So, only hide them in guest(tor) window.
+  if (!browser_->profile()->IsGuestSession()) {
+    InsertItemWithStringIdAt(
+        GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
+        IDC_SHOW_BRAVE_REWARDS,
+        IDS_SHOW_BRAVE_REWARDS);
+    if (brave_sync::BraveSyncService::is_enabled()) {
+      InsertItemWithStringIdAt(
+          GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS),
+          IDC_SHOW_BRAVE_SYNC,
+          IDS_SHOW_BRAVE_SYNC);
+    }
+  }
   InsertItemWithStringIdAt(
       GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
       IDC_SHOW_BRAVE_ADBLOCK,
@@ -40,16 +50,10 @@ void BraveAppMenuModel::InsertBraveMenuItems() {
         GetIndexOfCommandId(IDC_NEW_WINDOW),
         IDC_NEW_TOR_IDENTITY,
         IDS_NEW_TOR_IDENTITY);
-   } else {
+  } else {
     InsertItemWithStringIdAt(
         GetIndexOfCommandId(IDC_NEW_INCOGNITO_WINDOW) + 1,
         IDC_NEW_OFFTHERECORD_WINDOW_TOR,
         IDS_NEW_OFFTHERECORD_WINDOW_TOR);
   }
-  if (brave_sync::BraveSyncService::is_enabled() &&
-      !browser_->profile()->IsOffTheRecord())
-    InsertItemWithStringIdAt(
-        GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS),
-        IDC_SHOW_BRAVE_SYNC,
-        IDS_SHOW_BRAVE_SYNC);
 }

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -9,7 +9,6 @@
 
 class BraveAppMenuModel : public AppMenuModel {
  public:
-  using AppMenuModel::AppMenuModel;
   BraveAppMenuModel(ui::AcceleratorProvider* provider,
       Browser* browser,
       AppMenuIconController* app_menu_icon_controller = nullptr);

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -1,9 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BRWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_
-#define BRAVE_BRWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_
+#ifndef BRAVE_BROWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_
+#define BRAVE_BROWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_
 
 #include "chrome/browser/ui/toolbar/app_menu_model.h"
 
@@ -25,4 +26,4 @@ class BraveAppMenuModel : public AppMenuModel {
   DISALLOW_COPY_AND_ASSIGN(BraveAppMenuModel);
 };
 
-#endif  // BRAVE_BRWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_
+#endif  // BRAVE_BROWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/toolbar/brave_app_menu_model.h"
+
+#include <memory>
+
+#include "brave/app/brave_command_ids.h"
+#include "brave/browser/ui/brave_browser_command_controller.h"
+#include "chrome/browser/chrome_notification_types.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_window.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/test/test_utils.h"
+
+using BraveAppMenuBrowserTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, BasicTest) {
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  BraveAppMenuModel normal_model(browser_view->toolbar(), browser());
+  normal_model.Init();
+
+  // Check normal window has both menu items.
+  // -1 means |model| doesn't have passed command id.
+  EXPECT_NE(-1, normal_model.GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS));
+  EXPECT_NE(-1, normal_model.GetIndexOfCommandId(IDC_SHOW_BRAVE_SYNC));
+
+  auto* command_controller = browser()->command_controller();
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+
+  // Create proviate browser.
+  auto* private_browser = CreateIncognitoBrowser();
+  auto* private_browser_view =
+      BrowserView::GetBrowserViewForBrowser(private_browser);
+  BraveAppMenuModel private_model(private_browser_view->toolbar(),
+                                  private_browser);
+  private_model.Init();
+
+  // Check private window has both menu items.
+  // -1 means |model| doesn't have passed command id.
+  EXPECT_NE(-1, private_model.GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS));
+  EXPECT_NE(-1, private_model.GetIndexOfCommandId(IDC_SHOW_BRAVE_SYNC));
+
+  command_controller = private_browser->command_controller();
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+
+  content::WindowedNotificationObserver browser_creation_observer(
+      chrome::NOTIFICATION_BROWSER_OPENED,
+      content::NotificationService::AllSources());
+  profiles::SwitchToGuestProfile(ProfileManager::CreateCallback());
+
+  browser_creation_observer.Wait();
+
+  auto* browser_list = BrowserList::GetInstance();
+  Browser* guest_browser = nullptr;
+  for (Browser* browser : *browser_list) {
+    if (browser->profile()->IsGuestSession()) {
+      guest_browser = browser;
+      break;
+    }
+  }
+  DCHECK(guest_browser);
+
+  auto* guest_browser_view =
+      BrowserView::GetBrowserViewForBrowser(guest_browser);
+  BraveAppMenuModel guest_model(guest_browser_view->toolbar(), guest_browser);
+  guest_model.Init();
+
+  // Check guest window doesn't have them.
+  // -1 means |model| doesn't have passed command id.
+  EXPECT_EQ(-1, guest_model.GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS));
+  EXPECT_EQ(-1, guest_model.GetIndexOfCommandId(IDC_SHOW_BRAVE_SYNC));
+
+  command_controller = guest_browser->command_controller();
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -273,6 +273,7 @@ test("brave_browser_tests") {
     "//brave/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc",
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
+    "//brave/browser/ui/toolbar/brave_app_menu_model_browsertest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_service_browsertest.cc",


### PR DESCRIPTION
Sync & Rewards pages are only valid in normal window. And they are also
valid in private window because they are redirected to normal window.
However, they doesn't work properly in tor(guest) window. So, sync and
rewards items are should be visible only normal and private window's app
menu. Also, corresponding command ids should be disabled in tor(guest) window.

Fix https://github.com/brave/brave-browser/issues/3410

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Please refer to STR in https://github.com/brave/brave-browser/issues/3410
`yarn test brave_browser_tests --filter= BraveAppMenuBrowserTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source