### PR TITLE
Fixed Windows build error caused by "Implement additional ad event confirmations” 0.63.x Dev

### DIFF
--- a/vendor/bat-native-ads/include/bat/ads/ads_client.h
+++ b/vendor/bat-native-ads/include/bat/ads/ads_client.h
@@ -25,13 +25,13 @@
 
 namespace ads {
 
-enum ADS_EXPORT LogLevel {
+enum LogLevel {
   LOG_ERROR = 1,
   LOG_WARNING,
   LOG_INFO
 };
 
-enum ADS_EXPORT URLRequestMethod {
+enum URLRequestMethod {
   GET = 0,
   PUT = 1,
   POST = 2

--- a/vendor/bat-native-ads/include/bat/ads/client_info_platform_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/client_info_platform_type.h
@@ -6,11 +6,9 @@
 #ifndef BAT_ADS_CLIENT_INFO_PLATFORM_TYPE_H_
 #define BAT_ADS_CLIENT_INFO_PLATFORM_TYPE_H_
 
-#include "bat/ads/export.h"
-
 namespace ads {
 
-enum ADS_EXPORT ClientInfoPlatformType {
+enum ClientInfoPlatformType {
   UNKNOWN,
   WINDOWS,
   MACOS,

--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -6,10 +6,6 @@
 #ifndef BAT_ADS_CONFIRMATION_TYPE_H_
 #define BAT_ADS_CONFIRMATION_TYPE_H_
 
-#include <string>
-
-#include "bat/ads/export.h"
-
 namespace ads {
 
 static char kConfirmationTypeClick[] = "click";
@@ -17,7 +13,7 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum class ADS_EXPORT ConfirmationType {
+enum class ConfirmationType {
   UNKNOWN,
   CLICK,
   DISMISS,

--- a/vendor/bat-native-ads/include/bat/ads/notification_result_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/notification_result_type.h
@@ -6,11 +6,9 @@
 #ifndef BAT_ADS_NOTIFICATION_RESULT_TYPE_H_
 #define BAT_ADS_NOTIFICATION_RESULT_TYPE_H_
 
-#include "bat/ads/export.h"
-
 namespace ads {
 
-enum class ADS_EXPORT NotificationResultInfoResultType {
+enum class NotificationResultInfoResultType {
   CLICKED,
   DISMISSED,
   TIMEOUT

--- a/vendor/bat-native-ads/include/bat/ads/result.h
+++ b/vendor/bat-native-ads/include/bat/ads/result.h
@@ -6,11 +6,9 @@
 #ifndef BAT_ADS_RESULT_H_
 #define BAT_ADS_RESULT_H_
 
-#include "bat/ads/export.h"
-
 namespace ads {
 
-enum ADS_EXPORT Result {
+enum Result {
   SUCCESS,
   FAILED
 };

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -6,10 +6,6 @@
 #ifndef BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 #define BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 
-#include <string>
-
-#include "bat/confirmations/export.h"
-
 namespace confirmations {
 
 static char kConfirmationTypeClick[] = "click";
@@ -17,7 +13,7 @@ static char kConfirmationTypeDismiss[] = "dismiss";
 static char kConfirmationTypeView[] = "view";
 static char kConfirmationTypeLanded[] = "landed";
 
-enum class CONFIRMATIONS_EXPORT ConfirmationType {
+enum class ConfirmationType {
   UNKNOWN,
   CLICK,
   DISMISS,


### PR DESCRIPTION
Fixes brave/brave-browser#3679
Uplift request from #1913
