### PR TITLE
Disable use of default credentials in windows with Tor.

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -7,6 +7,8 @@ import("//build/config/features.gni")
 source_set("net") {
   configs += [ "//brave/build/geolocation" ]
   sources = [
+    "anon_http_auth_preferences.cc",
+    "anon_http_auth_preferences.h",
     "brave_ad_block_tp_network_delegate_helper.cc",
     "brave_ad_block_tp_network_delegate_helper.h",
     "brave_common_static_redirect_network_delegate_helper.cc",

--- a/browser/net/anon_http_auth_preferences.cc
+++ b/browser/net/anon_http_auth_preferences.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/anon_http_auth_preferences.h"
+
+namespace net {
+
+AnonHttpAuthPreferences::AnonHttpAuthPreferences() = default;
+AnonHttpAuthPreferences::~AnonHttpAuthPreferences() = default;
+
+bool AnonHttpAuthPreferences::CanUseDefaultCredentials(
+    const GURL& auth_origin) const {
+  return false;
+}
+
+}  // namespace net

--- a/browser/net/anon_http_auth_preferences.cc
+++ b/browser/net/anon_http_auth_preferences.cc
@@ -12,6 +12,7 @@ AnonHttpAuthPreferences::~AnonHttpAuthPreferences() = default;
 
 bool AnonHttpAuthPreferences::CanUseDefaultCredentials(
     const GURL& auth_origin) const {
+  LOG(ERROR) << "AnonHttpAuthPreferences::CanUseDefaultCredentials";
   return false;
 }
 

--- a/browser/net/anon_http_auth_preferences.h
+++ b/browser/net/anon_http_auth_preferences.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_NET_ANON_HTTP_AUTH_PREFERENCES_H_
+#define BRAVE_BROWSER_NET_ANON_HTTP_AUTH_PREFERENCES_H_
+
+#include "net/http/http_auth_preferences.h"
+#include "net/base/net_export.h"
+
+class GURL;
+
+namespace net {
+
+class NET_EXPORT AnonHttpAuthPreferences : public HttpAuthPreferences {
+ public:
+  AnonHttpAuthPreferences();
+  ~AnonHttpAuthPreferences() override;
+
+  bool CanUseDefaultCredentials(const GURL& auth_origin) const override;
+};
+
+}  // namespace net
+
+#endif  // BRAVE_BROWSER_NET_ANON_HTTP_AUTH_PREFERENCES_H_

--- a/browser/net/brave_tor_network_delegate_helper.cc
+++ b/browser/net/brave_tor_network_delegate_helper.cc
@@ -51,6 +51,7 @@ int OnBeforeURLRequest_TorWork(
   // to avoid accidentally identifying ourselves if the user hasn't
   // asked to do so.
   auto* auth_factory = url_request_context->http_auth_handler_factory();
+  LOG(ERROR) << "set auth factory " << auth_factory << "prefs";
   tor_profile_service->SetHttpAuthPreferences(auth_factory);
 
   // Set the proxy if necessary, or fail if the proxy is not ready yet.

--- a/browser/tor/mock_tor_profile_service_impl.cc
+++ b/browser/tor/mock_tor_profile_service_impl.cc
@@ -11,6 +11,7 @@
 #include "brave/common/tor/tor_test_constants.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/browser_thread.h"
+#include "net/http/http_auth_handler_factory.h"
 
 using content::BrowserThread;
 using tor::TorProxyConfigService;
@@ -40,6 +41,11 @@ const TorConfig& MockTorProfileServiceImpl::GetTorConfig() {
 }
 
 int64_t MockTorProfileServiceImpl::GetTorPid() { return -1; }
+
+void MockTorProfileServiceImpl::SetHttpAuthPreferences(
+    net::HttpAuthHandlerFactory* auth_factory) {
+  auth_factory->set_http_auth_preferences(&http_auth_prefs_);
+}
 
 int MockTorProfileServiceImpl::SetProxy(
     net::ProxyResolutionService* service, const GURL& request_url,

--- a/browser/tor/mock_tor_profile_service_impl.h
+++ b/browser/tor/mock_tor_profile_service_impl.h
@@ -8,6 +8,7 @@
 
 #include "brave/browser/tor/tor_profile_service.h"
 
+#include "brave/browser/net/anon_http_auth_preferences.h"
 
 namespace tor {
 
@@ -23,12 +24,16 @@ class MockTorProfileServiceImpl : public TorProfileService {
   const TorConfig& GetTorConfig() override;
   int64_t GetTorPid() override;
 
+  void SetHttpAuthPreferences(net::HttpAuthHandlerFactory*) override;
+
   int SetProxy(net::ProxyResolutionService*,
                const GURL& request_url,
                bool new_circuit) override;
 
  private:
   TorConfig config_;
+  net::AnonHttpAuthPreferences http_auth_prefs_;
+
   DISALLOW_COPY_AND_ASSIGN(MockTorProfileServiceImpl);
 };
 

--- a/browser/tor/tor_profile_service.h
+++ b/browser/tor/tor_profile_service.h
@@ -15,6 +15,7 @@
 #include "url/gurl.h"
 
 namespace net {
+class HttpAuthHandlerFactory;
 class ProxyResolutionService;
 }
 
@@ -42,6 +43,8 @@ class TorProfileService : public KeyedService {
                                 const base::Closure&) = 0;
   virtual const TorConfig& GetTorConfig() = 0;
   virtual int64_t GetTorPid() = 0;
+
+  virtual void SetHttpAuthPreferences(net::HttpAuthHandlerFactory*) = 0;
 
   virtual int SetProxy(net::ProxyResolutionService*,
                        const GURL& request_url,

--- a/browser/tor/tor_profile_service_impl.cc
+++ b/browser/tor/tor_profile_service_impl.cc
@@ -95,6 +95,11 @@ int64_t TorProfileServiceImpl::GetTorPid() {
 
 void TorProfileServiceImpl::SetHttpAuthPreferences(
     net::HttpAuthHandlerFactory* auth_factory) {
+  LOG(ERROR) << "TorProfileServiceImpl::SetHttpAuthPreferences("
+             << this
+             << ": " << auth_factory
+             << " -> " << &http_auth_prefs_
+             << ")";
   auth_factory->set_http_auth_preferences(&http_auth_prefs_);
 }
 

--- a/browser/tor/tor_profile_service_impl.cc
+++ b/browser/tor/tor_profile_service_impl.cc
@@ -15,6 +15,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/site_instance.h"
 #include "content/public/browser/storage_partition.h"
+#include "net/http/http_auth_handler_factory.h"
 #include "net/proxy_resolution/proxy_resolution_service.h"
 #include "net/url_request/url_request_context.h"
 #include "net/url_request/url_request_context_getter.h"
@@ -90,6 +91,11 @@ const TorConfig& TorProfileServiceImpl::GetTorConfig() {
 
 int64_t TorProfileServiceImpl::GetTorPid() {
   return tor_launcher_factory_->GetTorPid();
+}
+
+void TorProfileServiceImpl::SetHttpAuthPreferences(
+    net::HttpAuthHandlerFactory* auth_factory) {
+  auth_factory->set_http_auth_preferences(&http_auth_prefs_);
 }
 
 int TorProfileServiceImpl::SetProxy(net::ProxyResolutionService* service,

--- a/browser/tor/tor_profile_service_impl.h
+++ b/browser/tor/tor_profile_service_impl.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "base/memory/scoped_refptr.h"
+#include "brave/browser/net/anon_http_auth_preferences.h"
 #include "brave/browser/tor/tor_launcher_factory.h"
 #include "brave/browser/tor/tor_proxy_config_service.h"
 
@@ -38,6 +39,8 @@ class TorProfileServiceImpl : public TorProfileService,
   const TorConfig& GetTorConfig() override;
   int64_t GetTorPid() override;
 
+  void SetHttpAuthPreferences(net::HttpAuthHandlerFactory*) override;
+
   int SetProxy(net::ProxyResolutionService*,
                const GURL& request_url,
                bool new_circuit) override;
@@ -56,6 +59,8 @@ class TorProfileServiceImpl : public TorProfileService,
   Profile* profile_;  // NOT OWNED
   TorLauncherFactory* tor_launcher_factory_;  // Singleton
   TorProxyConfigService::TorProxyMap tor_proxy_map_;
+  net::AnonHttpAuthPreferences http_auth_prefs_;
+
   DISALLOW_COPY_AND_ASSIGN(TorProfileServiceImpl);
 };
 


### PR DESCRIPTION
fix brave/brave-browser#3603

- New class AnonHttpAuthPreferences is like HttpAuthPreferences, but
  unconditionally disables the use of default credentials.

- Each TorProfileServiceImpl owns an AnonHttpAuthPreferences object.

- OnBeforeURLRequest_TorWork sets the auth preferences to be the Tor
  profile's anonymous auth preferences.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
https://hackerone.com/reports/505764

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
