### PR TITLE
Issue 3816: Disabling metrics services provider

### DIFF
--- a/chromium_src/components/metrics/enabled_state_provider_unittest.cc
+++ b/chromium_src/components/metrics/enabled_state_provider_unittest.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/metrics/chrome_metrics_services_manager_client.h"
+
+#include "chrome/browser/metrics/chrome_metrics_service_accessor.h"
+#include "components/metrics/enabled_state_provider.h"
+#include "components/metrics/metrics_pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(ChromeMetricsServicesManagerClient, MetricsReportingDisabled) {
+  TestingPrefServiceSimple local_state;
+  metrics::RegisterMetricsReportingStatePrefs(local_state.registry());
+  local_state.registry()->RegisterBooleanPref(
+      metrics::prefs::kMetricsReportingEnabled, true);
+
+  ChromeMetricsServicesManagerClient client(&local_state);
+  const metrics::EnabledStateProvider& provider =
+      client.GetEnabledStateProviderForTesting();
+
+  // Reporting should never be enabled
+  EXPECT_FALSE(provider.IsReportingEnabled());
+}

--- a/patches/chrome-browser-metrics-chrome_metrics_services_manager_client.cc.patch
+++ b/patches/chrome-browser-metrics-chrome_metrics_services_manager_client.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/metrics/chrome_metrics_services_manager_client.cc b/chrome/browser/metrics/chrome_metrics_services_manager_client.cc
+index 3399a7c2830081d0f4d4e60f80cca69db66cda2d..b6174c7512e18c65bc6c6204d3bf0e7d568e1422 100644
+--- a/chrome/browser/metrics/chrome_metrics_services_manager_client.cc
++++ b/chrome/browser/metrics/chrome_metrics_services_manager_client.cc
+@@ -128,7 +128,7 @@ class ChromeMetricsServicesManagerClient::ChromeEnabledStateProvider
+   }
+ 
+   bool IsReportingEnabled() const override {
+-    return IsConsentGiven() &&
++    return false && IsConsentGiven() &&
+            ChromeMetricsServicesManagerClient::IsClientInSample();
+   }
+ 

--- a/patches/chrome-browser-metrics-chrome_metrics_services_manager_client.h.patch
+++ b/patches/chrome-browser-metrics-chrome_metrics_services_manager_client.h.patch
@@ -1,0 +1,15 @@
+diff --git a/chrome/browser/metrics/chrome_metrics_services_manager_client.h b/chrome/browser/metrics/chrome_metrics_services_manager_client.h
+index 00e7fc9bfae21162544c5ace0e9b0e799906a034..66d957a69e8f30ce6c151a4c9dda0b39070f0aa8 100644
+--- a/chrome/browser/metrics/chrome_metrics_services_manager_client.h
++++ b/chrome/browser/metrics/chrome_metrics_services_manager_client.h
+@@ -59,6 +59,10 @@ class ChromeMetricsServicesManagerClient
+   // sample rate is undefined. It is also undefined for clients that are not
+   // eligible for sampling.
+   static bool GetSamplingRatePerMille(int* rate);
++  
++  const metrics::EnabledStateProvider& GetEnabledStateProviderForTesting() {
++      return *enabled_state_provider_;
++  }
+ 
+ #if defined(OS_CHROMEOS)
+   void OnCrosSettingsCreated();

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -66,6 +66,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/chrome/browser/history/history_utils_unittest.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
+    "//brave/chromium_src/components/metrics/enabled_state_provider_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",


### PR DESCRIPTION
## Description

Initial patch for disabling metrics services (https://github.com/brave/brave-core/pull/2029/files#diff-df788f5fb2dd4d6366315886d1b2a0b2) was incompatible with C73, so we ended up reverting it with C74-revert.

This updated patch works with C73 but, uses patches:

https://github.com/brave/brave-core/pull/2095/files

The problem is the code that checks for enable reporting in C74 is:

```
bool IsReportingEnabled() const override {
    return metrics::EnabledStateProvider::IsReportingEnabled() &&
           IsClientInSampleImpl(local_state_);
  }
```

With C74, this worked because it was able to override `IsReportingEnabled` function in `EnabledStateProvider` to return false.

In C73 the code:

```
bool IsReportingEnabled() const override {
    return IsConsentGiven() &&
           ChromeMetricsServicesManagerClient::IsClientInSample();
  }
```

I investigated subclassing `ChromeEnabledStateProvider`, `ChromeMetricsServicesManagerClient` but that did not work. Disabling `kMetricsReportingFeature` does not work as well as its enabled by `field_trials`.

**This patch will be reverted with C74, and we can use the override then**

fix https://github.com/brave/brave-browser/issues/3816

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. `npm run network-audit` should pass.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
 