### PR TITLE
added generation and upload of pkg for all channels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3491,12 +3491,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3511,17 +3513,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3638,7 +3643,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3650,6 +3656,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3664,6 +3671,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3671,12 +3679,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3695,6 +3705,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3775,7 +3786,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3787,6 +3799,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3908,6 +3921,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -43,9 +43,8 @@ class TestGetBravePackages(unittest.TestCase):
                 name_linux_rpm = 'brave-browser' + channel_dashed + '-0.50.8-1.x86_64.rpm'
                 with open(os.path.join(self.get_pkgs_dir, 'darwin', name_darwin), 'w') as f:
                     f.write(name_darwin + '\n')
-                if channel in ['release', 'nightly']:
-                    with open(os.path.join(self.get_pkgs_dir, 'darwin', name_darwin_pkg), 'w') as f:
-                        f.write(name_darwin_pkg + '\n')
+                with open(os.path.join(self.get_pkgs_dir, 'darwin', name_darwin_pkg), 'w') as f:
+                    f.write(name_darwin_pkg + '\n')
                 with open(os.path.join(self.get_pkgs_dir, 'linux', name_linux_deb), 'w') as f:
                     f.write(name_linux_deb + '\n')
                 with open(os.path.join(self.get_pkgs_dir, 'linux', name_linux_rpm), 'w') as f:
@@ -61,31 +60,34 @@ class TestGetBravePackages(unittest.TestCase):
                         f.write(name32 + '\n')
         self.__class__._is_setup = True
 
-    def test_only_returns_release_darwin_packages(self):
-        upload.PLATFORM = 'darwin'
-        pkgs = list(upload.get_brave_packages(
-            os.path.join(self.get_pkgs_dir, upload.PLATFORM),
-            'release', '0.50.8'))
-        self.assertEquals(pkgs, sorted(['Brave-Browser.dmg', 'Brave-Browser.pkg']))
-
     def test_only_returns_nightly_darwin_packages(self):
         upload.PLATFORM = 'darwin'
         pkgs = list(upload.get_brave_packages(os.path.join(
             self.get_pkgs_dir, upload.PLATFORM), 'nightly', '0.50.8'))
-        self.assertEquals(pkgs, sorted(['Brave-Browser-Nightly.dmg', 'Brave-Browser-Nightly.pkg']))
+        self.assertEquals(pkgs, sorted(
+            ['Brave-Browser-Nightly.dmg', 'Brave-Browser-Nightly.pkg']))
 
     def test_only_returns_dev_darwin_package(self):
         upload.PLATFORM = 'darwin'
         pkgs = list(upload.get_brave_packages(os.path.join(
             self.get_pkgs_dir, upload.PLATFORM), 'dev', '0.50.8'))
-        self.assertEquals(pkgs, ['Brave-Browser-Dev.dmg'])
+        self.assertEquals(pkgs, sorted(
+            ['Brave-Browser-Dev.dmg', 'Brave-Browser-Dev.pkg']))
 
     def test_only_returns_beta_darwin_package(self):
         upload.PLATFORM = 'darwin'
         pkgs = list(upload.get_brave_packages(
+            os.path.join(self.get_pkgs_dir, upload.PLATFORM), 'beta', '0.50.8'))
+        self.assertEquals(pkgs, sorted(
+            ['Brave-Browser-Beta.dmg', 'Brave-Browser-Beta.pkg']))
+
+    def test_only_returns_release_darwin_packages(self):
+        upload.PLATFORM = 'darwin'
+        pkgs = list(upload.get_brave_packages(
             os.path.join(self.get_pkgs_dir, upload.PLATFORM),
-            'beta', '0.50.8'))
-        self.assertEquals(pkgs, ['Brave-Browser-Beta.dmg'])
+            'release', '0.50.8'))
+        self.assertEquals(pkgs, sorted(
+            ['Brave-Browser.dmg', 'Brave-Browser.pkg']))
 
     def test_only_returns_nightly_linux_packages(self):
         upload.PLATFORM = 'linux'

