### PR TITLE
Disables Ads on 0.61

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -192,6 +192,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
       std::string("rewards"), {
         { "adsCurrentEarnings",  IDS_BRAVE_REWARDS_LOCAL_ADS_CURRENT_EARNINGS },
         { "adsDesc",  IDS_BRAVE_REWARDS_LOCAL_ADS_DESC },
+        { "adsDisabledText", IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT },
         { "adsDisabledTextOne",  IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT_ONE },                // NOLINT
         { "adsDisabledTextTwo",  IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT_TWO },                // NOLINT
         { "adsNotificationsReceived",  IDS_BRAVE_REWARDS_LOCAL_ADS_NOTIFICATIONS_RECEIVED },     // NOLINT

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -452,11 +452,13 @@ void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
 }
 
 bool AdsServiceImpl::is_enabled() const {
-  bool ads_enabled = profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdsEnabled);
-  bool rewards_enabled = profile_->GetPrefs()->GetBoolean(
-      brave_rewards::prefs::kBraveRewardsEnabled);
-  return (ads_enabled && rewards_enabled);
+  // bool ads_enabled = profile_->GetPrefs()->GetBoolean(
+  //     prefs::kBraveAdsEnabled);
+  // bool rewards_enabled = profile_->GetPrefs()->GetBoolean(
+  //     brave_rewards::prefs::kBraveRewardsEnabled);
+  // return (ads_enabled && rewards_enabled);
+  // Ads are disabled in 0.61.x builds
+  return false;
 }
 
 bool AdsServiceImpl::IsAdsEnabled() const {

--- a/components/brave_rewards/resources/ui/components/adsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/adsBox.tsx
@@ -37,8 +37,7 @@ class AdsBox extends React.Component<Props, State> {
       <DisabledContent
         type={'ads'}
       >
-        • {getLocale('adsDisabledTextOne')} <br />
-        • {getLocale('adsDisabledTextTwo')}
+        <h3>{getLocale('adsDisabledText')}</h3>
       </DisabledContent>
     )
   }
@@ -89,27 +88,22 @@ class AdsBox extends React.Component<Props, State> {
 
   render () {
     let adsEnabled = false
-    let adsUIEnabled = false
-    const { adsData, enabledMain, firstLoad } = this.props.rewardsData
+    const { adsData, enabledMain } = this.props.rewardsData
 
     if (adsData) {
       adsEnabled = adsData.adsEnabled
-      adsUIEnabled = adsData.adsUIEnabled
     }
-
-    const toggle = !(!enabledMain || !adsUIEnabled)
-    const showDisabled = firstLoad !== false || !toggle || !adsEnabled
 
     return (
       <Box
         title={getLocale('adsTitle')}
         type={'ads'}
         description={getLocale('adsDesc')}
-        toggle={toggle}
+        toggle={false}
         checked={adsEnabled}
         settingsChild={this.adsSettings(adsEnabled && enabledMain)}
         testId={'braveAdsSettings'}
-        disabledContent={showDisabled ? this.adsDisabled() : null}
+        disabledContent={this.adsDisabled()}
         onToggle={this.onAdsSettingChange.bind(this, 'adsEnabled', '')}
         settingsOpened={this.state.settings}
         onSettingsClick={this.onSettingsToggle}

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -212,6 +212,7 @@
       <message name="IDS_BRAVE_REWARDS_LOCAL_CONTR_SITES" desc="">Supported sites</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_DONAT_TITLE" desc="">Tips</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_DONAT_DESC" desc="">Tip content creators directly as you browse. You can also set up recurring monthly tips so you can support sites continuously.</message>
+      <message name="IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT" desc="">Coming soon.</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT_ONE" desc="">Earnings are paid every month.</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_ADS_DISABLED_TEXT_TWO" desc="">Set your desired frequency to increase or decrease earnings.</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_CONTR_DISABLED_TEXT1" desc="">Reward creators for the content you love.</message>


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/3500

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Fresh profile, enable Rewards
2. Confirm that "Coming Soon" is shown under the Ads panel in Rewards settings
3. Confirm that the ad service is not running via logging
4. Repeat the test plan, but with an existing 0.61.x profile that had Ads enabled

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

cc: @mandar-brave @jsecretan 
