### PR TITLE
Strip xorigin top-level navigation referrers instead of spoofing

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -282,6 +282,7 @@ void BraveContentBrowserClient::MaybeHideReferrer(
     content::BrowserContext* browser_context,
     const GURL& request_url,
     const GURL& document_url,
+    bool is_main_frame,
     content::Referrer* referrer) {
   DCHECK(referrer);
   if (document_url.SchemeIs(kChromeExtensionScheme)) {
@@ -295,9 +296,15 @@ void BraveContentBrowserClient::MaybeHideReferrer(
   const bool shields_up = brave_shields::IsAllowContentSettingsForProfile(
       profile, document_url, GURL(), CONTENT_SETTINGS_TYPE_PLUGINS,
       brave_shields::kBraveShields);
+  // Top-level navigations get empty referrers (brave/brave-browser#3422).
+  GURL replacement_referrer_url;
+  if (!is_main_frame) {
+    // But iframe navigations get spoofed instead (brave/brave-browser#3988).
+    replacement_referrer_url = request_url.GetOrigin();
+  }
   brave_shields::ShouldSetReferrer(
       allow_referrers, shields_up, referrer->url, document_url, request_url,
-      request_url.GetOrigin(), referrer->policy, referrer);
+      replacement_referrer_url, referrer->policy, referrer);
 }
 
 GURL BraveContentBrowserClient::GetEffectiveURL(

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -73,6 +73,7 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
   void MaybeHideReferrer(content::BrowserContext* browser_context,
                          const GURL& request_url,
                          const GURL& document_url,
+                         bool is_main_frame,
                          content::Referrer* referrer) override;
 
   GURL GetEffectiveURL(content::BrowserContext* browser_context,

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -474,22 +474,45 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientReferrerTest,
                        DefaultBehaviour) {
   const GURL kRequestUrl("http://request.com/path?query");
   const GURL kDocumentUrl("http://document.com/path?query");
+  const GURL kSameOriginRequestUrl("http://document.com/different/path");
 
   content::Referrer kReferrer(kDocumentUrl,
                               network::mojom::ReferrerPolicy::kDefault);
 
-  // Should be hidden by default.
+  // Cross-origin navigations don't get a referrer.
   content::Referrer referrer = kReferrer;
   client()->MaybeHideReferrer(browser()->profile(),
-                              kRequestUrl, kDocumentUrl,
+                              kRequestUrl, kDocumentUrl, true,
+                              &referrer);
+  EXPECT_EQ(referrer.url, GURL());
+
+  // Same-origin navigations get full referrers.
+  referrer = kReferrer;
+  client()->MaybeHideReferrer(browser()->profile(),
+                              kSameOriginRequestUrl, kDocumentUrl, true,
+                              &referrer);
+  EXPECT_EQ(referrer.url, kDocumentUrl);
+
+  // Cross-origin iframe navigations get a spoofed referrer.
+  referrer = kReferrer;
+  client()->MaybeHideReferrer(browser()->profile(),
+                              kRequestUrl, kDocumentUrl, false,
                               &referrer);
   EXPECT_EQ(referrer.url, kRequestUrl.GetOrigin());
 
+  // Same-origin iframe navigations get full referrers.
+  referrer = kReferrer;
+  client()->MaybeHideReferrer(browser()->profile(),
+                              kSameOriginRequestUrl, kDocumentUrl, false,
+                              &referrer);
+  EXPECT_EQ(referrer.url, kDocumentUrl);
+
   // Special rule for extensions.
   const GURL kExtensionUrl("chrome-extension://abc/path?query");
+  referrer = kReferrer;
   referrer.url = kExtensionUrl;
   client()->MaybeHideReferrer(browser()->profile(),
-                              kRequestUrl, kExtensionUrl,
+                              kRequestUrl, kExtensionUrl, true,
                               &referrer);
   EXPECT_EQ(referrer.url, kExtensionUrl);
 
@@ -501,7 +524,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientReferrerTest,
       brave_shields::kReferrers, CONTENT_SETTING_ALLOW);
   referrer = kReferrer;
   client()->MaybeHideReferrer(browser()->profile(),
-                              kRequestUrl, kDocumentUrl,
+                              kRequestUrl, kDocumentUrl, true,
                               &referrer);
   EXPECT_EQ(referrer.url, kDocumentUrl);
 }

--- a/patches/content-browser-frame_host-navigation_request.cc.patch
+++ b/patches/content-browser-frame_host-navigation_request.cc.patch
@@ -1,14 +1,15 @@
 diff --git a/content/browser/frame_host/navigation_request.cc b/content/browser/frame_host/navigation_request.cc
-index ff845a4963826736b6030d7179a70dcd9d74d241..466cc388c20feafd1cc7ff53accef95e68a97911 100644
+index ff845a4963826736b6030d7179a70dcd9d74d241..72860a693c51b25e8dc06c841806d2501bb3e9c0 100644
 --- a/content/browser/frame_host/navigation_request.cc
 +++ b/content/browser/frame_host/navigation_request.cc
-@@ -1593,6 +1593,11 @@ void NavigationRequest::OnStartChecksComplete(
+@@ -1593,6 +1593,12 @@ void NavigationRequest::OnStartChecksComplete(
    headers.MergeFrom(navigation_handle_->TakeModifiedRequestHeaders());
    begin_params_->headers = headers.ToString();
  
 +  GetContentClient()->browser()->MaybeHideReferrer(browser_context,
 +                                                   common_params_.url,
 +                                                   top_document_url,
++                                                   frame_tree_node_->IsMainFrame(),
 +                                                   &common_params_.referrer);
 +
    loader_ = NavigationURLLoader::Create(

--- a/patches/content-public-browser-content_browser_client.h.patch
+++ b/patches/content-public-browser-content_browser_client.h.patch
@@ -1,16 +1,17 @@
 diff --git a/content/public/browser/content_browser_client.h b/content/public/browser/content_browser_client.h
-index 009991aa57e8f543d2fdb7095b2fe2c863373d71..00ab100aa8c17e4614f808ac2c0e2eea709c8243 100644
+index 009991aa57e8f543d2fdb7095b2fe2c863373d71..fddf6126c84e95c057301d69d7d297180c618050 100644
 --- a/content/public/browser/content_browser_client.h
 +++ b/content/public/browser/content_browser_client.h
-@@ -1516,6 +1516,13 @@ class CONTENT_EXPORT ContentBrowserClient {
+@@ -1516,6 +1516,14 @@ class CONTENT_EXPORT ContentBrowserClient {
    virtual ui::AXMode GetAXModeForBrowserContext(
        BrowserContext* browser_context);
  
-+  // Brave-speicific: allows the embedder to modify the referrer string
++  // Brave-specific: allows the embedder to modify the referrer string
 +  // according to user preferences.
 +  virtual void MaybeHideReferrer(BrowserContext* browser_context,
 +                                 const GURL& request_url,
 +                                 const GURL& document_url,
++                                 bool is_main_frame,
 +                                 Referrer* referrer) {}
 +
  #if defined(OS_ANDROID)

--- a/renderer/brave_content_settings_observer_browsertest.cc
+++ b/renderer/brave_content_settings_observer_browsertest.cc
@@ -17,6 +17,8 @@
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_types.h"
 #include "net/dns/mock_host_resolver.h"
+#include "net/http/http_request_headers.h"
+#include "net/test/embedded_test_server/http_request.h"
 
 const char kIframeID[] = "test";
 
@@ -61,15 +63,52 @@ class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
       base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
       embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
 
+      embedded_test_server()->RegisterRequestMonitor(
+          base::BindRepeating(
+              &BraveContentSettingsObserverBrowserTest::SaveReferrer,
+              base::Unretained(this)));
+
       ASSERT_TRUE(embedded_test_server()->Start());
 
       url_ = embedded_test_server()->GetURL("a.com", "/iframe.html");
       iframe_url_ = embedded_test_server()->GetURL("b.com", "/simple.html");
+      image_url_ = embedded_test_server()->GetURL("b.com", "/logo.png");
       top_level_page_pattern_ =
           ContentSettingsPattern::FromString("http://a.com/*");
       iframe_pattern_ = ContentSettingsPattern::FromString("http://b.com/*");
       first_party_pattern_ =
           ContentSettingsPattern::FromString("https://firstParty/*");
+    }
+
+    void SaveReferrer(const net::test_server::HttpRequest& request) {
+      base::AutoLock auto_lock(last_referrers_lock_);
+
+      // Replace "127.0.0.1:<port>" with the hostnames used in this test.
+      net::test_server::HttpRequest::HeaderMap::const_iterator pos =
+          request.headers.find(net::HttpRequestHeaders::kHost);
+      GURL::Replacements replace_host;
+      if (pos != request.headers.end()) {
+        replace_host.SetHostStr(pos->second);
+        replace_host.SetPortStr("");  // Host header includes the port already.
+      }
+      GURL request_url = request.GetURL();
+      request_url = request_url.ReplaceComponents(replace_host);
+
+      pos = request.headers.find(net::HttpRequestHeaders::kReferer);
+      if (pos == request.headers.end()) {
+        last_referrers_[request_url] = "";  // no referrer
+      } else {
+        last_referrers_[request_url] = pos->second;
+      }
+    }
+
+    std::string GetLastReferrer(const GURL& url) const {
+      base::AutoLock auto_lock(last_referrers_lock_);
+      auto pos = last_referrers_.find(url);
+      if (pos == last_referrers_.end()) {
+        return "(missing)";  // Fail test if we haven't seen this URL before.
+      }
+      return pos->second;
     }
 
     void TearDown() override {
@@ -79,6 +118,18 @@ class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
 
     const GURL& url() { return url_; }
     const GURL& iframe_url() { return iframe_url_; }
+    const GURL& image_url() { return image_url_; }
+
+    std::string create_image_script() {
+      std::string s;
+      s = " var img = document.createElement('img');"
+          " img.onload = function () {"
+          "   domAutomationController.send(img.src);"
+          " };"
+          " img.src = '" + image_url().spec() + "';"
+          " document.body.appendChild(img);";
+      return s;
+    }
 
     const ContentSettingsPattern& top_level_page_pattern() {
       return top_level_page_pattern_;
@@ -269,11 +320,14 @@ class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
   private:
     GURL url_;
     GURL iframe_url_;
+    GURL image_url_;
     ContentSettingsPattern top_level_page_pattern_;
     ContentSettingsPattern first_party_pattern_;
     ContentSettingsPattern iframe_pattern_;
     std::unique_ptr<ChromeContentClient> content_client_;
     std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+    mutable base::Lock last_referrers_lock_;
+    std::map<GURL, std::string> last_referrers_;
 
     base::ScopedTempDir temp_user_data_dir_;
 };
@@ -472,35 +526,66 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
   EXPECT_EQ(settings.size(), 0u) <<
       "There should not be any visible referrer rules.";
 
+  // The initial navigation doesn't have a referrer.
   NavigateToPageWithIframe();
-
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript,
       contents()).c_str(), "");
+  EXPECT_TRUE(GetLastReferrer(url()).empty());
+
+  // Sub-resources loaded within the page get their referrer spoofed.
+  EXPECT_EQ(ExecScriptGetStr(create_image_script(), contents()),
+            image_url().spec());
+  EXPECT_EQ(GetLastReferrer(image_url()), iframe_url().GetOrigin().spec());
+
+  // Cross-origin iframe navigations get their referrer spoofed.
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript,
       child_frame()).c_str(), iframe_url().GetOrigin().spec().c_str());
+  EXPECT_EQ(GetLastReferrer(iframe_url()), iframe_url().GetOrigin().spec());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrer) {
   BlockReferrers();
+
+  // The initial navigation doesn't have a referrer.
   NavigateToPageWithIframe();
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript,
       contents()).c_str(), "");
