### PR TITLE
Updated DEPS for sync js lib

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@b8ef1a3f85aec0a0522a9230d59b3958a2150fab",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@a8b5938c48acb336eba106f4eed99b46b93c6b79",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@76bf8f1295b46a7112756af631a8f5cd217953e6",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@518d17d97003d1ccb2116c498ab363e0834e184c",
   "vendor/bat-native-ads": "https://github.com/brave-intl/bat-native-ads.git@77224b70f0dda09e184c9cf1237d8bc74bc27aa3",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/3515 .
New sync lib head commit for DEPS is https://github.com/brave/sync/commit/76bf8f1295b46a7112756af631a8f5cd217953e6 .

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues/3515) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
The STR from https://github.com/brave/brave-browser/issues/3515

   1. Create sync chain on brave-core device A
   2. Connect to the sync chain device B with code words
   3. On the device A open the following tabs:
brave://bookmarks/
https://www.bing.com/search?q=BCA-01&qs=n&form=QBLH&sp=-1&pq=bca-01&sc=8-6&sk=&cvid=4CE2DC7674794F3C89E4F55DE31BBD2A
https://www.bing.com/search?q=BCA-02&qs=n&form=QBRE&sp=-1&pq=bca-02&sc=8-6&sk=&cvid=DA80C45365A54CF4880E4F853CE72332
https://www.bing.com/search?q=BCA-03&qs=n&form=QBRE&sp=-1&pq=bca-03&sc=8-6&sk=&cvid=5E00C210D471463EB9ECF64D9EC703DA
   4. On device A bookmark tabs of `BCA-01` and `BCA-02` as quick as possible
   5. On device B wait until `BCA-01` and `BCA-02` appear.  When this happened as quick as possible, on device A unbookmark `BCA-02` tab and bookmark `BCA-03` tab
   6. On device B `BCA-02` is removed   

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
