### PR TITLE
Fixed string for sync on device with wrong time

### DIFF
--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -571,7 +571,7 @@
       <message name="IDS_BRAVE_SYNC_ERROR_INIT_FAILED_TITLE" desc="Error message in dialog for when a Sync error happens in the back-end">Couldn't contact Sync servers</message>
       <message name="IDS_BRAVE_SYNC_ERROR_INIT_FAILED_DESCRIPTION" desc="Error message in dialog for when a Sync error happens in the back-end">You might be having network trouble, or there could be a problem with the Sync servers.</message>
       <message name="IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_TITLE" desc="Error message in dialog for when a Sync could not couldn't connect to Sync servers, because of wrong system time (title)">Couldn't connect to Sync servers</message>
-      <message name="IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_DESCRIPTION" desc="Error message in dialog for when a Sync could not couldn't connect to Sync servers, because of wrong system time (description)">You might be having wrong system time or timezone setup on your device. Please setup the correct time and timezone</message>
+      <message name="IDS_BRAVE_SYNC_REQUIRES_CORRECT_TIME_DESCRIPTION" desc="Error message in dialog for when a Sync could not connect to Sync servers, because of wrong system time (description)">Your computer's clock may be set to the wrong time or time zone. Check your clock settings.</message>
     </messages>
   </release>
 </grit>


### PR DESCRIPTION
This is fix according the comment https://github.com/brave/brave-core/pull/2155#discussion_r272385955 
For issue https://github.com/brave/brave-browser/issues/3962 .

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues/3962) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Adjust computer time 20 minutes forward.
2. Create a sync chain
3. Actual result:
See error of `You might be having wrong system time or timezone setup on your device. Please setup the correct time and timezone`
Expected result:
See error of `Your computer's clock may be set to the wrong time or time zone. Check your clock settings.`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
