### PR TITLE
Use brave theme type as a system dark mode on Windows

### DIFF
--- a/browser/themes/brave_theme_service.h
+++ b/browser/themes/brave_theme_service.h
@@ -64,6 +64,9 @@ class BraveThemeService : public ThemeService {
 
   void RecoverPrefStates(Profile* profile);
   void OverrideDefaultThemeIfNeeded(Profile* profile);
+#if defined(OS_WIN)
+  void OverrideSystemDarkModeIfNeeded(Profile* profile);
+#endif
 
   static bool SystemThemeModeEnabled();
 

--- a/browser/themes/brave_theme_service_browsertest.cc
+++ b/browser/themes/brave_theme_service_browsertest.cc
@@ -121,10 +121,8 @@ IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, NativeThemeObserverTest) {
   SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
 }
 
-#if defined(OS_MACOSX)
+#if defined(OS_MACOSX) || defined(OS_WIN)
 IN_PROC_BROWSER_TEST_F(BraveThemeServiceTest, SystemThemeChangeTest) {
-  // TODO(simonhong): Delete this when we gets dark mode enabled branch on
-  // MacOS.
   if (!BraveThemeService::SystemThemeModeEnabled())
     return;
 

--- a/chromium_src/ui/native_theme/native_theme_win.cc
+++ b/chromium_src/ui/native_theme/native_theme_win.cc
@@ -4,10 +4,12 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "ui/native_theme/native_theme_dark_aura.h"
+#include "ui/native_theme/native_theme_win.h"
 
-void NotifyProperThemeObserver();
+namespace {
 
-#include "../../../../ui/native_theme/native_theme_win.cc"  // NOLINT
+bool system_dark_mode_overridden = false;
+bool dark_mode_enabled = false;
 
 // TODO(simonhong): Move this function to ui namespace to share with
 // native_theme_mac.mm.
@@ -18,3 +20,26 @@ void NotifyProperThemeObserver() {
       ? ui::NativeTheme::GetInstanceForNativeUi()->NotifyObservers()
       : ui::NativeThemeDarkAura::instance()->NotifyObservers();
 }
+
+bool OverrideSystemDarkMode() {
+  return system_dark_mode_overridden;
+}
+
+bool GetSystemDarkModeEnabledOverrides() {
+  return dark_mode_enabled;
+}
+
+}  // namespace
+
+#include "../../../../ui/native_theme/native_theme_win.cc"  // NOLINT
+
+namespace ui {
+
+void SetOverrideSystemDarkMode(bool override,
+                               bool enable_dark_mode) {
+  system_dark_mode_overridden = override;
+  dark_mode_enabled = enable_dark_mode;
+}
+
+}  // namespace ui
+

--- a/chromium_src/ui/native_theme/native_theme_win.h
+++ b/chromium_src/ui/native_theme/native_theme_win.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "../../../../ui/native_theme/native_theme_win.h"
+
+// Custom header guard is used to avoid including function declaration multiple
+// times.
+#ifndef UI_NATIVE_THEME_NATIVE_THEME_WIN_H_BRAVE_  // NOLINT
+#define UI_NATIVE_THEME_NATIVE_THEME_WIN_H_BRAVE_  // NOLINT
+
+namespace ui {
+
+// If |override| is true, system dark mode is overridden by |enable_dark_mode|.
+// If |override| is false, |enable_dark_mode| is ignored.
+void NATIVE_THEME_EXPORT SetOverrideSystemDarkMode(bool override,
+                                                   bool enable_dark_mode);
+}  // namespace ui
+
+#endif  // UI_NATIVE_THEME_NATIVE_THEME_WIN_H_BRAVE_  // NOLINT

--- a/patches/ui-native_theme-native_theme_win.cc.patch
+++ b/patches/ui-native_theme-native_theme_win.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/ui/native_theme/native_theme_win.cc b/ui/native_theme/native_theme_win.cc
-index 0df107bf9757a81897e9312a9eba977b8a173646..61e4f4ce671c5e0f92208b54aade903110ddc7a7 100644
+index 0df107bf9757a81897e9312a9eba977b8a173646..760ea5114e984b4536b2f894f8e7a2fb1a24b372 100644
 --- a/ui/native_theme/native_theme_win.cc
 +++ b/ui/native_theme/native_theme_win.cc
-@@ -1934,7 +1934,11 @@ void NativeThemeWin::RegisterThemeRegkeyObserver() {
+@@ -592,6 +592,7 @@ bool NativeThemeWin::SystemDarkModeEnabled() const {
+   // ...unless --force-dark-mode was specified in which case caveat emptor.
+   if (UsesHighContrastColors() && !NativeTheme::SystemDarkModeEnabled())
+     return false;
++  if (OverrideSystemDarkMode()) return GetSystemDarkModeEnabledOverrides();
+   bool fDarkModeEnabled = false;
+   if (hkcu_themes_regkey_.Valid()) {
+     DWORD apps_use_light_theme = 1;
+@@ -1934,7 +1935,11 @@ void NativeThemeWin::RegisterThemeRegkeyObserver() {
    DCHECK(hkcu_themes_regkey_.Valid());
    hkcu_themes_regkey_.StartWatching(base::BindOnce(
        [](NativeThemeWin* native_theme) {


### PR DESCRIPTION
Aligning base UI theme(ex, context menu) with brave theme was not
implemented on Windows because Windows doesn't support per-application
theme. Whereas, MacOS support it. So, when user set dark or light, it is
set as a application theme.
To solve this on Windows, NativeThemeWin::SystemDarkModeEnabled() checks
whether dark mode enabling is overridden or not.
Overridden value is set by client(BraveThemeService).

Fix https://github.com/brave/brave-browser/issues/4056
Fix https://github.com/brave/brave-browser/issues/4272

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. Start browser on Win10 and open settings page
2. Set brave theme to light or dark
3. Change os theme to dark or light and check settings page theme is not changed.
4. Set brave theme to Same as Windows
5. Change os theme to dark or light and check settings page theme is changed
 
Other manual tests are described in related issues.

`yarn test brave_browser_tests --filter=BraveThemeServiceTest.SystemThemeChangeTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
