### PR TITLE
only update resources blocked after shields is active for the site

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
@@ -143,7 +143,10 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
       state = shieldsPanelState.updateResourceBlocked(
         state, tabId, action.details.blockType, action.details.subresource)
       if (tabId === currentTabId) {
-        shieldsPanelState.updateShieldsIconBadgeText(state)
+        const isShieldsActive: boolean = shieldsPanelState.isShieldsActive(state, tabId)
+        if (isShieldsActive) {
+          shieldsPanelState.updateShieldsIconBadgeText(state)
+        }
       }
       break
     }

--- a/components/brave_extension/extension/brave_extension/state/shieldsPanelState.ts
+++ b/components/brave_extension/extension/brave_extension/state/shieldsPanelState.ts
@@ -12,6 +12,13 @@ export const getActiveTabId: shieldState.GetActiveTabId = (state) => state.windo
 
 export const getActiveTabData: shieldState.GetActiveTabData = (state) => state.tabs[getActiveTabId(state)]
 
+export const isShieldsActive = (state: shieldState.State, tabId: number): boolean => {
+  if (!state.tabs[tabId]) {
+    return false
+  }
+  return state.tabs[tabId].braveShields !== 'block'
+}
+
 export const updateActiveTab: shieldState.UpdateActiveTab = (state, windowId, tabId) => {
   let windows: shieldState.Windows = { ...state.windows } || {}
   windows[windowId] = tabId

--- a/components/test/brave_extension/state/shieldsPanelState_test.ts
+++ b/components/test/brave_extension/state/shieldsPanelState_test.ts
@@ -51,6 +51,40 @@ describe('shieldsPanelState test', () => {
       })
     })
   })
+  describe('isShieldsActive', () => {
+    it('returns false if tab id can not be found', () => {
+      const assertion = shieldsPanelState.isShieldsActive(state, 123123123123)
+      expect(assertion).toBe(false)
+    })
+    it('returns false if braveShields is set to `block`', () => {
+      const newState: State = deepFreeze({
+        ...state,
+        tabs: {
+          ...state.tabs,
+          2: {
+            ...state.tabs[2],
+            braveShields: 'block'
+          }
+        }
+      })
+      const assertion = shieldsPanelState.isShieldsActive(newState, 2)
+      expect(assertion).toBe(false)
+    })
+    it('returns true if braveShields is not set to block', () => {
+      const newState: State = deepFreeze({
+        ...state,
+        tabs: {
+          ...state.tabs,
+          2: {
+            ...state.tabs[2],
+            braveShields: 'allow'
+          }
+        }
+      })
+      const assertion = shieldsPanelState.isShieldsActive(newState, 2)
+      expect(assertion).toBe(true)
+    })
+  })
   describe('updateActiveTab', () => {
     it('can update focused window', () => {
       expect(shieldsPanelState.updateActiveTab(state, 1, 4)).toEqual({


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/888

### Test Plan

1, open brave://newtab page
2. go to https://theverge.com
3. ensure that badge count is displayed only when shields is active (orange)