### PR TITLE
darwin upload fix

### DIFF
--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -35,12 +35,10 @@ class TestGetBravePackages(unittest.TestCase):
                 os.mkdir(win32_dir)
             for channel in ['nightly', 'dev', 'beta', 'release']:
                 channel_capitalized = channel.capitalize()
-                channel_capitalized_dashed = '' if (
-                    channel == 'release') else ('-' + channel_capitalized)
                 channel_dashed = '' if (
                     channel == 'release') else ('-' + channel)
-                name_darwin = 'Brave-Browser' + channel_capitalized_dashed + '.dmg'
-                name_darwin_pkg = 'Brave-Browser' + channel_capitalized_dashed + '.pkg'
+                name_darwin = 'Brave Browser ' + channel_capitalized + '.dmg'
+                name_darwin_pkg = 'Brave Browser ' + channel_capitalized + '.pkg'
                 name_linux_deb = 'brave-browser' + channel_dashed + '_0.50.8_amd64.deb'
                 name_linux_rpm = 'brave-browser' + channel_dashed + '-0.50.8-1.x86_64.rpm'
                 with open(os.path.join(self.get_pkgs_dir, 'darwin', name_darwin), 'w') as f:
@@ -68,15 +66,13 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'release', '0.50.8'))
-        self.assertEquals(sorted(pkgs), sorted(
-            ['Brave-Browser.dmg', 'Brave-Browser.pkg']))
+        self.assertEquals(pkgs, sorted(['Brave-Browser.dmg', 'Brave-Browser.pkg']))
 
     def test_only_returns_nightly_darwin_packages(self):
         upload.PLATFORM = 'darwin'
         pkgs = list(upload.get_brave_packages(os.path.join(
             self.get_pkgs_dir, upload.PLATFORM), 'nightly', '0.50.8'))
-        self.assertEquals(
-            sorted(pkgs), sorted(['Brave-Browser-Nightly.dmg', 'Brave-Browser-Nightly.pkg']))
+        self.assertEquals(pkgs, sorted(['Brave-Browser-Nightly.dmg', 'Brave-Browser-Nightly.pkg']))
 
     def test_only_returns_dev_darwin_package(self):
         upload.PLATFORM = 'darwin'
@@ -96,7 +92,7 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
                                                            upload.PLATFORM),
                                               'nightly', '0.50.8'))
-        self.assertEquals(sorted(pkgs),
+        self.assertEquals(pkgs,
                           sorted(['brave-browser-nightly-0.50.8-1.x86_64.rpm',
                                   'brave-browser-nightly_0.50.8_amd64.deb']))
 
@@ -105,7 +101,7 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
                                                            upload.PLATFORM),
                                               'dev', '0.50.8'))
-        self.assertEquals(sorted(pkgs),
+        self.assertEquals(pkgs,
                           sorted(['brave-browser-dev-0.50.8-1.x86_64.rpm',
                                   'brave-browser-dev_0.50.8_amd64.deb']))
 
@@ -114,7 +110,7 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
                                                            upload.PLATFORM),
                                               'beta', '0.50.8'))
-        self.assertEquals(sorted(pkgs),
+        self.assertEquals(pkgs,
                           sorted(['brave-browser-beta-0.50.8-1.x86_64.rpm',
                                   'brave-browser-beta_0.50.8_amd64.deb']))
 
@@ -123,7 +119,7 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
                                                            upload.PLATFORM),
                                               'release', '0.50.8'))
-        self.assertEquals(sorted(pkgs),
+        self.assertEquals(pkgs,
                           sorted(['brave-browser-0.50.8-1.x86_64.rpm',
                                   'brave-browser_0.50.8_amd64.deb']))
 
@@ -133,12 +129,12 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(
             self.get_pkgs_dir, upload.PLATFORM), 'nightly', '0.56.8'))
         self.assertEquals(
-            sorted(pkgs), sorted(['BraveBrowserNightlySetup.exe',
-                                  'BraveBrowserSilentNightlySetup.exe',
-                                  'BraveBrowserStandaloneNightlySetup.exe',
-                                  'BraveBrowserStandaloneSilentNightlySetup.exe',
-                                  'BraveBrowserStandaloneUntaggedNightlySetup.exe',
-                                  'BraveBrowserUntaggedNightlySetup.exe']))
+            pkgs, sorted(['BraveBrowserNightlySetup.exe',
+                          'BraveBrowserSilentNightlySetup.exe',
+                          'BraveBrowserStandaloneNightlySetup.exe',
+                          'BraveBrowserStandaloneSilentNightlySetup.exe',
+                          'BraveBrowserStandaloneUntaggedNightlySetup.exe',
+                          'BraveBrowserUntaggedNightlySetup.exe']))
 
     def test_only_returns_nightly_win_ia32_packages(self):
         upload.PLATFORM = 'win32'
