### PR TITLE
Add missing dep from chromium/ui/base to brave/app:brave_generated_resources_grit

### DIFF
--- a/patches/ui-base-BUILD.gn.patch
+++ b/patches/ui-base-BUILD.gn.patch
@@ -1,12 +1,12 @@
 diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
-index 085ef60055790df6a98f6b6c4b567e6dbf7b9785..03003fb05493fe5c852f4876be98ac6a8576b8eb 100644
+index 085ef60055790df6a98f6b6c4b567e6dbf7b9785..fdc6122ad838586cf571929fd118252c2df08578 100644
 --- a/ui/base/BUILD.gn
 +++ b/ui/base/BUILD.gn
-@@ -408,6 +408,7 @@ jumbo_component("base") {
-     "//base:base_static",
-     "//base:i18n",
-     "//base/third_party/dynamic_annotations",
-+    "//brave/ui/webui/resources",
-     "//net",
-     "//third_party/icu",
-     "//third_party/zlib:zlib",
+@@ -419,6 +419,7 @@ jumbo_component("base") {
+     "//ui/strings",
+     "//url",
+   ]
++  deps += [ "//brave/ui/base:chromium_deps" ]
+ 
+   if (!is_ios) {
+     # iOS does not use Chromium-specific code for event handling.

--- a/ui/base/BUILD.gn
+++ b/ui/base/BUILD.gn
@@ -1,0 +1,6 @@
+group("chromium_deps") {
+  deps = [
+    "//brave/ui/webui/resources",
+    "//brave/app:brave_generated_resources_grit",
+  ]
+}


### PR DESCRIPTION
This may be a strange technique to add a new BUILD.gn file at this specific path. Seeking advice on correct location for new .gn or .gni which is intended just to group chromium -> brave dependencies and minimize patch to 1 line.

Fix https://github.com/brave/brave-browser/issues/3854

> Investigation shows that we have modified a file in ui/base to include "chrome/grit/generated_resources.h" but that is rewritten to "brave/grit/brave_generated_resources.h" and there is no dep to the project which generates that.
>
> Setting milestone of 0.63.x since this code was introduced with brave/brave-core#1422

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Build

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
