### PR TITLE
fix unreadable shields dropdown on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,8 +1597,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#210a82491cf12d25c789c68b3634a41e3bc4b7c2",
-      "from": "github:brave/brave-ui#210a82491cf12d25c789c68b3634a41e3bc4b7c2",
+      "version": "github:brave/brave-ui#e0aff04ebfa2b4ce03043f31a06d6127afb17bea",
+      "from": "github:brave/brave-ui#e0aff04ebfa2b4ce03043f31a06d6127afb17bea",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@types/react-redux": "6.0.4",
     "@types/redux-logger": "^3.0.7",
     "awesome-typescript-loader": "^5.2.1",
-    "brave-ui": "github:brave/brave-ui#210a82491cf12d25c789c68b3634a41e3bc4b7c2",
+    "brave-ui": "github:brave/brave-ui#e0aff04ebfa2b4ce03043f31a06d6127afb17bea",
     "css-loader": "^2.1.1",
     "csstype": "^2.5.5",
     "deep-freeze-node": "^1.1.3",


### PR DESCRIPTION
Updates brave-ui dep: https://github.com/brave/brave-ui/compare/210a82491cf12d25c789c68b3634a41e3bc4b7c2...e0aff04ebfa2b4ce03043f31a06d6127afb17bea to bring in https://github.com/brave/brave-ui/pull/463
Fix: https://github.com/brave/brave-browser/issues/4213

Test Plan:

* Go to Shields (dark/light theme)
* Assert that dropdown menu have visible text