### PR TITLE
Uplift Disable in-page translation in release channel to 0.67.x

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -15,6 +15,7 @@
 #include "build/build_config.h"
 #include "brave/app/brave_command_line_helper.h"
 #include "brave/browser/brave_content_browser_client.h"
+#include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/brave_switches.h"
 #include "brave/common/resource_bundle_helper.h"
 #include "brave/components/brave_ads/browser/buildflags/buildflags.h"
@@ -27,6 +28,7 @@
 #include "components/autofill/core/common/autofill_features.h"
 #include "components/autofill/core/common/autofill_payments_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
+#include "components/translate/core/browser/translate_prefs.h"
 #include "components/unified_consent/feature.h"
 #include "content/public/common/content_features.h"
 #include "extensions/common/extension_features.h"
@@ -150,10 +152,11 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
       network::features::kNetworkService.name,
       unified_consent::kUnifiedConsent.name,
       features::kLookalikeUrlNavigationSuggestionsUI.name,
+#if !BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
+      translate::kTranslateUI.name,
+#endif
   };
-
   command_line.AppendFeatures(enabled_features, disabled_features);
-
 
   bool ret = ChromeMainDelegate::BasicStartupComplete(exit_code);
 

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -87,6 +87,7 @@ source_set("browser_process") {
     "ui",
     "//base",
     "//brave/browser/tor",
+    "//brave/browser/translate/buildflags",
     "//brave/common",
     "//brave/components/brave_ads/browser",
     "//brave/components/brave_component_updater/browser",

--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -1,4 +1,5 @@
 import("//brave/browser/tor/buildflags/buildflags.gni")
+import("//brave/browser/translate/buildflags/buildflags.gni")
 import("//brave/components/brave_webtorrent/browser/buildflags/buildflags.gni")
 import("//build/config/features.gni")
 
@@ -23,8 +24,6 @@ source_set("net") {
     "brave_static_redirect_network_delegate_helper.h",
     "brave_system_network_delegate.cc",
     "brave_system_network_delegate.h",
-    "brave_translate_redirect_network_delegate_helper.cc",
-    "brave_translate_redirect_network_delegate_helper.h",
     "url_context.cc",
     "url_context.h",
   ]
@@ -54,6 +53,13 @@ source_set("net") {
   if (enable_brave_webtorrent) {
     deps += [
       "//brave/components/brave_webtorrent/browser/net",
+    ]
+  }
+
+  if (enable_brave_translate) {
+    sources += [
+      "brave_translate_redirect_network_delegate_helper.cc",
+      "brave_translate_redirect_network_delegate_helper.h",
     ]
   }
 }

--- a/browser/net/brave_profile_network_delegate.cc
+++ b/browser/net/brave_profile_network_delegate.cc
@@ -10,8 +10,8 @@
 #include "brave/browser/net/cookie_network_delegate_helper.h"
 #include "brave/browser/net/brave_httpse_network_delegate_helper.h"
 #include "brave/browser/net/brave_site_hacks_network_delegate_helper.h"
-#include "brave/browser/net/brave_translate_redirect_network_delegate_helper.h"
 #include "brave/browser/tor/buildflags.h"
+#include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
@@ -28,6 +28,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
 #include "brave/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
+#include "brave/browser/net/brave_translate_redirect_network_delegate_helper.h"
 #endif
 
 BraveProfileNetworkDelegate::BraveProfileNetworkDelegate(
@@ -60,9 +64,11 @@ BraveProfileNetworkDelegate::BraveProfileNetworkDelegate(
   before_url_request_callbacks_.push_back(callback);
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
   callback = base::BindRepeating(
       brave::OnBeforeURLRequest_TranslateRedirectWork);
   before_url_request_callbacks_.push_back(callback);
+#endif
 
   brave::OnBeforeStartTransactionCallback start_transaction_callback =
       base::Bind(brave::OnBeforeStartTransaction_SiteHacksWork);

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/network_constants.h"
 #include "brave/common/translate_network_constants.h"
 #include "extensions/common/url_pattern.h"
@@ -33,11 +34,12 @@ int OnBeforeURLRequest_StaticRedirectWork(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix4);
   static URLPattern crxDownload_pattern(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRXDownloadPrefix);
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
   static URLPattern translate_pattern(URLPattern::SCHEME_HTTPS,
       kTranslateElementJSPattern);
   static URLPattern translate_language_pattern(URLPattern::SCHEME_HTTPS,
       kTranslateLanguagePattern);
-
+#endif
   if (geo_pattern.MatchesURL(ctx->request_url)) {
     ctx->new_url_spec = GURL(GOOGLEAPIS_ENDPOINT GOOGLEAPIS_API_KEY).spec();
     return net::OK;
@@ -89,7 +91,7 @@ int OnBeforeURLRequest_StaticRedirectWork(
     ctx->new_url_spec = ctx->request_url.ReplaceComponents(replacements).spec();
     return net::OK;
   }
-
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
   if (translate_pattern.MatchesURL(ctx->request_url)) {
     replacements.SetQueryStr(ctx->request_url.query_piece());
     replacements.SetPathStr(ctx->request_url.path_piece());
@@ -102,6 +104,7 @@ int OnBeforeURLRequest_StaticRedirectWork(
     ctx->new_url_spec = GURL(kBraveTranslateLanguageEndpoint).spec();
     return net::OK;
   }
+#endif
 
 #if !defined(NDEBUG)
   GURL gurl = ctx->request_url;

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "brave/browser/net/url_context.h"
+#include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/network_constants.h"
 #include "brave/common/translate_network_constants.h"
 #include "chrome/test/base/chrome_render_view_host_test_harness.h"
@@ -304,6 +305,7 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest,
   EXPECT_EQ(ret, net::OK);
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, RedirectTranslate) {
   net::TestDelegate test_delegate;
   std::string query_string(
@@ -350,5 +352,6 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest,
   EXPECT_EQ(before_url_context->new_url_spec, expected_url);
   EXPECT_EQ(ret, net::OK);
 }
+#endif
 
 }  // namespace

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -1,9 +1,12 @@
+import("//brave/build/config.gni")
 import("//chrome/browser/resources/optimize_webui.gni")
 import("//chrome/common/features.gni")
 import("//tools/grit/grit_rule.gni")
 
 grit("resources") {
   source = "settings_resources.grd"
+
+  defines = ["is_release_channel=$is_release_channel"]
 
   source_is_generated = optimize_webui
 

--- a/browser/resources/settings/brave_settings_overrides.js
+++ b/browser/resources/settings/brave_settings_overrides.js
@@ -320,7 +320,16 @@ BravePatching.RegisterPolymerTemplateModifications({
       console.error('[Brave Settings Overrides] Could not find manage payments link')
     }
     manageLink.remove()
+  },
+// <if expr="is_release_channel">
+  'settings-languages-page': (templateContent) => {
+    const offerTranslateToggle = templateContent.querySelector('#offerTranslateOtherLanguages')
+    if (!offerTranslateToggle) {
+      console.error('[Brave Settings Overrides] Could not find offer translate toggle')
+    }
+    offerTranslateToggle.remove()
   }
+// </if>
 })
 
 // Icons

--- a/browser/resources/settings/settings_resources.grd
+++ b/browser/resources/settings/settings_resources.grd
@@ -11,7 +11,7 @@
   <release seq="1">
     <structures>
       <structure name="IDR_SETTINGS_BRAVE_SETTINGS_OVERRIDES_HTML" file="brave_settings_overrides.html" type="chrome_html" />
-      <structure name="IDR_SETTINGS_BRAVE_SETTINGS_OVERRIDES_JS" file="brave_settings_overrides.js" type="chrome_html" />
+      <structure name="IDR_SETTINGS_BRAVE_SETTINGS_OVERRIDES_JS" file="brave_settings_overrides.js" type="chrome_html" preprocess="true" />
       <structure name="IDR_SETTINGS_BRAVE_ICONS_HTML" file="brave_icons.html" type="chrome_html" />
       <structure name="IDR_SETTINGS_DEFAULT_BRAVE_SHIELDS_BROWSER_PROXY_HTML" file="default_brave_shields_page/default_brave_shields_browser_proxy.html" type="chrome_html" />
       <structure name="IDR_SETTINGS_DEFAULT_BRAVE_SHIELDS_BROWSER_PROXY_JS" file="default_brave_shields_page/default_brave_shields_browser_proxy.js" type="chrome_html" preprocess="true" />

--- a/browser/translate/buildflags/BUILD.gn
+++ b/browser/translate/buildflags/BUILD.gn
@@ -1,0 +1,9 @@
+import("//build/buildflag_header.gni")
+import("//brave/browser/translate/buildflags/buildflags.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [
+    "ENABLE_BRAVE_TRANSLATE=$enable_brave_translate",
+  ]
+}

--- a/browser/translate/buildflags/buildflags.gni
+++ b/browser/translate/buildflags/buildflags.gni
@@ -1,0 +1,6 @@
+import("//brave/build/config.gni")
+import("//build/config/features.gni")
+
+declare_args() {
+  enable_brave_translate = !is_release_channel
+}

--- a/build/config.gni
+++ b/build/config.gni
@@ -8,7 +8,7 @@ declare_args() {
   # "nightly" for nightly channel release.
   # "" for stable channel release.
   brave_channel = ""
-
+  is_release_channel = true
   base_sparkle_update_url = ""
 
   brave_dsa_file = "dsa_pub.pem"
@@ -105,3 +105,5 @@ if (is_win) {
 } else if (is_linux) {
   brave_platform = "linux"
 }
+
+is_release_channel = brave_channel == ""

--- a/chromium_src/chrome/browser/translate/translate_service.cc
+++ b/chromium_src/chrome/browser/translate/translate_service.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/translate/buildflags/buildflags.h"
+
+namespace {
+bool IsBraveTranslateEnabled() {
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
+  return true;
+#endif
+  return false;
+}
+}  // namespace
+
+#include "../../../../../../chrome/browser/translate/translate_service.cc" // NOLINT

--- a/patches/chrome-browser-translate-translate_service.cc.patch
+++ b/patches/chrome-browser-translate-translate_service.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/translate/translate_service.cc b/chrome/browser/translate/translate_service.cc
+index 06eacc6c808221f905aea64e33dd64a3e373bb62..22e589b8729d7f197aeac2b1c9a230b9344d24b0 100644
+--- a/chrome/browser/translate/translate_service.cc
++++ b/chrome/browser/translate/translate_service.cc
+@@ -136,7 +136,7 @@ bool TranslateService::IsTranslatableURL(const GURL& url) {
+   // - Chrome OS file manager extension
+   // - an FTP page (as FTP pages tend to have long lists of filenames that may
+   //   confuse the CLD)
+-  return !url.is_empty() && !url.SchemeIs(content::kChromeUIScheme) &&
++  return IsBraveTranslateEnabled() && !url.is_empty() && !url.SchemeIs(content::kChromeUIScheme) &&
+          !url.SchemeIs(content::kChromeDevToolsScheme) &&
+ #if defined(OS_CHROMEOS)
+          !(url.SchemeIs(extensions::kExtensionScheme) &&

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1,4 +1,5 @@
 import("//brave/build/config.gni")
+import("//brave/browser/translate/buildflags/buildflags.gni")
 import("//brave/components/brave_ads/browser/buildflags/buildflags.gni")
 import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
 import("//testing/test.gni")
@@ -59,7 +60,6 @@ test("brave_unit_tests") {
     "//brave/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_tor_network_delegate_helper_unittest.cc",
-    "//brave/browser/net/brave_translate_redirect_network_delegate_helper_unittest.cc",
     "//brave/browser/profiles/tor_unittest_profile_manager.cc",
     "//brave/browser/profiles/tor_unittest_profile_manager.h",
     "//brave/browser/profiles/brave_profile_manager_unittest.cc",
@@ -141,6 +141,12 @@ test("brave_unit_tests") {
       "//brave/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_client_mock.cc",
       "//brave/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_client_mock.h",
       "//brave/vendor/bat-native-usermodel/test/usermodel_unittest.cc",
+    ]
+  }
+
+  if (enable_brave_translate) {
+    sources += [
+      "//brave/browser/net/brave_translate_redirect_network_delegate_helper_unittest.cc",
     ]
   }
 


### PR DESCRIPTION
Disable in-page translation in release channel
Uplift of https://github.com/brave/brave-core/pull/2542
Issue: https://github.com/brave/brave-browser/issues/4626