+  EXPECT_TRUE(GetLastReferrer(url()).empty());
+
+  // Sub-resources loaded within the page get their referrer spoofed.
+  EXPECT_EQ(ExecScriptGetStr(create_image_script(), contents()),
+            image_url().spec());
+  EXPECT_EQ(GetLastReferrer(image_url()), image_url().GetOrigin().spec());
+
+  // Cross-origin iframe navigations get their referrer spoofed.
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript, child_frame()).c_str(),
       iframe_url().GetOrigin().spec().c_str());
+  EXPECT_EQ(GetLastReferrer(iframe_url()), iframe_url().GetOrigin().spec());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowReferrer) {
   AllowReferrers();
-  NavigateToPageWithIframe();
 
+  // The initial navigation doesn't have a referrer.
+  NavigateToPageWithIframe();
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript,
       contents()).c_str(), "");
+  EXPECT_TRUE(GetLastReferrer(url()).empty());
+
+  // Sub-resources loaded within the page get the page URL as referrer.
+  EXPECT_EQ(ExecScriptGetStr(create_image_script(), contents()),
+            image_url().spec());
+  EXPECT_EQ(GetLastReferrer(image_url()), url().spec());
+
+  // A cross-origin iframe navigation gets the URL of the first one as
+  // referrer.
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
+  EXPECT_EQ(GetLastReferrer(iframe_url()), url());
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript, child_frame()).c_str(),
       url().spec().c_str());
 }
