### PR TITLE
Fixed Windows build error caused by "Implement additional ad event confirmations"

### DIFF
--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -6,8 +6,6 @@
 #ifndef BAT_ADS_CONFIRMATION_TYPE_H_
 #define BAT_ADS_CONFIRMATION_TYPE_H_
 
-#include <string>
-
 #include "bat/ads/export.h"
 
 namespace ads {
@@ -17,12 +15,12 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum class ADS_EXPORT ConfirmationType {
-  UNKNOWN,
-  CLICK,
-  DISMISS,
-  VIEW,
-  LANDED
+enum ADS_EXPORT ConfirmationType {
+  CONFIRMATION_TYPE_UNKNOWN,
+  CONFIRMATION_TYPE_CLICK,
+  CONFIRMATION_TYPE_DISMISS,
+  CONFIRMATION_TYPE_VIEW,
+  CONFIRMATION_TYPE_LANDED
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -1049,7 +1049,7 @@ void AdsImpl::SustainAdInteractionIfNeeded() {
 
   BLOG(INFO) << "Sustained ad interaction";
 
-  ConfirmAd(last_shown_notification_info_, ConfirmationType::LANDED);
+  ConfirmAd(last_shown_notification_info_, CONFIRMATION_TYPE_LANDED);
 }
 
 void AdsImpl::StopSustainingAdInteraction() {
@@ -1171,7 +1171,7 @@ void AdsImpl::GenerateAdReportingNotificationShownEvent(
   auto* json = buffer.GetString();
   ads_client_->EventLog(json);
 
-  ConfirmAd(info, ConfirmationType::VIEW);
+  ConfirmAd(info, CONFIRMATION_TYPE_VIEW);
 }
 
 void AdsImpl::GenerateAdReportingNotificationResultEvent(
@@ -1247,12 +1247,12 @@ void AdsImpl::GenerateAdReportingNotificationResultEvent(
 
   switch (type) {
     case NotificationResultInfoResultType::CLICKED: {
-      ConfirmAd(info, ConfirmationType::CLICK);
+      ConfirmAd(info, CONFIRMATION_TYPE_CLICK);
       break;
     }
 
     case NotificationResultInfoResultType::DISMISSED: {
-      ConfirmAd(info, ConfirmationType::DISMISS);
+      ConfirmAd(info, CONFIRMATION_TYPE_DISMISS);
       break;
     }
 
@@ -1284,27 +1284,27 @@ void AdsImpl::GenerateAdReportingConfirmationEvent(
 
   std::string type;
   switch (info.type) {
-    case ConfirmationType::UNKNOWN: {
+    case CONFIRMATION_TYPE_UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case ConfirmationType::CLICK: {
+    case CONFIRMATION_TYPE_CLICK: {
       type = kConfirmationTypeClick;
       break;
     }
 
-    case ConfirmationType::DISMISS: {
+    case CONFIRMATION_TYPE_DISMISS: {
       type = kConfirmationTypeDismiss;
       break;
     }
 
-    case ConfirmationType::VIEW: {
+    case CONFIRMATION_TYPE_VIEW: {
       type = kConfirmationTypeView;
       break;
     }
 
-    case ConfirmationType::LANDED: {
+    case CONFIRMATION_TYPE_LANDED: {
       type = kConfirmationTypeLanded;
       break;
     }

--- a/vendor/bat-native-ads/src/bat/ads/notification_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/notification_info.cc
@@ -19,7 +19,7 @@ NotificationInfo::NotificationInfo() :
     text(""),
     url(""),
     uuid(""),
-    type(ConfirmationType::UNKNOWN) {}
+    type(CONFIRMATION_TYPE_UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     creative_set_id(info.creative_set_id),
@@ -79,15 +79,15 @@ Result NotificationInfo::FromJson(
   if (document.HasMember("confirmation_type")) {
     std::string confirmation_type = document["confirmation_type"].GetString();
     if (confirmation_type == kConfirmationTypeClick) {
-      type = ConfirmationType::CLICK;
+      type = CONFIRMATION_TYPE_CLICK;
     } else if (confirmation_type == kConfirmationTypeDismiss) {
-      type = ConfirmationType::DISMISS;
+      type = CONFIRMATION_TYPE_DISMISS;
     } else if (confirmation_type == kConfirmationTypeView) {
-      type = ConfirmationType::VIEW;
+      type = CONFIRMATION_TYPE_VIEW;
     } else if (confirmation_type == kConfirmationTypeLanded) {
-      type = ConfirmationType::LANDED;
+      type = CONFIRMATION_TYPE_LANDED;
     } else {
-      type = ConfirmationType::UNKNOWN;
+      type = CONFIRMATION_TYPE_UNKNOWN;
     }
   }
 
@@ -117,27 +117,27 @@ void SaveToJson(JsonWriter* writer, const NotificationInfo& info) {
 
   writer->String("confirmation_type");
   switch (info.type) {
-    case ConfirmationType::UNKNOWN: {
+    case CONFIRMATION_TYPE_UNKNOWN: {
       writer->String("");
       break;
     }
 
-    case ConfirmationType::CLICK: {
+    case CONFIRMATION_TYPE_CLICK: {
       writer->String(kConfirmationTypeClick);
       break;
     }
 
-    case ConfirmationType::DISMISS: {
+    case CONFIRMATION_TYPE_DISMISS: {
       writer->String(kConfirmationTypeDismiss);
       break;
     }
 
-    case ConfirmationType::VIEW: {
+    case CONFIRMATION_TYPE_VIEW: {
       writer->String(kConfirmationTypeView);
       break;
     }
 
-    case ConfirmationType::LANDED: {
+    case CONFIRMATION_TYPE_LANDED: {
       writer->String(kConfirmationTypeLanded);
       break;
     }

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -6,8 +6,6 @@
 #ifndef BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 #define BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 
-#include <string>
-
 #include "bat/confirmations/export.h"
 
 namespace confirmations {
@@ -17,12 +15,12 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum class CONFIRMATIONS_EXPORT ConfirmationType {
-  UNKNOWN,
-  CLICK,
-  DISMISS,
-  VIEW,
-  LANDED
+enum CONFIRMATIONS_EXPORT ConfirmationType {
+  CONFIRMATION_TYPE_UNKNOWN,
+  CONFIRMATION_TYPE_CLICK,
+  CONFIRMATION_TYPE_DISMISS,
+  CONFIRMATION_TYPE_VIEW,
+  CONFIRMATION_TYPE_LANDED
 };
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_create_confirmation_request_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_create_confirmation_request_unittest.cc
@@ -87,7 +87,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, BuildBody_Viewed) {
   auto blinded_token = BlindedToken::decode_base64(blinded_token_base64);
 
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token, ConfirmationType::VIEW);
+      blinded_token, CONFIRMATION_TYPE_VIEW);
 
   // Act
   auto body = request_->BuildBody(payload);
@@ -140,7 +140,7 @@ TEST_F(
 
   // Act
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token, ConfirmationType::VIEW);
+      blinded_token, CONFIRMATION_TYPE_VIEW);
 
   // Assert
   std::string expected_payload = R"({"blindedPaymentToken":"PI3lFqpGVFKz4TH5yEwXI3R/QntmTpUgeBaK+STiBx8=","creativeInstanceId":"546fe7b0-5047-4f28-a11c-81f14edcf0f6","payload":{},"type":"view"})";  // NOLINT
@@ -163,7 +163,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, CreateCredential_Viewed) {
   auto blinded_token = BlindedToken::decode_base64(blinded_token_base64);
 
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token, ConfirmationType::VIEW);
+      blinded_token, CONFIRMATION_TYPE_VIEW);
 
   // Act
   auto credential = request_->CreateCredential(token_info, payload);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -510,27 +510,27 @@ void ConfirmationsImpl::AppendTransactionToTransactionHistory(
   info.estimated_redemption_value = estimated_redemption_value;
 
   switch (confirmation_type) {
-    case ConfirmationType::UNKNOWN: {
+    case CONFIRMATION_TYPE_UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case ConfirmationType::CLICK: {
+    case CONFIRMATION_TYPE_CLICK: {
       info.confirmation_type = kConfirmationTypeClick;
       break;
     }
 
-    case ConfirmationType::DISMISS: {
+    case CONFIRMATION_TYPE_DISMISS: {
       info.confirmation_type = kConfirmationTypeDismiss;
       break;
     }
 
-    case ConfirmationType::VIEW: {
+    case CONFIRMATION_TYPE_VIEW: {
       info.confirmation_type = kConfirmationTypeView;
       break;
     }
 
-    case ConfirmationType::LANDED: {
+    case CONFIRMATION_TYPE_LANDED: {
       info.confirmation_type = kConfirmationTypeLanded;
       break;
     }
@@ -552,27 +552,27 @@ void ConfirmationsImpl::ConfirmAd(std::unique_ptr<NotificationInfo> info) {
   BLOG(INFO) << "  advertiser: " << info->advertiser;
   BLOG(INFO) << "  uuid: " << info->uuid;
   switch (info->type) {
-    case ConfirmationType::UNKNOWN: {
+    case CONFIRMATION_TYPE_UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case ConfirmationType::CLICK: {
+    case CONFIRMATION_TYPE_CLICK: {
       BLOG(INFO) << "  confirmationType: click";
       break;
     }
 
-    case ConfirmationType::DISMISS: {
+    case CONFIRMATION_TYPE_DISMISS: {
       BLOG(INFO) << "  confirmationType: dismiss";
       break;
     }
 
-    case ConfirmationType::VIEW: {
+    case CONFIRMATION_TYPE_VIEW: {
       BLOG(INFO) << "  confirmationType: view";
       break;
     }
 
-    case ConfirmationType::LANDED: {
+    case CONFIRMATION_TYPE_LANDED: {
       BLOG(INFO) << "  confirmationType: landed";
       break;
     }

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
@@ -80,27 +80,27 @@ std::string CreateConfirmationRequest::CreateConfirmationRequestDTO(
 
   std::string type;
   switch (confirmation_type) {
-    case ConfirmationType::UNKNOWN: {
+    case CONFIRMATION_TYPE_UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case ConfirmationType::CLICK: {
+    case CONFIRMATION_TYPE_CLICK: {
       type = kConfirmationTypeClick;
       break;
     }
 
-    case ConfirmationType::DISMISS: {
+    case CONFIRMATION_TYPE_DISMISS: {
       type = kConfirmationTypeDismiss;
       break;
     }
 
-    case ConfirmationType::VIEW: {
+    case CONFIRMATION_TYPE_VIEW: {
       type = kConfirmationTypeView;
       break;
     }
 
-    case ConfirmationType::LANDED: {
+    case CONFIRMATION_TYPE_LANDED: {
       type = kConfirmationTypeLanded;
       break;
     }

--- a/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
@@ -14,7 +14,7 @@ NotificationInfo::NotificationInfo() :
     text(""),
     url(""),
     uuid(""),
-    type(ConfirmationType::UNKNOWN) {}
+    type(CONFIRMATION_TYPE_UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     creative_set_id(info.creative_set_id),

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1329,28 +1329,28 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
   notification_info->url = notification_info_ads.url;
   notification_info->uuid = notification_info_ads.uuid;
   switch (notification_info_ads.type) {
-    case ads::ConfirmationType::UNKNOWN: {
-      notification_info->type = confirmations::ConfirmationType::UNKNOWN;
+    case ads::CONFIRMATION_TYPE_UNKNOWN: {
+      notification_info->type = confirmations::CONFIRMATION_TYPE_UNKNOWN;
       break;
     }
 
-    case ads::ConfirmationType::CLICK: {
-      notification_info->type = confirmations::ConfirmationType::CLICK;
+    case ads::CONFIRMATION_TYPE_CLICK: {
+      notification_info->type = confirmations::CONFIRMATION_TYPE_CLICK;
       break;
     }
 
-    case ads::ConfirmationType::DISMISS: {
-      notification_info->type = confirmations::ConfirmationType::DISMISS;
+    case ads::CONFIRMATION_TYPE_DISMISS: {
+      notification_info->type = confirmations::CONFIRMATION_TYPE_DISMISS;
       break;
     }
 
-    case ads::ConfirmationType::VIEW: {
-      notification_info->type = confirmations::ConfirmationType::VIEW;
+    case ads::CONFIRMATION_TYPE_VIEW: {
+      notification_info->type = confirmations::CONFIRMATION_TYPE_VIEW;
       break;
     }
 
-    case ads::ConfirmationType::LANDED: {
-      notification_info->type = confirmations::ConfirmationType::LANDED;
+    case ads::CONFIRMATION_TYPE_LANDED: {
+      notification_info->type = confirmations::CONFIRMATION_TYPE_LANDED;
       break;
     }
   }


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3672

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
