### PR TITLE
Run dark mode test only on mojave

### DIFF
--- a/browser/ui/brave_dark_mode_observer_browsertest_mac.mm
+++ b/browser/ui/brave_dark_mode_observer_browsertest_mac.mm
@@ -27,23 +27,25 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 // Test whether DarkModeObserver observes proper NativeTheme.
 IN_PROC_BROWSER_TEST_F(BraveDarkModeObserverTest,
                        ObserveProperNativeThemeTest) {
-  base::test::ScopedFeatureList features;
-  features.InitAndEnableFeature(features::kWebUIDarkMode);
+  if (@available(macOS 10.14, *)) {
+    base::test::ScopedFeatureList features;
+    features.InitAndEnableFeature(features::kWebUIDarkMode);
 
-  Profile* profile = browser()->profile();
+    Profile* profile = browser()->profile();
 
-  // Load webui to instantiate BraveDarkModeObserver.
-  AddTabAtIndexToBrowser(
-      browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
+    // Load webui to instantiate BraveDarkModeObserver.
+    AddTabAtIndexToBrowser(
+        browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
 
-  // Initially set to light.
-  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
-  EXPECT_EQ(
-      ui::NativeTheme::GetInstanceForNativeUi(),
-      BraveDarkModeObserver::current_native_theme_for_testing_);
+    // Initially set to light.
+    SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+    EXPECT_EQ(
+        ui::NativeTheme::GetInstanceForNativeUi(),
+        BraveDarkModeObserver::current_native_theme_for_testing_);
 
-  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
-  EXPECT_EQ(
-      ui::NativeThemeDarkAura::instance(),
-      BraveDarkModeObserver::current_native_theme_for_testing_);
+    SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+    EXPECT_EQ(
+        ui::NativeThemeDarkAura::instance(),
+        BraveDarkModeObserver::current_native_theme_for_testing_);
+  }
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -309,7 +309,7 @@ test("brave_browser_tests") {
     "//brave/browser/renderer_context_menu/brave_mock_render_view_context_menu.h",
     "//brave/browser/renderer_context_menu/brave_spelling_menu_observer_browsertest.cc",
     "//brave/browser/search_engines/search_engine_provider_service_browsertest.cc",
-    "//brave/browser/ui/brave_dark_mode_observer_browsertest_mac.cc",
+    "//brave/browser/ui/brave_dark_mode_observer_browsertest_mac.mm",
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",
     "//brave/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/4073

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
`yarn test brave_browser_tests --filter=BraveDarkModeObserverTest.*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
