### PR TITLE
[0.62.x] block default chrome url in topsites list

### DIFF
--- a/components/brave_new_tab_ui/api.ts
+++ b/components/brave_new_tab_ui/api.ts
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux'
 import * as newTabActions from './actions/new_tab_actions'
 import { debounce } from '../common/debounce'
 import store from './store'
-import { isHttpOrHttps } from './helpers/newTabUtils'
 
 let actions: any
 
@@ -53,14 +52,15 @@ export const fetchBookmarkInfo = (url: string) => {
 export const getGridSites = (state: NewTab.State, checkBookmarkInfo?: boolean) => {
   const sizeToCount = { large: 18, medium: 12, small: 6 }
   const count = sizeToCount[state.gridLayoutSize || 'small']
+  const defaultChromeUrl = 'https://chrome.google.com/webstore?hl=en'
 
   // Start with top sites with filtered out ignored sites and pinned sites
   let gridSites = state.topSites.slice()
-    .filter((site) =>
-      !state.ignoredTopSites.find((ignoredSite) => ignoredSite.url === site.url) &&
-      !state.pinnedTopSites.find((pinnedSite) => pinnedSite.url === site.url) &&
-      !isHttpOrHttps(site.url)
-    )
+  .filter((site) =>
+    !state.ignoredTopSites.find((ignoredSite) => ignoredSite.url === site.url) &&
+    !state.pinnedTopSites.find((pinnedSite) => pinnedSite.url === site.url) &&
+    site.url !== defaultChromeUrl
+  )
 
   // Then add in pinned sites at the specified index, these need to be added in the same
   // order as the index they are.

--- a/components/test/brave_new_tab_ui/api_test.ts
+++ b/components/test/brave_new_tab_ui/api_test.ts
@@ -1,0 +1,52 @@
+/* global describe, it */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getGridSites } from '../../brave_new_tab_ui/api'
+
+describe('new tab api tests', () => {
+  const defaultState = {
+    topSites: [],
+    ignoredTopSites: [],
+    pinnedTopSites: [],
+    bookmarks: {}
+  }
+  describe('getGridSites', () => {
+    it('allows http sites', () => {
+      const url = 'http://cezaraugusto.net'
+      const newState = {
+        ...defaultState,
+        topSites: [
+          { url }
+        ]
+      }
+      const assertion = getGridSites(newState, true)
+      expect(assertion[0]).toBe(newState.topSites[0])
+      expect(assertion[0].url).toBe(url)
+    })
+    it('allows https sites', () => {
+      const url = 'https://cezaraugusto.net'
+      const newState = {
+        ...defaultState,
+        topSites: [
+          { url }
+        ]
+      }
+      const assertion = getGridSites(newState, true)
+      expect(assertion[0]).toBe(newState.topSites[0])
+      expect(assertion[0].url).toBe(url)
+    })
+    it('do not allow the default chrome topSites url', () => {
+      const url = 'https://chrome.google.com/webstore?hl=en'
+      const newState = {
+        ...defaultState,
+        topSites: [
+          { url }
+        ]
+      }
+      const assertion = getGridSites(newState, true)
+      expect(assertion[0]).toBe(undefined)
+    })
+  })
+})

--- a/components/test/testData.ts
+++ b/components/test/testData.ts
@@ -36,6 +36,19 @@ export const getMockChrome = () => {
     },
     braveRewards: {
       getPublisherData: (id: number, url: string, favicon: string) => undefined
+    },
+    extension: {
+      inIncognitoContext: new ChromeEvent()
+    },
+    topSites: {
+      get: function () {
+        return
+      }
+    },
+    bookmarks: {
+      search: function () {
+        return
+      }
     }
   }
 }


### PR DESCRIPTION
fix brave/brave-browser#3805
sibling of #2037 and #2038

test plan:
covered by automated tests