### PR TITLE
WIP: Parse changelog for specific Brave version

### DIFF
--- a/script/changelog.py
+++ b/script/changelog.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import re
+import sys
+
+from argparse import RawTextHelpFormatter
+
+from lib.changelog import *
+
+
+def main():
+    """
+    Download the brave-browser/CHANGELOG.md file, parse it, and
+    return either markdown or html for a particular Brave tag.
+
+    Example:
+    python script/changelog.py -t refs/tags/v0.61.51 \
+        -u https://raw.githubusercontent.com/brave/brave-browser/master/CHANGELOG.md -o markdown
+
+    ## [0.61.51](https://github.com/brave/brave-browser/releases/tag/v0.61.51)
+
+    - Added new setting that allows Brave Rewards icon in the URL to be hidden if Rewards \
+        is inactive. ([#2975](https://github.com/brave/brave-browser/issues/2975))
+
+    """
+
+    args = parse_args()
+
+    if args.debug:
+        logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+    changelog_url = args.url
+
+    tag = args.tag
+
+    if not re.match(r'^refs/tags/', tag) and not re.match(r'^v', tag):
+        logging.error(" Tag prefix must contain {} or {}".format("\"refs/tags/\"", "\"v\""))
+        exit(1)
+
+    match = re.match(r'^refs/tags/(.*)$', tag)
+    if match:
+        tag = match.group(1)
+
+    match = re.match(r'^v(.*)$', tag)
+    if match:
+        version = match.group(1)
+
+    logging.debug("CHANGELOG_URL: {}".format(changelog_url))
+    logging.debug("TAG: {}".format(tag))
+    logging.debug("VERSION: {}".format(version))
+
+    changelog_txt = download_from_url(args, logging, changelog_url)
+
+    if args.output == 'markdown':
+        print(render_markdown(changelog_txt, version, logging))
+    elif args.output == 'html':
+        print(render_html(changelog_txt, version, logging))
+
+
+def parse_args():
+    desc = "Parse Brave Browser changelog and return changes for a tag"
+
+    parser = argparse.ArgumentParser(
+        description=desc, formatter_class=RawTextHelpFormatter)
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='Print debug statements')
+    parser.add_argument('-o', '--output', help='Output format: markdown or html', required=True)
+    parser.add_argument('-t', '--tag',
+                        help='Brave version tag (allowed format: "v0.60.45" or "refs/tags/v0.60.45")', required=True)
+    parser.add_argument('-u', '--url', help='URL for Brave Browser raw markdown file (required)', required=True)
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/script/lib/changelog.py
+++ b/script/lib/changelog.py
@@ -1,0 +1,99 @@
+import requests
+import mistletoe
+
+from mistletoe import Document, ast_renderer
+
+
+def render_markdown(changelog_txt, version, logging):
+    """
+    Create an AST from the changelog document (which is in Markdown).
+    Search the AST for the version we're interested in, generate
+    and return markdown as a string for just that version.
+    """
+
+    d = Document(changelog_txt)
+    output = ast_renderer.get_ast(d)
+    s = str()
+
+    logging.debug("Locating the changelog AST for version: \'{}\'".format(version))
+
+    version_heading = ''
+    version_changes = ''
+    pos = 0
+    for item in output['children']:
+        if item['type'] == 'Heading' and item['level'] == 2:
+            if item['children'][0]['children'][0]['content'] == version:
+                version_heading = output['children'][pos]
+                version_changes = output['children'][pos+1]
+        pos = pos + 1
+    if version_heading and version_changes:
+        heading = reconstruct_heading(version_heading)
+        s = heading + '\n'
+        s = s + '\n'
+        changes = reconstruct_brave_changelog_list(version_changes)
+        for i in changes:
+            s = s + i + '\n'
+    else:
+        logging.error("Cannot Locate the changelog AST for version: \'{}\'".format(version))
+        exit(1)
+
+    return s
+
+
+def render_html(changelog_txt, version, logging):
+    """
+    Format an html rendered document from the render_markdown method above.
+    """
+
+    rendered = mistletoe.markdown(render_markdown(changelog_txt, version, logging))
+    return rendered
+
+
+def reconstruct_heading(heading):
+    """
+    heading is a dict
+    """
+
+    if heading['type'] is "Heading":
+        return ("{} [{}]({})".format('#'*heading['level'],
+                                     heading['children'][0]['children'][0]['content'],
+                                     heading['children'][0]['target']))
+
+
+def reconstruct_brave_changelog_list(li):
+    """
+    li is a list
+    """
+
+    changes = []
+
+    for item in li['children']:
+        for item2 in item['children']:
+            changes.append("{} {}[{}]({}){}".format(' -', item2['children'][0]['content'],
+                                                    item2['children'][1]['children'][0]['content'],
+                                                    item2['children'][1]['target'],
+                                                    item2['children'][2]['content']))
+    return changes
+
+
+def download_from_url(args, logging, changelog_url):
+    headers = {'Accept': 'application/octet-stream'}
+    if args.debug:
+        # disable urllib3 logging for this session to avoid showing
+        # access_token in logs
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.info("Downloading Changelog file: {}".format(changelog_url))
+    try:
+        r = requests.get(changelog_url, headers=headers)
+    except requests.exceptions.ConnectionError as e:
+        logging.error("Error: Received requests.exceptions.ConnectionError, Exiting...")
+        exit(1)
+    except Exception as e:
+        logging.error("Error: Received exception {},  Exiting...".format(type(e)))
+        exit(1)
+    logging.debug("r.status_code: {}".format(r.status_code))
+
+    if r.status_code == 200:
+        return r.text
+    else:
+        r.raise_for_status()

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -11,6 +11,7 @@ PLATFORM = {
     'cygwin': 'win32',
     'darwin': 'darwin',
     'linux2': 'linux',
+    'linux': 'linux',
     'win32': 'win32',
 }[sys.platform]
 
