### PR TITLE
'Insufficient Funds' notification now will not show if balance will cover verified sites.

### DIFF
--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -3,9 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <memory>
+
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/string_split.h"
+#include "base/memory/weak_ptr.h"
 #include "bat/ledger/internal/bat_helper.h"
 #include "bat/ledger/internal/static_values.h"
 #include "bat/ledger/ledger.h"
@@ -16,6 +19,8 @@
 #include "brave/components/brave_rewards/browser/rewards_service_factory.h"
 #include "brave/components/brave_rewards/browser/rewards_service_impl.h"
 #include "brave/components/brave_rewards/browser/rewards_service_observer.h"
+#include "brave/components/brave_rewards/browser/rewards_notification_service_impl.h"  // NOLINT
+#include "brave/components/brave_rewards/browser/rewards_notification_service_observer.h"  // NOLINT
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/common/chrome_paths.h"
@@ -94,8 +99,11 @@ namespace brave_test_resp {
   std::string surveyor_voting_credential_;
 }  // namespace brave_test_resp
 
-class BraveRewardsBrowserTest : public InProcessBrowserTest,
-                                public brave_rewards::RewardsServiceObserver {
+class BraveRewardsBrowserTest :
+    public InProcessBrowserTest,
+    public brave_rewards::RewardsServiceObserver,
+    public brave_rewards::RewardsNotificationServiceObserver,
+    public base::SupportsWeakPtr<BraveRewardsBrowserTest> {
  public:
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
@@ -210,7 +218,8 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
         *response = brave_test_resp::surveyor_voting_;
     } else if (URLMatches(url, GET_PUBLISHERS_LIST_V1, "",
                           SERVER_TYPES::PUBLISHER_DISTRO)) {
-      *response = "[[\"duckduckgo.com\",true,false]]";
+      *response =
+          "[[\"bumpsmack.com\",true,false],[\"duckduckgo.com\",true,false]]";
     }
   }
 
@@ -254,6 +263,14 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
       return;
     wait_for_reconcile_completed_loop_.reset(new base::RunLoop);
     wait_for_reconcile_completed_loop_->Run();
+  }
+
+  void WaitForInsufficientFundsNotification() {
+    if (insufficient_notification_would_have_already_shown_) {
+      return;
+    }
+    wait_for_insufficient_notification_loop_.reset(new base::RunLoop);
+    wait_for_insufficient_notification_loop_->Run();
   }
 
   void GetReconcileTime() {
@@ -490,7 +507,9 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
     EXPECT_NE(js_result.ExtractString().find("30.0 BAT"), std::string::npos);
   }
 
-  void VisitPublisher(const std::string& publisher, bool verified) {
+  void VisitPublisher(const std::string& publisher,
+                      bool verified,
+                      bool last_add = false) {
     GURL url = embedded_test_server()->GetURL(publisher, "/index.html");
     ui_test_utils::NavigateToURLWithDisposition(
         browser(), url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
@@ -513,8 +532,8 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
         contents(),
         "const delay = t => new Promise(resolve => setTimeout(resolve, t));"
         "delay(1000).then(() => "
-        "  document.querySelector(\"[data-test-id='autoContribute']\")."
-        "    getElementsByTagName('a')[0].innerText);",
+        "  document.querySelector(\"[data-test-id='ac_link_" + publisher + "']"
+        "\").innerText);",
         content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
         content::ISOLATED_WORLD_ID_CONTENT_END);
     EXPECT_STREQ(js_result.ExtractString().c_str(), publisher.c_str());
@@ -524,21 +543,25 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
       // favicon and the verified icon
       content::EvalJsResult js_result =
           EvalJs(contents(),
-                 "document.querySelector(\"[data-test-id='autoContribute']\")."
-                 "    getElementsByTagName('svg').length === 2;",
-                 content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
-                 content::ISOLATED_WORLD_ID_CONTENT_END);
+                "document.querySelector(\"[data-test-id='ac_link_" +
+                publisher + "']\").getElementsByTagName('svg').length === 1;",
+                content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                content::ISOLATED_WORLD_ID_CONTENT_END);
       EXPECT_TRUE(js_result.ExtractBool());
     } else {
       // An unverified site has one image associated with it, the site's
       // favicon
       content::EvalJsResult js_result =
           EvalJs(contents(),
-                 "document.querySelector(\"[data-test-id='autoContribute']\")."
-                 "    getElementsByTagName('svg').length === 1;",
-                 content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
-                 content::ISOLATED_WORLD_ID_CONTENT_END);
+                "document.querySelector(\"[data-test-id='ac_link_" +
+                publisher + "']\").getElementsByTagName('svg').length === 0;",
+                content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                content::ISOLATED_WORLD_ID_CONTENT_END);
       EXPECT_TRUE(js_result.ExtractBool());
