### PR TITLE
Issue 3920: Proxy requests for resources from storage.googleapis.com through the crlset redirector

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -26,6 +26,8 @@ int OnBeforeURLRequest_StaticRedirectWork(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix2);
   static URLPattern crlSet_pattern3(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix3);
+  static URLPattern crlSet_pattern4(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix4);
   static URLPattern crxDownload_pattern(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRXDownloadPrefix);
 
@@ -62,6 +64,13 @@ int OnBeforeURLRequest_StaticRedirectWork(
   }
 
   if (crlSet_pattern3.MatchesURL(ctx->request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr("crlsets.brave.com");
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (crlSet_pattern4.MatchesURL(ctx->request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr("crlsets.brave.com");
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -32,6 +32,9 @@ const char kCRLSetPrefix2[] =
     "*://*.gvt1.com/edgedl/release2/chrome_component/*crl-set*";
 const char kCRLSetPrefix3[] =
     "*://www.google.com/dl/release2/chrome_component/*crl-set*";
+const char kCRLSetPrefix4[] =
+    "*://storage.googleapis.com/update-delta/hfnkpimlhhgieaddgfemjhofmfblmnib"
+    "/*crxd";
 const char kGoogleTagManagerPattern[] =
     "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] =

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -26,6 +26,7 @@ extern const char kSafeBrowsingPrefix[];
 extern const char kCRLSetPrefix1[];
 extern const char kCRLSetPrefix2[];
 extern const char kCRLSetPrefix3[];
+extern const char kCRLSetPrefix4[];
 extern const char kTwitterPattern[];
 extern const char kTwitterReferrer[];
 extern const char kTwitterRedirectURL[];


### PR DESCRIPTION
PR builder passed here:  https://staging.ci.brave.com/job/brave-browser-build-pr/job/PR-3929/

## Description

fix: https://github.com/brave/brave-browser/issues/3920

CRLSets on windows started requesting resources from storage.googleapis.com. We updated the redirector to proxy requests for these resources: brave/redirector@372e442

This PR updates the network delegate to proxy requests for storage.googleapis.com through the redirector.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
1. Verify `npm run test-security` passes
2. Navigate to `brave://components` and verify that CRLSet component version is non-zero
2. revoked.badssl.com - shows a certificate error.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
