### PR TITLE
Instantiate BraveSharedResourcesDataSource at the right time

### DIFF
--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_ads/browser/ads_service_factory.h"
 #include "brave/components/brave_rewards/browser/rewards_service_factory.h"
 #include "brave/components/brave_sync/brave_sync_service_factory.h"
+#include "brave/content/browser/webui/brave_shared_resources_data_source.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/chrome_constants.h"
 #include "chrome/common/pref_names.h"
@@ -22,6 +23,7 @@
 #include "components/prefs/pref_service.h"
 #include "components/signin/core/browser/signin_pref_names.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/url_data_source.h"
 #include "content/public/common/webrtc_ip_handling_policy.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -100,6 +102,8 @@ void BraveProfileManager::DoFinalInitForServices(Profile* profile,
   brave_sync::BraveSyncServiceFactory::GetForProfile(profile);
   brave_ads::AdsServiceFactory::GetForProfile(profile);
   brave_rewards::RewardsServiceFactory::GetForProfile(profile);
+  content::URLDataSource::Add(profile,
+      std::make_unique<brave_content::BraveSharedResourcesDataSource>());
 }
 
 void BraveProfileManager::LaunchTorProcess(Profile* profile) {

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -1,8 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "brave/browser/profiles/brave_profile_manager.h"
+
+#include <memory>
+#include <string>
 
 #include "base/metrics/histogram_macros.h"
 #include "brave/browser/brave_browser_process_impl.h"

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -15,9 +15,7 @@
 #include "brave/common/webui_url_constants.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_sync/brave_sync_service.h"
-#include "brave/content/browser/webui/brave_shared_resources_data_source.h"
 #include "chrome/common/url_constants.h"
-#include "content/public/browser/url_data_source.h"
 #include "url/gurl.h"
 
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
@@ -90,8 +88,6 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
 
 WebUI::TypeID BraveWebUIControllerFactory::GetWebUIType(
       content::BrowserContext* browser_context, const GURL& url) const {
-  content::URLDataSource::Add(browser_context,
-            std::make_unique<brave_content::BraveSharedResourcesDataSource>());
   WebUIFactoryFunction function = GetWebUIFactoryFunction(NULL, url);
   if (function) {
     return reinterpret_cast<WebUI::TypeID>(function);


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3461

Follow up from https://github.com/brave/brave-core/pull/1422

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`npm test brave_unit_tests && npm test brave_browser_tests`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source