### PR TITLE
WIP: Treat .onion domains as secure origins through Tor.

### DIFF
--- a/patches/content-common-origin_util.cc.patch
+++ b/patches/content-common-origin_util.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/content/common/origin_util.cc b/content/common/origin_util.cc
+index 878cb24ad05208daed3caf101337e59dc271afc0..fa90fd95da4d6352e3c12fee9502cc3b21ab0033 100644
+--- a/content/common/origin_util.cc
++++ b/content/common/origin_util.cc
+@@ -40,6 +40,12 @@ bool IsOriginSecure(const GURL& url) {
+   if (net::IsLocalhost(url))
+     return true;
+ 
++  // As a special case, we treat HTTP URLs as secure if the transport
++  // is Tor onion services.  We could do this for more schemes, but
++  // only if the transport actually goes through Tor.
++  if (url.SchemeIs("http") && url.DomainIs("onion"))
++    return true;
++
+   if (base::ContainsValue(url::GetSecureSchemes(), url.scheme()))
+     return true;
+ 

--- a/patches/third_party-blink-renderer-platform-weborigin-security_origin.cc.patch
+++ b/patches/third_party-blink-renderer-platform-weborigin-security_origin.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/third_party/blink/renderer/platform/weborigin/security_origin.cc b/third_party/blink/renderer/platform/weborigin/security_origin.cc
+index d629c18cab9d466fa8560e7fac2a233b62d7aa2b..130d6175925cc03cc6faf3dcc1b0e6842911dfc8 100644
+--- a/third_party/blink/renderer/platform/weborigin/security_origin.cc
++++ b/third_party/blink/renderer/platform/weborigin/security_origin.cc
+@@ -268,6 +268,12 @@ bool SecurityOrigin::IsSecure(const KURL& url) {
+   if (SchemeRegistry::ShouldTreatURLSchemeAsSecure(url.Protocol()))
+     return true;
+ 
++  // As a special case, we treat HTTP URLs as secure if the transport
++  // is Tor onion services.  We could do this for more schemes, but
++  // only if the transport actually goes through Tor.
++  if (url.ProtocolIs("http") && url.Host().EndsWithIgnoringASCIICase(".onion"))
++    return true;
++
+   // URLs that wrap inner URLs are secure if those inner URLs are secure.
+   if (ShouldUseInnerURL(url) && SchemeRegistry::ShouldTreatURLSchemeAsSecure(
+                                     ExtractInnerURL(url).Protocol()))


### PR DESCRIPTION
fix brave/brave-browser#1135

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
