### PR TITLE
Fix invalid path and display name of folder for installed pwa on MacOS (uplift to 0.67.x)

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -415,6 +415,24 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <message name="IDS_BRAVE_TRANSLATE_BUBBLE_BEFORE_TRANSLATE_TITLE" desc="Title text for the translate bubble when asking to translate a page.">
         Translate this page? This will send all text on this page to Microsoft for translation.
       </message>
+      <!-- App shortcuts -->
+      <if expr="not is_win">
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_NIGHTLY" desc="Name for the Brave Apps Start Menu folder name.">
+          Brave Browser Nightly Apps
+        </message>
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_BETA" desc="Name for the Brave Apps Start Menu folder name.">
+          Brave Browser Beta Apps
+        </message>
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_DEV" desc="Name for the Brave Apps Start Menu folder name.">
+          Brave Browser Dev Apps
+        </message>
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_STABLE" desc="Name for the Brave Apps Start Menu folder name.">
+          Brave Browser Apps
+        </message>
+        <message name="IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_DEVELOPMENT" desc="Name for the Brave Apps Start Menu folder name.">
+          Brave Browser Development Apps
+        </message>
+      </if>
     </messages>
     <includes>
       <include name="IDR_BRAVE_TAG_SERVICES_POLYFILL" file="resources/js/tag_services_polyfill.js" type="BINDATA" />

--- a/chromium_src/chrome/browser/shell_integration.cc
+++ b/chromium_src/chrome/browser/shell_integration.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "build/build_config.h"
+
+#if !defined(OS_WIN)
+#include "chrome/grit/generated_resources.h"
+
+#define GetAppShortcutsSubdirName GetAppShortcutsSubdirName_UnUsed
+#endif
+
+#include "../../../../chrome/browser/shell_integration.cc"  // NOLINT
+
+#if !defined(OS_WIN)
+#undef GetAppShortcutsSubdirName
+#endif
+
+#if !defined(OS_WIN)
+namespace shell_integration {
+base::string16 GetAppShortcutsSubdirName() {
+  int id = IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_STABLE;
+  switch (chrome::GetChannel()) {
+    case version_info::Channel::STABLE:
+      id = IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_STABLE;
+      break;
+    case version_info::Channel::BETA:
+      id = IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_BETA;
+      break;
+    case version_info::Channel::DEV:
+      id = IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_DEV;
+      break;
+    case version_info::Channel::CANARY:
+      id = IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_NIGHTLY;
+      break;
+    case version_info::Channel::UNKNOWN:
+      id = IDS_APP_SHORTCUTS_SUBDIR_NAME_BRAVE_DEVELOPMENT;
+      break;
+    default:
+      NOTREACHED();
+      break;
+  }
+
+  return l10n_util::GetStringUTF16(id);
+}
+}  // namespace shell_integration
+#endif  // !defined(OS_WIN)

--- a/chromium_src/chrome/browser/web_applications/components/web_app_shortcut_mac.mm
+++ b/chromium_src/chrome/browser/web_applications/components/web_app_shortcut_mac.mm
@@ -1,0 +1,45 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+namespace base {
+class FilePath;
+}  // namespace base
+
+namespace {
+base::FilePath GetLocalizableBraveAppShortcutsSubdirName();
+}
+
+#include "../../../../../../chrome/browser/web_applications/components/web_app_shortcut_mac.mm"  // NOLINT
+
+namespace {
+base::FilePath GetLocalizableBraveAppShortcutsSubdirName() {
+  static const char kBraveBrowserDevelopmentAppDirName[] =
+      "Brave Browser Development Apps.localized";
+  static const char kBraveBrowserAppDirName[] =
+      "Brave Browser Apps.localized";
+  static const char kBraveBrowserBetaAppDirName[] =
+      "Brave Browser Beta Apps.localized";
+  static const char kBraveBrowserDevAppDirName[] =
+      "Brave Browser Dev Apps.localized";
+  static const char kBraveBrowserNightlyAppDirName[] =
+      "Brave Browser Nightly Apps.localized";
+
+  switch (chrome::GetChannel()) {
+    case version_info::Channel::STABLE:
+      return base::FilePath(kBraveBrowserAppDirName);
+    case version_info::Channel::BETA:
+      return base::FilePath(kBraveBrowserBetaAppDirName);
+    case version_info::Channel::DEV:
+      return base::FilePath(kBraveBrowserDevAppDirName);
+    case version_info::Channel::CANARY:
+      return base::FilePath(kBraveBrowserNightlyAppDirName);
+    case version_info::Channel::UNKNOWN:
+      return base::FilePath(kBraveBrowserDevelopmentAppDirName);
+    default:
+      NOTREACHED();
+      return base::FilePath(kBraveBrowserDevelopmentAppDirName);
+  }
+}
+}  // namespace

--- a/patches/chrome-browser-web_applications-components-web_app_shortcut_mac.mm.patch
+++ b/patches/chrome-browser-web_applications-components-web_app_shortcut_mac.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/web_applications/components/web_app_shortcut_mac.mm b/chrome/browser/web_applications/components/web_app_shortcut_mac.mm
+index 79f0cdfae88cf89136eefde95fc983b931317189..e18886ddd72040b70da344d97531eefa7e1062cf 100644
+--- a/chrome/browser/web_applications/components/web_app_shortcut_mac.mm
++++ b/chrome/browser/web_applications/components/web_app_shortcut_mac.mm
+@@ -905,6 +905,7 @@ base::FilePath WebAppShortcutCreator::GetApplicationsDirname() const {
+   if (path.empty())
+     return path;
+ 
++  return path.Append(GetLocalizableBraveAppShortcutsSubdirName());
+   return path.Append(GetLocalizableAppShortcutsSubdirName());
+ }
+ 


### PR DESCRIPTION
Uplift of #2617

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.