### PR TITLE
Fix rewards popup doesn't display translated strings in dist zip

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -162,12 +162,7 @@ if (!is_mac) {
 
     sources = []
     foreach(locale, locales) {
-      # print (locale)
-      if (is_mac) {
-        sources += [ "$root_gen_dir/repack/locales/$locale.pak" ]
-      } else {
-        sources += [ "$root_out_dir/locales/$locale.pak" ]
-      }
+      sources += [ "$root_out_dir/locales/$locale.pak" ]
     }
     outputs = [
       "$brave_dist_dir/locales/{{source_file_part}}",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -173,6 +173,32 @@ if (!is_mac) {
       "$brave_dist_dir/locales/{{source_file_part}}",
     ]
   }
+
+  group("brave_extension_locale_dist_resources") {
+    deps = [
+      "//brave/components/brave_rewards/resources/extension:locales",
+    ]
+
+    public_deps = []
+    foreach(locale, locales) {
+      # public_deps is used intentionaly because ":create_dist_zip" needs the all dependency
+      # of all locale files.
+      public_deps += [":brave_rewards_locales_${locale}"]
+    }
+  }
+
+  foreach(locale, locales) {
+    copy("brave_rewards_locales_${locale}") {
+      deps = [ "//brave/components/brave_rewards/resources/extension:locales_$locale" ]
+
+      locale = string_replace(locale, "-", "_")
+      locale = string_replace(locale, "nb", "no")
+      sources = [ "$root_out_dir/resources/brave_rewards/_locales/$locale/messages.json" ]
+      outputs = [
+        "$brave_dist_dir/resources/brave_rewards/_locales/$locale/{{source_file_part}}",
+      ]
+    }
+  }
 }
 
 if (target_cpu == "x86") {
@@ -341,6 +367,9 @@ action("create_dist_zips") {
   if (!is_mac) {
     inputs += get_target_outputs(":brave_dist_resources")
     inputs += get_target_outputs(":brave_locale_dist_resources")
+    foreach(locale, locales) {
+      inputs += get_target_outputs(":brave_rewards_locales_${locale}")
+    }
   }
 
   if (is_win) {
@@ -379,6 +408,7 @@ action("create_dist_zips") {
     deps += [
       ":brave_dist_resources",
       ":brave_locale_dist_resources",
+      ":brave_extension_locale_dist_resources",
     ]
   }
 


### PR DESCRIPTION
Rewards' locale files also should be included in dist zip.

Fix https://github.com/brave/brave-browser/issues/3399

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. `yarn create_dist Release`
2. run brave in ./out/Release/dist
3. Check rewards popup displays translated strings properly

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source