### PR TITLE
Ads first launch notification timer no longer fires after notification dismissal

### DIFF
--- a/components/brave_ads/browser/ads_service_factory.cc
+++ b/components/brave_ads/browser/ads_service_factory.cc
@@ -109,6 +109,9 @@ void AdsServiceFactory::RegisterProfilePrefs(
   registry->RegisterBooleanPref(
       prefs::kBraveAdShouldShowFirstLaunchNotification,
       true);
+  registry->RegisterBooleanPref(
+      prefs::kBraveAdsHasRemovedFirstLaunchNotification,
+      false);
 
   auto now = static_cast<uint64_t>(
       (base::Time::Now() - base::Time()).InSeconds());

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -443,7 +443,7 @@ void AdsServiceImpl::MaybeShowFirstLaunchNotification() {
       !ShouldShowFirstLaunchNotification() ||
       !profile_->GetPrefs()->GetBoolean(
           brave_rewards::prefs::kBraveRewardsEnabled)) {
-    StartFirstLaunchNotificationTimer();
+    MaybeStartFirstLaunchNotificationTimer();
     return;
   }
 
@@ -471,6 +471,9 @@ void AdsServiceImpl::RemoveFirstLaunchNotification() {
       rewards_service->GetNotificationService();
   rewards_notification_service->DeleteNotification(
       kRewardsNotificationAdsLaunch);
+
+  profile_->GetPrefs()->SetBoolean(
+    prefs::kBraveAdsHasRemovedFirstLaunchNotification, true);
 }
 
 void AdsServiceImpl::ShowFirstLaunchNotification() {
@@ -487,6 +490,18 @@ void AdsServiceImpl::ShowFirstLaunchNotification() {
 
   profile_->GetPrefs()->SetBoolean(
     prefs::kBraveAdShouldShowFirstLaunchNotification, false);
+}
+
+void AdsServiceImpl::MaybeStartFirstLaunchNotificationTimer() {
+  bool has_removed_notification =
+      profile_->GetPrefs()->GetBoolean(
+          prefs::kBraveAdsHasRemovedFirstLaunchNotification);
+
+  if (has_removed_notification) {
+    return;
+  }
+
+  StartFirstLaunchNotificationTimer();
 }
 
 void AdsServiceImpl::StartFirstLaunchNotificationTimer() {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -203,6 +203,7 @@ class AdsServiceImpl : public AdsService,
   bool ShouldShowFirstLaunchNotification();
   void RemoveFirstLaunchNotification();
   void ShowFirstLaunchNotification();
+  void MaybeStartFirstLaunchNotificationTimer();
   void StartFirstLaunchNotificationTimer();
   uint64_t GetFirstLaunchNotificationTimeout();
   uint64_t GetFirstLaunchNotificationTimerOffset();

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -19,6 +19,8 @@ const char kBraveAdShouldShowFirstLaunchNotification[] =
     "brave.brave_ads.should_show_first_launch_notification";
 const char kBraveAdsLaunchNotificationTimestamp[] =
     "brave.brave_ads.launch_notification_timestamp";
+const char kBraveAdsHasRemovedFirstLaunchNotification[] =
+    "brave.brave_ads.has_removed_first_launch_notification";
 
 const int kBraveAdsPrefsDefaultVersion = 1;
 const int kBraveAdsPrefsCurrentVersion = 2;

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -17,6 +17,7 @@ extern const char kBraveAdsIdleThreshold[];
 
 extern const char kBraveAdShouldShowFirstLaunchNotification[];
 extern const char kBraveAdsLaunchNotificationTimestamp[];
+extern const char kBraveAdsHasRemovedFirstLaunchNotification[];
 
 extern const int kBraveAdsPrefsDefaultVersion;
 extern const int kBraveAdsPrefsCurrentVersion;


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/4180

A preference was added to mark whether the ads notification has gone away. The pref, `kBraveAdsHasDeletedFirstLaunchNotification` will be set to true if the user dismisses the notification, engages with the notification, enables ads, or if the notification goes away on its own after its 7 day timeout. This is used as the crutch to determine whether we need to initialize the timeout timer or not.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
As there are no behavioral indicators that the deletion timer is still firing after the notification goes away, this will have to be confirmed via logging.

1. Create a profile from an older version of Brave where Ads was disabled (0.62.x), enable Rewards, copy profile to development directory.
2. Start Brave from this branch.
3. Dismiss the "Ads Have Arrived!" notification.
4. Restart the browser
5. Confirm via logging that the timer to trigger `OnFirstLaunchNotificationTimedOut` does not start up.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
