### PR TITLE
Update macOS postinstall script to properly build executable paths

### DIFF
--- a/build/mac/pkg-scripts/postinstall
+++ b/build/mac/pkg-scripts/postinstall
@@ -6,11 +6,26 @@
 installerPath=$1
 installationPath=$2
 
-# TODO: ugly to assume the name of the app, especially with multi-channel.
-# Luckily for now, release channel is the only channel with a pkg installer.
-installationAppPath="$installationPath/Brave Browser.app"
+# Detect if installer contained a referral promotion code within the filename
+# Will also get a channel-safe version of the application name (based on the .pkg file name)
 installerPathPromoCodeRegex='.+-(([a-zA-Z0-9]{3}[0-9]{3})|([a-zA-Z]{1,}-[a-zA-Z]{1,}))([[:blank:]]?\([0-9]+\))?\.pkg$'
-userDataDir="$HOME/Library/Application Support/BraveSoftware/Brave-Browser"
+if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
+  echo "Installer path matched for promo code"
+  n=${#BASH_REMATCH[*]}
+  if [ $n -ge 1 ]; then
+    promoCode=${BASH_REMATCH[1]}
+    echo "Got promo code: $promoCode"
+  fi
+  appName=$(basename "$1" | sed "s/.pkg//" | sed "s/ /\-/g" | sed "s/-${promoCode}//")
+else
+  echo "Installer path did not match for promo code"
+  promoCode=""
+  appName=$(basename "$1" | sed "s/.pkg//" | sed "s/ /\-/g")
+fi
+
+appNameNoDash=$(echo $appName | sed "s/-/ /g")
+installationAppPath="$installationPath/${appNameNoDash}.app"
+userDataDir="$HOME/Library/Application Support/BraveSoftware/${appName}"
 promoCodePath="$userDataDir/promoCode"
 
 # pkg runs this script as root so we need to get current username
@@ -28,25 +43,14 @@ sudo chmod -R 775 "$installationAppPath"
 sudo chown -R $userName "$installationAppPath"
 sudo chgrp -R admin "$installationAppPath"
 
-# Detect if installer contained a referral promotion code within the filename
-if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
-  echo "Installer path matched for promo code"
-  n=${#BASH_REMATCH[*]}
-  if [ $n -ge 1 ]; then
-    promoCode=${BASH_REMATCH[1]}
-    echo "Got promo code: $promoCode"
-    echo "Writing to user data directory at: $userDataDir/promoCode"
-    # TODO: it is a bit ugly to assume the user-data path here, and to manually
-    # write to it and hopefully set the correct permissions. An alternative would
-    # be to run Brave with a flag, similar to the process for Windows.
-    mkdir -p "$userDataDir"
-    echo "$promoCode" > "$promoCodePath"
-    # fix permissions
-    sudo chown "$userName" "$userDataDir"
-    sudo chown "$userName" "$promoCodePath"
-  fi
-else
-  echo "Installer path did not match for promo code"
+# handle promoCode specific logic (if promoCode was found)
+if [ "$promoCode" != "" ]; then
+  echo "Writing to user data directory at: $promoCodePath"
+  mkdir -p "$userDataDir"
+  echo "$promoCode" > "$promoCodePath"
+  # fix permissions
+  sudo chown "$userName" "$userDataDir"
+  sudo chown "$userName" "$promoCodePath"
 fi
 
 exit 0


### PR DESCRIPTION
Update postinstall script to properly build executable paths (install path + user data dir name)

Fixes https://github.com/brave/brave-browser/issues/4600

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Download the PKG file (message @bsclifton if unsure where/how to download)
2. Rename it in a format like `Brave Browser Dev-BSC123.pkg` (where `BSC123` is your referral promo code)
3. Run the installer
4. `promoCode` file should be created in `~/Library/BraveSoftware/Brave-Browser-Dev/promoCode`
5. Open file and verify contents are `BSC123` (or whatever your promo code was)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
