### PR TITLE
Enable chromecast support by default

### DIFF
--- a/chromium_src/extensions/common/feature_switch.cc
+++ b/chromium_src/extensions/common/feature_switch.cc
@@ -1,0 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GOOGLE_CHROME_BUILD
+#include "../../../../extensions/common/feature_switch.cc"  // NOLINT
+#undef GOOGLE_CHROME_BUILD

--- a/chromium_src/extensions/common/feature_switch_unittest.cc
+++ b/chromium_src/extensions/common/feature_switch_unittest.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "extensions/common/feature_switch.h"
+
+#include "base/command_line.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(BraveFeatureSwitchTest, LoadMediaRouterComponentExtensionFlagTest) {
+  EXPECT_TRUE(extensions::FeatureSwitch::load_media_router_component_extension()
+      ->IsEnabled());
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -69,6 +69,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",
+    "//brave/chromium_src/extensions/common/feature_switch_unittest.cc",
     "//brave/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc",
     "//brave/common/brave_content_client_unittest.cc",
     "//brave/common/importer/brave_mock_importer_bridge.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/209

<img width="756" alt="Screen Shot 2019-03-28 at 11 47 30 AM" src="https://user-images.githubusercontent.com/6786187/55126077-501f3700-514f-11e9-943b-4880f214ed2e.png">


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Manual test step:
1. Launch browser
2. Go to app menu and click `cast` menu item
3. Check cast dialog is visible and anchored to cast icon like above captured image
4. Available device list should be visible when chromecast is available in the same network

`yarn test brave_unit_tests --filter=BraveFeatureSwitchTest.LoadMediaRouterComponentExtensionFlagTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
