### PR TITLE
 Fixes unlimited growth of HTTPSERecentlyUsedCache.

### DIFF
--- a/components/brave_shields/browser/https_everywhere_recently_used_cache.h
+++ b/components/brave_shields/browser/https_everywhere_recently_used_cache.h
@@ -7,79 +7,39 @@
 #define BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_HTTPS_EVERYWHERE_RECENTLY_USED_CACHE_H_
 
 #include <string>
-#include <unordered_map>
-#include <vector>
 
+#include "base/containers/mru_cache.h"
 #include "base/synchronization/lock.h"
-
-template <class T> class RingBuffer {
- public:
-  explicit RingBuffer(int fixedSize) : count(fixedSize), data(count) {}
-
-  const T& at(int i) {
-    return data[(currentIdx - (i % count) + count) % count];
-  }
-
-  void add(const T& newValue) {
-    currentIdx = (currentIdx + 1) % count;
-    data[currentIdx] = newValue;
-  }
-
-  T oldest() {
-    return data[(currentIdx + 1) % count];
-  }
-
-  void clear() {
-    data = std::vector<T>(count);
-  }
-
- private:
-  int currentIdx = 0;
-  int count;
-  std::vector<T> data;
-};
 
 template <class T> class HTTPSERecentlyUsedCache {
  public:
-  explicit HTTPSERecentlyUsedCache(unsigned int size = 100) : keysByAge(size) {}
+  explicit HTTPSERecentlyUsedCache(size_t size = 100) : data_(size) {}
 
   void add(const std::string& key, const T& value) {
     base::AutoLock create(lock_);
-
-    data_[key] = value;
-    // https://github.com/brave/brave-browser/issues/3193
-    // std::string old = keysByAge.oldest();
-    // if (!old.empty()) {
-    //   keysByAge.data.erase(old);
-    // }
-    // keysByAge[key] = value;
+    data_.Put(key, value);
   }
 
   bool get(const std::string& key, T* value) {
     base::AutoLock create(lock_);
-
-    auto search = data_.find(key);
-    if (search != data_.end()) {
-      *value = search->second;
+    auto it = data_.Get(key);
+    if (it != data_.end()) {
+      *value = it->second;
       return true;
     }
     return false;
   }
 
   void remove(const std::string& key) {
-    data_.erase(key);
-  }
-
-  void clear() {
-    data_.clear();
-    // https://github.com/brave/brave-browser/issues/3193
-    // keysByAge.clear();
+    base::AutoLock lock(lock_);
+    auto it = data_.Peek(key);
+    if (it != data_.end())
+      data_.Erase(it);
   }
 
  private:
-  std::unordered_map<std::string, T> data_;
+  base::MRUCache<std::string, T> data_;
   base::Lock lock_;
-  RingBuffer<T> keysByAge;
 };
 
 #endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_BROWSER_HTTPS_EVERYWHERE_RECENTLY_USED_CACHE_H_

--- a/components/brave_shields/browser/https_everywhere_recently_used_cache_unittest.cpp
+++ b/components/brave_shields/browser/https_everywhere_recently_used_cache_unittest.cpp
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <string>
+
+#include "brave/components/brave_shields/browser/https_everywhere_recently_used_cache.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(HTTPSEverywhereRecentlyUsedCacheTest, Operations) {
+  using Cache = HTTPSERecentlyUsedCache<std::string>;
+  Cache cache(3);
+
+  // Test add/get and check that max size is maintained.
+  cache.add("kA", "vA");
+  cache.add("kB", "vB");
+  cache.add("kC", "vC");
+  std::string v;
+  ASSERT_TRUE(cache.get("kA", &v));
+  ASSERT_STREQ(v.c_str(), "vA");
+  // kA just became MRU, so adding a new k/v pair should evict the oldest.
+  cache.add("kD", "vD");
+  ASSERT_FALSE(cache.get("kB", &v));
+  ASSERT_TRUE(cache.get("kD", &v));
+
+  // Test remove.
+  cache.remove("kD");
+  ASSERT_FALSE(cache.get("kD", &v));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -72,6 +72,7 @@ test("brave_unit_tests") {
     "//brave/common/tor/tor_test_constants.h",
     "//brave/components/assist_ranker/ranker_model_loader_impl_unittest.cc",
     "//brave/components/brave_shields/browser/ad_block_regional_service_unittest.cc",
+    "//brave/components/brave_shields/browser/https_everywhere_recently_used_cache_unittest.cpp",
     "//brave/components/brave_sync/bookmark_order_util_unittest.cc",
     "//brave/components/brave_sync/brave_sync_service_unittest.cc",
     "//brave/components/brave_sync/client/bookmark_change_processor_unittest.cc",


### PR DESCRIPTION
- Removes unused RingBuffer from HTTPSERecentlyUsedCache,
- Switches HTTPSERecentlyUsedCache to use base::MRUCache. Wraps MRUCache
  to make it thread safe,
- Adds a unit test for cache operations: add,get, and remove.

Fixes brave/brave-browser#3193

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Automated testing:
`npm run test -- brave_unit_test --filter=HTTPSEverywhereRecentlyUsedCacheTest.Operations`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
