### PR TITLE
Add an explicitcancel ad-block filter option

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/ad-block": "https://github.com/brave/ad-block.git@74b167c8b49c33f3f61c15dafa2ffde953a25653",
+  "vendor/ad-block": "https://github.com/brave/ad-block.git@e54c59fe288d8f08de683b8f4f320a4c7bead4eb",
   "vendor/autoplay-whitelist": "https://github.com/brave/autoplay-whitelist.git@458053a3c95b403cbe0872f289a2aafa106ee9d8",
   "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@463e5e4e06e0ca84927176e8c72f6076ae9b6829",
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@29b1f86b11a8c7438fd7d57b446a77a84946712a",

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -98,22 +98,25 @@ void OnBeforeURLRequestAdBlockTPOnTaskRunner(
   std::string tab_host = ctx->tab_origin.host();
   if (!g_brave_browser_process->ad_block_service()->ShouldStartRequest(
           ctx->request_url, ctx->resource_type, tab_host,
-          &did_match_exception)) {
+          &did_match_exception, &ctx->cancel_request_explicitly)) {
     ctx->blocked_by = kAdBlocked;
   } else if (!did_match_exception &&
              !g_brave_browser_process->ad_block_regional_service()
                   ->ShouldStartRequest(ctx->request_url, ctx->resource_type,
-                                       tab_host, &did_match_exception)) {
+                                       tab_host, &did_match_exception,
+                                       &ctx->cancel_request_explicitly)) {
     ctx->blocked_by = kAdBlocked;
   } else if (!did_match_exception &&
              !g_brave_browser_process->ad_block_custom_filters_service()
                   ->ShouldStartRequest(ctx->request_url, ctx->resource_type,
-                                       tab_host, &did_match_exception)) {
+                                       tab_host, &did_match_exception,
+                                       &ctx->cancel_request_explicitly)) {
     ctx->blocked_by = kAdBlocked;
   } else if (!did_match_exception &&
              !g_brave_browser_process->tracking_protection_service()
                   ->ShouldStartRequest(ctx->request_url, ctx->resource_type,
-                                       tab_host, &did_match_exception)) {
+                                       tab_host, &did_match_exception,
+                                       &ctx->cancel_request_explicitly)) {
     ctx->blocked_by = kTrackerBlocked;
   }
 }

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -385,9 +385,8 @@ void BraveNetworkDelegateBase::RunNextCallback(
         RunCallbackForRequestIdentifier(ctx->request_identifier,
             net::ERR_ABORTED);
         return;
-      } else {
-        request->SetExtraRequestHeaderByName("X-Brave-Block", "", true);
       }
+      request->SetExtraRequestHeaderByName("X-Brave-Block", "", true);
     }
     rv = ChromeNetworkDelegate::OnBeforeURLRequest(
         request, std::move(wrapped_callback), ctx->new_url);

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -381,7 +381,13 @@ void BraveNetworkDelegateBase::RunNextCallback(
         ctx->blocked_by == brave::kTrackerBlocked) {
       // We are going to intercept this request and block it later in the
       // network stack.
-      request->SetExtraRequestHeaderByName("X-Brave-Block", "", true);
+      if (ctx->cancel_request_explicitly) {
+        RunCallbackForRequestIdentifier(ctx->request_identifier,
+            net::ERR_ABORTED);
+        return;
+      } else {
+        request->SetExtraRequestHeaderByName("X-Brave-Block", "", true);
+      }
     }
     rv = ChromeNetworkDelegate::OnBeforeURLRequest(
         request, std::move(wrapped_callback), ctx->new_url);

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -73,6 +73,7 @@ struct BraveRequestInfo {
   BraveNetworkDelegateEventType event_type = kUnknownEventType;
   const base::ListValue* referral_headers_list = nullptr;
   BlockedBy blocked_by = kNotBlocked;
+  bool cancel_request_explicitly = false;
   // Default to invalid type for resource_type, so delegate helpers
   // can properly detect that the info couldn't be obtained.
   content::ResourceType resource_type = content::RESOURCE_TYPE_LAST_TYPE;

--- a/components/brave_shields/browser/ad_block_base_service.h
+++ b/components/brave_shields/browser/ad_block_base_service.h
@@ -32,7 +32,8 @@ class AdBlockBaseService : public BaseBraveShieldsService {
   ~AdBlockBaseService() override;
 
   bool ShouldStartRequest(const GURL &url, content::ResourceType resource_type,
-    const std::string& tab_host, bool* matching_exception_filter) override;
+    const std::string& tab_host, bool* did_match_exception,
+    bool* cancel_request_explicitly) override;
   void EnableTag(const std::string& tag, bool enabled);
 
  protected:

--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -239,7 +239,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByDefaultBlocker) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 1, 0, 0);"
+                                          "setExpectations(0, 1, 0, 0, 0, 0);"
                                           "addImage('ad_banner.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -262,7 +262,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(1, 0, 0, 0);"
