### PR TITLE
Disabling metrics reporting; Updating ad-block deps to fix audit_deps error; Updating crypto deps to fix audit_deps error; 

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/ad-block": "https://github.com/brave/ad-block.git@e54c59fe288d8f08de683b8f4f320a4c7bead4eb",
+  "vendor/ad-block": "https://github.com/brave/ad-block.git@d5c7128599889e4e2a797b402a517c664d53fad2",
   "vendor/autoplay-whitelist": "https://github.com/brave/autoplay-whitelist.git@458053a3c95b403cbe0872f289a2aafa106ee9d8",
   "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@463e5e4e06e0ca84927176e8c72f6076ae9b6829",
   "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@29b1f86b11a8c7438fd7d57b446a77a84946712a",

--- a/DEPS
+++ b/DEPS
@@ -16,7 +16,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@b8ef1a3f85aec0a0522a9230d59b3958a2150fab",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@76bf8f1295b46a7112756af631a8f5cd217953e6",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@6691e9594f66050ba30206d9f49f90ce1a44bb51",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@0cd5dda4fd7c948d6c13107cb4f9b7d293ffc7e3",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@2c0e28f76e4b6f53947bf4faa5afd93614f96aca",

--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ deps = {
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@b8ef1a3f85aec0a0522a9230d59b3958a2150fab",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
   "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@76bf8f1295b46a7112756af631a8f5cd217953e6",
-  "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@518d17d97003d1ccb2116c498ab363e0834e184c",
+  "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@0cd5dda4fd7c948d6c13107cb4f9b7d293ffc7e3",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@2c0e28f76e4b6f53947bf4faa5afd93614f96aca",
 }

--- a/browser/metrics/metrics_reporting_util.cc
+++ b/browser/metrics/metrics_reporting_util.cc
@@ -18,7 +18,7 @@ bool GetDefaultPrefValueForMetricsReporting() {
     case version_info::Channel::CANARY:
       return true;
     case version_info::Channel::UNKNOWN:
-      return false;
+      return true;
     default:
       NOTREACHED();
       return false;

--- a/browser/metrics/metrics_reporting_util.cc
+++ b/browser/metrics/metrics_reporting_util.cc
@@ -18,7 +18,7 @@ bool GetDefaultPrefValueForMetricsReporting() {
     case version_info::Channel::CANARY:
       return true;
     case version_info::Channel::UNKNOWN:
-      return true;
+      return false;
     default:
       NOTREACHED();
       return false;

--- a/chromium_src/components/metrics/enabled_state_provider.cc
+++ b/chromium_src/components/metrics/enabled_state_provider.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/metrics/enabled_state_provider.h"
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+
+namespace metrics {
+
+bool EnabledStateProvider::IsReportingEnabled() const {
+  return false;
+}
+
+}  // namespace metrics

--- a/chromium_src/components/metrics/enabled_state_provider_unittest.cc
+++ b/chromium_src/components/metrics/enabled_state_provider_unittest.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/metrics/chrome_metrics_services_manager_client.h"
+
+#include "chrome/browser/metrics/chrome_metrics_service_accessor.h"
+#include "components/metrics/enabled_state_provider.h"
+#include "components/metrics/metrics_pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(ChromeMetricsServicesManagerClient, MetricsReportingDisabled) {
+  TestingPrefServiceSimple local_state;
+  metrics::RegisterMetricsReportingStatePrefs(local_state.registry());
+  local_state.registry()->RegisterBooleanPref(
+      metrics::prefs::kMetricsReportingEnabled, true);
+
+  ChromeMetricsServicesManagerClient client(&local_state);
+  const metrics::EnabledStateProvider& provider =
+      client.GetEnabledStateProviderForTesting();
+
+  // Reporting should never be enabled
+  EXPECT_FALSE(provider.IsReportingEnabled());
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -66,6 +66,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/chrome/browser/history/history_utils_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
+    "//brave/chromium_src/components/metrics/enabled_state_provider_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3816
fix https://github.com/brave/brave-browser/issues/3871
fix https://github.com/brave/brave-browser/issues/3877
fix https://github.com/brave/brave-browser/issues/3878

## Description
1. Disabling metrics reporting to avoid sending UMA metrics to google.
2. Updating DEPS to fix npm audit error by js-yaml in sync, crypto and ad-block

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
