### PR TITLE
Removed deprecated and unused GetClientInfo code from Ads Service

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -836,11 +836,6 @@ void AdsServiceImpl::OpenSettings(Profile* profile,
 }
 
 void AdsServiceImpl::GetClientInfo(ads::ClientInfo* client_info) const {
-  // TODO(bridiver) - these eventually get used in a catalog request
-  // and seem like potential privacy issues
-  // client_info->application_version = "";
-  // client_info->platform_version = "";
-  // client_info.application_version = chrome::kChromeVersion;
 #if defined(OS_MACOSX)
   client_info->platform = ads::ClientInfoPlatformType::MACOS;
 #elif defined(OS_WIN)


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3472
requires https://github.com/brave-intl/bat-native-ads/pull/142

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