+                                          "setExpectations(1, 0, 0, 0, 0, 0);"
                                           "addImage('logo.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -283,7 +283,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByCustomBlocker) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 1, 0, 0);"
+                                          "setExpectations(0, 1, 0, 0, 0, 0);"
                                           "addImage('ad_banner.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -307,7 +307,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(1, 0, 0, 0);"
+                                          "setExpectations(1, 0, 0, 0, 0, 0);"
                                           "addImage('logo.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -335,7 +335,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByRegionalBlocker) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 1, 0, 0);"
+                                          "setExpectations(0, 1, 0, 0, 0, 0);"
                                           "addImage('ad_fr.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -364,7 +364,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(1, 0, 0, 0);"
+                                          "setExpectations(1, 0, 0, 0, 0, 0);"
                                           "addImage('logo.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -398,7 +398,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 1, 0, 0);"
+                                          "setExpectations(0, 1, 0, 0, 0, 0);"
                                           "addImage('v4_specific_banner.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -421,7 +421,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TwoSameAdsGetCountedAsOne) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 0, 1, 2);"
+                                          "setExpectations(0, 0, 0, 1, 2, 0);"
                                           "xhr('adbanner.js');"
                                           "xhr('normal.js');"
                                           "xhr('adbanner.js')",
@@ -445,7 +445,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TwoDiffAdsGetCountedAsTwo) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 0, 1, 2);"
+                                          "setExpectations(0, 0, 0, 1, 2, 0);"
                                           "xhr('adbanner.js?1');"
                                           "xhr('normal.js');"
                                           "xhr('adbanner.js?2')",
@@ -469,7 +469,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NewTabContinuesToBlock) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 0, 0, 1);"
+                                          "setExpectations(0, 0, 0, 0, 1, 0);"
                                           "xhr('adbanner.js');",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -480,7 +480,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NewTabContinuesToBlock) {
 
   as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(0, 0, 0, 1);"
+                                          "setExpectations(0, 0, 0, 0, 1, 0);"
                                           "xhr('adbanner.js');",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -504,7 +504,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SubFrame) {
 
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents->GetAllFrames()[1],
-                                          "setExpectations(0, 0, 0, 1);"
+                                          "setExpectations(0, 0, 0, 0, 1, 0);"
                                           "xhr('adbanner.js?1');",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -544,7 +544,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
       browser()->tab_strip_model()->GetActiveWebContents();
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          "setExpectations(1, 0, 0, 0);"
+                                          "setExpectations(1, 0, 0, 0, 0, 0);"
                                           "addImage('ad_fr.png')",
                                           &as_expected));
   EXPECT_TRUE(as_expected);
@@ -570,11 +570,11 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   GURL test_url = embedded_test_server()->GetURL("365dm.com", "/logo.png");
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          base::StringPrintf(
-                                              "setExpectations(0, 1, 0, 0);"
-                                              "addImage('%s')",
-                                          test_url.spec().c_str()),
-                                          &as_expected));
+      base::StringPrintf(
+          "setExpectations(0, 1, 0, 0, 0, 0);"
+          "addImage('%s')",
+      test_url.spec().c_str()),
+      &as_expected));
   EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kTrackersBlocked),
       1ULL);
@@ -596,11 +596,11 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   GURL test_url = embedded_test_server()->GetURL("365dm.com", "/logo.png");
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          base::StringPrintf(
-                                              "setExpectations(1, 0, 0, 0);"
-                                              "addImage('%s')",
-                                          test_url.spec().c_str()),
-                                          &as_expected));
+      base::StringPrintf(
+          "setExpectations(1, 0, 0, 0, 0, 0);"
+          "addImage('%s')",
+      test_url.spec().c_str()),
+      &as_expected));
   EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kTrackersBlocked),
       0ULL);
@@ -620,11 +620,11 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdBlockThirdPartyWorksByETLDP1) {
       browser()->tab_strip_model()->GetActiveWebContents();
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          base::StringPrintf(
-                                              "setExpectations(1, 0, 0, 0);"
-                                              "addImage('%s')",
-                                          resource_url.spec().c_str()),
-                                          &as_expected));
+      base::StringPrintf(
+          "setExpectations(1, 0, 0, 0, 0, 0);"
+          "addImage('%s')",
+      resource_url.spec().c_str()),
+      &as_expected));
   EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
@@ -643,11 +643,11 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
       browser()->tab_strip_model()->GetActiveWebContents();
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-                                          base::StringPrintf(
-                                              "setExpectations(0, 1, 0, 0);"
-                                              "addImage('%s')",
-                                          resource_url.spec().c_str()),
-                                          &as_expected));
+      base::StringPrintf(
+          "setExpectations(0, 1, 0, 0, 0, 0);"
+          "addImage('%s')",
+      resource_url.spec().c_str()),
+      &as_expected));
   EXPECT_TRUE(as_expected);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
