### PR TITLE
Fix BraveThemeApiBrowserTest failure on Release build

### DIFF
--- a/browser/extensions/api/brave_theme_api_browsertest.cc
+++ b/browser/extensions/api/brave_theme_api_browsertest.cc
@@ -3,38 +3,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/values.h"
 #include "brave/browser/extensions/api/brave_theme_api.h"
 #include "brave/browser/extensions/brave_theme_event_router.h"
 #include "brave/browser/themes/brave_theme_service.h"
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
-#include "chrome/browser/extensions/extension_function_test_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/themes/theme_service_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "components/prefs/pref_service.h"
-#include "extensions/common/extension_builder.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
-using BTS = BraveThemeService;
-
-class BraveThemeAPIBrowserTest : public InProcessBrowserTest {
- public:
-  void SetUpOnMainThread() override {
-    InProcessBrowserTest::SetUpOnMainThread();
-    extension_ = extensions::ExtensionBuilder("Test").Build();
-  }
-
-  scoped_refptr<const extensions::Extension> extension() {
-    return extension_;
-  }
-
- private:
-  scoped_refptr<const extensions::Extension> extension_;
-};
+using BraveThemeAPIBrowserTest = InProcessBrowserTest;
 
 namespace {
 class MockBraveThemeEventRouter : public extensions::BraveThemeEventRouter {
@@ -50,9 +32,10 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 }
 }  // namespace
 
-IN_PROC_BROWSER_TEST_F(BraveThemeAPIBrowserTest,
-                       BraveThemeEventRouterTest) {
+IN_PROC_BROWSER_TEST_F(BraveThemeAPIBrowserTest, BraveThemeEventRouterTest) {
   Profile* profile = browser()->profile();
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+
   MockBraveThemeEventRouter* mock_router_ = new MockBraveThemeEventRouter;
   EXPECT_CALL(*mock_router_, OnBraveThemeTypeChanged(profile)).Times(1);
 


### PR DESCRIPTION
In browser test, initial active theme type is different on debug and
release build.
So, testing OnBraveThemeTypeChanged() is called or not by setting light
type should be failed on Release because initial active theme type of
release build is light. Setting same type doesn't trigger it.
So, set dark type explicitly before setting MockBraveThemeTypeEventRouter.

Fix https://github.com/brave/brave-browser/issues/3733

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveThemeAPI*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
