### PR TITLE
Disable rewards extension and its prefs in incognito window

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -118,9 +118,6 @@ bool BraveActionsContainer::ShouldAddAction(const std::string& id) const {
 }
 
 bool BraveActionsContainer::ShouldAddBraveRewardsAction() const {
-  // Guest (and Tor for now) should not show the action.
-  if (browser_->profile()->IsGuestSession())
-    return false;
   const PrefService* prefs = browser_->profile()->GetPrefs();
   return prefs->GetBoolean(brave_rewards::prefs::kBraveRewardsEnabled) ||
          !prefs->GetBoolean(kHideBraveRewardsButton);

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -21,6 +21,7 @@
 #include "brave/components/brave_rewards/browser/rewards_service_observer.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service_impl.h"  // NOLINT
 #include "brave/components/brave_rewards/browser/rewards_notification_service_observer.h"  // NOLINT
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/common/chrome_paths.h"
@@ -1836,4 +1837,16 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
     }
   }
   EXPECT_TRUE(notification_shown);
+}
+
+// Test whether rewards is diabled in private profile.
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, PrefsTestInPrivateWindow) {
+  EnableRewards();
+  auto* profile = browser()->profile();
+  EXPECT_TRUE(profile->GetPrefs()->GetBoolean(
+      brave_rewards::prefs::kBraveRewardsEnabled));
+
+  Profile* private_profile = profile->GetOffTheRecordProfile();
+  EXPECT_FALSE(private_profile->GetPrefs()->GetBoolean(
+      brave_rewards::prefs::kBraveRewardsEnabled));
 }

--- a/components/brave_rewards/browser/rewards_service_factory.h
+++ b/components/brave_rewards/browser/rewards_service_factory.h
@@ -7,8 +7,10 @@
 #define BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_REWARDS_SERVICE_FACTORY_H_
 
 #include "base/memory/singleton.h"
-#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+#include "content/public/browser/notification_observer.h"
+#include "content/public/browser/notification_registrar.h"
 
 class Profile;
 
@@ -17,7 +19,8 @@ class RewardsService;
 
 // Singleton that owns all RewardsService and associates them with
 // Profiles.
-class RewardsServiceFactory : public BrowserContextKeyedServiceFactory {
+class RewardsServiceFactory : public BrowserContextKeyedServiceFactory,
+                              public content::NotificationObserver {
  public:
   static brave_rewards::RewardsService* GetForProfile(Profile* profile);
 
@@ -37,6 +40,13 @@ class RewardsServiceFactory : public BrowserContextKeyedServiceFactory {
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;
   bool ServiceIsNULLWhileTesting() const override;
+
+  // content::NotificationObserver:
+  void Observe(int type,
+               const content::NotificationSource& source,
+               const content::NotificationDetails& details) override;
+
+  content::NotificationRegistrar registrar_;
 
   DISALLOW_COPY_AND_ASSIGN(RewardsServiceFactory);
 };

--- a/components/brave_rewards/resources/extension/brave_rewards/manifest.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/manifest.json
@@ -4,6 +4,7 @@
   "manifest_version": 2,
   "description": "Brave Rewards Extension",
   "default_locale": "en_US",
+  "incognito": "not_allowed",
   "background" : {
     "scripts": ["out/brave_rewards_panel_background.bundle.js"],
     "persistent": true


### PR DESCRIPTION
This hides rewards button in location bar and twitter tips button in twitter page from guest/tor/private window.

Fix https://github.com/brave/brave-browser/issues/4593

<img width="945" alt="Screen Shot 2019-05-29 at 17 11 58" src="https://user-images.githubusercontent.com/6786187/58540803-10e79200-8235-11e9-96bb-2fce3ad24f0a.png">


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
`yarn test brave_browser_tests --filter=BraveRewardsBrowserTest.PrefsTestInPrivateWindow`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
