### PR TITLE
Add provider to tip compliment

### DIFF
--- a/browser/ui/webui/brave_tip_ui.cc
+++ b/browser/ui/webui/brave_tip_ui.cc
@@ -347,22 +347,23 @@ void RewardsTipDOMHandler::OnRecurringTipSaved(
 }
 
 void RewardsTipDOMHandler::TweetTip(const base::ListValue *args) {
-  DCHECK_EQ(args->GetSize(), 2U);
+  DCHECK_EQ(args->GetSize(), 3U);
 
   if (!rewards_service_)
     return;
 
   // Retrieve the relevant metadata from arguments.
-  std::string name;
-  if (!args->GetString(0, &name))
+  std::string name = args->GetList()[0].GetString();
+  if (name.empty())
     return;
-  std::string tweet_id;
-  if (!args->GetString(1, &tweet_id))
-    return;
+  std::string tweet_id = args->GetList()[1].GetString();
+  std::string provider = args->GetList()[2].GetString();
+  if (provider.empty())
+     return;
 
   // Share the tip comment/compliment on Twitter.
   std::string comment = l10n_util::GetStringFUTF8(
-      IDS_BRAVE_REWARDS_LOCAL_COMPLIMENT_TWEET, base::UTF8ToUTF16(name));
+      IDS_BRAVE_REWARDS_LOCAL_COMPLIMENT_TWEET, base::UTF8ToUTF16(name), base::UTF8ToUTF16(provider));
   std::string hashtag = l10n_util::GetStringUTF8(
       IDS_BRAVE_REWARDS_LOCAL_COMPLIMENT_TWEET_HASHTAG);
   std::map<std::string, std::string> share_url_args;

--- a/components/brave_rewards/resources/tip/actions/tip_actions.ts
+++ b/components/brave_rewards/resources/tip/actions/tip_actions.ts
@@ -9,9 +9,10 @@ import { types } from '../constants/tip_types'
 
 export const onCloseDialog = () => action(types.ON_CLOSE_DIALOG)
 
-export const onTweet = (name: string, tweetId: string) => action(types.ON_TWEET, {
+export const onTweet = (name: string, tweetId: string, provider: string) => action(types.ON_TWEET, {
   name,
-  tweetId
+  tweetId,
+  provider
 })
 
 export const onPublisherBanner = (data: RewardsTip.Publisher) => action(types.ON_PUBLISHER_BANNER, {

--- a/components/brave_rewards/resources/tip/components/tipSite.tsx
+++ b/components/brave_rewards/resources/tip/components/tipSite.tsx
@@ -25,14 +25,14 @@ class TipSite extends React.Component<Props, {}> {
 
   onTweet = () => {
     let name = this.props.publisher.name
-    if (this.props.publisher.provider === 'twitter') {
+    let provider = this.props.publisher.provider
+    if (provider === 'twitter') {
       const url = this.props.url
       if (url && url.length > 0) {
         name = `@${url.replace(/^.*\/(.*)$/, '$1')}`
       }
     }
-
-    this.actions.onTweet(name, '')
+    this.actions.onTweet(name, '', provider)
     this.actions.onCloseDialog()
   }
 

--- a/components/brave_rewards/resources/tip/reducers/tip_reducer.ts
+++ b/components/brave_rewards/resources/tip/reducers/tip_reducer.ts
@@ -24,7 +24,6 @@ export const defaultState: RewardsTip.State = {
 
 const publishersReducer: Reducer<RewardsTip.State> = (state: RewardsTip.State = defaultState, action) => {
   const payload = action.payload
-
   switch (action.type) {
     case types.ON_CLOSE_DIALOG:
       state = { ...state }
@@ -34,7 +33,8 @@ const publishersReducer: Reducer<RewardsTip.State> = (state: RewardsTip.State = 
     case types.ON_TWEET:
       chrome.send('brave_rewards_tip.tweetTip', [
         payload.name,
-        payload.tweetId
+        payload.tweetId,
+        payload.provider
       ])
       break
     case types.ON_PUBLISHER_BANNER: {

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -260,7 +260,7 @@
       <message name="IDS_BRAVE_REWARDS_LOCAL_GRANT_ALREADY_CLAIMED_TEXT" desc="">Sorry, it appears that this grant has already been claimed.</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_DONAT_NEXT_DATE" desc="Description of the date in the donation box">Next monthly tip date</message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_COMPLIMENT_TWEET" desc="">
-        I just tipped <ph name="NAME">$1<ex>user</ex></ph> using the Brave Browser. Check it out at https://brave.com/tips.
+        I just tipped <ph name="NAME">$1<ex>user</ex></ph> on <ph name="PROVIDER">$2<ex>site</ex></ph> using the Brave Browser. Check it out at https://brave.com/tips.
       </message>
       <message name="IDS_BRAVE_REWARDS_LOCAL_COMPLIMENT_TWEET_HASHTAG" desc="">TipWithBrave</message>
 


### PR DESCRIPTION
Fixes brave/brave-browser#4586

Added publisher provider to tweetTip compliment string displayed when sharing a tip via tweet. 
Compliment string now reads "I just tipped [publisher] on [provider]"

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
See steps at brave/brave-browser#4586


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
