### PR TITLE
Upgrade python-patch to the latest upstream release

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ deps = {
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@9be5c63b14e094156e00c8b28f205e7794f0b92c",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
-  "vendor/python-patch": "https://github.com/svn2github/python-patch@a336a458016ced89aba90dfc3f4c8222ae3b1403",
+  "vendor/python-patch": "https://github.com/techtonik/python-patch@2148d5408fafd5c05ac6854dd7deb4e8a4ca4a49",
   "vendor/omaha":  "https://github.com/brave/omaha.git@22dec7e124881ba2c7e8f331d18d9c4dd40ed207",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",


### PR DESCRIPTION
This fixes brave/brave-browser#3932.

The version we were using was an svn import of `code.google.com` to GitHub but both `code.google.com` and the importer are now defunct:

http://piotr.gabryjeluk.pl/blog:closing-svn2github

The upstream developer, according to the PyPI project page (https://pypi.org/project/patch/), has moved to a dedicated repo on GitHub:

  https://github.com/techtonik/python-patch

I picked the latest upstream release (1.16):

  https://github.com/techtonik/python-patch/releases/tag/1.16
  https://github.com/techtonik/python-patch/commit/2148d5408fafd5c05ac6854dd7deb4e8a4ca4a49

as the commit to pin our dependency to since the only commits on master after that are related to a part of the package that we don't use and that has been moved to another package:

  https://github.com/techtonik/python-patch/commit/76f0205f67bb31cfd5f8fc0d9a4b84a1f385c8dd

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

To test that the new version gives me the same output with our current patches, I did the following under the old version:

```
$ cd src
$ git reset --hard
HEAD is now at 97cde3a81abd Publish DEPS for 74.0.3729.91
$ cd ..
$ npm run apply_patches
...
$ npm run update_patches
```

which gave me the following diff in `src/brave`: https://gist.github.com/fmarier/7b127e6d2d6b2b6076f98d81202defe2

Then I applied and updated the patches again:

    $ npm run apply_patches
    ...
    $ npm run update_patches

and got the following diff: https://gist.github.com/fmarier/2899dfd116a02a17fa31a1131825f89c

which is in line with [this known bug](https://github.com/brave/brave-browser/issues/155) (also [reported upstream](https://github.com/techtonik/python-patch/issues/55)).

I ran `gclient sync` and then tested applying the patches again.

I got the same results as above in the first and second runs.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
