### PR TITLE
Refactoring BraveToolbarView to live on flex layout

### DIFF
--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -9,29 +9,70 @@
 #include <memory>
 #include <utility>
 
+#include "base/bind.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/common/pref_names.h"
 #include "chrome/browser/defaults.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
-#include "chrome/browser/extensions/extension_util.h"
 #include "chrome/browser/ui/bookmarks/bookmark_bubble_sign_in_delegate.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bubble_view.h"
-#include "chrome/browser/ui/views/toolbar/browser_app_menu_button.h"
-#include "chrome/browser/ui/views/toolbar/home_button.h"
-#include "chrome/browser/ui/views/toolbar/reload_button.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "components/prefs/pref_service.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
-#include "ui/base/material_design/material_design_controller.h"
 
 namespace {
+constexpr int kLocationBarMaxWidth = 1080;
 
-int GetToolbarHorizontalPadding() {
-  // In the touch-optimized UI, we don't use any horizontal paddings; the back
-  // button starts from the beginning of the view, and the app menu button ends
-  // at the end of the view.
-  return ui::MaterialDesignController::touch_ui() ? 0 : 8;
+double GetLocationBarMarginHPercent(int toolbar_width) {
+  double location_bar_margin_h_pc = 0.07;
+  if (toolbar_width < 700)
+    location_bar_margin_h_pc = 0;
+  else if (toolbar_width < 850)
+    location_bar_margin_h_pc = 0.03;
+  else if (toolbar_width < 1000)
+    location_bar_margin_h_pc = 0.05;
+  return location_bar_margin_h_pc;
+}
+
+gfx::Insets CalcLocationBarMargin(int toolbar_width,
+                                  int available_location_bar_width,
+                                  int location_bar_min_width,
+                                  int location_bar_x) {
+  // Apply the target margin, adjusting for min and max width of LocationBar
+  // Make sure any margin doesn't shrink the LocationBar beyond minimum width
+  int location_bar_max_margin_h = (
+      available_location_bar_width - location_bar_min_width) / 2;
+  int location_bar_margin_h =
+      std::min(static_cast<int>(
+                   toolbar_width * GetLocationBarMarginHPercent(toolbar_width)),
+               location_bar_max_margin_h);
+  int location_bar_width =
+      available_location_bar_width - (location_bar_margin_h * 2);
+  // Allow the margin to expand so LocationBar is restrained to max width
+  if (location_bar_width > kLocationBarMaxWidth) {
+    location_bar_margin_h += (location_bar_width - kLocationBarMaxWidth) / 2;
+    location_bar_width = kLocationBarMaxWidth;
+  }
+
+  // Center LocationBar as much as possible within Toolbar
+  const int location_bar_toolbar_center_point =
+      location_bar_x + location_bar_margin_h + (location_bar_width / 2);
+  // Calculate offset - positive for move left and negative for move right
+  int location_bar_center_offset =
+      location_bar_toolbar_center_point - (toolbar_width / 2);
+  // Can't shim more than we have space for, so restrict to margin size
+  // or in the case of moving-right, 25% of the space since we want to avoid
+  // touching browser actions where possible
+  location_bar_center_offset = (location_bar_center_offset > 0)
+      ? std::min(location_bar_margin_h, location_bar_center_offset)
+      : std::max(static_cast<int>(-location_bar_margin_h * .25),
+                 location_bar_center_offset);
+
+  // // Apply offset to margin
+  const int location_bar_margin_l =
+      location_bar_margin_h - location_bar_center_offset;
+  const int location_bar_margin_r =
+      location_bar_margin_h + location_bar_center_offset;
+  return { 0, location_bar_margin_l, 0, location_bar_margin_r };
 }
 
 }  // namespace
@@ -44,6 +85,11 @@ BraveToolbarView::~BraveToolbarView() {}
 
 void BraveToolbarView::Init() {
   ToolbarView::Init();
+
+  // For non-normal mode, we don't have to more.
+  if (display_mode_ != DisplayMode::NORMAL)
+    return;
+
   // track changes in bookmarks enabled setting
   edit_bookmarks_enabled_.Init(
       bookmarks::prefs::kEditBookmarksEnabled, browser()->profile()->GetPrefs(),
@@ -54,23 +100,24 @@ void BraveToolbarView::Init() {
       kLocationBarIsWide, browser()->profile()->GetPrefs(),
       base::Bind(&BraveToolbarView::OnLocationBarIsWideChanged,
                  base::Unretained(this)));
-  // Only location bar in non-normal mode
-  if (display_mode_ != DisplayMode::NORMAL) {
-    return;
-  }
 
   bookmark_ = new BookmarkButton(this);
   bookmark_->set_triggerable_event_flags(
       ui::EF_LEFT_MOUSE_BUTTON | ui::EF_MIDDLE_MOUSE_BUTTON);
   bookmark_->Init();
-  AddChildView(bookmark_);
+
+  DCHECK(location_bar_);
+  AddChildViewAt(bookmark_, GetIndexOf(location_bar_));
 }
 
 void BraveToolbarView::OnEditBookmarksEnabledChanged() {
+  DCHECK_EQ(DisplayMode::NORMAL, display_mode_);
   Update(nullptr);
 }
 
 void BraveToolbarView::OnLocationBarIsWideChanged() {
+  DCHECK_EQ(DisplayMode::NORMAL, display_mode_);
+
   Layout();
   SchedulePaint();
 }
@@ -80,7 +127,7 @@ void BraveToolbarView::Update(content::WebContents* tab) {
   // Decide whether to show the bookmark button
   if (bookmark_) {
     bookmark_->SetVisible(browser_defaults::bookmarks_enabled &&
-      edit_bookmarks_enabled_.GetValue());
+                          edit_bookmarks_enabled_.GetValue());
   }
 }
 
@@ -91,239 +138,64 @@ void BraveToolbarView::ShowBookmarkBubble(
   // Show BookmarkBubble attached to Brave's bookmark button
   // or the location bar if there is no bookmark button
   // (i.e. in non-normal display mode).
-  views::View* anchor_view = location_bar();
-  BookmarkButton* const star_view = bookmark_button();
-  if (star_view && star_view->visible())
-    anchor_view = star_view;
+  views::View* anchor_view = location_bar_;
+  if (bookmark_ && bookmark_->visible())
+    anchor_view = bookmark_;
 
   std::unique_ptr<BubbleSyncPromoDelegate> delegate;
   delegate.reset(new BookmarkBubbleSignInDelegate(browser()));
   views::Widget* bubble_widget = BookmarkBubbleView::ShowBubble(
-      anchor_view, star_view, gfx::Rect(), nullptr,
+      anchor_view, bookmark_, gfx::Rect(), nullptr,
       observer, std::move(delegate), browser_->profile(),
       url, already_bookmarked);
 
-  if (bubble_widget && star_view)
-    star_view->OnBubbleWidgetCreated(bubble_widget);
-}
-
-// Returns right-margin
-int BraveToolbarView::SetLocationBarBounds(const int available_width,
-                                          const int location_bar_min_width,
-                                          const int next_element_x,
-                                          const int element_padding) {
-  DCHECK(initialized_);
-  DCHECK(display_mode_ == DisplayMode::NORMAL);
-  // Allow the option of the LocationBar having horizontal margin.
-  // With this option, we support a dynamic percentage of margin, with
-  // a maximum width.
-  const bool restrict_location_bar_width = !location_bar_is_wide_.GetValue();
-  const int location_bar_max_width = restrict_location_bar_width
-                                      ? 1080
-                                      : available_width;
-  const auto toolbar_width = width();
-  int location_bar_width = available_width;
-  int location_bar_margin_h = 0;
-  int location_bar_center_offset = 0;
-  if (restrict_location_bar_width) {
-    double location_bar_margin_h_pc = 0.07;
-    if (toolbar_width < 700)
-      location_bar_margin_h_pc = 0;
-    else if (toolbar_width < 850)
-      location_bar_margin_h_pc = 0.03;
-    else if (toolbar_width < 1000)
-      location_bar_margin_h_pc = 0.05;
-    // Apply the target margin, adjusting for min and max width of LocationBar
-    // Make sure any margin doesn't shrink the LocationBar beyond minimum width
-    if (available_width > location_bar_min_width) {
-      int location_bar_max_margin_h = (
-          available_width - location_bar_min_width) / 2;
-      location_bar_margin_h = std::min(static_cast<int>(toolbar_width *
-                                           location_bar_margin_h_pc),
-                                       location_bar_max_margin_h);
-      location_bar_width = available_width - (location_bar_margin_h * 2);
-      // Allow the margin to expand so LocationBar is restrained to max width
-      if (location_bar_width > location_bar_max_width) {
-        location_bar_margin_h += (location_bar_width - location_bar_max_width) /
-                                  2;
-        location_bar_width = location_bar_max_width;
-      }
-    }
-    // Center LocationBar as much as possible within Toolbar
-    const int location_bar_toolbar_center_point =
-                                        next_element_x +
-                                        location_bar_margin_h +
-                                        (location_bar_width / 2);
-    // Calculate offset - positive for move left and negative for move right
-    location_bar_center_offset = location_bar_toolbar_center_point -
-                                                            (toolbar_width / 2);
-    // Can't shim more than we have space for, so restrict to margin size
-    // or in the case of moving-right, 25% of the space since we want to avoid
-    // touching browser actions where possible
-    location_bar_center_offset = (location_bar_center_offset > 0)
-                                ? std::min(location_bar_margin_h,
-                                          location_bar_center_offset)
-                                : std::max(static_cast<int>(
-                                      -location_bar_margin_h * .25),
-                                    location_bar_center_offset);
-  }
-  // Apply offset to margin
-  const int location_bar_margin_l = location_bar_margin_h -
-                                    location_bar_center_offset;
-  const int location_bar_margin_r = location_bar_margin_h +
-                                    location_bar_center_offset;
-
-  const int location_x = next_element_x + location_bar_margin_l;
-  const int location_height = location_bar_->GetPreferredSize().height();
-  const int location_y = (height() - location_height) / 2;
-
-  location_bar_->SetBounds(location_x, location_y,
-                           location_bar_width,
-                           location_height);
-
-  return location_bar_margin_r;
+  if (bubble_widget && bookmark_)
+    bookmark_->OnBubbleWidgetCreated(bubble_widget);
 }
 
 void BraveToolbarView::Layout() {
-  // If we have not been initialized yet just do nothing.
+  ToolbarView::Layout();
+
   if (!initialized_)
     return;
 
-  if (display_mode_ != DisplayMode::NORMAL) {
-    location_bar_->SetBounds(0, 0, width(),
-                             location_bar_->GetPreferredSize().height());
+  // ToolbarView::Layout() handles below modes. So just return.
+  if (display_mode_ == DisplayMode::CUSTOM_TAB ||
+      display_mode_ == DisplayMode::LOCATION) {
     return;
   }
 
-  // We assume all toolbar buttons except for the browser actions are the same
-  // height. Set toolbar_button_y such that buttons appear vertically centered.
-  const int toolbar_button_height =
-      std::min(back_->GetPreferredSize().height(), height());
-  const int toolbar_button_y = (height() - toolbar_button_height) / 2;
-
-  // If the window is maximized, we extend the back button to the left so that
-  // clicking on the left-most pixel will activate the back button.
-  // TODO(abarth):  If the window becomes maximized but is not resized,
-  //                then Layout() might not be called and the back button
-  //                will be slightly the wrong size.  We should force a
-  //                Layout() in this case.
-  //                http://crbug.com/5540
-  const bool maximized =
-      browser_->window() && browser_->window()->IsMaximized();
-  // The padding at either end of the toolbar.
-  const int end_padding = GetToolbarHorizontalPadding();
-  back_->SetLeadingMargin(maximized ? end_padding : 0);
-  back_->SetBounds(maximized ? 0 : end_padding, toolbar_button_y,
-                   back_->GetPreferredSize().width(), toolbar_button_height);
-  const int element_padding = GetLayoutConstant(TOOLBAR_ELEMENT_PADDING);
-  int next_element_x = back_->bounds().right() + element_padding;
-
-  forward_->SetBounds(next_element_x, toolbar_button_y,
-                      forward_->GetPreferredSize().width(),
-                      toolbar_button_height);
-  next_element_x = forward_->bounds().right() + element_padding;
-
-  reload_->SetBounds(next_element_x, toolbar_button_y,
-                     reload_->GetPreferredSize().width(),
-                     toolbar_button_height);
-  next_element_x = reload_->bounds().right();
-
-  home_->SetSize(
-      gfx::Size(home_->GetPreferredSize().width(), toolbar_button_height));
-  if (show_home_button_.GetValue() ||
-      (browser_->is_app() && extensions::util::IsNewBookmarkAppsEnabled())) {
-    home_->SetVisible(true);
-    next_element_x += element_padding;
-    home_->SetPosition(gfx::Point(next_element_x, toolbar_button_y));
-    next_element_x += home_->width();
-  } else {
-    home_->SetVisible(false);
+  if (!location_bar_is_wide_.GetValue()) {
+    ResetLocationBarBounds();
+    ResetBookmarkButtonBounds();
   }
-  next_element_x += element_padding;
+}
 
-  // Position Brave's BookmarkButton
-  // Only reserve space since the positioning will happen after LocationBar
-  // position is calculated so we can anchor BookmarkButton inside LocationBar's
-  // margin.
-  const bool bookmark_show = (bookmark_ && bookmark_->visible());
-  if (bookmark_show)
-    next_element_x += bookmark_->GetPreferredSize().width() + element_padding;
-  int app_menu_width = app_menu_button_->GetPreferredSize().width();
-  const int right_padding = GetLayoutConstant(TOOLBAR_STANDARD_SPACING);
+void BraveToolbarView::ResetLocationBarBounds() {
+  DCHECK_EQ(DisplayMode::NORMAL, display_mode_);
 
-  // Note that the browser actions container has its own internal left and right
-  // padding to visually separate it from the location bar and app menu button.
-  // However if the container is empty we must account for the |right_padding|
-  // value used to visually separate the location bar and app menu button.
-  int available_width = std::max(
-      0,
-      width() - end_padding - app_menu_width -
-      (browser_actions_->GetPreferredSize().IsEmpty() ? right_padding : 0) -
-      next_element_x);
-  if (avatar_) {
-    available_width -= avatar_->GetPreferredSize().width();
-    available_width -= element_padding;
-  }
+  // Calculate proper location bar's margin and set its bounds.
+  const gfx::Insets margin =
+      CalcLocationBarMargin(width(),
+                            location_bar_->width(),
+                            location_bar_->GetMinimumSize().width(),
+                            location_bar_->x());
 
-  // Allow the extension actions to take up a share of the available width,
-  // but consider the minimum for the location bar
-  const int location_bar_min_width = location_bar_->GetMinimumSize().width();
-  const int browser_actions_width = browser_actions_->GetWidthForMaxWidth(
-      available_width - location_bar_min_width);
-  available_width -= browser_actions_width;
+  location_bar_->SetBounds(location_bar_->x() + margin.left(),
+                           location_bar_->y(),
+                           location_bar_->width() - margin.width(),
+                           location_bar_->height());
+}
 
-  const int location_bar_margin_r = SetLocationBarBounds(available_width,
-                                                        location_bar_min_width,
-                                                        next_element_x,
-                                                        element_padding);
-  // Position the bookmark button so it is anchored to the LocationBar
-  auto location_bar_bounds = location_bar_->bounds();
-  if (bookmark_show) {
-    const int bookmark_width = bookmark_->GetPreferredSize().width();
-    const int bookmark_x = location_bar_bounds.x() -
-                            bookmark_width -
-                            element_padding;
-    bookmark_->SetBounds(bookmark_x,
-                        toolbar_button_y,
-                        bookmark_width,
-                        toolbar_button_height);
-  }
-  next_element_x = location_bar_bounds.right() + location_bar_margin_r;
+void BraveToolbarView::ResetBookmarkButtonBounds() {
+  DCHECK_EQ(DisplayMode::NORMAL, display_mode_);
 
-  // Note height() may be zero in fullscreen.
-  const int browser_actions_height =
-      std::min(browser_actions_->GetPreferredSize().height(), height());
-  const int browser_actions_y = (height() - browser_actions_height) / 2;
-  browser_actions_->SetBounds(next_element_x, browser_actions_y,
-                              browser_actions_width, browser_actions_height);
-  next_element_x = browser_actions_->bounds().right();
-  if (!browser_actions_width)
-    next_element_x += right_padding;
+  if (!bookmark_ || !bookmark_->visible())
+    return;
 
-  // The browser actions need to do a layout explicitly, because when an
-  // extension is loaded/unloaded/changed, BrowserActionContainer removes and
-  // re-adds everything, regardless of whether it has a page action. For a
-  // page action, browser action bounds do not change, as a result of which
-  // SetBounds does not do a layout at all.
-  // TODO(sidchat): Rework the above behavior so that explicit layout is not
-  //                required.
-  browser_actions_->Layout();
-
-  if (avatar_) {
-    avatar_->SetBounds(next_element_x, toolbar_button_y,
-                       avatar_->GetPreferredSize().width(),
-                       toolbar_button_height);
-    next_element_x = avatar_->bounds().right() + element_padding;
-  }
-
-  // Extend the app menu to the screen's right edge in maximized mode just like
-  // we extend the back button to the left edge.
-  if (maximized)
-    app_menu_width += end_padding;
-
-  // Set trailing margin before updating the bounds so OnBoundsChange can use
-  // the trailing margin.
-  app_menu_button_->SetTrailingMargin(maximized ? end_padding : 0);
-  app_menu_button_->SetBounds(next_element_x, toolbar_button_y, app_menu_width,
-                              toolbar_button_height);
+  const int button_right_margin = GetLayoutConstant(TOOLBAR_STANDARD_SPACING);
+  const int bookmark_width = bookmark_->GetPreferredSize().width();
+  const int bookmark_x =
+      location_bar_->x() - bookmark_width - button_right_margin;
+  bookmark_->SetX(bookmark_x);
 }

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -26,10 +26,9 @@ class BraveToolbarView : public ToolbarView {
                           bool already_bookmarked,
                           bookmarks::BookmarkBubbleObserver* observer) override;
  private:
-  int SetLocationBarBounds(const int available_width,
-                           const int location_bar_min_width,
-                           const int next_element_x,
-                           const int element_padding);
+  void ResetLocationBarBounds();
+  void ResetBookmarkButtonBounds();
+
   BookmarkButton* bookmark_ = nullptr;
   // Tracks the preference to determine whether bookmark editing is allowed.
   BooleanPrefMember edit_bookmarks_enabled_;


### PR DESCRIPTION
ToolbarView is changed to use flex layout from maunual layout.
So, we also should live on that.
After finishing layout for wide mode, bounds of location bar and bookmark button
is reset.

This refactoring also fixes dcheck failure when minimizing/restore windows
Fix https://github.com/brave/brave-browser/issues/3559

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Launch browser on Windows
2. Minimize and Restore
3. Check crash doesn't happened

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
