### PR TITLE
Ensure component installer `ready` callback only fires once

### DIFF
--- a/browser/component_updater/brave_component_installer.cc
+++ b/browser/component_updater/brave_component_installer.cc
@@ -124,6 +124,7 @@ void BraveComponentInstallerPolicy::ComponentReady(
     const base::Version& version,
     const base::FilePath& install_dir,
     std::unique_ptr<base::DictionaryValue> manifest) {
+  DCHECK(!ready_callback_.is_null());
   std::move(ready_callback_).Run(
       install_dir,
       GetManifestString(std::move(manifest), base64_public_key_));

--- a/browser/component_updater/brave_component_installer.cc
+++ b/browser/component_updater/brave_component_installer.cc
@@ -124,10 +124,17 @@ void BraveComponentInstallerPolicy::ComponentReady(
     const base::Version& version,
     const base::FilePath& install_dir,
     std::unique_ptr<base::DictionaryValue> manifest) {
-  DCHECK(!ready_callback_.is_null());
-  std::move(ready_callback_).Run(
-      install_dir,
-      GetManifestString(std::move(manifest), base64_public_key_));
+  // It appears to be possible for the ComponentInstaller to call
+  // `ComponentReady` more than once. There is a call in
+  // ComponentInstaller::FinishRegistration and another one in
+  // ComponentInstaller::Install. So a call to Register followed by a call
+  // to Install could result in a crash here. See
+  // https://github.com/brave/brave-browser/issues/4624
+  if (!ready_callback_.is_null()) {
+    std::move(ready_callback_).Run(
+          install_dir,
+          GetManifestString(std::move(manifest), base64_public_key_));
+  }
 }
 
 base::FilePath BraveComponentInstallerPolicy::GetRelativeInstallDir() const {

--- a/browser/component_updater/brave_component_installer.cc
+++ b/browser/component_updater/brave_component_installer.cc
@@ -58,15 +58,14 @@ bool RewriteManifestFile(
   return true;
 }
 
-std::string GetManifestString(const base::DictionaryValue& manifest,
+std::string GetManifestString(std::unique_ptr<base::DictionaryValue> manifest,
     const std::string &public_key) {
-  std::unique_ptr<base::DictionaryValue> final_manifest(manifest.DeepCopy());
-  final_manifest->SetString("key", public_key);
+  manifest->SetString("key", public_key);
 
   std::string manifest_json;
   JSONStringValueSerializer serializer(&manifest_json);
   serializer.set_pretty_print(true);
-  if (!serializer.Serialize(*final_manifest)) {
+  if (!serializer.Serialize(*manifest)) {
     return "";
   }
   return manifest_json;
@@ -127,7 +126,7 @@ void BraveComponentInstallerPolicy::ComponentReady(
     std::unique_ptr<base::DictionaryValue> manifest) {
   std::move(ready_callback_).Run(
       install_dir,
-      GetManifestString(*manifest, base64_public_key_));
+      GetManifestString(std::move(manifest), base64_public_key_));
 }
 
 base::FilePath BraveComponentInstallerPolicy::GetRelativeInstallDir() const {


### PR DESCRIPTION
Possible fix for https://github.com/brave/brave-browser/issues/4624
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
