### PR TITLE
Don't add brave url to history

### DIFF
--- a/chromium_src/chrome/browser/history/history_utils.cc
+++ b/chromium_src/chrome/browser/history/history_utils.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define CanAddURLToHistory CanAddURLToHistory_ChromiumImpl
+#include "../../../../../chrome/browser/history/history_utils.cc"  // NOLINT
+#undef CanAddURLToHistory
+
+bool CanAddURLToHistory(const GURL& url) {
+  if (!CanAddURLToHistory_ChromiumImpl(url))
+    return false;
+
+  return !url.SchemeIs(content::kBraveUIScheme);
+}

--- a/chromium_src/chrome/browser/history/history_utils_unittest.cc
+++ b/chromium_src/chrome/browser/history/history_utils_unittest.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/history/history_utils.h"
+#include "components/previews/core/previews_experiments.h"
+#include "net/base/url_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace {
+// Refered IsLitePageRedirectPreviewDomain() to make sample lite page url.
+GURL GetSampleLitePageUrl() {
+  return net::AppendQueryParameter(
+      previews::params::GetLitePagePreviewsDomainURL(),
+      "u", "1234");
+}
+}  // namespace
+
+// This test covers all cases that upstream and our version of
+// CanAddURLToHistory().
+TEST(HistoryUtilsTest, VariousURLTest) {
+  EXPECT_TRUE(CanAddURLToHistory(GURL("https://www.brave.com/")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("brave://sync/")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("javascript://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("about://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("content://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("chrome-devtools://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("chrome://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("view-source://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("chrome-native://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("chrome-search://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GURL("chrome-distiller://test")));
+  EXPECT_FALSE(CanAddURLToHistory(GetSampleLitePageUrl()));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -59,6 +59,7 @@ test("brave_unit_tests") {
     "//brave/browser/resources/settings/reset_report_uploader_unittest.cc",
     "//brave/browser/resources/settings/brandcode_config_fetcher_unittest.cc",
     "//brave/chromium_src/chrome/browser/external_protocol/external_protocol_handler_unittest.cc",
+    "//brave/chromium_src/chrome/browser/history/history_utils_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3493

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_unit_tests --filter=HistoryUtilsTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
