### PR TITLE
Add null check in AutoplayPermissionContext::GetPermissionStatusInternal

### DIFF
--- a/browser/autoplay/autoplay_permission_context.cc
+++ b/browser/autoplay/autoplay_permission_context.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/browser/autoplay/autoplay_permission_context.cc
+++ b/browser/autoplay/autoplay_permission_context.cc
@@ -24,11 +24,12 @@ ContentSetting AutoplayPermissionContext::GetPermissionStatusInternal(
     content::RenderFrameHost* render_frame_host,
     const GURL& requesting_origin,
     const GURL& embedding_origin) const {
-    if (g_brave_browser_process->autoplay_whitelist_service()
-        ->ShouldAllowAutoplay(requesting_origin))
-      return CONTENT_SETTING_ALLOW;
-    return PermissionContextBase::GetPermissionStatusInternal(
-        render_frame_host, requesting_origin, embedding_origin);
+  if (g_brave_browser_process &&
+      g_brave_browser_process->autoplay_whitelist_service()
+      ->ShouldAllowAutoplay(requesting_origin))
+    return CONTENT_SETTING_ALLOW;
+  return PermissionContextBase::GetPermissionStatusInternal(
+    render_frame_host, requesting_origin, embedding_origin);
 }
 
 void AutoplayPermissionContext::UpdateTabContext(

--- a/browser/autoplay/autoplay_permission_context.h
+++ b/browser/autoplay/autoplay_permission_context.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/browser/autoplay/autoplay_permission_context.h
+++ b/browser/autoplay/autoplay_permission_context.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef ROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
-#define ROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
+#ifndef BRAVE_BROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
+#define BRAVE_BROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
 
 #include "base/macros.h"
 #include "chrome/browser/permissions/permission_context_base.h"
@@ -34,4 +34,4 @@ class AutoplayPermissionContext : public PermissionContextBase {
   DISALLOW_COPY_AND_ASSIGN(AutoplayPermissionContext);
 };
 
-#endif  // ROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
+#endif  // BRAVE_BROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_

--- a/browser/autoplay/autoplay_permission_context.h
+++ b/browser/autoplay/autoplay_permission_context.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
-#define BRAVE_BROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
+#ifndef ROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
+#define ROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
 
 #include "base/macros.h"
 #include "chrome/browser/permissions/permission_context_base.h"
@@ -34,4 +34,4 @@ class AutoplayPermissionContext : public PermissionContextBase {
   DISALLOW_COPY_AND_ASSIGN(AutoplayPermissionContext);
 };
 
-#endif  // BRAVE_BROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_
+#endif  // ROWSER_AUTOPLAY_AUTOPLAY_PERMISSION_CONTEXT_H_

--- a/components/brave_shields/browser/autoplay_whitelist_service.cc
+++ b/components/brave_shields/browser/autoplay_whitelist_service.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/components/brave_shields/browser/autoplay_whitelist_service.cc
+++ b/components/brave_shields/browser/autoplay_whitelist_service.cc
@@ -49,7 +49,8 @@ void AutoplayWhitelistService::OnDATFileDataReady() {
     return;
   }
   autoplay_whitelist_client_.reset(new AutoplayWhitelistParser());
-  if (!autoplay_whitelist_client_->deserialize((char*)&buffer_.front())) {
+  if (!autoplay_whitelist_client_->deserialize(
+        reinterpret_cast<char*>(&buffer_.front()))) {
     autoplay_whitelist_client_.reset();
     LOG(ERROR) << "Failed to deserialize autoplay whitelist data";
     return;
@@ -61,8 +62,8 @@ void AutoplayWhitelistService::OnComponentReady(
     const base::FilePath& install_dir,
     const std::string& manifest) {
 
-  base::FilePath dat_file_path =
-      install_dir.AppendASCII(AUTOPLAY_DAT_FILE_VERSION).AppendASCII(AUTOPLAY_DAT_FILE);
+  base::FilePath dat_file_path = install_dir.AppendASCII(
+    AUTOPLAY_DAT_FILE_VERSION).AppendASCII(AUTOPLAY_DAT_FILE);
 
   GetTaskRunner()->PostTaskAndReply(
       FROM_HERE,
@@ -71,7 +72,8 @@ void AutoplayWhitelistService::OnComponentReady(
                  weak_factory_.GetWeakPtr()));
 }
 
-scoped_refptr<base::SequencedTaskRunner> AutoplayWhitelistService::GetTaskRunner() {
+scoped_refptr<base::SequencedTaskRunner>
+  AutoplayWhitelistService::GetTaskRunner() {
   // We share the same task runner as ad-block code
   return g_brave_browser_process->ad_block_service()->GetTaskRunner();
 }
@@ -81,8 +83,10 @@ scoped_refptr<base::SequencedTaskRunner> AutoplayWhitelistService::GetTaskRunner
 // The autoplay whitelist factory. Using the Brave Shields as a singleton
 // is the job of the browser process.
 std::unique_ptr<AutoplayWhitelistService> AutoplayWhitelistServiceFactory() {
-  std::unique_ptr<AutoplayWhitelistService> service = std::make_unique<AutoplayWhitelistService>();
-  g_brave_browser_process->local_data_files_service()->AddObserver(service.get());
+  std::unique_ptr<AutoplayWhitelistService> service =
+    std::make_unique<AutoplayWhitelistService>();
+  g_brave_browser_process->local_data_files_service()->AddObserver(
+    service.get());
   return service;
 }
 

--- a/components/brave_shields/browser/autoplay_whitelist_service.h
+++ b/components/brave_shields/browser/autoplay_whitelist_service.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef OMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
-#define OMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
 
 #include <stdint.h>
 
@@ -60,4 +60,4 @@ std::unique_ptr<AutoplayWhitelistService> AutoplayWhitelistServiceFactory();
 
 }  // namespace brave_shields
 
-#endif  // OMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_

--- a/components/brave_shields/browser/autoplay_whitelist_service.h
+++ b/components/brave_shields/browser/autoplay_whitelist_service.h
@@ -3,14 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
-#define BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
+#ifndef OMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
+#define OMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
 
 #include <stdint.h>
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -61,4 +60,4 @@ std::unique_ptr<AutoplayWhitelistService> AutoplayWhitelistServiceFactory();
 
 }  // namespace brave_shields
 
-#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_
+#endif  // OMPONENTS_BRAVE_SHIELDS_BROWSER_AUTOPLAY_WHITELIST_SERVICE_H_

--- a/components/brave_shields/browser/autoplay_whitelist_service.h
+++ b/components/brave_shields/browser/autoplay_whitelist_service.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -23,6 +24,7 @@
 #include "url/gurl.h"
 
 class AutoplayWhitelistParser;
+class BraveContentSettingsObserverAutoplayTest;
 
 namespace brave_shields {
 
@@ -41,6 +43,8 @@ class AutoplayWhitelistService : public BaseLocalDataFilesObserver {
                         const std::string& manifest) override;
 
  private:
+  friend class ::BraveContentSettingsObserverAutoplayTest;
+
   void OnDATFileDataReady();
 
   brave_shields::DATFileDataBuffer buffer_;

--- a/renderer/brave_content_settings_observer_autoplay_browsertest.cc
+++ b/renderer/brave_content_settings_observer_autoplay_browsertest.cc
@@ -1,10 +1,14 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/path_service.h"
+#include "brave/browser/brave_browser_process_impl.h"
 #include "brave/browser/brave_content_browser_client.h"
+#include "brave/components/brave_shields/browser/autoplay_whitelist_service.h"
 #include "brave/common/brave_paths.h"
+#include "brave/vendor/autoplay-whitelist/autoplay_whitelist_parser.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/permission_bubble/mock_permission_prompt_factory.h"
@@ -43,6 +47,7 @@ class BraveContentSettingsObserverAutoplayTest : public InProcessBrowserTest {
 
       ASSERT_TRUE(embedded_test_server()->Start());
 
+      g_brave_browser_process->autoplay_whitelist_service()->autoplay_whitelist_client_->addHost("example.com");
       whitelisted_url_ = embedded_test_server()->GetURL("example.com", "/autoplay/autoplay_by_attr.html");
 
       user_blocklist_pattern_ =

--- a/renderer/brave_content_settings_observer_autoplay_browsertest.cc
+++ b/renderer/brave_content_settings_observer_autoplay_browsertest.cc
@@ -28,8 +28,8 @@ const char kVideoPlayingDetect[] =
   "textContent);";
 
 class BraveContentSettingsObserverAutoplayTest : public InProcessBrowserTest {
-  public:
-    void SetUpOnMainThread() override {
+ public:
+  void SetUpOnMainThread() override {
       InProcessBrowserTest::SetUpOnMainThread();
 
       content_client_.reset(new ChromeContentClient);
@@ -47,8 +47,10 @@ class BraveContentSettingsObserverAutoplayTest : public InProcessBrowserTest {
 
       ASSERT_TRUE(embedded_test_server()->Start());
 
-      g_brave_browser_process->autoplay_whitelist_service()->autoplay_whitelist_client_->addHost("example.com");
-      whitelisted_url_ = embedded_test_server()->GetURL("example.com", "/autoplay/autoplay_by_attr.html");
+      g_brave_browser_process->autoplay_whitelist_service()->
+        autoplay_whitelist_client_->addHost("example.com");
+      whitelisted_url_ = embedded_test_server()->GetURL(
+        "example.com", "/autoplay/autoplay_by_attr.html");
 
       user_blocklist_pattern_ =
           ContentSettingsPattern::FromString("http://example.com/*");
@@ -89,12 +91,13 @@ class BraveContentSettingsObserverAutoplayTest : public InProcessBrowserTest {
 
     void WaitForPlaying() {
       std::string msg_from_renderer;
-      ASSERT_TRUE(ExecuteScriptAndExtractString(contents(), "notifyWhenPlaying();",
-                                                &msg_from_renderer));
+      ASSERT_TRUE(ExecuteScriptAndExtractString(
+                    contents(), "notifyWhenPlaying();",
+                    &msg_from_renderer));
       ASSERT_EQ("PLAYING", msg_from_renderer);
     }
 
-  private:
+ private:
     GURL whitelisted_url_;
     ContentSettingsPattern user_blocklist_pattern_;
     std::unique_ptr<ChromeContentClient> content_client_;
@@ -102,7 +105,8 @@ class BraveContentSettingsObserverAutoplayTest : public InProcessBrowserTest {
 };
 
 // Allow autoplay on whitelisted URL by default
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest, AllowAutoplay) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest,
+                       AllowAutoplay) {
   std::string result;
   PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(
       contents());
@@ -124,7 +128,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest, AllowAutoplay) 
 
 // Block autoplay, even on whitelisted URL, if user has a blocklist pattern that
 // matches the whitelisted URL
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest, BlockAutoplay) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverAutoplayTest,
+                       BlockAutoplay) {
   std::string result;
   BlockAutoplay();
   PermissionRequestManager* manager = PermissionRequestManager::FromWebContents(


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3414

also fixes failing browsertest `BraveContentSettingsObserverAutoplayTest.AllowAutoplay`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source