### PR TITLE
Restore storage partition isolation by origin.

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -347,3 +347,35 @@ GURL BraveContentBrowserClient::GetEffectiveURL(
   return url;
 #endif
 }
+
+std::string BraveContentBrowserClient::GetStoragePartitionIdForSite(
+    content::BrowserContext* browser_context,
+    const GURL& site) {
+  std::string partition_id =
+    ChromeContentBrowserClient::GetStoragePartitionIdForSite(
+        browser_context, site);
+  if (browser_context->IsTorProfile()) {
+    partition_id = site.spec();
+  }
+  DCHECK(IsValidStoragePartitionId(browser_context, partition_id));
+  return partition_id;
+}
+
+void BraveContentBrowserClient::GetStoragePartitionConfigForSite(
+    content::BrowserContext* browser_context,
+    const GURL& site,
+    bool can_be_default,
+    std::string* partition_domain,
+    std::string* partition_name,
+    bool* in_memory) {
+  ChromeContentBrowserClient::GetStoragePartitionConfigForSite(
+      browser_context, site, can_be_default, partition_domain, partition_name,
+      in_memory);
+  if (browser_context->IsTorProfile()) {
+    if (!site.is_empty()) {
+      *partition_domain = site.host();
+      *partition_name = "tor";
+    }
+    *in_memory = true;
+  }
+}

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -80,6 +80,17 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
   GURL GetEffectiveURL(content::BrowserContext* browser_context,
                        const GURL& url) override;
 
+  std::string GetStoragePartitionIdForSite(
+      content::BrowserContext* browser_context,
+      const GURL& site) override;
+  void GetStoragePartitionConfigForSite(
+      content::BrowserContext* browser_context,
+      const GURL& site,
+      bool can_be_default,
+      std::string* partition_domain,
+      std::string* partition_name,
+      bool* in_memory) override;
+
  private:
   bool AllowAccessCookie(const GURL& url, const GURL& first_party,
       content::ResourceContext* context, int render_process_id,


### PR DESCRIPTION
This got lost in the transition from muon to brave-core.  OOPS.

fix https://github.com/brave/brave-browser/issues/4442

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