@@ -508,11 +593,23 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowReferrer) {
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrerShieldsDown) {
   BlockReferrers();
   ShieldsDown();
+
+  // The initial navigation doesn't have a referrer.
   NavigateToPageWithIframe();
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript,
       contents()).c_str(), "");
+  EXPECT_TRUE(GetLastReferrer(url()).empty());
+
+  // Sub-resources loaded within the page get the page URL as referrer.
+  EXPECT_EQ(ExecScriptGetStr(create_image_script(), contents()),
+            image_url().spec());
+  EXPECT_EQ(GetLastReferrer(image_url()), url().spec());
+
+  // A cross-origin iframe navigation gets the URL of the first one as
+  // referrer.
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
+  EXPECT_EQ(GetLastReferrer(iframe_url()), url());
   EXPECT_STREQ(ExecScriptGetStr(kReferrerScript, child_frame()).c_str(),
       url().spec().c_str());
 }

--- a/renderer/brave_content_settings_observer_browsertest.cc
+++ b/renderer/brave_content_settings_observer_browsertest.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -46,7 +47,7 @@ const char kReferrerScript[] =
     "domAutomationController.send(document.referrer);";
 
 class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
-  public:
+ public:
     void SetUpOnMainThread() override {
       InProcessBrowserTest::SetUpOnMainThread();
 
@@ -317,7 +318,7 @@ class BraveContentSettingsObserverBrowserTest : public InProcessBrowserTest {
       return WaitForLoadStop(contents());
     }
 
-  private:
+ private:
     GURL url_;
     GURL iframe_url_;
     GURL image_url_;
@@ -425,7 +426,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
   EXPECT_FALSE(isPointInPath);
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockFPShieldsDown) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       BlockFPShieldsDown) {
   BlockFingerprinting();
   ShieldsDown();
 
@@ -449,7 +451,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockFPShieldsDo
   EXPECT_TRUE(isPointInPath);
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, Block3PFPGetImageData) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       Block3PFPGetImageData) {
   Block3PFingerprinting();
 
   ContentSettingsForOneType fp_settings;
@@ -472,7 +475,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, Block3PFPGetImag
   EXPECT_EQ(0, bufLen);
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockFPGetImageData) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       BlockFPGetImageData) {
   BlockFingerprinting();
 
   ContentSettingsForOneType fp_settings;
@@ -495,7 +499,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockFPGetImageD
   EXPECT_EQ(0, bufLen);
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowFPGetImageData) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       AllowFPGetImageData) {
   AllowFingerprinting();
 
   ContentSettingsForOneType fp_settings;
@@ -545,7 +550,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
   EXPECT_EQ(GetLastReferrer(iframe_url()), iframe_url().GetOrigin().spec());
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrer) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       BlockReferrer) {
   BlockReferrers();
 
   // The initial navigation doesn't have a referrer.
@@ -567,7 +573,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrer) {
   EXPECT_EQ(GetLastReferrer(iframe_url()), iframe_url().GetOrigin().spec());
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowReferrer) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       AllowReferrer) {
   AllowReferrers();
 
   // The initial navigation doesn't have a referrer.
@@ -590,7 +597,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowReferrer) {
       url().spec().c_str());
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockReferrerShieldsDown) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       BlockReferrerShieldsDown) {
   BlockReferrers();
   ShieldsDown();
 
@@ -649,11 +657,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockCookies) {
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowCookies) {
   AllowCookies();
   NavigateToPageWithIframe();
-  EXPECT_STREQ(ExecScriptGetStr(kCookieScript, contents()).c_str(), COOKIE_STR);
+  EXPECT_STREQ(ExecScriptGetStr(kCookieScript, contents()).c_str(),
+               COOKIE_STR);
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
   EXPECT_STREQ(ExecScriptGetStr(kCookieScript, child_frame()).c_str(),
-      COOKIE_STR);
+               COOKIE_STR);
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
@@ -670,7 +679,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
   EXPECT_STREQ(ExecScriptGetStr(kCookieScript, contents()).c_str(), "");
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
-  EXPECT_STREQ(ExecScriptGetStr(kCookieScript, child_frame()).c_str(), COOKIE_STR);
+  EXPECT_STREQ(ExecScriptGetStr(kCookieScript, child_frame()).c_str(),
+               COOKIE_STR);
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
@@ -699,7 +709,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
   EXPECT_STREQ(ExecScriptGetStr(kCookieScript, contents()).c_str(), COOKIE_STR);
   ASSERT_TRUE(NavigateIframeToURL(contents(), kIframeID, iframe_url()));
   ASSERT_EQ(child_frame()->GetLastCommittedURL(), iframe_url());
