### PR TITLE
Get verified state from the list

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -483,6 +483,16 @@ class LedgerImpl : public ledger::Ledger,
 
   void OnRemovedRecurring(ledger::Result result);
 
+  void ModifyPublisherVerified(
+    ledger::Result result,
+    std::unique_ptr<ledger::PublisherInfo> publisher,
+    ledger::PublisherInfoCallback callback);
+
+  void ModifyPublisherListVerified(
+    const ledger::PublisherInfoList&,
+    uint32_t record,
+    ledger::PublisherInfoListCallback callback);
+
   // ledger::LedgerCallbacHandler implementation
   void OnPublisherStateLoaded(ledger::Result result,
                               const std::string& data) override;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3780

Depends on https://github.com/brave/brave-browser/issues/4025 and https://github.com/brave/brave-browser/issues/3953

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- clean profie
- enable rewards
- go to http://duckduckgo.com/ site
- add monthly tip
- do one time tip
- make sure that panel is verified
- make sure that you see verified check in tips section
- make sure that you added site to ac table and that you see verified check
- close the browser
- go to publisher_list and change verified status of to false: from `["duckduckgo.com",true,false,{}]` to `["duckduckgo.com",false,false,{}]`
- start the browser
- make sure that on rewards page and in the panel you see unverified status now

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source
