### PR TITLE
Improve widevine linux

### DIFF
--- a/browser/widevine/brave_widevine_bundle_manager.cc
+++ b/browser/widevine/brave_widevine_bundle_manager.cc
@@ -36,7 +36,7 @@
 #include "services/service_manager/public/cpp/connector.h"
 #include "third_party/widevine/cdm/widevine_cdm_common.h"
 #include "url/gurl.h"
-#include "widevine_cdm_version.h"
+#include "widevine_cdm_version.h"  // NOLINT
 
 namespace {
 
@@ -138,8 +138,7 @@ void BraveWidevineBundleManager::DownloadWidevineBundle(
   bundle_loader_->DownloadToTempFile(
       g_browser_process->system_network_context_manager()
           ->GetURLLoaderFactory(),
-      std::move(callback)
-  );
+      std::move(callback));
 }
 
 void BraveWidevineBundleManager::OnBundleDownloaded(
@@ -180,7 +179,7 @@ void BraveWidevineBundleManager::Unzip(
     const base::FilePath& target_bundle_dir) {
   if (is_test_) return;
 
-   BraveWidevineBundleUnzipper::Create(
+  BraveWidevineBundleUnzipper::Create(
       content::ServiceManagerConnection::GetForProcess()->GetConnector(),
       file_task_runner(),
       base::BindOnce(&BraveWidevineBundleManager::OnBundleUnzipped,
@@ -249,7 +248,7 @@ void BraveWidevineBundleManager::StartupCheck() {
   };
 
   // If cdms has widevine cdminfo, it means that filesystem has widevine lib.
-  if (std::find_if(cdms.begin(), cdms.end(), has_widevine) == cdms.end() ) {
+  if (std::find_if(cdms.begin(), cdms.end(), has_widevine) == cdms.end()) {
     DVLOG(1) << __func__ << ": reset widevine prefs state";
     // Widevine is not installed yet. Don't need to check.
     // Also reset prefs to make as initial state.

--- a/browser/widevine/brave_widevine_bundle_manager.h
+++ b/browser/widevine/brave_widevine_bundle_manager.h
@@ -66,6 +66,7 @@ class BraveWidevineBundleManager {
 
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, InProgressTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, UpdateTriggerTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, UpdateFailTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, InstallSuccessTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, DownloadFailTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, UnzipFailTest);

--- a/browser/widevine/brave_widevine_bundle_manager.h
+++ b/browser/widevine/brave_widevine_bundle_manager.h
@@ -67,6 +67,10 @@ class BraveWidevineBundleManager {
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, InProgressTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, UpdateTriggerTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, UpdateFailTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest,
+                           UpdateRetryAndFinallyFailedTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest,
+                           UpdateRetryAndFinallySuccessTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, InstallSuccessTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, DownloadFailTest);
   FRIEND_TEST_ALL_PREFIXES(BraveWidevineBundleManagerTest, UnzipFailTest);
@@ -91,6 +95,8 @@ class BraveWidevineBundleManager {
 
   void InstallDone(const std::string& error);
   void DoDelayedBackgroundUpdate();
+  void ScheduleBackgroundUpdate();
+  void OnBackgroundUpdateFinished(const std::string& error);
 
   scoped_refptr<base::SequencedTaskRunner> file_task_runner();
 
@@ -100,6 +106,7 @@ class BraveWidevineBundleManager {
   DoneCallback done_callback_;
   bool in_progress_ = false;
   bool needs_restart_ = false;
+  int background_update_retry_ = 0;
   std::unique_ptr<network::SimpleURLLoader> bundle_loader_;
   scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
 

--- a/browser/widevine/brave_widevine_bundle_manager_unittest.cc
+++ b/browser/widevine/brave_widevine_bundle_manager_unittest.cc
@@ -253,6 +253,79 @@ TEST_F(BraveWidevineBundleManagerTest, UpdateFailTest) {
   CheckPrefsStatesAreInitialState();
 }
 
+TEST_F(BraveWidevineBundleManagerTest, UpdateRetryAndFinallyFailedTest) {
+  PrepareTest(false);
+
+  initial_opted_in_value_ = true;
+  initial_version_string_ = "1.0.0.0";
+
+  // Set installed state with different version to trigger update.
+  pref_service()->SetBoolean(kWidevineOptedIn, initial_opted_in_value_);
+  pref_service()->SetString(kWidevineInstalledVersion, initial_version_string_);
+
+  manager_.StartupCheck();
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(1, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(2, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(3, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(4, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(5, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  // No retry anymore after five trying.
+  EXPECT_NE(6, manager_.background_update_retry_);
+
+  CheckPrefsStatesAreInitialState();
+}
+
+TEST_F(BraveWidevineBundleManagerTest, UpdateRetryAndFinallySuccessTest) {
+  PrepareTest(false);
+
+  initial_opted_in_value_ = true;
+  initial_version_string_ = "1.0.0.0";
+
+  // Set installed state with different version to trigger update.
+  pref_service()->SetBoolean(kWidevineOptedIn, initial_opted_in_value_);
+  pref_service()->SetString(kWidevineInstalledVersion, initial_version_string_);
+
+  manager_.StartupCheck();
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(1, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(2, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("failed");
+  EXPECT_EQ(3, manager_.background_update_retry_);
+
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("");
+
+  // No retry after install success.
+  EXPECT_EQ(3, manager_.background_update_retry_);
+
+  CheckPrefsStatesAreInstalledState();
+}
+
 TEST_F(BraveWidevineBundleManagerTest, MessageStringTest) {
   PrepareTest(true);
 

--- a/browser/widevine/brave_widevine_bundle_manager_unittest.cc
+++ b/browser/widevine/brave_widevine_bundle_manager_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/widevine/brave_widevine_bundle_manager.h"
 
+#include <vector>
+
 #include "base/files/scoped_temp_dir.h"
 #include "brave/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
@@ -21,7 +23,7 @@
 #include "media/base/decrypt_config.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/widevine/cdm/widevine_cdm_common.h"
-#include "widevine_cdm_version.h"
+#include "widevine_cdm_version.h"  // NOLINT
 
 class TestClient : public content::TestContentClient {
  public:

--- a/browser/widevine/brave_widevine_bundle_manager_unittest.cc
+++ b/browser/widevine/brave_widevine_bundle_manager_unittest.cc
@@ -88,14 +88,14 @@ class BraveWidevineBundleManagerTest : public testing::Test {
   }
 
   void CheckPrefsStatesAreInitialState() {
-    DCHECK_EQ(false, pref_service()->GetBoolean(kWidevineOptedIn));
-    DCHECK_EQ(BraveWidevineBundleManager::kWidevineInvalidVersion,
+    EXPECT_EQ(false, pref_service()->GetBoolean(kWidevineOptedIn));
+    EXPECT_EQ(BraveWidevineBundleManager::kWidevineInvalidVersion,
               pref_service()->GetString(kWidevineInstalledVersion));
   }
 
   void CheckPrefsStatesAreInstalledState() {
-    DCHECK_EQ(true, pref_service()->GetBoolean(kWidevineOptedIn));
-    DCHECK_EQ(WIDEVINE_CDM_VERSION_STRING,
+    EXPECT_EQ(true, pref_service()->GetBoolean(kWidevineOptedIn));
+    EXPECT_EQ(WIDEVINE_CDM_VERSION_STRING,
               pref_service()->GetString(kWidevineInstalledVersion));
   }
 
@@ -140,16 +140,16 @@ TEST_F(BraveWidevineBundleManagerTest, InProgressTest) {
   manager_.StartupCheck();
   manager_.InstallWidevineBundle(base::BindOnce([](const std::string&) {}),
                                  false);
-  DCHECK(manager_.in_progress());
+  EXPECT_TRUE(manager_.in_progress());
 
   manager_.InstallDone("");
-  DCHECK(!manager_.in_progress());
+  EXPECT_FALSE(manager_.in_progress());
 }
 
 TEST_F(BraveWidevineBundleManagerTest, InstallSuccessTest) {
   PrepareTest(true);
 
-  DCHECK(!manager_.needs_restart());
+  EXPECT_FALSE(manager_.needs_restart());
 
   manager_.StartupCheck();
   manager_.InstallWidevineBundle(base::BindOnce([](const std::string&) {}),
@@ -157,7 +157,7 @@ TEST_F(BraveWidevineBundleManagerTest, InstallSuccessTest) {
 
   manager_.InstallDone("");
 
-  DCHECK(manager_.needs_restart());
+  EXPECT_TRUE(manager_.needs_restart());
   CheckPrefsStatesAreInitialState();
 
   manager_.WillRestart();
@@ -167,20 +167,20 @@ TEST_F(BraveWidevineBundleManagerTest, InstallSuccessTest) {
 TEST_F(BraveWidevineBundleManagerTest, RetryInstallAfterFail) {
   PrepareTest(true);
 
-  DCHECK(!manager_.needs_restart());
+  EXPECT_FALSE(manager_.needs_restart());
   manager_.StartupCheck();
   manager_.InstallWidevineBundle(base::BindOnce([](const std::string&) {}),
                                  false);
 
   manager_.InstallDone("failed");
 
-  DCHECK(!manager_.needs_restart());
+  EXPECT_FALSE(manager_.needs_restart());
   CheckPrefsStatesAreInitialState();
 
   // Check request install again goes in-progress state.
   manager_.InstallWidevineBundle(base::BindOnce([](const std::string&) {}),
                                  false);
-  DCHECK(manager_.in_progress());
+  EXPECT_TRUE(manager_.in_progress());
 }
 
 TEST_F(BraveWidevineBundleManagerTest, DownloadFailTest) {
@@ -189,11 +189,11 @@ TEST_F(BraveWidevineBundleManagerTest, DownloadFailTest) {
   manager_.StartupCheck();
   manager_.InstallWidevineBundle(base::BindOnce([](const std::string&) {}),
                                  false);
-  DCHECK(manager_.in_progress());
+  EXPECT_TRUE(manager_.in_progress());
 
   // Empty path means download fail.
   manager_.OnBundleDownloaded(base::FilePath());
-  DCHECK(!manager_.in_progress());
+  EXPECT_FALSE(manager_.in_progress());
   CheckPrefsStatesAreInitialState();
 }
 
@@ -203,10 +203,10 @@ TEST_F(BraveWidevineBundleManagerTest, UnzipFailTest) {
   manager_.StartupCheck();
   manager_.InstallWidevineBundle(base::BindOnce([](const std::string&) {}),
                                  false);
-  DCHECK(manager_.in_progress());
+  EXPECT_TRUE(manager_.in_progress());
 
   manager_.OnBundleUnzipped("unzip failed");
-  DCHECK(!manager_.in_progress());
+  EXPECT_FALSE(manager_.in_progress());
   CheckPrefsStatesAreInitialState();
 }
 
@@ -217,20 +217,23 @@ TEST_F(BraveWidevineBundleManagerTest, UpdateTriggerTest) {
   pref_service()->SetBoolean(kWidevineOptedIn, true);
   pref_service()->SetString(kWidevineInstalledVersion, "1.0.0.0");
 
-  DCHECK(!manager_.update_requested_);
+  EXPECT_FALSE(manager_.update_requested_);
 
   manager_.StartupCheck();
-  DCHECK(manager_.update_requested_);
+  EXPECT_TRUE(manager_.update_requested_);
+  manager_.DoDelayedBackgroundUpdate();
+  manager_.InstallDone("");
+  CheckPrefsStatesAreInstalledState();
 }
 
 TEST_F(BraveWidevineBundleManagerTest, MessageStringTest) {
   PrepareTest(true);
 
-  DCHECK(!manager_.needs_restart());
-  DCHECK_EQ(IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_INSTALL,
+  EXPECT_FALSE(manager_.needs_restart());
+  EXPECT_EQ(IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_INSTALL,
             manager_.GetWidevinePermissionRequestTextFragment());
 
   manager_.set_needs_restart(true);
-  DCHECK_EQ(IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_RESTART_BROWSER,
+  EXPECT_EQ(IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_RESTART_BROWSER,
             manager_.GetWidevinePermissionRequestTextFragment());
 }

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -55,4 +55,6 @@ const char kEnableSmartTrackingProtection[] =
 // This prevents appending "Brave" to UA.
 const char kDisableOverrideUA[] = "disable-override-ua";
 
+const char kFastWidevineBundleUpdate[] = "fast-widevine-bundle-update";
+
 }  // namespace switches

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -38,6 +38,8 @@ extern const char kEnableSmartTrackingProtection[];
 
 extern const char kDisableOverrideUA[];
 
+extern const char kFastWidevineBundleUpdate[];
+
 }  // namespace switches
 
 #endif  // BRAVE_COMMON_BRAVE_SWITCHES_H_


### PR DESCRIPTION
This PR fixes widevine update bug and improves update logic.
Please see each commit's comment

Fix https://github.com/brave/brave-browser/issues/4638

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
`yarn test brave_unit_tests --filter=BraveWidevineBundle.*`

Manual update test step
1. Start debug build browser with clean profile with `--vmodule=brave_widevine_bundle*=2` to see install log in console.
2. Visit netflix and install widevine. This will install widevine `4.10.1196.0`.
3. you can see below logs w/o error
```
[23328:23328:0530/023725.488055:VERBOSE1:brave_widevine_bundle_manager.cc(108)] InstallWidevineBundle: Install widevine bundle
[23328:23328:0530/023725.488145:VERBOSE1:brave_widevine_bundle_manager.cc(219)] set_in_progress: 1
[23328:23328:0530/023726.093696:VERBOSE1:brave_widevine_bundle_manager.cc(160)] OnBundleDownloaded
[23328:23328:0530/023726.094842:VERBOSE1:brave_widevine_bundle_manager.cc(180)] OnGetTargetWidevineBundleDir
[23328:23328:0530/023726.094911:VERBOSE1:brave_widevine_bundle_unzipper.cc(62)] LoadFromZipFileInDir: zipped bundle file: /tmp/.org.chromium.Chromium.VwK0NM
[23328:23328:0530/023726.094953:VERBOSE1:brave_widevine_bundle_unzipper.cc(63)] LoadFromZipFileInDir: target install dir: /home/simon/.config/BraveSoftware/Brave-Browser-Development/WidevineCdm
[23328:23328:0530/023726.095191:VERBOSE1:brave_widevine_bundle_unzipper.cc(87)] OnGetTempDirForUnzip: temp unzip dir: /tmp/.org.chromium.Chromium.rPtswn
[23328:23328:0530/023726.176676:VERBOSE1:brave_widevine_bundle_manager.cc(207)] OnBundleUnzipped
[23328:23328:0530/023726.176744:VERBOSE1:brave_widevine_bundle_manager.cc(219)] set_in_progress: 0
[23328:23328:0530/023726.176793:VERBOSE1:brave_widevine_bundle_manager.cc(232)] set_needs_restart: 1
```
4. Restart browser and you can see below logs in console.
```
[24096:24096:0530/023919.702957:VERBOSE1:brave_widevine_bundle_manager.cc(287)] StartupCheck: widevine prefs state looks fine
[24096:24096:0530/023919.703073:VERBOSE1:brave_widevine_bundle_manager.cc(288)] StartupCheck: installed widevine version: 4.10.1196.0
[24096:24096:0530/023919.703121:VERBOSE1:brave_widevine_bundle_manager.cc(299)] StartupCheck: latest widevine version is installed.
```
5. Terminate browser and rebuild after modifying widevine version to `4.10.1146` in `package.json` of b-b.
5. Launch browser with `--vmodule=brave_widevine_bundle*=2 --fast-widevine-bundle-update` to show logs and quick update
6. After launching, you can see below update success logs.
```
[26759:26759:0530/024324.059892:VERBOSE1:brave_widevine_bundle_manager.cc(287)] StartupCheck: widevine prefs state looks fine
[26759:26759:0530/024324.059988:VERBOSE1:brave_widevine_bundle_manager.cc(288)] StartupCheck: installed widevine version: 4.10.1196.0
[26759:26759:0530/024324.060044:VERBOSE1:brave_widevine_bundle_manager.cc(292)] StartupCheck: new widevine version(4.10.1146.0) is found and background update is scheduled.
```
```
[26759:26759:0530/024324.259827:VERBOSE1:brave_widevine_bundle_manager.cc(335)] DoDelayedBackgroundUpdate: update widevine from 4.10.1196.0 to 4.10.1146.0
[26759:26759:0530/024324.259906:VERBOSE1:brave_widevine_bundle_manager.cc(108)] InstallWidevineBundle: Update widevine bundle
```
```
[26759:26759:0530/024325.209309:VERBOSE1:brave_widevine_bundle_manager.cc(160)] OnBundleDownloaded
[26759:26759:0530/024325.209706:VERBOSE1:brave_widevine_bundle_manager.cc(180)] OnGetTargetWidevineBundleDir
[26759:26759:0530/024325.209769:VERBOSE1:brave_widevine_bundle_unzipper.cc(62)] LoadFromZipFileInDir: zipped bundle file: /tmp/.org.chromium.Chromium.NfVqxn
[26759:26759:0530/024325.209811:VERBOSE1:brave_widevine_bundle_unzipper.cc(63)] LoadFromZipFileInDir: target install dir: /home/simon/.config/BraveSoftware/Brave-Browser-Development/WidevineCdm
[26759:26759:0530/024325.210157:VERBOSE1:brave_widevine_bundle_unzipper.cc(87)] OnGetTempDirForUnzip: temp unzip dir: /tmp/.org.chromium.Chromium.TqAN87
[26759:26759:0530/024325.347188:VERBOSE1:brave_widevine_bundle_manager.cc(207)] OnBundleUnzipped
[26759:26759:0530/024325.347261:VERBOSE1:brave_widevine_bundle_manager.cc(219)] set_in_progress: 0
[26759:26759:0530/024325.347316:VERBOSE1:brave_widevine_bundle_manager.cc(232)] set_needs_restart: 1
[26759:26759:0530/024325.347357:VERBOSE1:brave_widevine_bundle_manager.cc(323)] OnBackgroundUpdateFinished: Widevine update success
```
8. Restart browser and you can see below logs
```
[28209:28209:0530/024819.142718:VERBOSE1:brave_widevine_bundle_manager.cc(287)] StartupCheck: widevine prefs state looks fine
[28209:28209:0530/024819.142811:VERBOSE1:brave_widevine_bundle_manager.cc(288)] StartupCheck: installed widevine version: 4.10.1146.0
[28209:28209:0530/024819.142859:VERBOSE1:brave_widevine_bundle_manager.cc(301)] StartupCheck: latest widevine version is installed.
```

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
