### PR TITLE
Set a limit on cookie expiration (fixes brave/brave-browser#3443)

### DIFF
--- a/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc
+++ b/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc
@@ -1,0 +1,97 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "net/cookies/canonical_cookie.h"
+
+#include "net/cookies/cookie_constants.h"
+#include "net/cookies/cookie_options.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+static const std::string cookie_line1 =
+    "test1=yes; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+static const std::string cookie_line2 =
+    "test2=yes; max-age=630720000";  // 20 years
+static const std::string cookie_line3 =
+    "test3=yes; max-age=630720000; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+static const std::string cookie_line4 =
+    "test4=yes; max-age=172800";  // 2 days
+static const std::string cookie_line5 =
+    "test5=yes; httponly; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+
+namespace net {
+
+TEST(BraveCanonicalCookieTest, ClientSide) {
+  using base::TimeDelta;
+
+  GURL url("https://www.example.com/test");
+  base::Time creation_time = base::Time::Now();
+  CookieOptions options;
+
+  std::unique_ptr<CanonicalCookie> cookie(
+      CanonicalCookie::Create(url, cookie_line1, creation_time, options));
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(8));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(6));
+
+  cookie = CanonicalCookie::Create(url, cookie_line2, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(8));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(6));
+
+  cookie = CanonicalCookie::Create(url, cookie_line3, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(8));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(6));
+
+  // Short-lived cookies get to keep their shorter expiration.
+  cookie = CanonicalCookie::Create(url, cookie_line4, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(3));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(1));
+
+  // Cookies with 'httponly' can't be set using the document.cookie API.
+  cookie = CanonicalCookie::Create(url, cookie_line5, creation_time, options);
+  EXPECT_FALSE(cookie.get());
+}
+
+TEST(BraveCanonicalCookieTest, ServerSide) {
+  using base::TimeDelta;
+
+  GURL url("https://www.example.com/test");
+  base::Time creation_time = base::Time::Now();
+  CookieOptions options;
+  options.set_include_httponly();
+
+  std::unique_ptr<CanonicalCookie> cookie(
+      CanonicalCookie::Create(url, cookie_line1, creation_time, options));
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*7));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*5));
+
+  cookie = CanonicalCookie::Create(url, cookie_line2, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*7));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*5));
+
+  cookie = CanonicalCookie::Create(url, cookie_line3, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*7));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*5));
+
+  // Short-lived cookies get to keep their shorter expiration.
+  cookie = CanonicalCookie::Create(url, cookie_line4, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(3));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(1));
+
+  // HTTP cookies with 'httponly' work as expected.
+  cookie = CanonicalCookie::Create(url, cookie_line5, creation_time, options);
+  EXPECT_TRUE(cookie.get());
+  EXPECT_LT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*7));
+  EXPECT_GT(cookie->ExpiryDate(), creation_time + TimeDelta::FromDays(30*5));
+}
+
+}  // namespace

--- a/chromium_src/net/cookies/canonical_cookie.cc
+++ b/chromium_src/net/cookies/canonical_cookie.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "net/cookies/canonical_cookie.h"
+#include "net/cookies/parsed_cookie.h"
+
+namespace {
+
+const base::TimeDelta kMaxClientSideExpiration = base::TimeDelta::FromDays(7);
+const base::TimeDelta kMaxServerSideExpiration =
+    base::TimeDelta::FromDays(30*6);  // 6 months
+
+base::Time BraveCanonExpiration(const net::ParsedCookie& pc,
+                                const base::Time& current,
+                                const base::Time& server_time,
+                                const bool is_from_http) {
+  const base::Time max_expiration = current +
+      (is_from_http ? kMaxServerSideExpiration : kMaxClientSideExpiration);
+
+  return std::min(net::CanonicalCookie::CanonExpiration(pc, current, server_time),
+                  max_expiration);
+}
+
+}  // namespace
+
+#include "../../../../net/cookies/canonical_cookie.cc"

--- a/patches/net-cookies-canonical_cookie.cc.patch
+++ b/patches/net-cookies-canonical_cookie.cc.patch
@@ -1,0 +1,18 @@
+diff --git a/net/cookies/canonical_cookie.cc b/net/cookies/canonical_cookie.cc
+index 91611ac4171c19a031044ae6b1459acce246d427..c0636088e332f61c9ee8e6ed07f210fa8e47de58 100644
+--- a/net/cookies/canonical_cookie.cc
++++ b/net/cookies/canonical_cookie.cc
+@@ -228,9 +228,10 @@ std::unique_ptr<CanonicalCookie> CanonicalCookie::Create(
+     server_time = options.server_time();
+
+   DCHECK(!creation_time.is_null());
+-  Time cookie_expires = CanonicalCookie::CanonExpiration(parsed_cookie,
+-                                                         creation_time,
+-                                                         server_time);
++  Time cookie_expires = BraveCanonExpiration(parsed_cookie,
++                                             creation_time,
++                                             server_time,
++                                             !options.exclude_httponly());
+
+   CookiePrefix prefix = GetCookiePrefix(parsed_cookie.Name());
+   bool is_cookie_valid = IsCookiePrefixValid(prefix, url, parsed_cookie);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -67,6 +67,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",
+    "//brave/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc",
     "//brave/common/brave_content_client_unittest.cc",
     "//brave/common/importer/brave_mock_importer_bridge.cc",
     "//brave/common/importer/brave_mock_importer_bridge.h",


### PR DESCRIPTION
The client-side cookie (i.e. document.cookie API) expiry limit is based off of the limit set by both Safari and Firefox:

https://webkit.org/blog/8613/intelligent-tracking-prevention-2-1/
https://groups.google.com/forum/#!msg/mozilla.dev.platform/lECBPeiGTy4/cPP52vyZAwAJ

whereas the server-side cookie (i.e. Set-Cookie header) limit was picked to avoid interfering in a noticeable way with user logins.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Use the following test pages and examine the state of the cookie jar using the devtools:
- client-side cookies (7-day limit):
  - https://fmarier.github.io/brave-testing/document-cookie.html
- server-side cookies (6-month limit):
  - https://fmarier.org/document-cookie/set-cookie1.html
  - https://fmarier.org/document-cookie/set-cookie2.html
  - https://fmarier.org/document-cookie/set-cookie3.html
  - https://fmarier.org/document-cookie/set-cookie4.html

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