@@ -136,7 +137,7 @@ def s3_config():
 
 
 def enable_verbose_mode():
-    print 'Running in verbose mode'
+    print('Running in verbose mode')
     global verbose_mode
     verbose_mode = True
 

--- a/script/lib/github.py
+++ b/script/lib/github.py
@@ -6,7 +6,10 @@ import re
 import requests
 import sys
 import base64
-from util import execute, scoped_cwd
+try:
+    from util import execute, scoped_cwd
+except ImportError:
+    pass
 
 REQUESTS_DIR = os.path.abspath(os.path.join(__file__, '..', '..', '..',
                                             'vendor', 'requests'))

--- a/script/lib/helpers.py
+++ b/script/lib/helpers.py
@@ -36,6 +36,28 @@ def get_releases_by_tag(repo, tag_name, include_drafts=False):
                 r['tag_name'] == tag_name and not r['draft']]
 
 
+def get_release(repo, tag, allow_published_release_updates=False):
+    """
+    allow_published_release_updates determines whether we will
+    allow this process to update only a draft release, or will
+    we also allow a published release to be updated.
+    """
+    release = None
+    releases = get_releases_by_tag(repo, tag, include_drafts=True)
+    if releases:
+        print("[INFO] Found existing release draft")
+        if len(releases) > 1:
+            raise UserWarning("[INFO] More then one draft with the tag '{}' "
+                              "found, not sure which one to merge with."
+                              .format(tag))
+        release = releases[0]
+        if not allow_published_release_updates and not release['draft']:
+            raise UserWarning("[INFO] Release with tag '{}' is already "
+                              "published, aborting.".format(tag))
+
+    return release
+
+
 def release_channel():
     channel = os.environ['CHANNEL']
     message = ('Error: Please set the $CHANNEL '
@@ -50,14 +72,6 @@ def get_tag():
 
 def release_name():
     return '{0} Channel'.format(get_channel_display_name())
-
-
-def get_releases_by_tag(repo, tag_name, include_drafts=False):
-    if include_drafts:
-        return [r for r in repo.releases.get() if r['tag_name'] == tag_name]
-    else:
-        return [r for r in repo.releases.get() if
-                r['tag_name'] == tag_name and not r['draft']]
 
 
 def retry_func(try_func, catch, retries, catch_func=None):

--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -22,17 +22,17 @@ class TestGetDraft(unittest.TestCase):
 
     def test_returns_existing_draft(self):
         self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
-        self.assertEquals(upload.get_draft(self.repo,
-                                           'test')['tag_name'], 'test')
+        self.assertEquals(upload.get_release(self.repo,
+                                             'test')['tag_name'], 'test', False)
 
     def test_fails_on_existing_release(self):
         self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
-        self.assertRaises(UserWarning, upload.get_draft, self.repo, 'test')
+        self.assertRaises(UserWarning, upload.get_release, self.repo, 'test', True)
 
     def test_returns_none_on_new_draft(self):
         self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
-        upload.get_draft(self.repo, 'new')
-        self.assertEquals(upload.get_draft(self.repo, 'test'), None)
+        upload.get_release(self.repo, 'new', False)
+        self.assertEquals(upload.get_release(self.repo, 'test'), None)
 
 
 class TestGetBravePackages(unittest.TestCase):

--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -26,8 +26,8 @@ class TestGetDraft(unittest.TestCase):
                                              'test')['tag_name'], 'test', False)
 
     def test_fails_on_existing_release(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
-        self.assertRaises(UserWarning, upload.get_release, self.repo, 'test', True)
+        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False, 'allow_published_release_updates': False}]
+        self.assertRaises(UserWarning, upload.get_release, self.repo, 'test', False)
 
     def test_returns_none_on_new_draft(self):
         self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