+    }
+
+    if (last_add) {
+      last_publisher_added_ = true;
     }
   }
 
@@ -851,6 +874,46 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
     ac_low_amount_ = true;
   }
 
+  void OnNotificationAdded(
+      brave_rewards::RewardsNotificationService* rewards_notification_service,
+      const brave_rewards::RewardsNotificationService::RewardsNotification&
+      notification) {
+    const brave_rewards::RewardsNotificationService::RewardsNotificationsMap&
+        notifications = rewards_notification_service->GetAllNotifications();
+    for (const auto& notification : notifications) {
+      if (notification.second.type_ ==
+          brave_rewards::RewardsNotificationService::RewardsNotificationType
+          ::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS) {
+        insufficient_notification_would_have_already_shown_ = true;
+        if (wait_for_insufficient_notification_loop_) {
+          wait_for_insufficient_notification_loop_->Quit();
+        }
+      }
+    }
+  }
+
+  /**
+   * When using notification observer for insufficient funds, tests will fail
+   * for sufficient funds because observer will never be called for
+   * notification. Use this as callback to know when we come back with
+   * sufficient funds to prevent inf loop
+   * */
+  void ShowNotificationAddFundsForTesting(bool sufficient) {
+    if (sufficient) {
+      insufficient_notification_would_have_already_shown_ = true;
+      if (wait_for_insufficient_notification_loop_) {
+        wait_for_insufficient_notification_loop_->Quit();
+      }
+    }
+  }
+
+  void CheckInsufficientFundsForTesting() {
+    rewards_service_->MaybeShowNotificationAddFundsForTesting(
+        base::BindOnce(
+            &BraveRewardsBrowserTest::ShowNotificationAddFundsForTesting,
+            AsWeakPtr()));
+  }
+
   MOCK_METHOD1(OnGetProduction, void(bool));
   MOCK_METHOD1(OnGetDebug, void(bool));
   MOCK_METHOD1(OnGetReconcileTime, void(int32_t));
@@ -881,9 +944,13 @@ class BraveRewardsBrowserTest : public InProcessBrowserTest,
   bool reconcile_completed_ = false;
   unsigned int reconcile_status_ = ledger::LEDGER_ERROR;
 
+  std::unique_ptr<base::RunLoop> wait_for_insufficient_notification_loop_;
+  bool insufficient_notification_would_have_already_shown_ = false;
+
   bool contribution_made_ = false;
   bool tip_made = false;
   bool ac_low_amount_ = false;
+  bool last_publisher_added_ = false;
 };
 
 IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, RenderWelcome) {
@@ -1631,4 +1698,142 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, AddFundsCountryLimited) {
     content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
     content::ISOLATED_WORLD_ID_CONTENT_END);
   ASSERT_TRUE(js_result.ExtractBool());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
