### PR TITLE
Add urllib3 retry logic for upload POST action

### DIFF
--- a/script/lib/github.py
+++ b/script/lib/github.py
@@ -6,6 +6,10 @@ import re
 import requests
 import sys
 import base64
+import logging
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from urllib3.exceptions import MaxRetryError
 try:
     from util import execute, scoped_cwd
 except ImportError:
@@ -31,6 +35,22 @@ class GitHub:
     def __getattr__(self, attr):
         return _Callable(self, '/%s' % attr)
 
+    def retry_session(retries=5, session=None, backoff_factor=0.3, status_forcelist=(500, 502, 503, 504),
+                      raise_on_status=True):
+        session = session or requests.Session()
+        retry = Retry(
+            total=retries,
+            read=retries,
+            connect=retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=status_forcelist,
+            raise_on_status=True,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        return session
+
     def send(self, method, path, **kw):
         if 'headers' not in kw:
             kw['headers'] = dict()
@@ -48,10 +68,17 @@ class GitHub:
                 kw['data'] = json.dumps(kw['data'])
 
         try:
-            r = getattr(requests, method)(url, **kw).json()
+            if method == "post":
+                logging.debug("Using session to override urllib3 Retry function for POST actions")
+                session = self.retry_session()
+                r = getattr(session, method)(url, **kw).json()
+            else:
+                r = getattr(requests, method)(url, **kw).json()
         except ValueError:
             # Returned response may be empty in some cases
             r = {}
+        except MaxRetryError:
+            raise MaxRetryError
         if 'message' in r:
             raise Exception(json.dumps(r, indent=2, separators=(',', ': ')))
         return r

--- a/script/lib/helpers.py
+++ b/script/lib/helpers.py
@@ -6,7 +6,12 @@
 import os
 import json
 import requests
-from .config import get_raw_version, get_env_var
+import sys
+
+dirname = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(dirname, '..'))
+
+from config import get_raw_version, get_env_var  # noqa: E402
 
 BRAVE_REPO = "brave/brave-browser"
 BRAVE_CORE_REPO = "brave/brave-core"

--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -7,12 +7,16 @@
 import sys
 import unittest
 import os
-import upload
 from githubmock import Repo, Release, Asset
-from mock import MagicMock
+from mock import (Mock, MagicMock, patch)
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(dirname, '..'))
+sys.path.append(os.path.join(dirname, '..', 'lib'))
+
+from github import *                            # noqa: E402
+import upload                                   # noqa: E402
+from urllib3.exceptions import MaxRetryError    # noqa: E402
 
 
 # get an existing release (in draft status) from GitHub given a tag name
@@ -21,18 +25,17 @@ class TestGetDraft(unittest.TestCase):
         self.repo = Repo()
 
     def test_returns_existing_draft(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
-        self.assertEquals(upload.get_release(self.repo,
-                                             'test')['tag_name'], 'test', False)
+        self.repo.releases._releases = [{'tag_name': 'test', 'allow_published_release_updates': False}]
+        self.assertEquals(upload.get_release(self.repo, 'test', False), None)
 
     def test_fails_on_existing_release(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False, 'allow_published_release_updates': False}]
+        self.repo.releases._releases = [{'tag_name': 'test', 'allow_published_release_updates': False}]
         self.assertRaises(UserWarning, upload.get_release, self.repo, 'test', False)
 
     def test_returns_none_on_new_draft(self):
-        self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
+        self.repo.releases._releases = [{'tag_name': 'old', 'allow_published_release_updates': False}]
         upload.get_release(self.repo, 'new', False)
-        self.assertEquals(upload.get_release(self.repo, 'test'), None)
+        self.assertEquals(upload.get_release(self.repo, 'test', False), None)
 
 
 class TestGetBravePackages(unittest.TestCase):
@@ -289,6 +292,17 @@ class TestUploadBrave(unittest.TestCase):
         upload.upload_brave(self.repo, self.release, self.file_path)
         upload.upload_sha256_checksum.assert_called_with(
             self.release.tag_name, self.file_path)
+
+    @patch('github.GitHub.retry_session')
+    def test_retry_session(self, github_retry):
+        urlpart1 = "https://uploads.github.com:443/repos/brave/brave-browser/"
+        urlpart2 = "releases/17325413/assets?name=brave-browser-0.61.51-1.x86_64.rpm"
+        github_retry.side_effect = MaxRetryError("retry_session_pool", urlpart1 + urlpart2,
+                                                 MaxRetryError)
+        try:
+            github_retry()
+        except MaxRetryError as mre:
+            print("Caught MaxRetryError: {}".format(mre))
 
     # TODO: test `armv7l` code path
 


### PR DESCRIPTION
This should initiate 5 retries when we receive
502 Bad Gateway errors uploading to GitHub.

Fixes https://github.com/brave/devops/issues/943

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