@@ -52,10 +52,10 @@ class TestGetBravePackages(unittest.TestCase):
                                           else '', chan))
                         with open(os.path.join(self.get_pkgs_dir,
                                                'win32', name), 'w') as f:
-                            f.write(name)
+                            f.write(name + '\n')
                         with open(os.path.join(self.get_pkgs_dir,
                                                'win32', name32), 'w') as f:
-                            f.write(name32)
+                            f.write(name32 + '\n')
                 else:
                     for mode in ['Stub', 'Standalone']:
                         name = 'BraveBrowser{}Setup_70_0_56_8.exe'.format(
@@ -64,10 +64,10 @@ class TestGetBravePackages(unittest.TestCase):
                             mode if mode not in 'Stub' else '')
                         with open(os.path.join(
                                 self.get_pkgs_dir, 'win32', name), 'w') as f:
-                            f.write(name)
+                            f.write(name + '\n')
                         with open(os.path.join(
                                 self.get_pkgs_dir, 'win32', name32), 'w') as f:
-                            f.write(name32)
+                            f.write(name32 + '\n')
         self.__class__._is_setup = True
 
     def test_only_returns_nightly_darwin_package(self):
@@ -146,7 +146,8 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM), 'nightly', '0.56.8'))
         self.assertEquals(
-            pkgs, ['BraveBrowserNightlySetup32.exe', 'BraveBrowserStandaloneNightlySetup32.exe'])
+            sorted(pkgs), sorted(['BraveBrowserNightlySetup32.exe',
+                                  'BraveBrowserStandaloneNightlySetup32.exe']))
 
     def test_only_returns_dev_win_x64_package(self):
         upload.PLATFORM = 'win32'
@@ -154,7 +155,8 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(
             self.get_pkgs_dir, upload.PLATFORM), 'dev', '0.56.8'))
         self.assertEquals(
-            pkgs, ['BraveBrowserDevSetup.exe', 'BraveBrowserStandaloneDevSetup.exe'])
+            sorted(pkgs), sorted(['BraveBrowserDevSetup.exe',
+                                  'BraveBrowserStandaloneDevSetup.exe']))
 
     def test_only_returns_dev_win_ia32_package(self):
         upload.PLATFORM = 'win32'
@@ -162,7 +164,8 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM), 'dev', '0.56.8'))
         self.assertEquals(
-            pkgs, ['BraveBrowserDevSetup32.exe', 'BraveBrowserStandaloneDevSetup32.exe'])
+            sorted(pkgs), sorted(['BraveBrowserDevSetup32.exe',
+                                  'BraveBrowserStandaloneDevSetup32.exe']))
 
     def test_only_returns_beta_win_x64_package(self):
         upload.PLATFORM = 'win32'
@@ -171,7 +174,8 @@ class TestGetBravePackages(unittest.TestCase):
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'beta', '0.56.8'))
         self.assertEquals(
-            pkgs, ['BraveBrowserBetaSetup.exe', 'BraveBrowserStandaloneBetaSetup.exe'])
+            sorted(pkgs), sorted(['BraveBrowserBetaSetup.exe',
+                                  'BraveBrowserStandaloneBetaSetup.exe']))
 
     def test_only_returns_beta_win_ia32_package(self):
         upload.PLATFORM = 'win32'
@@ -180,7 +184,8 @@ class TestGetBravePackages(unittest.TestCase):
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'beta', '0.56.8'))
         self.assertEquals(
-            pkgs, ['BraveBrowserBetaSetup32.exe', 'BraveBrowserStandaloneBetaSetup32.exe'])
+            sorted(pkgs), sorted(['BraveBrowserBetaSetup32.exe',
+                                  'BraveBrowserStandaloneBetaSetup32.exe']))
 
     def test_only_returns_release_win_x64_package(self):
         upload.PLATFORM = 'win32'

