### PR TITLE
polish shields ui

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/header.tsx
+++ b/components/brave_extension/extension/brave_extension/components/header.tsx
@@ -97,7 +97,7 @@ export default class Header extends React.PureComponent<Props, {}> {
         <SiteOverview status={enabled ? 'enabled' : 'disabled'}>
           <SiteInfo>
             <Favicon src={favicon} />
-            <SiteInfoText id='hostname'>{hostname}</SiteInfoText>
+            <SiteInfoText id='hostname' title={hostname}>{hostname}</SiteInfoText>
           </SiteInfo>
           {
             enabled

--- a/components/brave_extension/extension/brave_extension/components/list/dynamic.tsx
+++ b/components/brave_extension/extension/brave_extension/components/list/dynamic.tsx
@@ -90,7 +90,7 @@ export default class DynamicList extends React.PureComponent<Props, {}> {
       <BlockedListContent>
         <BlockedListHeader>
           <Favicon src={favicon} />
-          <SiteInfoText>{hostname}</SiteInfoText>
+          <SiteInfoText title={hostname}>{hostname}</SiteInfoText>
         </BlockedListHeader>
         <details open={true}>
           <BlockedListSummary stats={false} onClick={onClose}>

--- a/components/brave_extension/extension/brave_extension/components/list/static.tsx
+++ b/components/brave_extension/extension/brave_extension/components/list/static.tsx
@@ -46,7 +46,7 @@ export default class StaticList extends React.PureComponent<Props, {}> {
       <BlockedListContent>
         <BlockedListHeader>
           <Favicon src={favicon} />
-          <SiteInfoText>{hostname}</SiteInfoText>
+          <SiteInfoText title={hostname}>{hostname}</SiteInfoText>
         </BlockedListHeader>
         <details open={true}>
           <BlockedListSummary onClick={onClose}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,8 +1617,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#83022ba9a7a56aac90e5f97b7e82bb612c6a355c",
-      "from": "github:brave/brave-ui#83022ba9a7a56aac90e5f97b7e82bb612c6a355c",
+      "version": "github:brave/brave-ui#918e8578c9607e458103f444ef98794cf8dbfebd",
+      "from": "github:brave/brave-ui#918e8578c9607e458103f444ef98794cf8dbfebd",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@types/react-redux": "6.0.4",
     "@types/redux-logger": "^3.0.7",
     "awesome-typescript-loader": "^5.2.1",
-    "brave-ui": "github:brave/brave-ui#83022ba9a7a56aac90e5f97b7e82bb612c6a355c",
+    "brave-ui": "github:brave/brave-ui#918e8578c9607e458103f444ef98794cf8dbfebd",
     "css-loader": "^0.28.9",
     "csstype": "^2.5.5",
     "deep-freeze-node": "^1.1.3",


### PR DESCRIPTION
updates brave-ui with https://github.com/brave/brave-ui/commit/918e8578c9607e458103f444ef98794cf8dbfebd

fix https://github.com/brave/brave-browser/issues/3791

* do not add opacity to shields row text when disabled
* do not wrap urls with queries in static list
* allow selection of blocked resources in the static list
* trim long site names