### PR TITLE
[0.65.x] Fix dropdown colors for Shields in Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,8 +1597,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#770f19c385f6fab0055e2d32411417ef76128ad2",
-      "from": "github:brave/brave-ui#770f19c385f6fab0055e2d32411417ef76128ad2",
+      "version": "github:brave/brave-ui#5b5da47c8e58d085b7e74f5fa5573e5cf837f852",
+      "from": "github:brave/brave-ui#5b5da47c8e58d085b7e74f5fa5573e5cf837f852",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@types/react-redux": "6.0.4",
     "@types/redux-logger": "^3.0.7",
     "awesome-typescript-loader": "^5.2.1",
-    "brave-ui": "github:brave/brave-ui#770f19c385f6fab0055e2d32411417ef76128ad2",
+    "brave-ui": "github:brave/brave-ui#5b5da47c8e58d085b7e74f5fa5573e5cf837f852",
     "css-loader": "^2.1.1",
     "csstype": "^2.5.5",
     "deep-freeze-node": "^1.1.3",


### PR DESCRIPTION
changes diff https://github.com/brave/brave-ui/compare/770f19c385f6fab0055e2d32411417ef76128ad2...5b5da47c8e58d085b7e74f5fa5573e5cf837f852

uplift request for https://github.com/brave/brave-core/pull/2378
uplift fix for https://github.com/brave/brave-browser/issues/4213

cc @brave/uplift-approvers this bug affects 0.64.60 as well. if you think it's valid to uplift in there please ping.