### PR TITLE
Resolved Ads Campaign ID, Daily Cap, Per Day and Total Max use incorrect database fields

### DIFF
--- a/components/brave_ads/browser/bundle_state_database.cc
+++ b/components/brave_ads/browser/bundle_state_database.cc
@@ -365,10 +365,10 @@ bool BundleStateDatabase::GetAdsForCategory(const std::string& region,
     info.start_timestamp = info_sql.ColumnString(4);
     info.end_timestamp = info_sql.ColumnString(5);
     info.uuid = info_sql.ColumnString(6);
-    info.campaign_id = info_sql.ColumnString(7);
-    info.daily_cap = info_sql.ColumnInt(8);
-    info.per_day = info_sql.ColumnInt(9);
-    info.total_max = info_sql.ColumnInt(10);
+    info.campaign_id = info_sql.ColumnString(8);
+    info.daily_cap = info_sql.ColumnInt(9);
+    info.per_day = info_sql.ColumnInt(10);
+    info.total_max = info_sql.ColumnInt(11);
     ads.emplace_back(info);
   }
 


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3530

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Navigate to www.imdb.com
- Wait 15 seconds for the browser to idle
- Open `Default/ads_service/client.json`
- campaignHistory array should show the campaign ID and not `US`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
