### PR TITLE
Fixes signing on mac after the bump to 75.0.3770.75

### DIFF
--- a/build/mac/sign_brave.py
+++ b/build/mac/sign_brave.py
@@ -70,6 +70,10 @@ def create_config(identity, keychain, development, provisioning_profile):
                 return set(('libwidevinecdm.dylib',
                             'sparkle-framework',))
 
+            @property
+            def run_spctl_assess(self):
+                return True
+
         config_class = ProvisioningProfileCodeSignConfig
 
     return config_class(identity, keychain)

--- a/patches/chrome-installer-mac-signing-signing.py.patch
+++ b/patches/chrome-installer-mac-signing-signing.py.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/installer/mac/signing/signing.py b/chrome/installer/mac/signing/signing.py
-index b56853e5e2649328a81a2de20228de5abda08f11..b460edf666adc54862e5d783b60352065ce67531 100644
+index b56853e5e2649328a81a2de20228de5abda08f11..85cd57d8d8a70133f54f1e1970c418c15cb6629b 100644
 --- a/chrome/installer/mac/signing/signing.py
 +++ b/chrome/installer/mac/signing/signing.py
-@@ -84,6 +84,12 @@ def get_parts(config):
+@@ -42,7 +42,6 @@ def get_parts(config):
+                 options=CodeSignOptions.RESTRICT,
+                 requirements=config.codesign_requirements_outer_app,
+                 identifier_requirement=False,
+-                resource_rules='app_resource_rules.plist',
+                 entitlements='app-entitlements.plist',
+                 verify_options=VerifyOptions.DEEP + VerifyOptions.NO_STRICT),
+         'framework':
+@@ -84,6 +83,12 @@ def get_parts(config):
                  options=CodeSignOptions.RESTRICT +
                  CodeSignOptions.LIBRARY_VALIDATION,
                  verify_options=VerifyOptions.IGNORE_RESOURCES),


### PR DESCRIPTION
Fixes brave/brave-browser#4739

1. Patches chrome/installer/mac/signing/signing.py to remove passing
of --resource-rules to codesign when signing the browser app.

2. Modifies configuration in brave/build/mac/sign_brave.py to verify
signature with spctl (for official builds).

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Try installing Brave Mac build from a .dmg.
2. Verify that the application doesn't get prevented from starting by the Gatekeeper.

Alternatively, once .dgm is open, copy the app to a folder and verify with:
`spctl --assess --verbose Brave\ Browser\ Nightly.app/`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
