### PR TITLE
Youtube channels with special characters in name now appear correctly

### DIFF
--- a/vendor/bat-native-ledger/src/bat_get_media.cc
+++ b/vendor/bat-native-ledger/src/bat_get_media.cc
@@ -1132,7 +1132,16 @@ std::string BatGetMedia::extractData(const std::string& data,
 }
 
 std::string BatGetMedia::getNameFromChannel(const std::string& data) {
-  return extractData(data, "channelMetadataRenderer\":{\"title\":\"", "\"");
+  std::string publisher_name;
+  const std::string publisher_json_name =
+      extractData(data, "channelMetadataRenderer\":{\"title\":\"", "\"");
+  const std::string publisher_json = "{\"brave_publisher\":\"" +
+      publisher_json_name + "\"}";
+  // scraped data could come in with JSON code points added.
+  // Make to JSON object above so we can decode.
+  braveledger_bat_helper::getJSONValue(
+      "brave_publisher", publisher_json, publisher_name);
+  return publisher_name;
 }
 
 std::string BatGetMedia::parseChannelIdFromCustomPathPage(

--- a/vendor/bat-native-ledger/src/bat_get_media.h
+++ b/vendor/bat-native-ledger/src/bat_get_media.h
@@ -274,6 +274,7 @@ class BatGetMedia {
   FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, GetYoutubePublisherKeyFromUrl);
   FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, GetYoutubeUserFromUrl);
   FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, getRealEnteredYTPath);
+  FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, GetNameFromChannel);
 };
 
 }  // namespace braveledger_bat_get_media

--- a/vendor/bat-native-ledger/src/bat_get_media_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat_get_media_unittest.cc
@@ -262,4 +262,73 @@ TEST(BatGetMediaTest, getRealEnteredYTPath) {
   delete bat_get_media_;
 }
 
+TEST(BatGetMediaTest, GetNameFromChannel) {
+  braveledger_bat_get_media::BatGetMedia* bat_get_media_ =
+      new braveledger_bat_get_media::BatGetMedia(nullptr);
+  const std::string json_envelope_open(
+      "channelMetadataRenderer\":{\"title\":\"");
+  const std::string json_envelope_close("\"}");
+
+  // empty string
+  std::string resolve =
+      bat_get_media_->getNameFromChannel(std::string());
+  ASSERT_EQ(resolve, std::string());
+
+  // quote
+  resolve =
+      bat_get_media_->getNameFromChannel("\"");
+  ASSERT_EQ(resolve, std::string());
+
+  // double quote
+  resolve =
+      bat_get_media_->getNameFromChannel("\"\"");
+  ASSERT_EQ(resolve, std::string());
+
+  // invalid json
+  std::string subject(
+      json_envelope_open + "invalid\"json\"}" + json_envelope_close);
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "invalid");
+
+  // ampersand (&)
+  subject = json_envelope_open + "A\\u0026B" + json_envelope_close;
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "A&B");
+
+  // quotation mark (")
+  subject = json_envelope_open + "A\\u0022B" + json_envelope_close;
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "A\"B");
+
+  // pound (#)
+  subject = json_envelope_open + "A\\u0023B" + json_envelope_close;
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "A#B");
+
+  // dollar ($)
+  subject = json_envelope_open + "A\\u0024B" + json_envelope_close;
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "A$B");
+
+  // percent (%)
+  subject = json_envelope_open + "A\\u0025B" + json_envelope_close;
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "A%B");
+
+  // single quote (')
+  subject = json_envelope_open + "A\\u0027B" + json_envelope_close;
+  resolve =
+      bat_get_media_->getNameFromChannel(subject);
+  ASSERT_EQ(resolve, "A'B");
+
+  // cleanup
+  delete bat_get_media_;
+}
+
 }  // braveledger_bat_get_media


### PR DESCRIPTION
Fixes brave/brave-browser#2028

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Open Brave and enable Rewards
2. Visit youtube publisher with ampersand in name 
    (https://www.youtube.com/channel/UC5v8uRCMdzHXgEOZC4rtbXg)
    (https://www.youtube.com/channel/UCp3QO2qJy2hvIBrRoWSaCRw)

(& seems to be the only character that youtube performs JSON encoding on, however, all encoding is handled through this PR)

3. Open panel and make sure publisher name is correct

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source