### PR TITLE
Close settings modal when rewards are off

### DIFF
--- a/components/brave_rewards/resources/ui/components/adsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/adsBox.tsx
@@ -36,6 +36,15 @@ class AdsBox extends React.Component<Props, State> {
     }
   }
 
+  componentDidUpdate (prevProps: Props) {
+    if (
+      prevProps.rewardsData.enabledMain &&
+      !this.props.rewardsData.enabledMain
+    ) {
+      this.setState({ settings: false })
+    }
+  }
+
   adsDisabled = () => {
     return (
       <DisabledContent

--- a/components/brave_rewards/resources/ui/components/contributeBox.tsx
+++ b/components/brave_rewards/resources/ui/components/contributeBox.tsx
@@ -38,6 +38,15 @@ class ContributeBox extends React.Component<Props, State> {
     }
   }
 
+  componentDidUpdate (prevProps: Props) {
+    if (
+      prevProps.rewardsData.enabledMain &&
+      !this.props.rewardsData.enabledMain
+    ) {
+      this.setState({ settings: false })
+    }
+  }
+
   getContributeRows = (list: Rewards.Publisher[]) => {
     return list.map((item: Rewards.Publisher) => {
       let faviconUrl = `chrome://favicon/size/48@1x/${item.url}`


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3553

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- open settings for ac and ads
- disable rewards
- make sure that you see disabled content

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
