### PR TITLE
Fixes publisher info getting lost on publishers not in activity table

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1039,19 +1039,23 @@ void RewardsServiceImpl::LoadActivityInfo(
           0, 2, filter, publisher_info_backend_.get()),
       base::Bind(&RewardsServiceImpl::OnActivityInfoLoaded,
                      AsWeakPtr(),
-                     callback));
+                     callback,
+                     filter.id));
 }
 
 void RewardsServiceImpl::OnActivityInfoLoaded(
     ledger::PublisherInfoCallback callback,
+    const std::string& publisher_key,
     const ledger::PublisherInfoList list) {
   if (!Connected()) {
     return;
   }
 
+  // activity info not found
   if (list.size() == 0) {
-    callback(ledger::Result::NOT_FOUND,
-        std::unique_ptr<ledger::PublisherInfo>());
+    // we need to try to get at least publisher info in this case
+    // this way we preserve publisher info
+    LoadPublisherInfo(publisher_key, callback);
     return;
   } else if (list.size() > 1) {
     callback(ledger::Result::TOO_MANY_RESULTS,

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -221,7 +221,8 @@ class RewardsServiceImpl : public RewardsService,
                             std::unique_ptr<ledger::PublisherInfo> info,
                             bool success);
   void OnActivityInfoLoaded(ledger::PublisherInfoCallback callback,
-                             const ledger::PublisherInfoList list);
+                            const std::string& publisher_key,
+                            const ledger::PublisherInfoList list);
   void OnMediaPublisherInfoSaved(bool success);
   void OnPublisherInfoLoaded(ledger::PublisherInfoCallback callback,
                              std::unique_ptr<ledger::PublisherInfo> info);


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3551

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- clean profile 
- enable rewards
- visit a site and add it to ac table
- make sure that you see it the panel
- visit another site (don't stay on it for min visit time, if needed adjust min visit time to a minute)
- exclude site
- make sure that you see 1 excluded site in settings page
- close panel and open it again
- make sure that exclude status is preserved

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source
