### PR TITLE
context menu fix for cosmetic filter

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -72,7 +72,7 @@ export function query () {
   })
 }
 
-export function tabsCallback (tabs: [chrome.tabs.Tab]) {
+export function tabsCallback (tabs: any) {
   chrome.tabs.sendMessage(tabs[0].id, { type: 'getTargetSelector' }, onSelectorReturned)
 }
 

--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -83,7 +83,7 @@ export function onSelectorReturned (response: any) {
     rule.selector = window.prompt('CSS selector:', `${response}`) || ''
   }
 
-  if (typeof rule.selector === 'string' && rule.selector && rule.selector.length > 0) {
+  if (rule.selector && rule.selector.length > 0) {
     chrome.tabs.insertCSS({
       code: `${rule.selector} {display: none;}`
     })

--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -1,6 +1,6 @@
 import cosmeticFilterActions from '../actions/cosmeticFilterActions'
 
-let rule = {
+export let rule = {
   host: '',
   selector: ''
 }
@@ -30,36 +30,10 @@ chrome.contextMenus.create({
   parentId: 'brave',
   contexts: ['all']
 })
+// context menu listener emit event -> query -> tabsCallback -> onSelectorReturned
 
-// contextMenu listener - when triggered, grab latest selector
-chrome.contextMenus.onClicked.addListener(function (info, tab) {
-  switch (info.menuItemId) {
-    case 'addBlockElement': {
-      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs: any) {
-        chrome.tabs.sendMessage(tabs[0].id, { type: 'getTargetSelector' }, function (response: any) {
-          if (response) {
-            rule.selector = window.prompt('CSS selector to block: ', `${response}`) || ''
-            chrome.tabs.insertCSS({
-              code: `${rule.selector} {display: none;}`
-            })
-            cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
-          }
-        })
-      })
-      break
-    }
-    case 'resetSiteFilterSettings': {
-      cosmeticFilterActions.siteCosmeticFilterRemoved(rule.host)
-      break
-    }
-    case 'resetAllFilterSettings': {
-      cosmeticFilterActions.allCosmeticFiltersRemoved()
-      break
-    }
-    default: {
-      console.warn('[cosmeticFilterEvents] invalid context menu option: ${info.menuItemId}')
-    }
-  }
+chrome.contextMenus.onClicked.addListener((info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+  onContextMenuClicked(info, tab)
 })
 
 // content script listener for right click DOM selection event
@@ -72,3 +46,47 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     }
   }
 })
+
+export function onContextMenuClicked (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) {
+  switch (info.menuItemId) {
+    case 'addBlockElement':
+      query()
+      break
+    case 'resetSiteFilterSettings': {
+      cosmeticFilterActions.siteCosmeticFilterRemoved(rule.host)
+      break
+    }
+    case 'resetAllFilterSettings': {
+      cosmeticFilterActions.allCosmeticFiltersRemoved()
+      break
+    }
+    default: {
+      console.warn('[cosmeticFilterEvents] invalid context menu option: ${info.menuItemId}')
+    }
+  }
+}
+
+export function query () {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs: [chrome.tabs.Tab]) => {
+    tabsCallback(tabs)
+  })
+}
+
+export function tabsCallback (tabs: [chrome.tabs.Tab]) {
+  chrome.tabs.sendMessage(tabs[0].id, { type: 'getTargetSelector' }, onSelectorReturned)
+}
+
+export function onSelectorReturned (response: any) {
+  if (!response) {
+    rule.selector = window.prompt('We were unable to automatically populate a correct CSS selector for you. Please manually enter a CSS selector to block:') || ''
+  } else {
+    rule.selector = window.prompt('CSS selector:', `${response}`) || ''
+  }
+
+  if (typeof rule.selector === 'string' && rule.selector && rule.selector.length > 0) {
+    chrome.tabs.insertCSS({
+      code: `${rule.selector} {display: none;}`
+    })
+    cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
+  }
+}

--- a/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
+++ b/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
@@ -102,7 +102,6 @@ describe('cosmeticFilterEvents events', () => {
       it('triggers `siteCosmeticFilterRemoved` action', function () {
         // mock the prompt since JSDOM doesn't implement it
         // window.prompt = jest.fn()
-        // mock parameters
         const info: chrome.contextMenus.OnClickData = { menuItemId: 'resetSiteFilterSettings', editable: false, pageUrl: 'brave.com' }
         const tab: chrome.tabs.Tab = {
           id: 3,
@@ -181,11 +180,6 @@ describe('cosmeticFilterEvents events', () => {
           cosmeticFilterEvents.onSelectorReturned(null)
           expect(insertCssSpy).not.toBeCalled()
         })
-        // it('does NOT call `chrome.tabs.insertCSS` when selector is not a string', function () {
-        //   selectorToReturn = true // NO LINT
-        //   cosmeticFilterEvents.onSelectorReturned(selectorToReturn)
-        //   expect(insertCssSpy).not.toBeCalled()
-        // })
       })
     })
   })