@@ -146,12 +142,12 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM), 'nightly', '0.56.8'))
         self.assertEquals(
-            sorted(pkgs), sorted(['BraveBrowserNightlySetup32.exe',
-                                  'BraveBrowserSilentNightlySetup32.exe',
-                                  'BraveBrowserStandaloneNightlySetup32.exe',
-                                  'BraveBrowserStandaloneSilentNightlySetup32.exe',
-                                  'BraveBrowserStandaloneUntaggedNightlySetup32.exe',
-                                  'BraveBrowserUntaggedNightlySetup32.exe']))
+            pkgs, sorted(['BraveBrowserNightlySetup32.exe',
+                          'BraveBrowserSilentNightlySetup32.exe',
+                          'BraveBrowserStandaloneNightlySetup32.exe',
+                          'BraveBrowserStandaloneSilentNightlySetup32.exe',
+                          'BraveBrowserStandaloneUntaggedNightlySetup32.exe',
+                          'BraveBrowserUntaggedNightlySetup32.exe']))
 
     def test_only_returns_dev_win_x64_packages(self):
         upload.PLATFORM = 'win32'
@@ -159,12 +155,12 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(os.path.join(
             self.get_pkgs_dir, upload.PLATFORM), 'dev', '0.56.8'))
         self.assertEquals(
-            sorted(pkgs), sorted(['BraveBrowserDevSetup.exe',
-                                  'BraveBrowserSilentDevSetup.exe',
-                                  'BraveBrowserStandaloneDevSetup.exe',
-                                  'BraveBrowserStandaloneSilentDevSetup.exe',
-                                  'BraveBrowserStandaloneUntaggedDevSetup.exe',
-                                  'BraveBrowserUntaggedDevSetup.exe']))
+            pkgs, sorted(['BraveBrowserDevSetup.exe',
+                          'BraveBrowserSilentDevSetup.exe',
+                          'BraveBrowserStandaloneDevSetup.exe',
+                          'BraveBrowserStandaloneSilentDevSetup.exe',
+                          'BraveBrowserStandaloneUntaggedDevSetup.exe',
+                          'BraveBrowserUntaggedDevSetup.exe']))
 
     def test_only_returns_dev_win_ia32_packages(self):
         upload.PLATFORM = 'win32'
@@ -172,12 +168,12 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM), 'dev', '0.56.8'))
         self.assertEquals(
-            sorted(pkgs), sorted(['BraveBrowserDevSetup32.exe',
-                                  'BraveBrowserSilentDevSetup32.exe',
-                                  'BraveBrowserStandaloneDevSetup32.exe',
-                                  'BraveBrowserStandaloneSilentDevSetup32.exe',
-                                  'BraveBrowserStandaloneUntaggedDevSetup32.exe',
-                                  'BraveBrowserUntaggedDevSetup32.exe']))
+            pkgs, sorted(['BraveBrowserDevSetup32.exe',
+                          'BraveBrowserSilentDevSetup32.exe',
+                          'BraveBrowserStandaloneDevSetup32.exe',
+                          'BraveBrowserStandaloneSilentDevSetup32.exe',
+                          'BraveBrowserStandaloneUntaggedDevSetup32.exe',
+                          'BraveBrowserUntaggedDevSetup32.exe']))
 
     def test_only_returns_beta_win_x64_packages(self):
         upload.PLATFORM = 'win32'
@@ -186,12 +182,12 @@ class TestGetBravePackages(unittest.TestCase):
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'beta', '0.56.8'))
         self.assertEquals(
-            sorted(pkgs), sorted(['BraveBrowserBetaSetup.exe',
-                                  'BraveBrowserSilentBetaSetup.exe',
-                                  'BraveBrowserStandaloneBetaSetup.exe',
-                                  'BraveBrowserStandaloneSilentBetaSetup.exe',
-                                  'BraveBrowserStandaloneUntaggedBetaSetup.exe',
-                                  'BraveBrowserUntaggedBetaSetup.exe']))
+            pkgs, sorted(['BraveBrowserBetaSetup.exe',
+                          'BraveBrowserSilentBetaSetup.exe',
+                          'BraveBrowserStandaloneBetaSetup.exe',
+                          'BraveBrowserStandaloneSilentBetaSetup.exe',
+                          'BraveBrowserStandaloneUntaggedBetaSetup.exe',
+                          'BraveBrowserUntaggedBetaSetup.exe']))
 
     def test_only_returns_beta_win_ia32_packages(self):
         upload.PLATFORM = 'win32'
