### PR TITLE
Add tracking (and ad-blocking) exception for graph.facebook.com

### DIFF
--- a/components/brave_shields/browser/tracking_protection_service.cc
+++ b/components/brave_shields/browser/tracking_protection_service.cc
@@ -30,6 +30,7 @@ TrackingProtectionService::TrackingProtectionService()
   : tracking_protection_client_(new CTPParser()),
     // See comment in tracking_protection_service.h for white_list_
     white_list_({
+      "graph.facebook.com",
       "connect.facebook.net",
       "connect.facebook.com",
       "staticxx.facebook.com",


### PR DESCRIPTION
This PR adds Facebook's Graph API to the tracker exceptions in order to unbreak numerous Facebook login integrations. Additionally -- since the ad-block service also catches these request after they make it through the tracker protection -- an ad-blocking exception is needed for `@@graph.facebook.com^`, too.


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source