### PR TITLE
add script to get latest tag from github

### DIFF
--- a/script/locate_latest_github_tag.py
+++ b/script/locate_latest_github_tag.py
@@ -1,0 +1,83 @@
+import json
+import os
+import re
+import requests
+
+from argparse import RawTextHelpFormatter
+from distutils.version import LooseVersion
+from functools import cmp_to_key
+
+
+def call_github_api(url, headers):
+    try:
+        r = requests.get(url, headers=headers)
+    except requests.exceptions.ConnectionError as e:
+        print("Error: Received requests.exceptions.ConnectionError, Exiting...")
+        exit(1)
+    except Exception as e:
+        raise Exception(e)
+
+    if r.status_code is 200:
+        return r
+
+
+def loose_version_cmp(a, b):
+    if LooseVersion(a) == LooseVersion(b):
+        return 0
+    if LooseVersion(a) > LooseVersion(b):
+        return 1
+    if LooseVersion(a) < LooseVersion(b):
+        return -1
+
+
+def get_github_tags(branch):
+
+    GITHUB_URL = 'https://api.github.com'
+
+    tags = []
+
+    next_request = ""
+    headers = {'Accept': 'application/vnd.github+json',
+               'Authorization': 'token ' + os.environ.get('BRAVE_GITHUB_TOKEN')
+               }
+    tag_url = GITHUB_URL + "/repos/brave/brave-core/tags" + '?page=1&per_page=100'
+
+    r = call_github_api(tag_url, headers=headers)
+    next_request = ""
+
+    # The GitHub API returns paginated results of 100 items maximum per
+    # response. We will loop until there is no next link header returned
+    # in the response header. This is documented here:
+    # https://developer.github.com/v3/#pagination
+    while next_request is not None:
+        for item in r.json():
+            match = re.search(branch, item['name'])
+            if match:
+                tags.append(item['name'])
+        if r.links.get("next"):
+            next_request = r.links["next"]["url"]
+            r = call_github_api(next_request, headers=headers)
+        else:
+            next_request = None
+
+    return tags
+
+
+def main():
+    branch = os.environ.get('CHANNEL_BRANCH')
+    match = re.search(r'\d+[.]\d+', branch)
+    if match:
+        branch = match.group(0)
+    else:
+        print("Error: Malformed branch \'{}\'".format(branch))
+        exit(1)
+
+    items = get_github_tags(branch)
+
+    sorted_list = sorted(items, key=cmp_to_key(loose_version_cmp), reverse=True)
+    print(sorted_list[0])
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
This will be called via the
brave-browser-build.yml Jenkins job.

Fixes https://github.com/brave/devops/issues/1034

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
