### PR TITLE
Fix issue with confirmations _is_production boolean flag not matching ledger

### DIFF
--- a/vendor/bat-native-ledger/src/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/ledger_impl.cc
@@ -228,6 +228,8 @@ void LedgerImpl::OnLedgerStateLoaded(ledger::Result result,
 void LedgerImpl::SetConfirmationsWalletInfo(
     const braveledger_bat_helper::WALLET_INFO_ST& wallet_info) {
   if (!bat_confirmations_) {
+    confirmations::_is_production = ledger::is_production;
+
     bat_confirmations_.reset(
         confirmations::Confirmations::CreateInstance(ledger_client_));
   }


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3498

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Launch browser with `--rewards=staging=false` or an official build
- Check log to confirm production https://ads-serve.brave.com is used for communications with Ads Serve and not https://ads-serve.bravesoftware.com which is the staging serve


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