--- a/script/upload.py
+++ b/script/upload.py
@@ -45,8 +45,7 @@ def main():
     if os.environ.get('DEBUG_HTTP_HEADERS') == 'true':
         logging.basicConfig(level=logging.DEBUG)
         logging.getLogger("urllib3").setLevel(logging.DEBUG)
-        logging.debug(
-            "DEBUG_HTTP_HEADERS env var is enabled, logging HTTP headers")
+        logging.debug("DEBUG_HTTP_HEADERS env var is enabled, logging HTTP headers")
         debug_requests_on()
 
     # BRAVE_REPO is defined in lib/helpers.py for now
@@ -62,10 +61,8 @@ def main():
 
     print('[INFO] Uploading release {}'.format(release['tag_name']))
     # Upload Brave with GitHub Releases API.
-    upload_brave(repo, release, os.path.join(dist_dir(), DIST_NAME),
-                 force=args.force)
-    upload_brave(repo, release, os.path.join(dist_dir(), SYMBOLS_NAME),
-                 force=args.force)
+    upload_brave(repo, release, os.path.join(dist_dir(), DIST_NAME), force=args.force)
+    upload_brave(repo, release, os.path.join(dist_dir(), SYMBOLS_NAME), force=args.force)
     # if PLATFORM == 'darwin':
     #     upload_brave(repo, release, os.path.join(dist_dir(), DSYM_NAME))
     # elif PLATFORM == 'win32':
@@ -73,43 +70,31 @@ def main():
 
     # Upload chromedriver and mksnapshot.
     chromedriver = get_zip_name('chromedriver', get_chromedriver_version())
-    upload_brave(repo, release, os.path.join(dist_dir(), chromedriver),
-                 force=args.force)
+    upload_brave(repo, release, os.path.join(dist_dir(), chromedriver), force=args.force)
 
-    pkgs = get_brave_packages(output_dir(), release_channel(),
-                              get_raw_version())
+    pkgs = get_brave_packages(output_dir(), release_channel(), get_raw_version())
 
     if PLATFORM == 'darwin':
         for pkg in pkgs:
-            upload_brave(repo, release, os.path.join(output_dir(), pkg),
-                         force=args.force)
+            upload_brave(repo, release, os.path.join(output_dir(), pkg), force=args.force)
     elif PLATFORM == 'win32':
         if get_target_arch() == 'x64':