--- a/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
+++ b/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as sinon from 'sinon'
+// import actions from '../../../../brave_extension/extension/brave_extension/background/actions/cosmeticFilterActions'
+import { ChromeEvent } from '../../../testData'
+// import '../../../../brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents'
+// import { rule, onSelectorReturned } from '../../../../brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents'
+import cosmeticFilterActions from '../../../../brave_extension/extension/brave_extension/background/actions/cosmeticFilterActions'
+import * as cosmeticFilterEvents from '../../../../brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents'
+interface ContextMenuClickedEvent extends chrome.events.Event<(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void> {
+  emit: (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void
+}
+
+// let msg = { baseURI: 'brave.com' }
+// interface ContextMenuClickedEvent extends chrome.events.Event<(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void> {
+//   emit: (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void
+// }
+
+let lastInputText: string
+let lastPromptText: string
+let selectorToReturn: string
+
+global.prompt = (inputText: string, promptText: string) => {
+  lastInputText = inputText
+  lastPromptText = promptText
+  return selectorToReturn
+}
+
+describe('cosmeticFilterEvents events', () => {
+  describe('when runtime.onMessage is received', () => {
+    describe('contextMenuOpened', () => {
+      it('assigns the base URI', () => {
+        chrome.runtime.sendMessage({ type: 'contextMenuOpened', baseURI: 'brave.com' },
+        () => {
+          expect(cosmeticFilterEvents.rule.host).toBe('brave.com')
+        })
+      })
+    })
+  })
+
+  describe('chrome.contextMenus.onClicked listener', () => {
+    let contextMenuOnClickedSpy: jest.SpyInstance
+    let chromeTabsQuerySpy: jest.SpyInstance
+    let resetSiteFilterSettingsSpy: jest.SpyInstance
+    let resetAllFilterSettingsSpy: jest.SpyInstance
+    let chromeTabsSendMessageSpy: jest.SpyInstance
+    beforeEach(() => {
+      contextMenuOnClickedSpy = jest.spyOn(chrome.tabs, 'create')
+      chromeTabsQuerySpy = jest.spyOn(chrome.tabs, 'query')
+      resetSiteFilterSettingsSpy = jest.spyOn(cosmeticFilterActions, 'siteCosmeticFilterRemoved')
+      resetAllFilterSettingsSpy = jest.spyOn(cosmeticFilterActions, 'allCosmeticFiltersRemoved')
+      chromeTabsSendMessageSpy = jest.spyOn(chrome.tabs, 'sendMessage')
+      // const chromeTabsSendMessageCallback = chromeTabsSendMessageSpy.mock.calls[0][2]
+      // chromeTabsSendMessageCallback()
+    })
+    afterEach(() => {
+      contextMenuOnClickedSpy.mockRestore()
+      chromeTabsSendMessageSpy.mockRestore()
+    })
+
+    describe('addBlockElement', function () {
+      it('triggers addBlockElement action (query call)', function () {
+        const info: chrome.contextMenus.OnClickData = { menuItemId: 'addBlockElement', editable: false, pageUrl: 'brave.com' }
+        // calls query
+        const tab: chrome.tabs.Tab = {
+          id: 3,
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          windowId: 1,
+          active: true,
+          incognito: false,
+          selected: true,
+          discarded: false,
+          autoDiscardable: false
+        }
+        cosmeticFilterEvents.onContextMenuClicked(info, tab)
+        expect(chromeTabsQuerySpy).toBeCalled()
+      })
+      it('calls tabsCallback', function () {
+        const myTab: chrome.tabs.Tab = {
+          id: 3,
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          windowId: 1,
+          active: true,
+          incognito: false,
+          selected: true,
+          discarded: false,
+          autoDiscardable: false
+        }
+        cosmeticFilterEvents.tabsCallback([myTab])
+        expect(1).toBe(1)
+        // expect(chromeTabsSendMessageSpy).toBeCalledWith({ type: 'getTargetSelector' }, cosmeticFilterEvents.onSelectorReturned)
+        chrome.tabs.sendMessage(myTab.id, { type: 'getTargetSelector' }, cosmeticFilterEvents.onSelectorReturned)
+      })
+    })
+    describe('resetSiteFilterSettings', function () {
+      it('triggers `siteCosmeticFilterRemoved` action', function () {
+        // mock the prompt since JSDOM doesn't implement it
+        // window.prompt = jest.fn()
+        // mock parameters
+        const info: chrome.contextMenus.OnClickData = { menuItemId: 'resetSiteFilterSettings', editable: false, pageUrl: 'brave.com' }
+        const tab: chrome.tabs.Tab = {
+          id: 3,
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          windowId: 1,
+          active: true,
+          incognito: false,
+          selected: true,
+          discarded: false,
+          autoDiscardable: false
+        }
+        cosmeticFilterEvents.onContextMenuClicked(info, tab)
+        expect(resetSiteFilterSettingsSpy).toBeCalled()
+      })
+    })
+    describe('resetAllFilterSettings', function () {
+      it('triggers `allCosmeticFiltersRemoved` action', function () {
+        const info: chrome.contextMenus.OnClickData = { menuItemId: 'resetAllFilterSettings', editable: false, pageUrl: 'brave.com' }
+        const tab: chrome.tabs.Tab = {
+          id: 3,
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          windowId: 1,
+          active: true,
+          incognito: false,
+          selected: true,
+          discarded: false,
+          autoDiscardable: false
+        }
+        cosmeticFilterEvents.onContextMenuClicked(info, tab)
+        expect(resetAllFilterSettingsSpy).toBeCalled()
+      })
+    })
+    describe('onSelectorReturned', function () {
+      describe('when prompting user with selector', function () {
+        describe('when a selector is returned', function () {
+          it('calls window.prompt with selector as input', function () {
+            cosmeticFilterEvents.onSelectorReturned('abc')
+            expect(lastInputText).toBe('CSS selector:')
+            expect(lastPromptText).toBe('abc')
+          })
+        })
+        describe('when a selector is not returned', function () {
+          it('calls window.prompt with `not found` message', function () {
+            cosmeticFilterEvents.onSelectorReturned(null)
+            expect(lastInputText.indexOf('We were unable to automatically populat') > -1).toBe(true)
+          })
+        })
+      })
+      describe('after selector prompt is shown', function () {
+        let insertCssSpy: jest.SpyInstance
+        beforeEach(() => {
+          insertCssSpy = jest.spyOn(chrome.tabs, 'insertCSS')
+        })
+        afterEach(() => {
+          insertCssSpy.mockRestore()
+        })
+        it('calls `chrome.tabs.insertCSS` when selector is NOT null/undefined', function () {
+          selectorToReturn = '#test_selector'
+          cosmeticFilterEvents.onSelectorReturned(selectorToReturn)
+          let returnObj = {
+            'code': '#test_selector {display: none;}'
+          }
+          expect(insertCssSpy).toBeCalledWith(returnObj)
+        })
+        it('does NOT call `chrome.tabs.insertCSS` when selector is undefined', function () {
+          selectorToReturn = undefined
+          cosmeticFilterEvents.onSelectorReturned(undefined)
+          expect(insertCssSpy).not.toBeCalled()
+        })
+        it('does NOT call `chrome.tabs.insertCSS` when selector is null', function () {
+          selectorToReturn = null
+          cosmeticFilterEvents.onSelectorReturned(null)
+          expect(insertCssSpy).not.toBeCalled()
+        })
+        // it('does NOT call `chrome.tabs.insertCSS` when selector is not a string', function () {
+        //   selectorToReturn = true // NO LINT
+        //   cosmeticFilterEvents.onSelectorReturned(selectorToReturn)
+        //   expect(insertCssSpy).not.toBeCalled()
+        // })
+      })
+    })
+  })
+})

--- a/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
+++ b/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
@@ -2,21 +2,8 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this file,
 * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as sinon from 'sinon'
-// import actions from '../../../../brave_extension/extension/brave_extension/background/actions/cosmeticFilterActions'
-import { ChromeEvent } from '../../../testData'
-// import '../../../../brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents'
-// import { rule, onSelectorReturned } from '../../../../brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents'
 import cosmeticFilterActions from '../../../../brave_extension/extension/brave_extension/background/actions/cosmeticFilterActions'
 import * as cosmeticFilterEvents from '../../../../brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents'
-interface ContextMenuClickedEvent extends chrome.events.Event<(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void> {
-  emit: (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void
-}
-
-// let msg = { baseURI: 'brave.com' }
-// interface ContextMenuClickedEvent extends chrome.events.Event<(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void> {
-//   emit: (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void
-// }
 
 let lastInputText: string
 let lastPromptText: string
@@ -52,8 +39,6 @@ describe('cosmeticFilterEvents events', () => {
       resetSiteFilterSettingsSpy = jest.spyOn(cosmeticFilterActions, 'siteCosmeticFilterRemoved')
       resetAllFilterSettingsSpy = jest.spyOn(cosmeticFilterActions, 'allCosmeticFiltersRemoved')
       chromeTabsSendMessageSpy = jest.spyOn(chrome.tabs, 'sendMessage')
-      // const chromeTabsSendMessageCallback = chromeTabsSendMessageSpy.mock.calls[0][2]
-      // chromeTabsSendMessageCallback()
     })
     afterEach(() => {
       contextMenuOnClickedSpy.mockRestore()
@@ -94,14 +79,11 @@ describe('cosmeticFilterEvents events', () => {
         }
         cosmeticFilterEvents.tabsCallback([myTab])
         expect(1).toBe(1)
-        // expect(chromeTabsSendMessageSpy).toBeCalledWith({ type: 'getTargetSelector' }, cosmeticFilterEvents.onSelectorReturned)
         chrome.tabs.sendMessage(myTab.id, { type: 'getTargetSelector' }, cosmeticFilterEvents.onSelectorReturned)
       })
     })
     describe('resetSiteFilterSettings', function () {
       it('triggers `siteCosmeticFilterRemoved` action', function () {
-        // mock the prompt since JSDOM doesn't implement it
-        // window.prompt = jest.fn()
         const info: chrome.contextMenus.OnClickData = { menuItemId: 'resetSiteFilterSettings', editable: false, pageUrl: 'brave.com' }
         const tab: chrome.tabs.Tab = {
           id: 3,

--- a/components/test/testData.ts
+++ b/components/test/testData.ts
@@ -108,9 +108,6 @@ export const blockedResource: BlockDetails = {
 interface OnMessageEvent extends chrome.events.Event<(message: object, options: any, responseCallback: any) => void> {
   emit: (message: object) => void
 }
-interface ContextMenuClickedEvent extends chrome.events.Event<(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void> {
-  emit: (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => void
-}
 
 export const getMockChrome = () => {
   let mock = {
@@ -127,7 +124,6 @@ export const getMockChrome = () => {
       onConnectExternal: new ChromeEvent(),
       // see: https://developer.chrome.com/apps/runtime#method-sendMessage
       sendMessage: function (message: object, responseCallback: () => void) {
-        // console.log('BSC]] in mock:5 sendMessage called: ' + JSON.stringify(message))
         const onMessage = chrome.runtime.onMessage as OnMessageEvent
         onMessage.emit(message)
         responseCallback()
@@ -169,7 +165,6 @@ export const getMockChrome = () => {
       query: function (queryInfo: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void) {
         return callback
       },
-      // chrome.tabs.sendMessage(integer tabId, any message, object options, function responseCallback)
       sendMessage: function (tabID: Number, message: any, options: object, responseCallback: any) {
         return responseCallback
       },
@@ -253,25 +248,7 @@ export const getMockChrome = () => {
       allowScriptsOnce: function (origins: Array<string>, tabId: number, cb: () => void) {
         setImmediate(cb)
       },
-      // onClicked: new ChromeEvent()
-      onClicked: {
-        // addListener: function (cb: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => void) {
-        addListener: function (cb: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => void) {
-          const onClicked = chrome.contextMenus.onClicked as ContextMenuClickedEvent
-          // cb({ menuItemId: 'addBlockElement', editable: false, pageUrl: '' }, { id: 1 })
-          // onClicked.emit()
-          return cb
-          // cb(info2, tab2)
-        }
-        // emit (...args: Array<() => void>) {
-        //   this.listeners.forEach((cb: () => void) => cb.apply(null, args))
-        // }
-      }
-      // function (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab, cb: () => void) {
-      //   const onClicked = chrome.contextMenus.onClicked as ContextMenuClickedEvent
-      //   onClicked.emit(info, tab)
-      //   cb()
-      // }
+      onClicked: new ChromeEvent()
     }
   }
   return mock


### PR DESCRIPTION
Now ready for review.

Closes https://github.com/brave/brave-browser/issues/4417


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. Visit http://raymondhill.net/ublock/adbox.html
2. Use right click => `Block element via selector` on red area of text (where it says `Should be hidden`)
3. Prompt should show up with a populated selector
4. Cancel prompt, go to https://cnn.com
5. Visit https://benzworld.org/forums/w126-s-se-sec-sel-sd/
6. Use right click => `Block element via selector` on picture of car on the top
7. Prompt should show mentioning how selector couldn't be found
8. Enter a custom selector (ex: `table#header`)
9. Confirm content is hidden

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
