### PR TITLE
Fix tokens are not redeemed for viewed Ads at server side when passing --rewards=debug=true command-line arg 0.64.x

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -883,26 +883,16 @@ void ConfirmationsImpl::RefillTokensIfNecessary() const {
 }
 
 uint64_t ConfirmationsImpl::CalculateTokenRedemptionTimeInSeconds() {
+  if (next_token_redemption_date_in_seconds_ == 0) {
+    UpdateNextTokenRedemptionDate();
+  }
+
   auto now_in_seconds = Time::NowInSeconds();
 
   uint64_t start_timer_in;
-
-  if (_is_debug) {
-    if (next_token_redemption_date_in_seconds_ - now_in_seconds >=
-        kDebugNextTokenRedemptionAfterSeconds) {
-      UpdateNextTokenRedemptionDate();
-      SaveState();
-    }
-  }
-
-  if (next_token_redemption_date_in_seconds_ == 0) {
-    UpdateNextTokenRedemptionDate();
-    SaveState();
-  }
-
   if (now_in_seconds >= next_token_redemption_date_in_seconds_) {
     // Browser was launched after the token redemption date
-    start_timer_in = base::RandInt(0, 5 * base::Time::kSecondsPerMinute);
+    start_timer_in = base::RandInt(0, 1 * base::Time::kSecondsPerMinute);
   } else {
     start_timer_in = next_token_redemption_date_in_seconds_ - now_in_seconds;
   }
@@ -923,6 +913,8 @@ void ConfirmationsImpl::UpdateNextTokenRedemptionDate() {
     next_token_redemption_date_in_seconds_ +=
         kDebugNextTokenRedemptionAfterSeconds;
   }
+
+  SaveState();
 }
 
 void ConfirmationsImpl::StartRetryingFailedConfirmations(

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.cc
@@ -129,7 +129,6 @@ void PayoutTokens::OnPayout(const Result result) {
 
 void PayoutTokens::ScheduleNextPayout() const {
   confirmations_->UpdateNextTokenRedemptionDate();
-  confirmations_->SaveState();
 
   auto start_timer_in = confirmations_->CalculateTokenRedemptionTimeInSeconds();
   confirmations_->StartPayingOutRedeemedTokens(start_timer_in);


### PR DESCRIPTION
Uplift for https://github.com/brave/brave-core/pull/2300
Fixes https://github.com/brave/brave-browser/issues/4186