### PR TITLE
WebUI: Navigation Bar gets dark mode support

### DIFF
--- a/ui/webui/resources/br_elements/br_toolbar/br_toolbar.html
+++ b/ui/webui/resources/br_elements/br_toolbar/br_toolbar.html
@@ -99,6 +99,10 @@
         padding: 5px;
         color: #222;
       }
+      :host-context([dark]) .toolbar-extra.-slot-filled {
+        background: #444;
+        color: #dde1e2;
+      }
 
     </style>
     <div class$="br-toolbar [[fontsLoadedClassName]]">


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3965

This regression only presents in c74, so submitting a direct PR to that branch.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
- Ensure dark mode no longer has light-on-light as per https://github.com/brave/brave-browser/issues/3965
- Ensure light mode still has dark-on-light

This applies to Bookmarks and Extensions pages

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
