### PR TITLE
Rewards panel now opens in 'First Run' state with Rewards page when wallet is corrupt

### DIFF
--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -258,6 +258,12 @@
         "parameters": []
       },
       {
+        "name": "onWalletCorrupted",
+        "type": "function",
+        "description": "Fired when wallet is corrupt",
+        "parameters": []
+      },
+      {
         "name": "onPublisherListNormalized",
         "type": "function",
         "description": "Fired when publisher list was updated and normalized",

--- a/components/brave_rewards/browser/extension_rewards_service_observer.cc
+++ b/components/brave_rewards/browser/extension_rewards_service_observer.cc
@@ -44,6 +44,12 @@ void ExtensionRewardsServiceObserver::OnWalletInitialized(
         extensions::api::brave_rewards::OnWalletCreated::kEventName,
         std::move(args)));
       event_router->BroadcastEvent(std::move(event));
+    } else if (result == ledger::Result::CORRUPTED_WALLET) {
+      std::unique_ptr<extensions::Event> event(new extensions::Event(
+        extensions::events::BRAVE_START,
+        extensions::api::brave_rewards::OnWalletCorrupted::kEventName,
+        std::move(args)));
+      event_router->BroadcastEvent(std::move(event));
     } else if (result != ledger::Result::LEDGER_OK) {
       std::unique_ptr<extensions::Event> event(new extensions::Event(
         extensions::events::BRAVE_WALLET_FAILED,
@@ -60,6 +66,14 @@ void ExtensionRewardsServiceObserver::OnWalletProperties(
     std::unique_ptr<brave_rewards::WalletProperties> wallet_properties) {
   auto* event_router =
       extensions::EventRouter::Get(profile_);
+  if (error_code == 17) {  // ledger::Result::CORRUPT_WALLET
+    std::unique_ptr<base::ListValue> args(new base::ListValue());
+    std::unique_ptr<extensions::Event> event(new extensions::Event(
+        extensions::events::BRAVE_START,
+        extensions::api::brave_rewards::OnWalletCorrupted::kEventName,
+        std::move(args)));
+    event_router->BroadcastEvent(std::move(event));
+  }
   if (event_router && wallet_properties) {
     extensions::api::brave_rewards::OnWalletProperties::Properties properties;
 

--- a/components/brave_rewards/resources/extension/brave_rewards/actions/rewards_panel_actions.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/actions/rewards_panel_actions.ts
@@ -13,6 +13,8 @@ export const onWalletCreated = () => action(types.ON_WALLET_CREATED, {})
 
 export const onWalletCreateFailed = () => action(types.ON_WALLET_CREATE_FAILED, {})
 
+export const onWalletCorrupted = () => action(types.ON_WALLET_CORRUPTED)
+
 export const onTabId = (tabId: number | undefined) => action(types.ON_TAB_ID, {
   tabId
 })

--- a/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
@@ -63,6 +63,10 @@ chrome.braveRewards.onWalletFailed.addListener(() => {
   rewardsPanelActions.onWalletCreateFailed()
 })
 
+chrome.braveRewards.onWalletCorrupted.addListener(() => {
+  rewardsPanelActions.onWalletCorrupted()
+})
+
 chrome.braveRewards.onPublisherListNormalized.addListener((properties: RewardsExtension.PublisherNormalized[]) => {
   rewardsPanelActions.onPublisherListNormalized(properties)
 })

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -39,12 +39,14 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       state.walletCreating = true
       state.walletCreateFailed = false
       state.walletCreated = false
+      state.walletCorrupted = false
       break
     case types.ON_WALLET_CREATED:
       state = { ...state }
       state.walletCreated = true
       state.walletCreateFailed = false
       state.walletCreating = false
+      state.walletCorrupted = false
       chrome.braveRewards.saveAdsSetting('adsEnabled', 'true')
       chrome.storage.local.get(['is_dismissed'], function (result) {
         if (result && result['is_dismissed'] === 'false') {
@@ -60,6 +62,11 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       state.walletCreateFailed = true
       state.walletCreating = false
       state.walletCreated = false
+      state.walletCorrupted = false
+      break
+    case types.ON_WALLET_CORRUPTED:
+      state = { ...state }
+      state.walletCorrupted = true
       break
     case types.ON_TAB_ID:
       if (payload.tabId) {

--- a/components/brave_rewards/resources/extension/brave_rewards/background/storage.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/storage.ts
@@ -8,6 +8,7 @@ import { debounce } from '../../../../../common/debounce'
 const keyName = 'rewards-panel-data'
 
 export const defaultState: RewardsExtension.State = {
+  walletCorrupted: false,
   walletCreated: false,
   walletCreating: false,
   walletCreateFailed: false,

--- a/components/brave_rewards/resources/extension/brave_rewards/components/app.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/app.tsx
@@ -193,13 +193,14 @@ export class RewardsPanel extends React.Component<Props, State> {
       walletCreateFailed,
       walletCreated,
       walletCreating,
-      walletProperties
+      walletProperties,
+      walletCorrupted
     } = this.props.rewardsPanelData
 
     const { balance, grants, rates } = walletProperties
     const converted = utils.convertBalance(balance.toString(), rates)
 
-    if (!walletCreated) {
+    if (!walletCreated || walletCorrupted) {
       return (
         <PanelWelcome
           error={walletCreateFailed}

--- a/components/brave_rewards/resources/extension/brave_rewards/constants/rewards_panel_types.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/constants/rewards_panel_types.ts
@@ -6,6 +6,7 @@ export const enum types {
   CREATE_WALLET = '@@rewards_panel/CREATE_WALLET',
   ON_WALLET_CREATED = '@@rewards_panel/ON_WALLET_CREATED',
   ON_WALLET_CREATE_FAILED = '@@rewards_panel/ON_WALLET_CREATE_FAILED',
+  ON_WALLET_CORRUPTED = '@@rewards_panel/ON_WALLET_CORRUPTED',
   ON_TAB_ID = '@@rewards_panel/ON_TAB_ID',
   ON_TAB_RETRIEVED = '@@rewards_panel/ON_TAB_RETRIEVED',
   ON_PUBLISHER_DATA = '@@rewards_panel/ON_PUBLISHER_DATA',

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -56,6 +56,9 @@ declare namespace chrome.braveRewards {
   const onWalletFailed: {
     addListener: (callback: () => void) => void
   }
+  const onWalletCorrupted: {
+    addListener: (callback: () => void) => void
+  }
   const getACEnabled: (callback: (enabled: boolean) => void) => {}
   const onPublisherListNormalized: {
     addListener: (callback: (properties: RewardsExtension.PublisherNormalized[]) => void) => void

--- a/components/definitions/rewardsExtensions.d.ts
+++ b/components/definitions/rewardsExtensions.d.ts
@@ -9,6 +9,7 @@ declare namespace RewardsExtension {
     report: Report
     grants?: GrantInfo[]
     pendingContributionTotal: number
+    walletCorrupted: boolean
     walletCreated: boolean
     walletCreating: boolean
     walletCreateFailed: boolean

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -280,8 +280,11 @@ void LedgerImpl::OnPublisherStateLoaded(ledger::Result result,
       BLOG(this, ledger::LogLevel::LOG_DEBUG) <<
         "Failed publisher state: " << data;
   }
-
-  OnWalletInitialized(result);
+  if (GetPaymentId().empty() || GetWalletPassphrase().empty()) {
+    OnWalletInitialized(ledger::Result::CORRUPTED_WALLET);
+  } else {
+    OnWalletInitialized(result);
+  }
 }
 
 void LedgerImpl::SaveLedgerState(const std::string& data) {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/3697

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Open Brave with this profile https://github.com/brave/brave-browser/files/2823589/Brave-Browser-Beta-05925.zip
2. Click Rewards panel and make sure that panel is at 'First Run' 'Join Now' screen.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
