### PR TITLE
Update sync extension to include fix for `test-security`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -16,7 +16,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@9b119931c702d55be994117eb505d56310720b1d",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@b8ef1a3f85aec0a0522a9230d59b3958a2150fab",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@1b4362968c8f22720bfb75af6f506d4ecc0f3116",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@2c39026d72c1568eb51dd21b749c7d1192dc8863",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@9b10ade6bab5c98a000b7bcf5c84bac3097fe506",
   "components/brave_sync/extension/brave-crypto": "https://github.com/brave/crypto@54f35a7bd6e297620c6add188f1b31af3d0ec561",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@c3b6111aa862c5c452c84be8a225d5f1df32b284",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@2c0e28f76e4b6f53947bf4faa5afd93614f96aca",


### PR DESCRIPTION
Manual uplift of https://github.com/brave/brave-core/pull/2361

Fixes https://github.com/brave/sync/pull/262 in `0.64.x`