### PR TITLE
Make proper native theme observer gets native theme change noti (uplift to 0.64.x)

### DIFF
--- a/patches/ui-native_theme-native_theme_win.cc.patch
+++ b/patches/ui-native_theme-native_theme_win.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/ui/native_theme/native_theme_win.cc b/ui/native_theme/native_theme_win.cc
+index 0df107bf9757a81897e9312a9eba977b8a173646..61e4f4ce671c5e0f92208b54aade903110ddc7a7 100644
+--- a/ui/native_theme/native_theme_win.cc
++++ b/ui/native_theme/native_theme_win.cc
+@@ -1934,7 +1934,11 @@ void NativeThemeWin::RegisterThemeRegkeyObserver() {
+   DCHECK(hkcu_themes_regkey_.Valid());
+   hkcu_themes_regkey_.StartWatching(base::BindOnce(
+       [](NativeThemeWin* native_theme) {
++#if defined(BRAVE_CHROMIUM_BUILD)
++        NotifyProperThemeObserver();
++#else
+         native_theme->NotifyObservers();
++#endif
+         // RegKey::StartWatching only provides one notification. Reregistration
+         // is required to get future notifications.
+         native_theme->RegisterThemeRegkeyObserver();


### PR DESCRIPTION
Uplift of #2219
Issue: brave/brave-browser#4059