### PR TITLE
Fixed Windows build error caused by "Implement additional ad event confirmations”

### DIFF
--- a/vendor/bat-native-ads/include/bat/ads/ads_client.h
+++ b/vendor/bat-native-ads/include/bat/ads/ads_client.h
@@ -25,13 +25,13 @@
 
 namespace ads {
 
-enum ADS_EXPORT LogLevel {
+enum LogLevel {
   LOG_ERROR = 1,
   LOG_WARNING,
   LOG_INFO
 };
 
-enum ADS_EXPORT URLRequestMethod {
+enum URLRequestMethod {
   GET = 0,
   PUT = 1,
   POST = 2

--- a/vendor/bat-native-ads/include/bat/ads/client_info_platform_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/client_info_platform_type.h
@@ -6,11 +6,9 @@
 #ifndef BAT_ADS_CLIENT_INFO_PLATFORM_TYPE_H_
 #define BAT_ADS_CLIENT_INFO_PLATFORM_TYPE_H_
 
-#include "bat/ads/export.h"
-
 namespace ads {
 
-enum ADS_EXPORT ClientInfoPlatformType {
+enum ClientInfoPlatformType {
   UNKNOWN,
   WINDOWS,
   MACOS,

--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -6,10 +6,6 @@
 #ifndef BAT_ADS_CONFIRMATION_TYPE_H_
 #define BAT_ADS_CONFIRMATION_TYPE_H_
 
-#include <string>
-
-#include "bat/ads/export.h"
-
 namespace ads {
 
 static char kConfirmationTypeClick[] = "click";
@@ -17,7 +13,7 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum class ADS_EXPORT ConfirmationType {
+enum class ConfirmationType {
   UNKNOWN,
   CLICK,
   DISMISS,

--- a/vendor/bat-native-ads/include/bat/ads/notification_result_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/notification_result_type.h
@@ -6,11 +6,9 @@
 #ifndef BAT_ADS_NOTIFICATION_RESULT_TYPE_H_
 #define BAT_ADS_NOTIFICATION_RESULT_TYPE_H_
 
-#include "bat/ads/export.h"
-
 namespace ads {
 
-enum class ADS_EXPORT NotificationResultInfoResultType {
+enum class NotificationResultInfoResultType {
   CLICKED,
   DISMISSED,
   TIMEOUT

--- a/vendor/bat-native-ads/include/bat/ads/result.h
+++ b/vendor/bat-native-ads/include/bat/ads/result.h
@@ -6,11 +6,9 @@
 #ifndef BAT_ADS_RESULT_H_
 #define BAT_ADS_RESULT_H_
 
-#include "bat/ads/export.h"
-
 namespace ads {
 
-enum ADS_EXPORT Result {
+enum Result {
   SUCCESS,
   FAILED
 };

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -17,7 +17,7 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum class CONFIRMATIONS_EXPORT ConfirmationType {
+enum class ConfirmationType {
   UNKNOWN,
   CLICK,
   DISMISS,


### PR DESCRIPTION

fixes https://github.com/brave/brave-browser/issues/3679

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
