### PR TITLE
Adds missing params to GetGrantCaptcha mock [0.63]

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_client_mock.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_client_mock.h
@@ -136,7 +136,9 @@ class MockConfirmationsClient : public ConfirmationsClient {
       ledger::Result result,
       const ledger::Grant& grant));
 
-  MOCK_METHOD0(GetGrantCaptcha, void());
+  MOCK_METHOD2(GetGrantCaptcha, void(
+      const std::string& promotion_id,
+      const std::string& promotion_type));
 
   MOCK_METHOD2(OnGrantCaptcha, void(
       const std::string& image,


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/3727
Original PR: https://github.com/brave/brave-core/pull/1961