### PR TITLE
Introduce saveBookmarkOrder API to simplify order saving task

### DIFF
--- a/browser/extensions/api/brave_sync_api.cc
+++ b/browser/extensions/api/brave_sync_api.cc
@@ -1,8 +1,13 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/extensions/api/brave_sync_api.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "brave/common/extensions/api/brave_sync.h"
 #include "brave/components/brave_sync/client/brave_sync_client.h"
@@ -76,8 +81,7 @@ ExtensionFunction::ResponseAction BraveSyncSaveInitDataFunction::Run() {
   DCHECK(sync_service);
   sync_service->GetSyncClient()->sync_message_handler()->OnSaveInitData(
       params->seed ? *params->seed : std::vector<uint8_t>(),
-      params->device_id ? *params->device_id : std::vector<uint8_t>()
-  );
+      params->device_id ? *params->device_id : std::vector<uint8_t>());
 
   return RespondNow(NoArguments());
 }
@@ -126,15 +130,16 @@ ExtensionFunction::ResponseAction BraveSyncResolvedSyncRecordsFunction::Run() {
   return RespondNow(NoArguments());
 }
 
-ExtensionFunction::ResponseAction BraveSyncSaveBookmarksBaseOrderFunction::Run() {
+ExtensionFunction::ResponseAction
+BraveSyncSaveBookmarksBaseOrderFunction::Run() {
   std::unique_ptr<brave_sync::SaveBookmarksBaseOrder::Params> params(
       brave_sync::SaveBookmarksBaseOrder::Params::Create(*args_));
   EXTENSION_FUNCTION_VALIDATE(params.get());
 
   BraveSyncService* sync_service = GetBraveSyncService(browser_context());
   DCHECK(sync_service);
-  sync_service->GetSyncClient()->sync_message_handler()->OnSaveBookmarksBaseOrder(
-      params->order);
+  sync_service->GetSyncClient()->sync_message_handler()
+    ->OnSaveBookmarksBaseOrder(params->order);
 
   return RespondNow(NoArguments());
 }
@@ -159,7 +164,8 @@ ExtensionFunction::ResponseAction BraveSyncSyncWordsPreparedFunction::Run() {
 
   BraveSyncService* sync_service = GetBraveSyncService(browser_context());
   DCHECK(sync_service);
-  sync_service->GetSyncClient()->sync_message_handler()->OnSyncWordsPrepared(params->words);
+  sync_service->GetSyncClient()->sync_message_handler()
+    ->OnSyncWordsPrepared(params->words);
 
   return RespondNow(NoArguments());
 }

--- a/browser/extensions/api/brave_sync_api.cc
+++ b/browser/extensions/api/brave_sync_api.cc
@@ -139,6 +139,19 @@ ExtensionFunction::ResponseAction BraveSyncSaveBookmarksBaseOrderFunction::Run()
   return RespondNow(NoArguments());
 }
 
+ExtensionFunction::ResponseAction BraveSyncSaveBookmarkOrderFunction::Run() {
+  std::unique_ptr<brave_sync::SaveBookmarkOrder::Params> params(
+      brave_sync::SaveBookmarkOrder::Params::Create(*args_));
+  EXTENSION_FUNCTION_VALIDATE(params.get());
+
+  BraveSyncService* sync_service = GetBraveSyncService(browser_context());
+  DCHECK(sync_service);
+  sync_service->GetSyncClient()->sync_message_handler()->OnSaveBookmarkOrder(
+      params->object_id, params->order);
+
+  return RespondNow(NoArguments());
+}
+
 ExtensionFunction::ResponseAction BraveSyncSyncWordsPreparedFunction::Run() {
   std::unique_ptr<brave_sync::SyncWordsPrepared::Params> params(
       brave_sync::SyncWordsPrepared::Params::Create(*args_));

--- a/browser/extensions/api/brave_sync_api.h
+++ b/browser/extensions/api/brave_sync_api.h
@@ -58,6 +58,12 @@ class BraveSyncSaveBookmarksBaseOrderFunction : public UIThreadExtensionFunction
   ResponseAction Run() override;
 };
 
