### PR TITLE
only use brave:// url for display purposes because chrome does some s…

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -91,25 +91,14 @@ bool HandleURLOverrideRewrite(GURL* url,
 
 bool HandleURLReverseOverrideRewrite(GURL* url,
                              content::BrowserContext* browser_context) {
-  if (url->host() == chrome::kChromeUIWelcomeHost ||
-      url->host() == chrome::kChromeUISyncHost) {
-    GURL::Replacements replacements;
-    replacements.SetSchemeStr(kBraveUIScheme);
-    *url = url->ReplaceComponents(replacements);
+  if (HandleURLOverrideRewrite(url, browser_context))
     return true;
-  }
 
   return false;
 }
 
 bool HandleURLRewrite(GURL* url,
                       content::BrowserContext* browser_context) {
-  if (url->SchemeIs(kBraveUIScheme)) {
-    GURL::Replacements replacements;
-    replacements.SetSchemeStr(content::kChromeUIScheme);
-    *url = url->ReplaceComponents(replacements);
-  }
-
   if (HandleURLOverrideRewrite(url, browser_context))
     return true;
 

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "base/path_service.h"
+#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/brave_content_browser_client.h"
 #include "brave/common/brave_paths.h"
 #include "brave/common/extensions/extension_constants.h"
@@ -133,9 +134,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadChromeURL) {
       ui_test_utils::NavigateToURL(browser(), GURL(scheme + page + "/"));
       ASSERT_TRUE(WaitForLoadStop(contents));
 
+      EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
+                      ->GetFormattedFullURL()).c_str(),
+                   ("brave://" + page).c_str());
       EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                        ->GetVirtualURL().spec().c_str(),
-                   ("brave://" + page + "/").c_str());
+                   ("chrome://" + page + "/").c_str());
       EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                        ->GetURL().spec().c_str(),
                    ("chrome://" + page + "/").c_str());
@@ -164,9 +168,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadCustomBravePages) {
       ui_test_utils::NavigateToURL(browser(), GURL(scheme + page + "/"));
       ASSERT_TRUE(WaitForLoadStop(contents));
 
+      EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
+                      ->GetFormattedFullURL()).c_str(),
+                   ("brave://" + page).c_str());
       EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                        ->GetVirtualURL().spec().c_str(),
-                   ("brave://" + page + "/").c_str());
+                   ("chrome://" + page + "/").c_str());
       EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                        ->GetURL().spec().c_str(),
                    ("chrome://" + page + "/").c_str());
@@ -186,9 +193,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadAboutHost) {
     ui_test_utils::NavigateToURL(browser(), GURL(scheme + "about/"));
       ASSERT_TRUE(WaitForLoadStop(contents));
 
+      EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
+                      ->GetFormattedFullURL()).c_str(),
+                   "brave://about");
       EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                        ->GetVirtualURL().spec().c_str(),
-                   "brave://about/");
+                   "chrome://about/");
       EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                        ->GetURL().spec().c_str(),
                    "chrome://chrome-urls/");
@@ -209,9 +219,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
         browser(), GURL(scheme + chrome::kChromeUISyncInternalsHost));
     ASSERT_TRUE(WaitForLoadStop(contents));
 
+    EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
+                    ->GetFormattedFullURL()).c_str(),
+                 "brave://sync");
     EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                      ->GetVirtualURL().spec().c_str(),
-                 "brave://sync/");
+                 "chrome://sync/");
     EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                      ->GetURL().spec().c_str(),
                  "chrome://sync/");
@@ -233,9 +246,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
         GURL(scheme + chrome::kChromeUIWelcomeWin10Host));
     ASSERT_TRUE(WaitForLoadStop(contents));
 
+    EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
+                    ->GetFormattedFullURL()).c_str(),
+                 "brave://welcome");
     EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                      ->GetVirtualURL().spec().c_str(),
-                 "brave://welcome/");
+                 "chrome://welcome/");
     EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                      ->GetURL().spec().c_str(),
                  "chrome://welcome/");