@@ -200,12 +196,12 @@ class TestGetBravePackages(unittest.TestCase):
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'beta', '0.56.8'))
         self.assertEquals(
-            sorted(pkgs), sorted(['BraveBrowserBetaSetup32.exe',
-                                  'BraveBrowserSilentBetaSetup32.exe',
-                                  'BraveBrowserStandaloneBetaSetup32.exe',
-                                  'BraveBrowserStandaloneSilentBetaSetup32.exe',
-                                  'BraveBrowserStandaloneUntaggedBetaSetup32.exe',
-                                  'BraveBrowserUntaggedBetaSetup32.exe']))
+            pkgs, sorted(['BraveBrowserBetaSetup32.exe',
+                          'BraveBrowserSilentBetaSetup32.exe',
+                          'BraveBrowserStandaloneBetaSetup32.exe',
+                          'BraveBrowserStandaloneSilentBetaSetup32.exe',
+                          'BraveBrowserStandaloneUntaggedBetaSetup32.exe',
+                          'BraveBrowserUntaggedBetaSetup32.exe']))
 
     def test_only_returns_release_win_x64_packages(self):
         upload.PLATFORM = 'win32'
@@ -213,12 +209,12 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'release', '0.56.8'))
-        self.assertEquals(sorted(pkgs), sorted(['BraveBrowserSetup.exe',
-                                                'BraveBrowserSilentSetup.exe',
-                                                'BraveBrowserStandaloneSetup.exe',
-                                                'BraveBrowserStandaloneSilentSetup.exe',
-                                                'BraveBrowserStandaloneUntaggedSetup.exe',
-                                                'BraveBrowserUntaggedSetup.exe']))
+        self.assertEquals(pkgs, sorted(['BraveBrowserSetup.exe',
+                                        'BraveBrowserSilentSetup.exe',
+                                        'BraveBrowserStandaloneSetup.exe',
+                                        'BraveBrowserStandaloneSilentSetup.exe',
+                                        'BraveBrowserStandaloneUntaggedSetup.exe',
+                                        'BraveBrowserUntaggedSetup.exe']))
 
     def test_only_returns_release_win_ia32_packages(self):
         upload.PLATFORM = 'win32'
@@ -226,12 +222,12 @@ class TestGetBravePackages(unittest.TestCase):
         pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
             'release', '0.56.8'))
-        self.assertEquals(sorted(pkgs), sorted(['BraveBrowserSetup32.exe',
-                                                'BraveBrowserSilentSetup32.exe',
-                                                'BraveBrowserStandaloneSetup32.exe',
-                                                'BraveBrowserStandaloneSilentSetup32.exe',
-                                                'BraveBrowserStandaloneUntaggedSetup32.exe',
-                                                'BraveBrowserUntaggedSetup32.exe']))
+        self.assertEquals(pkgs, sorted(['BraveBrowserSetup32.exe',
+                                        'BraveBrowserSilentSetup32.exe',
+                                        'BraveBrowserStandaloneSetup32.exe',
+                                        'BraveBrowserStandaloneSilentSetup32.exe',
+                                        'BraveBrowserStandaloneUntaggedSetup32.exe',
+                                        'BraveBrowserUntaggedSetup32.exe']))
 
 
 # get an existing release (in draft status) from GitHub given a tag name

--- a/script/upload.py
+++ b/script/upload.py
@@ -169,16 +169,17 @@ def get_brave_packages(dir, channel, version):
                 file_desired = 'Brave-Browser' + channel_capitalized_dashed + '.dmg'
                 file_desired_pkg = 'Brave-Browser' + channel_capitalized_dashed + '.pkg'
 
-                if re.match(r'Brave Browser ' + channel_capitalized_spaced + r'.*\.dmg$', file):
+                if re.match(r'Brave Browser' + channel_capitalized_spaced + r'.*\.dmg$', file):
                     filecopy(file_path, file_desired)
                     pkgs.append(file_desired)
-                elif file == file_desired and file_desired not in pkgs:
+                elif file == file_desired:
                     pkgs.append(file_desired)
+
                 if channel in ['release', 'nightly']:
-                    if re.match(r'Brave Browser ' + channel_capitalized_spaced + r'.*\.pkg$', file):
+                    if re.match(r'Brave Browser' + channel_capitalized_spaced + r'.*\.pkg$', file):
                         filecopy(file_path, file_desired_pkg)
                         pkgs.append(file_desired_pkg)
-                    elif file == file_desired_pkg and file_desired_pkg not in pkgs:
+                    elif file == file_desired_pkg:
                         pkgs.append(file_desired_pkg)
             elif PLATFORM == 'linux':
                 if channel == 'release':
@@ -234,7 +235,8 @@ def get_brave_packages(dir, channel, version):
                               file):
                     filecopy(file_path, file_desired_standalone_untagged)
                     pkgs.append(file_desired_standalone_untagged)
-    return pkgs
+
+    return sorted(list(set(pkgs)))
 
 
 def parse_args():
@@ -329,13 +331,13 @@ you're looking for a little extra spice and adventure in your browsing.'''
 
     body = '''{warning}
 
-### Mac installation
+# Mac installation
 Install Brave-Browser.dmg on your system.
 
-### Linux install instructions
+# Linux install instructions
 http://brave-browser.readthedocs.io/en/latest/installing-brave.html#linux
 
-### Windows
+# Windows
 {win} will fetch and install the latest available version from our
 update server.'''.format(warning=warning, win=winstallers)
 


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