+class BraveSyncSaveBookmarkOrderFunction : public UIThreadExtensionFunction {
+  ~BraveSyncSaveBookmarkOrderFunction() override {}
+  DECLARE_EXTENSION_FUNCTION("braveSync.saveBookmarkOrder", UNKNOWN)
+  ResponseAction Run() override;
+};
+
 class BraveSyncSyncWordsPreparedFunction : public UIThreadExtensionFunction {
   ~BraveSyncSyncWordsPreparedFunction() override {}
   DECLARE_EXTENSION_FUNCTION("braveSync.syncWordsPrepared", UNKNOWN)

--- a/browser/extensions/api/brave_sync_api.h
+++ b/browser/extensions/api/brave_sync_api.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -52,7 +53,8 @@ class BraveSyncResolvedSyncRecordsFunction : public UIThreadExtensionFunction {
   ResponseAction Run() override;
 };
 
-class BraveSyncSaveBookmarksBaseOrderFunction : public UIThreadExtensionFunction {
+class BraveSyncSaveBookmarksBaseOrderFunction
+    : public UIThreadExtensionFunction {
   ~BraveSyncSaveBookmarksBaseOrderFunction() override {}
   DECLARE_EXTENSION_FUNCTION("braveSync.saveBookmarksBaseOrder", UNKNOWN)
   ResponseAction Run() override;
@@ -70,13 +72,14 @@ class BraveSyncSyncWordsPreparedFunction : public UIThreadExtensionFunction {
   ResponseAction Run() override;
 };
 
-class BraveSyncExtensionInitializedFunction : public UIThreadExtensionFunction {
+class BraveSyncExtensionInitializedFunction
+    : public UIThreadExtensionFunction {
   ~BraveSyncExtensionInitializedFunction() override {}
   DECLARE_EXTENSION_FUNCTION("braveSync.extensionInitialized", UNKNOWN)
   ResponseAction Run() override;
 };
 
-} // namespace api
-} // namespace extensions
+}   // namespace api
+}   // namespace extensions
 
-#endif // BRAVE_BROWSER_EXTENSIONS_API_BRAVE_SYNC_API_H_
+#endif    // BRAVE_BROWSER_EXTENSIONS_API_BRAVE_SYNC_API_H_

