### PR TITLE
Re-enable Confirmations for Android only branch

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -14,9 +14,7 @@
 #include "base/task/task_scheduler/task_scheduler.h"
 #include "bat/ads/issuers_info.h"
 #include "bat/ads/notification_info.h"
-#if !defined(OS_ANDROID)
 #include "bat/confirmations/confirmations.h"
-#endif
 #include "bat/ledger/internal/bat_client.h"
 #include "bat/ledger/internal/bat_contribution.h"
 #include "bat/ledger/internal/bat_get_media.h"
@@ -239,9 +237,7 @@ void LedgerImpl::OnLedgerStateLoaded(ledger::Result result,
       OnWalletInitialized(ledger::Result::INVALID_LEDGER_STATE);
     } else {
       auto wallet_info = bat_state_->GetWalletInfo();
-#if !defined(OS_ANDROID)
       SetConfirmationsWalletInfo(wallet_info);
-#endif
 
       LoadPublisherState(this);
       bat_contribution_->OnStartUp();
@@ -258,7 +254,6 @@ void LedgerImpl::OnLedgerStateLoaded(ledger::Result result,
   }
 }
 
-#if !defined(OS_ANDROID)
 void LedgerImpl::SetConfirmationsWalletInfo(
     const braveledger_bat_helper::WALLET_INFO_ST& wallet_info) {
   if (!bat_confirmations_) {
@@ -274,7 +269,6 @@ void LedgerImpl::SetConfirmationsWalletInfo(
   bat_confirmations_->SetWalletInfo(
       std::make_unique<confirmations::WalletInfo>(confirmations_wallet_info));
 }
-#endif
 
 void LedgerImpl::LoadPublisherState(ledger::LedgerCallbackHandler* handler) {
   ledger_client_->LoadPublisherState(handler);
@@ -853,10 +847,8 @@ void LedgerImpl::DownloadPublisherList(
 }
 
 void LedgerImpl::OnTimer(uint32_t timer_id) {
-#if !defined(OS_ANDROID)
   if (bat_confirmations_->OnTimer(timer_id))
     return;
-#endif
 
   if (timer_id == last_pub_load_timer_id_) {
     last_pub_load_timer_id_ = 0;
@@ -1215,12 +1207,9 @@ void LedgerImpl::SetWalletInfo(
     const braveledger_bat_helper::WALLET_INFO_ST& info) {
   bat_state_->SetWalletInfo(info);
 
-#if !defined(OS_ANDROID)
   SetConfirmationsWalletInfo(info);
-#endif
 }
 
-#if !defined(OS_ANDROID)
 const confirmations::WalletInfo LedgerImpl::GetConfirmationsWalletInfo(
     const braveledger_bat_helper::WALLET_INFO_ST& info) const {
   confirmations::WalletInfo wallet_info;
@@ -1240,7 +1229,6 @@ const confirmations::WalletInfo LedgerImpl::GetConfirmationsWalletInfo(
 
   return wallet_info;
 }
-#endif
 
 void LedgerImpl::GetRewardsInternalsInfo(ledger::RewardsInternalsInfo* info) {
   // Retrieve the payment id.
@@ -1431,7 +1419,6 @@ void LedgerImpl::SetAddresses(std::map<std::string, std::string> addresses) {
 }
 
 void LedgerImpl::SetCatalogIssuers(const std::string& info) {
-#if !defined(OS_ANDROID)
   ads::IssuersInfo issuers_info_ads;
   if (issuers_info_ads.FromJson(info) != ads::Result::SUCCESS)
     return;
@@ -1446,11 +1433,9 @@ void LedgerImpl::SetCatalogIssuers(const std::string& info) {
   }
 
   bat_confirmations_->SetCatalogIssuers(std::move(issuers_info));
-#endif
 }
 
 void LedgerImpl::ConfirmAd(const std::string& info) {
-#if !defined(OS_ANDROID)
   ads::NotificationInfo notification_info_ads;
   if (notification_info_ads.FromJson(info) != ads::Result::SUCCESS)
     return;
@@ -1491,14 +1476,11 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
   }
 
   bat_confirmations_->ConfirmAd(std::move(notification_info));
-#endif
 }
 
 void LedgerImpl::GetTransactionHistoryForThisCycle(
     ledger::GetTransactionHistoryForThisCycleCallback callback) {
-#if !defined(OS_ANDROID)
   bat_confirmations_->GetTransactionHistoryForThisCycle(callback);
-#endif
 }
 
 void LedgerImpl::RefreshPublisher(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -13,9 +13,7 @@
 #include <vector>
 
 #include "base/memory/scoped_refptr.h"
-#if !defined(OS_ANDROID)
 #include "bat/confirmations/confirmations_client.h"
-#endif
 #include "bat/ledger/internal/bat_helper.h"
 #include "bat/ledger/internal/logging.h"
 
@@ -47,11 +45,9 @@ namespace braveledger_bat_contribution {
 class BatContribution;
 }
 
-#if !defined(OS_ANDROID)
 namespace confirmations {
 class Confirmations;
 }
-#endif
 
 namespace bat_ledger {
 
@@ -175,10 +171,8 @@ class LedgerImpl : public ledger::Ledger,
 
   void LoadNicewareList(ledger::GetNicewareListCallback callback);
 
-#if !defined(OS_ANDROID)
   void SetConfirmationsWalletInfo(
       const braveledger_bat_helper::WALLET_INFO_ST& wallet_info);
-#endif
 
   void LoadLedgerState(ledger::LedgerCallbackHandler* handler);
 
@@ -362,10 +356,8 @@ class LedgerImpl : public ledger::Ledger,
 
   void SetWalletInfo(const braveledger_bat_helper::WALLET_INFO_ST& info);
 
-#if !defined(OS_ANDROID)
   const confirmations::WalletInfo GetConfirmationsWalletInfo(
       const braveledger_bat_helper::WALLET_INFO_ST& info) const;
-#endif
 
   const braveledger_bat_helper::WALLET_PROPERTIES_ST&
   GetWalletProperties() const;
@@ -548,9 +540,7 @@ class LedgerImpl : public ledger::Ledger,
   std::unique_ptr<braveledger_bat_state::BatState> bat_state_;
   std::unique_ptr<braveledger_bat_contribution::BatContribution>
   bat_contribution_;
-#if !defined(OS_ANDROID)
   std::unique_ptr<confirmations::Confirmations> bat_confirmations_;
-#endif
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   bool initialized_task_scheduler_;
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/4387
Requires https://github.com/brave/brave-core/pull/2415

**IMPORTANT:** https://github.com/brave/brave-core/pull/2415 needs to be merged to `master` and cherry-picked to `android_74-brave-ads`