### PR TITLE
Fix Shows supported region correctly for Ads on first load after upgrade.

### DIFF
--- a/components/brave_rewards/resources/ui/components/settingsPage.tsx
+++ b/components/brave_rewards/resources/ui/components/settingsPage.tsx
@@ -60,7 +60,10 @@ class SettingsPage extends React.Component<Props, {}> {
 
     if (this.props.rewardsData.firstLoad === false) {
       this.refreshActions()
+    } else {
+      this.actions.getAdsData()
     }
+
     this.actions.checkImported()
     this.actions.getGrants()
     this.actions.getRewardsMainEnabled()


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/4154

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. Create a profile from a Brave browser version `<0.63.x`
2. Copy that profile to the development path.
3. Build and run from this pull request
4. (For supported regions) navigate to `brave://rewards` and ensure that Ads is disabled, but no unsupported message is shown.
5. (For un-supported regions) navigate to `brave://rewards` and ensure that Ads is disabled and the un-supported message is shown.

Additionally, ensure that Ads enabled state persists when restarting the browser, and through enabling and disabling Brave Rewards.

Ensure that behavior is appropriate on a clean profile path as well.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
