### PR TITLE
Fixes false insufficient funds notification

### DIFF
--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -48,6 +48,8 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
                                   base::TimeDelta::FromDays(7));
   registry->RegisterTimeDeltaPref(prefs::kRewardsBackupNotificationInterval,
                                   base::TimeDelta::FromDays(7));
+  registry->RegisterTimeDeltaPref(prefs::kRewardsNotificationStartupDelay,
+                                  base::TimeDelta::FromSeconds(30));
   registry->RegisterBooleanPref(prefs::kRewardsBackupSucceeded, false);
   registry->RegisterBooleanPref(prefs::kRewardsUserHasFunded, false);
   registry->RegisterTimePref(prefs::kRewardsAddFundsNotification, base::Time());

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2340,15 +2340,18 @@ RewardsNotificationService* RewardsServiceImpl::GetNotificationService() const {
 void RewardsServiceImpl::StartNotificationTimers(bool main_enabled) {
   if (!main_enabled) return;
 
-  // Startup timer, begins after 3-second delay.
+  // Startup timer, begins after 30-second delay.
+  PrefService* pref_service = profile_->GetPrefs();
   notification_startup_timer_ = std::make_unique<base::OneShotTimer>();
   notification_startup_timer_->Start(
-      FROM_HERE, base::TimeDelta::FromSeconds(3), this,
+      FROM_HERE,
+      pref_service->GetTimeDelta(
+        prefs::kRewardsNotificationStartupDelay),
+      this,
       &RewardsServiceImpl::OnNotificationTimerFired);
   DCHECK(notification_startup_timer_->IsRunning());
 
   // Periodic timer, runs once per day by default.
-  PrefService* pref_service = profile_->GetPrefs();
   base::TimeDelta periodic_timer_interval =
       pref_service->GetTimeDelta(prefs::kRewardsNotificationTimerInterval);
   notification_periodic_timer_ = std::make_unique<base::RepeatingTimer>();

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -18,6 +18,7 @@ const char kRewardsBackupNotificationInterval[] =
 const char kRewardsBackupSucceeded[] = "brave.rewards.backup_succeeded";
 const char kRewardsUserHasFunded[] = "brave.rewards.user_has_funded";
 const char kRewardsAddFundsNotification[] = "brave.rewards.add_funds_notification";
+const char kRewardsNotificationStartupDelay[] = "brave.rewards.notification_startup_delay";
 
 }  // namespace prefs
 }  // namespace brave_rewards

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -17,6 +17,7 @@ extern const char kRewardsBackupNotificationInterval[];
 extern const char kRewardsBackupSucceeded[];
 extern const char kRewardsUserHasFunded[];
 extern const char kRewardsAddFundsNotification[];
+extern const char kRewardsNotificationStartupDelay[];
 
 }  // namespace prefs
 }  // namespace brave_rewards


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/3640

Essentially there was a race condition with the arbitrary notification timer delay, so balance was unavailable in `bat_state` when the check would happen.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Start Brave, enable Rewards.
2. Claim a grant, set AC amount to something less than the grant amount.
3. Add sites to your AC table.
4. Stop Brave, set your reconcileStamp back
5. Restart Brave, ensure that the notification is not shown and auto contribute is processing.
6. Repeat steps, but with a higher AC amount than wallet balance and ensure that the notification does show.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
