### PR TITLE
Make proper native theme observer gets native theme change noti

### DIFF
--- a/patches/ui-native_theme-native_theme_win.cc.patch
+++ b/patches/ui-native_theme-native_theme_win.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/ui/native_theme/native_theme_win.cc b/ui/native_theme/native_theme_win.cc
+index 0df107bf9757a81897e9312a9eba977b8a173646..61e4f4ce671c5e0f92208b54aade903110ddc7a7 100644
+--- a/ui/native_theme/native_theme_win.cc
++++ b/ui/native_theme/native_theme_win.cc
+@@ -1934,7 +1934,11 @@ void NativeThemeWin::RegisterThemeRegkeyObserver() {
+   DCHECK(hkcu_themes_regkey_.Valid());
+   hkcu_themes_regkey_.StartWatching(base::BindOnce(
+       [](NativeThemeWin* native_theme) {
++#if defined(BRAVE_CHROMIUM_BUILD)
++        NotifyProperThemeObserver();
++#else
+         native_theme->NotifyObservers();
++#endif
+         // RegKey::StartWatching only provides one notification. Reregistration
+         // is required to get future notifications.
+         native_theme->RegisterThemeRegkeyObserver();


### PR DESCRIPTION
Chromium supports dark theme on Windows since C74.
So, brave should get proper native theme change noti when os theme
changes because brave uses two native theme - default and native theme
dark aura.

Fix https://github.com/brave/brave-browser/issues/4059

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:
Specified in https://github.com/brave/brave-browser/issues/4059

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
