### PR TITLE
Cookie exception to unbreak Google logins

### DIFF
--- a/common/brave_cookie_blocking.cc
+++ b/common/brave_cookie_blocking.cc
@@ -2,6 +2,7 @@
 
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "url/gurl.h"
+#include "brave/common/shield_exceptions.h"
 
 bool ShouldBlockCookie(bool allow_brave_shields, bool allow_1p_cookies,
     bool allow_3p_cookies, const GURL& primary_url, const GURL& url) {
@@ -21,6 +22,11 @@ bool ShouldBlockCookie(bool allow_brave_shields, bool allow_1p_cookies,
 
   // If 3p is allowed, we have nothing extra to block
   if (allow_3p_cookies) {
+    return false;
+  }
+
+  // If it is whitelisted, we shouldn't block
+  if (brave::IsWhitelistedCookieException(primary_url, url)) {
     return false;
   }
 

--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -113,10 +113,26 @@ bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
     });
 }
 
-bool IsWhitelistedCookieExeption(const GURL& firstPartyOrigin,
+bool IsWhitelistedCookieException(const GURL& firstPartyOrigin,
     const GURL& subresourceUrl) {
   // Note that there's already an exception for TLD+1, so don't add those here.
   // Check with the security team before adding exceptions.
+
+  // 1st-party-INdependent whitelist
+  std::vector<URLPattern> fpi_whitelist_patterns = {
+    URLPattern(URLPattern::SCHEME_ALL,
+        "https://accounts.google.com/o/oauth2/*")
+  };
+  bool any_match = std::any_of(fpi_whitelist_patterns.begin(),
+      fpi_whitelist_patterns.end(),
+      [&subresourceUrl](const URLPattern& pattern) {
+        return pattern.MatchesURL(subresourceUrl);
+      });
+  if (any_match) {
+    return true;
+  }
+
+  // 1st-party-dependent whitelist
   static std::map<GURL, std::vector<URLPattern> > whitelist_patterns = {};
   std::map<GURL, std::vector<URLPattern> >::iterator i =
       whitelist_patterns.find(firstPartyOrigin);

--- a/common/shield_exceptions.h
+++ b/common/shield_exceptions.h
@@ -9,8 +9,8 @@ namespace brave {
 bool IsEmptyDataURLRedirect(const GURL& gurl);
 bool IsUAWhitelisted(const GURL& gurl);
 bool IsBlockedResource(const GURL& gurl);
-bool IsWhitelistedCookieExeption(const GURL& firstPartyOrigin,
-                                 const GURL& subresourceUrl);
+bool IsWhitelistedCookieException(const GURL& firstPartyOrigin,
+                                  const GURL& subresourceUrl);
 bool IsWhitelistedReferrer(const GURL& firstPartyOrigin,
                            const GURL& subresourceUrl);
 

--- a/common/shield_exceptions_unittest.cc
+++ b/common/shield_exceptions_unittest.cc
@@ -11,6 +11,7 @@ namespace {
 
 typedef testing::Test BraveShieldsExceptionsTest;
 using brave::IsWhitelistedReferrer;
+using brave::IsWhitelistedCookieException;
 
 TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
   // *.fbcdn.net not allowed on some other URL
@@ -53,6 +54,14 @@ TEST_F(BraveShieldsExceptionsTest, IsWhitelistedReferrer) {
       GURL("https://content.googleapis.com/cryptauth/v1/authzen/awaittx")));
   EXPECT_FALSE(IsWhitelistedReferrer(GURL("https://accounts.google.com"),
       GURL("https://ajax.googleapis.com/ajax/libs/d3js/5.7.0/d3.min.js")));
+}
+
+TEST_F(BraveShieldsExceptionsTest, IsWhitelistedCookieException) {
+  // Cookie exceptions for Google auth domains
+  EXPECT_TRUE(IsWhitelistedCookieException(GURL("https://www.airbnb.com/"),
+      GURL("https://accounts.google.com/o/oauth2/iframe")));
+  EXPECT_FALSE(IsWhitelistedCookieException(GURL("https://www.mozilla.org/"),
+      GURL("https://www.googletagmanager.com/gtm.js")));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/3534.

This PR wires in the already existing cookie exception checking method to the cookie blocking workflow, adds capability for 1st-party-independent exceptions (e.g., specific iframe hosts that should be allowed to access cookies no matter the hosting site), and adds an exception to `https://accounts.google.com/o/oauth2/*` to allow iframe-based Google login integration on many sites, as per our slack discussions.


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source