### PR TITLE
Adding method to get Rewards enabled status in webui

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -106,6 +106,8 @@ class RewardsDOMHandler : public WebUIMessageHandler,
       brave_rewards::RewardsService* rewards_service) override;
   void GetAddressesForPaymentId(const base::ListValue* args);
   void GetConfirmationsHistory(const base::ListValue* args);
+  void GetRewardsMainEnabled(const base::ListValue* args);
+  void OnGetRewardsMainEnabled(bool enabled);
 
   void OnConfirmationsHistory(int total_viewed, double estimated_earnings);
 
@@ -272,6 +274,9 @@ void RewardsDOMHandler::RegisterMessages() {
       base::Unretained(this)));
   web_ui()->RegisterMessageCallback("brave_rewards.getConfirmationsHistory",
       base::BindRepeating(&RewardsDOMHandler::GetConfirmationsHistory,
+      base::Unretained(this)));
+  web_ui()->RegisterMessageCallback("brave_rewards.getRewardsMainEnabled",
+      base::BindRepeating(&RewardsDOMHandler::GetRewardsMainEnabled,
       base::Unretained(this)));
 }
 
@@ -990,6 +995,21 @@ void RewardsDOMHandler::OnConfirmationsHistoryChanged(
   if (web_ui()->CanCallJavascript()) {
     web_ui()->CallJavascriptFunctionUnsafe(
         "brave_rewards.confirmationsHistoryChanged");
+  }
+}
+
+void RewardsDOMHandler::GetRewardsMainEnabled(
+    const base::ListValue* args) {
+  rewards_service_->GetRewardsMainEnabled(base::Bind(
+          &RewardsDOMHandler::OnGetRewardsMainEnabled,
+          weak_factory_.GetWeakPtr()));
+}
+
+void RewardsDOMHandler::OnGetRewardsMainEnabled(
+    bool enabled) {
+  if (web_ui()->CanCallJavascript()) {
+    web_ui()->CallJavascriptFunctionUnsafe("brave_rewards.rewardsEnabled",
+        base::Value(enabled));
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/3598
Partially fixes: https://github.com/brave/browser-android-tabs/issues/1232

The issue in Android is that Rewards can now be enabled from the panel, and if `brave://rewards` is closed when this happens, the result of `OnRewardsMainEnabled` never fires and updates the setting state. 

This provides `brave_rewards.getRewardsMainEnabled` which can be called in the Android client side code to get the enabled status on settings page mount. We do not need to modify any JS in core for now.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
