### PR TITLE
Fixes missing twitch image for clips

### DIFF
--- a/vendor/bat-native-ledger/src/bat_get_media.cc
+++ b/vendor/bat-native-ledger/src/bat_get_media.cc
@@ -924,6 +924,27 @@ void BatGetMedia::onMediaPublisherActivity(ledger::Result result,
     }
   } else {
     if (providerType == TWITCH_MEDIA_TYPE) {
+      if (info->verified && info->favicon_url.empty()) {
+        std::string publisher_name;
+        std::string publisher_favicon_url;
+        updateTwitchPublisherData(publisher_name,
+                                  publisher_favicon_url,
+                                  publisher_blob);
+
+        if (!publisher_favicon_url.empty()) {
+          savePublisherInfo(0,
+                            media_key,
+                            providerType,
+                            visit_data.url,
+                            publisher_name,
+                            visit_data,
+                            windowId,
+                            publisher_favicon_url,
+                            media_id);
+          return;
+        }
+      }
+
       ledger_->OnPanelPublisherInfo(result, std::move(info), windowId);
     } else if (providerType == YOUTUBE_MEDIA_TYPE) {
       fetchPublisherDataFromDB(windowId,


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3404

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
* start with production flag
* enable rewards from BR panel
* visit twitch.tv and search for `neoness007` or `ekan1975`
* watch any clips from either of the publisher
* check BR panel and make sure that favicon is shown
* go to ac table and make sure that icon is there as well

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source