@@ -255,9 +271,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
     ui_test_utils::NavigateToURL(browser(), GURL(scheme + "welcome-win10/"));
     ASSERT_TRUE(WaitForLoadStop(contents));
 
+    EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
+                    ->GetFormattedFullURL()).c_str(),
+                 "brave://welcome");
     EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                      ->GetVirtualURL().spec().c_str(),
-                 "brave://welcome/");
+                 "chrome://welcome/");
     EXPECT_STREQ(contents->GetController().GetLastCommittedEntry()
                      ->GetURL().spec().c_str(),
                  "chrome://welcome/");

--- a/browser/brave_scheme_load_browsertest.cc
+++ b/browser/brave_scheme_load_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "base/path_service.h"
 #include "base/strings/pattern.h"
+#include "base/strings/utf_string_conversions.h"
 #include "brave/common/brave_paths.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -59,7 +60,7 @@ class BraveSchemeLoadBrowserTest : public InProcessBrowserTest,
 
   // Check loading |url| in private window is redirected to normal
   // window.
-  void TestURLIsNotLoadedInPrivateWindow(const GURL& url) {
+  void TestURLIsNotLoadedInPrivateWindow(const std::string& url) {
     Browser* private_browser = CreateIncognitoBrowser(nullptr);
     TabStripModel* private_model = private_browser->tab_strip_model();
 
@@ -73,12 +74,16 @@ class BraveSchemeLoadBrowserTest : public InProcessBrowserTest,
     browser()->tab_strip_model()->AddObserver(this);
 
     // Load url to private window.
-    NavigateParams params(private_browser, url, ui::PAGE_TRANSITION_TYPED);
+    NavigateParams params(
+        private_browser, GURL(url), ui::PAGE_TRANSITION_TYPED);
     Navigate(&params);
 
     browser()->tab_strip_model()->RemoveObserver(this);
 
-    EXPECT_EQ(url, active_contents()->GetVisibleURL());
+    EXPECT_STREQ(url.c_str(),
+                 base::UTF16ToUTF8(browser()->location_bar_model()
+                      ->GetFormattedFullURL()).c_str());
+    // EXPECT_EQ(url, active_contents()->GetVisibleURL());
     EXPECT_EQ(2, browser()->tab_strip_model()->count());
     // Private window stays as initial state.
     EXPECT_EQ("about:blank",
@@ -232,15 +237,15 @@ IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
 // window.
 IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
                        SettingsPageIsNotAllowedInPrivateWindow) {
-  TestURLIsNotLoadedInPrivateWindow(GURL("brave://settings/"));
+  TestURLIsNotLoadedInPrivateWindow("brave://settings");
 }
 
 IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
                        SyncPageIsNotAllowedInPrivateWindow) {
-  TestURLIsNotLoadedInPrivateWindow(GURL("brave://sync/"));
+  TestURLIsNotLoadedInPrivateWindow("brave://sync");
 }
 
 IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
                        RewardsPageIsNotAllowedInPrivateWindow) {
-  TestURLIsNotLoadedInPrivateWindow(GURL("brave://rewards/"));
+  TestURLIsNotLoadedInPrivateWindow("brave://rewards");
 }

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -30,6 +30,8 @@ source_set("ui") {
     "omnibox/brave_omnibox_client.h",
     "toolbar/brave_app_menu_model.cc",
     "toolbar/brave_app_menu_model.h",
+    "toolbar/brave_location_bar_model_delegate.cc",
+    "toolbar/brave_location_bar_model_delegate.h",
     "toolbar/brave_toolbar_actions_model.cc",
     "toolbar/brave_toolbar_actions_model.h",
     "views/brave_layout_provider.cc",

--- a/browser/ui/toolbar/brave_location_bar_model_delegate.cc
+++ b/browser/ui/toolbar/brave_location_bar_model_delegate.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/toolbar/brave_location_bar_model_delegate.h"
+
+#include "base/strings/utf_string_conversions.h"
+
+BraveLocationBarModelDelegate::BraveLocationBarModelDelegate(
+    Browser* browser) : BrowserLocationBarModelDelegate(browser) {}
+
+BraveLocationBarModelDelegate::~BraveLocationBarModelDelegate() {}
+
+base::string16
+BraveLocationBarModelDelegate::FormattedStringWithEquivalentMeaning(
+    const GURL& url,
+    const base::string16& formatted_url) const {
+  base::string16 new_formatted_url =
+      BrowserLocationBarModelDelegate::FormattedStringWithEquivalentMeaning(
+          url, formatted_url);
+
+  if (url.SchemeIs("chrome")) {
+    base::ReplaceFirstSubstringAfterOffset(
+        &new_formatted_url,
+        0,
+        base::UTF8ToUTF16("chrome://"),
+        base::UTF8ToUTF16("brave://"));
+  }
+
+  return new_formatted_url;
+}

--- a/browser/ui/toolbar/brave_location_bar_model_delegate.h
+++ b/browser/ui/toolbar/brave_location_bar_model_delegate.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_TOOLBAR_BRAVE_LOCATION_BAR_MODEL_DELEGATE_H_
+#define BRAVE_BROWSER_UI_TOOLBAR_BRAVE_LOCATION_BAR_MODEL_DELEGATE_H_
+
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "chrome/browser/ui/browser_location_bar_model_delegate.h"
+
+class Browser;
+
+class BraveLocationBarModelDelegate : public BrowserLocationBarModelDelegate {
+ public:
+  explicit BraveLocationBarModelDelegate(Browser* browser);
+  ~BraveLocationBarModelDelegate() override;
+
+ private:
+  base::string16 FormattedStringWithEquivalentMeaning(
+      const GURL& url,
+      const base::string16& formatted_url) const override;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveLocationBarModelDelegate);
+};
+
+#endif  // BRAVE_BROWSER_UI_TOOLBAR_BRAVE_LOCATION_BAR_MODEL_DELEGATE_H_

