### PR TITLE
Turn on crash report by default on beta channel

### DIFF
--- a/browser/metrics/metrics_reporting_util.cc
+++ b/browser/metrics/metrics_reporting_util.cc
@@ -11,9 +11,9 @@
 
 bool GetDefaultPrefValueForMetricsReporting() {
   switch (chrome::GetChannel()) {
-    case version_info::Channel::STABLE:  // fall through
-    case version_info::Channel::BETA:
+    case version_info::Channel::STABLE:
       return false;
+    case version_info::Channel::BETA:    // fall through
     case version_info::Channel::DEV:     // fall through
     case version_info::Channel::CANARY:
       return true;

--- a/browser/metrics/metrics_reporting_util_unittest_linux.cc
+++ b/browser/metrics/metrics_reporting_util_unittest_linux.cc
@@ -20,7 +20,7 @@ TEST(MetricsUtilTest, DefaultValueTest) {
 
   env->SetVar("CHROME_VERSION_EXTRA", LINUX_CHANNEL_BETA);
   EXPECT_EQ(version_info::Channel::BETA, chrome::GetChannel());
-  EXPECT_FALSE(GetDefaultPrefValueForMetricsReporting());
+  EXPECT_TRUE(GetDefaultPrefValueForMetricsReporting());
 
   env->SetVar("CHROME_VERSION_EXTRA", LINUX_CHANNEL_DEV);
   EXPECT_EQ(version_info::Channel::DEV, chrome::GetChannel());


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3861

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
