### PR TITLE
Enable Widevine VMP on MacOS and Windows

### DIFF
--- a/build/config.gni
+++ b/build/config.gni
@@ -26,12 +26,9 @@ declare_args() {
   tag_ap =""
 
   skip_signing = false
-}
 
-brave_enable_cdm_host_verification = is_official_build &&
-                                     getenv("SIGN_WIDEVINE_CERT") != "" &&
-                                     getenv("SIGN_WIDEVINE_KEY") != "" &&
-                                     getenv("SIGN_WIDEVINE_PASSPHRASE") != ""
+  brave_enable_cdm_host_verification = false
+}
 
 if (base_sparkle_update_url == "") {
   base_sparkle_update_url = "https://updates.bravesoftware.com/sparkle/Brave-Browser"

--- a/build/config.gni
+++ b/build/config.gni
@@ -28,6 +28,11 @@ declare_args() {
   skip_signing = false
 }
 
+brave_enable_cdm_host_verification = is_official_build &&
+                                     getenv("SIGN_WIDEVINE_CERT") != "" &&
+                                     getenv("SIGN_WIDEVINE_KEY") != "" &&
+                                     getenv("SIGN_WIDEVINE_PASSPHRASE") != ""
+
 if (base_sparkle_update_url == "") {
   base_sparkle_update_url = "https://updates.bravesoftware.com/sparkle/Brave-Browser"
 }

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -1,5 +1,7 @@
 import("//brave/build/config.gni")
 import("//build/config/mac/base_rules.gni")
+import("//build/util/version.gni")
+import("//third_party/widevine/cdm/widevine.gni")
 
 declare_args() {
   # find with `security find-identity -v -p codesigning`
@@ -82,6 +84,9 @@ action("create_pkg") {
   ]
 
   deps = [":sign_app"]
+  if (enable_widevine_cdm_host_verification) {
+    deps += [ ":sign_chrome_framework_for_widevine" ]
+  }
 }
 
 action("sign_pkg") {
@@ -175,6 +180,47 @@ action("sign_dmg") {
   ]
 
   deps = [":create_dmg"]
+}
+
+if (enable_widevine_cdm_host_verification) {
+  action("sign_chrome_framework_for_widevine") {
+    script = "//third_party/widevine/scripts/signature_generator.py"
+
+    chrome_framework_name = chrome_product_full_name + " Framework"
+    brave_version_path = "$root_out_dir/$chrome_product_full_name.app/Contents/Versions/$chrome_version_full"
+
+    file = "$brave_version_path/$chrome_framework_name.framework/Versions/Current/$chrome_framework_name"
+    signature_file = "$brave_version_path/Widevine Resources.bundle/Contents/Resources/$chrome_framework_name.sig"
+    flags = 1  # blessed binary
+
+    sources = [
+      "$root_out_dir/$brave_exe"
+    ]
+
+    outputs = [
+      "$signature_file",
+    ]
+
+    args = [
+      "--input_file",
+      rebase_path("$file", root_build_dir),
+      "--output_file",
+      rebase_path("$signature_file", root_build_dir),
+      "--flags",
+      "$flags",
+      "--certificate",
+      getenv("SIGN_WIDEVINE_CERT"),
+      "--private_key",
+      getenv("SIGN_WIDEVINE_KEY"),
+      "--private_key_passphrase",
+      getenv("SIGN_WIDEVINE_PASSPHRASE"),
+    ]
+
+    deps = [
+      ":sign_app",
+      "//brave:chrome_app",
+    ]
+  }
 }
 
 group("create_dist_mac") {

--- a/chromium_src/chrome/common/media/cdm_host_file_path.cc
+++ b/chromium_src/chrome/common/media/cdm_host_file_path.cc
@@ -1,0 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GOOGLE_CHROME_BUILD
+#include "../../../../../chrome/common/media/cdm_host_file_path.cc"  // NOLINT
+#undef GOOGLE_CHROME_BUILD

--- a/patches/chrome-BUILD.gn.patch
+++ b/patches/chrome-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index 3bd3fb2b18fb6309b22d2ffff5b3372afd6e486d..f00997794e6104ac3bfbc2546f333cbc487f8962 100644
+index 3bd3fb2b18fb6309b22d2ffff5b3372afd6e486d..e64e935247607c5ddbb74e4ff760aac3e423dcf6 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -191,6 +191,10 @@ if (!is_android && !is_mac) {
@@ -66,6 +66,15 @@ index 3bd3fb2b18fb6309b22d2ffff5b3372afd6e486d..f00997794e6104ac3bfbc2546f333cbc
            "-v",
            rebase_path(chrome_version_file, root_build_dir),
            "-g",
+@@ -1111,7 +1124,7 @@ if (is_win) {
+       bundle_resources_dir = "$bundle_contents_dir/Resources"
+ 
+       deps = [
+-        ":framework_widevine_signature",
++        #":framework_widevine_signature",
+         ":widevine_resources_plist_bundle_data",
+       ]
+     }
 @@ -1199,6 +1212,7 @@ if (is_win) {
        "//services/service_manager/embedder",
        "//third_party/cld_3/src/src:cld_3",

--- a/patches/chrome-common-media-cdm_host_file_path.cc.patch
+++ b/patches/chrome-common-media-cdm_host_file_path.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/common/media/cdm_host_file_path.cc b/chrome/common/media/cdm_host_file_path.cc
+index cd13f95bfd55ef03654e97324d527eae5d816334..b79301f3cf9cca64da5a6257ea2ffcc539efbacf 100644
+--- a/chrome/common/media/cdm_host_file_path.cc
++++ b/chrome/common/media/cdm_host_file_path.cc
+@@ -43,7 +43,11 @@ void AddCdmHostFilePaths(
+ #if defined(OS_WIN)
+ 
+   static const base::FilePath::CharType* const kUnversionedFiles[] = {
++#if defined(BRAVE_CHROMIUM_BUILD)
++      FILE_PATH_LITERAL("brave.exe")};
++#else
+       FILE_PATH_LITERAL("chrome.exe")};
++#endif
+   static const base::FilePath::CharType* const kVersionedFiles[] = {
+       FILE_PATH_LITERAL("chrome.dll"), FILE_PATH_LITERAL("chrome_child.dll")};
+ 

--- a/patches/chrome-installer-mini_installer-BUILD.gn.patch
+++ b/patches/chrome-installer-mini_installer-BUILD.gn.patch
@@ -1,24 +1,12 @@
 diff --git a/chrome/installer/mini_installer/BUILD.gn b/chrome/installer/mini_installer/BUILD.gn
-index ec629333b0062239ff2dec63c1a5bf79738de301..20e341e5b3ed8dd968abcb1ef29dedbfe88adda5 100644
+index ec629333b0062239ff2dec63c1a5bf79738de301..a6c74a6eecbb1b14302e5db1d42c8d594ce09032 100644
 --- a/chrome/installer/mini_installer/BUILD.gn
 +++ b/chrome/installer/mini_installer/BUILD.gn
-@@ -12,6 +12,10 @@ import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
- import("//ui/base/ui_features.gni")
- import("//v8/gni/v8.gni")
- 
-+if (brave_chromium_build) {
-+  import("//brave/build/config.gni")
-+}
-+
- declare_args() {
-   # The Chrome archive is compressed in official builds to reduce the size of
-   # the installer. By default: non-official or component builds, a build mode
-@@ -182,6 +186,22 @@ template("generate_mini_installer") {
+@@ -182,6 +182,21 @@ template("generate_mini_installer") {
        "//third_party/icu:icudata",
        chrome_dll_target,
      ]
 +    if (brave_chromium_build) {
-+      if (skip_signing) { args += [ "--skip_signing" ] }
 +      inputs -= [
 +        "$root_out_dir/chrome.exe",
 +      ]

--- a/patches/chrome-installer-mini_installer-chrome.release.patch
+++ b/patches/chrome-installer-mini_installer-chrome.release.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..cda55a0113704a0fd6bf719b1b785a0b66077392 100644
+index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..bc994fb104924c62715817a8b82d7f55c044563b 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
 @@ -6,7 +6,7 @@
@@ -11,16 +11,22 @@ index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..cda55a0113704a0fd6bf719b1b785a0b
  chrome_proxy.exe: %(ChromeDir)s\
  #
  # Chrome version dir assembly manifest.
-@@ -19,6 +19,8 @@ chrome_proxy.exe: %(ChromeDir)s\
+@@ -18,9 +18,14 @@ chrome_proxy.exe: %(ChromeDir)s\
+ #
  # Chrome version dir entries, sorted alphabetically.
  #
++brave.exe.sig: %(VersionDir)s\
  chrome.dll: %(VersionDir)s\
++chrome.dll.sig: %(VersionDir)s\
 +brave_resources.pak: %(VersionDir)s\
 +brave_100_percent.pak: %(VersionDir)s\
  chrome_100_percent.pak: %(VersionDir)s\
  chrome_child.dll: %(VersionDir)s\
++chrome_child.dll.sig: %(VersionDir)s\
  chrome_elf.dll: %(VersionDir)s\
-@@ -75,6 +77,7 @@ MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
+ chrome_watcher.dll: %(VersionDir)s\
+ d3dcompiler_47.dll: %(VersionDir)s\
+@@ -75,6 +80,7 @@ MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
  
  [HIDPI]
  chrome_200_percent.pak: %(VersionDir)s\

--- a/patches/chrome-tools-build-win-create_installer_archive.py.patch
+++ b/patches/chrome-tools-build-win-create_installer_archive.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/tools/build/win/create_installer_archive.py b/chrome/tools/build/win/create_installer_archive.py
-index b16b16bdc439014bf647f80ca9b7ce8215cfbb6c..cf36aac8b0d18fb0a1dd6f9018dcd53e9042a331 100755
+index b16b16bdc439014bf647f80ca9b7ce8215cfbb6c..46fdb870dda9de5a3c855c34941ff36b6fc09fe6 100755
 --- a/chrome/tools/build/win/create_installer_archive.py
 +++ b/chrome/tools/build/win/create_installer_archive.py
 @@ -112,6 +112,60 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
@@ -63,23 +63,11 @@ index b16b16bdc439014bf647f80ca9b7ce8215cfbb6c..cf36aac8b0d18fb0a1dd6f9018dcd53e
  
  def CopySectionFilesToStagingDir(config, section, staging_dir, src_dir):
    """Copies installer archive files specified in section from src_dir to
-@@ -531,6 +585,10 @@ def main(options):
-     version_numbers = prev_version.split('.')
-     prev_build_number = version_numbers[2] + '.' + version_numbers[3]
- 
-+  if not options.skip_signing:
-+    from sign_binaries import sign_binaries
-+    sign_binaries(staging_dir)
-+
-   # Name of the archive file built (for example - chrome.7z or
-   # patch-<old_version>-<new_version>.7z or patch-<new_version>.7z
-   archive_file = CreateArchiveFile(options, staging_dir,
-@@ -599,6 +657,8 @@ def _ParseOptions():
-            'with the installer archive {x86|x64}.')
+@@ -600,6 +654,7 @@ def _ParseOptions():
    parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
                      default=False)
-+  parser.add_option('--skip_signing', default=False)
-+
  
++
    options, _ = parser.parse_args()
    if not options.build_dir:
+     parser.error('You must provide a build dir.')

--- a/patches/media-media_options.gni.patch
+++ b/patches/media-media_options.gni.patch
@@ -1,0 +1,22 @@
+diff --git a/media/media_options.gni b/media/media_options.gni
+index fbd9f139ebad0c3b8bc7411baf5282df3050f7c0..7dab1cf2e476281571d420a2bc5d03d1c6f93b1d 100644
+--- a/media/media_options.gni
++++ b/media/media_options.gni
+@@ -9,6 +9,7 @@ import("//build/config/jumbo.gni")
+ import("//media/gpu/args.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//third_party/libaom/options.gni")
++if (brave_chromium_build) { import("//brave/build/config.gni") }
+ 
+ # Do not expand this list without double-checking with OWNERS, this is a list of
+ # all targets which roll up into the //media component. It controls visibility
+@@ -163,6 +164,9 @@ declare_args() {
+   # Windows and Mac.
+   enable_cdm_host_verification =
+       enable_library_cdms && (is_mac || is_win) && is_chrome_branded
++  if (brave_chromium_build) {
++    enable_cdm_host_verification = brave_enable_cdm_host_verification && enable_library_cdms && (is_mac || is_win)
++  }
+ 
+   # Enable Storage ID which is used by CDMs. This is only available with chrome
+   # branding, but may be overridden by other embedders.

--- a/script/sign_binaries.py
+++ b/script/sign_binaries.py
@@ -1,5 +1,7 @@
+import optparse
 import os
 import subprocess
+import sys
 
 cert = os.environ.get('CERT')
 signtool_args = (os.environ.get('SIGNTOOL_ARGS') or
@@ -44,3 +46,27 @@ def sign_binaries(base_dir):
 def sign_binary(binary):
     cmd = get_sign_cmd(binary)
     run_cmd(cmd)
+
+
+def _ParseOptions():
+    parser = optparse.OptionParser()
+    parser.add_option(
+        '-b', '--build_dir',
+        help='Build directory. The paths in input_file are relative to this.')
+
+    options, _ = parser.parse_args()
+    if not options.build_dir:
+        parser.error('You must provide a build dir.')
+
+    options.build_dir = os.path.normpath(options.build_dir)
+
+    return options
+
+
+def main(options):
+    sign_binaries(options.build_dir)
+
+
+if '__main__' == __name__:
+    options = _ParseOptions()
+    sys.exit(main(options))


### PR DESCRIPTION
VMP is enabled with official build and all below envs are set.
SIGN_WIDEVINE_KEY: private key
SIGN_WIDEVINE_CERT: widevine cert
SIGN_WIDEVINE_PASSPHRASE: pass for key

sig generator should be located in
//third_party/widevine/scripts/signature_generator.py before build starts on buildbot.

Issue https://github.com/brave/brave-browser/issues/944

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Check sig file is in installed folder.
On MacOS, sig file(`Brave Browser Framework.sig`) is in `Brave Browser.app/Contents/Versions/7x.x.x.x/Widevine Resources.bundle/Contents/Resources/Brave Browser Framework.sig`
On Windows, sig files(`brave.exe.sig`, `chrome.dll.sig` and `chrome_child.dll.sig`) are in `C:\Program Files (x86)\BraveSoftware\Brave-Browser-XXX\Application\7x.x.x.x\`

2. Check netflix works
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
