### PR TITLE
Fix GetShareURL tests for Twitter

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/media/twitter.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/media/twitter.cc
@@ -229,7 +229,7 @@ std::string MediaTwitter::GetShareURL(
   // If a tweet ID was specified, then quote the original tweet along
   // with the supplied comment; otherwise, just tweet the comment.
   std::string share_url;
-  if (!tweet_id->second.empty()) {
+  if (tweet_id != args.end() && !tweet_id->second.empty()) {
     std::string quoted_tweet_url =
         base::StringPrintf("https://twitter.com/%s/status/%s",
                            name->second.c_str(), tweet_id->second.c_str());


### PR DESCRIPTION
Fix brave/brave-browser#4625

Fix failing `GetShareURL` tests for Twitter (were passing on Windows, but failing on Mac).