--- a/common/extensions/api/brave_sync.json
+++ b/common/extensions/api/brave_sync.json
@@ -419,6 +419,21 @@
         ]
       },
       {
+        "name": "saveBookmarkOrder",
+        "type": "function",
+        "description": "Browser update order of certain object",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "object_id"
+          },
+          {
+            "type": "string",
+            "name": "order"
+          }
+        ]
+      },
+      {
         "name": "syncWordsPrepared",
         "type": "function",
         "description": "Browser gets notified the sync words are ready",

--- a/components/brave_sync/brave_sync_service_impl.cc
+++ b/components/brave_sync/brave_sync_service_impl.cc
@@ -518,6 +518,13 @@ void BraveSyncServiceImpl::OnSaveBookmarksBaseOrder(const std::string& order)  {
   OnSyncReady();
 }
 
+void BraveSyncServiceImpl::OnSaveBookmarkOrder(const std::string& object_id,
+                                               const std::string& order)  {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(!order.empty());
+  bookmark_change_processor_->ApplyOrder(object_id, order);
+}
+
 void BraveSyncServiceImpl::OnSyncWordsPrepared(const std::string& words) {
   NotifyHaveSyncWords(words);
 }

--- a/components/brave_sync/brave_sync_service_impl.h
+++ b/components/brave_sync/brave_sync_service_impl.h
@@ -128,6 +128,8 @@ class BraveSyncServiceImpl
   void OnDeletedSyncUser() override;
   void OnDeleteSyncSiteSettings() override;
   void OnSaveBookmarksBaseOrder(const std::string& order) override;
+  void OnSaveBookmarkOrder(const std::string& object_id,
+                                const std::string& order) override;
   void OnSyncWordsPrepared(const std::string& words) override;
 
   void OnResolvedHistorySites(const RecordsList &records);

--- a/components/brave_sync/client/bookmark_change_processor.cc
+++ b/components/brave_sync/client/bookmark_change_processor.cc
@@ -967,4 +967,13 @@ void BookmarkChangeProcessor::SendUnsynced(
 
 void BookmarkChangeProcessor::InitialSync() {}
 
+void BookmarkChangeProcessor::ApplyOrder(const std::string& object_id,
+                                         const std::string& order) {
+  ScopedPauseObserver pause(this);
+  auto* node = FindByObjectId(bookmark_model_, object_id);
+  if (node) {
+    bookmark_model_->SetNodeMetaInfo(node, "order", order);
+  }
+}
+
 }  // namespace brave_sync

--- a/components/brave_sync/client/bookmark_change_processor.h
+++ b/components/brave_sync/client/bookmark_change_processor.h
@@ -49,6 +49,8 @@ class BookmarkChangeProcessor : public ChangeProcessor,
   void SendUnsynced(base::TimeDelta unsynced_send_interval) override;
   void InitialSync() override;
 
+  void ApplyOrder(const std::string& object_id, const std::string& order);
+
  private:
   friend class ::BraveBookmarkChangeProcessorTest;
   FRIEND_TEST_ALL_PREFIXES(::BraveBookmarkChangeProcessorTest,

--- a/components/brave_sync/client/bookmark_change_processor_unittest.cc
+++ b/components/brave_sync/client/bookmark_change_processor_unittest.cc
@@ -43,6 +43,7 @@
 // GetAllSyncData              | +
 // SendUnsynced                | +
 // InitialSync                 | N/A
+// ApplyOrder                  | +
 
 // bookmarks::BookmarkModelObserver overrides:
 // Name                        | Covered
@@ -1385,4 +1386,20 @@ TEST_F(BraveBookmarkChangeProcessorTest, MigrateOrdersForPermanentNodes) {
   EXPECT_EQ(OB_order, "1.0.2.1");
 
   EXPECT_EQ(sync_prefs()->GetMigratedBookmarksVersion(), 1);
+}
+
+TEST_F(BraveBookmarkChangeProcessorTest, ApplyOrder) {
+  BookmarkCreatedFromSyncImpl();
+  const char* record_a_object_id =
+      "121, 194, 37, 61, 199, 11, 166, 234, "
+      "214, 197, 45, 215, 241, 206, 219, 130";
+  const char* new_order = "1.1.1.3";
+  change_processor()->ApplyOrder(record_a_object_id, new_order);
+  std::vector<const BookmarkNode*> nodes_a;
+  model()->GetNodesByURL(GURL("https://a.com/"), &nodes_a);
+  ASSERT_EQ(nodes_a.size(), 1u);
+  const auto* node_a = nodes_a.at(0);
+  std::string order;
+  node_a->GetMetaInfo("order", &order);
+  EXPECT_EQ(order, new_order);
 }

--- a/components/brave_sync/client/brave_sync_client.h
+++ b/components/brave_sync/client/brave_sync_client.h
@@ -49,8 +49,10 @@ class SyncMessageHandler {
   //DELETE_SYNC_SITE_SETTINGS
   virtual void OnDeleteSyncSiteSettings() = 0;
   //SAVE_BOOKMARKS_BASE_ORDER
-  virtual void OnSaveBookmarksBaseOrder(const std::string &order) = 0;
-  virtual void OnSyncWordsPrepared(const std::string &words) = 0;
+  virtual void OnSaveBookmarksBaseOrder(const std::string& order) = 0;
+  virtual void OnSaveBookmarkOrder(const std::string& object_id,
+                                   const std::string& order) = 0;
+  virtual void OnSyncWordsPrepared(const std::string& words) = 0;
 };
 
 class BraveSyncClient {

--- a/components/brave_sync/client/brave_sync_client.h
+++ b/components/brave_sync/client/brave_sync_client.h
@@ -1,9 +1,10 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_CLIENT_H
-#define BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_CLIENT_H
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_CLIENT_BRAVE_SYNC_CLIENT_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_CLIENT_BRAVE_SYNC_CLIENT_H_
 
 #include <string>
 #include <vector>
@@ -26,29 +27,29 @@ class SyncMessageHandler {
   virtual void BackgroundSyncStarted(bool startup) = 0;
   virtual void BackgroundSyncStopped(bool shutdown) = 0;
 
-  //SYNC_DEBUG
+  // SYNC_DEBUG
   virtual void OnSyncDebug(const std::string &message) = 0;
-  //SYNC_SETUP_ERROR
+  // SYNC_SETUP_ERROR
   virtual void OnSyncSetupError(const std::string &error) = 0;
-  //GET_INIT_DATA
+  // GET_INIT_DATA
   virtual void OnGetInitData(const std::string &sync_version) = 0;
-  //SAVE_INIT_DATA
+  // SAVE_INIT_DATA
   virtual void OnSaveInitData(const Uint8Array& seed,
                               const Uint8Array& device_id) = 0;
-  //SYNC_READY
+  // SYNC_READY
   virtual void OnSyncReady() = 0;
-  //GET_EXISTING_OBJECTS
+  // GET_EXISTING_OBJECTS
   virtual void OnGetExistingObjects(const std::string &category_name,
       std::unique_ptr<RecordsList> records,
       const base::Time &last_record_time_stamp, const bool is_truncated) = 0;
-  //RESOLVED_SYNC_RECORDS
+  // RESOLVED_SYNC_RECORDS
   virtual void OnResolvedSyncRecords(const std::string &category_name,
     std::unique_ptr<RecordsList> records) = 0;
-  //DELETED_SYNC_USER
+  // DELETED_SYNC_USER
   virtual void OnDeletedSyncUser() = 0;
-  //DELETE_SYNC_SITE_SETTINGS
+  // DELETE_SYNC_SITE_SETTINGS
   virtual void OnDeleteSyncSiteSettings() = 0;
-  //SAVE_BOOKMARKS_BASE_ORDER
+  // SAVE_BOOKMARKS_BASE_ORDER
   virtual void OnSaveBookmarksBaseOrder(const std::string& order) = 0;
   virtual void OnSaveBookmarkOrder(const std::string& object_id,
                                    const std::string& order) = 0;
@@ -91,6 +92,6 @@ class BraveSyncClient {
   virtual void ClearOrderMap() = 0;
 };
 
-} // namespace brave_sync
+}   // namespace brave_sync
 
-#endif // BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_CLIENT_H
+#endif    // BRAVE_COMPONENTS_BRAVE_SYNC_CLIENT_BRAVE_SYNC_CLIENT_H_

--- a/components/brave_sync/extension/background.js
+++ b/components/brave_sync/extension/background.js
@@ -51,16 +51,13 @@ chrome.braveSync.onResolveSyncRecords.addListener(function(category_name, record
 chrome.braveSync.onSendSyncRecords.addListener(function(category_name, records) {
   // Fixup ids
   for (var i = 0; i < records.length; ++i) {
-    fixupSyncRecordBrowserToExt(records[i]);
+    // getOrder requires objectIdStr to send back order
     getOrder(records[i]);
+    fixupSyncRecordBrowserToExt(records[i]);
     removeLocalMeta(records[i]);
   }
   console.log(`"send-sync-records" category_name=${JSON.stringify(category_name)} records=${JSON.stringify(records)}`);
   callbackList["send-sync-records"](null, category_name, records);
-  if (category_name == 'BOOKMARKS') {
-    fixupSyncRecordsArrayExtensionToBrowser(records);
-    chrome.braveSync.resolvedSyncRecords(category_name, records);
-  }
 });
 
 chrome.braveSync.onSendGetBookmarksBaseOrder.addListener(function(deviceId, platform) {
@@ -97,6 +94,8 @@ function getOrder(record) {
         record.bookmark.order = order;
         if (record.objectId)
           orderMap[record.objectId] = order;
+        if (record.objectIdStr)
+          chrome.braveSync.saveBookmarkOrder(record.objectIdStr, order);
         getBookmarkOrderCallback = null;
       }
 


### PR DESCRIPTION
 instead of using resolvedSyncRecords which will trigger ApplyChangesFromSyncModel

fix https://github.com/brave/brave-browser/issues/4208

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
