### PR TITLE
Fixes scrollbar for unverified notice on MacOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,8 +1597,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#aebb6e72fc37d360a79b6490f8f92f1061aa27f4",
-      "from": "github:brave/brave-ui#aebb6e72fc37d360a79b6490f8f92f1061aa27f4",
+      "version": "github:brave/brave-ui#44513d1b6c27f4bcdf2564baef092af9fabf5665",
+      "from": "github:brave/brave-ui#44513d1b6c27f4bcdf2564baef092af9fabf5665",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@types/react-redux": "6.0.4",
     "@types/redux-logger": "^3.0.7",
     "awesome-typescript-loader": "^5.2.1",
-    "brave-ui": "github:brave/brave-ui#aebb6e72fc37d360a79b6490f8f92f1061aa27f4",
+    "brave-ui": "github:brave/brave-ui#44513d1b6c27f4bcdf2564baef092af9fabf5665",
     "css-loader": "^2.1.1",
     "csstype": "^2.5.5",
     "deep-freeze-node": "^1.1.3",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/3930
UI: https://github.com/brave/brave-ui/pull/439

# Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Defined in issue, but for testing on MacOS please go in to general preferences and make sure that scrollbar is always set to show.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
