### PR TITLE
Fixing nightly

### DIFF
--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index 3d9a560e26e43fb2da1332dff339c1039cfb1a3e..7b2d1041533f1aacdeefb8524a4c433f390091b0 100644
+index 3d9a560e26e43fb2da1332dff339c1039cfb1a3e..4050aa4ee4122124f154ceeff1e3ac8326576b22 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@

--- a/patches/net-cookies-canonical_cookie.cc.patch
+++ b/patches/net-cookies-canonical_cookie.cc.patch
@@ -4,7 +4,7 @@ index 91611ac4171c19a031044ae6b1459acce246d427..c0636088e332f61c9ee8e6ed07f210fa
 +++ b/net/cookies/canonical_cookie.cc
 @@ -228,9 +228,10 @@ std::unique_ptr<CanonicalCookie> CanonicalCookie::Create(
      server_time = options.server_time();
-
+ 
    DCHECK(!creation_time.is_null());
 -  Time cookie_expires = CanonicalCookie::CanonExpiration(parsed_cookie,
 -                                                         creation_time,
@@ -13,6 +13,6 @@ index 91611ac4171c19a031044ae6b1459acce246d427..c0636088e332f61c9ee8e6ed07f210fa
 +                                             creation_time,
 +                                             server_time,
 +                                             !options.exclude_httponly());
-
+ 
    CookiePrefix prefix = GetCookiePrefix(parsed_cookie.Name());
    bool is_cookie_valid = IsCookiePrefixValid(prefix, url, parsed_cookie);


### PR DESCRIPTION
## Description

To revert C74, PR #2088 was merged unintentionally instead of #2079. 

See more details here: https://bravesoftware.slack.com/archives/CA5FPHWLF/p1553697892501200?thread_ts=1553678935.487200&cid=CA5FPHWLF

Instead of re-reverting the original PR and pushing the new pr, @mihaiplesa and I worked on a PR that has the missing commits from #2079. 

From #2079 :

Related: brave/brave-browser#3896

Reverts:
brave/brave-browser#3790
#2029
#2072

Fixes brave/brave-browser#3898

Unfixes:
brave/brave-browser#3502
brave/brave-browser#3662
brave/brave-browser#3816

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Go into Jenkins for this PR
2. Verify everything passes on all platforms
3. If anything fails, don't merge

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
