### PR TITLE
Fixes tab icons for welcome and rewards pages on MacOS' dark theme.

### DIFF
--- a/chromium_src/chrome/browser/ui/views/tabs/tab_icon.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_icon.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/common/webui_url_constants.h"
+#include "url/gurl.h"
+
+namespace {
+// Forward delcare replacement function. The original file is patched to
+// call this replacement.
+bool BraveShouldThemifyFaviconForUrl(const GURL& url);
+}  // namespace
+
+#define ShouldThemifyFaviconForUrl ShouldThemifyFaviconForUrl_ChromiumImpl
+#include "../../../../../../chrome/browser/ui/views/tabs/tab_icon.cc"  // NOLINT
+#undef ShouldThemifyFaviconForUrl
+
+namespace {
+// Implementation of the replacement function checks for Brave-specific URLs for
+// which the favicon should not be themified and then falls back onto the
+// original Chromium implementation for all other URLs.
+bool BraveShouldThemifyFaviconForUrl(const GURL& url) {
+  if (url.SchemeIs(content::kChromeUIScheme) &&
+      (url.host_piece() == kWelcomeHost ||
+       url.host_piece() == kRewardsHost))
+    return false;
+
+  return ShouldThemifyFaviconForUrl_ChromiumImpl(url);
+}
+}  // namespace

--- a/patches/chrome-browser-ui-views-tabs-tab_icon.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab_icon.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/tabs/tab_icon.cc b/chrome/browser/ui/views/tabs/tab_icon.cc
+index abc8f3ae7d289187a8844499b779a4aa86d49d38..2994ecf2a58be23b240089e294f3aece68bfaf58 100644
+--- a/chrome/browser/ui/views/tabs/tab_icon.cc
++++ b/chrome/browser/ui/views/tabs/tab_icon.cc
+@@ -357,7 +357,7 @@ void TabIcon::SetIcon(const GURL& url, const gfx::ImageSkia& icon) {
+ 
+   favicon_ = icon;
+ 
+-  if (!HasNonDefaultFavicon() || ShouldThemifyFaviconForUrl(url)) {
++  if (!HasNonDefaultFavicon() || BraveShouldThemifyFaviconForUrl(url)) {
+     themed_favicon_ = ThemeImage(icon);
+   } else {
+     themed_favicon_ = gfx::ImageSkia();


### PR DESCRIPTION
Fixes brave/brave-browser#3933

Patches chrome/browser/ui/views/tabs/tab_icon.cc's to use our version of
ShouldThemifyFaviconForUrl function which adds welcome and rewards pages
to the list of pages for which the favicon should not be "themified".

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

1. Start Brave browser
2. Navigate to brave://settings/appearance and change Theme setting to Light
3. In a new tab, navigate to brave://welcome. Verify that the tab icon is shown correctly.
4. In a new tab, navigate to brave://rewards. Verify that the tab icon is shown correctly.
5. In the brave://settings/appearance tab, switch the Theme setting to Dark.
6. Verify that the brave://welcome and brave://rewards tabs icons are shown correctly.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
