### PR TITLE
"Ad notifications received" should show Ads viewed between the 1st of the month and the 4th of the following month

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1479,25 +1479,37 @@ void RewardsServiceImpl::SetCatalogIssuers(const std::string& json) {
 }
 
 std::pair<uint64_t, uint64_t> RewardsServiceImpl::GetEarningsRange() {
-  auto one_day_in_seconds = base::Time::kMicrosecondsPerDay /
-      base::Time::kMicrosecondsPerSecond;
-
   auto now = base::Time::Now();
   base::Time::Exploded exploded;
   now.LocalExplode(&exploded);
 
-  uint64_t offset_in_seconds;
-  if (exploded.day_of_month > 5) {
-    offset_in_seconds = (exploded.day_of_month - 5) * one_day_in_seconds;
-  } else {
-    offset_in_seconds = exploded.day_of_month * one_day_in_seconds;
+  if (exploded.day_of_month < 5) {
+    exploded.month--;
+    if (exploded.month < 1) {
+      exploded.month = 12;
+
+      exploded.year--;
+    }
   }
 
-  auto now_in_seconds = (now - base::Time()).InSeconds();
-  uint64_t from_timestamp = now_in_seconds - offset_in_seconds;
-  uint64_t to_timestamp = now_in_seconds;
+  exploded.day_of_month = 1;
 
-  return std::make_pair(from_timestamp, to_timestamp);
+  exploded.hour = 0;
+  exploded.minute = 0;
+  exploded.second = 0;
+  exploded.millisecond = 0;
+
+  base::Time from_timestamp;
+  auto success = base::Time::FromLocalExploded(exploded, &from_timestamp);
+  DCHECK(success);
+
+  uint64_t from_timestamp_in_seconds =
+      (from_timestamp - base::Time()).InSeconds();
+
+  uint64_t to_timestamp_in_seconds =
+      (now - base::Time()).InSeconds();
+
+  return std::make_pair(from_timestamp_in_seconds, to_timestamp_in_seconds);
 }
 
 void RewardsServiceImpl::ConfirmAd(const std::string& json) {


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/3958

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

If the day of the month is less than 5 then "Ad notifications received" stats should include ads viewed between 1st of the previous month (at midnight) and the 4th of the current month (23:59:59). If the day of the month is 5 or higher then "Ad notifications received" stats should include ads viewed from the 1st of the month up until now.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