-  EXPECT_STREQ(ExecScriptGetStr(kCookieScript, child_frame()).c_str(), COOKIE_STR);
+  EXPECT_STREQ(ExecScriptGetStr(kCookieScript, child_frame()).c_str(),
+               COOKIE_STR);
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
@@ -729,7 +740,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowScripts) {
   EXPECT_EQ(contents()->GetAllFrames().size(), 3u);
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockScriptsShieldsDown) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       BlockScriptsShieldsDown) {
   BlockScripts();
   ShieldsDown();
 
@@ -738,7 +750,8 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockScriptsShie
   EXPECT_EQ(contents()->GetAllFrames().size(), 3u);
 }
 
-IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, BlockScriptsShieldsDownInOtherTab) {
+IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
+                       BlockScriptsShieldsDownInOtherTab) {
   // Turn off shields in a.com.
   ShieldsDown();
   // Block scripts in b.com.


### PR DESCRIPTION
Fixes brave/brave-browser#3422.

This is based on the brave/brave-core#2070 pull request which was committed in 501f4e0c78515c12093e6c67b51f2ca8980851e0 and then reverted in 056ce155f50bdefe1a32fc72b3f998c102713846 because of brave/brave-browser#3988.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

This can be manually tested using https://fmarier.github.io/brave-testing/referrer-spoofing.html.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.