### PR TITLE
Revert "Fixed Windows build error caused by "Implement additional ad event confirmations""

### DIFF
--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -6,6 +6,8 @@
 #ifndef BAT_ADS_CONFIRMATION_TYPE_H_
 #define BAT_ADS_CONFIRMATION_TYPE_H_
 
+#include <string>
+
 #include "bat/ads/export.h"
 
 namespace ads {
@@ -15,12 +17,12 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum ADS_EXPORT ConfirmationType {
-  CONFIRMATION_TYPE_UNKNOWN,
-  CONFIRMATION_TYPE_CLICK,
-  CONFIRMATION_TYPE_DISMISS,
-  CONFIRMATION_TYPE_VIEW,
-  CONFIRMATION_TYPE_LANDED
+enum class ADS_EXPORT ConfirmationType {
+  UNKNOWN,
+  CLICK,
+  DISMISS,
+  VIEW,
+  LANDED
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -1049,7 +1049,7 @@ void AdsImpl::SustainAdInteractionIfNeeded() {
 
   BLOG(INFO) << "Sustained ad interaction";
 
-  ConfirmAd(last_shown_notification_info_, CONFIRMATION_TYPE_LANDED);
+  ConfirmAd(last_shown_notification_info_, ConfirmationType::LANDED);
 }
 
 void AdsImpl::StopSustainingAdInteraction() {
@@ -1171,7 +1171,7 @@ void AdsImpl::GenerateAdReportingNotificationShownEvent(
   auto* json = buffer.GetString();
   ads_client_->EventLog(json);
 
-  ConfirmAd(info, CONFIRMATION_TYPE_VIEW);
+  ConfirmAd(info, ConfirmationType::VIEW);
 }
 
 void AdsImpl::GenerateAdReportingNotificationResultEvent(
@@ -1247,12 +1247,12 @@ void AdsImpl::GenerateAdReportingNotificationResultEvent(
 
   switch (type) {
     case NotificationResultInfoResultType::CLICKED: {
-      ConfirmAd(info, CONFIRMATION_TYPE_CLICK);
+      ConfirmAd(info, ConfirmationType::CLICK);
       break;
     }
 
     case NotificationResultInfoResultType::DISMISSED: {
-      ConfirmAd(info, CONFIRMATION_TYPE_DISMISS);
+      ConfirmAd(info, ConfirmationType::DISMISS);
       break;
     }
 
@@ -1284,27 +1284,27 @@ void AdsImpl::GenerateAdReportingConfirmationEvent(
 
   std::string type;
   switch (info.type) {
-    case CONFIRMATION_TYPE_UNKNOWN: {
+    case ConfirmationType::UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case CONFIRMATION_TYPE_CLICK: {
+    case ConfirmationType::CLICK: {
       type = kConfirmationTypeClick;
       break;
     }
 
-    case CONFIRMATION_TYPE_DISMISS: {
+    case ConfirmationType::DISMISS: {
       type = kConfirmationTypeDismiss;
       break;
     }
 
-    case CONFIRMATION_TYPE_VIEW: {
+    case ConfirmationType::VIEW: {
       type = kConfirmationTypeView;
       break;
     }
 
-    case CONFIRMATION_TYPE_LANDED: {
+    case ConfirmationType::LANDED: {
       type = kConfirmationTypeLanded;
       break;
     }

--- a/vendor/bat-native-ads/src/bat/ads/notification_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/notification_info.cc
@@ -19,7 +19,7 @@ NotificationInfo::NotificationInfo() :
     text(""),
     url(""),
     uuid(""),
-    type(CONFIRMATION_TYPE_UNKNOWN) {}
+    type(ConfirmationType::UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     creative_set_id(info.creative_set_id),
@@ -79,15 +79,15 @@ Result NotificationInfo::FromJson(
   if (document.HasMember("confirmation_type")) {
     std::string confirmation_type = document["confirmation_type"].GetString();
     if (confirmation_type == kConfirmationTypeClick) {
-      type = CONFIRMATION_TYPE_CLICK;
+      type = ConfirmationType::CLICK;
     } else if (confirmation_type == kConfirmationTypeDismiss) {
-      type = CONFIRMATION_TYPE_DISMISS;
+      type = ConfirmationType::DISMISS;
     } else if (confirmation_type == kConfirmationTypeView) {
-      type = CONFIRMATION_TYPE_VIEW;
+      type = ConfirmationType::VIEW;
     } else if (confirmation_type == kConfirmationTypeLanded) {
-      type = CONFIRMATION_TYPE_LANDED;
+      type = ConfirmationType::LANDED;
     } else {
-      type = CONFIRMATION_TYPE_UNKNOWN;
+      type = ConfirmationType::UNKNOWN;
     }
   }
 
@@ -117,27 +117,27 @@ void SaveToJson(JsonWriter* writer, const NotificationInfo& info) {
 
   writer->String("confirmation_type");
   switch (info.type) {
-    case CONFIRMATION_TYPE_UNKNOWN: {
+    case ConfirmationType::UNKNOWN: {
       writer->String("");
       break;
     }
 
-    case CONFIRMATION_TYPE_CLICK: {
+    case ConfirmationType::CLICK: {
       writer->String(kConfirmationTypeClick);
       break;
     }
 
-    case CONFIRMATION_TYPE_DISMISS: {
+    case ConfirmationType::DISMISS: {
       writer->String(kConfirmationTypeDismiss);
       break;
     }
 
-    case CONFIRMATION_TYPE_VIEW: {
+    case ConfirmationType::VIEW: {
       writer->String(kConfirmationTypeView);
       break;
     }
 
-    case CONFIRMATION_TYPE_LANDED: {
+    case ConfirmationType::LANDED: {
       writer->String(kConfirmationTypeLanded);
       break;
     }

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -6,6 +6,8 @@
 #ifndef BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 #define BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 
+#include <string>
+
 #include "bat/confirmations/export.h"
 
 namespace confirmations {
@@ -15,12 +17,12 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum CONFIRMATIONS_EXPORT ConfirmationType {
-  CONFIRMATION_TYPE_UNKNOWN,
-  CONFIRMATION_TYPE_CLICK,
-  CONFIRMATION_TYPE_DISMISS,
-  CONFIRMATION_TYPE_VIEW,
-  CONFIRMATION_TYPE_LANDED
+enum class CONFIRMATIONS_EXPORT ConfirmationType {
+  UNKNOWN,
+  CLICK,
+  DISMISS,
+  VIEW,
+  LANDED
 };
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_create_confirmation_request_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_create_confirmation_request_unittest.cc
@@ -87,7 +87,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, BuildBody_Viewed) {
   auto blinded_token = BlindedToken::decode_base64(blinded_token_base64);
 
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token, CONFIRMATION_TYPE_VIEW);
+      blinded_token, ConfirmationType::VIEW);
 
   // Act
   auto body = request_->BuildBody(payload);
@@ -140,7 +140,7 @@ TEST_F(
 
   // Act
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token, CONFIRMATION_TYPE_VIEW);
+      blinded_token, ConfirmationType::VIEW);
 
   // Assert
   std::string expected_payload = R"({"blindedPaymentToken":"PI3lFqpGVFKz4TH5yEwXI3R/QntmTpUgeBaK+STiBx8=","creativeInstanceId":"546fe7b0-5047-4f28-a11c-81f14edcf0f6","payload":{},"type":"view"})";  // NOLINT
@@ -163,7 +163,7 @@ TEST_F(ConfirmationsCreateConfirmationRequestTest, CreateCredential_Viewed) {
   auto blinded_token = BlindedToken::decode_base64(blinded_token_base64);
 
   auto payload = request_->CreateConfirmationRequestDTO(creative_instance_id,
-      blinded_token, CONFIRMATION_TYPE_VIEW);
+      blinded_token, ConfirmationType::VIEW);
 
   // Act
   auto credential = request_->CreateCredential(token_info, payload);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -510,27 +510,27 @@ void ConfirmationsImpl::AppendTransactionToTransactionHistory(
   info.estimated_redemption_value = estimated_redemption_value;
 
   switch (confirmation_type) {
-    case CONFIRMATION_TYPE_UNKNOWN: {
+    case ConfirmationType::UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case CONFIRMATION_TYPE_CLICK: {
+    case ConfirmationType::CLICK: {
       info.confirmation_type = kConfirmationTypeClick;
       break;
     }
 
-    case CONFIRMATION_TYPE_DISMISS: {
+    case ConfirmationType::DISMISS: {
       info.confirmation_type = kConfirmationTypeDismiss;
       break;
     }
 
-    case CONFIRMATION_TYPE_VIEW: {
+    case ConfirmationType::VIEW: {
       info.confirmation_type = kConfirmationTypeView;
       break;
     }
 
-    case CONFIRMATION_TYPE_LANDED: {
+    case ConfirmationType::LANDED: {
       info.confirmation_type = kConfirmationTypeLanded;
       break;
     }
@@ -552,27 +552,27 @@ void ConfirmationsImpl::ConfirmAd(std::unique_ptr<NotificationInfo> info) {
   BLOG(INFO) << "  advertiser: " << info->advertiser;
   BLOG(INFO) << "  uuid: " << info->uuid;
   switch (info->type) {
-    case CONFIRMATION_TYPE_UNKNOWN: {
+    case ConfirmationType::UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case CONFIRMATION_TYPE_CLICK: {
+    case ConfirmationType::CLICK: {
       BLOG(INFO) << "  confirmationType: click";
       break;
     }
 
-    case CONFIRMATION_TYPE_DISMISS: {
+    case ConfirmationType::DISMISS: {
       BLOG(INFO) << "  confirmationType: dismiss";
       break;
     }
 
-    case CONFIRMATION_TYPE_VIEW: {
+    case ConfirmationType::VIEW: {
       BLOG(INFO) << "  confirmationType: view";
       break;
     }
 
-    case CONFIRMATION_TYPE_LANDED: {
+    case ConfirmationType::LANDED: {
       BLOG(INFO) << "  confirmationType: landed";
       break;
     }

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
@@ -80,27 +80,27 @@ std::string CreateConfirmationRequest::CreateConfirmationRequestDTO(
 
   std::string type;
   switch (confirmation_type) {
-    case CONFIRMATION_TYPE_UNKNOWN: {
+    case ConfirmationType::UNKNOWN: {
       DCHECK(false) << "Invalid confirmation type";
       break;
     }
 
-    case CONFIRMATION_TYPE_CLICK: {
+    case ConfirmationType::CLICK: {
       type = kConfirmationTypeClick;
       break;
     }
 
-    case CONFIRMATION_TYPE_DISMISS: {
+    case ConfirmationType::DISMISS: {
       type = kConfirmationTypeDismiss;
       break;
     }
 
-    case CONFIRMATION_TYPE_VIEW: {
+    case ConfirmationType::VIEW: {
       type = kConfirmationTypeView;
       break;
     }
 
-    case CONFIRMATION_TYPE_LANDED: {
+    case ConfirmationType::LANDED: {
       type = kConfirmationTypeLanded;
       break;
     }

--- a/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
@@ -14,7 +14,7 @@ NotificationInfo::NotificationInfo() :
     text(""),
     url(""),
     uuid(""),
-    type(CONFIRMATION_TYPE_UNKNOWN) {}
+    type(ConfirmationType::UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     creative_set_id(info.creative_set_id),

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1329,28 +1329,28 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
   notification_info->url = notification_info_ads.url;
   notification_info->uuid = notification_info_ads.uuid;
   switch (notification_info_ads.type) {
-    case ads::CONFIRMATION_TYPE_UNKNOWN: {
-      notification_info->type = confirmations::CONFIRMATION_TYPE_UNKNOWN;
+    case ads::ConfirmationType::UNKNOWN: {
+      notification_info->type = confirmations::ConfirmationType::UNKNOWN;
       break;
     }
 
-    case ads::CONFIRMATION_TYPE_CLICK: {
-      notification_info->type = confirmations::CONFIRMATION_TYPE_CLICK;
+    case ads::ConfirmationType::CLICK: {
+      notification_info->type = confirmations::ConfirmationType::CLICK;
       break;
     }
 
-    case ads::CONFIRMATION_TYPE_DISMISS: {
-      notification_info->type = confirmations::CONFIRMATION_TYPE_DISMISS;
+    case ads::ConfirmationType::DISMISS: {
+      notification_info->type = confirmations::ConfirmationType::DISMISS;
       break;
     }
 
-    case ads::CONFIRMATION_TYPE_VIEW: {
-      notification_info->type = confirmations::CONFIRMATION_TYPE_VIEW;
+    case ads::ConfirmationType::VIEW: {
+      notification_info->type = confirmations::ConfirmationType::VIEW;
       break;
     }
 
-    case ads::CONFIRMATION_TYPE_LANDED: {
-      notification_info->type = confirmations::CONFIRMATION_TYPE_LANDED;
+    case ads::ConfirmationType::LANDED: {
+      notification_info->type = confirmations::ConfirmationType::LANDED;
       break;
     }
   }


### PR DESCRIPTION
Reverts brave/brave-core#1910 as after checking with @simonhong builds were still failing