@@ -666,7 +666,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, BlockNYP) {
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
                                           base::StringPrintf(
-                                            "setExpectations(0, 1, 0, 0);"
+                                            "setExpectations(0, 1, 0, 0, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str()),
                                           &as_expected));
@@ -692,7 +692,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SocialButttonAdBLockTagTest) {
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
                                           base::StringPrintf(
-                                            "setExpectations(0, 1, 0, 0);"
+                                            "setExpectations(0, 1, 0, 0, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str()),
                                           &as_expected));
@@ -717,7 +717,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SocialButttonAdBlockDiffTagTest) {
   bool as_expected = false;
   ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
                                           base::StringPrintf(
-                                            "setExpectations(1, 0, 0, 0);"
+                                            "setExpectations(1, 0, 0, 0, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str()),
                                           &as_expected));
@@ -771,4 +771,26 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TagPrefsControlTags) {
   AssertTagExists(brave_shields::kFacebookEmbeds, true);
   AssertTagExists(brave_shields::kTwitterEmbeds, true);
   AssertTagExists(brave_shields::kLinkedInEmbeds, false);
+}
+
+// Make sure that cancelrequest actually blocks
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CancelRequestOptionTest) {
+  AddRulesToAdBlock("logo.png$explicitcancel");
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+  GURL tab_url = embedded_test_server()->GetURL("b.com",
+                                                kAdBlockTestPage);
+  GURL resource_url =
+    embedded_test_server()->GetURL("example.com", "/logo.png");
+  ui_test_utils::NavigateToURL(browser(), tab_url);
+  content::WebContents* contents =
+    browser()->tab_strip_model()->GetActiveWebContents();
+  bool as_expected = false;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
+                                          base::StringPrintf(
+                                            "setExpectations(0, 0, 1, 0, 0, 0);"
+                                            "addImage('%s')",
+                                            resource_url.spec().c_str()),
+                                          &as_expected));
+  EXPECT_TRUE(as_expected);
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }

