### PR TITLE
Enable crash report on dev/nightly channel by default (uplift to 0.63.x)

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -47,6 +47,8 @@ source_set("browser_process") {
     "mac/sparkle_glue.mm",
     "mac/sparkle_glue.h",
     "mac/su_updater.h",
+    "metrics/metrics_reporting_util.cc",
+    "metrics/metrics_reporting_util.h",
     "search_engines/guest_window_search_engine_provider_service.cc",
     "search_engines/guest_window_search_engine_provider_service.h",
     "search_engines/private_window_search_engine_provider_service.cc",

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -6,10 +6,12 @@
 
 #include "base/values.h"
 #include "brave/browser/brave_stats_updater.h"
+#include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/tor/tor_profile_service.h"
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
 #include "chrome/browser/first_run/first_run.h"
 #include "chrome/common/pref_names.h"
+#include "components/metrics/metrics_pref_names.h"
 #include "components/prefs/pref_registry_simple.h"
 
 namespace brave {
@@ -24,6 +26,10 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 #endif
   tor::TorProfileService::RegisterLocalStatePrefs(registry);
   RegisterPrefsForMuonMigration(registry);
+
+  registry->SetDefaultPrefValue(
+      metrics::prefs::kMetricsReportingEnabled,
+      base::Value(GetDefaultPrefValueForMetricsReporting()));
 }
 
 }  // namespace brave

--- a/browser/metrics/metrics_reporting_util.cc
+++ b/browser/metrics/metrics_reporting_util.cc
@@ -1,0 +1,26 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/metrics/metrics_reporting_util.h"
+
+#include "base/logging.h"
+#include "chrome/common/channel_info.h"
+#include "components/version_info/channel.h"
+
+bool GetDefaultPrefValueForMetricsReporting() {
+  switch (chrome::GetChannel()) {
+    case version_info::Channel::STABLE:  // fall through
+    case version_info::Channel::BETA:
+      return false;
+    case version_info::Channel::DEV:     // fall through
+    case version_info::Channel::CANARY:
+      return true;
+    case version_info::Channel::UNKNOWN:
+      return false;
+    default:
+      NOTREACHED();
+      return false;
+  }
+}

--- a/browser/metrics/metrics_reporting_util.h
+++ b/browser/metrics/metrics_reporting_util.h
@@ -1,0 +1,11 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_METRICS_METRICS_REPORTING_UTIL_H_
+#define BRAVE_BROWSER_METRICS_METRICS_REPORTING_UTIL_H_
+
+bool GetDefaultPrefValueForMetricsReporting();
+
+#endif  // BRAVE_BROWSER_METRICS_METRICS_REPORTING_UTIL_H_

--- a/browser/metrics/metrics_reporting_util_unittest_linux.cc
+++ b/browser/metrics/metrics_reporting_util_unittest_linux.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/metrics/metrics_reporting_util.h"
+
+#include "base/environment.h"
+#include "chrome/common/channel_info.h"
+#include "components/version_info/channel.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(MetricsUtilTest, DefaultValueTest) {
+#if defined(OFFICIAL_BUILD)
+  auto env = base::Environment::Create();
+
+  env->SetVar("CHROME_VERSION_EXTRA", LINUX_CHANNEL_STABLE);
+  EXPECT_EQ(version_info::Channel::STABLE, chrome::GetChannel());
+  EXPECT_FALSE(GetDefaultPrefValueForMetricsReporting());
+
+  env->SetVar("CHROME_VERSION_EXTRA", LINUX_CHANNEL_BETA);
+  EXPECT_EQ(version_info::Channel::BETA, chrome::GetChannel());
+  EXPECT_FALSE(GetDefaultPrefValueForMetricsReporting());
+
+  env->SetVar("CHROME_VERSION_EXTRA", LINUX_CHANNEL_DEV);
+  EXPECT_EQ(version_info::Channel::DEV, chrome::GetChannel());
+  EXPECT_TRUE(GetDefaultPrefValueForMetricsReporting());
+
+  env->SetVar("CHROME_VERSION_EXTRA", BRAVE_LINUX_CHANNEL_NIGHTLY);
+  EXPECT_EQ(version_info::Channel::CANARY, chrome::GetChannel());
+  EXPECT_TRUE(GetDefaultPrefValueForMetricsReporting());
+#else  // OFFICIAL_BUILD
+  EXPECT_EQ(version_info::Channel::UNKNOWN, chrome::GetChannel());
+  EXPECT_FALSE(GetDefaultPrefValueForMetricsReporting());
+#endif
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -46,6 +46,7 @@ test("brave_unit_tests") {
     "//brave/browser/tor/mock_tor_profile_service_impl.h",
     "//brave/browser/tor/mock_tor_profile_service_factory.cc",
     "//brave/browser/tor/mock_tor_profile_service_factory.h",
+    "//brave/browser/metrics/metrics_reporting_util_unittest_linux.cc",
     "//brave/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_httpse_network_delegate_helper_unittest.cc",


### PR DESCRIPTION
Enable crash report on dev/nightly channel by default

Uplift for https://github.com/brave/brave-core/pull/1985
Fixes https://github.com/brave/brave-browser/issues/1630