### PR TITLE
Make nightly can set as a default browser on MacOS

### DIFF
--- a/chromium_src/chrome/browser/shell_integration_mac.mm
+++ b/chromium_src/chrome/browser/shell_integration_mac.mm
@@ -1,0 +1,16 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GetDefaultWebClientSetPermission GetDefaultWebClientSetPermission_Unused
+#include "../../../../chrome/browser/shell_integration_mac.mm"  // NOLINT
+#undef GetDefaultWebClientSetPermission
+
+namespace shell_integration {
+
+DefaultWebClientSetPermission GetDefaultWebClientSetPermission() {
+  return SET_DEFAULT_UNATTENDED;
+}
+
+}  // shell_integration

--- a/chromium_src/chrome/browser/shell_integration_unittest_mac.cc
+++ b/chromium_src/chrome/browser/shell_integration_unittest_mac.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/shell_integration.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace shell_integration {
+
+TEST(BraveShellIntegrationTest, MakeDefaultBrowserTestOnMac) {
+  EXPECT_EQ(SET_DEFAULT_UNATTENDED, GetDefaultWebClientSetPermission());
+}
+
+}  // namespace shell_integration

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -64,6 +64,7 @@ test("brave_unit_tests") {
     "//brave/browser/themes/brave_theme_service_unittest.cc",
     "//brave/chromium_src/chrome/browser/external_protocol/external_protocol_handler_unittest.cc",
     "//brave/chromium_src/chrome/browser/history/history_utils_unittest.cc",
+    "//brave/chromium_src/chrome/browser/shell_integration_unittest_mac.cc",
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3817

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveShellIntegrationTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