+    InsufficientNotificationForVerifiedsZeroAmountZeroPublishers) {
+  rewards_service_->GetNotificationService()->AddObserver(this);
+  EnableRewards();
+  CheckInsufficientFundsForTesting();
+  WaitForInsufficientFundsNotification();
+  const brave_rewards::RewardsNotificationService::RewardsNotificationsMap&
+      notifications = rewards_service_->GetAllNotifications();
+
+  if (notifications.empty()) {
+    SUCCEED();
+  }
+  bool notification_shown = false;
+  for (const auto& notification : notifications) {
+    if (notification.second.type_ ==
+        brave_rewards::RewardsNotificationService::RewardsNotificationType
+        ::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS) {
+      notification_shown = true;
+      break;
+    }
+  }
+  EXPECT_FALSE(notification_shown);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
+                       InsufficientNotificationForVerifiedsDefaultAmount) {
+  rewards_service_->AddObserver(this);
+  rewards_service_->GetNotificationService()->AddObserver(this);
+  EnableRewards();
+  // Claim grant using panel
+  const bool use_panel = true;
+  ClaimGrant(use_panel);
+
+  // Visit publishers
+  const bool verified = true;
+  while (!last_publisher_added_) {
+    VisitPublisher("duckduckgo.com", verified);
+    VisitPublisher("bumpsmack.com", verified);
+    VisitPublisher("google.com", !verified, true);
+  }
+
+  CheckInsufficientFundsForTesting();
+  WaitForInsufficientFundsNotification();
+  const brave_rewards::RewardsNotificationService::RewardsNotificationsMap&
+      notifications = rewards_service_->GetAllNotifications();
+
+  if (notifications.empty()) {
+    SUCCEED();
+  }
+  bool notification_shown = false;
+  for (const auto& notification : notifications) {
+    if (notification.second.type_ ==
+        brave_rewards::RewardsNotificationService::RewardsNotificationType
+        ::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS) {
+      notification_shown = true;
+      break;
+    }
+  }
+  EXPECT_FALSE(notification_shown);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
+                       InsufficientNotificationForVerifiedsSufficientAmount) {
+  rewards_service_->AddObserver(this);
+  rewards_service_->GetNotificationService()->AddObserver(this);
+
+  EnableRewards();
+  // Claim grant using panel
+  const bool use_panel = true;
+  ClaimGrant(use_panel);
+
+  // Visit publishers
+  const bool verified = true;
+  while (!last_publisher_added_) {
+    VisitPublisher("duckduckgo.com", verified);
+    VisitPublisher("bumpsmack.com", verified);
+    VisitPublisher("google.com", !verified, true);
+  }
+
+  rewards_service_->SetContributionAmount(40.0);
+
+  CheckInsufficientFundsForTesting();
+  WaitForInsufficientFundsNotification();
+  const brave_rewards::RewardsNotificationService::RewardsNotificationsMap&
+      notifications = rewards_service_->GetAllNotifications();
+  if (notifications.empty()) {
+    SUCCEED();
+  }
+  bool notification_shown = false;
+  for (const auto& notification : notifications) {
+    if (notification.second.type_ ==
+        brave_rewards::RewardsNotificationService::RewardsNotificationType
+        ::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS) {
+      notification_shown = true;
+      break;
+    }
+  }
+  EXPECT_FALSE(notification_shown);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
+                       InsufficientNotificationForVerifiedsInsufficientAmount) {
+  rewards_service_->AddObserver(this);
+  rewards_service_->GetNotificationService()->AddObserver(this);
+  EnableRewards();
+  // Claim grant using panel
+  const bool use_panel = true;
+  ClaimGrant(use_panel);
+
+  // Visit publishers
+  const bool verified = true;
+  while (!last_publisher_added_) {
+    VisitPublisher("duckduckgo.com", verified);
+    VisitPublisher("bumpsmack.com", verified);
+    VisitPublisher("google.com", !verified, true);
+  }
+  rewards_service_->SetContributionAmount(100.0);
+
+  rewards_service_->CheckInsufficientFundsForTesting();
+  WaitForInsufficientFundsNotification();
+  const brave_rewards::RewardsNotificationService::RewardsNotificationsMap&
+      notifications = rewards_service_->GetAllNotifications();
+
+  if (notifications.empty()) {
+    FAIL() << "Should see Insufficient Funds notification";
+  }
+  bool notification_shown = false;
+  for (const auto& notification : notifications) {
+    if (notification.second.type_ ==
+        brave_rewards::RewardsNotificationService::RewardsNotificationType
+        ::REWARDS_NOTIFICATION_INSUFFICIENT_FUNDS) {
+      notification_shown = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(notification_shown);
 }

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2513,6 +2513,11 @@ void RewardsServiceImpl::MaybeShowNotificationAddFunds() {
         AsWeakPtr()));
 }
 
