### PR TITLE
Shields UI switches between dark and light theme

### DIFF
--- a/components/brave_extension/extension/brave_extension/braveShieldsPanel.tsx
+++ b/components/brave_extension/extension/brave_extension/braveShieldsPanel.tsx
@@ -4,34 +4,39 @@
 
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-
-import Theme from 'brave-ui/theme/brave-default'
-import { ThemeProvider } from 'brave-ui/theme'
-
+import shieldsDarkTheme from 'brave-ui/theme/shields-dark'
+import shieldsLightTheme from 'brave-ui/theme/shields-light'
 import { Provider } from 'react-redux'
 import { Store } from 'react-chrome-redux'
+import BraveCoreThemeProvider from '../../../common/BraveCoreThemeProvider'
 import BraveShields from './containers/braveShields'
 require('../../../fonts/muli.css')
 require('../../../fonts/poppins.css')
 
-chrome.storage.local.get('state', (obj) => {
-  const store: any = new Store({
-    portName: 'BRAVE'
-  })
+const store: any = new Store({
+  portName: 'BRAVE'
+})
 
-  store.ready()
-    .then(() => {
-      const mountNode: HTMLElement | null = document.querySelector('#root')
-      ReactDOM.render(
-        <Provider store={store}>
-          <ThemeProvider theme={Theme}>
-            <BraveShields />
-          </ThemeProvider>
-        </Provider>,
-        mountNode
-      )
-    })
-    .catch(() => {
-      console.error('Problem mounting brave shields')
-    })
+Promise.all([
+  store.ready(),
+  new Promise(resolve => chrome.braveTheme.getBraveThemeType(resolve))
+])
+.then(([ , themeType ]: [ undefined, chrome.braveTheme.ThemeType ]) => {
+  const mountNode: HTMLElement | null = document.querySelector('#root')
+  ReactDOM.render(
+    <Provider store={store}>
+      <BraveCoreThemeProvider
+        initialThemeType={themeType}
+        dark={shieldsDarkTheme}
+        light={shieldsLightTheme}
+      >
+        <BraveShields />
+      </BraveCoreThemeProvider>
+    </Provider>,
+    mountNode
+  )
+})
+.catch((e) => {
+  console.error('Problem mounting brave shields')
+  console.error(e)
 })

--- a/components/common/BraveCoreThemeProvider.tsx
+++ b/components/common/BraveCoreThemeProvider.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { ThemeProvider } from 'brave-ui/theme'
+import IBraveTheme from 'brave-ui/theme/theme-interface'
+
+export type Props = {
+  initialThemeType?: chrome.braveTheme.ThemeType
+  dark: IBraveTheme,
+  light: IBraveTheme
+}
+type State = {
+  themeType?: chrome.braveTheme.ThemeType
+}
+
+function themeTypeToState (themeType: chrome.braveTheme.ThemeType): State {
+  return {
+    themeType
+  }
+}
+
+export default class BraveCoreThemeProvider extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    if (props.initialThemeType) {
+      this.state = themeTypeToState(props.initialThemeType)
+    }
+    chrome.braveTheme.onBraveThemeTypeChanged.addListener(this.setThemeState)
+  }
+
+  setThemeState = (themeType: chrome.braveTheme.ThemeType) => {
+    this.setState(themeTypeToState(themeType))
+  }
+
+  render () {
+    // Don't render until we have a theme
+    if (!this.state.themeType) return null
+    // Render provided dark or light theme
+    const selectedShieldsTheme = this.state.themeType === 'Dark'
+                ? this.props.dark
+                : this.props.light
+    return (
+      <ThemeProvider theme={selectedShieldsTheme}>
+        {React.Children.only(this.props.children)}
+      </ThemeProvider>
+    )
+  }
+}

--- a/components/common/typescript.gni
+++ b/components/common/typescript.gni
@@ -7,6 +7,7 @@ brave_common_web_compile_inputs = [
   rebase_path("dns.ts"),
   rebase_path("debounce.ts"),
   rebase_path("locale.ts"),
+  rebase_path("BraveCoreThemeProvider.tsx"),
   # common definitions change
   rebase_path("../definitions/adBlock.d.ts"),
   rebase_path("../definitions/chromel.d.ts"),

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -118,3 +118,12 @@ declare namespace chrome.braveShields {
   const javascript: any
   const plugins: any
 }
+
+declare namespace chrome.braveTheme {
+  type ThemeType = 'Light' | 'Dark'
+  type ThemeTypeCallback = (themeType: ThemeType) => void
+  const getBraveThemeType: (themeType: ThemeTypeCallback) => void
+  const onBraveThemeTypeChanged: {
+    addListener: (callback: ThemeTypeCallback) => void
+  }
+}


### PR DESCRIPTION
Introduces BraveCoreThemeProvider which uses the `chrome.braveTheme` API to choose which provided _dark_ or _light_ brave-ui `IBraveTheme` to use.

Does an initial get from that API before rendering to make sure there's no-flash-of-un-themed-content but future testing may deem that unnecessary.

Fix https://github.com/brave/brave-browser/issues/3870
Should be uplifted to wherever https://github.com/brave/brave-core/pull/1931 is since that changed theme from always-dark to always-light.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
On issue https://github.com/brave/brave-browser/issues/3870

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
