### PR TITLE
Make stable brave-browser depend on brave-keyring

### DIFF
--- a/patches/chrome-installer-linux-debian-build.sh.patch
+++ b/patches/chrome-installer-linux-debian-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/debian/build.sh b/chrome/installer/linux/debian/build.sh
-index 306b59c138b7cb5df21ad6e9d502bb7a46a104c6..b0f4d4287297fddf2bbaa3b5b6fc40706c8d1349 100755
+index 306b59c138b7cb5df21ad6e9d502bb7a46a104c6..a8ff37b5a7d31b442e3fe812a0d9d091d7eda66d 100755
 --- a/chrome/installer/linux/debian/build.sh
 +++ b/chrome/installer/linux/debian/build.sh
 @@ -21,7 +21,7 @@ gen_changelog() {
@@ -71,3 +71,14 @@ index 306b59c138b7cb5df21ad6e9d502bb7a46a104c6..b0f4d4287297fddf2bbaa3b5b6fc4070
  verify_channel
  
  # Some Debian packaging tools want these set.
+@@ -270,6 +285,10 @@ COMMON_DEPS=$(sed ':a;N;$!ba;s/\n/, /g' "${DEB_COMMON_DEPS}")
+ COMMON_PREDEPS="dpkg (>= 1.14.0)"
+ COMMON_RECOMMENDS="libu2f-udev"
+ 
++# Ensure that our signing key is up-to-date (brave/brave-browser#4205).
++if [ "$CHANNEL" = "stable" ]; then
++  COMMON_DEPS="${COMMON_DEPS}, brave-keyring"
++fi
+ 
+ # Make everything happen in the OUTPUTDIR.
+ cd "${OUTPUTDIR}"

--- a/patches/chrome-installer-linux-rpm-build.sh.patch
+++ b/patches/chrome-installer-linux-rpm-build.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/rpm/build.sh b/chrome/installer/linux/rpm/build.sh
-index 0bcd8689d45850ad539f99423fa211785db4f343..9a2d8eeb97e096db8b80aac7e26006888200e9f8 100755
+index 0bcd8689d45850ad539f99423fa211785db4f343..cec0813f491a570fb499e7de5adb9d13e950e7e4 100755
 --- a/chrome/installer/linux/rpm/build.sh
 +++ b/chrome/installer/linux/rpm/build.sh
 @@ -15,8 +15,9 @@ gen_spec() {
@@ -13,7 +13,20 @@ index 0bcd8689d45850ad539f99423fa211785db4f343..9a2d8eeb97e096db8b80aac7e2600688
      local INSTALLDIR="${INSTALLDIR}-${CHANNEL}"
      local PACKAGE="${PACKAGE}-${CHANNEL}"
      local MENUNAME="${MENUNAME} (${CHANNEL})"
-@@ -108,7 +109,10 @@ do_package() {
+@@ -87,6 +88,12 @@ do_package() {
+   PROVIDES="${PACKAGE}"
+   RPM_COMMON_DEPS="${BUILDDIR}/rpm_common.deps"
+   DEPENDS=$(cat "${RPM_COMMON_DEPS}" | tr '\n' ',')
++
++  # Ensure that our signing key is up-to-date (brave/brave-browser#4205).
++  if [ "$CHANNEL" = "stable" ]; then
++    DEPENDS="brave-keyring, ${DEPENDS}"
++  fi
++
+   gen_spec
+ 
+   # Create temporary rpmbuild dirs.
+@@ -108,7 +115,10 @@ do_package() {
      --define "${COMPRESSION_OPT}" \
      --define "__os_install_post  %{nil}" \
      "${SPEC}"
@@ -25,7 +38,7 @@ index 0bcd8689d45850ad539f99423fa211785db4f343..9a2d8eeb97e096db8b80aac7e2600688
    mv "$RPMBUILD_DIR/RPMS/$ARCHITECTURE/${PKGNAME}.${ARCHITECTURE}.rpm" \
       "${OUTPUTDIR}"
    # Make sure the package is world-readable, otherwise it causes problems when
-@@ -145,7 +149,10 @@ verify_channel() {
+@@ -145,7 +155,10 @@ verify_channel() {
        CHANNEL=stable
        ;;
      unstable|dev|alpha )


### PR DESCRIPTION
Fixes brave/brave-browser#4205.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

With packages on the release channel:

- try installing them without the `brave-keyring` package (it won't work)

With packages on the beta or dev channel:

- try installing them without the `brave-keyring` (it will work)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
