### PR TITLE
Fix switching Ads off and then back on stops Ad notifications from showing unless you quit the browser

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -105,7 +105,7 @@ void AdsImpl::InitializeStep3() {
 }
 
 void AdsImpl::Deinitialize() {
-  if (!IsInitialized()) {
+  if (!is_initialized_) {
     BLOG(WARNING) << "Failed to deinitialize as not initialized";
 
     return;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -67,12 +67,9 @@ void ConfirmationsImpl::Initialize() {
   LoadState();
 }
 
-void ConfirmationsImpl::CheckReady() {
-  if (is_initialized_) {
-    return;
-  }
-
-  if (!state_has_loaded_ ||
+void ConfirmationsImpl::MaybeStart() {
+  if (is_initialized_ ||
+      !state_has_loaded_ ||
       !wallet_info_.IsValid() ||
       catalog_issuers_.empty()) {
     return;
@@ -690,7 +687,7 @@ void ConfirmationsImpl::OnStateLoaded(
 
   NotifyAdsIfConfirmationsIsReady();
 
-  CheckReady();
+  MaybeStart();
 }
 
 void ConfirmationsImpl::ResetState() {
@@ -721,7 +718,9 @@ void ConfirmationsImpl::SetWalletInfo(std::unique_ptr<WalletInfo> info) {
   BLOG(INFO) << "  Payment id: " << wallet_info_.payment_id;
   BLOG(INFO) << "  Public key: " << wallet_info_.public_key;
 
-  CheckReady();
+  NotifyAdsIfConfirmationsIsReady();
+
+  MaybeStart();
 }
 
 void ConfirmationsImpl::SetCatalogIssuers(std::unique_ptr<IssuersInfo> info) {
@@ -741,7 +740,9 @@ void ConfirmationsImpl::SetCatalogIssuers(std::unique_ptr<IssuersInfo> info) {
     catalog_issuers_.insert({issuer.public_key, issuer.name});
   }
 
-  CheckReady();
+  NotifyAdsIfConfirmationsIsReady();
+
+  MaybeStart();
 }
 
 std::map<std::string, std::string> ConfirmationsImpl::GetCatalogIssuers()

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -84,7 +84,7 @@ class ConfirmationsImpl : public Confirmations {
 
  private:
   bool is_initialized_;
-  void CheckReady();
+  void MaybeStart();
 
   // Wallet
   WalletInfo wallet_info_;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/4748

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Turn Ads off, then back on and confirm Ad notifications are still shown and that "Confirmations not ready" does not appear in the logs

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
