### PR TITLE
Enable admin mode install of nightly on Windows

### DIFF
--- a/chromium_src/chrome/install_static/brave_install_modes_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_install_modes_unittest.cc
@@ -184,4 +184,11 @@ TEST(InstallModes, GetBinariesClientStateMediumKeyPath) {
   }
 }
 
+#if defined(OFFICIAL_BUILD)
+TEST(InstallModes, NightlyModesTest) {
+  EXPECT_TRUE(kInstallModes[NIGHTLY_INDEX].supports_system_level);
+  EXPECT_TRUE(kInstallModes[NIGHTLY_INDEX].supports_set_as_default_browser);
+}
+#endif
+
 }  // namespace install_static

--- a/chromium_src/chrome/install_static/brave_install_modes_unittest.cc
+++ b/chromium_src/chrome/install_static/brave_install_modes_unittest.cc
@@ -4,10 +4,10 @@
 
 #include "chrome/install_static/install_modes.h"
 
-#include <windows.h>
+#include <windows.h>  // NOLINT
 
-#include <cguid.h>
-#include <ctype.h>
+#include <cguid.h>  // NOLINT
+#include <ctype.h>  // NOLINT
 
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -140,20 +140,23 @@ TEST(InstallModes, GetClientStateKeyPath) {
 
 TEST(InstallModes, GetBinariesClientsKeyPath) {
   if (kUseGoogleUpdateIntegration) {
-    ASSERT_THAT(GetBinariesClientsKeyPath(),
-                StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\Clients\\")
-                          .append(kBinariesAppGuid)));
+    ASSERT_THAT(
+        GetBinariesClientsKeyPath(),
+        StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\Clients\\")
+                  .append(kBinariesAppGuid)));
   } else {
-    ASSERT_THAT(GetBinariesClientsKeyPath(),
-                StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));
+    ASSERT_THAT(
+        GetBinariesClientsKeyPath(),
+        StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));
   }
 }
 
 TEST(InstallModes, GetBinariesClientStateKeyPath) {
   if (kUseGoogleUpdateIntegration) {
-    ASSERT_THAT(GetBinariesClientStateKeyPath(),
-                StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\ClientState\\")
-                          .append(kBinariesAppGuid)));
+    ASSERT_THAT(
+        GetBinariesClientStateKeyPath(),
+        StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\ClientState\\")
+                  .append(kBinariesAppGuid)));
   } else {
     ASSERT_THAT(GetBinariesClientStateKeyPath(),
                 StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));
@@ -164,8 +167,9 @@ TEST(InstallModes, GetClientStateMediumKeyPath) {
   constexpr wchar_t kAppGuid[] = L"test";
 
   if (kUseGoogleUpdateIntegration) {
-    ASSERT_THAT(GetClientStateMediumKeyPath(kAppGuid),
-                StrEq(L"Software\\BraveSoftware\\Update\\ClientStateMedium\\test"));
+    ASSERT_THAT(
+        GetClientStateMediumKeyPath(kAppGuid),
+        StrEq(L"Software\\BraveSoftware\\Update\\ClientStateMedium\\test"));
   } else {
     ASSERT_THAT(GetClientStateMediumKeyPath(kAppGuid),
                 StrEq(std::wstring(L"Software\\").append(kProductPathName)));
@@ -176,8 +180,8 @@ TEST(InstallModes, GetBinariesClientStateMediumKeyPath) {
   if (kUseGoogleUpdateIntegration) {
     ASSERT_THAT(
         GetBinariesClientStateMediumKeyPath(),
-        StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\ClientStateMedium\\")
-                  .append(kBinariesAppGuid)));
+        StrEq(std::wstring(L"Software\\BraveSoftware\\Update\\"
+                            "ClientStateMedium\\").append(kBinariesAppGuid)));
   } else {
     ASSERT_THAT(GetBinariesClientStateMediumKeyPath(),
                 StrEq(std::wstring(L"Software\\").append(kBinariesPathName)));

--- a/chromium_src/chrome/install_static/chromium_install_modes.cc
+++ b/chromium_src/chrome/install_static/chromium_install_modes.cc
@@ -183,8 +183,8 @@ const InstallConstants kInstallModes[] = {
             0xe7 } },
         L"nightly",                                  // Forced channel name.
         ChannelStrategy::FIXED,
-        false,  // Does not support system-level installs.
-        false,  // Does not support in-product set as default browser UX.
+        true,   // Support system-level installs.
+        true,   // Support in-product set as default browser UX.
         true,   // Supports retention experiments.
         false,  // Did not support multi-install.
         icon_resources::kSxSApplicationIndex,  // App icon resource index.

--- a/chromium_src/chrome/install_static/chromium_install_modes.cc
+++ b/chromium_src/chrome/install_static/chromium_install_modes.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -157,10 +158,10 @@ const InstallConstants kInstallModes[] = {
     // A secondary install mode for Brave SxS (canary).
     {
         sizeof(kInstallModes[0]),
-        NIGHTLY_INDEX, // The mode for the side-by-side nightly channel.
-        "chrome-sxs",  // Install switch.
-        L"-Nightly",   // Install suffix.
-        L"Canary",     // Logo suffix.
+        NIGHTLY_INDEX,  // The mode for the side-by-side nightly channel.
+        "chrome-sxs",   // Install switch.
+        L"-Nightly",    // Install suffix.
+        L"Canary",      // Logo suffix.
         L"{C6CB981E-DB30-4876-8639-109F8933582C}",  // A distinct app GUID.
         L"Brave Nightly",                    // A distinct base_app_name.
         L"BraveNightly",                            // A distinct base_app_id.
@@ -202,7 +203,7 @@ const InstallConstants kInstallModes[] = {
         "",               // No install switch for the primary install mode.
         L"",              // Empty install_suffix for the primary install mode.
         L"",              // No logo suffix for the primary install mode.
-        L"",              // Empty app_guid since no integraion with Brave Update.
+        L"",            // Empty app_guid since no integraion with Brave Update.
         L"Brave Development",  // A distinct base_app_name.
         L"BraveDevelopment",   // A distinct base_app_id.
         L"BraveDevHTM",                             // ProgID prefix.


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3728

I verified nightly standalone installer works with admin mode with this PR on my local Windows machine.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_unit_tests Release --filter=InstallModes. NightlyModesTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
