### PR TITLE
Monthly tips are now shown in Rewards panel summary.

### DIFF
--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -195,7 +195,7 @@
                 "type": "string",
                 "description": "balance defined in probi"
               },
-              "recurring": {
+              "donation": {
                 "type": "string",
                 "description": "balance defined in probi"
               },

--- a/components/brave_rewards/browser/extension_rewards_service_observer.cc
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.cc
@@ -105,7 +105,7 @@ void ExtensionRewardsServiceObserver::OnGetCurrentBalanceReport(
     properties.tips = balance_report.one_time_donation;
     properties.opening = balance_report.opening_balance;
     properties.total = balance_report.total;
-    properties.recurring = balance_report.recurring_donation;
+    properties.donation = balance_report.recurring_donation;
 
     std::unique_ptr<base::ListValue> args(
         extensions::api::brave_rewards::OnCurrentReport::Create(properties)


### PR DESCRIPTION
Fixes brave/brave-browser#3177

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave clean profile with `reconcile-interval=10` (or lower if faster) and enable rewards.
2. Create a recurring monthly donation to a verified publisher.
3. optionally visit sites to populate autocontribute table.
4. optionally make one time tip to verified publisher.
5. When reconcilation has occurred, make sure Monthly Tips is displayed in Rewards panel summary


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source