### PR TITLE
guard on ref promo code

### DIFF
--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -10,12 +10,15 @@
 #include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/tor/tor_profile_service.h"
 #include "brave/components/brave_referrals/buildflags/buildflags.h"
-#include "brave/components/brave_referrals/browser/brave_referrals_service.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
 #include "chrome/browser/first_run/first_run.h"
 #include "chrome/common/pref_names.h"
 #include "components/metrics/metrics_pref_names.h"
 #include "components/prefs/pref_registry_simple.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
+#include "brave/components/brave_referrals/browser/brave_referrals_service.h"
+#endif
 
 namespace brave {
 

--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -9,6 +9,7 @@
 #include "brave/browser/brave_stats_updater_util.h"
 #include "brave/browser/version_info.h"
 #include "brave/common/pref_names.h"
+#include "brave/components/brave_referrals/buildflags/buildflags.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/net/system_network_context_manager.h"
 #include "chrome/common/channel_info.h"
@@ -97,6 +98,7 @@ void BraveStatsUpdater::Start() {
   // code.
   DCHECK(!server_ping_startup_timer_);
   server_ping_startup_timer_ = std::make_unique<base::OneShotTimer>();
+#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   if (pref_service_->GetBoolean(kReferralCheckedForPromoCodeFile)) {
     StartServerPingStartupTimer();
   } else {
@@ -107,6 +109,9 @@ void BraveStatsUpdater::Start() {
         base::Bind(&BraveStatsUpdater::OnReferralCheckedForPromoCodeFileChanged,
                    base::Unretained(this)));
   }
+#else
+  StartServerPingStartupTimer();
+#endif
 
   // Periodic timer.
   DCHECK(!server_ping_periodic_timer_);

--- a/browser/brave_stats_updater_params.cc
+++ b/browser/brave_stats_updater_params.cc
@@ -6,6 +6,7 @@
 #include <cmath>
 
 #include "brave/browser/brave_stats_updater_params.h"
+#include "brave/components/brave_referrals/buildflags/buildflags.h"
 
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
@@ -69,7 +70,9 @@ void BraveStatsUpdaterParams::LoadPrefs() {
   week_of_installation_ = pref_service_->GetString(kWeekOfInstallation);
   if (week_of_installation_.empty())
     week_of_installation_ = GetLastMondayAsYMD();
+#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   referral_promo_code_ = pref_service_->GetString(kReferralPromoCode);
+#endif
 }
 
 void BraveStatsUpdaterParams::SavePrefs() {

--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -28,7 +28,8 @@ void ContentSettingsRegistry::BraveInit() {
                     CONTENT_SETTING_ASK,
                     CONTENT_SETTING_DETECT_IMPORTANT_CONTENT),
       WebsiteSettingsInfo::SINGLE_ORIGIN_WITH_EMBEDDED_EXCEPTIONS_SCOPE,
-      WebsiteSettingsRegistry::DESKTOP,
+      WebsiteSettingsRegistry::DESKTOP |
+          WebsiteSettingsRegistry::PLATFORM_ANDROID,
       ContentSettingsInfo::INHERIT_IN_INCOGNITO,
       ContentSettingsInfo::EPHEMERAL,
       ContentSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -149,7 +149,6 @@ void BraveReferralsService::OnReferralInitLoadComplete(
     return;
   }
 
-#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   const base::Value* download_id = root->FindKey("download_id");
   pref_service_->SetString(kReferralDownloadID, download_id->GetString());
 
@@ -167,7 +166,6 @@ void BraveReferralsService::OnReferralInitLoadComplete(
   task_runner_->PostTask(FROM_HERE,
                          base::Bind(&BraveReferralsService::DeletePromoCodeFile,
                                     base::Unretained(this)));
-#endif
 }
 
 void BraveReferralsService::OnReferralFinalizationCheckLoadComplete(
@@ -209,13 +207,11 @@ void BraveReferralsService::OnReferralFinalizationCheckLoadComplete(
 }
 
 void BraveReferralsService::OnReadPromoCodeComplete() {
-#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   pref_service_->SetBoolean(kReferralCheckedForPromoCodeFile, true);
   if (!promo_code_.empty()) {
     pref_service_->SetString(kReferralPromoCode, promo_code_);
     InitReferral();
   }
-#endif
 }
 
 void BraveReferralsService::GetFirstRunTime() {
@@ -321,11 +317,9 @@ void BraveReferralsService::MaybeDeletePromoCodePref() const {
   if (!delete_time_str.empty())
     base::StringToUint64(delete_time_str, &delete_time);
 
-#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   base::Time now = base::Time::Now();
   if (now - first_run_timestamp_ >= base::TimeDelta::FromSeconds(delete_time))
     pref_service_->ClearPref(kReferralPromoCode);
-#endif
 }
 
 std::string BraveReferralsService::BuildReferralInitPayload() const {

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -149,6 +149,7 @@ void BraveReferralsService::OnReferralInitLoadComplete(
     return;
   }
 
+#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   const base::Value* download_id = root->FindKey("download_id");
   pref_service_->SetString(kReferralDownloadID, download_id->GetString());
 
@@ -166,6 +167,7 @@ void BraveReferralsService::OnReferralInitLoadComplete(
   task_runner_->PostTask(FROM_HERE,
                          base::Bind(&BraveReferralsService::DeletePromoCodeFile,
                                     base::Unretained(this)));
+#endif
 }
 
 void BraveReferralsService::OnReferralFinalizationCheckLoadComplete(
@@ -207,11 +209,13 @@ void BraveReferralsService::OnReferralFinalizationCheckLoadComplete(
 }
 
 void BraveReferralsService::OnReadPromoCodeComplete() {
+#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   pref_service_->SetBoolean(kReferralCheckedForPromoCodeFile, true);
   if (!promo_code_.empty()) {
     pref_service_->SetString(kReferralPromoCode, promo_code_);
     InitReferral();
   }
+#endif
 }
 
 void BraveReferralsService::GetFirstRunTime() {
@@ -317,9 +321,11 @@ void BraveReferralsService::MaybeDeletePromoCodePref() const {
   if (!delete_time_str.empty())
     base::StringToUint64(delete_time_str, &delete_time);
 
+#if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   base::Time now = base::Time::Now();
   if (now - first_run_timestamp_ >= base::TimeDelta::FromSeconds(delete_time))
     pref_service_->ClearPref(kReferralPromoCode);
+#endif
 }
 
 std::string BraveReferralsService::BuildReferralInitPayload() const {


### PR DESCRIPTION
closes https://github.com/brave/brave-browser/issues/4487
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