--- a/script/update_release_changelog.py
+++ b/script/update_release_changelog.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import re
+import sys
+
+from argparse import RawTextHelpFormatter
+
+from lib.changelog import *
+from lib.config import (PLATFORM, get_env_var)
+from lib.github import GitHub
+from lib.helpers import *
+
+
+def main():
+
+    """
+    Download the brave-browser/CHANGELOG.md file, parse it and
+    convert to markdown, then update the release notes for the
+    release specified.
+
+    """
+
+    args = parse_args()
+
+    if args.debug:
+        logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+    changelog_url = args.url
+
+    tag = args.tag
+
+    if not re.match(r'^refs/tags/', tag) and not re.match(r'^v', tag):
+        logging.error(" Tag prefix must contain {} or {}".format("\"refs/tags/\"", "\"v\""))
+        exit(1)
+
+    match = re.match(r'^refs/tags/(.*)$', tag)
+    if match:
+        tag = match.group(1)
+
+    match = re.match(r'^v(.*)$', tag)
+    if match:
+        version = match.group(1)
+
+    logging.debug("CHANGELOG_URL: {}".format(changelog_url))
+    logging.debug("TAG: {}".format(tag))
+    logging.debug("VERSION: {}".format(version))
+
+    changelog_txt = download_from_url(args, logging, changelog_url)
+
+    tag_changelog_txt = render_markdown(changelog_txt, version, logging)
+
+    # BRAVE_REPO is defined in lib/helpers.py
+    repo = GitHub(get_env_var('GITHUB_TOKEN')).repos(BRAVE_REPO)
+    release = get_release(repo, tag, allow_published_release_updates=True)
+
+    logging.debug("Release body before update: \n\'{}\'".format(release['body']))
+
+    logging.info("Merging original release body with changelog")
+    new_body = release['body'] + '\n\n### Release Notes' + '\n\n' + \
+        tag_changelog_txt
+    logging.debug("release body is now: \n\'{}\'".format(new_body))
+
+    data = dict(tag_name=tag, name=release['name'], body=new_body)
+    id = release['id']
+    logging.debug("Updating release with id: {}".format(id))
+    release = retry_func(
+        lambda run: repo.releases.__call__(f'{id}').patch(data=data),
+        catch=requests.exceptions.ConnectionError, retries=3
+    )
+    logging.debug("Release body after update: \n\'{}\'".format(release['body']))
+
+
+def parse_args():
+    desc = "Parse Brave Browser changelog and add markdown to release notes for tag"
+
+    parser = argparse.ArgumentParser(
+        description=desc, formatter_class=RawTextHelpFormatter)
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='Print debug statements')
+    parser.add_argument('-t', '--tag',
+                        help='Brave version tag (allowed format: "v0.60.45" or "refs/tags/v0.60.45")', required=True)
+    parser.add_argument('-u', '--url', help='URL for Brave Browser raw markdown file (required)', required=True)
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/script/upload.py
+++ b/script/upload.py
@@ -39,7 +39,7 @@ def main():
     repo = GitHub(get_env_var('GITHUB_TOKEN')).repos(BRAVE_REPO)
 
     tag = get_brave_version()
-    release = get_draft(repo, tag)
+    release = get_release(repo, tag, allow_published_release_updates=False)
 
     if not release:
         print("[INFO] No existing release found, creating new "
@@ -344,24 +344,6 @@ def get_brave_packages(dir, channel, version):
                         filecopy(file_path, file_desired_standalone_untagged)
                         pkgs.append(file_desired_standalone_untagged)
     return pkgs
-
-
-def get_draft(repo, tag):
-    release = None
-    releases = get_releases_by_tag(repo, tag, include_drafts=True)
-    if releases:
-        print("[INFO] Found existing release draft, merging this upload with "
-              "it")
-        if len(releases) > 1:
-            raise UserWarning("[INFO] More then one draft with the tag '{}' "
-                              "found, not sure which one to merge with."
-                              .format(tag))
-        release = releases[0]
-        if not release['draft']:
-            raise UserWarning("[INFO] Release with tag '{}' is already "
-                              "published, aborting.".format(tag))
-
-    return release
 
 
 def parse_args():


### PR DESCRIPTION
There are 2 scripts now, `script/changelog.py` is more of a demo type script for use by individuals, and `script/update_release_changelog.py` which actually can update the release with the changelog markdown after a tag has been published. This second script will be built into a Jenkins job, and the first may be removed at some point in the future.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
