### PR TITLE
Fix rewards extension state (notifications) array attempt to set by named property (uplift to 0.64.x)

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -143,11 +143,13 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
         return
       }
 
-      const id = payload.id
-      let notifications: Record<number, RewardsExtension.Notification> = state.notifications
+      const id: string = payload.id
+      let notifications: Record<string, RewardsExtension.Notification> = state.notifications
 
-      if (!notifications) {
-        notifications = []
+      // Array check for previous version of state types
+      // (https://github.com/brave/brave-browser/issues/4344)
+      if (!notifications || Array.isArray(notifications)) {
+        notifications = {}
       }
 
       notifications[id] = {
@@ -324,7 +326,7 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       break
     }
     case types.ON_ALL_NOTIFICATIONS: {
-      const list = payload.list
+      const list: RewardsExtension.Notification[] = payload.list
 
       if (!list) {
         break
@@ -333,8 +335,10 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       let notifications: Record<number, RewardsExtension.Notification> = state.notifications
       let id = ''
 
-      if (!notifications) {
-        notifications = []
+      // Array check for previous version of state types
+      // (https://github.com/brave/brave-browser/issues/4344)
+      if (!notifications || Array.isArray(notifications)) {
+        notifications = {}
       }
 
       list.forEach((notification: RewardsExtension.Notification) => {

--- a/components/definitions/rewardsExtensions.d.ts
+++ b/components/definitions/rewardsExtensions.d.ts
@@ -4,7 +4,7 @@ declare namespace RewardsExtension {
     currentNotification?: string
     enabledAC: boolean
     enabledMain: boolean
-    notifications: Record<number, Notification>
+    notifications: Record<string, Notification>
     publishers: Record<string, Publisher>
     report: Report
     grants?: GrantInfo[]


### PR DESCRIPTION
Uplift of #2407

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.