### PR TITLE
fix ts lint on windows not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "tslint --project tsconfig-lint.json 'components/**/*.{ts,tsx}'",
+    "lint": "tslint --project tsconfig-lint.json \"components/**/*.{ts,tsx}\"",
     "pep8": "pycodestyle --max-line-length 120 -r script",
     "web-ui-gen-grd": "node components/webpack/gen-webpack-grd",
     "web-ui": "webpack --config components/webpack/webpack.config.js --progress --colors",


### PR DESCRIPTION
@emerick spotted that linting TS files doesn't work on Windows and came up with a fix here https://bravesoftware.slack.com/archives/C7VLGSR55/p1552936275370400?thread_ts=1552890829.349400&cid=C7VLGSR55. I'm just applying the fix.

Test Plan:

```
npm run lint
```

fix https://github.com/brave/brave-browser/issues/3767