### PR TITLE
Show error about wrong time on sync init

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -16,7 +16,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@b8ef1a3f85aec0a0522a9230d59b3958a2150fab",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@42a3630239648383968db17732480f817039e6c1",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@36470f7b7c19ac0e072f772535065e16c8741b12",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@0cd5dda4fd7c948d6c13107cb4f9b7d293ffc7e3",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@2c0e28f76e4b6f53947bf4faa5afd93614f96aca",

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -524,6 +524,8 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "errorMissingCodeTitle", IDS_BRAVE_SYNC_ERROR_MISSING_SYNC_CODE_TITLE },               // NOLINT
         { "errorSyncInitFailedTitle", IDS_BRAVE_SYNC_ERROR_INIT_FAILED_TITLE },
         { "errorSyncInitFailedDescription", IDS_BRAVE_SYNC_ERROR_INIT_FAILED_DESCRIPTION },      // NOLINT
+        { "errorSyncRequiresCorrectTimeTitle", IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_TITLE },     // NOLINT
+        { "errorSyncRequiresCorrectTimeDescription", IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_DESCRIPTION }, // NOLINT
       }
     }, {
       std::string("adblock"), {

--- a/components/brave_sync/extension/background.js
+++ b/components/brave_sync/extension/background.js
@@ -234,8 +234,10 @@ class InjectedObject {
         chrome.braveSync.getInitData(arg1/*syncVersion*/);
         break;
       case "sync-setup-error":
-        console.log(`"sync-setup-error" error=${JSON.stringify(arg1)}`);
-        chrome.braveSync.syncSetupError('ERR_SYNC_INIT_FAILED');
+        console.log(`"sync-setup-error" error=${arg1}`);
+        var errorToPass = (arg1 === 'Credential server response 400. Signed request body of the client timestamp is required.') ?
+            'ERR_SYNC_REQUIRES_CORRECT_TIME' : 'ERR_SYNC_INIT_FAILED'
+        chrome.braveSync.syncSetupError(errorToPass);
         break;
       case "sync-debug":
         console.log(`"sync-debug" message=${JSON.stringify(arg1)}`);

--- a/components/brave_sync/ui/components/enabledContent.tsx
+++ b/components/brave_sync/ui/components/enabledContent.tsx
@@ -204,6 +204,14 @@ export default class SyncEnabledContent extends React.PureComponent<Props, State
             : null
           }
           {
+            syncData.error === 'ERR_SYNC_REQUIRES_CORRECT_TIME'
+            ? <AlertBox okString={getLocale('ok')} onClickOk={this.onUserNoticedError}>
+                <Title>{getLocale('errorSyncRequiresCorrectTimeTitle')}</Title>
+                <SubTitle>{getLocale('errorSyncRequiresCorrectTimeDescription')}</SubTitle>
+              </AlertBox>
+            : null
+          }
+          {
             removeDevice
               ? (
                 <RemoveDeviceModal

--- a/components/brave_sync/ui/components/modals/deviceType.tsx
+++ b/components/brave_sync/ui/components/modals/deviceType.tsx
@@ -89,6 +89,14 @@ export default class DeviceTypeModal extends React.PureComponent<Props, State> {
           : null
         }
         {
+          syncData.error === 'ERR_SYNC_REQUIRES_CORRECT_TIME'
+          ? <AlertBox okString={getLocale('ok')} onClickOk={this.onUserNoticedError}>
+              <Title>{getLocale('errorSyncRequiresCorrectTimeTitle')}</Title>
+              <SubTitle>{getLocale('errorSyncRequiresCorrectTimeDescription')}</SubTitle>
+            </AlertBox>
+          : null
+        }
+        {
           scanCode
           ? (
             <ScanCode

--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -125,6 +125,14 @@ export default class EnterSyncCodeModal extends React.PureComponent<Props, State
             </AlertBox>
           : null
         }
+        {
+          syncData.error === 'ERR_SYNC_REQUIRES_CORRECT_TIME'
+          ? <AlertBox okString={getLocale('ok')} onClickOk={this.onUserNoticedError}>
+              <Title>{getLocale('errorSyncRequiresCorrectTimeTitle')}</Title>
+              <SubTitle>{getLocale('errorSyncRequiresCorrectTimeDescription')}</SubTitle>
+            </AlertBox>
+          : null
+        }
         <ModalHeader>
           <div>
             <ModalTitle level={1}>{getLocale('enterSyncCode')}</ModalTitle>

--- a/components/definitions/sync.d.ts
+++ b/components/definitions/sync.d.ts
@@ -27,6 +27,7 @@ export type SetupErrorType =
   'ERR_SYNC_MISSING_WORDS' |
   'ERR_SYNC_WRONG_WORDS' |
   'ERR_SYNC_INIT_FAILED' |
+  'ERR_SYNC_REQUIRES_CORRECT_TIME' |
   undefined
 
   export interface State {

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -562,6 +562,8 @@
       <message name="IDS_BRAVE_SYNC_ERROR_MISSING_SYNC_CODE_TITLE" desc="Error message in dialog for when device name is missing (description)">Please add a sync code.</message>
       <message name="IDS_BRAVE_SYNC_ERROR_INIT_FAILED_TITLE" desc="Error message in dialog for when a Sync error happens in the back-end">Couldn't contact Sync servers</message>
       <message name="IDS_BRAVE_SYNC_ERROR_INIT_FAILED_DESCRIPTION" desc="Error message in dialog for when a Sync error happens in the back-end">You might be having network trouble, or there could be a problem with the Sync servers.</message>
+      <message name="IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_TITLE" desc="Error message in dialog for when a Sync could not couldn't connect to Sync servers, because of wrong system time (title)">Couldn't connect to Sync servers</message>
+      <message name="IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_DESCRIPTION" desc="Error message in dialog for when a Sync could not couldn't connect to Sync servers, because of wrong system time (description)">You might be having wrong system time or timezone setup on your device. Please setup the correct time and timezone</message>
     </messages>
   </release>
 </grit>


### PR DESCRIPTION
## Submitter Checklist:

Fixes https://github.com/brave/brave-browser/issues/3962.

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues/3962) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Adjust computer time 20 minutes forward.
2. Create a sync chain
3. Should see:`You might be having wrong system time or timezone setup on your device. Please setup the correct time and timezone`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
