### PR TITLE
Dont send bookmarks until chain is created. Re-do of brave-core pr#2016

### DIFF
--- a/components/brave_sync/brave_profile_sync_service.cc
+++ b/components/brave_sync/brave_profile_sync_service.cc
@@ -485,7 +485,7 @@ void BraveProfileSyncService::OnSyncReady() {
     ProfileSyncService::GetUserSettings()
       ->SetSelectedTypes(false, syncer::UserSelectableTypeSet());
     // default enable bookmark
-    OnSetSyncBookmarks(true);
+    brave_sync_prefs_->SetSyncBookmarksEnabled(true);
     ProfileSyncService::GetUserSettings()->SetSyncRequested(true);
   }
 }
@@ -692,6 +692,7 @@ void BraveProfileSyncService::OnResolvedPreferences(
   bool contains_only_one_device = false;
 
   auto sync_devices = brave_sync_prefs_->GetSyncDevices();
+  auto old_devices_size = sync_devices->size();
   for (const auto &record : records) {
     DCHECK(record->has_device() || record->has_sitesetting());
     if (record->has_device()) {
@@ -714,6 +715,12 @@ void BraveProfileSyncService::OnResolvedPreferences(
   }  // for each device
 
   brave_sync_prefs_->SetSyncDevices(*sync_devices);
+
+  if (old_devices_size < 2 && sync_devices->size() >= 2) {
+    // Re-enable sync of bookmarks
+    bool sync_bookmarks = brave_sync_prefs_->GetSyncBookmarksEnabled();
+    OnSetSyncBookmarks(sync_bookmarks);
+  }
 
   if (this_device_deleted) {
     ResetSyncInternal();

--- a/components/brave_sync/brave_profile_sync_service.cc
+++ b/components/brave_sync/brave_profile_sync_service.cc
@@ -490,6 +490,14 @@ void BraveProfileSyncService::OnSyncReady() {
   }
 }
 
+syncer::ModelTypeSet BraveProfileSyncService::GetPreferredDataTypes() const {
+  // Force DEVICE_INFO type to have nudge cycle each time to fetch
+  // Brave sync devices.
+  // Will be picked up by ProfileSyncService::ConfigureDataTypeManager
+  return Union(ProfileSyncService::GetPreferredDataTypes(),
+      { syncer::DEVICE_INFO });
+}
+
 void BraveProfileSyncService::OnGetExistingObjects(
     const std::string& category_name,
     std::unique_ptr<RecordsList> records,

--- a/components/brave_sync/brave_profile_sync_service.h
+++ b/components/brave_sync/brave_profile_sync_service.h
@@ -95,6 +95,8 @@ class BraveProfileSyncService : public syncer::ProfileSyncService,
   bool IsBraveSyncInitialized() const;
   bool IsBraveSyncConfigured() const;
 
+  syncer::ModelTypeSet GetPreferredDataTypes() const override;
+
  private:
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, BookmarkAdded);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, BookmarkDeleted);


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
