### PR TITLE
Make bookmark toggle on NTP whether bookmark is empty or not

### DIFF
--- a/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc
+++ b/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc
@@ -1,0 +1,64 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <vector>
+
+#include "chrome/browser/bookmarks/bookmark_model_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search/search.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/webui/ntp/new_tab_ui.h"
+#include "chrome/common/url_constants.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/bookmarks/browser/bookmark_model.h"
+#include "components/bookmarks/browser/bookmark_utils.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test_utils.h"
+#include "url/gurl.h"
+
+using BookmarkTabHelperBrowserTest = InProcessBrowserTest;
+
+namespace {
+
+bool IsNTP(content::WebContents* web_contents) {
+  // Use the committed entry so the bookmarks bar disappears at the same time
+  // the page does.
+  content::NavigationEntry* entry =
+      web_contents->GetController().GetLastCommittedEntry();
+  if (!entry)
+    entry = web_contents->GetController().GetVisibleEntry();
+  return (entry && NewTabUI::IsNewTab(entry->GetURL())) ||
+         search::NavEntryIsInstantNTP(web_contents, entry);
+}
+
+}  // namespace
+
+IN_PROC_BROWSER_TEST_F(BookmarkTabHelperBrowserTest,
+                       BookmarkBarOnNTPToggleTest) {
+  auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
+  EXPECT_TRUE(content::NavigateToURL(contents,
+                                     GURL(chrome::kChromeUINewTabURL)));
+  EXPECT_TRUE(IsNTP(contents));
+  chrome::ToggleBookmarkBar(browser());
+  EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
+
+  const GURL url = GURL("https://www.brave.com");
+  bookmarks::BookmarkModel* bookmark_model =
+      BookmarkModelFactory::GetForBrowserContext(browser()->profile());
+
+  std::vector<const bookmarks::BookmarkNode*> nodes;
+  bookmark_model->GetNodesByURL(url, &nodes);
+  EXPECT_EQ(0UL, nodes.size());
+
+  bookmarks::AddIfNotBookmarked(bookmark_model, url, base::string16());
+  bookmark_model->GetNodesByURL(url, &nodes);
+  EXPECT_EQ(1UL, nodes.size());
+
+  chrome::ToggleBookmarkBar(browser());
+  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
+}

--- a/patches/chrome-browser-ui-bookmarks-bookmark_tab_helper.cc.patch
+++ b/patches/chrome-browser-ui-bookmarks-bookmark_tab_helper.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc b/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
+index f6ef61a0ac86ae55e8f9e80ece0758253af48520..888d656cf7080ebc32e90fc492e70a9b394d7026 100644
+--- a/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
++++ b/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
+@@ -67,6 +67,7 @@ bool BookmarkTabHelper::ShouldShowBookmarkBar() const {
+       !prefs->GetBoolean(bookmarks::prefs::kShowBookmarkBar))
+     return false;
+ 
++  return false;
+   // The bookmark bar is only shown on the NTP if the user
+   // has added something to it.
+   return IsNTP(web_contents()) && bookmark_model_ &&

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -335,6 +335,7 @@ test("brave_browser_tests") {
     "//brave/browser/renderer_context_menu/brave_mock_render_view_context_menu.h",
     "//brave/browser/renderer_context_menu/brave_spelling_menu_observer_browsertest.cc",
     "//brave/browser/search_engines/search_engine_provider_service_browsertest.cc",
+    "//brave/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc",
     "//brave/browser/ui/brave_dark_mode_observer_browsertest_mac.mm",
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/1306

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`yarn test brave_browser_tests --filter=BookmarkTabHelper*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