--- a/browser/ui/webui/brave_welcome_ui_browsertest.cc
+++ b/browser/ui/webui/brave_welcome_ui_browsertest.cc
@@ -40,7 +40,7 @@ IN_PROC_BROWSER_TEST_F(BraveWelcomeUIBrowserTest, PRE_StartupURLTest) {
   content::WebContents* web_contents = tab_strip->GetWebContentsAt(0);
   content::TestNavigationObserver observer(web_contents, 1);
   observer.Wait();
-  EXPECT_STREQ("brave://welcome/",
+  EXPECT_STREQ("chrome://welcome/",
             tab_strip->GetWebContentsAt(0)
                 ->GetController().GetLastCommittedEntry()
                     ->GetVirtualURL().possibly_invalid_spec().c_str());

--- a/browser/widevine/widevine_permission_request_browsertest.cc
+++ b/browser/widevine/widevine_permission_request_browsertest.cc
@@ -96,7 +96,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, VisibilityTest) {
   // Check permission is requested again after new navigation.
   observer.bubble_added_ = false;
   EXPECT_TRUE(content::NavigateToURL(GetActiveWebContents(),
-                                     GURL("brave://version/")));
+                                     GURL("chrome://version/")));
   drm_tab_helper->OnWidevineKeySystemAccessRequest();
   content::RunAllTasksUntilIdle();
   EXPECT_TRUE(observer.bubble_added_);

