### PR TITLE
Resolved Confirmations state could be reset due to race condition when saving/loading state

### DIFF
--- a/vendor/bat-native-confirmations/src/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/confirmations_impl.cc
@@ -315,6 +315,10 @@ bool ConfirmationsImpl::GetTransactionHistoryFromDictionary(
 }
 
 void ConfirmationsImpl::SaveState() {
+  if (!is_initialized_) {
+    return;
+  }
+
   BLOG(INFO) << "Saving confirmations state";
 
   std::string json = ToJSON();


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3532

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- View an Ad
- Close browser
- Open `Defaults/rewards_service/confirmations.json` and confirm state changes after each Ad viewing, and does not reset to default values

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
