### PR TITLE
Avoid clobering user input on newtab

### DIFF
--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index 3c26e3145cfbeb4928c98357912c90b7b6c4f669..50bdeeab1c597f55ad35713bface77f2a5d832cc 100644
+index 3c26e3145cfbeb4928c98357912c90b7b6c4f669..08d2fac4f5c3d6a93e87a930d5eaeb85183e2c00 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@

--- a/patches/chrome-browser-global_keyboard_shortcuts_mac.mm.patch
+++ b/patches/chrome-browser-global_keyboard_shortcuts_mac.mm.patch
@@ -2,7 +2,7 @@ diff --git a/chrome/browser/global_keyboard_shortcuts_mac.mm b/chrome/browser/gl
 index 733785418f6e0fd4090f2c5b82517d01982ab8a5..7b8a57bc712fe2ff3c82ad35f8261cc5451afea0 100644
 --- a/chrome/browser/global_keyboard_shortcuts_mac.mm
 +++ b/chrome/browser/global_keyboard_shortcuts_mac.mm
-@@ -166,6 +166,7 @@ const std::vector<KeyboardShortcutData>& GetShortcutsNotPresentInMainMenu() {
+@@ -166,6 +166,7 @@ CommandForKeyEventResult ShortcutCommand(int cmd) {
      {true, false, false, true,  kVK_ANSI_L,             IDC_SHOW_DOWNLOADS},
      {true,  true,  false, false, kVK_ANSI_C,            IDC_DEV_TOOLS_INSPECT},
      {true,  false,  false, true, kVK_ANSI_C,            IDC_DEV_TOOLS_INSPECT},

--- a/patches/chrome-browser-notifications-notification_platform_bridge_mac.mm.patch
+++ b/patches/chrome-browser-notifications-notification_platform_bridge_mac.mm.patch
@@ -2,7 +2,7 @@ diff --git a/chrome/browser/notifications/notification_platform_bridge_mac.mm b/
 index 08078c5f168ebf562fd19c0ebd621f1f7a5a6b5d..8bcd16b11888402fa48926564e13f78657442a05 100644
 --- a/chrome/browser/notifications/notification_platform_bridge_mac.mm
 +++ b/chrome/browser/notifications/notification_platform_bridge_mac.mm
-@@ -226,6 +226,7 @@ void NotificationPlatformBridgeMac::Display(
+@@ -226,6 +226,7 @@ @interface AlertDispatcherImpl : NSObject<AlertDispatcher>
        initWithCloseLabel:l10n_util::GetNSString(IDS_NOTIFICATION_BUTTON_CLOSE)
              optionsLabel:l10n_util::GetNSString(IDS_NOTIFICATION_BUTTON_MORE)
             settingsLabel:l10n_util::GetNSString(

--- a/patches/chrome-browser-ui-browser.cc.patch
+++ b/patches/chrome-browser-ui-browser.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/browser.cc b/chrome/browser/ui/browser.cc
+index 939a669e01d34f83247786cd0a940cbc93cdc6f1..0a66f41df4fd551f907b4b4cadc4e7dda9dbe7e6 100644
+--- a/chrome/browser/ui/browser.cc
++++ b/chrome/browser/ui/browser.cc
+@@ -1121,7 +1121,7 @@ void Browser::SetFocusToLocationBar() {
+   //     the focus.  FocusLocationBar() is only reached when the location bar is
+   //     focusable, but this may be reached at other times, e.g. while in
+   //     fullscreen mode, where we need to leave focus in a consistent state.
+-  window_->SetFocusToLocationBar();
++  window_->SetFocusToLocationBar(false);
+ }
+ 
+ content::KeyboardEventProcessingResult Browser::PreHandleKeyboardEvent(

--- a/patches/chrome-browser-ui-browser_commands.cc.patch
+++ b/patches/chrome-browser-ui-browser_commands.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/browser_commands.cc b/chrome/browser/ui/browser_commands.cc
+index 662ff6224d64249902fac4099b4326df83149997..c2cdd1def36a20747b9b9d056bbf26432926178e 100644
+--- a/chrome/browser/ui/browser_commands.cc
++++ b/chrome/browser/ui/browser_commands.cc
+@@ -1105,7 +1105,7 @@ void FocusToolbar(Browser* browser) {
+ 
+ void FocusLocationBar(Browser* browser) {
+   base::RecordAction(UserMetricsAction("FocusLocation"));
+-  browser->window()->SetFocusToLocationBar();
++  browser->window()->SetFocusToLocationBar(true);
+ }
+ 
+ void FocusSearch(Browser* browser) {

--- a/patches/chrome-browser-ui-browser_window.h.patch
+++ b/patches/chrome-browser-ui-browser_window.h.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/browser_window.h b/chrome/browser/ui/browser_window.h
+index 3f42805e9b42a5bf104b8b37c4fe6e20dbb777e6..f5c499c8c37645888764c79dedbfcfc62c02f408 100644
+--- a/chrome/browser/ui/browser_window.h
++++ b/chrome/browser/ui/browser_window.h
+@@ -241,7 +241,7 @@ class BrowserWindow : public ui::BaseWindow {
+ 
+   // Tries to focus the location bar.  Clears the window focus (to avoid
+   // inconsistent state) if this fails.
+-  virtual void SetFocusToLocationBar() = 0;
++  virtual void SetFocusToLocationBar(bool select_all) = 0;
+ 
+   // Informs the view whether or not a load is in progress for the current tab.
+   // The view can use this notification to update the reload/stop button.

--- a/patches/chrome-browser-ui-cocoa-accelerators_cocoa.mm.patch
+++ b/patches/chrome-browser-ui-cocoa-accelerators_cocoa.mm.patch
@@ -2,7 +2,7 @@ diff --git a/chrome/browser/ui/cocoa/accelerators_cocoa.mm b/chrome/browser/ui/c
 index 37baab628592ff2a2ee93f8af0c2e687d35bab42..2145c7b6463628dcea7e0a8b4826d90e00b251d0 100644
 --- a/chrome/browser/ui/cocoa/accelerators_cocoa.mm
 +++ b/chrome/browser/ui/cocoa/accelerators_cocoa.mm
-@@ -40,6 +40,8 @@ const struct AcceleratorMapping {
+@@ -40,6 +40,8 @@
       ui::VKEY_N},
      {IDC_NEW_TAB, ui::EF_COMMAND_DOWN, ui::VKEY_T},
      {IDC_NEW_WINDOW, ui::EF_COMMAND_DOWN, ui::VKEY_N},

--- a/patches/chrome-browser-ui-location_bar-location_bar.h.patch
+++ b/patches/chrome-browser-ui-location_bar-location_bar.h.patch
@@ -1,7 +1,16 @@
 diff --git a/chrome/browser/ui/location_bar/location_bar.h b/chrome/browser/ui/location_bar/location_bar.h
-index 239d3bac4ecff88a3a12b5cc6cf1c2fa8ff0c500..5d5072c10236b2e324f756c069cf98ac767f968e 100644
+index 239d3bac4ecff88a3a12b5cc6cf1c2fa8ff0c500..070bacb8c9cf9e832bb2358deb62f678f41c33c3 100644
 --- a/chrome/browser/ui/location_bar/location_bar.h
 +++ b/chrome/browser/ui/location_bar/location_bar.h
+@@ -45,7 +45,7 @@ class LocationBar {
+   virtual void AcceptInput(base::TimeTicks match_selection_timestamp) = 0;
+ 
+   // Focuses the location bar and selects its contents.
+-  virtual void FocusLocation() = 0;
++  virtual void FocusLocation(bool select_all) = 0;
+ 
+   // Puts the user into keyword mode with their default search provider.
+   virtual void FocusSearch() = 0;
 @@ -81,7 +81,7 @@ class LocationBar {
    virtual ~LocationBar();
  

--- a/patches/chrome-browser-ui-views-frame-browser_view.cc.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_view.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/ui/views/frame/browser_view.cc b/chrome/browser/ui/views/frame/browser_view.cc
+index 5d0eb9abffb86b584d96b89feec0b25119b883e7..ddf77fc72f61c9c9f18648410c0972795d89c4a1 100644
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -1121,7 +1121,7 @@ LocationBar* BrowserView::GetLocationBar() const {
+   return GetLocationBarView();
+ }
+ 
+-void BrowserView::SetFocusToLocationBar() {
++void BrowserView::SetFocusToLocationBar(bool select_all) {
+   // On Windows, changing focus to the location bar causes the browser window to
+   // become active. This can steal focus if the user has another window open
+   // already. On Chrome OS, changing focus makes a view believe it has a focus
+@@ -1133,7 +1133,7 @@ void BrowserView::SetFocusToLocationBar() {
+ #endif
+ 
+   LocationBarView* location_bar = GetLocationBarView();
+-  location_bar->FocusLocation();
++  location_bar->FocusLocation(select_all);
+   if (!location_bar->omnibox_view()->HasFocus()) {
+     // If none of location bar got focus, then clear focus.
+     views::FocusManager* focus_manager = GetFocusManager();

--- a/patches/chrome-browser-ui-views-frame-browser_view.h.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_view.h.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/frame/browser_view.h b/chrome/browser/ui/views/frame/browser_view.h
+index 417ba26f75d9637856ace03b791b4fd6b5aad822..2c35cf8efc2785ef96e7ef5650ea1624b675082d 100644
+--- a/chrome/browser/ui/views/frame/browser_view.h
++++ b/chrome/browser/ui/views/frame/browser_view.h
+@@ -341,7 +341,7 @@ class BrowserView : public BrowserWindow,
+   bool IsFullscreenBubbleVisible() const override;
+   PageActionIconContainer* GetPageActionIconContainer() override;
+   LocationBar* GetLocationBar() const override;
+-  void SetFocusToLocationBar() override;
++  void SetFocusToLocationBar(bool select_all) override;
+   void UpdateReloadStopState(bool is_loading, bool force) override;
+   void UpdateToolbar(content::WebContents* contents) override;
+   void UpdateToolbarVisibility(bool visible, bool animate) override;

--- a/patches/chrome-browser-ui-views-location_bar-location_bar_view.cc.patch
+++ b/patches/chrome-browser-ui-views-location_bar-location_bar_view.cc.patch
@@ -1,8 +1,26 @@
 diff --git a/chrome/browser/ui/views/location_bar/location_bar_view.cc b/chrome/browser/ui/views/location_bar/location_bar_view.cc
-index 10bea76273f59c769553722bc2070850ed872d6b..d34a76d834e144ec35aeae55e391d241bd31c71c 100644
+index 10bea76273f59c769553722bc2070850ed872d6b..eee3a12ac8dbc2f7c4cf868b27a86271aa6b5522 100644
 --- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
 +++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
-@@ -424,7 +424,7 @@ gfx::Size LocationBarView::CalculatePreferredSize() const {
+@@ -337,13 +337,16 @@ void LocationBarView::SelectAll() {
+ ////////////////////////////////////////////////////////////////////////////////
+ // LocationBarView, public LocationBar implementation:
+ 
+-void LocationBarView::FocusLocation() {
++void LocationBarView::FocusLocation(bool select_all) {
+   const bool omnibox_already_focused = omnibox_view_->HasFocus();
+ 
+   omnibox_view_->SetFocus();
+   if (omnibox_already_focused)
+     omnibox_view()->model()->ClearKeyword();
+ 
++  if (!select_all)
++    return;
++
+   omnibox_view_->SelectAll(true);
+ 
+   // Only exit Query in Omnibox mode on focus command if the location bar was
+@@ -424,7 +427,7 @@ gfx::Size LocationBarView::CalculatePreferredSize() const {
    return gfx::Size(width, height);
  }
  
@@ -11,7 +29,7 @@ index 10bea76273f59c769553722bc2070850ed872d6b..d34a76d834e144ec35aeae55e391d241
    if (!IsInitialized())
      return;
  
-@@ -517,6 +517,11 @@ void LocationBarView::Layout() {
+@@ -517,6 +520,11 @@ void LocationBarView::Layout() {
      }
    };
  
@@ -23,3 +41,12 @@ index 10bea76273f59c769553722bc2070850ed872d6b..d34a76d834e144ec35aeae55e391d241
    if (star_view_)
      add_trailing_decoration(star_view_);
    add_trailing_decoration(page_action_icon_container_view_);
+@@ -1186,7 +1194,7 @@ void LocationBarView::OnOmniboxHovered(bool is_hovering) {
+ // LocationBarView, private DropdownBarHostDelegate implementation:
+ 
+ void LocationBarView::FocusAndSelectAll() {
+-  FocusLocation();
++  FocusLocation(true);
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////

--- a/patches/chrome-browser-ui-views-location_bar-location_bar_view.h.patch
+++ b/patches/chrome-browser-ui-views-location_bar-location_bar_view.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/location_bar/location_bar_view.h b/chrome/browser/ui/views/location_bar/location_bar_view.h
-index 7550088b46f3cb5a731c10f680fd47c42fc12746..90de2ac7d98d2a3f2500556c4f487be3c9d281c7 100644
+index 7550088b46f3cb5a731c10f680fd47c42fc12746..3e5b98d09c7477a09fd0a31d38ab8f3a76f8b31e 100644
 --- a/chrome/browser/ui/views/location_bar/location_bar_view.h
 +++ b/chrome/browser/ui/views/location_bar/location_bar_view.h
 @@ -114,6 +114,7 @@ class LocationBarView : public LocationBar,
@@ -18,6 +18,15 @@ index 7550088b46f3cb5a731c10f680fd47c42fc12746..90de2ac7d98d2a3f2500556c4f487be3
    void Update(const content::WebContents* contents);
  
    // Clears the location bar's state for |contents|.
+@@ -201,7 +203,7 @@ class LocationBarView : public LocationBar,
+   bool ActivateFirstInactiveBubbleForAccessibility();
+ 
+   // LocationBar:
+-  void FocusLocation() override;
++  void FocusLocation(bool select_all) override;
+   void Revert() override;
+   OmniboxView* GetOmniboxView() override;
+ 
 @@ -210,6 +212,7 @@ class LocationBarView : public LocationBar,
    void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
    gfx::Size GetMinimumSize() const override;

--- a/patches/chrome-browser-ui-views-toolbar-toolbar_view.cc.patch
+++ b/patches/chrome-browser-ui-views-toolbar-toolbar_view.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/toolbar/toolbar_view.cc b/chrome/browser/ui/views/toolbar/toolbar_view.cc
+index fa70d696076a6bc031ce5980d291d0443c3fa2b0..c5d8d916ce0d3431cf367511ef88d5fb6ed35334 100644
+--- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
++++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
+@@ -593,7 +593,7 @@ void ToolbarView::ChildPreferredSizeChanged(views::View* child) {
+ bool ToolbarView::SetPaneFocusAndFocusDefault() {
+   if (!location_bar_->HasFocus()) {
+     SetPaneFocus(location_bar_);
+-    location_bar_->FocusLocation();
++    location_bar_->FocusLocation(true);
+     return true;
+   }
+ 

--- a/patches/chrome-test-base-test_browser_window.h.patch
+++ b/patches/chrome-test-base-test_browser_window.h.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/test/base/test_browser_window.h b/chrome/test/base/test_browser_window.h
+index 72d532db62eda2618ab5b581ee9ffbde68b9d05b..2745c291a6b0bbdfa099b763546089bb4fd85462 100644
+--- a/chrome/test/base/test_browser_window.h
++++ b/chrome/test/base/test_browser_window.h
+@@ -88,7 +88,7 @@ class TestBrowserWindow : public BrowserWindow {
+   bool IsFullscreenBubbleVisible() const override;
+   LocationBar* GetLocationBar() const override;
+   PageActionIconContainer* GetPageActionIconContainer() override;
+-  void SetFocusToLocationBar() override {}
++  void SetFocusToLocationBar(bool select_all) override {}
+   void UpdateReloadStopState(bool is_loading, bool force) override {}
+   void UpdateToolbar(content::WebContents* contents) override {}
+   void UpdateToolbarVisibility(bool visible, bool animate) override {}
+@@ -195,7 +195,7 @@ class TestBrowserWindow : public BrowserWindow {
+     base::TimeTicks GetMatchSelectionTimestamp() const override;
+     void AcceptInput() override {}
+     void AcceptInput(base::TimeTicks match_selection_timestamp) override {}
+-    void FocusLocation() override {}
++    void FocusLocation(bool select_all) override {}
+     void FocusSearch() override {}
+     void UpdateContentSettingsIcons() override {}
+     void UpdateSaveCreditCardIcon() override {}

--- a/patches/components-crash-content-app-crashpad_mac.mm.patch
+++ b/patches/components-crash-content-app-crashpad_mac.mm.patch
@@ -2,7 +2,7 @@ diff --git a/components/crash/content/app/crashpad_mac.mm b/components/crash/con
 index a76d264648d23e7e228dd54f00a01035a29a76ad..ee7d94be5982353fced6174afef990713228af37 100644
 --- a/components/crash/content/app/crashpad_mac.mm
 +++ b/components/crash/content/app/crashpad_mac.mm
-@@ -136,6 +136,8 @@ base::FilePath PlatformCrashpadInitialization(
+@@ -136,6 +136,8 @@ void DumpProcessWithoutCrashing(task_t task_port) {
        // Only allow the possibility of report upload in official builds. This
        // crash server won't have symbols for any other build types.
        std::string url = "https://clients2.google.com/cr/report";

--- a/patches/components-os_crypt-keychain_password_mac.mm.patch
+++ b/patches/components-os_crypt-keychain_password_mac.mm.patch
@@ -10,7 +10,7 @@ index 73cd30591119969e5de1b2de56b984e54cdf6bac..4d14a957e73354cf79fabb0bb1be9bda
  #include "base/mac/mac_logging.h"
  #include "base/mac/scoped_cftyperef.h"
  #include "base/rand_util.h"
-@@ -51,8 +52,8 @@ std::string AddRandomPasswordToKeychain(const AppleKeychain& keychain,
+@@ -51,8 +52,8 @@
  const char KeychainPassword::service_name[] = "Chrome Safe Storage";
  const char KeychainPassword::account_name[] = "Chrome";
  #else
@@ -21,7 +21,7 @@ index 73cd30591119969e5de1b2de56b984e54cdf6bac..4d14a957e73354cf79fabb0bb1be9bda
  #endif
  
  KeychainPassword::KeychainPassword(
-@@ -63,31 +64,50 @@ KeychainPassword::KeychainPassword(
+@@ -63,31 +64,50 @@
  KeychainPassword::~KeychainPassword() = default;
  
  std::string KeychainPassword::GetPassword() const {

--- a/patches/components-os_crypt-os_crypt_mac.mm.patch
+++ b/patches/components-os_crypt-os_crypt_mac.mm.patch
@@ -2,7 +2,7 @@ diff --git a/components/os_crypt/os_crypt_mac.mm b/components/os_crypt/os_crypt_
 index 88304b2c3865ea3b126789f6a976d8bae4aa50ba..43dc62d9b829dbfbb605e7bfbf30cc0180daafc5 100644
 --- a/components/os_crypt/os_crypt_mac.mm
 +++ b/components/os_crypt/os_crypt_mac.mm
-@@ -100,6 +100,10 @@ crypto::SymmetricKey* GetEncryptionKey() {
+@@ -100,6 +100,10 @@
      DCHECK(!g_key_creation_util);
      g_key_creation_util = new os_crypt::EncryptionKeyCreationUtilIOS();
  #endif

--- a/patches/ui-native_theme-native_theme_mac.mm.patch
+++ b/patches/ui-native_theme-native_theme_mac.mm.patch
@@ -2,7 +2,7 @@ diff --git a/ui/native_theme/native_theme_mac.mm b/ui/native_theme/native_theme_
 index de3389fac98a708420374851dbf7c0970cb68102..32ca3fede8784b0f519174f314c302761dd0be75 100644
 --- a/ui/native_theme/native_theme_mac.mm
 +++ b/ui/native_theme/native_theme_mac.mm
-@@ -55,7 +55,11 @@
+@@ -55,7 +55,11 @@ - (void)observeValueForKeyPath:(NSString*)forKeyPath
                        ofObject:(id)object
                          change:(NSDictionary*)change
                         context:(void*)context {


### PR DESCRIPTION
This just pulls in a fix that was done upstream in C75 into C74.
The upstream fix will happen in 75.0.3760.0, at which point we can drop these patches.

Fix https://github.com/brave/brave-browser/issues/3756

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
