### PR TITLE
Bypass google api key check in translate manager

### DIFF
--- a/chromium_src/components/translate/core/browser/translate_manager.cc
+++ b/chromium_src/components/translate/core/browser/translate_manager.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/translate/core/browser/translate_manager.h"
+
+#define HasAPIKeyConfigured BraveHasAPIKeyConfigured
+#include "../../../../../../components/translate/core/browser/translate_manager.cc" // NOLINT
+#undef HasAPIKeyConfigured
+
+namespace google_apis {
+
+bool BraveHasAPIKeyConfigured() {
+  // Google API key is not used in brave for translation service, always return
+  // true for the API key check so the flow won't be blocked because of missing
+  // keys.
+  return true;
+}
+
+}  // namespace google_apis

--- a/chromium_src/components/translate/core/browser/translate_manager_unittest.cc
+++ b/chromium_src/components/translate/core/browser/translate_manager_unittest.cc
@@ -4,12 +4,17 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "../../../../../../components/translate/core/browser/translate_manager_unittest.cc" // NOLINT
+#include "google_apis/google_api_keys.h"
 
 namespace translate {
 
 namespace testing {
 
 TEST_F(TranslateManagerTest, CanManuallyTranslate_WithoutAPIKey) {
+  const std::string api_key = ::google_apis::GetAPIKey();
+  ::google_apis::SetAPIKeyForTesting("dummytoken");
+  EXPECT_FALSE(::google_apis::HasAPIKeyConfigured());
+
   TranslateManager::SetIgnoreMissingKeyForTesting(false);
   translate_manager_.reset(new translate::TranslateManager(
         &mock_translate_client_,
@@ -23,6 +28,30 @@ TEST_F(TranslateManagerTest, CanManuallyTranslate_WithoutAPIKey) {
 
   translate_manager_->GetLanguageState().LanguageDetermined("de", true);
   EXPECT_TRUE(translate_manager_->CanManuallyTranslate());
+
+  ::google_apis::SetAPIKeyForTesting(api_key);
+}
+
+TEST_F(TranslateManagerTest, CanManuallyTranslate_WithAPIKey) {
+  const std::string api_key = ::google_apis::GetAPIKey();
+  ::google_apis::SetAPIKeyForTesting("notdummytoken");
+  EXPECT_TRUE(::google_apis::HasAPIKeyConfigured());
+
+  TranslateManager::SetIgnoreMissingKeyForTesting(false);
+  translate_manager_.reset(new translate::TranslateManager(
+        &mock_translate_client_,
+        &mock_translate_ranker_,
+        &mock_language_model_));
+
+  prefs_.SetBoolean(prefs::kOfferTranslateEnabled, true);
+  ON_CALL(mock_translate_client_, IsTranslatableURL(GURL::EmptyGURL()))
+          .WillByDefault(Return(true));
+  network_notifier_.SimulateOnline();
+
+  translate_manager_->GetLanguageState().LanguageDetermined("de", true);
+  EXPECT_TRUE(translate_manager_->CanManuallyTranslate());
+
+  ::google_apis::SetAPIKeyForTesting(api_key);
 }
 
 }  // namespace testing

--- a/chromium_src/components/translate/core/browser/translate_manager_unittest.cc
+++ b/chromium_src/components/translate/core/browser/translate_manager_unittest.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "../../../../../../components/translate/core/browser/translate_manager_unittest.cc" // NOLINT
+
+namespace translate {
+
+namespace testing {
+
+TEST_F(TranslateManagerTest, CanManuallyTranslate_WithoutAPIKey) {
+  TranslateManager::SetIgnoreMissingKeyForTesting(false);
+  translate_manager_.reset(new translate::TranslateManager(
+        &mock_translate_client_,
+        &mock_translate_ranker_,
+        &mock_language_model_));
+
+  prefs_.SetBoolean(prefs::kOfferTranslateEnabled, true);
+  ON_CALL(mock_translate_client_, IsTranslatableURL(GURL::EmptyGURL()))
+          .WillByDefault(Return(true));
+  network_notifier_.SimulateOnline();
+
+  translate_manager_->GetLanguageState().LanguageDetermined("de", true);
+  EXPECT_TRUE(translate_manager_->CanManuallyTranslate());
+}
+
+}  // namespace testing
+
+}  // namespace translate

--- a/chromium_src/google_apis/google_api_keys.cc
+++ b/chromium_src/google_apis/google_api_keys.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/chromium_src/google_apis/google_api_keys.h"
+#include "../../../google_apis/google_api_keys.cc" // NOLINT
+
+namespace google_apis {
+
+void SetAPIKeyForTesting(const std::string& api_key) {
+  g_api_key_cache.Get().set_api_key_for_testing(api_key);
+}
+
+}  // namespace google_apis

--- a/chromium_src/google_apis/google_api_keys.h
+++ b/chromium_src/google_apis/google_api_keys.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_GOOGLE_APIS_GOOGLE_API_KEYS_H_
+#define BRAVE_CHROMIUM_SRC_GOOGLE_APIS_GOOGLE_API_KEYS_H_
+
+#include "../../../google_apis/google_api_keys.h"
+#include <string>
+
+namespace google_apis {
+
+void SetAPIKeyForTesting(const std::string& api_key);
+
+}  // namespace google_apis
+
+#endif  // BRAVE_CHROMIUM_SRC_GOOGLE_APIS_GOOGLE_API_KEYS_H_

--- a/patches/google_apis-google_api_keys.cc.patch
+++ b/patches/google_apis-google_api_keys.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/google_apis/google_api_keys.cc b/google_apis/google_api_keys.cc
+index 48aa4820f5658ecc590a84b52b3ea70c70271472..6ad9ef37c463f6c1621b930c196ab2e926b410d5 100644
+--- a/google_apis/google_api_keys.cc
++++ b/google_apis/google_api_keys.cc
+@@ -216,6 +216,7 @@ class APIKeyCache {
+ #if defined(OS_IOS)
+   void set_api_key(const std::string& api_key) { api_key_ = api_key; }
+ #endif
++  void set_api_key_for_testing(const std::string& api_key) { api_key_ = api_key; }
+   std::string api_key_non_stable() const { return api_key_non_stable_; }
+   std::string api_key_remoting_ftl() const { return api_key_remoting_ftl_; }
+ 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -70,6 +70,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/components/metrics/enabled_state_provider_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
+    "//brave/chromium_src/components/translate/core/browser/translate_manager_unittest.cc",
     "//brave/chromium_src/components/version_info/brave_version_info_unittest.cc",
     "//brave/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc",
     "//brave/common/brave_content_client_unittest.cc",
@@ -176,6 +177,7 @@ test("brave_unit_tests") {
     "//content/test:test_support",
     "//components/signin/core/browser",
     "//components/sync_preferences",
+    "//components/translate/core/browser:test_support",
     "//content/public/common",
     "//third_party/cacheinvalidation",
   ]


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/4089
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
npm test brave_unit_tests -- --filter=TranslateManagerTest.CanManuallyTranslate_WithoutAPIKey
manual test steps specified in https://github.com/brave/brave-browser/issues/4089

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
