### PR TITLE
Implement additional ad event confirmations

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -606,8 +606,8 @@ void AdsServiceImpl::SetCatalogIssuers(std::unique_ptr<ads::IssuersInfo> info) {
   rewards_service_->SetCatalogIssuers(info->ToJson());
 }
 
-void AdsServiceImpl::AdSustained(std::unique_ptr<ads::NotificationInfo> info) {
-  rewards_service_->AdSustained(info->ToJson());
+void AdsServiceImpl::ConfirmAd(std::unique_ptr<ads::NotificationInfo> info) {
+  rewards_service_->ConfirmAd(info->ToJson());
 }
 
 void AdsServiceImpl::NotificationTimedOut(uint32_t timer_id,

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -110,7 +110,7 @@ class AdsServiceImpl : public AdsService,
   const std::string GenerateUUID() const override;
   void ShowNotification(std::unique_ptr<ads::NotificationInfo> info) override;
   void SetCatalogIssuers(std::unique_ptr<ads::IssuersInfo> info) override;
-  void AdSustained(std::unique_ptr<ads::NotificationInfo> info) override;
+  void ConfirmAd(std::unique_ptr<ads::NotificationInfo> info) override;
   uint32_t SetTimer(const uint64_t time_offset) override;
   void KillTimer(uint32_t timer_id) override;
   void URLRequest(const std::string& url,

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -172,7 +172,7 @@ class RewardsService : public KeyedService {
   // TODO(Terry Mancey): remove this hack when ads is moved to the same process
   // as ledger
   virtual void SetCatalogIssuers(const std::string& json) = 0;
-  virtual void AdSustained(const std::string& json) = 0;
+  virtual void ConfirmAd(const std::string& json) = 0;
   virtual void GetRewardsInternalsInfo(
       GetRewardsInternalsInfoCallback callback) = 0;
 

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1477,12 +1477,12 @@ std::pair<uint64_t, uint64_t> RewardsServiceImpl::GetEarningsRange() {
   return std::make_pair(from_timestamp, to_timestamp);
 }
 
-void RewardsServiceImpl::AdSustained(const std::string& json) {
+void RewardsServiceImpl::ConfirmAd(const std::string& json) {
   if (!Connected()) {
     return;
   }
 
-  bat_ledger_->AdSustained(json);
+  bat_ledger_->ConfirmAd(json);
 }
 
 void RewardsServiceImpl::SetConfirmationsIsReady(const bool is_ready) {
@@ -1525,12 +1525,17 @@ void RewardsServiceImpl::OnGetConfirmationsHistory(
     callback.Run(0, 0.0);
   }
 
-  int total_viewed = info->transactions.size();
   double estimated_earnings = 0.0;
-  if (total_viewed > 0) {
-    for (const auto& transaction : info->transactions) {
-      estimated_earnings += transaction.estimated_redemption_value;
+  int total_viewed = 0;
+
+  for (const auto& transaction : info->transactions) {
+    // "view" is defined in confirmations::kConfirmationTypeView
+    if (transaction.confirmation_type != "view") {
+      continue;
     }
+
+    estimated_earnings += transaction.estimated_redemption_value;
+    total_viewed++;
   }
 
   callback.Run(total_viewed, estimated_earnings);

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -338,7 +338,7 @@ class RewardsServiceImpl : public RewardsService,
   void SetUserChangedContribution() const override;
   void SetAutoContribute(bool enabled) const override;
   void SetCatalogIssuers(const std::string& json) override;
-  void AdSustained(const std::string& json) override;
+  void ConfirmAd(const std::string& json) override;
   void SetConfirmationsIsReady(const bool is_ready) override;
   void GetConfirmationsHistory(
       brave_rewards::ConfirmationsHistoryCallback callback) override;

--- a/components/services/bat_ads/bat_ads_client_mojo_bridge.cc
+++ b/components/services/bat_ads/bat_ads_client_mojo_bridge.cc
@@ -163,12 +163,12 @@ void BatAdsClientMojoBridge::SetCatalogIssuers(
   bat_ads_client_->SetCatalogIssuers(info->ToJson());
 }
 
-void BatAdsClientMojoBridge::AdSustained(
+void BatAdsClientMojoBridge::ConfirmAd(
     std::unique_ptr<ads::NotificationInfo> info) {
   if (!connected())
     return;
 
-  bat_ads_client_->AdSustained(info->ToJson());
+  bat_ads_client_->ConfirmAd(info->ToJson());
 }
 
 uint32_t BatAdsClientMojoBridge::SetTimer(const uint64_t time_offset) {

--- a/components/services/bat_ads/bat_ads_client_mojo_bridge.h
+++ b/components/services/bat_ads/bat_ads_client_mojo_bridge.h
@@ -32,7 +32,7 @@ class BatAdsClientMojoBridge : public ads::AdsClient {
   const std::string GenerateUUID() const override;
   void ShowNotification(std::unique_ptr<ads::NotificationInfo> info) override;
   void SetCatalogIssuers(std::unique_ptr<ads::IssuersInfo> info) override;
-  void AdSustained(std::unique_ptr<ads::NotificationInfo> info) override;
+  void ConfirmAd(std::unique_ptr<ads::NotificationInfo> info) override;
   uint32_t SetTimer(const uint64_t time_offset) override;
   void KillTimer(uint32_t timer_id) override;
   void URLRequest(const std::string& url,

--- a/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.cc
+++ b/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.cc
@@ -314,10 +314,10 @@ void AdsClientMojoBridge::SetCatalogIssuers(
   }
 }
 
-void AdsClientMojoBridge::AdSustained(const std::string& notification_info) {
+void AdsClientMojoBridge::ConfirmAd(const std::string& notification_info) {
   auto info = std::make_unique<ads::NotificationInfo>();
   if (info->FromJson(notification_info) == ads::Result::SUCCESS)
-    ads_client_->AdSustained(std::move(info));
+    ads_client_->ConfirmAd(std::move(info));
 }
 
 // static

--- a/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.h
+++ b/components/services/bat_ads/public/cpp/ads_client_mojo_bridge.h
@@ -74,7 +74,7 @@ class AdsClientMojoBridge : public mojom::BatAdsClient,
   void LoadSampleBundle(LoadSampleBundleCallback callback) override;
   void ShowNotification(const std::string& notification_info) override;
   void SetCatalogIssuers(const std::string& issuers_info) override;
-  void AdSustained(const std::string& notification_info) override;
+  void ConfirmAd(const std::string& notification_info) override;
   void SaveBundleState(const std::string& bundle_state,
                        SaveBundleStateCallback callback) override;
   void GetAds(const std::string& region,

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -53,7 +53,7 @@ interface BatAdsClient {
       (int32 status_code, string content, map<string, string> headers);
   ShowNotification(string notification_info);
   SetCatalogIssuers(string issuers_info);
-  AdSustained(string notification_info);
+  ConfirmAd(string notification_info);
   SaveBundleState(string bundle_state) => (int32 result);
   GetAds(string region, string category) =>
       (int32 result, string region, string category, array<string> ad_info);

--- a/components/services/bat_ledger/bat_ledger_impl.cc
+++ b/components/services/bat_ledger/bat_ledger_impl.cc
@@ -372,8 +372,8 @@ void BatLedgerImpl::SetCatalogIssuers(const std::string& info) {
   ledger_->SetCatalogIssuers(info);
 }
 
-void BatLedgerImpl::AdSustained(const std::string& info) {
-  ledger_->AdSustained(info);
+void BatLedgerImpl::ConfirmAd(const std::string& info) {
+  ledger_->ConfirmAd(info);
 }
 
 // static

--- a/components/services/bat_ledger/bat_ledger_impl.h
+++ b/components/services/bat_ledger/bat_ledger_impl.h
@@ -135,7 +135,7 @@ class BatLedgerImpl : public mojom::BatLedger,
 
  private:
   void SetCatalogIssuers(const std::string& info) override;
-  void AdSustained(const std::string& info) override;
+  void ConfirmAd(const std::string& info) override;
 
   // workaround to pass base::OnceCallback into std::bind
   template <typename Callback>

--- a/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
+++ b/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
@@ -97,7 +97,7 @@ interface BatLedger {
   GetAddressesForPaymentId() => (map<string, string> addresses);
 
   SetCatalogIssuers(string info);
-  AdSustained(string info);
+  ConfirmAd(string info);
   GetConfirmationsHistory(uint64 from_timestamp_seconds,
       uint64 to_timestamp_seconds) => (string transactions);
   GetRewardsInternalsInfo() => (string info);

--- a/vendor/bat-native-ads/BUILD.gn
+++ b/vendor/bat-native-ads/BUILD.gn
@@ -59,6 +59,7 @@ source_set("ads") {
     # add this only when ledger and confirmations are in the same process
     # rebase_path("bat-native-ledger", dep_base),
     # rebase_path("bat-native-ads", dep_base),
+    "//brave/test:*",
   ]
 
   output_name = "bat_native_ads"
@@ -70,6 +71,7 @@ source_set("ads") {
     "include/bat/ads/bundle_state.h",
     "include/bat/ads/client_info_platform_type.h",
     "include/bat/ads/client_info.h",
+    "include/bat/ads/confirmation_type.h",
     "include/bat/ads/export.h",
     "include/bat/ads/issuer_info.h",
     "include/bat/ads/issuers_info.h",

--- a/vendor/bat-native-ads/README.md
+++ b/vendor/bat-native-ads/README.md
@@ -206,9 +206,9 @@ void ShowNotification(std::unique_ptr<NotificationInfo> info)
   void SetCatalogIssuers(std::unique_ptr<IssuersInfo> info)
 ```
 
-`AdSustained` should be called to inform Confirmations that an ad was sustained
+`ConfirmAd` should be called to inform Confirmations that an Ad was clicked, viewed, dismissed or landed
 ```
-void AdSustained(std::unique_ptr<NotificationInfo> info)
+void ConfirmAd(std::unique_ptr<NotificationInfo> info)
 ```
 
 `SetTimer` should create a timer to trigger after the time offset specified in seconds. If the timer was created successfully a unique identifier should be returned, otherwise returns `0`

--- a/vendor/bat-native-ads/include/bat/ads/ads_client.h
+++ b/vendor/bat-native-ads/include/bat/ads/ads_client.h
@@ -111,7 +111,7 @@ class ADS_EXPORT AdsClient {
   virtual void SetCatalogIssuers(std::unique_ptr<IssuersInfo> info) = 0;
 
   // Should be called to inform Confirmations that an ad was sustained
-  virtual void AdSustained(std::unique_ptr<NotificationInfo> info) = 0;
+  virtual void ConfirmAd(std::unique_ptr<NotificationInfo> info) = 0;
 
   // Should create a timer to trigger after the time offset specified in
   // seconds. If the timer was created successfully a unique identifier should

--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BAT_ADS_CONFIRMATION_TYPE_H_
+#define BAT_ADS_CONFIRMATION_TYPE_H_
+
+#include <string>
+
+#include "bat/ads/export.h"
+
+namespace ads {
+
+static char kConfirmationTypeClick[] = "click";
+static char kConfirmationTypeDismiss[] = "dismiss";
+static char kConfirmationTypeView[] = "view";
+static char kConfirmationTypeLanded[] = "landed";
+
+enum class ADS_EXPORT ConfirmationType {
+  UNKNOWN,
+  CLICK,
+  DISMISS,
+  VIEW,
+  LANDED
+};
+
+}  // namespace ads
+
+#endif  // BAT_ADS_CONFIRMATION_TYPE_H_

--- a/vendor/bat-native-ads/include/bat/ads/notification_info.h
+++ b/vendor/bat-native-ads/include/bat/ads/notification_info.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "bat/ads/export.h"
+#include "bat/ads/confirmation_type.h"
 #include "bat/ads/result.h"
 
 namespace ads {
@@ -29,6 +30,7 @@ struct ADS_EXPORT NotificationInfo {
   std::string text;
   std::string url;
   std::string uuid;
+  ConfirmationType type;
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/include/bat/ads/notification_result_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/notification_result_type.h
@@ -10,7 +10,7 @@
 
 namespace ads {
 
-enum ADS_EXPORT NotificationResultInfoResultType {
+enum class ADS_EXPORT NotificationResultInfoResultType {
   CLICKED,
   DISMISSED,
   TIMEOUT

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_client_mock.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_client_mock.h
@@ -74,7 +74,7 @@ class MockAdsClient : public AdsClient {
   MOCK_METHOD1(SetCatalogIssuers, void(
       std::unique_ptr<IssuersInfo> info));
 
-  MOCK_METHOD1(AdSustained, void(
+  MOCK_METHOD1(ConfirmAd, void(
       std::unique_ptr<NotificationInfo> info));
 
   MOCK_METHOD1(SetTimer, uint32_t(

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
@@ -144,6 +144,7 @@ class AdsImpl : public Ads {
   void StopSustainingAdInteraction();
   bool IsSustainingAdInteraction() const;
   bool IsStillViewingAd() const;
+  void ConfirmAd(const NotificationInfo& info, const ConfirmationType type);
 
   void OnTimer(const uint32_t timer_id) override;
 
@@ -153,7 +154,7 @@ class AdsImpl : public Ads {
   void GenerateAdReportingNotificationResultEvent(
       const NotificationInfo& info,
       const NotificationResultInfoResultType type) override;
-  void GenerateAdReportingSustainEvent(const NotificationInfo& info);
+  void GenerateAdReportingConfirmationEvent(const NotificationInfo& info);
   void GenerateAdReportingLoadEvent(const LoadInfo& info);
   void GenerateAdReportingBackgroundEvent();
   void GenerateAdReportingForegroundEvent();

--- a/vendor/bat-native-confirmations/README.md
+++ b/vendor/bat-native-confirmations/README.md
@@ -30,9 +30,9 @@ void GetTransactionHistory(
     OnGetTransactionHistoryCallback callback)
 ```
 
-`AdSustained` should be called by Ads to be rewarded for viewing an Ad
+`ConfirmAd` should be called by Ads when clicking, viewing, dismissing or landing an Ad
 ```
-void AdSustained(
+void ConfirmAd(
     std::unique_ptr<NotificationInfo> info)
 ```
 

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
+#define BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
+
+#include <string>
+
+#include "bat/confirmations/export.h"
+
+namespace confirmations {
+
+static char kConfirmationTypeClick[] = "click";
+static char kConfirmationTypeDismiss[] = "dismiss";
+static char kConfirmationTypeView[] = "view";
+static char kConfirmationTypeLanded[] = "landed";
+
+enum class CONFIRMATIONS_EXPORT ConfirmationType {
+  UNKNOWN,
+  CLICK,
+  DISMISS,
+  VIEW,
+  LANDED
+};
+
+}  // namespace confirmations
+
+#endif  // BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmations.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmations.h
@@ -55,7 +55,7 @@ class CONFIRMATIONS_EXPORT Confirmations {
       OnGetTransactionHistoryCallback callback) = 0;
 
   // Should be called when an ad is sustained in Ads
-  virtual void AdSustained(std::unique_ptr<NotificationInfo> info) = 0;
+  virtual void ConfirmAd(std::unique_ptr<NotificationInfo> info) = 0;
 
   // Should be called when a timer is triggered
   virtual bool OnTimer(const uint32_t timer_id) = 0;

--- a/vendor/bat-native-confirmations/include/bat/confirmations/notification_info.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/notification_info.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "bat/confirmations/export.h"
+#include "bat/confirmations/confirmation_type.h"
 
 namespace confirmations {
 
@@ -23,6 +24,7 @@ struct CONFIRMATIONS_EXPORT NotificationInfo {
   std::string text;
   std::string url;
   std::string uuid;
+  ConfirmationType type;
 };
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_create_confirmation_request_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_create_confirmation_request_unittest.cc
@@ -78,7 +78,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, GetMethod) {
   EXPECT_EQ(URLRequestMethod::POST, method);
 }
 
-TEST_F(ConfirmationsCreateConfirmationRequestTest, BuildBody) {
+TEST_F(ConfirmationsCreateConfirmationRequestTest, BuildBody_Viewed) {
   // Arrange
   std::string creative_instance_id = "546fe7b0-5047-4f28-a11c-81f14edcf0f6";
 
@@ -87,7 +87,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, BuildBody) {
   auto blinded_token = BlindedToken::decode_base64(blinded_token_base64);
 
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token);
+      blinded_token, ConfirmationType::VIEW);
 
   // Act
   auto body = request_->BuildBody(payload);
@@ -128,8 +128,9 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, GetContentType) {
   EXPECT_EQ(content_type, "application/json");
 }
 
-TEST_F(ConfirmationsCreateConfirmationRequestTest,
-    CreateConfirmationRequestDTO) {
+TEST_F(
+    ConfirmationsCreateConfirmationRequestTest,
+    CreateConfirmationRequestDTO_Viewed) {
   // Arrange
   std::string creative_instance_id = "546fe7b0-5047-4f28-a11c-81f14edcf0f6";
 
@@ -139,14 +140,14 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest,
 
   // Act
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token);
+      blinded_token, ConfirmationType::VIEW);
 
   // Assert
   std::string expected_payload = R"({"blindedPaymentToken":"PI3lFqpGVFKz4TH5yEwXI3R/QntmTpUgeBaK+STiBx8=","creativeInstanceId":"546fe7b0-5047-4f28-a11c-81f14edcf0f6","payload":{},"type":"view"})";  // NOLINT
   EXPECT_EQ(expected_payload, payload);
 }
 
-TEST_F(ConfirmationsCreateConfirmationRequestTest, CreateCredential) {
+TEST_F(ConfirmationsCreateConfirmationRequestTest, CreateCredential_Viewed) {
   // Arrange
   std::string unblinded_token_base64 = "PLowz2WF2eGD5zfwZjk9p76HXBLDKMq/3EAZHeG/fE2XGQ48jyte+Ve50ZlasOuYL5mwA8CU2aFMlJrt3DDgC3B1+VD/uyHPfa/+bwYRrpVH5YwNSDEydVx8S4r+BYVY";  // NOLINT
 
@@ -162,7 +163,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, CreateCredential) {
   auto blinded_token = BlindedToken::decode_base64(blinded_token_base64);
 
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token);
+      blinded_token, ConfirmationType::VIEW);
 
   // Act
   auto credential = request_->CreateCredential(token_info, payload);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -47,8 +47,9 @@ class ConfirmationsImpl : public Confirmations {
       const uint64_t from_timestamp_in_seconds,
       const uint64_t to_timestamp_in_seconds,
       OnGetTransactionHistoryCallback callback) override;
-  void AppendEstimatedRedemptionValueToTransactionHistory(
-      double estimated_redemption_value);
+  void AppendTransactionToTransactionHistory(
+      const double estimated_redemption_value,
+      const ConfirmationType confirmation_type);
 
   // Scheduled events
   bool OnTimer(const uint32_t timer_id) override;
@@ -58,7 +59,7 @@ class ConfirmationsImpl : public Confirmations {
   void StartRetryingToGetRefillSignedTokens(const uint64_t start_timer_in);
 
   // Redeem unblinded tokens
-  void AdSustained(std::unique_ptr<NotificationInfo> info) override;
+  void ConfirmAd(std::unique_ptr<NotificationInfo> info) override;
 
   // Payout redeemed tokens
   void StartPayingOutRedeemedTokens(const uint64_t start_timer_in);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "bat/confirmations/confirmation_type.h"
+
 #include "bat/confirmations/internal/create_confirmation_request.h"
 #include "bat/confirmations/internal/ads_serve_helper.h"
 #include "bat/confirmations/internal/security_helper.h"
@@ -63,7 +65,8 @@ std::string CreateConfirmationRequest::GetContentType() const {
 
 std::string CreateConfirmationRequest::CreateConfirmationRequestDTO(
     const std::string& creative_instance_id,
-    const BlindedToken& token) const {
+    const BlindedToken& token,
+    const ConfirmationType confirmation_type) const {
   DCHECK(!creative_instance_id.empty());
 
   base::Value payload(base::Value::Type::DICTIONARY);
@@ -75,7 +78,35 @@ std::string CreateConfirmationRequest::CreateConfirmationRequestDTO(
   auto token_base64 = token.encode_base64();
   payload.SetKey("blindedPaymentToken", base::Value(token_base64));
 
-  payload.SetKey("type", base::Value("view"));
+  std::string type;
+  switch (confirmation_type) {
+    case ConfirmationType::UNKNOWN: {
+      DCHECK(false) << "Invalid confirmation type";
+      break;
+    }
+
+    case ConfirmationType::CLICK: {
+      type = kConfirmationTypeClick;
+      break;
+    }
+
+    case ConfirmationType::DISMISS: {
+      type = kConfirmationTypeDismiss;
+      break;
+    }
+
+    case ConfirmationType::VIEW: {
+      type = kConfirmationTypeView;
+      break;
+    }
+
+    case ConfirmationType::LANDED: {
+      type = kConfirmationTypeLanded;
+      break;
+    }
+  }
+
+  payload.SetKey("type", base::Value(type));
 
   std::string json;
   base::JSONWriter::Write(payload, &json);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.h
@@ -11,6 +11,7 @@
 
 #include "bat/confirmations/confirmations_client.h"
 #include "bat/confirmations/internal/token_info.h"
+#include "bat/confirmations/confirmation_type.h"
 
 #include "wrapper.hpp"  // NOLINT
 
@@ -39,7 +40,8 @@ class CreateConfirmationRequest {
 
   std::string CreateConfirmationRequestDTO(
       const std::string& creative_instance_id,
-      const BlindedToken& token) const;
+      const BlindedToken& token,
+      const ConfirmationType confirmation_type) const;
 
   std::string CreateCredential(
       const TokenInfo& token_info,

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
@@ -12,6 +12,7 @@
 
 #include "bat/confirmations/confirmations_client.h"
 #include "bat/confirmations/internal/token_info.h"
+#include "bat/confirmations/confirmation_type.h"
 
 #include "wrapper.hpp"  // NOLINT
 
@@ -34,23 +35,27 @@ class RedeemToken {
   ~RedeemToken();
 
   void Redeem(
-      const std::string& creative_instance_id);
+      const std::string& creative_instance_id,
+      const ConfirmationType confirmation_type);
 
  private:
   void CreateConfirmation(
       const std::string& creative_instance_id,
-      const TokenInfo& token_info);
+      const TokenInfo& token_info,
+      const ConfirmationType confirmation_type);
   void OnCreateConfirmation(
       const std::string& url,
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers,
+      const ConfirmationType confirmation_type,
       const std::string& confirmation_id,
       const Token& payment_token,
       const BlindedToken& blinded_payment_token,
       const TokenInfo& token_info);
 
   void FetchPaymentToken(
+      const ConfirmationType confirmation_type,
       const std::string& confirmation_id,
       const Token& payment_token,
       const BlindedToken& blinded_payment_token,
@@ -60,6 +65,7 @@ class RedeemToken {
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers,
+      const ConfirmationType confirmation_type,
       const Token& payment_token,
       const BlindedToken& blinded_payment_token,
       const TokenInfo& token_info);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.cc
@@ -14,7 +14,7 @@
 
 #include "base/base64.h"
 
-#include "tweetnacl.h"
+#include "tweetnacl.h"  // NOLINT
 
 namespace helper {
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
@@ -13,7 +13,8 @@ NotificationInfo::NotificationInfo() :
     advertiser(""),
     text(""),
     url(""),
-    uuid("") {}
+    uuid(""),
+    type(ConfirmationType::UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     creative_set_id(info.creative_set_id),
@@ -21,7 +22,8 @@ NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     advertiser(info.advertiser),
     text(info.text),
     url(info.url),
-    uuid(info.uuid) {}
+    uuid(info.uuid),
+    type(info.type) {}
 
 NotificationInfo::~NotificationInfo() = default;
 

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -270,7 +270,7 @@ class LEDGER_EXPORT Ledger {
 
   virtual void SetCatalogIssuers(const std::string& info) = 0;
 
-  virtual void AdSustained(const std::string& info) = 0;
+  virtual void ConfirmAd(const std::string& info) = 0;
   virtual void GetConfirmationsHistory(
       const uint64_t from_timestamp_seconds,
       const uint64_t to_timestamp_seconds,

--- a/vendor/bat-native-ledger/include/bat/ledger/transaction_info.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/transaction_info.h
@@ -20,6 +20,7 @@ LEDGER_EXPORT struct TransactionInfo {
 
   uint64_t timestamp_in_seconds;
   double estimated_redemption_value;
+  std::string confirmation_type;
 };
 
 }  // namespace ledger

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1316,7 +1316,7 @@ void LedgerImpl::SetCatalogIssuers(const std::string& info) {
   bat_confirmations_->SetCatalogIssuers(std::move(issuers_info));
 }
 
-void LedgerImpl::AdSustained(const std::string& info) {
+void LedgerImpl::ConfirmAd(const std::string& info) {
   ads::NotificationInfo notification_info_ads;
   if (notification_info_ads.FromJson(info) != ads::Result::SUCCESS)
     return;
@@ -1328,8 +1328,34 @@ void LedgerImpl::AdSustained(const std::string& info) {
   notification_info->text = notification_info_ads.text;
   notification_info->url = notification_info_ads.url;
   notification_info->uuid = notification_info_ads.uuid;
+  switch (notification_info_ads.type) {
+    case ads::ConfirmationType::UNKNOWN: {
+      notification_info->type = confirmations::ConfirmationType::UNKNOWN;
+      break;
+    }
 
-  bat_confirmations_->AdSustained(std::move(notification_info));
+    case ads::ConfirmationType::CLICK: {
+      notification_info->type = confirmations::ConfirmationType::CLICK;
+      break;
+    }
+
+    case ads::ConfirmationType::DISMISS: {
+      notification_info->type = confirmations::ConfirmationType::DISMISS;
+      break;
+    }
+
+    case ads::ConfirmationType::VIEW: {
+      notification_info->type = confirmations::ConfirmationType::VIEW;
+      break;
+    }
+
+    case ads::ConfirmationType::LANDED: {
+      notification_info->type = confirmations::ConfirmationType::LANDED;
+      break;
+    }
+  }
+
+  bat_confirmations_->ConfirmAd(std::move(notification_info));
 }
 
 void LedgerImpl::GetConfirmationsHistory(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -421,7 +421,7 @@ class LedgerImpl : public ledger::Ledger,
   void SetAddresses(std::map<std::string, std::string> addresses);
 
   void SetCatalogIssuers(const std::string& info) override;
-  void AdSustained(const std::string& info) override;
+  void ConfirmAd(const std::string& info) override;
   void GetConfirmationsHistory(
       const uint64_t from_timestamp_seconds,
       const uint64_t to_timestamp_seconds,

--- a/vendor/bat-native-ledger/src/bat/ledger/transaction_info.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/transaction_info.cc
@@ -9,11 +9,13 @@ namespace ledger {
 
 TransactionInfo::TransactionInfo() :
     timestamp_in_seconds(0),
-    estimated_redemption_value(0) {}
+    estimated_redemption_value(0),
+    confirmation_type("") {}
 
 TransactionInfo::TransactionInfo(const TransactionInfo& info) :
     timestamp_in_seconds(info.timestamp_in_seconds),
-    estimated_redemption_value(info.estimated_redemption_value) {}
+    estimated_redemption_value(info.estimated_redemption_value),
+    confirmation_type(info.confirmation_type) {}
 
 TransactionInfo::~TransactionInfo() = default;
 

--- a/vendor/bat-native-ledger/src/bat/ledger/transactions_info.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/transactions_info.cc
@@ -31,6 +31,9 @@ const std::string TransactionsInfo::ToJson() const {
     transaction_dictionary.SetKey("estimated_redemption_value",
         base::Value(transaction.estimated_redemption_value));
 
+    transaction_dictionary.SetKey("confirmation_type",
+        base::Value(transaction.confirmation_type));
+
     list.GetList().push_back(std::move(transaction_dictionary));
   }
 
@@ -81,6 +84,14 @@ bool TransactionsInfo::FromJson(
     }
     info.estimated_redemption_value =
         estimated_redemption_value_value->GetDouble();
+
+    // Confirmation type
+    auto* confirmation_type_value =
+        transaction_dictionary->FindKey("confirmation_type");
+    if (!confirmation_type_value) {
+      return false;
+    }
+    info.confirmation_type = confirmation_type_value->GetString();
 
     new_transactions.push_back(info);
   }


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3587

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Confirm clicked, viewed, dismissed and landed Ads are redeemed on Ads Serve and timed out Ads are not redeemed on Ads Serve


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
