### PR TITLE
Fixes tab icons for welcome and rewards pages on MacOS' dark theme.

### DIFF
--- a/chromium_src/chrome/browser/ui/views/tabs/tab_icon.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_icon.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/common/webui_url_constants.h"
+#include "url/gurl.h"
+
+namespace {
+// Forward delcare replacement function. The original file is patched to
+// call this replacement.
+bool BraveShouldThemifyFaviconForUrl(const GURL& url);
+}  // namespace
+
+#define ShouldThemifyFaviconForUrl ShouldThemifyFaviconForUrl_ChromiumImpl
+#include "../../../../../../chrome/browser/ui/views/tabs/tab_icon.cc"  // NOLINT
+#undef ShouldThemifyFaviconForUrl
+
+namespace {
+// Implementation of the replacement function checks for Brave-specific URLs for
+// which the favicon should not be themified and then falls back onto the
+// original Chromium implementation for all other URLs.
+bool BraveShouldThemifyFaviconForUrl(const GURL& url) {
+  if (url.SchemeIs(content::kChromeUIScheme) &&
+      (url.host_piece() == kWelcomeHost ||
+       url.host_piece() == kRewardsHost))
+    return false;
+
+  return ShouldThemifyFaviconForUrl_ChromiumImpl(url);
+}
+}  // namespace

--- a/patches/chrome-browser-ui-views-tabs-tab_icon.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab_icon.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/tabs/tab_icon.cc b/chrome/browser/ui/views/tabs/tab_icon.cc
+index abc8f3ae7d289187a8844499b779a4aa86d49d38..2994ecf2a58be23b240089e294f3aece68bfaf58 100644
+--- a/chrome/browser/ui/views/tabs/tab_icon.cc
++++ b/chrome/browser/ui/views/tabs/tab_icon.cc
+@@ -357,7 +357,7 @@ void TabIcon::SetIcon(const GURL& url, const gfx::ImageSkia& icon) {
+ 
+   favicon_ = icon;
+ 
+-  if (!HasNonDefaultFavicon() || ShouldThemifyFaviconForUrl(url)) {
++  if (!HasNonDefaultFavicon() || BraveShouldThemifyFaviconForUrl(url)) {
+     themed_favicon_ = ThemeImage(icon);
+   } else {
+     themed_favicon_ = gfx::ImageSkia();


### PR DESCRIPTION
Fixes brave/brave-browser#3933
Uplift request from #2494 