--- a/components/brave_shields/browser/base_brave_shields_service.cc
+++ b/components/brave_shields/browser/base_brave_shields_service.cc
@@ -61,10 +61,12 @@ void BaseBraveShieldsService::Stop() {
 bool BaseBraveShieldsService::ShouldStartRequest(const GURL& url,
     content::ResourceType resource_type,
     const std::string& tab_host,
-    bool* did_match_exception) {
+    bool* did_match_exception,
+    bool* cancel_request_explicitly) {
   if (did_match_exception) {
     *did_match_exception = false;
   }
+  // Intentionally don't set cancel_request_explicitly
   return true;
 }
 

--- a/components/brave_shields/browser/base_brave_shields_service.h
+++ b/components/brave_shields/browser/base_brave_shields_service.h
@@ -34,7 +34,8 @@ class BaseBraveShieldsService : public BraveComponentExtension {
   virtual bool ShouldStartRequest(const GURL& url,
       content::ResourceType resource_type,
       const std::string& tab_host,
-      bool* did_match_exception);
+      bool* did_match_exception,
+      bool* cancel_request_explicitly);
   virtual scoped_refptr<base::SequencedTaskRunner> GetTaskRunner();
 
  protected:

--- a/components/brave_shields/browser/tracking_protection_service.cc
+++ b/components/brave_shields/browser/tracking_protection_service.cc
@@ -40,12 +40,14 @@ TrackingProtectionService::~TrackingProtectionService() {
 bool TrackingProtectionService::ShouldStartRequest(const GURL& url,
     content::ResourceType resource_type,
     const std::string &tab_host,
-    bool* matching_exception_filter) {
+    bool* matching_exception_filter,
+    bool* cancel_request_explicitly) {
   // There are no exceptions in the TP service, but exceptions are
   // combined with brave/ad-block.
   if (matching_exception_filter) {
     *matching_exception_filter = false;
   }
+  // Intentionally don't set cancel_request_explicitly
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   std::string host = url.host();
   if (!tracking_protection_client_->matchesTracker(

--- a/components/brave_shields/browser/tracking_protection_service.h
+++ b/components/brave_shields/browser/tracking_protection_service.h
@@ -38,7 +38,8 @@ class TrackingProtectionService : public BaseLocalDataFilesObserver {
   bool ShouldStartRequest(const GURL& spec,
                           content::ResourceType resource_type,
                           const std::string& tab_host,
-                          bool* matching_exception_filter);
+                          bool* matching_exception_filter,
+                          bool* cancel_request_explicitly);
   scoped_refptr<base::SequencedTaskRunner> GetTaskRunner();
 
   // implementation of BaseLocalDataFilesObserver

--- a/test/data/blocking.html
+++ b/test/data/blocking.html
@@ -2,21 +2,28 @@
 <head>
 <script>
 let expectedImgLoaded = 0
+let expectedImgLoadedBlank = 0
 let expectedImgBlocked = 0
 let expectedXHRLoaded = 0
+let expectedXHRLoadedBlank = 0
 let expectedXHRBlocked = 0
 let numXHRLoaded = 0
+let numXHRLoadedBlank = 0
 let numXHRBlocked = 0
+let numImgLoaded = 0
+let numImgLoadedBlank = 0
+let numImgBlocked = 0
 
 // Performs an XHR for the specified src
 function xhr(src) {
   const xhr = new XMLHttpRequest();
   xhr.open('GET', src, true);
   xhr.onload = function(e) {
-    if (xhr.response.length !== 0)
+    if (xhr.response.length !== 0) {
       numXHRLoaded++
-    else
-      numXHRBlocked++
+    } else {
+      numXHRLoadedBlank++
+    }
     onLoad()
   }
   xhr.onerror = function(e) {
@@ -32,41 +39,50 @@ function addImage(src) {
   img.src = src
   img.className = 'adImage'
   img.addEventListener('load', onLoad)
+  img.addEventListener('error', () => {
+    onLoad()
+  })
+
+  img.addEventListener('load', () => {
+    if (img.complete &&
+        (img.naturalHeight !== 1 || img.naturalWidth !== 1)) {
+      numImgLoaded++
+    } else {
+      numImgLoadedBlank++
+    }
+    onLoad()
+  })
+  img.addEventListener('error', () => {
+    numImgBlocked++
+    onLoad()
+  })
   document.body.appendChild(img)
 }
 
 // Sets the expectation for the number of images and XHR loaded and blocked
-function setExpectations(numImgLoaded, numImgBlocked, numXHRLoaded, numXHRBlocked) {
+function setExpectations(numImgLoaded, numImgLoadedBlank, numImgBlocked, numXHRLoaded, numXHRLoadedBlank, numXHRBlocked) {
   expectedImgLoaded = numImgLoaded
+  expectedImgLoadedBlank = numImgLoadedBlank
   expectedImgBlocked = numImgBlocked
   expectedXHRLoaded = numXHRLoaded
+  expectedXHRLoadedBlank = numXHRLoadedBlank
   expectedXHRBlocked = numXHRBlocked
 }
 
 function onLoad() {
-  const adImages = Array.from(document.querySelectorAll('.adImage'))
-  if (adImages.length !== expectedImgLoaded + expectedImgBlocked ||
-      numXHRLoaded + numXHRBlocked !== expectedXHRLoaded + expectedXHRBlocked) {
+  if (numImgLoaded + numImgLoadedBlank + numImgBlocked !== expectedImgLoaded + expectedImgBlocked + expectedImgLoadedBlank ||
+      numXHRLoaded + numXHRLoadedBlank + numXHRBlocked !== expectedXHRLoaded + expectedXHRLoadedBlank + expectedXHRBlocked) {
     return;
   }
-
-  // Blocked image should be a 1x1 stub
-  const numImgLoaded = adImages.reduce((total, adImage) => {
-    if (adImage.complete &&
-        (adImage.naturalHeight !== 1 || adImage.naturalWidth !== 1)) {
-      return total + 1
-    }
-    return total
-  }, 0);
-
-  const numImgBlocked = adImages.length - numImgLoaded
   const result = numImgLoaded == expectedImgLoaded &&
+      expectedImgLoadedBlank == numImgLoadedBlank &&
       expectedImgBlocked == numImgBlocked &&
       numXHRLoaded === expectedXHRLoaded &&
+      numXHRLoadedBlank === expectedXHRLoadedBlank &&
       numXHRBlocked === expectedXHRBlocked
   // For debugging:
-  // console.log('sending: ' + JSON.stringify({result, expectedImgLoaded, expectedImgBlocked, numImgBlocked,
-  //    numXHRLoaded, expectedXHRLoaded, numXHRBlocked, expectedXHRBlocked}))
+  // console.log('sending: ' + JSON.stringify({result, expectedImgLoaded, expectedImgLoadedBlank, expectedImgBlocked, numImgLoadedBlank, numImgBlocked,
+  //   numXHRLoaded, expectedXHRLoaded, numXHRLoadedBlank, numXHRBlocked, expectedXHRLoadedBlank, expectedXHRBlocked}))
   window.domAutomationController.send(result)
 }
 </script>


### PR DESCRIPTION
Fix brave/brave-browser#3749
Fix brave/brave-browser#2286
Fix brave/brave-browser#2931

Related PR: https://github.com/brave/ad-block/pull/197

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
