### PR TITLE
Fixes unlimited growth of HTTPSERecentlyUsedCache.

### DIFF
--- a/components/brave_shields/browser/https_everywhere_recently_used_cache.h
+++ b/components/brave_shields/browser/https_everywhere_recently_used_cache.h
@@ -12,74 +12,86 @@
 
 #include "base/synchronization/lock.h"
 
-template <class T> class RingBuffer {
+template <class T>
+class FixedSizeAgeQueue {
  public:
-  explicit RingBuffer(int fixedSize) : count(fixedSize), data(count) {}
+  explicit FixedSizeAgeQueue(size_t max_size) : max_size_(max_size) {}
 
-  const T& at(int i) {
-    return data[(currentIdx - (i % count) + count) % count];
+  T add(const T& value) {
+    T t;
+    // If we already have this value, just mark it the youngest.
+    if (!make_youngest(value)) {
+      // Check if at the size limit and if so pop the oldest value.
+      if (data_.size() == max_size_) {
+        t = data_.front();
+        data_.pop_front();
+      }
+      data_.push_back(value);
+    }
+    return t;
   }
 
-  void add(const T& newValue) {
-    currentIdx = (currentIdx + 1) % count;
-    data[currentIdx] = newValue;
+  bool make_youngest(const T& value){
+    auto it = std::find(data_.begin(), data_.end(), value);
+    if (it != data_.end()) {
+      std::rotate(it, std::next(it), data_.end());
+      return true;
+    }
+    return false;
   }
 
-  T oldest() {
-    return data[(currentIdx + 1) % count];
+  void erase(const T& value) {
+    auto it = std::find(data_.begin(), data_.end(), value);
+    if (it != data_.end())
+      data_.erase(it);
   }
 
-  void clear() {
-    data = std::vector<T>(count);
-  }
+  void clear() { data_.clear(); }
 
  private:
-  int currentIdx = 0;
-  int count;
-  std::vector<T> data;
+  size_t max_size_;
+  std::deque<T> data_;
 };
 
 template <class T> class HTTPSERecentlyUsedCache {
  public:
-  explicit HTTPSERecentlyUsedCache(unsigned int size = 100) : keysByAge(size) {}
+  explicit HTTPSERecentlyUsedCache(size_t size = 100) : keys_by_age_(size) {}
 
   void add(const std::string& key, const T& value) {
     base::AutoLock create(lock_);
-
     data_[key] = value;
-    // https://github.com/brave/brave-browser/issues/3193
-    // std::string old = keysByAge.oldest();
-    // if (!old.empty()) {
-    //   keysByAge.data.erase(old);
-    // }
-    // keysByAge[key] = value;
+    T t = keys_by_age_.add(key);
+    if (t != T())
+      data_.erase(t);
   }
 
   bool get(const std::string& key, T* value) {
     base::AutoLock create(lock_);
-
     auto search = data_.find(key);
     if (search != data_.end()) {
       *value = search->second;
+      keys_by_age_.make_youngest(key);
       return true;
     }
     return false;
   }
 
   void remove(const std::string& key) {
+    base::AutoLock lock(lock_);
     data_.erase(key);
+    keys_by_age_.erase(key);
   }
 
   void clear() {
+    base::AutoLock lock(lock_);
     data_.clear();
-    // https://github.com/brave/brave-browser/issues/3193
-    // keysByAge.clear();
+    keys_by_age_.clear();
   }
 
  private:
   std::unordered_map<std::string, T> data_;
   base::Lock lock_;
-  RingBuffer<T> keysByAge;
+  FixedSizeAgeQueue<T> keys_by_age_;
 };
 
 #endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_HTTPS_EVERYWHERE_RECENTLY_USED_CACHE_H_


### PR DESCRIPTION
- Removes unused RingBuffer from HTTPSERecentlyUsedCache,
- Adds a FixedSizeAgeQueue to the cache. The queue orginizes its entries
  not just by the order they've been added to the cache, but also by
  when they are being retrieved from the cache. When the queue max size
  is reached, the oldest/least used entry is removed from both the queue
  and the cache.

Fixes brave/brave-browser#3193

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
