### PR TITLE
Fixes to uplift script

### DIFF
--- a/script/lib/github.py
+++ b/script/lib/github.py
@@ -165,13 +165,16 @@ def get_file_contents(token, repo_name, filename, branch=None):
     return file['content']
 
 
-def add_reviewers_to_pull_request(token, repo_name, pr_number, reviewers=[], verbose=False, dryrun=False):
+def add_reviewers_to_pull_request(token, repo_name, pr_number, reviewers=[], team_reviewers=[],
+                                  verbose=False, dryrun=False):
     # add reviewers to pull request
     # for more info see: https://developer.github.com/v3/pulls/review_requests/
     repo = GitHub(token).repos(repo_name)
     patch_data = {}
     if len(reviewers) > 0:
         patch_data['reviewers'] = reviewers
+    if len(team_reviewers) > 0:
+        patch_data['team_reviewers'] = team_reviewers
     if dryrun:
         print('[INFO] would call `repo.pulls(' + str(pr_number) +
               ').requested_reviewers.post(' + str(patch_data) + ')`')

--- a/script/lib/github.py
+++ b/script/lib/github.py
@@ -277,4 +277,5 @@ def push_branches_to_remote(path, branches_to_push, dryrun=False):
             for branch_to_push in branches_to_push:
                 print('- pushing ' + branch_to_push + '...')
                 # TODO: if they already exist, force push?? or error??
+                # NOTE: this fails if clone was done via https
                 execute(['git', 'push', '-u', 'origin', branch_to_push])

--- a/script/lib/github.py
+++ b/script/lib/github.py
@@ -269,7 +269,7 @@ def get_title_from_first_commit(path, branch_to_compare):
         return title_list[0]
 
 
-def push_branches_to_remote(path, branches_to_push, dryrun=False):
+def push_branches_to_remote(path, branches_to_push, dryrun=False, token=None):
     if dryrun:
         print('[INFO] would push the following local branches to remote: ' + str(branches_to_push))
     else:
@@ -277,5 +277,11 @@ def push_branches_to_remote(path, branches_to_push, dryrun=False):
             for branch_to_push in branches_to_push:
                 print('- pushing ' + branch_to_push + '...')
                 # TODO: if they already exist, force push?? or error??
-                # NOTE: this fails if clone was done via https
-                execute(['git', 'push', '-u', 'origin', branch_to_push])
+                response = execute(['git', 'remote', 'get-url', '--push', 'origin']).strip()
+                if response.startswith('https://'):
+                    if len(str(token)) == 0:
+                        raise Exception('GitHub token cannot be null or empty!')
+                    remote = response.replace('https://', 'https://' + token + ':x-oauth-basic@')
+                    execute(['git', 'push', '-u', remote, branch_to_push])
+                else:
+                    execute(['git', 'push', '-u', 'origin', branch_to_push])

--- a/script/pr.py
+++ b/script/pr.py
@@ -279,7 +279,7 @@ def main():
         return 1
 
     print('\nPushing local branches to remote...')
-    push_branches_to_remote(BRAVE_CORE_ROOT, config.branches_to_push, dryrun=config.is_dryrun)
+    push_branches_to_remote(BRAVE_CORE_ROOT, config.branches_to_push, dryrun=config.is_dryrun, token=config.github_token)
 
     try:
         print('\nCreating the pull requests...')

--- a/script/pr.py
+++ b/script/pr.py
@@ -361,6 +361,16 @@ def create_branch(channel, top_level_base, remote_base, local_branch):
                 output = execute(['git', 'cherry-pick', sha]).split('\n')
                 print('- picked ' + sha + ' (' + output[0] + ')')
 
+            # squash all commits into one
+            # NOTE: master is not squashed. This only runs for uplifts.
+            execute(['git', 'reset', '--soft', remote_base])
+            squash_message = 'Squash of commits from branch ' + str(local_branch)
+            if int(config.master_pr_number) > 0:
+                squash_message = 'Uplift of #' + str(config.master_pr_number) + ' (squashed)'
+            execute(['git', 'commit', '-m', squash_message])
+            squash_hash = execute(['git', 'log', '--pretty="%h"', '-n1'])
+            print('- squashed all commits into ' + squash_hash)
+
         finally:
             # switch back to original branch
             execute(['git', 'checkout', local_branch])


### PR DESCRIPTION
## Description
A few important updates:
- Script renamed to `uplift.py`
- Argument `--uplift-using-pr` is no longer optional; **_you can ONLY uplift MERGED pull requests_**
- Commits for uplifts are squashed and PR number is linked / release channel is mentioned (ex: `Uplift of #1762 (squashed) to dev`)
- Removed `--reviewers` argument and instead assign the [Uplift Approvers team](https://github.com/orgs/brave/teams/uplift-approvers)
- Script now works properly for https 😄 (which means we can use in Jenkins)

## Actions to take after merge
- [ ] Finalize the Jenkins job: https://staging.ci.brave.com/view/wip/job/mihai-create-uplift-prs/
- [ ] Update the documentation: https://github.com/brave/brave-browser/wiki/Uplifting-a-pull-request