### PR TITLE
Remove source and referrer URLs from download metadata

### DIFF
--- a/patches/components-download-internal-common-download_item_impl.cc.patch
+++ b/patches/components-download-internal-common-download_item_impl.cc.patch
@@ -1,0 +1,15 @@
+diff --git a/components/download/internal/common/download_item_impl.cc b/components/download/internal/common/download_item_impl.cc
+index 4b536f504a4cd61aefb1efcc42e5de801586d62b..24c153bd00a14d6215ff5798f290e7845b328c2c 100644
+--- a/components/download/internal/common/download_item_impl.cc
++++ b/components/download/internal/common/download_item_impl.cc
+@@ -1680,8 +1680,8 @@ void DownloadItemImpl::OnDownloadCompleting() {
+                      base::Unretained(download_file_.get()),
+                      GetTargetFilePath(),
+                      delegate_->GetApplicationClientIdForFileScanning(),
+-                     delegate_->IsOffTheRecord() ? GURL() : GetURL(),
+-                     delegate_->IsOffTheRecord() ? GURL() : GetReferrerUrl(),
++                     GURL(),  // Never leak download URLs in metadata.
++                     GURL(),  // See brave-browser#2766.
+                      std::move(callback)));
+ }
+ 


### PR DESCRIPTION
This fixes brave/brave-browser#2766 by making the download
metadata the same whether it's coming from normal, private or Tor
windows.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Download the tarball found at https://pypi.org/project/canadian-ham-exam/#files in a normal window and then look at the metadata on each platform:

1. On Linux, the following command should not return anything:

       getfattr download/canadian-ham-exam-0.2.0.tar.gz 
2. On macOS, the following command should not return anything:

       mdfind 'kMDItemWhereFroms == "https://files.pythonhosted.org/*"'

3. On Windows, the contents of the following file opened from the command line:

       C:\Downloads>notepad.exe canadian-ham-exam-0.2.0.tar.gz:Zone.Identifier

should consist of only:

    [ZoneTransfer]
    ZoneId=3

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source