### PR TITLE
lock node to v11.10.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "11.10.1"
 
 dist: trusty
 sudo: required


### PR DESCRIPTION
@yachtcaptain23 pointed out this bug https://github.com/facebook/jest/issues/8069 which is affecting us as well.

solution is to lock Node in Travis until an upstream fix happens. v11.10.1 is the latest version before the bug that I did the check.