### PR TITLE
Settings: text, background color, icon size

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -267,10 +267,10 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         Bat Ledger Service
       </message>
       <message name="IDS_SETTINGS_BRAVE_GET_STARTED_TITLE" desc="The title for the Get Started section in settings">
-        Get Started
+        Get started
       </message>
       <message name="IDS_SETTINGS_BRAVE_ADDITIONAL_SETTINGS" desc="The title for a group of settings which are more advanced">
-        Additional Settings
+        Additional settings
       </message>
       <!-- Brave Shields  -->
       <message name="IDS_SETTINGS_BRAVE_SHIELDS_TITLE" desc="The title for Brave shields section in settings">
@@ -283,13 +283,13 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         Your current per-site settings will be retained.
       </message>
       <message name="IDS_SETTINGS_SOCIAL_BLOCKING_DEFAULTS_TITLE" desc="The title the settings section which has options for blocking third-party embeds, commonly from social media sites">
-        Social Media Blocking
+        Social media blocking
       </message>
       <message name="IDS_SETTINGS_BRAVE_SHIELDS_AD_CONTROL_LABEL" desc="Default Brave ad control setting label">
-        Ad Control
+        Ad control
       </message>
       <message name="IDS_SETTINGS_BRAVE_SHIELDS_COOKIE_CONTROL_LABEL" desc="Default Brave cookie control setting label">
-        Cookie Control
+        Cookie control
       </message>
       <message name="IDS_SETTINGS_BRAVE_SHIELDS_FINGERPRINTING_CONTROL_LABEL" desc="Default Brave fingerprinting control setting label">
         Fingerprinting protection
@@ -310,7 +310,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         Allow Twitter embedded tweets
       </message>
       <message name="IDS_SETTINGS_BRAVE_SHIELDS_LINKEDIN_EMBEDDED_POSTS_LABEL" desc="Label for a switch control which allows LinkedIn embedded posts">
-        Allow LinkedIn embeds
+        Allow LinkedIn embedded posts
       </message>
       <message name="IDS_SETTINGS_BLOCK_ADS" desc="Select value">
         Block ads
@@ -381,7 +381,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       </if>
       <if expr="is_macosx">
         <message name="IDS_BRAVE_THEME_TYPE_SYSTEM" desc="Text for system theme type">
-          Same as MacOS
+          Same as macOS
         </message>
       </if>
       <!-- Brave Default Extensions -->
@@ -398,7 +398,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         Uses IPFS companion component to support IPFS in the browser.
       </message>
       <message name="IDS_SETTINGS_MANAGE_EXTENSIONS_LABEL" desc="The label of manage extensions link in settings">
-        Manage Extensions
+        Manage extensions
       </message>
       <!-- Extensions page strings -->
       <message name="IDS_MD_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE" desc="The text to indicate that an extension is from the Web Extensions Store.">

--- a/browser/resources/settings/brave_settings_overrides.html
+++ b/browser/resources/settings/brave_settings_overrides.html
@@ -30,7 +30,7 @@
     <style>
       :host {
         display: inline-block;
-        --setings-card-max-width: 790px !important;
+        --settings-card-max-width: 790px !important;
       }
       cr-drawer {
         display: none !important;
@@ -40,11 +40,15 @@
         flex-direction: row;
         justify-content: center;
         align-items: flex-start;
+        background: #F1F3F5; /* neutral100 */
       }
       @media only screen and  (max-width: 815px) {
         settings-menu {
           display: none;
         }
+      }
+      :host-context([dark]) #container {
+        background: #1E2127;
       }
     </style>
   </template>
@@ -70,18 +74,16 @@
         margin: 0 12px 0 12px !important;
         max-height: calc(100vh - 56px - (var(--brave-settings-menu-margin-v) * 2) - (var(--brave-settings-menu-padding) * 2));
         min-width: 172px;
-        border: 1px solid #E5E5EA !important;
         border-radius: 6px;
         background-color: #fff;
         overflow-y: auto;
         padding: 30px !important;
       }
 
-
       :host-context([dark]) {
         --settings-nav-item-color: #F4F4F4 !important;
         border-color: transparent !important;
-        background-color: #27282B;
+        background-color: #161719;
       }
 
       a[href] {
@@ -102,8 +104,8 @@
       iron-icon {
         color: var(--settings-nav-item-color);
         margin-inline-end: 16px !important;
-        width: 24px;
-        height: 24px;
+        width: 20px;
+        height: 20px;
       }
 
       :host-context([dark]) a[href].iron-selected iron-icon {

--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.html
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.html
@@ -12,12 +12,8 @@
       .label.shields-primary-title
       {
         font-weight: 700;
-        padding-top: .1em;
+        padding-top: 1em;
         font-size: 1.05em;
-      }
-      .label.shields-secondary-title
-      {
-        font-style: italic;
       }
     </style>
     <div class="settings-box first">


### PR DESCRIPTION
There is a pending PR addressing changes to the shields section and since the custom styling on the top li of that section was being annoying, figured it best to just ditch it now. https://github.com/brave/brave-core/pull/2149

The only remaining thing I can't figure out that visually might need addressed for this is the border on top of this `li`. 

![Screen Shot on 2019-04-10 at 16:15:26](https://user-images.githubusercontent.com/29072694/55919761-f9cce200-5bab-11e9-808e-ffae97497846.png)
