### PR TITLE
Fixes ads state being out of sync

### DIFF
--- a/components/brave_rewards/resources/ui/components/settingsPage.tsx
+++ b/components/brave_rewards/resources/ui/components/settingsPage.tsx
@@ -40,6 +40,7 @@ class SettingsPage extends React.Component<Props, {}> {
     this.actions.getReconcileStamp()
     this.actions.getConfirmationsHistory()
     this.actions.getExcludedPublishersNumber()
+    this.actions.getAdsData()
   }
 
   componentDidMount () {
@@ -59,7 +60,6 @@ class SettingsPage extends React.Component<Props, {}> {
 
     if (this.props.rewardsData.firstLoad === false) {
       this.refreshActions()
-      this.actions.getAdsData()
     }
     this.actions.checkImported()
     this.actions.getGrants()


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3309

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- enable rewards
- turn rewards off
- reload page
- turn rewards on
- make sure that ads are turned on

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
