### PR TITLE
Make widevine works by reloading after installing it (uplift to 0.66.x)

### DIFF
--- a/patches/media-blink-key_system_config_selector.cc.patch
+++ b/patches/media-blink-key_system_config_selector.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/media/blink/key_system_config_selector.cc b/media/blink/key_system_config_selector.cc
+index 2ccbefd181f142e1a996c61e23249125996a4dcc..7dbaf1d772264e84315a26f3b2d741420f475e31 100644
+--- a/media/blink/key_system_config_selector.cc
++++ b/media/blink/key_system_config_selector.cc
+@@ -903,6 +903,7 @@ void KeySystemConfigSelector::SelectConfig(
+     return;
+   }
+ 
++  KeySystems::GetInstance();
+   std::string key_system_ascii = key_system.Ascii();
+   if (!key_systems_->IsSupportedKeySystem(key_system_ascii)) {
+     not_supported_cb.Run();


### PR DESCRIPTION
Uplift of #2514
Fixes https://github.com/brave/brave-browser/issues/4604

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.