### PR TITLE
Twitch channels in auto-contribute list with an underscore character are now linked correctly

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/media/twitch.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/media/twitch.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "base/gtest_prod_util.h"
 #include "bat/ledger/ledger.h"
@@ -41,7 +42,7 @@ class MediaTwitch : public ledger::LedgerCallbackHandler {
                                  const std::string& referrer);
 
  private:
-  static std::string GetMediaIdFromParts(
+  static std::pair<std::string, std::string> GetMediaIdFromParts(
       const std::map<std::string, std::string>& parts);
 
   static std::string GetMediaURL(const std::string& mediaId);
@@ -77,6 +78,7 @@ class MediaTwitch : public ledger::LedgerCallbackHandler {
     const ledger::TwitchEventInfo& twitch_info,
     const ledger::VisitData& visit_data,
     const uint64_t window_id,
+    const std::string& user_id,
     ledger::Result result,
     std::unique_ptr<ledger::PublisherInfo> publisher_info);
 
@@ -90,6 +92,7 @@ class MediaTwitch : public ledger::LedgerCallbackHandler {
     const std::string& media_url,
     const ledger::VisitData& visit_data,
     const uint64_t window_id,
+    const std::string& user_id,
     int response_status_code,
     const std::string& response,
     const std::map<std::string, std::string>& headers);


### PR DESCRIPTION
Fixes brave/brave-browser#4045

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone

## Test Plan:

1. Start Brave, enable Rewards
2. go to https://twitch.tv/anatomyz_2
3. View live stream for required time and check database and ensure that `publisher_id` and `url` point to correct publisher (`activity_info`, `publisher_info` and `media_publisher_info`
4. Go to videos and view a VOD
5. Ensure that `publisher_id` and `url` point to correct publisher
6. Go to Rewards page and make sure that publisher is listed in ac table and that clicking on it takes you to correct publisher page.
7. Tip publisher's live stream and ensure `pending_contributions` has correct `publisher_id`
8. Repeat with VOD
9. If available, repeat tip with a verified publisher with an underscore in the middle of it's user id and ensure that `contribution_info->publisher_id` points to correct publisher


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source
