### PR TITLE
Lint fixes from #2384

### DIFF
--- a/browser/ui/webui/navigation_bar_data_provider.h
+++ b/browser/ui/webui/navigation_bar_data_provider.h
@@ -3,18 +3,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifndef BRAVE_BROWSER_UI_WEBUI_NAVIGATION_BAR_DATA_PROVIDER_H
-#define BRAVE_BROWSER_UI_WEBUI_NAVIGATION_BAR_DATA_PROVIDER_H
+#ifndef BRAVE_BROWSER_UI_WEBUI_NAVIGATION_BAR_DATA_PROVIDER_H_
+#define BRAVE_BROWSER_UI_WEBUI_NAVIGATION_BAR_DATA_PROVIDER_H_
 
 namespace content {
 class WebUIDataSource;
 }
 
 class NavigationBarDataProvider {
-  public:
-    // Sets load-time constants on |source|. This handles a flicker-free initial
-    // page load (i.e. loadTimeData.getString('brToolbarSettingsTitle')).
-    static void Initialize(content::WebUIDataSource* source);
+ public:
+  // Sets load-time constants on |source|. This handles a flicker-free initial
+  // page load (i.e. loadTimeData.getString('brToolbarSettingsTitle')).
+  static void Initialize(content::WebUIDataSource* source);
 };
 
-#endif
+#endif  // BRAVE_BROWSER_UI_WEBUI_NAVIGATION_BAR_DATA_PROVIDER_H_

--- a/chromium_src/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
@@ -13,5 +13,5 @@ void BraveCustomizeBookmarksDataSource(content::WebUIDataSource* source) {
 
 }  // namespace
 
-#include "../../../../../../chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc"
+#include "../../../../../../chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc"  // NOLINT
 

--- a/chromium_src/chrome/browser/ui/webui/history_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/history_ui.cc
@@ -13,5 +13,5 @@ void BraveCustomizeHistoryDataSource(content::WebUIDataSource* source) {
 
 }  // namespace
 
-#include "../../../../../chrome/browser/ui/webui/history_ui.cc"
+#include "../../../../../chrome/browser/ui/webui/history_ui.cc"  // NOLINT
 

--- a/chromium_src/ui/base/webui/web_ui_util.cc
+++ b/chromium_src/ui/base/webui/web_ui_util.cc
@@ -1,3 +1,8 @@
+// Copyright (c) 2019 The Brave Authors
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
 #include "ui/base/webui/web_ui_util.h"
 
 #include "brave/ui/webui/resources/grit/brave_webui_resources.h"
@@ -8,7 +13,7 @@
 #define IDR_WEBUI_CSS_TEXT_DEFAULTS_MD_PREVIOUS IDR_WEBUI_CSS_TEXT_DEFAULTS_MD
 #undef IDR_WEBUI_CSS_TEXT_DEFAULTS_MD
 #define IDR_WEBUI_CSS_TEXT_DEFAULTS_MD IDR_BRAVE_WEBUI_CSS_TEXT_DEFAULTS
-#include "../../../../../ui/base/webui/web_ui_util.cc"
+#include "../../../../../ui/base/webui/web_ui_util.cc"  // NOLINT
 #undef IDR_WEBUI_CSS_TEXT_DEFAULTS_MD
 #define IDR_WEBUI_CSS_TEXT_DEFAULTS_MD IDR_WEBUI_CSS_TEXT_DEFAULTS_MD_PREVIOUS
 


### PR DESCRIPTION
This is a no-code-change follow-up to #2384

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
`npm run lint`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
