### PR TITLE
Add retry on NETWORK_CHANGED error

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -71,6 +71,7 @@ const char kRewardsNotificationAdsLaunch[] =
     "rewards_notification_ads_launch";
 
 }
+const static unsigned int _retries_count_on_network_change = 1;
 
 class LogStreamImpl : public ads::LogStream {
  public:
@@ -1153,6 +1154,7 @@ void AdsServiceImpl::URLRequest(
   net::URLFetcher* fetcher = net::URLFetcher::Create(
       GURL(url), request_type, this).release();
   fetcher->SetRequestContext(g_browser_process->system_request_context());
+  fetcher->SetAutomaticallyRetryOnNetworkChanges(_retries_count_on_network_change);
 
   for (size_t i = 0; i < headers.size(); i++)
     fetcher->AddExtraRequestHeader(headers[i]);

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -71,7 +71,7 @@ const char kRewardsNotificationAdsLaunch[] =
     "rewards_notification_ads_launch";
 
 }
-const static unsigned int _retries_count_on_network_change = 1;
+const static unsigned int kRetriesCountOnNetworkChange = 1;
 
 class LogStreamImpl : public ads::LogStream {
  public:
@@ -1154,7 +1154,7 @@ void AdsServiceImpl::URLRequest(
   net::URLFetcher* fetcher = net::URLFetcher::Create(
       GURL(url), request_type, this).release();
   fetcher->SetRequestContext(g_browser_process->system_request_context());
-  fetcher->SetAutomaticallyRetryOnNetworkChanges(_retries_count_on_network_change);
+  fetcher->SetAutomaticallyRetryOnNetworkChanges(kRetriesCountOnNetworkChange);
 
   for (size_t i = 0; i < headers.size(); i++)
     fetcher->AddExtraRequestHeader(headers[i]);

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -71,7 +71,7 @@ const char kRewardsNotificationAdsLaunch[] =
     "rewards_notification_ads_launch";
 
 }
-const static unsigned int kRetriesCountOnNetworkChange = 1;
+static const unsigned int kRetriesCountOnNetworkChange = 1;
 
 class LogStreamImpl : public ads::LogStream {
  public:

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -90,7 +90,7 @@ using std::placeholders::_2;
 
 namespace brave_rewards {
 
-const static unsigned int _retries_count_on_network_change = 1;
+const static unsigned int kRetriesCountOnNetworkChange = 1;
 
 class LogStreamImpl : public ledger::LogStream {
  public:
@@ -1240,7 +1240,7 @@ void RewardsServiceImpl::LoadURL(
   net::URLFetcher* fetcher = net::URLFetcher::Create(
       parsed_url, request_type, this).release();
   fetcher->SetRequestContext(g_browser_process->system_request_context());
-  fetcher->SetAutomaticallyRetryOnNetworkChanges(_retries_count_on_network_change);
+  fetcher->SetAutomaticallyRetryOnNetworkChanges(kRetriesCountOnNetworkChange);
 
   for (size_t i = 0; i < headers.size(); i++)
     fetcher->AddExtraRequestHeader(headers[i]);

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -90,7 +90,7 @@ using std::placeholders::_2;
 
 namespace brave_rewards {
 
-const static unsigned int kRetriesCountOnNetworkChange = 1;
+static const unsigned int kRetriesCountOnNetworkChange = 1;
 
 class LogStreamImpl : public ledger::LogStream {
  public:

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -88,6 +88,8 @@ using net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
+#define RETRIES_COUNT_ON_NETWORK_CHANGE 1
+
 namespace brave_rewards {
 
 class LogStreamImpl : public ledger::LogStream {
@@ -1238,6 +1240,7 @@ void RewardsServiceImpl::LoadURL(
   net::URLFetcher* fetcher = net::URLFetcher::Create(
       parsed_url, request_type, this).release();
   fetcher->SetRequestContext(g_browser_process->system_request_context());
+  fetcher->SetAutomaticallyRetryOnNetworkChanges(RETRIES_COUNT_ON_NETWORK_CHANGE);
 
   for (size_t i = 0; i < headers.size(); i++)
     fetcher->AddExtraRequestHeader(headers[i]);

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -88,9 +88,9 @@ using net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-#define RETRIES_COUNT_ON_NETWORK_CHANGE 1
-
 namespace brave_rewards {
+
+const static unsigned int _retries_count_on_network_change = 1;
 
 class LogStreamImpl : public ledger::LogStream {
  public:
@@ -1240,7 +1240,7 @@ void RewardsServiceImpl::LoadURL(
   net::URLFetcher* fetcher = net::URLFetcher::Create(
       parsed_url, request_type, this).release();
   fetcher->SetRequestContext(g_browser_process->system_request_context());
-  fetcher->SetAutomaticallyRetryOnNetworkChanges(RETRIES_COUNT_ON_NETWORK_CHANGE);
+  fetcher->SetAutomaticallyRetryOnNetworkChanges(_retries_count_on_network_change);
 
   for (size_t i = 0; i < headers.size(); i++)
     fetcher->AddExtraRequestHeader(headers[i]);


### PR DESCRIPTION
closes https://github.com/brave/brave-browser/issues/4153
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
