### PR TITLE
Uplift #1958 to 0.63.x - Fix mac build error with sdk 10.13

### DIFF
--- a/browser/themes/brave_theme_utils_mac.mm
+++ b/browser/themes/brave_theme_utils_mac.mm
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "base/mac/sdk_forward_declarations.h"
+
 bool SystemThemeSupportDarkMode() {
   // Dark mode is supported since Mojave.
   if (@available(macOS 10.14, *))


### PR DESCRIPTION
This is an uplift request for 0.63.x for #1958.
W/o this, macos buildbot will see build error because it uses sdk 10.13.

Fix brave/brave-browser#3724

sdk_forward_declarations.h should be included when dark theme
related constants is used.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
