### PR TITLE
Show brave url on status bubble

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -38,6 +38,8 @@ source_set("ui") {
     "views/brave_actions/brave_action_view.h",
     "views/brave_actions/brave_actions_container.cc",
     "views/brave_actions/brave_actions_container.h",
+    "views/brave_status_bubble_views.cc",
+    "views/brave_status_bubble_views.h",
     "views/download/brave_download_item_view.cc",
     "views/download/brave_download_item_view.h",
     "views/frame/brave_browser_view.cc",

--- a/browser/ui/views/brave_status_bubble_views.cc
+++ b/browser/ui/views/brave_status_bubble_views.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_status_bubble_views.h"
+
+#include "content/public/common/url_constants.h"
+#include "url/gurl.h"
+
+void BraveStatusBubbleViews::SetURL(const GURL& url) {
+  GURL revised_url = url;
+  if (revised_url.SchemeIs(content::kChromeUIScheme)) {
+    GURL::Replacements replacements;
+    replacements.SetSchemeStr(content::kBraveUIScheme);
+    revised_url = revised_url.ReplaceComponents(replacements);
+  }
+
+  StatusBubbleViews::SetURL(revised_url);
+}

--- a/browser/ui/views/brave_status_bubble_views.h
+++ b/browser/ui/views/brave_status_bubble_views.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_STATUS_BUBBLE_VIEWS_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_STATUS_BUBBLE_VIEWS_H_
+
+#include "chrome/browser/ui/views/status_bubble_views.h"
+
+class BraveStatusBubbleViews : public StatusBubbleViews {
+ public:
+  using StatusBubbleViews::StatusBubbleViews;
+  ~BraveStatusBubbleViews() override = default;
+
+  // StatusBubbleViews overrides:
+  void SetURL(const GURL& url) override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(BraveStatusBubbleViews);
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_STATUS_BUBBLE_VIEWS_H_

--- a/browser/ui/views/brave_status_bubble_views_unittest.cc
+++ b/browser/ui/views/brave_status_bubble_views_unittest.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_status_bubble_views.h"
+
+#include "chrome/test/views/chrome_views_test_base.h"
+#include "ui/views/widget/widget.h"
+
+class BraveStatusBubbleViewsTest : public ChromeViewsTestBase {
+ protected:
+  // ChromeViewsTestBase overrides:
+  void SetUp() override {
+    ChromeViewsTestBase::SetUp();
+    CreateWidget();
+  }
+
+  void TearDown() override {
+    if (widget_ && !widget_->IsClosed())
+      widget_->Close();
+
+     ChromeViewsTestBase::TearDown();
+  }
+
+  views::Widget* widget() const {
+    return widget_;
+  }
+
+ private:
+  void CreateWidget() {
+    DCHECK(!widget_);
+    widget_ = new views::Widget;
+    views::Widget::InitParams params =
+        CreateParams(views::Widget::InitParams::TYPE_WINDOW_FRAMELESS);
+    widget_->Init(params);
+  }
+
+  views::Widget* widget_ = nullptr;
+};
+
+TEST_F(BraveStatusBubbleViewsTest, SetURLTest) {
+  BraveStatusBubbleViews bubble(widget()->GetContentsView());
+  bubble.SetURL(GURL("chrome://settings/"));
+  EXPECT_EQ(GURL("brave://settings/"), bubble.url_);
+
+  const GURL brave_url("https://www.brave.com/");
+  bubble.SetURL(brave_url);
+  EXPECT_EQ(brave_url, bubble.url_);
+}

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
@@ -1,6 +1,13 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "brave/browser/ui/views/brave_status_bubble_views.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 
 #define ToolbarView BraveToolbarView
+#define StatusBubbleViews BraveStatusBubbleViews
 
-#include "../../../../../../../chrome/browser/ui/views/frame/browser_view.cc"
+#include "../../../../../../../chrome/browser/ui/views/frame/browser_view.cc"  // NOLINT

--- a/patches/chrome-browser-ui-views-status_bubble_views.h.patch
+++ b/patches/chrome-browser-ui-views-status_bubble_views.h.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/ui/views/status_bubble_views.h b/chrome/browser/ui/views/status_bubble_views.h
+index b2ad6e5d19f119f58df8deb7fa8a840a04681628..036d48dbdccc20eb300ba43bff0413e1ac281f99 100644
+--- a/chrome/browser/ui/views/status_bubble_views.h
++++ b/chrome/browser/ui/views/status_bubble_views.h
+@@ -70,6 +70,9 @@ class StatusBubbleViews : public StatusBubble {
+ 
+  private:
+   friend class StatusBubbleViewsTest;
++#if defined(BRAVE_CHROMIUM_BUILD)
++  FRIEND_TEST_ALL_PREFIXES(BraveStatusBubbleViewsTest, SetURLTest);
++#endif
+ 
+   class StatusView;
+   class StatusViewAnimation;

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -42,6 +42,7 @@ test("brave_unit_tests") {
     "//brave/browser/brave_resources_util_unittest.cc",
     "//brave/browser/brave_stats_updater_unittest.cc",
     "//brave/browser/download/brave_download_item_model_unittest.cc",
+    "//brave/browser/ui/views/brave_status_bubble_views_unittest.cc",
     "//brave/browser/tor/mock_tor_profile_service_impl.cc",
     "//brave/browser/tor/mock_tor_profile_service_impl.h",
     "//brave/browser/tor/mock_tor_profile_service_factory.cc",


### PR DESCRIPTION
SetURL() is called when renderer sent ViewHostMsg_UpdateTargetURL message.
So, replacing that url should be done at bubble instead of the middle of that path.

Fix https://github.com/brave/brave-browser/issues/2566

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_unit_tests --filter= BraveStatusBubbleViewsTest*`

1. Open new tab
2. Hover settings button
3. Check status bubble shows brave://settings instead of chrome://settings
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
