### PR TITLE
Run dark mode test only on mojave

### DIFF
--- a/browser/ui/brave_dark_mode_observer_browsertest_mac.mm
+++ b/browser/ui/brave_dark_mode_observer_browsertest_mac.mm
@@ -27,23 +27,25 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 // Test whether DarkModeObserver observes proper NativeTheme.
 IN_PROC_BROWSER_TEST_F(BraveDarkModeObserverTest,
                        ObserveProperNativeThemeTest) {
-  base::test::ScopedFeatureList features;
-  features.InitAndEnableFeature(features::kWebUIDarkMode);
+  if (@available(macOS 10.14, *)) {
+    base::test::ScopedFeatureList features;
+    features.InitAndEnableFeature(features::kWebUIDarkMode);
 
-  Profile* profile = browser()->profile();
+    Profile* profile = browser()->profile();
 
-  // Load webui to instantiate BraveDarkModeObserver.
-  AddTabAtIndexToBrowser(
-      browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
+    // Load webui to instantiate BraveDarkModeObserver.
+    AddTabAtIndexToBrowser(
+        browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
 
-  // Initially set to light.
-  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
-  EXPECT_EQ(
-      ui::NativeTheme::GetInstanceForNativeUi(),
-      BraveDarkModeObserver::current_native_theme_for_testing_);
+    // Initially set to light.
+    SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+    EXPECT_EQ(
+        ui::NativeTheme::GetInstanceForNativeUi(),
+        BraveDarkModeObserver::current_native_theme_for_testing_);
 
-  SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
-  EXPECT_EQ(
-      ui::NativeThemeDarkAura::instance(),
-      BraveDarkModeObserver::current_native_theme_for_testing_);
+    SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+    EXPECT_EQ(
+        ui::NativeThemeDarkAura::instance(),
+        BraveDarkModeObserver::current_native_theme_for_testing_);
+  }
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -308,7 +308,7 @@ test("brave_browser_tests") {
     "//brave/browser/renderer_context_menu/brave_mock_render_view_context_menu.h",
     "//brave/browser/renderer_context_menu/brave_spelling_menu_observer_browsertest.cc",
     "//brave/browser/search_engines/search_engine_provider_service_browsertest.cc",
-    "//brave/browser/ui/brave_dark_mode_observer_browsertest_mac.cc",
+    "//brave/browser/ui/brave_dark_mode_observer_browsertest_mac.mm",
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",
     "//brave/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc",


### PR DESCRIPTION
Uplift https://github.com/brave/brave-core/pull/2202
Fix brave/brave-browser#4073
