### PR TITLE
Fix dependency from ui/base to brave/ui/webui/resources

### DIFF
--- a/patches/ui-base-BUILD.gn.patch
+++ b/patches/ui-base-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index 195435b5cc3a6aefc5464f9a5bd8919884783bcb..25349fd0787e0fd9c913fab16d3c646bf856f1f9 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -395,6 +395,7 @@ jumbo_component("base") {
+     "//base:base_static",
+     "//base:i18n",
+     "//base/third_party/dynamic_annotations",
++    "//brave/ui/webui/resources",
+     "//net",
+     "//third_party/icu",
+     "//third_party/zlib:zlib",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3451
This dependency is required because a chromium_src override changes resource IDs from chromium to match resources in brave/ui/webui/resources:
https://github.com/brave/brave-core/blob/master/chromium_src/ui/base/webui/web_ui_util.cc#L7

Note that this (potential) bug was introduced with #1422 so should be uplifted wherever that is.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Get a successful build

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source