### PR TITLE
Fix debug build dependency resolution for md_extensions webui

### DIFF
--- a/browser/resources/md_extensions/BUILD.gn
+++ b/browser/resources/md_extensions/BUILD.gn
@@ -18,36 +18,34 @@ grit("resources") {
   resource_ids = "//brave/browser/resources/resource_ids"
 }
 
-if (optimize_webui) {
-  group("unpak") {
-    deps = [
-      ":unpak_brave_extensions_resources",
-    ]
-  }
+group("unpak") {
+  deps = [
+    ":unpak_brave_extensions_resources",
+  ]
+}
 
-  action("unpak_brave_extensions_resources") {
-    script = "//chrome/browser/resources/unpack_pak.py"
+action("unpak_brave_extensions_resources") {
+  script = "//chrome/browser/resources/unpack_pak.py"
 
-    pak_file = "brave_extensions_resources.pak"
-    out_folder = "$root_gen_dir/chrome/browser/resources/md_extensions/extensions_resources.unpak"
+  pak_file = "brave_extensions_resources.pak"
+  out_folder = "$root_gen_dir/chrome/browser/resources/md_extensions/extensions_resources.unpak"
 
-    inputs = [
-      "$target_gen_dir/brave_extensions_resources.pak",
-    ]
+  inputs = [
+    "$target_gen_dir/brave_extensions_resources.pak",
+  ]
 
-    outputs = [
-      "${out_folder}/brave_unpack.stamp",
-    ]
+  outputs = [
+    "${out_folder}/brave_unpack.stamp",
+  ]
 
-    deps = [
-      ":resources",
-    ]
+  deps = [
+    ":resources",
+  ]
 
-    args = [
-      "--out_folder",
-      rebase_path(out_folder, root_build_dir),
-      "--pak_file",
-      rebase_path("$target_gen_dir/${pak_file}", root_build_dir),
-    ]
-  }
+  args = [
+    "--out_folder",
+    rebase_path(out_folder, root_build_dir),
+    "--pak_file",
+    rebase_path("$target_gen_dir/${pak_file}", root_build_dir),
+  ]
 }


### PR DESCRIPTION
For this specific webui, chromium compiles the optimized version in debug too, so brave needs to provide the extra resources in debug too.

Fix https://github.com/brave/brave-browser/issues/3747

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Build in debug

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
