### PR TITLE
Publisher should be empty if it doesn't exist

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1115,9 +1115,10 @@ void RewardsServiceImpl::OnPublisherActivityInfoLoaded(
     ledger::PublisherInfoCallback callback,
     uint32_t result,
     const std::string& info_json) {
-  auto publisher = std::make_unique<ledger::PublisherInfo>();
+  std::unique_ptr<ledger::PublisherInfo> publisher;
 
   if (!info_json.empty()) {
+    publisher = std::make_unique<ledger::PublisherInfo>();
     publisher->loadFromJson(info_json);
   }
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/4044

Fixes regression from https://github.com/brave/brave-core/pull/2166

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

- Clean profile and enable rewards
- Go to some youtube video
- Click on panel
- Make sure that publisher is displayed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
