### PR TITLE
move out state helpers from shields reducer

### DIFF
--- a/components/brave_extension/extension/brave_extension/types/state/shieldsPannelState.ts
+++ b/components/brave_extension/extension/brave_extension/types/state/shieldsPannelState.ts
@@ -92,3 +92,19 @@ export interface ResetNoScriptInfo {
 export interface ChangeAllNoScriptSettings {
   (state: State, tabId: number, shouldBlock: boolean): State
 }
+
+export interface UpdateShieldsIconBadgeText {
+  (state: State): void
+}
+export interface UpdateShieldsIconImage {
+  (state: State): void
+}
+export interface UpdateShieldsIcon {
+  (state: State): void
+}
+export interface FocusedWindowChanged {
+  (state: State, windowId: number): State
+}
+export interface RequestDataAndUpdateActiveTab {
+  (state: State, windowId: number, tabId: number): State
+}


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/4606
### Test Plan

```
npm run test-unit -- shieldsPanelState
```