### PR TITLE
Always waiting for user interaction to fill the password form in Brave

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -136,7 +136,6 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
   const std::unordered_set<const char*> enabled_features = {
       extensions_features::kNewExtensionUpdaterService.name,
       features::kDesktopPWAWindowing.name,
-      password_manager::features::kFillOnAccountSelect.name,
   };
 
   // Disabled features.

--- a/browser/brave_features_browsertest.cc
+++ b/browser/brave_features_browsertest.cc
@@ -1,21 +1,15 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/feature_list.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/autofill/core/common/autofill_features.h"
-#include "components/password_manager/core/common/password_manager_features.h"
 #include "components/unified_consent/feature.h"
 #include "content/public/common/content_features.h"
 
 using BraveFeaturesBrowserTest = InProcessBrowserTest;
-
-IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, AutoFillPasswordDefault) {
-  EXPECT_TRUE(
-    base::FeatureList::IsEnabled(
-      password_manager::features::kFillOnAccountSelect));
-}
 
 IN_PROC_BROWSER_TEST_F(BraveFeaturesBrowserTest, AutoFillServerCommunication) {
   EXPECT_FALSE(

--- a/patches/components-password_manager-core-browser-password_form_filling.cc.patch
+++ b/patches/components-password_manager-core-browser-password_form_filling.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/components/password_manager/core/browser/password_form_filling.cc b/components/password_manager/core/browser/password_form_filling.cc
+index d234228194e800046f8db8ee90e8baa97af8dc0f..2cc1cd29e69a91f7fdd9c3e2d1b66a730c48a7ac 100644
+--- a/components/password_manager/core/browser/password_form_filling.cc
++++ b/components/password_manager/core/browser/password_form_filling.cc
+@@ -190,6 +190,9 @@ LikelyFormFilling SendFillInformationToRenderer(
+ 
+   bool wait_for_username =
+       wait_for_username_reason != WaitForUsernameReason::kDontWait;
++#if defined(BRAVE_CHROMIUM_BUILD)
++  wait_for_username = true;
++#endif
+ 
+   if (wait_for_username) {
+     metrics_recorder->SetManagerAction(


### PR DESCRIPTION
instead of using kFillOnAccountSelect which will show suggestions on page load
![Untitled](https://user-images.githubusercontent.com/11330831/54569509-5ae00c00-4998-11e9-9e07-40218e3d366f.gif)
fix https://github.com/brave/brave-browser/issues/1713
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
###
 1. Use built-in password manager to store credentials for twitter
 2. Go to twitter.com
 3. There is no password suggestions nor automatically filled password on page load
 4. Click on username/password filed to show suggestions
###
 1. Go to https://senglehardt.com/demo/no_boundaries/loginmanager/index.html
 2. Save fake credentials
 3. Follow the instructions of the website
 4. The result should be `Sniffed email: ? Sniffed password: ?`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
