### PR TITLE
Have `create-uplift-prs` Jenkins job assign `uplift-approvers` group instead of individuals

### DIFF
--- a/script/uplift.py
+++ b/script/uplift.py
@@ -42,7 +42,7 @@ class PrConfig:
     branches_to_push = []
     master_pr_number = -1
     github_token = None
-    reviewers = ['bbondy', 'bsclifton', 'kjozwiak', 'rebron', 'srirambv']
+    team_reviewers = ['uplift-approvers']
     parsed_owners = []
     milestones = None
     title = None
@@ -445,7 +445,7 @@ def submit_pr(channel, top_level_base, remote_base, local_branch):
 
         # assign milestone / reviewer(s) / owner(s)
         add_reviewers_to_pull_request(config.github_token, BRAVE_CORE_REPO, number,
-                                      reviewers=config.reviewers,
+                                      team_reviewers=config.team_reviewers,
                                       verbose=config.is_verbose, dryrun=config.is_dryrun)
         set_issue_details(config.github_token, BRAVE_CORE_REPO, number, milestone_number,
                           config.parsed_owners, config.labels,


### PR DESCRIPTION
This reverts commit 9500b116326560d2186324b62c866823d4816a92, reversing
changes made to 8167ade2296e6c323da767951c810473d9c00139.

## Notes
- The `create-uplift-prs` job runs as the [brave-builds](https://github.com/brave-builds) user
- `brave-builds` is granted `Admin` access on both `brave-browser` and `brave-core` under collaborators
    <img width="435" alt="Screen Shot 2019-04-17 at 9 18 54 AM" src="https://user-images.githubusercontent.com/4733304/56304019-04c6cb80-60f2-11e9-9374-1413627696ad.png">
- `brave-builds` is **not** a [member of the Brave org](https://github.com/orgs/brave/people)
- per GitHub API limitations, only users with org `member` status can assign team reviewers. More details available in https://github.com/brave/brave-core/pull/1857

## Actions needed before merging
- [x] Add `brave-builds` to the Brave org
- [x] Update Jenkins job to point at this branch
- [x] Test an uplift; verify it uses `uplift-approvers` instead of the individual names