### PR TITLE
"Brave Ads has arrived!" notification should be shown on Linux after upgrade from 0.62.x - 0.63.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -427,8 +427,13 @@ void AdsServiceImpl::Start() {
 }
 
 void AdsServiceImpl::MaybeShowFirstLaunchNotification() {
-  auto ads_enabled = profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdsEnabled);
+  #if defined(OS_LINUX)
+    auto ads_enabled = true;
+  #else
+    auto ads_enabled =
+        profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
+  #endif
+
   auto prefs_migrated_from_62 = profile_->GetPrefs()->GetBoolean(
       prefs::kBraveAdsPrefsMigratedFrom62);
 


### PR DESCRIPTION
Uplift for https://github.com/brave/brave-core/pull/2321
Fixes https://github.com/brave/brave-browser/issues/4202