### PR TITLE
[Ad] should pre-pend advertiser title and not CTA for Ads 0.63.x Dev

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -794,9 +794,9 @@ bool AdsImpl::ShowAd(
   }
 
   auto notification_info = std::make_unique<NotificationInfo>();
-  notification_info->advertiser = ad_info.advertiser;
+  notification_info->advertiser = "[Ad] " + ad_info.advertiser;
   notification_info->category = category;
-  notification_info->text = "[Ad] " + ad_info.notification_text;
+  notification_info->text = ad_info.notification_text;
   notification_info->url = helper::Uri::GetUri(ad_info.notification_url);
   notification_info->creative_set_id = ad_info.creative_set_id;
   notification_info->uuid = ad_info.uuid;


### PR DESCRIPTION
Fixes brave/brave-browser#3732
Uplift request from #1963
