### PR TITLE
Auto-Contribute list percentages now do not underflow

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_publishers.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_publishers.cc
@@ -461,11 +461,15 @@ void BatPublishers::synopsisNormalizerInternal(
     }
     if (percents.size() != 0) {
       if (totalPercents > 100) {
-        percents[valueToChange] -= 1;
-        totalPercents -= 1;
+        if (percents[valueToChange] != 0) {
+          percents[valueToChange] -= 1;
+          totalPercents -= 1;
+        }
       } else {
-        percents[valueToChange] += 1;
-        totalPercents += 1;
+        if (percents[valueToChange] != 100) {
+          percents[valueToChange] += 1;
+          totalPercents += 1;
+        }
       }
       roundoffs[valueToChange] = 0;
     }

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_publishers.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_publishers.h
@@ -218,6 +218,7 @@ class BatPublishers : public ledger::LedgerCallbackHandler {
   friend class BatPublishersTest;
   FRIEND_TEST_ALL_PREFIXES(BatPublishersTest, calcScoreConsts);
   FRIEND_TEST_ALL_PREFIXES(BatPublishersTest, concaveScore);
+  FRIEND_TEST_ALL_PREFIXES(BatPublishersTest, synopsisNormalizerInternal);
 };
 
 }  // namespace braveledger_bat_publishers


### PR DESCRIPTION
Fixes brave/brave-browser#3668

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave clean profile, enable rewards.
2. Add a lot of sites to auto-contribute
3. Go to Rewards page and start excluding sites.
4. Make sure highest percentage does not go above 100%


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