-            upload_brave(repo, release, os.path.join(output_dir(),
-                                                     'brave_installer.exe'),
+            upload_brave(repo, release, os.path.join(output_dir(), 'brave_installer.exe'),
                          'brave_installer-x64.exe', force=args.force)
             for pkg in pkgs:
-                upload_brave(repo, release, os.path.join(output_dir(), pkg),
-                             force=args.force)
+                upload_brave(repo, release, os.path.join(output_dir(), pkg), force=args.force)
         else:
-            upload_brave(repo, release, os.path.join(output_dir(),
-                                                     'brave_installer.exe'),
+            upload_brave(repo, release, os.path.join(output_dir(), 'brave_installer.exe'),
                          'brave_installer-ia32.exe', force=args.force)
             for pkg in pkgs:
-                upload_brave(repo, release, os.path.join(output_dir(), pkg),
-                             force=args.force)
+                upload_brave(repo, release, os.path.join(output_dir(), pkg), force=args.force)
     else:
         if get_target_arch() == 'x64':
             for pkg in pkgs:
-                upload_brave(repo, release, os.path.join(output_dir(), pkg),
-                             force=args.force)
+                upload_brave(repo, release, os.path.join(output_dir(), pkg), force=args.force)
         else:
-            upload_brave(repo, release, os.path.join(output_dir(),
-                                                     'brave-i386.rpm'),
-                         force=args.force)
-            upload_brave(repo, release, os.path.join(output_dir(),
-                                                     'brave-i386.deb'),
-                         force=args.force)
+            upload_brave(repo, release, os.path.join(output_dir(), 'brave-i386.rpm'), force=args.force)
+            upload_brave(repo, release, os.path.join(output_dir(), 'brave-i386.deb'), force=args.force)
 
     # mksnapshot = get_zip_name('mksnapshot', get_brave_version())
     # upload_brave(repo, release, os.path.join(dist_dir(), mksnapshot))
@@ -151,8 +136,7 @@ def get_brave_packages(dir, channel, version):
     def filecopy(file_path, file_desired):
         file_desired_path = os.path.join(dir, file_desired)
         if os.path.isfile(file_path):
-            print('[INFO] Copying file ' + file_path + ' to ' +
-                  file_desired_path)
+            print('[INFO] Copying file ' + file_path + ' to ' + file_desired_path)
             shutil.copy(file_path, file_desired_path)
         return file_desired_path
 
@@ -162,79 +146,57 @@ def get_brave_packages(dir, channel, version):
         if os.path.isfile(os.path.join(dir, file)):
             file_path = os.path.join(dir, file)
             if PLATFORM == 'darwin':
-                channel_capitalized_dashed = '' if (
-                    channel == 'release') else ('-' + channel_capitalized)
-                channel_capitalized_spaced = '' if (
-                    channel == 'release') else (' ' + channel_capitalized)
-                file_desired = 'Brave-Browser' + channel_capitalized_dashed + '.dmg'
-                file_desired_pkg = 'Brave-Browser' + channel_capitalized_dashed + '.pkg'
+                channel_capitalized_dashed = '' if (channel == 'release') else ('-' + channel_capitalized)
+                channel_capitalized_spaced = '' if (channel == 'release') else (' ' + channel_capitalized)
+                file_dmg = 'Brave-Browser' + channel_capitalized_dashed + '.dmg'
+                file_pkg = 'Brave-Browser' + channel_capitalized_dashed + '.pkg'
 
                 if re.match(r'Brave Browser' + channel_capitalized_spaced + r'.*\.dmg$', file):
-                    filecopy(file_path, file_desired)
-                    pkgs.append(file_desired)
-                elif file == file_desired:
-                    pkgs.append(file_desired)
-
-                if channel in ['release', 'nightly']:
-                    if re.match(r'Brave Browser' + channel_capitalized_spaced + r'.*\.pkg$', file):
-                        filecopy(file_path, file_desired_pkg)
-                        pkgs.append(file_desired_pkg)
-                    elif file == file_desired_pkg:
-                        pkgs.append(file_desired_pkg)
+                    filecopy(file_path, file_dmg)
+                    pkgs.append(file_dmg)
+                elif file == file_dmg:
+                    pkgs.append(file_dmg)
+                elif re.match(r'Brave Browser' + channel_capitalized_spaced + r'.*\.pkg$', file):
+                    filecopy(file_path, file_pkg)
+                    pkgs.append(file_pkg)
+                elif file == file_pkg:
+                    pkgs.append(file_pkg)
             elif PLATFORM == 'linux':
-                if channel == 'release':
-                    if re.match(r'brave-browser' + '_' + version +
-                                r'.*\.deb$', file) \
-                        or re.match(r'brave-browser' + '-' + version +
-                                    r'.*\.rpm$', file):
-                        pkgs.append(file)
-                else:
-                    if re.match(r'brave-browser-' + channel + '_' +
-                                version + r'.*\.deb$', file) \
-                        or re.match(r'brave-browser-' + channel + '-' +
-                                    version + r'.*\.rpm$', file):
-                        pkgs.append(file)
+                channel_dashed = '' if (channel == 'release') else ('-' + channel)
+                if re.match(r'brave-browser' + channel_dashed + '_' + version + r'.*\.deb$', file):
+                    pkgs.append(file)
+                elif re.match(r'brave-browser' + channel_dashed + '-' + version + r'.*\.rpm$', file):
+                    pkgs.append(file)
             elif PLATFORM == 'win32':
                 arch = '32' if (get_target_arch() == 'ia32') else ''
-                file_desired_stub = 'BraveBrowser' + channel_capitalized + 'Setup' + arch + '.exe'
-                file_desired_stub_silent = 'BraveBrowserSilent' + \
-                    channel_capitalized + 'Setup' + arch + '.exe'
-                file_desired_stub_untagged = 'BraveBrowserUntagged' + \
-                    channel_capitalized + 'Setup' + arch + '.exe'
-                file_desired_standalone = 'BraveBrowserStandalone' + \
-                    channel_capitalized + 'Setup' + arch + '.exe'
-                file_desired_standalone_silent = 'BraveBrowserStandaloneSilent' + \
-                    channel_capitalized + 'Setup' + arch + '.exe'
-                file_desired_standalone_untagged = 'BraveBrowserStandaloneUntagged' + \
-                    channel_capitalized + 'Setup' + arch + '.exe'
+                channel_arch_extension = channel_capitalized + 'Setup' + arch + '.exe'
+                file_stub = 'BraveBrowser' + channel_arch_extension
+                file_stub_silent = 'BraveBrowserSilent' + channel_arch_extension
+                file_stub_untagged = 'BraveBrowserUntagged' + channel_arch_extension
+                file_stn = 'BraveBrowserStandalone' + channel_arch_extension
+                file_stn_silent = 'BraveBrowserStandaloneSilent' + channel_arch_extension
+                file_stn_untagged = 'BraveBrowserStandaloneUntagged' + channel_arch_extension
 
-                if re.match(r'BraveBrowser' + channel_capitalized +
-                            r'Setup' + arch + r'_.*\.exe', file):
-                    filecopy(file_path, file_desired_stub)
-                    pkgs.append(file_desired_stub)
-                elif re.match(r'BraveBrowserSilent' + channel_capitalized +
-                              r'Setup' + arch + r'_.*\.exe', file):
-                    filecopy(file_path, file_desired_stub_silent)
-                    pkgs.append(file_desired_stub_silent)
-                elif re.match(r'BraveBrowserUntagged' + channel_capitalized +
-                              r'Setup' + arch + r'_.*\.exe', file):
-                    filecopy(file_path, file_desired_stub_untagged)
-                    pkgs.append(file_desired_stub_untagged)
-                elif re.match(r'BraveBrowserStandalone' +
-                              channel_capitalized + r'Setup' + arch + r'_.*\.exe',
-                              file):
-                    filecopy(file_path, file_desired_standalone)
-                    pkgs.append(file_desired_standalone)
-                elif re.match(r'BraveBrowserStandaloneSilent' +
-                              channel_capitalized + r'Setup' + arch + r'_.*\.exe',
-                              file):
-                    filecopy(file_path, file_desired_standalone_silent)
-                    pkgs.append(file_desired_standalone_silent)
-                elif re.match(r'BraveBrowserStandaloneUntagged' +
-                              channel_capitalized + r'Setup' + arch + r'_.*\.exe',
-                              file):
-                    filecopy(file_path, file_desired_standalone_untagged)
-                    pkgs.append(file_desired_standalone_untagged)
+                if re.match(r'BraveBrowser' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
+                    filecopy(file_path, file_stub)
+                    pkgs.append(file_stub)
+                elif re.match(r'BraveBrowserSilent' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
+                    filecopy(file_path, file_stub_silent)
+                    pkgs.append(file_stub_silent)
+                elif re.match(r'BraveBrowserUntagged' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
+                    filecopy(file_path, file_stub_untagged)
+                    pkgs.append(file_stub_untagged)
+                elif re.match(r'BraveBrowserStandalone' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
+                    filecopy(file_path, file_stn)
+                    pkgs.append(file_stn)
+                elif re.match(r'BraveBrowserStandaloneSilent' + channel_capitalized + r'Setup' + arch +
+                              r'_.*\.exe', file):
+                    filecopy(file_path, file_stn_silent)
+                    pkgs.append(file_stn_silent)
+                elif re.match(r'BraveBrowserStandaloneUntagged' + channel_capitalized + r'Setup' + arch +
+                              r'_.*\.exe', file):
+                    filecopy(file_path, file_stn_untagged)
+                    pkgs.append(file_stn_untagged)
 
     return sorted(list(set(pkgs)))
 
@@ -294,6 +256,9 @@ def get_text_with_editor(name):
 
 def create_release_draft(repo, tag):
     name = '{0} {1}'.format(release_name(), tag)
+    channel = release_channel()
+    channel_capitalized_dashed = '' if (channel == 'release') else ('-' + channel.capitalize())
+
     # TODO: Parse release notes from CHANGELOG.md
 
     nightly_winstallers = (
@@ -308,21 +273,21 @@ def create_release_draft(repo, tag):
     nightly_dev_beta_warning = '''*This is not the released version of Brave.
 **Be careful** - things are unstable and might even be broken.*
 
-These builds are an unpolished and unfinished early preview for the new
-version of Brave on the desktop. These builds show our work in progress and
-they aren't for the faint-of-heart. Features may be missing or broken in new
-and exciting ways; familiar functionality may have unfamiliar side-effects.
-These builds showcase the newest advances that we're bringing to your browser,
-but this is still a prototype, not a reliable daily driver. Try it out only if
+These builds are an unpolished and unfinished early preview for the new \
+version of Brave on the desktop. These builds show our work in progress and \
+they aren't for the faint-of-heart. Features may be missing or broken in new \
+and exciting ways; familiar functionality may have unfamiliar side-effects. \
+These builds showcase the newest advances that we're bringing to your browser, \
+but this is still a prototype, not a reliable daily driver. Try it out only if \
 you're looking for a little extra spice and adventure in your browsing.'''
 
-    if release_channel() in 'nightly':
+    if channel == 'nightly':
         winstallers = nightly_winstallers
         warning = nightly_dev_beta_warning
-    elif release_channel() in 'dev':
+    elif channel == 'dev':
         winstallers = dev_winstallers
         warning = nightly_dev_beta_warning
-    elif release_channel() in 'beta':
+    elif channel == 'beta':
         winstallers = beta_winstallers
         warning = nightly_dev_beta_warning
     else:
@@ -332,21 +297,19 @@ you're looking for a little extra spice and adventure in your browsing.'''
     body = '''{warning}
 
 # Mac installation
-Install Brave-Browser.dmg on your system.
+Install Brave-Browser{channel_capitalized_dashed}.dmg on your system.
 
 # Linux install instructions
 http://brave-browser.readthedocs.io/en/latest/installing-brave.html#linux
 
 # Windows
-{win} will fetch and install the latest available version from our
-update server.'''.format(warning=warning, win=winstallers)
+{win} will fetch and install the latest available version from our \
+update server.'''.format(warning=warning, channel_capitalized_dashed=channel_capitalized_dashed, win=winstallers)
 
     data = dict(tag_name=tag, name=name, body=body, draft=True)
 
-    release = retry_func(
-        lambda run: repo.releases.post(data=data),
-        catch=requests.exceptions.ConnectionError, retries=3
-    )
+    release = retry_func(lambda run: repo.releases.post(data=data),
+                         catch=requests.exceptions.ConnectionError, retries=3)
     return release
 
 
@@ -373,8 +336,7 @@ def upload_brave(github, release, file_path, filename=None, force=False):
             print('[INFO] force deleted "' + filename + '".')
 
         retry_func(
-            lambda ran: upload_io_to_github(github, release, filename, f,
-                                            'application/zip'),
+            lambda ran: upload_io_to_github(github, release, filename, f, 'application/zip'),
             catch_func=lambda ran: delete_file(github, release, filename),
             catch=requests.exceptions.ConnectionError, retries=3
         )
@@ -430,12 +392,9 @@ def delete_file(github, release, name, retries=3):
     )
     for asset in release['assets']:
         if asset['name'] == name:
-            print("[INFO] Deleting file name '{}' with asset id {}"
-                  .format(name, asset['id']))
-            retry_func(
-                lambda run: github.releases.assets(asset['id']).delete(),
-                catch=requests.exceptions.ConnectionError, retries=3
-            )
+            print("[INFO] Deleting file name '{}' with asset id {}".format(name, asset['id']))
+            retry_func(lambda run: github.releases.assets(asset['id']).delete(),
+                       catch=requests.exceptions.ConnectionError, retries=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
