### PR TITLE
Change payment token redemption timing

### DIFF
--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -387,6 +387,41 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, HandleFlagsSingleArg) {
   GetProduction();
   RunUntilIdle();
 
+  // SetDebug(true)
+  EXPECT_CALL(*this, OnGetDebug(true));
+  // Debug - true and 1
+  EXPECT_CALL(*this, OnGetDebug(false)).Times(2);
+  // Debug - false and random
+  EXPECT_CALL(*this, OnGetDebug(true)).Times(2);
+
+  rewards_service()->SetDebug(true);
+  GetDebug();
+  RunUntilIdle();
+
+  // Debug - true
+  rewards_service()->SetDebug(true);
+  rewards_service()->HandleFlags("debug=true");
+  GetDebug();
+  RunUntilIdle();
+
+  // Debug - 1
+  rewards_service()->SetDebug(true);
+  rewards_service()->HandleFlags("debug=1");
+  GetDebug();
+  RunUntilIdle();
+
+  // Debug - false
+  rewards_service()->SetDebug(false);
+  rewards_service()->HandleFlags("debug=false");
+  GetDebug();
+  RunUntilIdle();
+
+  // Debug - random
+  rewards_service()->SetDebug(false);
+  rewards_service()->HandleFlags("debug=werwe");
+  GetDebug();
+  RunUntilIdle();
+
   // positive number
   EXPECT_CALL(*this, OnGetReconcileTime(10));
   // negative number and string
@@ -428,36 +463,42 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, HandleFlagsSingleArg) {
 
 IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, HandleFlagsMultipleFlags) {
   EXPECT_CALL(*this, OnGetProduction(false));
+  EXPECT_CALL(*this, OnGetDebug(false));
   EXPECT_CALL(*this, OnGetReconcileTime(10));
   EXPECT_CALL(*this, OnGetShortRetries(true));
 
   rewards_service()->SetProduction(true);
+  rewards_service()->SetDebug(true);
   rewards_service()->SetReconcileTime(0);
   rewards_service()->SetShortRetries(false);
 
   rewards_service()->HandleFlags(
-      "staging=true,short-retries=true,reconcile-interval=10");
+      "staging=true,debug=true,short-retries=true,reconcile-interval=10");
 
   GetReconcileTime();
   GetShortRetries();
   GetProduction();
+  GetDebug();
   RunUntilIdle();
 }
 
 IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, HandleFlagsWrongInput) {
   EXPECT_CALL(*this, OnGetProduction(true));
+  EXPECT_CALL(*this, OnGetDebug(true));
   EXPECT_CALL(*this, OnGetReconcileTime(0));
   EXPECT_CALL(*this, OnGetShortRetries(false));
 
   rewards_service()->SetProduction(true);
+  rewards_service()->SetDebug(true);
   rewards_service()->SetReconcileTime(0);
   rewards_service()->SetShortRetries(false);
 
   rewards_service()->HandleFlags(
-      "staging=,shortretries=true,reconcile-interval");
+      "staging=,debug=,shortretries=true,reconcile-interval");
 
   GetReconcileTime();
   GetShortRetries();
   GetProduction();
