### PR TITLE
Remove redundant UrlHandler pair

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -89,7 +89,6 @@ bool HandleURLOverrideRewrite(GURL* url,
   return false;
 }
 
-
 bool HandleURLReverseOverrideRewrite(GURL* url,
                              content::BrowserContext* browser_context) {
   if (url->host() == chrome::kChromeUIWelcomeHost ||
@@ -142,8 +141,6 @@ void BraveContentBrowserClient::BrowserURLHandlerCreated(
   handler->AddHandlerPair(&HandleURLRewrite,
                           &HandleURLReverseOverrideRewrite);
   ChromeContentBrowserClient::BrowserURLHandlerCreated(handler);
-  handler->AddHandlerPair(&HandleURLOverrideRewrite,
-                          &HandleURLReverseOverrideRewrite);
 }
 
 bool BraveContentBrowserClient::AllowAccessCookie(

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -205,15 +205,40 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
   for (const std::string& scheme : schemes) {
     content::WebContents* contents =
         browser()->tab_strip_model()->GetActiveWebContents();
-    ui_test_utils::NavigateToURL(browser(), GURL(scheme + "sync-internals/"));
-      ASSERT_TRUE(WaitForLoadStop(contents));
+    ui_test_utils::NavigateToURL(
+        browser(), GURL(scheme + chrome::kChromeUISyncInternalsHost));
+    ASSERT_TRUE(WaitForLoadStop(contents));
 
-      EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
-                       ->GetVirtualURL().spec().c_str(),
-                   "brave://sync/");
-      EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
-                       ->GetURL().spec().c_str(),
-                   "chrome://sync/");
+    EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
+                     ->GetVirtualURL().spec().c_str(),
+                 "brave://sync/");
+    EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
+                     ->GetURL().spec().c_str(),
+                 "chrome://sync/");
+  }
+}
+
+IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
+    RewriteWelcomeWin10Host) {
+  std::vector<std::string> schemes {
+    "brave://",
+    "chrome://",
+  };
+
+  for (const std::string& scheme : schemes) {
+    content::WebContents* contents =
+        browser()->tab_strip_model()->GetActiveWebContents();
+    ui_test_utils::NavigateToURL(
+        browser(),
+        GURL(scheme + chrome::kChromeUIWelcomeWin10Host));
+    ASSERT_TRUE(WaitForLoadStop(contents));
+
+    EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
+                     ->GetVirtualURL().spec().c_str(),
+                 "brave://welcome/");
+    EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
+                     ->GetURL().spec().c_str(),
+                 "chrome://welcome/");
   }
 }
 


### PR DESCRIPTION
Last added url handler pair can be removed because sync/welcome host
handling is already done in the previous handler(HandleURLRewrite()).
Also, test for welcome page rewriter is added.

Fix https://github.com/brave/brave-browser/issues/3433

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveContentBrowserClient.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source