### PR TITLE
WIP: Redirect .onion URLs to a private window with Tor, if possible.

### DIFF
--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -3,19 +3,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/profiles/brave_profile_manager.h"
 #include "brave/browser/renderer_host/brave_navigation_ui_data.h"
 #include "brave/common/webui_url_constants.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_navigator_params.h"
 #include "chrome/common/webui_url_constants.h"
 #include "url/gurl.h"
 
 namespace {
-void AdjustNavigateParamsForURLBraveImpl(NavigateParams* params) {
+bool AdjustNavigateParamsForURLBraveImpl(NavigateParams* params) {
   if (params->url.SchemeIs(content::kBraveUIScheme)) {
     GURL::Replacements replacements;
     replacements.SetSchemeStr(content::kChromeUIScheme);
     params->url = params->url.ReplaceComponents(replacements);
   }
+  if (params->url.SchemeIsHTTPOrHTTPS() &&
+      params->url.DomainIs("onion")) {
+    ProfileManager* profile_manager = g_browser_process->profile_manager();
+    Profile* profile = profile_manager->GetProfileByPath(
+        BraveProfileManager::GetTorProfilePath());
+    if (profile) {
+      Browser* browser = chrome::FindTabbedBrowser(profile, true);
+      DCHECK(browser);
+      params->disposition = WindowOpenDisposition::SINGLETON_TAB;
+      params->browser = browser;
+      params->window_action = NavigateParams::SHOW_WINDOW;
+    } else {
+      LOG(ERROR) << "Tried to load .onion without Tor ready";
+      return false;
+    }
+  }
+  return true;
 }
 
 bool IsHostAllowedInIncognitoBraveImpl(const base::StringPiece& host) {

--- a/patches/chrome-browser-ui-browser_navigator.cc.patch
+++ b/patches/chrome-browser-ui-browser_navigator.cc.patch
@@ -1,16 +1,17 @@
 diff --git a/chrome/browser/ui/browser_navigator.cc b/chrome/browser/ui/browser_navigator.cc
-index 0d1221f617040499eeff4955458d6139b6baa1b2..6806bcaaef009be13f8c79d3a045bfdd09d72ca7 100644
+index 0d1221f617040499eeff4955458d6139b6baa1b2..4b71fc2c63f9c6259e35dd7a9a6bcd2b3c34a429 100644
 --- a/chrome/browser/ui/browser_navigator.cc
 +++ b/chrome/browser/ui/browser_navigator.cc
-@@ -105,6 +105,7 @@ Browser* GetOrCreateBrowser(Profile* profile, bool user_gesture) {
+@@ -105,6 +105,8 @@ Browser* GetOrCreateBrowser(Profile* profile, bool user_gesture) {
  // Returns true on success. Otherwise, if changing params leads the browser into
  // an erroneous state, returns false.
  bool AdjustNavigateParamsForURL(NavigateParams* params) {
-+  AdjustNavigateParamsForURLBraveImpl(params);
++  if (!AdjustNavigateParamsForURLBraveImpl(params))
++    return false;
    if (params->contents_to_insert || params->switch_to_singleton_tab ||
        IsURLAllowedInIncognito(params->url, params->initiating_profile) ||
        params->initiating_profile->IsGuestSession()) {
-@@ -724,6 +725,7 @@ void Navigate(NavigateParams* params) {
+@@ -724,6 +726,7 @@ void Navigate(NavigateParams* params) {
  bool IsHostAllowedInIncognito(const GURL& url) {
    std::string scheme = url.scheme();
    base::StringPiece host = url.host_piece();


### PR DESCRIPTION
fix brave/brave-browser#806

- If there is no private window with Tor open, fail.

  => TODO: This should fail noisily, beyond a console message.

  => One may be tempted to just create a private window with Tor, but:
     . This is not obviously easy to do here.
     . Users may not be happy if simply clicking a link can have the
       effect of using Tor when they didn't intend.

- If there is a private window with Tor open, create a new tab to load
  the page.

  => User expectations around onion services are likely to be that
     they provide anonymity, so opening them in the non-anonymous
     window may be surprising.

  => It is not clear how easy it would be to load in a non-Tor window
     and ensure that everything is nevertheless loaded through Tor --
     and likewise links from it, &c.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. Start a fresh Brave instance.
2. In a _non-Tor_ window, open a .onion site like http://duskgytldkxiuqc6.onion/ or https://facebookcorewwwi.onion/
3. Confirm that it fails.
4. Open a private window with Tor.
5. Again in a _non-Tor_ window, open the .onion site again.
6. Confirm that it opens in the private window with Tor instead.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