+  GetDebug();
   RunUntilIdle();
 }

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -401,6 +401,8 @@ void RewardsServiceImpl::StartLedger() {
   #endif
   SetProduction(isProduction);
 
+  SetDebug(false);
+
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
 
@@ -2453,6 +2455,20 @@ void RewardsServiceImpl::HandleFlags(const std::string& options) {
       continue;
     }
 
+    if (name == "debug") {
+      bool is_debug;
+      std::string lower = base::ToLowerASCII(value);
+
+      if (lower == "true" || lower == "1") {
+        is_debug = true;
+      } else {
+        is_debug = false;
+      }
+
+      SetDebug(is_debug);
+      continue;
+    }
+
     if (name == "reconcile-interval") {
       int reconcile_int;
       bool success = base::StringToInt(value, &reconcile_int);
@@ -2555,6 +2571,10 @@ void RewardsServiceImpl::GetShortRetries(
 
 void RewardsServiceImpl::SetProduction(bool production) {
   bat_ledger_service_->SetProduction(production);
+}
+
+void RewardsServiceImpl::SetDebug(bool debug) {
+  bat_ledger_service_->SetDebug(debug);
 }
 
 void RewardsServiceImpl::SetReconcileTime(int32_t time) {

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -66,6 +66,7 @@ class PublisherInfoDatabase;
 class RewardsNotificationServiceImpl;
 
 using GetProductionCallback = base::Callback<void(bool)>;
+using GetDebugCallback = base::Callback<void(bool)>;
 using GetReconcileTimeCallback = base::Callback<void(int32_t)>;
 using GetShortRetriesCallback = base::Callback<void(bool)>;
 
@@ -176,6 +177,8 @@ class RewardsServiceImpl : public RewardsService,
   void HandleFlags(const std::string& options);
   void SetProduction(bool production);
   void GetProduction(const GetProductionCallback& callback);
+  void SetDebug(bool debug);
+  void GetDebug(const GetDebugCallback& callback);
   void SetReconcileTime(int32_t time);
   void GetReconcileTime(const GetReconcileTimeCallback& callback);
   void SetShortRetries(bool short_retries);

--- a/components/services/bat_ledger/bat_ledger_service_impl.cc
+++ b/components/services/bat_ledger/bat_ledger_service_impl.cc
@@ -17,6 +17,10 @@ bool testing() {
   return ledger::is_testing;
 }
 
+bool debug() {
+  return ledger::is_debug;
+}
+
 }
 
 namespace bat_ledger {
@@ -44,6 +48,11 @@ void BatLedgerServiceImpl::SetProduction(bool is_production) {
   ledger::is_production = is_production;
 }
 
+void BatLedgerServiceImpl::SetDebug(bool is_debug) {
+  DCHECK(!initialized_ || debug());
+  ledger::is_debug = is_debug;
+}
+
 void BatLedgerServiceImpl::SetReconcileTime(int32_t time) {
   DCHECK(!initialized_ || testing());
   ledger::reconcile_time = time;
@@ -60,6 +69,10 @@ void BatLedgerServiceImpl::SetTesting() {
 
 void BatLedgerServiceImpl::GetProduction(GetProductionCallback callback) {
   std::move(callback).Run(ledger::is_production);
+}
+
+void BatLedgerServiceImpl::GetDebug(GetDebugCallback callback) {
+  std::move(callback).Run(ledger::is_debug);
 }
 
 void BatLedgerServiceImpl::GetReconcileTime(GetReconcileTimeCallback callback) {

--- a/components/services/bat_ledger/bat_ledger_service_impl.h
+++ b/components/services/bat_ledger/bat_ledger_service_impl.h
@@ -1,9 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_SERVICES_BAT_LEDGER_BAT_LEDGER_SERVICE_IMPL_H_
-#define BRAVE_COMPONENTS_SERVICES_BAT_LEDGER_BAT_LEDGER_SERVICE_IMPL_H_
+#ifndef COMPONENTS_SERVICES_BAT_LEDGER_BAT_LEDGER_SERVICE_IMPL_H_
+#define COMPONENTS_SERVICES_BAT_LEDGER_BAT_LEDGER_SERVICE_IMPL_H_
 
 #include <memory>
 
@@ -13,31 +14,33 @@
 namespace bat_ledger {
 
 class BatLedgerServiceImpl : public mojom::BatLedgerService {
-  public:
-    explicit BatLedgerServiceImpl(
-        std::unique_ptr<service_manager::ServiceContextRef> service_ref);
-    ~BatLedgerServiceImpl() override;
+ public:
+  explicit BatLedgerServiceImpl(
+      std::unique_ptr<service_manager::ServiceContextRef> service_ref);
+  ~BatLedgerServiceImpl() override;
 
-    // bat_ledger::mojom::BatLedgerService
-    void Create(mojom::BatLedgerClientAssociatedPtrInfo client_info,
-                mojom::BatLedgerAssociatedRequest bat_ledger) override;
+  // bat_ledger::mojom::BatLedgerService
+  void Create(mojom::BatLedgerClientAssociatedPtrInfo client_info,
+              mojom::BatLedgerAssociatedRequest bat_ledger) override;
 
-    void SetProduction(bool isProduction) override;
-    void SetReconcileTime(int32_t time) override;
-    void SetShortRetries(bool short_retries) override;
-    void SetTesting() override;
+  void SetProduction(bool isProduction) override;
+  void SetDebug(bool isDebug) override;
+  void SetReconcileTime(int32_t time) override;
+  void SetShortRetries(bool short_retries) override;
+  void SetTesting() override;
 
-    void GetProduction(GetProductionCallback callback) override;
-    void GetReconcileTime(GetReconcileTimeCallback callback) override;
-    void GetShortRetries(GetShortRetriesCallback callback) override;
+  void GetProduction(GetProductionCallback callback) override;
+  void GetDebug(GetDebugCallback callback) override;
+  void GetReconcileTime(GetReconcileTimeCallback callback) override;
+  void GetShortRetries(GetShortRetriesCallback callback) override;
 
-  private:
-    const std::unique_ptr<service_manager::ServiceContextRef> service_ref_;
-    bool initialized_;
+ private:
+  const std::unique_ptr<service_manager::ServiceContextRef> service_ref_;
+  bool initialized_;
 
-    DISALLOW_COPY_AND_ASSIGN(BatLedgerServiceImpl);
+  DISALLOW_COPY_AND_ASSIGN(BatLedgerServiceImpl);
 };
 
-} // namespace bat_ledger
+}  // namespace bat_ledger
 
-#endif // BRAVE_COMPONENTS_SERVICES_BAT_LEDGER_BAT_LEDGER_SERVICE_IMPL_H_
+#endif  // COMPONENTS_SERVICES_BAT_LEDGER_BAT_LEDGER_SERVICE_IMPL_H_

--- a/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
+++ b/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
@@ -9,11 +9,13 @@ interface BatLedgerService {
   Create(associated BatLedgerClient bat_ledger_client,
          associated BatLedger& bat_ledger);
   SetProduction(bool isProduction);
+  SetDebug(bool isDebug);
   SetReconcileTime(int32 time);
   SetShortRetries(bool short_retries);
   SetTesting();
 
   GetProduction() => (bool production);
+  GetDebug() => (bool debug);
   GetReconcileTime() => (int32 time);
   GetShortRetries() => (bool short_retries);
 };

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_serve.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_serve.cc
@@ -199,6 +199,9 @@ void AdsServe::RetryDownloadingCatalog() {
     next_retry_start_timer_in_ *= 2;
   }
 
+  auto rand_delay = base::RandInt(0, next_retry_start_timer_in_ / 10);
+  next_retry_start_timer_in_ += rand_delay;
+
   ads_->StartCollectingActivity(next_retry_start_timer_in_);
 }
 

--- a/vendor/bat-native-confirmations/BUILD.gn
+++ b/vendor/bat-native-confirmations/BUILD.gn
@@ -74,6 +74,8 @@ source_set("bat-native-confirmations") {
     "src/bat/confirmations/internal/security_helper.h",
     "src/bat/confirmations/internal/string_helper.cc",
     "src/bat/confirmations/internal/string_helper.h",
+    "src/bat/confirmations/internal/time.cc",
+    "src/bat/confirmations/internal/time.h",
     "src/bat/confirmations/internal/token_info.cc",
     "src/bat/confirmations/internal/token_info.h",
     "src/bat/confirmations/internal/unblinded_tokens.cc",

--- a/vendor/bat-native-confirmations/README.md
+++ b/vendor/bat-native-confirmations/README.md
@@ -131,6 +131,12 @@ Use staging Ads Serve as defined by `STAGING_SERVER` in `static_values.h`. Defau
 --rewards=staging=true
 ```
 
+Use shorter timers to help with testing token redemption as defined by `kDebugNextTokenRedemptionAfterSeconds` in `static_values.h`.
+
+```
+--rewards=debug=true
+```
+
 Enable diagnostic logging, where `#` should set to a minimum log level. Valid values are from 0 to 3 where INFO = 0, WARNING = 1, ERROR = 2 and FATAL = 3. So if you want INFO, WARNING and ERROR you would choose 2
 
 ```

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmations.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmations.h
@@ -23,6 +23,9 @@ namespace confirmations {
 // Determines whether to use the staging or production Ad Serve
 extern bool _is_production;
 
+// Determines whether to enable or disable debugging
+extern bool _is_debug;
+
 extern const char _confirmations_name[];
 
 using TransactionInfo = ::ledger::TransactionInfo;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/confirmations.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/confirmations.cc
@@ -10,6 +10,7 @@
 namespace confirmations {
 
 bool _is_production = false;
+bool _is_debug = false;
 
 const char _confirmations_name[] = "confirmations.json";
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -14,7 +14,9 @@
 #include "bat/confirmations/internal/redeem_token.h"
 #include "bat/confirmations/internal/payout_tokens.h"
 #include "bat/confirmations/internal/unblinded_tokens.h"
+#include "bat/confirmations/internal/time.h"
 
+#include "base/rand_util.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "base/time/time.h"
@@ -39,6 +41,7 @@ ConfirmationsImpl::ConfirmationsImpl(
     payout_redeemed_tokens_timer_id_(0),
     payout_tokens_(std::make_unique<PayoutTokens>(this, confirmations_client,
         unblinded_payment_tokens_.get())),
+    next_token_redemption_date_in_seconds_(0),
     state_has_loaded_(false),
     confirmations_client_(confirmations_client) {
 }
@@ -76,7 +79,9 @@ void ConfirmationsImpl::CheckReady() {
   is_initialized_ = true;
   BLOG(INFO) << "Successfully initialized";
 
-  PayoutRedeemedTokens();
+  auto start_timer_in = CalculateTokenRedemptionTimeInSeconds();
+  StartPayingOutRedeemedTokens(start_timer_in);
+
   RefillTokensIfNecessary();
 }
 
@@ -92,6 +97,10 @@ std::string ConfirmationsImpl::ToJSON() const {
   auto catalog_issuers =
       GetCatalogIssuersAsDictionary(public_key_, catalog_issuers_);
   dictionary.SetKey("catalog_issuers", base::Value(std::move(catalog_issuers)));
+
+  // Next token redemption date
+  dictionary.SetKey("next_token_redemption_date_in_seconds", base::Value(
+      std::to_string(next_token_redemption_date_in_seconds_)));
 
   // Transaction history
   auto transaction_history =
@@ -329,9 +338,7 @@ bool ConfirmationsImpl::GetTransactionHistoryFromDictionary(
           std::stoull(timestamp_in_seconds_value->GetString());
     } else {
       // timestamp missing, fallback to default
-      auto now = base::Time::Now();
-      info.timestamp_in_seconds =
-          static_cast<uint64_t>((now - base::Time()).InSeconds());
+      info.timestamp_in_seconds = Time::NowInSeconds();
     }
 
     // Estimated redemption value
@@ -555,11 +562,8 @@ double ConfirmationsImpl::GetEstimatedRedemptionValue(
 void ConfirmationsImpl::AppendTransactionToTransactionHistory(
     const double estimated_redemption_value,
     const ConfirmationType confirmation_type) {
-  auto now = base::Time::Now();
-  auto now_in_seconds = (now - base::Time()).InSeconds();
-
   TransactionInfo info;
-  info.timestamp_in_seconds = now_in_seconds;
+  info.timestamp_in_seconds = Time::NowInSeconds();
   info.estimated_redemption_value = estimated_redemption_value;
 
   switch (confirmation_type) {
@@ -656,6 +660,49 @@ bool ConfirmationsImpl::OnTimer(const uint32_t timer_id) {
 
 void ConfirmationsImpl::RefillTokensIfNecessary() const {
   refill_tokens_->Refill(wallet_info_, public_key_);
+}
+
+uint64_t ConfirmationsImpl::CalculateTokenRedemptionTimeInSeconds() {
+  auto now_in_seconds = Time::NowInSeconds();
+
+  uint64_t start_timer_in;
+
+  if (_is_debug) {
+    if (now_in_seconds - next_token_redemption_date_in_seconds_ >=
+        kDebugNextTokenRedemptionAfterSeconds) {
+      UpdateNextTokenRedemptionDate();
+      SaveState();
+    }
+  }
+
+  if (next_token_redemption_date_in_seconds_ == 0) {
+    UpdateNextTokenRedemptionDate();
+    SaveState();
+  }
+
+  if (now_in_seconds >= next_token_redemption_date_in_seconds_) {
+    // Browser was launched after the token redemption date
+    start_timer_in = base::RandInt(0, 5 * base::Time::kSecondsPerMinute);
+  } else {
+    start_timer_in = next_token_redemption_date_in_seconds_ - now_in_seconds;
+  }
+
+  auto rand_delay = base::RandInt(0, start_timer_in / 10);
+  start_timer_in += rand_delay;
+
+  return start_timer_in;
+}
+
+void ConfirmationsImpl::UpdateNextTokenRedemptionDate() {
+  next_token_redemption_date_in_seconds_ = Time::NowInSeconds();
+
+  if (!_is_debug) {
+    next_token_redemption_date_in_seconds_ +=
+        kNextTokenRedemptionAfterSeconds;
+  } else {
+    next_token_redemption_date_in_seconds_ +=
+        kDebugNextTokenRedemptionAfterSeconds;
+  }
 }
 
 void ConfirmationsImpl::StartPayingOutRedeemedTokens(

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -62,6 +62,8 @@ class ConfirmationsImpl : public Confirmations {
   void ConfirmAd(std::unique_ptr<NotificationInfo> info) override;
 
   // Payout redeemed tokens
+  void UpdateNextTokenRedemptionDate();
+  uint64_t CalculateTokenRedemptionTimeInSeconds();
   void StartPayingOutRedeemedTokens(const uint64_t start_timer_in);
 
   // State
@@ -103,6 +105,7 @@ class ConfirmationsImpl : public Confirmations {
   void StopPayingOutRedeemedTokens();
   bool IsPayingOutRedeemedTokens() const;
   std::unique_ptr<PayoutTokens> payout_tokens_;
+  uint64_t next_token_redemption_date_in_seconds_;
 
   // State
   void OnStateSaved(const Result result);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.h
@@ -42,7 +42,8 @@ class PayoutTokens {
   void OnPayout(const Result result);
 
   void ScheduleNextPayout() const;
-  uint64_t CalculateTimerForNextPayout() const;
+  uint64_t next_retry_start_timer_in_;
+  void RetryNextPayout();
 
   ConfirmationsImpl* confirmations_;  // NOT OWNED
   ConfirmationsClient* confirmations_client_;  // NOT OWNED

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/static_values.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/static_values.h
@@ -20,8 +20,11 @@ static const int kMaximumUnblindedTokens = 50;
 
 static const uint64_t kRetryGettingRefillSignedTokensAfterSeconds = 15;
 
-static const uint64_t kPayoutAfterSeconds =
-    base::Time::kSecondsPerHour * base::Time::kHoursPerDay;
+static const uint64_t kNextTokenRedemptionAfterSeconds =
+    base::Time::kMicrosecondsPerWeek / base::Time::kMicrosecondsPerSecond;
+
+static const uint64_t kDebugNextTokenRedemptionAfterSeconds =
+    25 * base::Time::kSecondsPerMinute;
 
 }  // namespace confirmations
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/time.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/time.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/confirmations/internal/time.h"
+
+#include "base/time/time.h"
+
+namespace confirmations {
+
+uint64_t Time::NowInSeconds() {
+  auto now = base::Time::Now();
+  return static_cast<uint64_t>((now - base::Time()).InSeconds());
+}
+
+}  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/time.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/time.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BAT_CONFIRMATIONS_INTERNAL_TIME_H_
+#define BAT_CONFIRMATIONS_INTERNAL_TIME_H_
+
+#include <stdint.h>
+
+namespace confirmations {
+
+class Time {
+ public:
+  static uint64_t NowInSeconds();
+};
+
+}  // namespace confirmations
+
+#endif  // BAT_CONFIRMATIONS_INTERNAL_TIME_H_

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -22,6 +22,7 @@
 namespace ledger {
 
 extern bool is_production;
+extern bool is_debug;
 extern bool is_testing;
 extern int reconcile_time;  // minutes
 extern bool short_retries;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -247,6 +247,7 @@ void LedgerImpl::SetConfirmationsWalletInfo(
     const braveledger_bat_helper::WALLET_INFO_ST& wallet_info) {
   if (!bat_confirmations_) {
     confirmations::_is_production = ledger::is_production;
+    confirmations::_is_debug = ledger::is_debug;
 
     bat_confirmations_.reset(
         confirmations::Confirmations::CreateInstance(ledger_client_));

--- a/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
@@ -14,6 +14,7 @@
 namespace ledger {
 
 bool is_production = true;
+bool is_debug = false;
 bool is_testing = false;
 int reconcile_time = 0;  // minutes
 bool short_retries = false;


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3659

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- View an Ad and confirm token was redeemed on the server (speak with @maikelmclauflin and/or Jimmy for help with confirming). You can pass `--rewards=debug=true` to reduce token redemption from 7 days +/- jitter to 25 minutes +/- jitter. Test both fresh and existing user profiles. See console log and search for `Start paying out` for diagnostic information.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
