### PR TITLE
Tokens that fail to redeem due to network errors should be added to a queue and retried

### DIFF
--- a/vendor/bat-native-ads/BUILD.gn
+++ b/vendor/bat-native-ads/BUILD.gn
@@ -83,6 +83,7 @@ source_set("ads") {
     "src/bat/ads/bundle_state.cc",
     "src/bat/ads/client_info.cc",
     "src/bat/ads/issuer_info.cc",
+    "src/bat/ads/confirmation_type.cc",
     "src/bat/ads/issuers_info.cc",
     "src/bat/ads/notification_info.cc",
     "src/bat/ads/internal/ads_impl.cc",

--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -6,19 +6,37 @@
 #ifndef BAT_ADS_CONFIRMATION_TYPE_H_
 #define BAT_ADS_CONFIRMATION_TYPE_H_
 
+#include <string>
+
 namespace ads {
 
-static char kConfirmationTypeClick[] = "click";
-static char kConfirmationTypeDismiss[] = "dismiss";
-static char kConfirmationTypeView[] = "view";
-static char kConfirmationTypeLanded[] = "landed";
+class ConfirmationType {
+ public:
+  enum Value : int {
+    UNKNOWN,
+    CLICK,
+    DISMISS,
+    VIEW,
+    LANDED
+  };
 
-enum class ConfirmationType {
-  UNKNOWN,
-  CLICK,
-  DISMISS,
-  VIEW,
-  LANDED
+  ConfirmationType() = default;
+
+  // Allow implicit conversion of the enum value to this wrapper
+  constexpr ConfirmationType(const Value& value) : value_(value) {}  // NOLINT
+
+  explicit ConfirmationType(const std::string& value);
+
+  bool IsSupported() const;
+
+  int value() const;
+  operator std::string() const;
+
+  bool operator==(ConfirmationType type) const;
+  bool operator!=(ConfirmationType type) const;
+
+ private:
+  Value value_;
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/confirmation_type.cc
+++ b/vendor/bat-native-ads/src/bat/ads/confirmation_type.cc
@@ -1,0 +1,69 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/confirmation_type.h"
+
+namespace ads {
+
+static const char kConfirmationTypeClick[] = "click";
+static const char kConfirmationTypeDismiss[] = "dismiss";
+static const char kConfirmationTypeView[] = "view";
+static const char kConfirmationTypeLanded[] = "landed";
+
+ConfirmationType::ConfirmationType(const std::string& value) {
+  if (value == kConfirmationTypeClick) {
+    value_ = CLICK;
+  } else if (value == kConfirmationTypeDismiss) {
+    value_ = DISMISS;
+  } else if (value == kConfirmationTypeView) {
+    value_ = VIEW;
+  } else if (value == kConfirmationTypeLanded) {
+    value_ = LANDED;
+  } else {
+    value_ = UNKNOWN;
+  }
+}
+
+bool ConfirmationType::IsSupported() const {
+  return value_ != UNKNOWN;
+}
+
+int ConfirmationType::value() const {
+  return value_;
+}
+
+ConfirmationType::operator std::string() const {
+  switch (value_) {
+    case UNKNOWN: {
+      return "";
+    }
+
+    case CLICK: {
+      return kConfirmationTypeClick;
+    }
+
+    case DISMISS: {
+      return kConfirmationTypeDismiss;
+    }
+
+    case VIEW: {
+      return kConfirmationTypeView;
+    }
+
+    case LANDED: {
+      return kConfirmationTypeLanded;
+    }
+  }
+}
+
+bool ConfirmationType::operator==(ConfirmationType type) const {
+  return value_ == type.value_;
+}
+
+bool ConfirmationType::operator!=(ConfirmationType type) const {
+  return value_ != type.value_;
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -1289,35 +1289,8 @@ void AdsImpl::GenerateAdReportingConfirmationEvent(
   writer.String("notificationId");
   writer.String(info.uuid.c_str());
 
-  std::string type;
-  switch (info.type) {
-    case ConfirmationType::UNKNOWN: {
-      DCHECK(false) << "Invalid confirmation type";
-      break;
-    }
-
-    case ConfirmationType::CLICK: {
-      type = kConfirmationTypeClick;
-      break;
-    }
-
-    case ConfirmationType::DISMISS: {
-      type = kConfirmationTypeDismiss;
-      break;
-    }
-
-    case ConfirmationType::VIEW: {
-      type = kConfirmationTypeView;
-      break;
-    }
-
-    case ConfirmationType::LANDED: {
-      type = kConfirmationTypeLanded;
-      break;
-    }
-  }
-
   writer.String("notificationType");
+  auto type = std::string(info.type);
   writer.String(type.c_str());
 
   writer.EndObject();

--- a/vendor/bat-native-ads/src/bat/ads/notification_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/notification_info.cc
@@ -78,17 +78,7 @@ Result NotificationInfo::FromJson(
 
   if (document.HasMember("confirmation_type")) {
     std::string confirmation_type = document["confirmation_type"].GetString();
-    if (confirmation_type == kConfirmationTypeClick) {
-      type = ConfirmationType::CLICK;
-    } else if (confirmation_type == kConfirmationTypeDismiss) {
-      type = ConfirmationType::DISMISS;
-    } else if (confirmation_type == kConfirmationTypeView) {
-      type = ConfirmationType::VIEW;
-    } else if (confirmation_type == kConfirmationTypeLanded) {
-      type = ConfirmationType::LANDED;
-    } else {
-      type = ConfirmationType::UNKNOWN;
-    }
+    type = ConfirmationType(confirmation_type);
   }
 
   return SUCCESS;
@@ -116,32 +106,8 @@ void SaveToJson(JsonWriter* writer, const NotificationInfo& info) {
   writer->String(info.uuid.c_str());
 
   writer->String("confirmation_type");
-  switch (info.type) {
-    case ConfirmationType::UNKNOWN: {
-      writer->String("");
-      break;
-    }
-
-    case ConfirmationType::CLICK: {
-      writer->String(kConfirmationTypeClick);
-      break;
-    }
-
-    case ConfirmationType::DISMISS: {
-      writer->String(kConfirmationTypeDismiss);
-      break;
-    }
-
-    case ConfirmationType::VIEW: {
-      writer->String(kConfirmationTypeView);
-      break;
-    }
-
-    case ConfirmationType::LANDED: {
-      writer->String(kConfirmationTypeLanded);
-      break;
-    }
-  }
+  auto type = std::string(info.type);
+  writer->String(type.c_str());
 
   writer->EndObject();
 }

--- a/vendor/bat-native-confirmations/BUILD.gn
+++ b/vendor/bat-native-confirmations/BUILD.gn
@@ -37,6 +37,7 @@ source_set("bat-native-confirmations") {
   ]
 
   sources = [
+    "include/bat/confirmations/confirmation_type.h",
     "include/bat/confirmations/confirmations_client.h",
     "include/bat/confirmations/confirmations.h",
     "include/bat/confirmations/export.h",
@@ -44,6 +45,7 @@ source_set("bat-native-confirmations") {
     "include/bat/confirmations/issuers_info.h",
     "include/bat/confirmations/notification_info.h",
     "include/bat/confirmations/wallet_info.h",
+    "src/bat/confirmations/confirmation_type.cc",
     "src/bat/confirmations/confirmations.cc",
     "src/bat/confirmations/issuer_info.cc",
     "src/bat/confirmations/issuers_info.cc",
@@ -51,6 +53,8 @@ source_set("bat-native-confirmations") {
     "src/bat/confirmations/wallet_info.cc",
     "src/bat/confirmations/internal/ads_serve_helper.cc",
     "src/bat/confirmations/internal/ads_serve_helper.h",
+    "src/bat/confirmations/internal/confirmation_info.cc",
+    "src/bat/confirmations/internal/confirmation_info.h",
     "src/bat/confirmations/internal/confirmations_impl.cc",
     "src/bat/confirmations/internal/confirmations_impl.h",
     "src/bat/confirmations/internal/create_confirmation_request.cc",

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -6,19 +6,37 @@
 #ifndef BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 #define BAT_CONFIRMATIONS_CONFIRMATION_TYPE_H_
 
+#include <string>
+
 namespace confirmations {
 
-static char kConfirmationTypeClick[] = "click";
-static char kConfirmationTypeDismiss[] = "dismiss";
-static char kConfirmationTypeView[] = "view";
-static char kConfirmationTypeLanded[] = "landed";
+class ConfirmationType {
+ public:
+  enum Value : int {
+    UNKNOWN,
+    CLICK,
+    DISMISS,
+    VIEW,
+    LANDED
+  };
 
-enum class ConfirmationType {
-  UNKNOWN,
-  CLICK,
-  DISMISS,
-  VIEW,
-  LANDED
+  ConfirmationType() = default;
+
+  // Allow implicit conversion of the enum value to this wrapper
+  constexpr ConfirmationType(const Value& value) : value_(value) {}  // NOLINT
+
+  explicit ConfirmationType(const std::string& value);
+
+  bool IsSupported() const;
+
+  int value() const;
+  operator std::string() const;
+
+  bool operator==(ConfirmationType type) const;
+  bool operator!=(ConfirmationType type) const;
+
+ private:
+  Value value_;
 };
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/confirmation_type.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/confirmation_type.cc
@@ -1,0 +1,69 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/confirmations/confirmation_type.h"
+
+namespace confirmations {
+
+static const char kConfirmationTypeClick[] = "click";
+static const char kConfirmationTypeDismiss[] = "dismiss";
+static const char kConfirmationTypeView[] = "view";
+static const char kConfirmationTypeLanded[] = "landed";
+
+ConfirmationType::ConfirmationType(const std::string& value) {
+  if (value == kConfirmationTypeClick) {
+    value_ = CLICK;
+  } else if (value == kConfirmationTypeDismiss) {
+    value_ = DISMISS;
+  } else if (value == kConfirmationTypeView) {
+    value_ = VIEW;
+  } else if (value == kConfirmationTypeLanded) {
+    value_ = LANDED;
+  } else {
+    value_ = UNKNOWN;
+  }
+}
+
+bool ConfirmationType::IsSupported() const {
+  return value_ != UNKNOWN;
+}
+
+int ConfirmationType::value() const {
+  return value_;
+}
+
+ConfirmationType::operator std::string() const {
+  switch (value_) {
+    case UNKNOWN: {
+      return "";
+    }
+
+    case CLICK: {
+      return kConfirmationTypeClick;
+    }
+
+    case DISMISS: {
+      return kConfirmationTypeDismiss;
+    }
+
+    case VIEW: {
+      return kConfirmationTypeView;
+    }
+
+    case LANDED: {
+      return kConfirmationTypeLanded;
+    }
+  }
+}
+
+bool ConfirmationType::operator==(ConfirmationType type) const {
+  return value_ == type.value_;
+}
+
+bool ConfirmationType::operator!=(ConfirmationType type) const {
+  return value_ != type.value_;
+}
+
+}  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/confirmations/internal/confirmation_info.h"
+
+namespace confirmations {
+
+ConfirmationInfo::ConfirmationInfo() :
+    id(""),
+    creative_instance_id(""),
+    type(ConfirmationType::UNKNOWN),
+    token_info(TokenInfo()),
+    payment_token(nullptr),
+    blinded_payment_token(nullptr),
+    credential("") {}
+
+ConfirmationInfo::ConfirmationInfo(const ConfirmationInfo& info) :
+    id(info.id),
+    creative_instance_id(info.creative_instance_id),
+    type(info.type),
+    token_info(info.token_info),
+    payment_token(info.payment_token),
+    blinded_payment_token(info.blinded_payment_token),
+    credential(info.credential) {}
+
+ConfirmationInfo::~ConfirmationInfo() {}
+
+}  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BAT_CONFIRMATIONS_INTERNAL_CONFIRMATION_INFO_H_
+#define BAT_CONFIRMATIONS_INTERNAL_CONFIRMATION_INFO_H_
+
+#include <string>
+
+#include "bat/confirmations/confirmation_type.h"
+#include "bat/confirmations/internal/token_info.h"
+
+#include "wrapper.hpp"  // NOLINT
+
+using challenge_bypass_ristretto::Token;
+using challenge_bypass_ristretto::BlindedToken;
+
+namespace confirmations {
+
+struct ConfirmationInfo {
+  ConfirmationInfo();
+  explicit ConfirmationInfo(const ConfirmationInfo& info);
+  ~ConfirmationInfo();
+
+  std::string id;
+  std::string creative_instance_id;
+  ConfirmationType type;
+  TokenInfo token_info;
+  Token payment_token;
+  BlindedToken blinded_payment_token;
+  std::string credential;
+};
+
+}  // namespace confirmations
+
+#endif  // BAT_CONFIRMATIONS_INTERNAL_CONFIRMATION_INFO_H_

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
@@ -78,34 +78,7 @@ std::string CreateConfirmationRequest::CreateConfirmationRequestDTO(
   auto token_base64 = token.encode_base64();
   payload.SetKey("blindedPaymentToken", base::Value(token_base64));
 
-  std::string type;
-  switch (confirmation_type) {
-    case ConfirmationType::UNKNOWN: {
-      DCHECK(false) << "Invalid confirmation type";
-      break;
-    }
-
-    case ConfirmationType::CLICK: {
-      type = kConfirmationTypeClick;
-      break;
-    }
-
-    case ConfirmationType::DISMISS: {
-      type = kConfirmationTypeDismiss;
-      break;
-    }
-
-    case ConfirmationType::VIEW: {
-      type = kConfirmationTypeView;
-      break;
-    }
-
-    case ConfirmationType::LANDED: {
-      type = kConfirmationTypeLanded;
-      break;
-    }
-  }
-
+  auto type = std::string(confirmation_type);
   payload.SetKey("type", base::Value(type));
 
   std::string json;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
@@ -12,6 +12,7 @@
 
 #include "bat/confirmations/confirmations_client.h"
 #include "bat/confirmations/internal/token_info.h"
+#include "bat/confirmations/internal/confirmation_info.h"
 #include "bat/confirmations/confirmation_type.h"
 
 #include "wrapper.hpp"  // NOLINT
@@ -37,8 +38,12 @@ class RedeemToken {
   void Redeem(
       const std::string& creative_instance_id,
       const ConfirmationType confirmation_type);
+  void Redeem(
+    const ConfirmationInfo& confirmation_info);
 
  private:
+  void CreateConfirmation(
+      const ConfirmationInfo& confirmation_info);
   void CreateConfirmation(
       const std::string& creative_instance_id,
       const TokenInfo& token_info,
@@ -48,31 +53,24 @@ class RedeemToken {
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers,
-      const ConfirmationType confirmation_type,
-      const std::string& confirmation_id,
-      const Token& payment_token,
-      const BlindedToken& blinded_payment_token,
-      const TokenInfo& token_info);
+      const ConfirmationInfo& confirmation_info);
 
   void FetchPaymentToken(
-      const ConfirmationType confirmation_type,
-      const std::string& confirmation_id,
-      const Token& payment_token,
-      const BlindedToken& blinded_payment_token,
-      const TokenInfo& token_info);
+      const ConfirmationInfo& confirmation_info);
   void OnFetchPaymentToken(
       const std::string& url,
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers,
-      const ConfirmationType confirmation_type,
-      const Token& payment_token,
-      const BlindedToken& blinded_payment_token,
-      const TokenInfo& token_info);
+      const ConfirmationInfo& confirmation_info);
 
   void OnRedeem(
       const Result result,
-      const TokenInfo& token_info);
+      const ConfirmationInfo& confirmation_info,
+      const bool should_retry = true);
+
+  void ScheduleNextRetryForFailedConfirmations() const;
+  uint64_t CalculateTimerForNextRetryForFailedConfirmations() const;
 
   ConfirmationsImpl* confirmations_;  // NOT OWNED
   ConfirmationsClient* confirmations_client_;  // NOT OWNED

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.cc
@@ -45,7 +45,8 @@ std::string Security::Sign(
   std::vector<uint8_t> signed_message(crypto_sign_BYTES +
       concatenated_message.length());
 
-  unsigned long long signed_message_size = 0;
+  // Resolving the following linter error breaks the build on Windows
+  unsigned long long signed_message_size = 0;  // NOLINT
   crypto_sign(&signed_message.front(), &signed_message_size,
       reinterpret_cast<const unsigned char*>(concatenated_message.c_str()),
       concatenated_message.length(), &public_key.front());
@@ -60,7 +61,7 @@ std::string Security::Sign(
 }
 
 std::vector<Token> Security::GenerateTokens(const int count) {
-  DCHECK_NE(count, 0);
+  DCHECK_GT(count, 0);
 
   std::vector<Token> tokens;
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/static_values.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/static_values.h
@@ -26,6 +26,9 @@ static const uint64_t kNextTokenRedemptionAfterSeconds =
 static const uint64_t kDebugNextTokenRedemptionAfterSeconds =
     25 * base::Time::kSecondsPerMinute;
 
+static const uint64_t kRetryFailedConfirmationsAfterSeconds =
+    5 * base::Time::kSecondsPerMinute;
+
 }  // namespace confirmations
 
 #endif  // BAT_CONFIRMATIONS_INTERNAL_STATIC_VALUES_H_

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/unblinded_tokens.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/unblinded_tokens.cc
@@ -114,8 +114,7 @@ bool UnblindedTokens::RemoveToken(const TokenInfo& token) {
 
   auto it = std::find_if(tokens_.begin(), tokens_.end(),
       [=](const TokenInfo& info) {
-        return (info.unblinded_token == unblinded_token &&
-            info.public_key == public_key);
+        return (info.unblinded_token == unblinded_token);
       });
 
   if (it == tokens_.end()) {
@@ -141,8 +140,7 @@ bool UnblindedTokens::TokenExists(const TokenInfo& token) {
 
   auto it = std::find_if(tokens_.begin(), tokens_.end(),
       [=](const TokenInfo& info) {
-        return (info.unblinded_token == unblinded_token &&
-            info.public_key == public_key);
+        return (info.unblinded_token == unblinded_token);
       });
 
   if (it == tokens_.end()) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1341,7 +1341,8 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
   notification_info->text = notification_info_ads.text;
   notification_info->url = notification_info_ads.url;
   notification_info->uuid = notification_info_ads.uuid;
-  switch (notification_info_ads.type) {
+
+  switch (notification_info_ads.type.value()) {
     case ads::ConfirmationType::UNKNOWN: {
       notification_info->type = confirmations::ConfirmationType::UNKNOWN;
       break;


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3662

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

Confirm failed requests are added to the `Defaults/rewards_service/confirmations.json` under `confirmations`/`failed_confirmations` and confirmation redemption is retried every 5 minutes +/- jitter until successful. Items that are retried and fail should move to the back of the queue.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
