### PR TITLE
patch linux notifications to remove settings button

### DIFF
--- a/patches/chrome-browser-notifications-notification_platform_bridge_linux.cc.patch
+++ b/patches/chrome-browser-notifications-notification_platform_bridge_linux.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/notifications/notification_platform_bridge_linux.cc b/chrome/browser/notifications/notification_platform_bridge_linux.cc
+index aa6d15f6ebbdcc6e70374a46ca9c11d4c1bff854..5c2bdec672a402edbc3602887fdad9e3cc0056a8 100644
+--- a/chrome/browser/notifications/notification_platform_bridge_linux.cc
++++ b/chrome/browser/notifications/notification_platform_bridge_linux.cc
+@@ -632,6 +632,7 @@ class NotificationPlatformBridgeLinuxImpl
+       actions.push_back("Activate");
+       // Always add a settings button for web notifications.
+       if (notification_type != NotificationHandler::Type::EXTENSION &&
++          notification_type != NotificationHandler::Type::BRAVE_ADS &&
+           notification_type != NotificationHandler::Type::SEND_TAB_TO_SELF) {
+         actions.push_back(kSettingsButtonId);
+         actions.push_back(


### PR DESCRIPTION
We patch Mac to do this but the patch was never made for linux. (See `patches/chrome-browser-notifications-notification_platform_bridge_mac.mm.patch`.)

This fixes brave/brave-browser#4231.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
On Linux:
- Enable ads in rewards settings.
- Wait for ad to show.
- Verify ad does not include "Settings" button.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
