### PR TITLE
Fix no components/omnibox/browser/buildflags.h file not found

### DIFF
--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -15,6 +15,7 @@ source_set("browser") {
 
   deps = [
      "//base",
+     "//components/omnibox/browser:buildflags",
      "//components/security_state/core",
      "//skia",
      "//third_party/metrics_proto",


### PR DESCRIPTION
Add "//components/omnibox/browser:buildflags" to deps list of
//brave/components/omnibox/browser target.
It would be better to add dependecy explicitly when we use it.

I wonder what order gn handles each target in deps list.
It would have its rule but unclear to me for now because  I didn't see this error on my local and only buildbot saw this rarely.

Fix https://github.com/brave/brave-browser/issues/2399

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
