### PR TITLE
Make brave://version display UA properly

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -110,7 +110,6 @@ source_set("browser_process") {
     "//components/unified_consent",
     "//components/update_client:patch_impl",
     "//components/update_client:unzip_impl",
-    "//components/version_info",
     "//content/public/browser",
     "//content/public/common",
     "//extensions/buildflags",

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -39,7 +39,6 @@
 #include "chrome/common/url_constants.h"
 #include "components/content_settings/core/browser/cookie_settings.h"
 #include "components/services/heap_profiling/public/mojom/heap_profiling_client.mojom.h"
-#include "components/version_info/version_info.h"
 #include "content/browser/frame_host/render_frame_host_impl.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_task_traits.h"
@@ -348,13 +347,4 @@ GURL BraveContentBrowserClient::GetEffectiveURL(
 #else
   return url;
 #endif
-}
-
-std::string BraveContentBrowserClient::GetUserAgent() const {
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kDisableOverrideUA))
-    return ChromeContentBrowserClient::GetUserAgent();
-
-  return ChromeContentBrowserClient::GetUserAgent() +
-      " Brave/" + version_info::GetMajorVersionNumber();
 }

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -80,8 +80,6 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
   GURL GetEffectiveURL(content::BrowserContext* browser_context,
                        const GURL& url) override;
 
-  std::string GetUserAgent() const override;
-
  private:
   bool AllowAccessCookie(const GURL& url, const GURL& first_party,
       content::ResourceContext* context, int render_process_id,

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -533,11 +533,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientReferrerTest,
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, OverrideUATest) {
   const std::string appended_ua =
-      GetUserAgent() + " Brave/" + version_info::GetMajorVersionNumber();
+      "Brave/" + version_info::GetMajorVersionNumber();
   content::EvalJsResult js_result =
       EvalJs(browser()->tab_strip_model()->GetActiveWebContents(),
              "navigator.userAgent");
-  EXPECT_EQ(js_result.ExtractString(), appended_ua);
+  EXPECT_TRUE(js_result.ExtractString().find(appended_ua) != std::string::npos);
 }
 
 class BraveContentBrowserClientWithoutUAOverride

--- a/patches/chrome-browser-chrome_content_browser_client.cc.patch
+++ b/patches/chrome-browser-chrome_content_browser_client.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
+index 139a600b09250af07e4771852d02e1be4fe84e2c..13f4b3aeae9b647bc15a98c76e517ca86cdd431c 100644
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -30,6 +30,7 @@
+ #include "base/system/sys_info.h"
+ #include "base/task/post_task.h"
+ #include "base/threading/thread_task_runner_handle.h"
++#include "brave/common/brave_switches.h"
+ #include "build/build_config.h"
+ #include "chrome/app/chrome_content_browser_overlay_manifest.h"
+ #include "chrome/app/chrome_content_gpu_overlay_manifest.h"
+@@ -1073,6 +1074,11 @@ std::string GetUserAgent() {
+   if (command_line->HasSwitch(switches::kUseMobileUserAgent))
+     product += " Mobile";
+ #endif
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
++         switches::kDisableOverrideUA)) {
++    return content::BuildUserAgentFromProduct(product) +
++        " Brave/" + version_info::GetMajorVersionNumber();
++  }
+   return content::BuildUserAgentFromProduct(product);
+ }
+ 


### PR DESCRIPTION
::GetUserAgent() should be used for applying new UA to chrome and content
layers.

Fix https://github.com/brave/brave-browser/issues/4623

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
`yarn test brave_browser_test --filter=BraveContentBrowserClient*Override*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
