### PR TITLE
Upgrade patches from Chromium 75.0.3770.75 to Chromium 75.0.3770.80 (Uplift to 0.66.x)

### DIFF
--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,11 +1,11 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index 9ede91db965fbc2e37d9754fe42d157720ac1875..f46a41aba723a314a3daad24067a14a904d745ad 100644
+index 0ee0cc242efb549e768e918a69f5db4838f2ae26..a0cf3fe3a9407abe47a811f634c95b123405cd43 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@
  MAJOR=75
  MINOR=0
 -BUILD=3770
--PATCH=75
+-PATCH=80
 +BUILD=66
 +PATCH=83

--- a/patches/content-common-BUILD.gn.patch
+++ b/patches/content-common-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/content/common/BUILD.gn b/content/common/BUILD.gn
-index 775996a26f581c43b54d5834ae2cb37d7ea74af3..522aace4a0e4f8510a890f6444fed30e49885ff1 100644
+index 080d08c52d851effe4f602dc108e57e0c00d66db..295a65b81edc3adaeec13fbda459adaac4d55bc3 100644
 --- a/content/common/BUILD.gn
 +++ b/content/common/BUILD.gn
 @@ -31,7 +31,7 @@ source_set("common") {


### PR DESCRIPTION
Related https://github.com/brave/brave-browser/pull/4726
Uplift of https://github.com/brave/brave-browser/pull/4718
Fixes https://github.com/brave/brave-browser/issues/4724
