### PR TITLE
Fix to publisher info db unit tests.

### DIFF
--- a/components/brave_rewards/browser/publisher_info_database_unittest.cc
+++ b/components/brave_rewards/browser/publisher_info_database_unittest.cc
@@ -115,7 +115,15 @@ class PublisherInfoDatabaseTest : public ::testing::Test {
           base::KEEP_WHITESPACE,
           base::SPLIT_WANT_NONEMPTY);
 
-      data = base::JoinString(split, "\n") + "\n";
+      if (split.size() > 1) {
+        data = base::JoinString(split, "\n") + "\n";
+      } else if (split.size() == 1) {
+        bool ends_with_newline = (data.at(data.size() - 1) == '\n');
+        data = split[0];
+        if (ends_with_newline && data.at(data.size() - 1) != '\n') {
+          data += "\n";
+        }
+      }
     #endif
 
     return data;

--- a/components/brave_rewards/browser/publisher_info_database_unittest.cc
+++ b/components/brave_rewards/browser/publisher_info_database_unittest.cc
@@ -107,25 +107,8 @@ class PublisherInfoDatabaseTest : public ::testing::Test {
 
     std::string data;
     base::ReadFileToString(path, &data);
-
-    #if defined(OS_WIN)
-      auto split = base::SplitStringUsingSubstr(
-          data,
-          "\r\n",
-          base::KEEP_WHITESPACE,
-          base::SPLIT_WANT_NONEMPTY);
-
-      if (split.size() > 1) {
-        data = base::JoinString(split, "\n") + "\n";
-      } else if (split.size() == 1) {
-        bool ends_with_newline = (data.at(data.size() - 1) == '\n');
-        data = split[0];
-        if (ends_with_newline && data.at(data.size() - 1) != '\n') {
-          data += "\n";
-        }
-      }
-    #endif
-
+    DCHECK(data.find("\r\n", 0) == std::string::npos)
+        << "Do not add test data files with Windows line endings.";
     return data;
   }
 


### PR DESCRIPTION
Fixes brave/brave-browser#4195

The tests make special accommodation for reading on Windows (\r\n ->
\n), however the files don't have any \r\n. Added code to check if only
one string was returned from tokenizer and only append \n if one isn't
already there.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
N/A

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
