### PR TITLE
Non-referral downloads should use generic refcode

### DIFF
--- a/browser/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats_updater_browsertest.cc
@@ -117,8 +117,9 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest, StatsUpdaterSetsFirstCheckP
 }
 
 // Run the stats updater with no active referral and verify that the
-// update url doesn't include a referral code
-IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest, StatsUpdaterStartupPingWithNoReferralCode) {
+// update url specifies the default referral code
+IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
+                       StatsUpdaterStartupPingWithDefaultReferralCode) {
   // Ensure that checked for promo code file preference is false
   ASSERT_FALSE(GetLocalState()->GetBoolean(kReferralCheckedForPromoCodeFile));
 
@@ -154,7 +155,7 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest, StatsUpdaterStartupPingWith
 
   // Verify that there is no referral code
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "ref", &query_value));
-  EXPECT_STREQ(query_value.c_str(), "none");
+  EXPECT_STREQ(query_value.c_str(), "BRV001");
 }
 
 // Run the stats updater with an active referral and verify that the

--- a/browser/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats_updater_browsertest.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -37,7 +38,8 @@ class BraveStatsUpdaterBrowserTest : public InProcessBrowserTest {
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
     brave::RegisterPrefsForBraveStatsUpdater(testing_local_state_.registry());
-    brave::RegisterPrefsForBraveReferralsService(testing_local_state_.registry());
+    brave::RegisterPrefsForBraveReferralsService(
+        testing_local_state_.registry());
     InitEmbeddedTestServer();
     SetBaseUpdateURLForTest();
   }
@@ -90,7 +92,8 @@ class BraveStatsUpdaterBrowserTest : public InProcessBrowserTest {
 };
 
 // Run the stats updater and verify that it sets the first check preference
-IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest, StatsUpdaterSetsFirstCheckPreference) {
+IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
+                       StatsUpdaterSetsFirstCheckPreference) {
   // Ensure that first check preference is false
   ASSERT_FALSE(GetLocalState()->GetBoolean(kFirstCheckMade));
 
@@ -160,7 +163,8 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
 
 // Run the stats updater with an active referral and verify that the
 // update url includes the referral code
-IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest, StatsUpdaterStartupPingWithReferralCode) {
+IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
+                       StatsUpdaterStartupPingWithReferralCode) {
   // Ensure that checked for promo code file preference is false
   ASSERT_FALSE(GetLocalState()->GetBoolean(kReferralCheckedForPromoCodeFile));
 

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -44,6 +44,10 @@ const int kFetchReferralHeadersFrequency = 60 * 60 * 24;
 // Maximum size of the referral server response in bytes.
 const int kMaxReferralServerResponseSizeBytes = 1024 * 1024;
 
+// Default promo code, used when no promoCode file exists on first
+// run.
+const char kDefaultPromoCode[] = "BRV001";
+
 namespace {
 
 std::string GetPlatformIdentifier() {
@@ -326,6 +330,7 @@ base::FilePath BraveReferralsService::GetPromoCodeFileName() const {
 void BraveReferralsService::ReadPromoCode() {
   base::FilePath promo_code_file = GetPromoCodeFileName();
   if (!base::PathExists(promo_code_file)) {
+    promo_code_ = kDefaultPromoCode;
     return;
   }
   if (!base::ReadFileToString(promo_code_file, &promo_code_)) {

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -448,7 +448,8 @@ std::string BraveReferralsService::BuildReferralFinalizationCheckPayload()
 
 void BraveReferralsService::FetchReferralHeaders() {
   net::NetworkTrafficAnnotationTag traffic_annotation =
-      net::DefineNetworkTrafficAnnotation("brave_referral_headers_fetcher", R"(
+      net::DefineNetworkTrafficAnnotation(
+        "brave_referral_headers_fetcher", R"(
         semantics {
           sender:
             "Brave Referrals Service"


### PR DESCRIPTION
Fixes brave/brave-browser#2547

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Download a non-referral stub installer (i.e., no referral code embedded in its filename)
- Delete existing profile
- Run the installer
- After the installer completes, launch Brave and wait ~10 seconds
- Confirm that `Local State` file (e.g., `/c/Users/emerick/AppData/Local/BraveSoftware/Brave-Browser-Development/User Data/Local State`) contains `"promo_code":"BRV001"` entry
- Confirm with server team that daily ping for this run looked similar to this (in particular, `ref` is `BRV001`):

    `https://laptop-updates.brave.com/1/usage/brave-core?platform=winx64-bc&channel=release&version=0.64.4&daily=true&weekly=true&monthly=true&first=true&w oi=2019-03-11&ref=BRV001`

- Should also confirm that regular referral downloads continue to work as normal

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
