### PR TITLE
Fix BraveThemeApiBrowserTest failure on Release build (uplift to 0.63.x)

### DIFF
--- a/browser/extensions/api/brave_theme_api_browsertest.cc
+++ b/browser/extensions/api/brave_theme_api_browsertest.cc
@@ -3,38 +3,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/values.h"
 #include "brave/browser/extensions/api/brave_theme_api.h"
 #include "brave/browser/extensions/brave_theme_event_router.h"
 #include "brave/browser/themes/brave_theme_service.h"
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
-#include "chrome/browser/extensions/extension_function_test_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/themes/theme_service_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "components/prefs/pref_service.h"
-#include "extensions/common/extension_builder.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
-using BTS = BraveThemeService;
-
-class BraveThemeAPIBrowserTest : public InProcessBrowserTest {
- public:
-  void SetUpOnMainThread() override {
-    InProcessBrowserTest::SetUpOnMainThread();
-    extension_ = extensions::ExtensionBuilder("Test").Build();
-  }
-
-  scoped_refptr<const extensions::Extension> extension() {
-    return extension_;
-  }
-
- private:
-  scoped_refptr<const extensions::Extension> extension_;
-};
+using BraveThemeAPIBrowserTest = InProcessBrowserTest;
 
 namespace {
 class MockBraveThemeEventRouter : public extensions::BraveThemeEventRouter {
@@ -50,9 +32,10 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 }
 }  // namespace
 
-IN_PROC_BROWSER_TEST_F(BraveThemeAPIBrowserTest,
-                       BraveThemeEventRouterTest) {
+IN_PROC_BROWSER_TEST_F(BraveThemeAPIBrowserTest, BraveThemeEventRouterTest) {
   Profile* profile = browser()->profile();
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+
   MockBraveThemeEventRouter* mock_router_ = new MockBraveThemeEventRouter;
   EXPECT_CALL(*mock_router_, OnBraveThemeTypeChanged(profile)).Times(1);
 


### PR DESCRIPTION
Uplift of #1965 
@brave/uplift-approvers asking for uplift because Release mode test failure introduced with https://github.com/brave/brave-core/pull/1805 which is on 0.63 via https://github.com/brave/brave-core/pull/1936