### PR TITLE
Making Rewards panel height dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,8 +1617,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#c5ebe17ba382dd4208f5ec235ec9737010ccaf06",
-      "from": "github:brave/brave-ui#c5ebe17ba382dd4208f5ec235ec9737010ccaf06",
+      "version": "github:brave/brave-ui#83022ba9a7a56aac90e5f97b7e82bb612c6a355c",
+      "from": "github:brave/brave-ui#83022ba9a7a56aac90e5f97b7e82bb612c6a355c",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@types/react-redux": "6.0.4",
     "@types/redux-logger": "^3.0.7",
     "awesome-typescript-loader": "^5.2.1",
-    "brave-ui": "github:brave/brave-ui#c5ebe17ba382dd4208f5ec235ec9737010ccaf06",
+    "brave-ui": "github:brave/brave-ui#83022ba9a7a56aac90e5f97b7e82bb612c6a355c",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "deep-freeze-node": "^1.1.3",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2874
UI: https://github.com/brave/brave-ui/pull/375

(See UI PR for screenshots of new behavior)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Start Brave, Enable Rewards
2. Ensure that unverified copy in gray box for unverified publishers maxes at 50px
3. Ensure that Rewards panel height shrinks and expands to fit content appropriately (switch between panel and summary)
4. Repeat step 3 with different publishers, verified and unverified

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
