### PR TITLE
Enable Widevine VMP

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -9,6 +9,7 @@ import("//media/cdm/library_cdm/cdm_paths.gni")
 import("//brave/brave_paks.gni")
 import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
 import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
+import("//third_party/widevine/cdm/widevine.gni")
 
 if (is_mac) {
   import("//build/config/mac/rules.gni")
@@ -46,6 +47,14 @@ group("brave") {
     "build/$target_os:brave",
     "//chrome",
   ]
+
+  if (is_win && enable_widevine_cdm_host_verification) {
+    deps += [
+      "//brave/build/win:sign_brave_exe_for_widevine",
+      "//brave/build/win:sign_chrome_dll_for_widevine",
+      "//brave/build/win:sign_chrome_child_dll_for_widevine",
+    ]
+  }
 }
 
 group("resources") {

--- a/build/config.gni
+++ b/build/config.gni
@@ -26,6 +26,8 @@ declare_args() {
   tag_ap =""
 
   skip_signing = false
+
+  brave_enable_cdm_host_verification = is_official_build
 }
 
 if (base_sparkle_update_url == "") {

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -1,5 +1,6 @@
 import("//brave/build/config.gni")
 import("//build/config/mac/base_rules.gni")
+import("//build/util/version.gni")
 
 declare_args() {
   # find with `security find-identity -v -p codesigning`

--- a/build/win/BUILD.gn
+++ b/build/win/BUILD.gn
@@ -1,4 +1,5 @@
 import("//brave/build/config.gni")
+import("//third_party/widevine/cdm/widevine.gni")
 
 group("brave") {
   public_deps = [
@@ -55,4 +56,31 @@ action("create_signed_installer") {
   deps = [
     "//chrome/installer/mini_installer"
   ]
+}
+
+if (enable_widevine_cdm_host_verification) {
+  widevine_sign_file("sign_brave_exe_for_widevine") {
+    file = "$root_out_dir/brave.exe"
+    flags = 1  # blessed binary
+    signature_file = "$root_out_dir/chrome.exe.sig"
+    deps = [
+      ":copy_exe",
+    ]
+  }
+
+  widevine_sign_file("sign_chrome_dll_for_widevine") {
+    file = "$root_out_dir/chrome.dll"
+    signature_file = "$root_out_dir/chrome.dll.sig"
+    deps = [
+      "//chrome:main_dll",
+    ]
+  }
+
+  widevine_sign_file("sign_chrome_child_dll_for_widevine") {
+    file = "$root_out_dir/chrome_child.dll"
+    signature_file = "$root_out_dir/chrome_child.dll.sig"
+    deps = [
+      "//chrome:chrome_child",
+    ]
+  }
 }

--- a/chromium_src/chrome/common/media/cdm_host_file_path.cc
+++ b/chromium_src/chrome/common/media/cdm_host_file_path.cc
@@ -1,0 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GOOGLE_CHROME_BUILD
+#include "../../../../../chrome/common/media/cdm_host_file_path.cc"
+#undef GOOGLE_CHROME_BUILD

--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index 3d9a560e26e43fb2da1332dff339c1039cfb1a3e..7b2d1041533f1aacdeefb8524a4c433f390091b0 100644
+index 3d9a560e26e43fb2da1332dff339c1039cfb1a3e..46bef9388b0ed5d886bfa349da4d4b51db3168bd 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@

--- a/patches/chrome-installer-mini_installer-chrome.release.patch
+++ b/patches/chrome-installer-mini_installer-chrome.release.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..cda55a0113704a0fd6bf719b1b785a0b66077392 100644
+index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..8c42edb0ea35ff4d0512a8252268910d78721232 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
 @@ -6,7 +6,7 @@
@@ -11,16 +11,22 @@ index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..cda55a0113704a0fd6bf719b1b785a0b
  chrome_proxy.exe: %(ChromeDir)s\
  #
  # Chrome version dir assembly manifest.
-@@ -19,6 +19,8 @@ chrome_proxy.exe: %(ChromeDir)s\
+@@ -18,9 +18,14 @@ chrome_proxy.exe: %(ChromeDir)s\
+ #
  # Chrome version dir entries, sorted alphabetically.
  #
++chrome.exe.sig: %(VersionDir)s\
  chrome.dll: %(VersionDir)s\
++chrome.dll.sig: %(VersionDir)s\
 +brave_resources.pak: %(VersionDir)s\
 +brave_100_percent.pak: %(VersionDir)s\
  chrome_100_percent.pak: %(VersionDir)s\
  chrome_child.dll: %(VersionDir)s\
++chrome_child.dll.sig: %(VersionDir)s\
  chrome_elf.dll: %(VersionDir)s\
-@@ -75,6 +77,7 @@ MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
+ chrome_watcher.dll: %(VersionDir)s\
+ d3dcompiler_47.dll: %(VersionDir)s\
+@@ -75,6 +80,7 @@ MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
  
  [HIDPI]
  chrome_200_percent.pak: %(VersionDir)s\

--- a/patches/media-media_options.gni.patch
+++ b/patches/media-media_options.gni.patch
@@ -1,0 +1,22 @@
+diff --git a/media/media_options.gni b/media/media_options.gni
+index a31937713ace5c365c19998c0f8410deedde803c..c6a5e43584a2bae5f309fe37a1d84b009c4a4710 100644
+--- a/media/media_options.gni
++++ b/media/media_options.gni
+@@ -7,6 +7,7 @@ import("//build/config/chromecast_build.gni")
+ import("//build/config/features.gni")
+ import("//media/gpu/args.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
++if (brave_chromium_build) { import("//brave/build/config.gni") }
+ 
+ # Do not expand this list without double-checking with OWNERS, this is a list of
+ # all targets which roll up into the //media component. It controls visibility
+@@ -153,6 +154,9 @@ declare_args() {
+   # Windows and Mac.
+   enable_cdm_host_verification =
+       enable_library_cdms && (is_mac || is_win) && is_chrome_branded
++  if (brave_chromium_build) {
++    enable_cdm_host_verification = brave_enable_cdm_host_verification && enable_library_cdms && (is_mac || is_win)
++  }
+ 
+   # Enable Storage ID which is used by CDMs. This is only available with chrome
+   # branding, but may be overridden by other embedders.

--- a/patches/third_party-widevine-cdm-widevine.gni.patch
+++ b/patches/third_party-widevine-cdm-widevine.gni.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/widevine/cdm/widevine.gni b/third_party/widevine/cdm/widevine.gni
-index 1fe47e92ffb1442159ead7b696884bc8cc4bda83..cef3cb33eb2d7f396830540b7c7086aceae47ec0 100644
+index 1fe47e92ffb1442159ead7b696884bc8cc4bda83..22b34bf0264dae166bc8deeb8400d488243ea51c 100644
 --- a/third_party/widevine/cdm/widevine.gni
 +++ b/third_party/widevine/cdm/widevine.gni
 @@ -37,6 +37,9 @@ enable_widevine_cdm_component =
@@ -12,3 +12,11 @@ index 1fe47e92ffb1442159ead7b696884bc8cc4bda83..cef3cb33eb2d7f396830540b7c7086ac
  
  enable_widevine_cdm_host_verification =
      enable_library_widevine_cdm && enable_cdm_host_verification
+@@ -62,6 +65,7 @@ template("widevine_sign_file") {
+     }
+ 
+     script = "//third_party/widevine/scripts/signature_generator.py"
++    if (brave_chromium_build) { script = "//brave/script/signature_generator.py" }
+     sources = [
+       "$file",
+     ]


### PR DESCRIPTION
Confirmed that verification method is called and it doesn't return failed state.

Log on MacOS
```
[80149:775:0321/150112.963103:VERBOSE1:cdm_host_files.cc(57)] InitVerification
[80149:775:0321/150112.963335:VERBOSE1:cdm_host_files.cc(87)] InitVerification: Calling VerifyCdmHost_0() with 2 files.
[80149:775:0321/150112.963505:VERBOSE1:cdm_host_files.cc(90)]  - File Path: /Users/simonhong/Projects/brave/brave-browser/src/out/Release/Brave Browser.app/Contents/Versions/73.0.64.7/Brave Browser Framework.framework/Brave Browser Framework
[80149:775:0321/150112.963612:VERBOSE1:cdm_host_files.cc(91)]  - File: 25
[80149:775:0321/150112.963711:VERBOSE1:cdm_host_files.cc(92)]  - Sig File: 26
[80149:775:0321/150112.963798:VERBOSE1:cdm_host_files.cc(90)]  - File Path: /Users/simonhong/Library/Application Support/BraveSoftware/Brave-Browser/WidevineCdm/4.10.1196.0/_platform_specific/mac_x64/libwidevinecdm.dylib
[80149:775:0321/150112.963894:VERBOSE1:cdm_host_files.cc(91)]  - File: 23
[80149:775:0321/150112.963989:VERBOSE1:cdm_host_files.cc(92)]  - Sig File: 24
```

Log on Windows(Win10)
```
[12820:12796:0321/113149.197:VERBOSE1:cdm_host_files.cc(41)] CdmHostFiles
[12820:12796:0321/113149.197:VERBOSE1:cdm_host_file.cc(27)] Create
[12820:12796:0321/113149.197:VERBOSE1:cdm_host_file.cc(31)]   1: C:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\User Data\WidevineCdm\4.10.1196.0\_platform_specific\win_x64\widevinecdm.dll
[12820:12796:0321/113149.197:VERBOSE1:cdm_host_file.cc(36)]   1: C:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\User Data\WidevineCdm\4.10.1196.0\_platform_specific\win_x64\widevinecdm.dll.sig
[12820:12796:0321/113149.198:VERBOSE1:cdm_host_file.cc(27)] Create
[12820:12796:0321/113149.198:VERBOSE1:cdm_host_file.cc(31)]   1: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\brave.exe
[12820:12796:0321/113149.198:VERBOSE1:cdm_host_file.cc(36)]   1: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\brave.exe.sig
[12820:12796:0321/113149.198:VERBOSE1:cdm_host_file.cc(27)] Create
[12820:12796:0321/113149.199:VERBOSE1:cdm_host_file.cc(31)]   1: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\chrome.dll
[12820:12796:0321/113149.199:VERBOSE1:cdm_host_file.cc(36)]   1: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\chrome.dll.sig
[12820:12796:0321/113149.199:VERBOSE1:cdm_host_file.cc(27)] Create
[12820:12796:0321/113149.199:VERBOSE1:cdm_host_file.cc(31)]   1: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\chrome_child.dll
[12820:12796:0321/113149.199:VERBOSE1:cdm_host_file.cc(36)]   1: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\chrome_child.dll.sig
[12820:12796:0321/113149.200:VERBOSE1:cdm_host_files.cc(57)] InitVerification
[12820:12796:0321/113149.200:VERBOSE1:cdm_host_files.cc(87)] InitVerification: Calling VerifyCdmHost_0() with 4 files.
[12820:12796:0321/113149.200:VERBOSE1:cdm_host_files.cc(90)]  - File Path: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\brave.exe
[12820:12796:0321/113149.200:VERBOSE1:cdm_host_files.cc(91)]  - File: 00000000000003DC
[12820:12796:0321/113149.200:VERBOSE1:cdm_host_files.cc(92)]  - Sig File: 00000000000003E0
[12820:12796:0321/113149.200:VERBOSE1:cdm_host_files.cc(90)]  - File Path: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\chrome.dll
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(91)]  - File: 00000000000003E4
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(92)]  - Sig File: 00000000000003E8
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(90)]  - File Path: c:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\Application\73.0.64.4\chrome_child.dll
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(91)]  - File: 00000000000003EC
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(92)]  - Sig File: 00000000000003F0
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(90)]  - File Path: C:\Users\simon\AppData\Local\BraveSoftware\Brave-Browser\User Data\WidevineCdm\4.10.1196.0\_platform_specific\win_x64\widevinecdm.dll
[12820:12796:0321/113149.201:VERBOSE1:cdm_host_files.cc(91)]  - File: 00000000000003D4
[12820:12796:0321/113149.202:VERBOSE1:cdm_host_files.cc(92)]  - Sig File: 00000000000003D8
[12820:12796:0321/113149.202:VERBOSE1:cdm_host_files.cc(45)] ~CdmHostFiles
```

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
