### PR TITLE
add support for Shields theming

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/reducers/cosmeticFilterReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/cosmeticFilterReducer.ts
@@ -42,7 +42,9 @@ const updateActiveTab = (state: State, windowId: number, tabId: number): State =
 export default function cosmeticFilterReducer (state: State = {
   tabs: {},
   windows: {},
-  currentWindowId: -1 },
+  currentWindowId: -1,
+  theme: 'Light'
+},
   action: Actions) {
   switch (action.type) {
     case webNavigationTypes.ON_COMMITTED: {

--- a/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
@@ -48,6 +48,7 @@ const updateShieldsIconImage = (state: State) => {
 const updateShieldsIcon = (state: State) => {
   updateShieldsIconBadgeText(state)
   updateShieldsIconImage(state)
+  shieldsPanelState.updateThemeType(state)
 }
 
 const focusedWindowChanged = (state: State, windowId: number): State => {
@@ -68,7 +69,7 @@ const updateActiveTab = (state: State, windowId: number, tabId: number): State =
   return shieldsPanelState.updateActiveTab(state, windowId, tabId)
 }
 
-export default function shieldsPanelReducer (state: State = { tabs: {}, windows: {}, currentWindowId: -1 }, action: Actions) {
+export default function shieldsPanelReducer (state: State = { tabs: {}, windows: {}, currentWindowId: -1, theme: 'Light' }, action: Actions) {
   switch (action.type) {
     case webNavigationTypes.ON_COMMITTED: {
       if (action.isMainFrame) {

--- a/components/brave_extension/extension/brave_extension/braveShieldsPanel.tsx
+++ b/components/brave_extension/extension/brave_extension/braveShieldsPanel.tsx
@@ -5,8 +5,10 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
-import Theme from 'brave-ui/theme/brave-default'
+import shieldsDarkTheme from 'brave-ui/theme/shields-dark'
+import shieldsLightTheme from 'brave-ui/theme/shields-light'
 import { ThemeProvider } from 'brave-ui/theme'
+import { ThemeType } from './types/other/theme'
 
 import { Provider } from 'react-redux'
 import { Store } from 'react-chrome-redux'
@@ -18,13 +20,14 @@ chrome.storage.local.get('state', (obj) => {
   const store: any = new Store({
     portName: 'BRAVE'
   })
-
   store.ready()
     .then(() => {
       const mountNode: HTMLElement | null = document.querySelector('#root')
+      const theme: ThemeType = store.state.shieldsPanel.theme
+      const getTheme = theme === 'Dark' ? shieldsDarkTheme : shieldsLightTheme
       ReactDOM.render(
         <Provider store={store}>
-          <ThemeProvider theme={Theme}>
+          <ThemeProvider theme={getTheme}>
             <BraveShields />
           </ThemeProvider>
         </Provider>,

--- a/components/brave_extension/extension/brave_extension/state/shieldsPanelState.ts
+++ b/components/brave_extension/extension/brave_extension/state/shieldsPanelState.ts
@@ -4,10 +4,18 @@
 
 import * as shieldState from '../types/state/shieldsPannelState'
 import { unique } from '../helpers/arrayUtils'
+import { ThemeType } from '../types/other/theme'
 
 export const getActiveTabId: shieldState.GetActiveTabId = (state) => state.windows[state.currentWindowId]
 
 export const getActiveTabData: shieldState.GetActiveTabData = (state) => state.tabs[getActiveTabId(state)]
+
+export const updateThemeType: shieldState.UpdateThemeType = (state) => {
+  chrome.braveTheme.getBraveThemeType((themeType: ThemeType) => {
+    state.theme = themeType
+  })
+  return { ...state }
+}
 
 export const updateActiveTab: shieldState.UpdateActiveTab = (state, windowId, tabId) => {
   let windows: shieldState.Windows = { ...state.windows } || {}

--- a/components/brave_extension/extension/brave_extension/types/other/theme.ts
+++ b/components/brave_extension/extension/brave_extension/types/other/theme.ts
@@ -1,0 +1,1 @@
+export type ThemeType = 'Light' | 'Dark'

--- a/components/brave_extension/extension/brave_extension/types/state/shieldsPannelState.ts
+++ b/components/brave_extension/extension/brave_extension/types/state/shieldsPannelState.ts
@@ -4,6 +4,7 @@
 
 import { BlockOptions, BlockTypes, BlockFPOptions, BlockCookiesOptions } from '../other/blockTypes'
 import { NoScriptInfo } from '../other/noScriptInfo'
+import { ThemeType } from '../other/theme'
 
 export interface Tab {
   ads: BlockOptions
@@ -43,6 +44,7 @@ export interface State {
   currentWindowId: number
   tabs: Tabs
   windows: Windows
+  theme: ThemeType
 }
 
 export interface GetActiveTabId {
@@ -91,4 +93,8 @@ export interface ResetNoScriptInfo {
 
 export interface ChangeAllNoScriptSettings {
   (state: State, tabId: number, shouldBlock: boolean): State
+}
+
+export interface UpdateThemeType {
+  (state: State): State
 }

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -98,6 +98,9 @@ interface BlockDetails {
   tabId: number
   subresource: string
 }
+
+type ThemeType = 'Light' | 'Dark'
+
 declare namespace chrome.tabs {
   const setAsync: any
   const getAsync: any
@@ -116,4 +119,8 @@ declare namespace chrome.braveShields {
   const allowScriptsOnce: any
   const javascript: any
   const plugins: any
+}
+
+declare namespace chrome.braveTheme {
+  const getBraveThemeType: (callback: (themeType: ThemeType) => void) => void
 }

--- a/components/test/brave_extension/background/reducers/cosmeticFilterReducer_test.ts
+++ b/components/test/brave_extension/background/reducers/cosmeticFilterReducer_test.ts
@@ -305,6 +305,7 @@ describe('cosmeticFilterReducer', () => {
             details
           })).toEqual({
             currentWindowId: -1,
+            theme: 'Light',
             tabs: {
               [tabId]: {
                 adsBlocked: 0,

--- a/components/test/brave_extension/background/reducers/shieldsPanelReducer_test.ts
+++ b/components/test/brave_extension/background/reducers/shieldsPanelReducer_test.ts
@@ -307,6 +307,7 @@ describe('braveShieldsPanelReducer', () => {
           details
         })).toEqual({
           currentWindowId: -1,
+          theme: 'Light',
           tabs: {
             [tabId]: {
               adsBlocked: 0,

--- a/components/test/testData.ts
+++ b/components/test/testData.ts
@@ -7,6 +7,7 @@ import { defaultState as rewardsData } from '../../components/brave_rewards/reso
 import { defaultState as adblockData } from '../../components/brave_adblock_ui/storage'
 import { defaultState as syncData } from '../../components/brave_sync/ui/storage'
 import { Tab } from '../brave_extension/extension/brave_extension/types/state/shieldsPannelState'
+import { ThemeType } from '../brave_extension/extension/brave_extension/types/other/theme'
 import { BlockDetails } from '../brave_extension/extension/brave_extension/types/actions/shieldsPanelActions'
 import * as deepFreeze from 'deep-freeze-node'
 
@@ -180,6 +181,11 @@ export const getMockChrome = () => {
     },
     extension: {
       inIncognitoContext: new ChromeEvent()
+    },
+    braveTheme: {
+      getBraveThemeType: function (cb: (themeType: ThemeType) => void) {
+        cb('Light')
+      }
     }
   }
 }
@@ -188,12 +194,14 @@ export const initialState = deepFreeze({
   cosmeticFilter: {
     currentWindowId: -1,
     tabs: {},
-    windows: {}
+    windows: {},
+    theme: 'Light'
   },
   runtime: {},
   shieldsPanel: {
     currentWindowId: -1,
     tabs: {},
-    windows: {}
+    windows: {},
+    theme: 'Light'
   }
 })


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3870

Test Plan:

1. Go to chrome://settings/appearance
2. Switch theme
3. Shields should match whether dark/light