### PR TITLE
fix missing deps of ads resource paks

### DIFF
--- a/brave_paks.gni
+++ b/brave_paks.gni
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_ads/browser/buildflags/buildflags.gni")
 import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
 import("//brave/components/brave_webtorrent/browser/buildflags/buildflags.gni")
 import("//build/config/locales.gni")
@@ -61,7 +62,6 @@ template("brave_extra_paks") {
       "$root_gen_dir/brave/browser/resources/settings/brave_settings_resources.pak",
       "$root_gen_dir/components/brave_components_resources.pak",
       "$root_gen_dir/brave/components/brave_ads/resources/brave_ads_resources.pak",
-      "$root_gen_dir/bat/ads/resources/bat_ads_resources.pak",
       "$root_gen_dir/brave/components/brave_rewards/resources/brave_rewards_resources.pak",
       "$root_gen_dir/brave/components/brave_sync/brave_sync_resources.pak",
       "$root_gen_dir/brave/ui/webui/resources/brave_webui_resources.pak",
@@ -112,6 +112,16 @@ template("brave_extra_paks") {
           "//brave/components/brave_rewards/resources/extension:resources",
         ]
       }
+    }
+
+    if (brave_ads_enabled) {
+      sources += [
+        "$root_gen_dir/bat/ads/resources/bat_ads_resources.pak",
+      ]
+
+      deps += [
+        "//brave/vendor/bat-native-ads/resources",
+      ]
     }
 
     if (defined(invoker.deps)) {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/4401
The missing deps was introduced by https://github.com/brave/brave-core/pull/2415 which added bat/ads/resources/bat_ads_resources.pak into brave_extra_paks.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
