### PR TITLE
Avoid GetSiteForURL in the IO thread.

### DIFF
--- a/browser/tor/mock_tor_profile_service_factory.cc
+++ b/browser/tor/mock_tor_profile_service_factory.cc
@@ -44,9 +44,8 @@ MockTorProfileServiceFactory::~MockTorProfileServiceFactory() {}
 
 KeyedService* MockTorProfileServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  Profile* profile = Profile::FromBrowserContext(context);
   std::unique_ptr<tor::TorProfileService> tor_profile_service(
-      new tor::MockTorProfileServiceImpl(profile));
+      new tor::MockTorProfileServiceImpl());
   return tor_profile_service.release();
 }
 

--- a/browser/tor/mock_tor_profile_service_impl.h
+++ b/browser/tor/mock_tor_profile_service_impl.h
@@ -8,13 +8,12 @@
 
 #include "brave/browser/tor/tor_profile_service.h"
 
-class Profile;
 
 namespace tor {
 
 class MockTorProfileServiceImpl : public TorProfileService {
  public:
-  explicit MockTorProfileServiceImpl(Profile* profile);
+  MockTorProfileServiceImpl();
   ~MockTorProfileServiceImpl() override;
 
   // TorProfileService:
@@ -29,7 +28,6 @@ class MockTorProfileServiceImpl : public TorProfileService {
                bool new_circuit) override;
 
  private:
-  Profile* profile_;  // NOT OWNED
   TorConfig config_;
   DISALLOW_COPY_AND_ASSIGN(MockTorProfileServiceImpl);
 };

--- a/browser/tor/tor_profile_service.h
+++ b/browser/tor/tor_profile_service.h
@@ -51,6 +51,8 @@ class TorProfileService : public KeyedService {
  protected:
   base::ObserverList<TorLauncherServiceObserver> observers_;
 
+  static std::string CircuitIsolationKey(const GURL& request_url);
+
  private:
   DISALLOW_COPY_AND_ASSIGN(TorProfileService);
 };

--- a/browser/tor/tor_profile_service_impl.cc
+++ b/browser/tor/tor_profile_service_impl.cc
@@ -15,14 +15,12 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/site_instance.h"
 #include "content/public/browser/storage_partition.h"
-#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "net/proxy_resolution/proxy_resolution_service.h"
 #include "net/url_request/url_request_context.h"
 #include "net/url_request/url_request_context_getter.h"
 
 using content::BrowserContext;
 using content::BrowserThread;
-using content::SiteInstance;
 
 namespace tor {
 
@@ -46,26 +44,6 @@ void TorProfileServiceImpl::LaunchTor(const TorConfig& config) {
 
 void TorProfileServiceImpl::ReLaunchTor(const TorConfig& config) {
   tor_launcher_factory_->ReLaunchTorProcess(config);
-}
-
-std::string TorProfileServiceImpl::CircuitIsolationKey(const GURL& url) {
-  // https://2019.www.torproject.org/projects/torbrowser/design/#privacy
-  //
-  //    For the purposes of the unlinkability requirements of this
-  //    section as well as the descriptions in the implementation
-  //    section, a URL bar origin means at least the second-level DNS
-  //    name.  For example, for mail.google.com, the origin would be
-  //    google.com.  Implementations MAY, at their option, restrict
-  //    the URL bar origin to be the entire fully qualified domain
-  //    name.
-  //
-  // In particular, we need not isolate by the scheme,
-  // username/password, port, path, or query part of the URL.
-  url::Origin origin = url::Origin::Create(url);
-  std::string domain = net::registry_controlled_domains::GetDomainAndRegistry(
-      origin.host(),
-      net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
-  return domain;
 }
 
 void TorProfileServiceImpl::SetNewTorCircuitOnIOThread(

--- a/browser/tor/tor_profile_service_impl.h
+++ b/browser/tor/tor_profile_service_impl.h
@@ -52,6 +52,7 @@ class TorProfileServiceImpl : public TorProfileService,
  private:
   void SetNewTorCircuitOnIOThread(
       const scoped_refptr<net::URLRequestContextGetter>&, std::string);
+  std::string CircuitIsolationKey(const GURL& request_url);
 
   Profile* profile_;  // NOT OWNED
   TorLauncherFactory* tor_launcher_factory_;  // Singleton

--- a/browser/tor/tor_profile_service_impl.h
+++ b/browser/tor/tor_profile_service_impl.h
@@ -52,7 +52,6 @@ class TorProfileServiceImpl : public TorProfileService,
  private:
   void SetNewTorCircuitOnIOThread(
       const scoped_refptr<net::URLRequestContextGetter>&, std::string);
-  std::string CircuitIsolationKey(const GURL& request_url);
 
   Profile* profile_;  // NOT OWNED
   TorLauncherFactory* tor_launcher_factory_;  // Singleton


### PR DESCRIPTION
fix brave/brave-browser#4321

Calling it in the IO thread is prohibited at least as of
https://github.com/chromium/chromium/commit/ea6921f717f21e9a72d321a15c4bf50d47d10310
and possibly earlier.

Instead, call url::Origin::Create and
net::registry_controlled_domains::GetDomainAndRegistry directly to get
a first-party origin for a circuit isolation key.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
- browse in a private window with Tor using a Debug build with DCHECKs enabled
- confirm no DCHECKs

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