--- a/browser/widevine/widevine_permission_request_browsertest.cc
+++ b/browser/widevine/widevine_permission_request_browsertest.cc
@@ -132,7 +132,7 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest, BubbleTest) {
 IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest,
                        CheckOptedInPrefStateForComponent) {
   PrefService* prefs = ProfileManager::GetActiveUserProfile()->GetPrefs();
-   // Before we allow, opted in should be false
+  // Before we allow, opted in should be false
   EXPECT_FALSE(prefs->GetBoolean(kWidevineOptedIn));
 
   GetPermissionRequestManager()->set_auto_response_for_test(
@@ -186,7 +186,7 @@ class ScriptTriggerWidevinePermissionRequestBrowserTest
   ScriptTriggerWidevinePermissionRequestBrowserTest()
       : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
 
-   void SetUpOnMainThread() override {
+  void SetUpOnMainThread() override {
     CertVerifierBrowserTest::SetUpOnMainThread();
     host_resolver()->AddRule("*", "127.0.0.1");
     // Chromium allows the API under test only on HTTPS domains.
@@ -204,13 +204,13 @@ class ScriptTriggerWidevinePermissionRequestBrowserTest
     GetPermissionRequestManager()->RemoveObserver(&observer);
   }
 
-   void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
+  void SetUpDefaultCommandLine(base::CommandLine* command_line) override {
     command_line->AppendSwitchASCII(
         "enable-blink-features",
         "EncryptedMediaEncryptionSchemeQuery");
   }
 
-   content::WebContents* active_contents() {
+  content::WebContents* active_contents() {
     return browser()->tab_strip_model()->GetActiveWebContents();
   }
 
@@ -227,7 +227,7 @@ class ScriptTriggerWidevinePermissionRequestBrowserTest
     observer.added_count_ = 0;
   }
 
-  protected:
+ protected:
   void SetUpMockCertVerifierForHttpsServer(net::CertStatus cert_status,
                                            int net_result) {
     scoped_refptr<net::X509Certificate> cert(https_server_.GetCertificate());

--- a/chromium_src/chrome/browser/browser_about_handler.cc
+++ b/chromium_src/chrome/browser/browser_about_handler.cc
@@ -25,10 +25,9 @@ bool FixupBrowserAboutURL(GURL* url,
     *url = url->ReplaceComponents(replacements);
   }
 
-  if (url->SchemeIs(content::kChromeUIScheme) &&
-      url->host() != chrome::kChromeUINewTabHost) {
+  if (url->SchemeIs(kBraveUIScheme)) {
     GURL::Replacements replacements;
-    replacements.SetSchemeStr(kBraveUIScheme);
+    replacements.SetSchemeStr(content::kChromeUIScheme);
     *url = url->ReplaceComponents(replacements);
   }
 

--- a/chromium_src/chrome/browser/ui/browser.cc
+++ b/chromium_src/chrome/browser/ui/browser.cc
@@ -7,10 +7,13 @@
 #include "chrome/browser/ui/browser_content_setting_bubble_model_delegate.h"
 #include "brave/browser/ui/brave_browser_content_setting_bubble_model_delegate.h"
 #include "brave/browser/ui/brave_browser_command_controller.h"
+#include "brave/browser/ui/toolbar/brave_location_bar_model_delegate.h"
 
 #define BrowserContentSettingBubbleModelDelegate \
   BraveBrowserContentSettingBubbleModelDelegate
 #define BrowserCommandController BraveBrowserCommandController
+#define BrowserLocationBarModelDelegate BraveLocationBarModelDelegate
 #include "../../../../../chrome/browser/ui/browser.cc"  // NOLINT
+#undef BrowserLocationBarModelDelegate
 #undef BrowserContentSettingBubbleModelDelegate
 #undef BrowserCommandController

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -213,7 +213,8 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, RenderWelcome) {
   // Enable Rewards
   EnableRewards();
   EXPECT_STREQ(contents()->GetLastCommittedURL().spec().c_str(),
-    rewards_url().spec().c_str());
+      // actual url is always chrome://
+      "chrome://rewards/");
 }
 
 IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, ToggleRewards) {

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -30,7 +31,7 @@ namespace brave_test_resp {
 
 namespace brave_net {
 class BraveURLFetcher : public net::TestURLFetcher {
-  public:
+ public:
   BraveURLFetcher(bool success,
                  const GURL& url,
                  const std::string& results,
@@ -48,19 +49,19 @@ class BraveURLFetcher : public net::TestURLFetcher {
   DISALLOW_COPY_AND_ASSIGN(BraveURLFetcher);
 };
 
-void split(std::vector<std::string>& tmp, std::string query, char delimiter) {
+void split(std::vector<std::string>* tmp, std::string query, char delimiter) {
   std::stringstream ss(query);
   std::string item;
   while (std::getline(ss, item, delimiter)) {
     if (query[0] != '\n') {
-      tmp.push_back(item);
+      tmp->push_back(item);
     }
   }
 }
 
 void BraveURLFetcher::DetermineURLResponsePath(std::string url) {
   std::vector<std::string> tmp;
-  brave_net::split(tmp, url, '/');
+  brave_net::split(&tmp, url, '/');
   if (url.find(braveledger_bat_helper::buildURL(REGISTER_PERSONA, PREFIX_V2,
     braveledger_bat_helper::SERVER_TYPES::LEDGER)) == 0
     && tmp.size() == 6) {
@@ -174,7 +175,7 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest {
     // Load rewards page
     ui_test_utils::NavigateToURL(browser(), rewards_url());
     WaitForLoadStop(contents());
-    //opt in and create wallet to enable rewards
+    // opt in and create wallet to enable rewards
     ASSERT_TRUE(ExecJs(contents(),
       "document.querySelector(\"[data-test-id='optInAction']\").click();",
       content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
@@ -288,10 +289,12 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, ToggleAutoContribute) {
     "  if (document.querySelector(\"[data-test-id2='autoContribution']\")) {"
     "    if (!toggleClicked) {"
     "      toggleClicked = true;"
-    "      document.querySelector(\"[data-test-id2='autoContribution']\").click();"
+    "      document.querySelector("
+    "          \"[data-test-id2='autoContribution']\").click();"
     "    } else {"
     "      clearInterval(interval);"
-    "      resolve(document.querySelector(\"[data-test-id2='autoContribution']\")"
+    "      resolve(document.querySelector("
+    "          \"[data-test-id2='autoContribution']\")"
     "        .getAttribute(\"data-toggled\") === 'false');"
     "    }"
     "  }"
@@ -407,8 +410,8 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, HandleFlagsSingleArg) {
   GetReconcileTime();
   RunUntilIdle();
 
-  EXPECT_CALL(*this, OnGetShortRetries(true)); // on
-  EXPECT_CALL(*this, OnGetShortRetries(false)); // off
+  EXPECT_CALL(*this, OnGetShortRetries(true));  // on
+  EXPECT_CALL(*this, OnGetShortRetries(false));  // off
 
   // Short retries - on
   rewards_service()->SetShortRetries(false);

--- a/patches/chrome-browser-ui-toolbar-chrome_location_bar_model_delegate.h.patch
+++ b/patches/chrome-browser-ui-toolbar-chrome_location_bar_model_delegate.h.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.h b/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.h
+index 26d74e9c5d80d2c699df1a6ee16f4ed494d563dd..130e4bd112aac15e81e2de967da2d1c419acdae0 100644
+--- a/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.h
++++ b/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.h
+@@ -37,6 +37,7 @@ class ChromeLocationBarModelDelegate : public LocationBarModelDelegate {
+   content::NavigationEntry* GetNavigationEntry() const;
+ 
+  private:
++  friend class BraveLocationBarModelDelegate;
+   base::string16 FormattedStringWithEquivalentMeaning(
+       const GURL& url,
+       const base::string16& formatted_url) const override;


### PR DESCRIPTION
…ecurity checks based on the virtual url

fix https://github.com/brave/brave-browser/issues/3411

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Load `chrome://version` in the urlbar - should load version page and urlbar should display `brave://version`
2. Load `brave://settings` in the urlbar - should load settings page
3. search for `sync` in the settings page and click on the link for `brave://sync` - should load sync page

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
