### PR TITLE
Remove rebase logic from PR builder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,9 @@ pipeline {
                             echo "Failed to rebase (conflicts), will need to be manually rebased!"
                             git rebase --abort
                         else
+                            # unfortunately, no other option than to force push
                             echo "Rebased ${BRANCH_TO_BUILD} against ${TARGET_BRANCH}"
-                            git push ${BB_REPO}
+                            git push --force ${BB_REPO}
                         fi
                         set -e
                     fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                     fi
 
                     echo "Cloning brave-browser..."
-                    git clone -b ${TARGET_BRANCH} ${BB_REPO} || git clone ${BB_REPO}
+                    git clone --branch ${TARGET_BRANCH} ${BB_REPO} || git clone ${BB_REPO}
                     cd brave-browser
 
                     git config user.name brave-builds
@@ -37,21 +37,21 @@ pipeline {
 
                     if [ "`curl -s -w %{http_code} -o /dev/null ${BB_REPO}/tree/${BRANCH_TO_BUILD}`" = "404" ]; then
                         echo "Creating ${BRANCH_TO_BUILD} branch in brave-browser..."
-                        git checkout -f -b ${BRANCH_TO_BUILD}
+                        git checkout --force --branch ${BRANCH_TO_BUILD}
 
                         echo "Pinning brave-core to branch ${BRANCH_TO_BUILD}..."
                         jq "del(.config.projects[\\"brave-core\\"].branch) | .config.projects[\\"brave-core\\"].branch=\\"${BRANCH_TO_BUILD}\\"" package.json > package.json.new
                         mv package.json.new package.json
 
                         echo "Pushing changes..."
-                        git commit -a -m "pin brave-core to branch ${BRANCH_TO_BUILD}"
+                        git commit --all --message "pin brave-core to branch ${BRANCH_TO_BUILD}"
                         git push ${BB_REPO}
                     else
                         echo "Rebasing brave-browser branch against ${TARGET_BRANCH}..."
                         git checkout ${BRANCH_TO_BUILD}
 
                         set +e
-                        git fetch -p
+                        git fetch --prune
                         git rebase origin/${TARGET_BRANCH}
                         if [ \$? -ne 0 ]; then
                             echo "Failed to rebase (conflicts), will need to be manually rebased!"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,22 +46,6 @@ pipeline {
                         echo "Pushing changes..."
                         git commit --all --message "pin brave-core to branch ${BRANCH_TO_BUILD}"
                         git push ${BB_REPO}
-                    else
-                        echo "Rebasing brave-browser branch against ${TARGET_BRANCH}..."
-                        git checkout ${BRANCH_TO_BUILD}
-
-                        set +e
-                        git fetch --prune
-                        git rebase origin/${TARGET_BRANCH}
-                        if [ \$? -ne 0 ]; then
-                            echo "Failed to rebase (conflicts), will need to be manually rebased!"
-                            git rebase --abort
-                        else
-                            # unfortunately, no other option than to force push
-                            echo "Rebased ${BRANCH_TO_BUILD} against ${TARGET_BRANCH}"
-                            git push --force ${BB_REPO}
-                        fi
-                        set -e
                     fi
 
                     echo "Sleeping 5m so new branch is discovered or associated PR created in brave-browser..."


### PR DESCRIPTION
Required because otherwise the push (after a rebase) will fail if any new changes are pulled in