### PR TITLE
Ensure task scheduler used by ledger lib is initialized before creati…

### DIFF
--- a/vendor/bat-native-ledger/src/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/ledger_impl.h
@@ -505,6 +505,7 @@ class LedgerImpl : public ledger::Ledger,
   bat_contribution_;
   std::unique_ptr<confirmations::Confirmations> bat_confirmations_;
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
+  bool initialized_task_scheduler_;
 
   bool initialized_;
   bool initializing_;


### PR DESCRIPTION
…ng the task runner.

Task scheduler used in the ledger lib is already initialized by chromium code
in the desktop case, which is running in an utility process, but not in iOS.
This commit add a check to initialize a task scheduler if it is not initialized
to fix crashes in iOS.

Fix https://github.com/brave/brave-browser/issues/3571

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
desktop: See test plan specified in https://github.com/brave/brave-core/pull/1800
iOS: create wallet should work

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
