### PR TITLE
Merge pull request #2213 from brave/bsc-update-sync

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -16,7 +16,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@b8ef1a3f85aec0a0522a9230d59b3958a2150fab",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@42a3630239648383968db17732480f817039e6c1",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@f5c542168cb465615b63d6f9ea21a3fc107eacfb",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@3968d39938a505801ed3c0738e4efadb18037c4d",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@2c0e28f76e4b6f53947bf4faa5afd93614f96aca",


### PR DESCRIPTION
Update sync ref to include fix for https://www.npmjs.com/advisories/803

This is uplift of https://github.com/brave/brave-core/pull/2213 into 0.64.x