### PR TITLE
WebUI: dark mode overrides for buttons

### DIFF
--- a/ui/webui/resources/css/paper_button_style.css
+++ b/ui/webui/resources/css/paper_button_style.css
@@ -39,3 +39,10 @@ paper-button {
 
   --flat-focus-shadow-color: rgba(255, 69, 48, .4)  !important;
 }
+
+[dark] paper-button,
+:host-context([dark]) paper-button {
+  --text-color: var(--cr-primary-text-color) !important;
+  --brave-hover-color: rgb(63, 63, 63) !important;
+  --flat-text-color-action: #242536 !important;
+}


### PR DESCRIPTION
This affects C74 and since is a regression only with C74, is asked to merge to c74 branch.

Fix https://github.com/brave/brave-browser/issues/3894

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
On https://github.com/brave/brave-browser/issues/3894

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
