### PR TITLE
Fix chrome webui theme is not changed when brave theme is changed

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -8,6 +8,8 @@ source_set("ui") {
     "brave_browser_command_controller.h",
     "brave_browser_content_setting_bubble_model_delegate.cc",
     "brave_browser_content_setting_bubble_model_delegate.h",
+    "brave_dark_mode_observer.cc",
+    "brave_dark_mode_observer.h",
     "brave_pages.cc",
     "brave_pages.h",
     "brave_layout_constants.cc",

--- a/browser/ui/brave_dark_mode_observer.cc
+++ b/browser/ui/brave_dark_mode_observer.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_dark_mode_observer.h"
+
+#include "ui/native_theme/native_theme_dark_aura.h"
+
+namespace {
+
+using ui::NativeTheme;
+
+}  // namespace
+
+// static
+ui::NativeTheme* BraveDarkModeObserver::current_native_theme_for_testing_;
+
+void BraveDarkModeObserver::OnNativeThemeUpdated(NativeTheme* observed_theme) {
+  DCHECK(theme_observer_.IsObserving(observed_theme));
+  RunCallbackIfChanged();
+  ResetThemeObserver();
+}
+
+void BraveDarkModeObserver::Start() {
+  DarkModeObserver::Start();
+  ResetThemeObserver();
+}
+
+void BraveDarkModeObserver::ResetThemeObserver() {
+  auto* current_native_theme = theme_->SystemDarkModeEnabled()
+      ? ui::NativeThemeDarkAura::instance()
+      : ui::NativeTheme::GetInstanceForNativeUi();
+  current_native_theme_for_testing_ = current_native_theme;
+
+  if (!theme_observer_.IsObserving(current_native_theme)) {
+    theme_observer_.RemoveAll();
+    theme_observer_.Add(current_native_theme);
+  }
+}
+

--- a/browser/ui/brave_dark_mode_observer.h
+++ b/browser/ui/brave_dark_mode_observer.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_BRAVE_DARK_MODE_OBSERVER_H_
+#define BRAVE_BROWSER_UI_BRAVE_DARK_MODE_OBSERVER_H_
+
+#include "base/gtest_prod_util.h"
+#include "chrome/browser/ui/dark_mode_observer.h"
+
+// This class is introduced to handle two different native themes that brave
+// uses for brave theme. DarkModeObserver only observes default NativeTheme.
+// However, brave also uses NativeDarkThemeAura for dark theme.
+// So, DarkModeObserver should also observe NativeDarkThemeAura when current
+// active brave theme is dark.
+// Observed NativeTheme is changed when native theme is updated.
+class BraveDarkModeObserver : public DarkModeObserver {
+ public:
+  using DarkModeObserver::DarkModeObserver;
+
+  void Start() override;
+
+ private:
+  FRIEND_TEST_ALL_PREFIXES(BraveDarkModeObserverTest,
+                           ObserveProperNativeThemeTest);
+
+  // DarkModeObserver overrides:
+  void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
+
+  void ResetThemeObserver();
+
+  static ui::NativeTheme* current_native_theme_for_testing_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveDarkModeObserver);
+};
+
+#endif  // BRAVE_BROWSER_UI_BRAVE_DARK_MODE_OBSERVER_H_

--- a/browser/ui/brave_dark_mode_observer_browsertest.cc
+++ b/browser/ui/brave_dark_mode_observer_browsertest.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/themes/brave_theme_service.h"
+#include "brave/browser/ui/brave_dark_mode_observer.h"
+#include "brave/common/pref_names.h"
+#include "chrome/browser/browser_features.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
+#include "ui/native_theme/native_theme_dark_aura.h"
+
+using BraveDarkModeObserverTest = InProcessBrowserTest;
+
+namespace {
+
+void SetBraveThemeType(Profile* profile, BraveThemeType type) {
+  profile->GetPrefs()->SetInteger(kBraveThemeType, type);
+}
+
+}  // namespace
+
+// Test whether DarkModeObserver observes proper NativeTheme.
+IN_PROC_BROWSER_TEST_F(BraveDarkModeObserverTest,
+                       ObserveProperNativeThemeTest) {
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeature(features::kWebUIDarkMode);
+
+  Profile* profile = browser()->profile();
+
+  // Load webui to instantiate BraveDarkModeObserver.
+  AddTabAtIndexToBrowser(
+      browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
+
+  // Initially set to light.
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+  EXPECT_EQ(
+      ui::NativeTheme::GetInstanceForNativeUi(),
+      BraveDarkModeObserver::current_native_theme_for_testing_);
+
+  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+  EXPECT_EQ(
+      ui::NativeThemeDarkAura::instance(),
+      BraveDarkModeObserver::current_native_theme_for_testing_);
+}

--- a/chromium_src/chrome/browser/ui/webui/dark_mode_handler.h
+++ b/chromium_src/chrome/browser/ui/webui/dark_mode_handler.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_DARK_MODE_HANDLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_DARK_MODE_HANDLER_H_
+
+#include "brave/browser/ui/brave_dark_mode_observer.h"
+
+#define DarkModeObserver BraveDarkModeObserver
+#include "../../../../../../chrome/browser/ui/webui/dark_mode_handler.h"  // NOLINT
+#undef DarkModeObserver
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_DARK_MODE_HANDLER_H_

--- a/patches/chrome-browser-ui-dark_mode_observer.h.patch
+++ b/patches/chrome-browser-ui-dark_mode_observer.h.patch
@@ -1,0 +1,21 @@
+diff --git a/chrome/browser/ui/dark_mode_observer.h b/chrome/browser/ui/dark_mode_observer.h
+index 2f81334a8f292450c57dce7be8ddff191a704aad..2ac608d5f10ff9bb0df088559cf2ce319462bc0a 100644
+--- a/chrome/browser/ui/dark_mode_observer.h
++++ b/chrome/browser/ui/dark_mode_observer.h
+@@ -21,7 +21,7 @@ class DarkModeObserver : public ui::NativeThemeObserver {
+   // Observe |theme| for changes in dark mode. |callback_| may be immediately
+   // run if |theme_->SystemDarkModeEnabled()| has changed since construction or
+   // last time |Stop()| was called.
+-  void Start();
++  virtual void Start();
+ 
+   // Stop observing |theme|. |callback_| will never be called after stopping.
+   void Stop();
+@@ -29,6 +29,7 @@ class DarkModeObserver : public ui::NativeThemeObserver {
+   bool InDarkMode() const { return in_dark_mode_; }
+ 
+  private:
++  friend class BraveDarkModeObserver;
+   // ui::NativeThemeObserver:
+   void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
+ 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -308,6 +308,7 @@ test("brave_browser_tests") {
     "//brave/browser/renderer_context_menu/brave_mock_render_view_context_menu.h",
     "//brave/browser/renderer_context_menu/brave_spelling_menu_observer_browsertest.cc",
     "//brave/browser/search_engines/search_engine_provider_service_browsertest.cc",
+    "//brave/browser/ui/brave_dark_mode_observer_browsertest.cc",
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",
     "//brave/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc",


### PR DESCRIPTION
Chrome WebUI gets theme change notification by using DarkModeObserver.
Brave browser uses default NativeTheme for light theme and NativeDarkThemeAura
for dark theme. So, DarkModeObserver should observe NativeDarkThemeAura when
brave dark theme is set.
If not, DarkModeObserver can't get theme change notification properly.
BraveDarkModeObserver controls this.

Fix https://github.com/brave/brave-browser/issues/3881

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveDarkModeHandlerTest.ProperNativeThemeObserveTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
