### PR TITLE
Fix build dependencies.

### DIFF
--- a/components/services/BUILD.gn
+++ b/components/services/BUILD.gn
@@ -7,8 +7,16 @@ source_set("brave_content_browser_overlay_manifest") {
 
   deps = [
     "//base",
+    "//brave/components/services/bat_ads/public/cpp:manifest",
+    "//brave/components/services/bat_ledger/public/cpp:manifest",
     "//services/service_manager/public/cpp",
   ]
+
+  if (!is_android) {
+    deps += [
+      "//brave/utility/tor/public/cpp:manifest",
+    ]
+  }
 }
 
 source_set("brave_content_packaged_service_overlay_manifest") {

--- a/patches/chrome-app-BUILD.gn.patch
+++ b/patches/chrome-app-BUILD.gn.patch
@@ -1,8 +1,17 @@
 diff --git a/chrome/app/BUILD.gn b/chrome/app/BUILD.gn
-index 8670f53f406ec4fbc41f7e35667fa0f73f6037cb..5547f4533046725932967cba9eb6519cb6d2e7c9 100644
+index 8670f53f406ec4fbc41f7e35667fa0f73f6037cb..3a80596751fa3d8843b0feb413f3a58553b44679 100644
 --- a/chrome/app/BUILD.gn
 +++ b/chrome/app/BUILD.gn
-@@ -259,7 +259,7 @@ grit("google_chrome_strings") {
+@@ -182,6 +182,8 @@ grit("generated_resources") {
+   if (is_android) {
+     outputs += android_generated_java_resources
+   }
++
++  deps = [ "//brave/app:brave_generated_resources_grit" ]
+ }
+ 
+ if (is_android) {
+@@ -259,7 +261,7 @@ grit("google_chrome_strings") {
  }
  
  grit("chromium_strings") {
@@ -11,7 +20,7 @@ index 8670f53f406ec4fbc41f7e35667fa0f73f6037cb..5547f4533046725932967cba9eb6519c
    defines = chrome_grit_defines
    output_dir = "$root_gen_dir/chrome"
    outputs = [
-@@ -344,6 +344,7 @@ static_library("test_support") {
+@@ -344,6 +346,7 @@ static_library("test_support") {
      "//components/nacl/common:buildflags",
      "//components/startup_metric_utils/browser:lib",
      "//components/tracing",


### PR DESCRIPTION
1. Add brave/components/services/brave_content_browser_overlay_manifest.cc
   dependencies on the manifests of services it includes.

2. Add a patch for chrome/app:generated_resources to include dependency on
   brave/app:brave_generated_resources_grit. Needed because we overwrite
   generated grit/generated_resources.h in chromium_src and include our
   generated grit/brave_generated_resources.h into it.

Fixes brave/brave-browser#4063

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
N/A

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
