### PR TITLE
Youtube videos with embedding disabled now show properly in Rewards panel

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_get_media.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_get_media.h
@@ -261,7 +261,21 @@ class BatGetMedia {
 
   std::string parseChannelIdFromCustomPathPage(
       const std::string& data);
+
   std::string getRealEnteredYTPath(const std::string& path) const;
+
+  void onFetchDataFromNonEmbeddable(
+    uint64_t windowId,
+    const ledger::VisitData& visit_data,
+    const std::string& providerType,
+    const uint64_t& duration,
+    const std::string& media_key,
+    const std::string& mediaURL,
+    int response_status_code,
+    const std::string& response,
+    const std::map<std::string, std::string>& headers);
+
+  static std::string parsePublisherName(const std::string& data);
 
   bat_ledger::LedgerImpl* ledger_;  // NOT OWNED
 
@@ -274,6 +288,7 @@ class BatGetMedia {
   FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, GetYoutubeUserFromUrl);
   FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, getRealEnteredYTPath);
   FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, GetNameFromChannel);
+  FRIEND_TEST_ALL_PREFIXES(BatGetMediaTest, ParsePublisherName);
 };
 
 }  // namespace braveledger_bat_get_media

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_get_media_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_get_media_unittest.cc
@@ -331,4 +331,55 @@ TEST(BatGetMediaTest, GetNameFromChannel) {
   delete bat_get_media_;
 }
 
+TEST(BatGetMediaTest, ParsePublisherName) {
+  braveledger_bat_get_media::BatGetMedia* bat_get_media_ =
+      new braveledger_bat_get_media::BatGetMedia(nullptr);
+
+  const std::string json_envelope(
+      "\"author\":\"");
+
+  // empty string
+  std::string publisher_name =
+      bat_get_media_->parsePublisherName(std::string());
+  ASSERT_EQ(publisher_name, std::string());
+
+  // quote
+  publisher_name =
+      bat_get_media_->parsePublisherName("\"");
+  ASSERT_EQ(publisher_name, std::string());
+
+  // double quote
+  publisher_name =
+      bat_get_media_->parsePublisherName("\"\"");
+  ASSERT_EQ(publisher_name, std::string());
+
+  // invalid json
+  std::string subject(
+      json_envelope + "invalid\"json}");
+  publisher_name =
+      bat_get_media_->parsePublisherName(subject);
+  ASSERT_EQ(publisher_name, "invalid");
+
+  // string name
+  subject = json_envelope + "publisher_name";
+  publisher_name =
+      bat_get_media_->parsePublisherName(subject);
+  ASSERT_EQ(publisher_name, "publisher_name");
+
+  // ampersand (& code point)
+  subject = json_envelope + "A\\u0026B";
+  publisher_name =
+      bat_get_media_->parsePublisherName(subject);
+  ASSERT_EQ(publisher_name, "A&B");
+
+  // ampersand (&) straight
+  subject = json_envelope + "A&B";
+  publisher_name =
+      bat_get_media_->parsePublisherName(subject);
+  ASSERT_EQ(publisher_name, "A&B");
+
+  // cleanup
+  delete bat_get_media_;
+}
+
 }  // namespace braveledger_bat_get_media


### PR DESCRIPTION
Fixes brave/brave-browser#3335

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave with clean profile and enable Rewards.
2. Go to https://www.youtube.com/watch?v=9y2EvgxxMXc and make sure that a verified publisher with video embedding disabled shows up in the panel properly.

1. Start Brave with clean profile and enable Rewards.
2. Go to https://www.youtube.com/watch?v=XUmVfYDJDEM and make sure that a non-verified publisher with video embedding disabled shows up in the panel properly.

1. Start Brave with clean profile and enable Rewards.
2. View youtube verified and non-verified publisher videos with embedding enabled to make sure they still show up in the panel properly.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source