### PR TITLE
Enable widevine cdm host verification

### DIFF
--- a/build/config.gni
+++ b/build/config.gni
@@ -27,6 +27,8 @@ declare_args() {
   target_apk_base=""
 
   skip_signing = false
+
+  brave_enable_cdm_host_verification = false
 }
 
 if (base_sparkle_update_url == "") {

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -1,6 +1,8 @@
 import("//brave/build/config.gni")
 import("//build/config/mac/base_rules.gni")
 import("//build/util/version.gni")
+import("//chrome/common/features.gni")
+import("//third_party/widevine/cdm/widevine.gni")
 
 declare_args() {
   # find with `security find-identity -v -p codesigning`
@@ -80,6 +82,9 @@ action("create_pkg") {
   ]
 
   deps = [":sign_app"]
+  if (enable_widevine_cdm_host_verification) {
+    deps += [ ":sign_chrome_framework_for_widevine" ]
+  }
 }
 
 action("sign_pkg") {
@@ -152,6 +157,10 @@ action("create_unsigned_dmg") {
     "//brave:chrome_app",
     "//chrome/installer/mac"
   ]
+
+  if (enable_widevine_cdm_host_verification) {
+    deps += [ ":sign_chrome_framework_for_widevine" ]
+  }
 }
 
 action("sign_dmg") {
@@ -173,6 +182,59 @@ action("sign_dmg") {
   ]
 
   deps = [":create_dmg"]
+}
+
+if (enable_widevine_cdm_host_verification) {
+  action("sign_chrome_framework_for_widevine") {
+    script = "//third_party/widevine/scripts/signature_generator.py"
+
+    chrome_framework_name = chrome_product_full_name + " Framework"
+    target_app_path = "$_target_app_path"
+    if (skip_signing) {
+      target_app_path = "$root_out_dir/$chrome_product_full_name.app"
+    }
+
+    if (new_mac_bundle_structure) {
+      brave_version_path = "$target_app_path/Contents/Frameworks/$chrome_framework_name.framework/Versions/$chrome_version_full"
+      file = "$brave_version_path/$chrome_framework_name"
+      signature_file = "$brave_version_path/Resources/$chrome_framework_name.sig"
+    } else {
+      brave_version_path = "$target_app_path/Contents/Versions/$chrome_version_full"
+      file = "$brave_version_path/$chrome_framework_name.framework/Versions/Current/$chrome_framework_name"
+      signature_file = "$brave_version_path/Widevine Resources.bundle/Contents/Resources/$chrome_framework_name.sig"
+    }
+
+    flags = 1  # blessed binary
+
+    sources = [
+      "$root_out_dir/$brave_exe"
+    ]
+
+    outputs = [
+      "$signature_file",
+    ]
+
+    args = [
+      "--input_file",
+      rebase_path("$file", root_build_dir),
+      "--output_file",
+      rebase_path("$signature_file", root_build_dir),
+      "--flags",
+      "$flags",
+      "--certificate",
+      getenv("SIGN_WIDEVINE_CERT"),
+      "--private_key",
+      getenv("SIGN_WIDEVINE_KEY"),
+      "--private_key_passphrase",
+      getenv("SIGN_WIDEVINE_PASSPHRASE"),
+    ]
+
+    deps = [ "//brave:chrome_app" ]
+
+    if (!skip_signing) {
+      deps += [ ":sign_app" ]
+    }
+  }
 }
 
 group("create_dist_mac") {

--- a/chromium_src/chrome/common/media/cdm_host_file_path.cc
+++ b/chromium_src/chrome/common/media/cdm_host_file_path.cc
@@ -1,0 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GOOGLE_CHROME_BUILD
+#include "../../../../../chrome/common/media/cdm_host_file_path.cc"  // NOLINT
+#undef GOOGLE_CHROME_BUILD

--- a/patches/chrome-BUILD.gn.patch
+++ b/patches/chrome-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index b8c378b044d9142c9936c97e686fb6bfcb37c918..38e96be506e2ba20aa421c8a7b0e051f57c8da42 100644
+index b8c378b044d9142c9936c97e686fb6bfcb37c918..58f9f4c565cd52c6f7c4b334da4cd91e888e9cd7 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -190,6 +190,10 @@ if (!is_android && !is_mac) {
@@ -66,6 +66,24 @@ index b8c378b044d9142c9936c97e686fb6bfcb37c918..38e96be506e2ba20aa421c8a7b0e051f
            "-v",
            rebase_path(chrome_version_file, root_build_dir),
            "-g",
+@@ -781,7 +794,7 @@ if (is_win) {
+         # framework itself, that would cause a cyclical dependency. Instead,
+         # this dependency directly copies the file into the framework's
+         # resources directory.
+-        public_deps += [ ":chrome_framework_widevine_signature" ]
++        #public_deps += [ ":chrome_framework_widevine_signature" ]
+       } else {
+         sources += [ "$root_out_dir/Widevine Resources.bundle" ]
+         public_deps += [ ":widevine_resources_bundle" ]
+@@ -1184,7 +1197,7 @@ if (is_win) {
+         bundle_resources_dir = "$bundle_contents_dir/Resources"
+ 
+         deps = [
+-          ":framework_widevine_signature",
++          #":framework_widevine_signature",
+           ":widevine_resources_plist_bundle_data",
+         ]
+       }
 @@ -1273,6 +1286,7 @@ if (is_win) {
        "//services/service_manager/embedder",
        "//third_party/cld_3/src/src:cld_3",

--- a/patches/chrome-common-media-cdm_host_file_path.cc.patch
+++ b/patches/chrome-common-media-cdm_host_file_path.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/common/media/cdm_host_file_path.cc b/chrome/common/media/cdm_host_file_path.cc
+index a1624dfbd226cf1c664187853a89f9531c8a777e..31e8a3200359ca0f55898be318f9de42fc487a66 100644
+--- a/chrome/common/media/cdm_host_file_path.cc
++++ b/chrome/common/media/cdm_host_file_path.cc
+@@ -44,7 +44,11 @@ void AddCdmHostFilePaths(
+ #if defined(OS_WIN)
+ 
+   static const base::FilePath::CharType* const kUnversionedFiles[] = {
++#if defined(BRAVE_CHROMIUM_BUILD)
++      FILE_PATH_LITERAL("brave.exe")};
++#else
+       FILE_PATH_LITERAL("chrome.exe")};
++#endif
+   static const base::FilePath::CharType* const kVersionedFiles[] = {
+       FILE_PATH_LITERAL("chrome.dll"), FILE_PATH_LITERAL("chrome_child.dll")};
+ 

--- a/patches/chrome-installer-mini_installer-chrome.release.patch
+++ b/patches/chrome-installer-mini_installer-chrome.release.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..cda55a0113704a0fd6bf719b1b785a0b66077392 100644
+index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..bc994fb104924c62715817a8b82d7f55c044563b 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
 @@ -6,7 +6,7 @@
@@ -11,16 +11,22 @@ index bdf0219561c2e52fbe2e16407ac0fa9ae2e3ef30..cda55a0113704a0fd6bf719b1b785a0b
  chrome_proxy.exe: %(ChromeDir)s\
  #
  # Chrome version dir assembly manifest.
-@@ -19,6 +19,8 @@ chrome_proxy.exe: %(ChromeDir)s\
+@@ -18,9 +18,14 @@ chrome_proxy.exe: %(ChromeDir)s\
+ #
  # Chrome version dir entries, sorted alphabetically.
  #
++brave.exe.sig: %(VersionDir)s\
  chrome.dll: %(VersionDir)s\
++chrome.dll.sig: %(VersionDir)s\
 +brave_resources.pak: %(VersionDir)s\
 +brave_100_percent.pak: %(VersionDir)s\
  chrome_100_percent.pak: %(VersionDir)s\
  chrome_child.dll: %(VersionDir)s\
++chrome_child.dll.sig: %(VersionDir)s\
  chrome_elf.dll: %(VersionDir)s\
-@@ -75,6 +77,7 @@ MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
+ chrome_watcher.dll: %(VersionDir)s\
+ d3dcompiler_47.dll: %(VersionDir)s\
+@@ -75,6 +80,7 @@ MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
  
  [HIDPI]
  chrome_200_percent.pak: %(VersionDir)s\

--- a/patches/chrome-tools-build-win-create_installer_archive.py.patch
+++ b/patches/chrome-tools-build-win-create_installer_archive.py.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/tools/build/win/create_installer_archive.py b/chrome/tools/build/win/create_installer_archive.py
-index b16b16bdc439014bf647f80ca9b7ce8215cfbb6c..cf36aac8b0d18fb0a1dd6f9018dcd53e9042a331 100755
+index b16b16bdc439014bf647f80ca9b7ce8215cfbb6c..cbe2de456427ec4ac1c9073f5b124dc36394281a 100755
 --- a/chrome/tools/build/win/create_installer_archive.py
 +++ b/chrome/tools/build/win/create_installer_archive.py
-@@ -112,6 +112,60 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
+@@ -112,6 +112,71 @@ def CopyAllFilesToStagingDir(config, distribution, staging_dir, build_dir,
    if enable_hidpi == '1':
      CopySectionFilesToStagingDir(config, 'HIDPI', staging_dir, build_dir)
  
@@ -60,26 +60,37 @@ index b16b16bdc439014bf647f80ca9b7ce8215cfbb6c..cf36aac8b0d18fb0a1dd6f9018dcd53e
 +        rel_file = os.path.join(rel_dir, name)
 +        candidate = os.path.join('.', 'resources', 'brave_rewards' '_locales', rel_file)
 +        g_archive_inputs.append(candidate)
++
++def CopyPreSignedBinaries(output_dir, staging_dir, current_version):
++  """Copies already signed three binaries - brave.exe, chrome.dll and chrome_child.dll
++  These files are signed during the build phase to create widevine sig files.
++  """
++  src_dir = os.path.join(output_dir, 'signed_binaries')
++  chrome_dir = os.path.join(staging_dir, CHROME_DIR)
++  version_dir = os.path.join(chrome_dir, current_version)
++  shutil.copy(os.path.join(src_dir, 'brave.exe'), chrome_dir)
++  shutil.copy(os.path.join(src_dir, 'chrome.dll'), version_dir)
++  shutil.copy(os.path.join(src_dir, 'chrome_child.dll'), version_dir)
  
  def CopySectionFilesToStagingDir(config, section, staging_dir, src_dir):
    """Copies installer archive files specified in section from src_dir to
-@@ -531,6 +585,10 @@ def main(options):
+@@ -531,6 +596,11 @@ def main(options):
      version_numbers = prev_version.split('.')
      prev_build_number = version_numbers[2] + '.' + version_numbers[3]
  
 +  if not options.skip_signing:
 +    from sign_binaries import sign_binaries
 +    sign_binaries(staging_dir)
++    CopyPreSignedBinaries(options.output_dir, staging_dir, current_version)
 +
    # Name of the archive file built (for example - chrome.7z or
    # patch-<old_version>-<new_version>.7z or patch-<new_version>.7z
    archive_file = CreateArchiveFile(options, staging_dir,
-@@ -599,6 +657,8 @@ def _ParseOptions():
+@@ -599,6 +669,7 @@ def _ParseOptions():
             'with the installer archive {x86|x64}.')
    parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
                      default=False)
 +  parser.add_option('--skip_signing', default=False)
-+
  
    options, _ = parser.parse_args()
    if not options.build_dir:

--- a/patches/media-media_options.gni.patch
+++ b/patches/media-media_options.gni.patch
@@ -1,0 +1,22 @@
+diff --git a/media/media_options.gni b/media/media_options.gni
+index 0c62e9b40706d4b03cec9f00d976d4061b336b50..01561cf6ba297102fc334386f040f578b6fbbfff 100644
+--- a/media/media_options.gni
++++ b/media/media_options.gni
+@@ -9,6 +9,7 @@ import("//build/config/jumbo.gni")
+ import("//media/gpu/args.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//third_party/libaom/options.gni")
++if (brave_chromium_build) { import("//brave/build/config.gni") }
+ 
+ # Do not expand this list without double-checking with OWNERS, this is a list of
+ # all targets which roll up into the //media component. It controls visibility
+@@ -164,6 +165,9 @@ declare_args() {
+   # Windows and Mac.
+   enable_cdm_host_verification =
+       enable_library_cdms && (is_mac || is_win) && is_chrome_branded
++  if (brave_chromium_build) {
++    enable_cdm_host_verification = brave_enable_cdm_host_verification && enable_library_cdms && (is_mac || is_win)
++  }
+ 
+   # Enable Storage ID which is used by CDMs. This is only available with chrome
+   # branding, but may be overridden by other embedders.

--- a/script/sign_binaries.py
+++ b/script/sign_binaries.py
@@ -1,5 +1,7 @@
+import optparse
 import os
 import subprocess
+import sys
 
 cert = os.environ.get('CERT')
 signtool_args = (os.environ.get('SIGNTOOL_ARGS') or
@@ -30,11 +32,11 @@ def run_cmd(cmd):
     assert p.returncode == 0, "Error signing"
 
 
-def sign_binaries(base_dir):
+def sign_binaries(base_dir, endswidth=('.exe', '.dll')):
     matches = []
     for root, dirnames, filenames in os.walk(base_dir):
         for filename in filenames:
-            if filename.endswith(('.exe', '.dll')):
+            if filename.endswith(endswidth):
                 matches.append(os.path.join(root, filename))
 
     for binary in matches:
@@ -44,3 +46,27 @@ def sign_binaries(base_dir):
 def sign_binary(binary):
     cmd = get_sign_cmd(binary)
     run_cmd(cmd)
+
+
+def _ParseOptions():
+    parser = optparse.OptionParser()
+    parser.add_option(
+        '-b', '--build_dir',
+        help='Build directory. The paths in input_file are relative to this.')
+
+    options, _ = parser.parse_args()
+    if not options.build_dir:
+        parser.error('You must provide a build dir.')
+
+    options.build_dir = os.path.normpath(options.build_dir)
+
+    return options
+
+
+def main(options):
+    sign_binaries(options.build_dir, ('brave.exe', 'chrome.dll', 'chrome_child.dll'))
+
+
+if '__main__' == __name__:
+    options = _ParseOptions()
+    sys.exit(main(options))


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/944
Related: https://github.com/brave/brave-browser/pull/4000

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
