### PR TITLE
Determine third-party status in Brave-Core

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/ad-block": "https://github.com/brave/ad-block.git@23684aace94dd2ca655c5fb8a6efb8932439dde3",
+  "vendor/ad-block": "https://github.com/brave/ad-block.git@8a69dcea5eaef9e019d0ea7a98b4c35469ae2f1c",
   "vendor/autoplay-whitelist": "https://github.com/brave/autoplay-whitelist.git@458053a3c95b403cbe0872f289a2aafa106ee9d8",
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@e67738e656244f7ab6e0ed9815071ca744f5468f",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@4b55fe39bb25bb0d8b11a43d547d75f00c6c46fb",

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -20,7 +20,10 @@
 #include "base/threading/thread_restrictions.h"
 #include "brave/components/brave_shields/browser/dat_file_util.h"
 #include "brave/vendor/ad-block/ad_block_client.h"
+#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
+#include "url/origin.h"
 
+using namespace net::registry_controlled_domains;  // NOLINT
 
 namespace {
 
@@ -115,6 +118,17 @@ bool AdBlockBaseService::ShouldStartRequest(const GURL& url,
     bool* did_match_exception) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   FilterOption current_option = ResourceTypeToFilterOption(resource_type);
+
+  // Determine third-party here so the library doesn't need to figure it out.
+  // CreateFromNormalizedTuple is needed because SameDomainOrHost needs
+  // a URL or origin and not a string to a host name.
+  if (SameDomainOrHost(url, url::Origin::CreateFromNormalizedTuple(
+        "https", tab_host.c_str(), 80), INCLUDE_PRIVATE_REGISTRIES)) {
+    current_option = static_cast<FilterOption>(
+        current_option | FONotThirdParty);
+  } else {
+    current_option = static_cast<FilterOption>(current_option | FOThirdParty);
+  }
 
   Filter* matching_exception_filter = nullptr;
   if (ad_block_client_->matches(url.spec().c_str(),


### PR DESCRIPTION
Fix: https://github.com/brave/brave-browser/issues/3535
See also:  https://github.com/brave/ad-block/pull/188

Currently ad-block determines third party by sub-domain rules.
It should instead do eTLD+1 for this detection.
This makes it work more closely to uBlock and other ad-blocking libraries. 

Note to reviewer: 
I will update DEPS after the above `brave/ad-block` PR is landed.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
