### PR TITLE
Issue 4328: Proxying requests for sb-ssl.google.com for file proxy checks through sb-ssl.brave.com (uplift to 0.65.x)

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -21,6 +21,8 @@ int OnBeforeURLRequest_StaticRedirectWork(
   static URLPattern geo_pattern(URLPattern::SCHEME_HTTPS, kGeoLocationsPattern);
   static URLPattern safeBrowsing_pattern(URLPattern::SCHEME_HTTPS,
                                          kSafeBrowsingPrefix);
+  static URLPattern safebrowsingfilecheck_pattern(URLPattern::SCHEME_HTTPS,
+                                         kSafeBrowsingFileCheckPrefix);
   static URLPattern crlSet_pattern1(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix1);
   static URLPattern crlSet_pattern2(
@@ -43,6 +45,12 @@ int OnBeforeURLRequest_StaticRedirectWork(
 
   if (safeBrowsing_pattern.MatchesHost(ctx->request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
+    ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
+    return net::OK;
+  }
+
+  if (safebrowsingfilecheck_pattern.MatchesHost(ctx->request_url)) {
+    replacements.SetHostStr(kBraveSafeBrowsingFileCheckProxy);
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -283,6 +283,27 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
   EXPECT_EQ(ret, net::OK);
 }
 
+TEST_F(BraveStaticRedirectNetworkDelegateHelperTest,
+       ModifySafeBrowsingFileCheckURL) {
+  net::TestDelegate test_delegate;
+  GURL url(
+      "https://sb-ssl.google.com/safebrowsing/clientreport/download?"
+      "key=DUMMY_KEY");
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL expected_url(
+      "https://sb-ssl.brave.com/safebrowsing/clientreport/download?"
+      "key=DUMMY_KEY");
+  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
+  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+  EXPECT_EQ(ret, net::OK);
+}
+
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, RedirectTranslate) {
   net::TestDelegate test_delegate;
   std::string query_string(

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -16,6 +16,8 @@ const char kBraveReferralsHeadersPath[] = "/promo/custom-headers";
 const char kBraveReferralsInitPath[] = "/promo/initialize/nonua";
 const char kBraveReferralsActivityPath[] = "/promo/activity";
 
+const char kBraveSafeBrowsingFileCheckProxy[] = "sb-ssl.brave.com";
+
 const char kCRXDownloadPrefix[] =
     "*://clients2.googleusercontent.com/crx/blobs/*crx*";
 const char kEmptyDataURI[] = "data:text/plain,";
@@ -26,6 +28,7 @@ const char kJSDataURLPrefix[] = "data:application/javascript;base64,";
 const char kGeoLocationsPattern[] =
     "https://www.googleapis.com/geolocation/v1/geolocate?key=*";
 const char kSafeBrowsingPrefix[] = "https://safebrowsing.googleapis.com/";
+const char kSafeBrowsingFileCheckPrefix[] = "https://sb-ssl.google.com/";
 const char kCRLSetPrefix1[] =
     "*://dl.google.com/release2/chrome_component/*crl-set*";
 const char kCRLSetPrefix2[] =

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -12,6 +12,7 @@ extern const char kBraveReferralsServer[];
 extern const char kBraveReferralsHeadersPath[];
 extern const char kBraveReferralsInitPath[];
 extern const char kBraveReferralsActivityPath[];
+extern const char kBraveSafeBrowsingFileCheckProxy[];
 
 extern const char kCRXDownloadPrefix[];
 extern const char kEmptyDataURI[];
@@ -23,6 +24,7 @@ extern const char kGoogleTagServicesPattern[];
 extern const char kForbesPattern[];
 extern const char kForbesExtraCookies[];
 extern const char kSafeBrowsingPrefix[];
+extern const char kSafeBrowsingFileCheckPrefix[];
 extern const char kCRLSetPrefix1[];
 extern const char kCRLSetPrefix2[];
 extern const char kCRLSetPrefix3[];


### PR DESCRIPTION
Uplift of #2377

## Uplift Checklist

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly.
- [x] The PR milestones match the branch they're landing to.

PR Builder passed here: https://staging.ci.brave.com/job/brave-browser-build-pr/job/pr2377_sbssl_proxy_0.65.x/1/ - Failures on lint for uplift request are expected