### PR TITLE
Fix undefined kTranslateUI symbol link error on windows release build(0.67.x)

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -152,8 +152,8 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
       network::features::kNetworkService.name,
       unified_consent::kUnifiedConsent.name,
       features::kLookalikeUrlNavigationSuggestionsUI.name,
-#if !BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
-      translate::kTranslateUI.name,
+#if !defined(CHROME_MULTIPLE_DLL_CHILD) && !BUILDFLAG(ENABLE_BRAVE_TRANSLATE)
+      translate::kTranslateUI.name,  // only available in browser process
 #endif
   };
   command_line.AppendFeatures(enabled_features, disabled_features);


### PR DESCRIPTION
Uplift of #2557
Issue: brave/brave-browser#4656