### PR TITLE
Sync dont send bookmarks when no chain

### DIFF
--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -1,6 +1,7 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 
@@ -91,7 +92,8 @@ bool Prefs::GetSyncSiteSettingsEnabled() const {
 }
 
 void Prefs::SetSyncSiteSettingsEnabled(const bool sync_site_settings_enabled) {
-  pref_service_->SetBoolean(kSyncSiteSettingsEnabled, sync_site_settings_enabled);
+  pref_service_->SetBoolean(
+      kSyncSiteSettingsEnabled, sync_site_settings_enabled);
 }
 
 bool Prefs::GetSyncHistoryEnabled() const {
@@ -170,5 +172,5 @@ void Prefs::Clear() {
   pref_service_->ClearPref(kSyncApiVersion);
 }
 
-} // namespace prefs
-} // namespace brave_sync
+}  // namespace prefs
+}  // namespace brave_sync

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -1,8 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
-#ifndef BRAVE_COMPONENT_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_
-#define BRAVE_COMPONENT_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_
 
 #include <string>
 #include <memory>
@@ -54,8 +56,8 @@ extern const char kSyncDeviceList[];
 extern const char kSyncApiVersion[];
 
 class Prefs {
-public:
-  Prefs(PrefService* pref_service);
+ public:
+  explicit Prefs(PrefService* pref_service);
 
   std::string GetSeed() const;
   void SetSeed(const std::string& seed);
@@ -92,14 +94,14 @@ public:
 
   void Clear();
 
-private:
+ private:
   // May be null.
   PrefService* pref_service_;
 
   DISALLOW_COPY_AND_ASSIGN(Prefs);
 };
 
-} // namespace prefs
-} // namespace brave_sync
+}  // namespace prefs
+}  // namespace brave_sync
 
-#endif //BRAVE_COMPONENT_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_

--- a/components/brave_sync/brave_sync_service_factory.cc
+++ b/components/brave_sync/brave_sync_service_factory.cc
@@ -1,8 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/brave_sync/brave_sync_service_factory.h"
+
+#include <memory>
+#include <string>
 
 #include "base/memory/singleton.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"

--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -537,12 +537,23 @@ void BraveSyncServiceImpl::RequestSyncData() {
 
   if (tools::IsTimeEmpty(last_fetch_time)) {
     SendCreateDevice();
+  }
 
+  sync_client_->SendFetchSyncDevices();
+
+  if (sync_prefs_->GetSyncDevices()->size() <= 1) {
+    // No sense to fetch or sync bookmarks when there no at least two devices
+    // in chain
+    // Set last fetch time here because we had fetched devices at least
+    sync_prefs_->SetLastFetchTime(base::Time::Now());
+    return;
+  }
+
+  if (tools::IsTimeEmpty(last_fetch_time)) {
     bookmark_change_processor_->InitialSync();
   }
 
   FetchSyncRecords(bookmarks, history, preferences, 1000);
-  sync_client_->SendFetchSyncDevices();
 }
 
 void BraveSyncServiceImpl::FetchSyncRecords(const bool bookmarks,

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -644,12 +644,34 @@ TEST_F(BraveSyncServiceTest, OnSyncReadyAlreadyWithSync) {
   EXPECT_FALSE(sync_service()->IsSyncInitialized());
   profile()->GetPrefs()->SetString(
                            brave_sync::prefs::kSyncBookmarksBaseOrder, "1.1.");
-  // OnSyncPrefsChanged => OnSyncStateChanged for kSyncSiteSettingsEnabled
-  EXPECT_CALL(*observer(), OnSyncStateChanged);
+  // OnSyncPrefsChanged => OnSyncStateChanged for
+  // kSyncSiteSettingsEnabled (1)  and kSyncDeviceList (2)
+  EXPECT_CALL(*observer(), OnSyncStateChanged).Times(2);
   profile()->GetPrefs()->SetBoolean(
                             brave_sync::prefs::kSyncSiteSettingsEnabled, true);
   profile()->GetPrefs()->SetTime(
                      brave_sync::prefs::kSyncLastFetchTime, base::Time::Now());
+  const char* devices_json = R"(
+    {
+       "devices":[
+          {
+             "device_id":"0",
+             "last_active":1552993896717.0,
+             "name":"Device1",
+             "object_id":"186, 247, 230, 75, 57, 111, 76, 166, 51, 142, 217, 221, 219, 237, 229, 235"
+          },
+          {
+             "device_id":"1",
+             "last_active":1552993909257.0,
+             "name":"Device2",
+             "object_id":"36, 138, 200, 221, 191, 81, 214, 65, 134, 48, 55, 119, 162, 93, 33, 226"
+          }
+       ]
+    }
+  )";
+
+  profile()->GetPrefs()->SetString(
+                    brave_sync::prefs::kSyncDeviceList, devices_json);
   EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
   EXPECT_CALL(*sync_client(), SendFetchSyncDevices).Times(1);
   sync_service()->OnSyncReady();


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/3777 (Sync: not all bookmarks synced). 
Fixes https://github.com/brave/brave-browser/issues/3509 (Bookmarks are synced when not connected to sync chain).
Fixes https://github.com/brave/brave-browser/issues/2687 (Sync sends bookmarks even when chain is not fully created).

For #3509 and #2687 fix is obvious.
For #3777 description is https://github.com/brave/brave-browser/issues/3777#issuecomment-474833556.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Use STR from 
https://github.com/brave/brave-browser/issues/3777
https://github.com/brave/brave-browser/issues/3509
https://github.com/brave/brave-browser/issues/2687

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