+void RewardsServiceImpl::MaybeShowNotificationAddFundsForTesting(
+    base::OnceCallback<void(bool)> callback) {
+  bat_ledger_->HasSufficientBalanceToReconcile(std::move(callback));
+}
+
 bool RewardsServiceImpl::ShouldShowNotificationAddFunds() const {
   base::Time next_time =
       profile_->GetPrefs()->GetTime(prefs::kRewardsAddFundsNotification);
@@ -2715,6 +2720,10 @@ void RewardsServiceImpl::SetLedgerEnvForTesting() {
 
 void RewardsServiceImpl::StartAutoContributeForTest() {
   bat_ledger_->StartAutoContribute();
+}
+
+void RewardsServiceImpl::CheckInsufficientFundsForTesting() {
+  MaybeShowNotificationAddFunds();
 }
 
 void RewardsServiceImpl::GetProduction(const GetProductionCallback& callback) {

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -66,6 +66,7 @@ namespace brave_rewards {
 
 class PublisherInfoDatabase;
 class RewardsNotificationServiceImpl;
+class BraveRewardsBrowserTest;
 
 using GetProductionCallback = base::Callback<void(bool)>;
 using GetDebugCallback = base::Callback<void(bool)>;
@@ -246,10 +247,13 @@ class RewardsServiceImpl : public RewardsService,
   // Testing methods
   void SetLedgerEnvForTesting();
   void StartAutoContributeForTest();
+  void CheckInsufficientFundsForTesting();
+  void MaybeShowNotificationAddFundsForTesting(
+      base::OnceCallback<void(bool)> callback);
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(RewardsServiceTest, OnWalletProperties);
   friend class ::BraveRewardsBrowserTest;
+  FRIEND_TEST_ALL_PREFIXES(RewardsServiceTest, OnWalletProperties);
 
   const base::OneShotEvent& ready() const { return ready_; }
   void OnLedgerStateSaved(ledger::LedgerCallbackHandler* handler,

--- a/components/services/bat_ledger/bat_ledger_impl.cc
+++ b/components/services/bat_ledger/bat_ledger_impl.cc
@@ -380,9 +380,21 @@ void BatLedgerImpl::GetRewardsMainEnabled(
   std::move(callback).Run(ledger_->GetRewardsMainEnabled());
 }
 
+void BatLedgerImpl::OnHasSufficientBalanceToReconcile(
+    CallbackHolder<HasSufficientBalanceToReconcileCallback>* holder,
+    bool sufficient) {
+  if (holder->is_valid()) {
+    std::move(holder->get()).Run(sufficient);
+  }
+  delete holder;
+}
+
 void BatLedgerImpl::HasSufficientBalanceToReconcile(
     HasSufficientBalanceToReconcileCallback callback) {
-  std::move(callback).Run(ledger_->HasSufficientBalanceToReconcile());
+  auto* holder = new CallbackHolder<HasSufficientBalanceToReconcileCallback>(
+      AsWeakPtr(), std::move(callback));
+  ledger_->HasSufficientBalanceToReconcile(
+      std::bind(BatLedgerImpl::OnHasSufficientBalanceToReconcile, holder, _1));
 }
 
 // static

--- a/components/services/bat_ledger/bat_ledger_impl.h
+++ b/components/services/bat_ledger/bat_ledger_impl.h
@@ -278,6 +278,10 @@ class BatLedgerImpl : public mojom::BatLedger,
     CallbackHolder<GetAddressesCallback>* holder,
     std::map<std::string, std::string> addresses);
 
+  static void OnHasSufficientBalanceToReconcile(
+    CallbackHolder<HasSufficientBalanceToReconcileCallback>* holder,
+    bool sufficient);
+
   std::unique_ptr<BatLedgerClientMojoProxy> bat_ledger_client_mojo_proxy_;
   std::unique_ptr<ledger::Ledger> ledger_;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,8 +1597,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#51d11775d3f6612755d045e319235dd6e4092d16",
-      "from": "github:brave/brave-ui#51d11775d3f6612755d045e319235dd6e4092d16",
+      "version": "github:brave/brave-ui#f56139e46ba4194ca1f9315b4cc152f253d4393a",
+      "from": "github:brave/brave-ui#f56139e46ba4194ca1f9315b4cc152f253d4393a",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@types/react-redux": "6.0.4",
     "@types/redux-logger": "^3.0.7",
     "awesome-typescript-loader": "^5.2.1",
-    "brave-ui": "github:brave/brave-ui#8ae8f96d6668a5e50d2d5b166fcabfc727b83124",
+    "brave-ui": "github:brave/brave-ui#fcfff859b016944886d29252001e5de77f8901ab",
     "css-loader": "^2.1.1",
     "csstype": "^2.5.5",
     "deep-freeze-node": "^1.1.3",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -118,6 +118,7 @@ test("brave_unit_tests") {
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/media/twitch_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/media/twitter_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/media/youtube_unittest.cc",
+      "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_helper_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_helper_unittest.h",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_publishers_unittest.cc",

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -69,6 +69,7 @@ using OnRefreshPublisherCallback =
     std::function<void(bool)>;
 using GetAddressesCallback =
     std::function<void(std::map<std::string, std::string>)>;
+using HasSufficientBalanceToReconcileCallback = std::function<void(bool)>;
 
 class LEDGER_EXPORT Ledger {
  public:
@@ -269,7 +270,8 @@ class LEDGER_EXPORT Ledger {
 
   virtual uint64_t GetBootStamp() const = 0;
 
-  virtual bool HasSufficientBalanceToReconcile() = 0;
+  virtual void HasSufficientBalanceToReconcile(
+      HasSufficientBalanceToReconcileCallback callback) = 0;
 
   virtual void GetAddressesForPaymentId(
       ledger::WalletAddressesCallback callback) = 0;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <cmath>
 #include <ctime>
@@ -90,6 +92,102 @@ std::string BatContribution::GetAnonizeProof(
   }
 
   return proof;
+}
+
+void BatContribution::HasSufficientBalance(
+    ledger::HasSufficientBalanceToReconcileCallback callback) {
+  ledger_->FetchWalletProperties(
+      std::bind(&BatContribution::OnSufficientBalanceWallet,
+        this, _1, _2, callback));
+}
+
+void BatContribution::GetVerifiedAutoAmount(
+    const ledger::PublisherInfoList& publisher_list,
+    uint32_t record,
+    double balance,
+    ledger::HasSufficientBalanceToReconcileCallback callback) {
+  double ac_amount = ledger_->GetContributionAmount();
+  double total_reconcile_amount(GetAmountFromVerifiedAuto(
+      publisher_list, ac_amount));
+  if (balance < total_reconcile_amount && !publisher_list.empty()) {
+    callback(false);
+    return;
+  }
+  ledger_->GetRecurringTips(
+      std::bind(&BatContribution::GetVerifiedRecurringAmount,
+                this,
+                _1,
+                _2,
+                balance,
+                total_reconcile_amount,
+                callback));
+}
+
+// static
+double BatContribution::GetAmountFromVerifiedAuto(
+    const ledger::PublisherInfoList& publisher_list,
+    double ac_amount) {
+  double non_verified_bat = 0.0;
+  for (const auto& publisher : publisher_list) {
+    if (!publisher->verified) {
+      non_verified_bat += (publisher->percent / 100.0) * ac_amount;
+    }
+  }
+  return ac_amount - non_verified_bat;
+}
+
+void BatContribution::GetVerifiedRecurringAmount(
+    const ledger::PublisherInfoList& publisher_list,
+    uint32_t record,
+    double balance,
+    double total_reconcile_amount,
+    ledger::HasSufficientBalanceToReconcileCallback callback) {
+  if (publisher_list.empty()) {
+    callback(true);
+    return;
+  }
+  total_reconcile_amount += GetAmountFromVerifiedRecurring(publisher_list);
+  callback(balance >= total_reconcile_amount);
+}
+
+// static
+double BatContribution::GetAmountFromVerifiedRecurring(
+    const ledger::PublisherInfoList& publisher_list) {
+  double total_recurring_amount(0.0);
+  for (const auto& publisher : publisher_list) {
+    if (publisher->id.empty()) {
+      continue;
+    }
+    if (publisher->verified) {
+      total_recurring_amount += publisher->weight;
+    }
+  }
+  return total_recurring_amount;
+}
+
+void BatContribution::OnSufficientBalanceWallet(
+    ledger::Result result,
+    std::unique_ptr<ledger::WalletInfo> info,
+    ledger::HasSufficientBalanceToReconcileCallback callback) {
+  if (result == ledger::Result::LEDGER_OK && info) {
+    ledger::ActivityInfoFilter filter = ledger_->CreateActivityFilter(
+      std::string(),
+      ledger::EXCLUDE_FILTER::FILTER_ALL_EXCEPT_EXCLUDED,
+      true,
+      ledger_->GetReconcileStamp(),
+      ledger_->GetPublisherAllowNonVerified(),
+      ledger_->GetPublisherMinVisits());
+  ledger_->GetActivityInfoList(
+      0,
+      0,
+      filter,
+      std::bind(&BatContribution::GetVerifiedAutoAmount,
+                this,
+                _1,
+                _2,
+                info->balance_,
+                callback));
+  }
 }
 
 ledger::PublisherInfoList BatContribution::GetVerifiedListAuto(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "bat/ledger/ledger.h"
 #include "bat/ledger/internal/bat_helper.h"
 
@@ -146,6 +147,8 @@ class BatContribution {
                                   ledger::ACTIVITY_MONTH month,
                                   int year,
                                   uint32_t date);
+  void HasSufficientBalance(
+    ledger::HasSufficientBalanceToReconcileCallback callback);
 
   // Triggers contribution process for auto contribute table
   void StartAutoContribute();
@@ -298,11 +301,41 @@ class BatContribution {
 
   void DoRetry(const std::string& viewing_id);
 
+  void GetVerifiedAutoAmount(
+      const ledger::PublisherInfoList& publisher_list,
+      uint32_t record,
+      double balance,
+      ledger::HasSufficientBalanceToReconcileCallback callback);
+
+  void GetVerifiedRecurringAmount(
+      const ledger::PublisherInfoList& publisher_list,
+      uint32_t record,
+      double balance,
+      double budget,
+      ledger::HasSufficientBalanceToReconcileCallback callback);
+
+  static double GetAmountFromVerifiedAuto(
+      const ledger::PublisherInfoList& publisher_list,
+      double ac_amount);
+
+  static double GetAmountFromVerifiedRecurring(
+      const ledger::PublisherInfoList& publisher_list);
+
+  void OnSufficientBalanceWallet(
+      ledger::Result result,
+      std::unique_ptr<ledger::WalletInfo> info,
+      ledger::HasSufficientBalanceToReconcileCallback callback);
+
   bat_ledger::LedgerImpl* ledger_;  // NOT OWNED
   uint32_t last_reconcile_timer_id_;
   uint32_t last_prepare_vote_batch_timer_id_;
   uint32_t last_vote_batch_timer_id_;
   std::map<std::string, uint32_t> retry_timers_;
+
+  // For testing purposes
+  friend class BatContributionTest;
+  FRIEND_TEST_ALL_PREFIXES(BatContributionTest, GetAmountFromVerifiedAuto);
+  FRIEND_TEST_ALL_PREFIXES(BatContributionTest, GetAmountFromVerifiedRecurring);
 };
 
 }  // namespace braveledger_bat_contribution

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_contribution_unittest.cc
@@ -1,0 +1,175 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "bat/ledger/internal/logging.h"
+#include "bat/ledger/internal/bat_contribution.h"
+#include "bat/ledger/ledger.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BatContributionTest.*
+
+namespace braveledger_bat_contribution {
+
+class BatContributionTest : public testing::Test {
+ protected:
+  void GetPublishersForAuto(
+      ledger::PublisherInfoList* publisher_info_list,
+      uint32_t iterations,  /* total count of publishers */
+      uint32_t variation  /* total count of verifieds */) {
+    // Can't have more verified publishers than total publishers
+    DCHECK(variation <= iterations);
+    for (uint32_t ix = 0; ix < iterations; ix++) {
+      ledger::PublisherInfoPtr publisher_info = ledger::PublisherInfo::New();
+      publisher_info->id = "example" + std::to_string(ix) + ".com";
+      publisher_info->verified = ix < variation;
+      publisher_info->percent = (1.0 / iterations) * 100.0;
+      publisher_info_list->push_back(std::move(publisher_info));
+    }
+  }
+
+  void GetPublishersForRecurring(
+      ledger::PublisherInfoList* publisher_info_list,
+      uint32_t iterations,
+      std::vector<uint32_t> amounts,
+      uint32_t variation) {
+    for (uint32_t ix = 0; ix < iterations; ix++) {
+      ledger::PublisherInfoPtr publisher_info = ledger::PublisherInfo::New();
+      publisher_info->id = "recurringexample" + std::to_string(ix) + ".com";
+      publisher_info->weight = amounts[ix % amounts.size()];
+      publisher_info->verified = ix < variation;
+      publisher_info_list->push_back(std::move(publisher_info));
+    }
+  }
+
+  bool WillTriggerNotification(
+      uint32_t auto_iterations,
+      uint32_t auto_variations,
+      double auto_amount_selected,
+      uint32_t recurring_iterations,
+      std::vector<uint32_t> recurring_amounts_selected,
+      uint32_t recurring_variation,
+      double wallet_balance) {
+    ledger::PublisherInfoList publisher_info_list_auto;
+    ledger::PublisherInfoList publisher_info_list_recurring;
+    GetPublishersForAuto(
+        &publisher_info_list_auto, auto_iterations, auto_variations);
+    double total_reconcile_amount =
+        BatContribution::GetAmountFromVerifiedAuto(
+          publisher_info_list_auto, auto_amount_selected);
+    GetPublishersForRecurring(
+        &publisher_info_list_recurring,
+        recurring_iterations,
+        recurring_amounts_selected,
+        recurring_variation);
+    total_reconcile_amount +=
+        BatContribution::GetAmountFromVerifiedRecurring(
+          publisher_info_list_recurring);
+    return wallet_balance < total_reconcile_amount &&
+        !publisher_info_list_auto.empty() &&
+        !publisher_info_list_recurring.empty();
+  }
+};
+
+TEST_F(BatContributionTest, GetAmountFromVerifiedAuto) {
+  ledger::PublisherInfoList publisher_info_list;
+
+  // 0 publishers and budget of 0 BAT
+  GetPublishersForAuto(&publisher_info_list, 0, 0);
+  double amount =
+      BatContribution::GetAmountFromVerifiedAuto(publisher_info_list, 0);
+  EXPECT_EQ(amount, 0);
+
+  // 10 publishers total with 5 verified and budget of 30 BAT
+  GetPublishersForAuto(&publisher_info_list, 10, 5);
+  amount =
+      BatContribution::GetAmountFromVerifiedAuto(publisher_info_list, 30);
+  EXPECT_EQ(amount, 15);
+
+  // 20 publishers total with 10 verified and budget of 30 BAT
+  publisher_info_list.clear();
+  GetPublishersForAuto(&publisher_info_list, 20, 10);
+  amount =
+      BatContribution::GetAmountFromVerifiedAuto(publisher_info_list, 30);
+  EXPECT_EQ(amount, 15);
+
+  // 50 publishers total with 5 verified and budget of 100 BAT
+  publisher_info_list.clear();
+  GetPublishersForAuto(&publisher_info_list, 50, 5);
+  amount =
+      BatContribution::GetAmountFromVerifiedAuto(publisher_info_list, 100);
+  EXPECT_EQ(amount, 10);
+
+  // 100 publishers total with 80 verified and budget of 1478 BAT
+  publisher_info_list.clear();
+  GetPublishersForAuto(&publisher_info_list, 100, 80);
+  amount =
+      BatContribution::GetAmountFromVerifiedAuto(publisher_info_list, 1478);
+  EXPECT_EQ(amount, 1182.40);
+
+  // 100 publishers total with 4 verified and budget of 100 BAT
+  publisher_info_list.clear();
+  GetPublishersForAuto(&publisher_info_list, 100, 4);
+  amount =
+      BatContribution::GetAmountFromVerifiedAuto(publisher_info_list, 100);
+  EXPECT_EQ(amount, 4);
+}
+
+TEST_F(BatContributionTest, GetAmountFromVerifiedRecurring) {
+  ledger::PublisherInfoList publisher_info_list;
+  GetPublishersForRecurring(&publisher_info_list, 5, {1, 5, 10}, 2);
+  double amount =
+      BatContribution::GetAmountFromVerifiedRecurring(publisher_info_list);
+  EXPECT_EQ(amount, 6);
+
+  publisher_info_list.clear();
+  GetPublishersForRecurring(&publisher_info_list, 7, {1, 5, 10}, 5);
+  amount =
+      BatContribution::GetAmountFromVerifiedRecurring(publisher_info_list);
+  EXPECT_EQ(amount, 22);
+
+  publisher_info_list.clear();
+  GetPublishersForRecurring(&publisher_info_list, 10, {5, 10, 20}, 7);
+  amount =
+      BatContribution::GetAmountFromVerifiedRecurring(publisher_info_list);
+  EXPECT_EQ(amount, 75);
+
+  publisher_info_list.clear();
+  GetPublishersForRecurring(&publisher_info_list, 10, {10, 20, 50}, 9);
+  amount =
+      BatContribution::GetAmountFromVerifiedRecurring(publisher_info_list);
+  EXPECT_EQ(amount, 240);
+
+  publisher_info_list.clear();
+  GetPublishersForRecurring(&publisher_info_list, 5, {1, 5, 10, 20, 50}, 5);
+  amount =
+      BatContribution::GetAmountFromVerifiedRecurring(publisher_info_list);
+  EXPECT_EQ(amount, 86);
+}
+
+TEST_F(BatContributionTest, WillTriggerNotification) {
+  // 0 auto, 0 tips, 0 balance
+  EXPECT_FALSE(WillTriggerNotification(0, 0, 20, 0, {1, 5, 10}, 0, 0.0));
+
+  EXPECT_TRUE(WillTriggerNotification(10, 5, 30, 5, {1, 5, 10}, 2, 20.9));
+  EXPECT_FALSE(WillTriggerNotification(10, 5, 30, 5, {1, 5, 10}, 2, 21));
+  EXPECT_TRUE(WillTriggerNotification(20, 10, 30, 7, {1, 5, 10}, 5, 36.9));
+  EXPECT_FALSE(WillTriggerNotification(20, 10, 30, 7, {1, 5, 10}, 5, 37));
+  EXPECT_TRUE(WillTriggerNotification(50, 5, 100, 10, {5, 10, 20}, 7, 84.9));
+  EXPECT_FALSE(WillTriggerNotification(50, 5, 100, 10, {5, 10, 20}, 7, 85));
+  EXPECT_TRUE(WillTriggerNotification(
+      100, 80, 1478, 10, {10, 20, 50}, 9, 1422.39));
+  EXPECT_FALSE(WillTriggerNotification(
+      100, 80, 1478, 10, {10, 20, 50}, 9, 1422.40));
+  EXPECT_TRUE(WillTriggerNotification(
+      100, 4, 100, 5, {1, 5, 10, 20, 50}, 5, 89.9));
+  EXPECT_FALSE(WillTriggerNotification(
+      100, 4, 100, 5, {1, 5, 10, 20, 50}, 5, 90));
+}
+
+}  // namespace braveledger_bat_contribution

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1436,8 +1436,9 @@ double LedgerImpl::GetDefaultContributionAmount() {
   return bat_state_->GetDefaultContributionAmount();
 }
 
-bool LedgerImpl::HasSufficientBalanceToReconcile() {
-  return GetBalance() >= GetContributionAmount();
+void LedgerImpl::HasSufficientBalanceToReconcile(
+    ledger::HasSufficientBalanceToReconcileCallback callback) {
+  bat_contribution_->HasSufficientBalance(callback);
 }
 
 void LedgerImpl::SaveNormalizedPublisherList(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -417,7 +417,8 @@ class LedgerImpl : public ledger::Ledger,
 
   double GetDefaultContributionAmount() override;
 
-  bool HasSufficientBalanceToReconcile() override;
+  void HasSufficientBalanceToReconcile(
+      ledger::HasSufficientBalanceToReconcileCallback callback) override;
 
   void SaveNormalizedPublisherList(
       ledger::PublisherInfoList normalized_list);


### PR DESCRIPTION
Fixes brave/brave-browser#3707

brave-ui PR: https://github.com/brave/brave-ui/pull/471

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave clean profile with `-- --rewards=reconcile-interval=20` (or some other value less than 4320 [3 days])
2. Visit a verified site to add to AC and non-verified site to add to AC preferably with same time duration.
3. Accept grant (at present time 30 BAT)
4. Go to Rewards page and set AC budget to 50 BAT
5. Quit browser and restart to reinitiate timer
6. Wait a few moments and make sure that you don't see 'Insufficient Funds' notification
7. Go to Rewards page and set AC budget to 100 BAT
8. Quit Browser and restart.
9. Wait a few moments and make sure you get BAT icon notification Re: 'Insufficient Funds'

Repeat the steps above with a different combination of verified and unverified sites and make sure notification does not show if the balance would cover the verified sites contribution.

Repeat the steps above using also a combination of verified and unverified recurring donations.
Verify that 'Insufficient Funds notifications are not shown if the combined reconcile amount of all verified publishers is under the wallet balance. Likewise make sure the notification is shown if the wallet balance is insufficient.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
