### PR TITLE
DONT MERGE - test branch for Chromium 74 `go updater`

### DIFF
--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -6,7 +6,9 @@
 #include "brave/common/network_constants.h"
 
 const char kBraveUpdatesExtensionsEndpoint[] =
-    "https://go-updater.brave.com/extensions";
+    // "https://go-updater.brave.com/extensions";
+    // TODO(bsclifton): remove me
+    "http://18.188.45.225/extensions";
 // For debgugging:
 // const char kBraveUpdatesExtensionsEndpoint[] =
 // "http://localhost:8192/extensions";


### PR DESCRIPTION
DO NOT MERGE

`go-updater` has been updated with https://github.com/brave/go-update/pull/25 (still WIP)

@jumde is going through test plan right now. As part of our testing, we need to ensure that Chromium 74 still works fine (and uses XML).  The intention of this PR is to allow PR builder to create the artifacts so that we can do a proper QA test

cc: @kjozwiak