### PR TITLE
modify HTMLHtmlElement to reject async-hide when set by JS

### DIFF
--- a/chromium_src/third_party/blink/renderer/core/dom/element_additions.cc
+++ b/chromium_src/third_party/blink/renderer/core/dom/element_additions.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/dom/node.cc"
+#include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
+#include "third_party/blink/renderer/platform/wtf/text/string_view.cc"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+
+namespace blink {
+
+AtomicString PossiblyModifyAttrParam(const Element& elm,
+    const QualifiedName& name, const AtomicString& new_value) {
+  // Check to see if the following conditions are true, to work around
+  // the google tag manager (and related) block-the-screen stuff.
+  //   1) The class being modified
+  //   2) The element being modified is the <html> element
+  //   3) The new class value includes "async-hide"
+  // https://github.com/brave/brave-browser/issues/4402
+  const StringView async_hide_class_token("async-hide");
+  const bool should_strip_async_hide_class = (
+    name == kClassAttr &&
+    elm.tagName().LowerASCII() == "html" &&
+    new_value.Find(async_hide_class_token) != kNotFound);
+
+  if (!should_strip_async_hide_class) {
+    return new_value;
+  }
+
+  String prev_attr_value = new_value.GetString();
+  AtomicString modified_value(prev_attr_value.Replace(
+    async_hide_class_token, StringView("")));
+
+  return modified_value;
+}
+
+}  // namespace blink
+

--- a/patches/third_party-blink-renderer-core-dom-element.cc.patch
+++ b/patches/third_party-blink-renderer-core-dom-element.cc.patch
@@ -1,0 +1,45 @@
+diff --git a/third_party/blink/renderer/core/dom/element.cc b/third_party/blink/renderer/core/dom/element.cc
+index 8a7abaeb53db0fdbe3f1ba9d52c7a2770ad9438b..1ad787c8cc0110ce99089c9bd8eddcab0cebfce5 100644
+--- a/third_party/blink/renderer/core/dom/element.cc
++++ b/third_party/blink/renderer/core/dom/element.cc
+@@ -162,6 +162,10 @@
+ #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
+ #include "third_party/blink/renderer/platform/wtf/text/text_position.h"
+ 
++#if defined(BRAVE_CHROMIUM_BUILD)
++#include "third_party/blink/renderer/core/dom/element_additions.cc"
++#endif
++
+ namespace blink {
+ 
+ using namespace html_names;
+@@ -1699,8 +1703,11 @@ ALWAYS_INLINE void Element::SetAttributeInternal(
+     return;
+   }
+ 
++  // Brave addition
++  AtomicString modified_value = PossiblyModifyAttrParam(*this, name, new_value);
++
+   if (index == kNotFound) {
+-    AppendAttributeInternal(name, new_value,
++    AppendAttributeInternal(name, modified_value,
+                             in_synchronization_of_lazy_attribute);
+     return;
+   }
+@@ -1712,12 +1719,12 @@ ALWAYS_INLINE void Element::SetAttributeInternal(
+ 
+   if (!in_synchronization_of_lazy_attribute)
+     WillModifyAttribute(existing_attribute_name, existing_attribute_value,
+-                        new_value);
+-  if (new_value != existing_attribute_value)
+-    EnsureUniqueElementData().Attributes().at(index).SetValue(new_value);
++                        modified_value);
++  if (modified_value != existing_attribute_value)
++    EnsureUniqueElementData().Attributes().at(index).SetValue(modified_value);
+   if (!in_synchronization_of_lazy_attribute)
+     DidModifyAttribute(existing_attribute_name, existing_attribute_value,
+-                       new_value);
++                       modified_value);
+ }
+ 
+ static inline AtomicString MakeIdForStyleResolution(const AtomicString& value,


### PR DESCRIPTION
## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [X] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [X] macOS
  - [ ] Linux
- [X] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
