### PR TITLE
Issue 3539: Disabling client hints

### DIFF
--- a/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc
+++ b/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc
@@ -1,0 +1,76 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/bind.h"
+#include "base/path_service.h"
+#include "base/run_loop.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/http/http_request_headers.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/http_request.h"
+#include "third_party/blink/public/common/client_hints/client_hints.h"
+
+const char kClientHints[] = "/ch.html";
+
+class ClientHintsBrowserTest : public InProcessBrowserTest {
+ public:
+  ClientHintsBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS),
+        count_client_hints_headers_seen_(0) {
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    https_server_.RegisterRequestMonitor(
+        base::BindRepeating(&ClientHintsBrowserTest::MonitorResourceRequest,
+                            base::Unretained(this)));
+
+    EXPECT_TRUE(https_server_.Start());
+
+    client_hints_url_ = https_server_.GetURL(kClientHints);
+  }
+
+  ~ClientHintsBrowserTest() override {}
+
+  void SetUp() override { InProcessBrowserTest::SetUp(); }
+
+  void SetUpOnMainThread() override {
+    host_resolver()->AddRule("*", "127.0.0.1");
+    base::RunLoop().RunUntilIdle();
+  }
+
+  void TearDownOnMainThread() override {}
+
+  const GURL& client_hints_url() const { return client_hints_url_; }
+
+  size_t count_client_hints_headers_seen() const {
+    return count_client_hints_headers_seen_;
+  }
+
+ private:
+  void MonitorResourceRequest(const net::test_server::HttpRequest& request) {
+    for (size_t i = 0; i < blink::kClientHintsMappingsCount; ++i) {
+      if (base::ContainsKey(request.headers,
+                            blink::kClientHintsHeaderMapping[i])) {
+        count_client_hints_headers_seen_++;
+      }
+    }
+  }
+
+  net::EmbeddedTestServer https_server_;
+  GURL client_hints_url_;
+  size_t count_client_hints_headers_seen_;
+
+  DISALLOW_COPY_AND_ASSIGN(ClientHintsBrowserTest);
+};
+
+IN_PROC_BROWSER_TEST_F(ClientHintsBrowserTest, ClientHintsDisabled) {
+  ui_test_utils::NavigateToURL(browser(), client_hints_url());
+  EXPECT_EQ(0u, count_client_hints_headers_seen());
+}

--- a/chromium_src/third_party/blink/public/platform/web_client_hints_type.h
+++ b/chromium_src/third_party/blink/public/platform/web_client_hints_type.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_PUBLIC_PLATFORM_WEB_CLIENT_HINTS_TYPE_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_PUBLIC_PLATFORM_WEB_CLIENT_HINTS_TYPE_H_
+
+#include "third_party/blink/public/mojom/web_client_hints/web_client_hints_types.mojom-shared.h"
+
+namespace blink {
+
+// WebEnabledClientHints stores all the client hints along with whether the hint
+// is enabled or not.
+struct WebEnabledClientHints {
+  WebEnabledClientHints() = default;
+
+  bool IsEnabled(mojom::WebClientHintsType type) const { return false; }
+
+  void SetIsEnabled(mojom::WebClientHintsType type, bool should_send) {
+    enabled_types_[static_cast<int>(type)] = false;
+  }
+
+  bool enabled_types_[static_cast<int>(mojom::WebClientHintsType::kMaxValue) +
+                      1] = {};
+};
+
+}  // namespace blink
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_PUBLIC_PLATFORM_WEB_CLIENT_HINTS_TYPE_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -327,6 +327,7 @@ test("brave_browser_tests") {
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/browser/ui/toolbar/brave_app_menu_model_browsertest.cc",
+    "//brave/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_service_browsertest.cc",

--- a/test/data/ch.html
+++ b/test/data/ch.html
@@ -1,0 +1,4 @@
+<html>
+Hello World!
+<img src="non-existing-image.jpg"></img>
+</html>

--- a/test/data/ch.html.mock-http-headers
+++ b/test/data/ch.html.mock-http-headers
@@ -1,0 +1,2 @@
+HTTP/1.1 200 OK
+Accept-CH: dpr,device-memory,viewport-width,rtt,downlink,ect,lang,ua,arch,platform,model


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3539

## Description

Client hints pose a significant privacy risk. See here: httpwg/http-extensions#767

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Navigate to https://client-hints-demo.appspot.com and verify that client hints are not displayed for the main and sub-frames.

2. Navigate to `DevTools`, refresh after a min and verify none of the client hints: 
```
   "device-memory",
    "dpr",
    "width",
    "viewport-width",
    "rtt",
    "downlink",
    "ect",
    "sec-ch-lang",
    "sec-ch-ua",
    "sec-ch-ua-arch",
    "sec-ch-ua-platform",
    "sec-ch-ua-model"
```

are not part of the request headers.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
