### PR TITLE
Fix ads not shown if a background tab is playing video

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -248,7 +248,9 @@ void AdsImpl::OnMediaStopped(const int32_t tab_id) {
 }
 
 bool AdsImpl::IsMediaPlaying() const {
-  if (media_playing_.empty()) {
+  auto tab = media_playing_.find(last_shown_tab_id_);
+  if (tab == media_playing_.end()) {
+    // Media is not playing in the last shown tab
     return false;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_tabs_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_tabs_unittest.cc
@@ -140,6 +140,7 @@ class AdsTabsTest : public ::testing::Test {
 
 TEST_F(AdsTabsTest, Media_IsPlaying) {
   // Arrange
+  ads_->TabUpdated(1, "https://brave.com", true, false);
   ads_->OnMediaPlaying(1);
 
   // Act
@@ -151,6 +152,8 @@ TEST_F(AdsTabsTest, Media_IsPlaying) {
 
 TEST_F(AdsTabsTest, Media_NotPlaying) {
   // Arrange
+  ads_->TabUpdated(1, "https://brave.com", true, false);
+
   ads_->OnMediaPlaying(1);
   ads_->OnMediaPlaying(2);
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/3779

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Test that Ads are shown if media is playing on a non-active (blurred) tab
- Test that Ads are not shown if media is playing on the active (focused) tab


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
