### PR TITLE
Sign libchallenge_bypass_ristretto.dylib on Mac (Uplift to 0.66.x). 

### DIFF
--- a/patches/chrome-installer-mac-signing-signing.py.patch
+++ b/patches/chrome-installer-mac-signing-signing.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mac/signing/signing.py b/chrome/installer/mac/signing/signing.py
-index b56853e5e2649328a81a2de20228de5abda08f11..85cd57d8d8a70133f54f1e1970c418c15cb6629b 100644
+index b56853e5e2649328a81a2de20228de5abda08f11..b0e4a28355f410efb2105273f423d4f38d1425c5 100644
 --- a/chrome/installer/mac/signing/signing.py
 +++ b/chrome/installer/mac/signing/signing.py
 @@ -42,7 +42,6 @@ def get_parts(config):
@@ -10,7 +10,7 @@ index b56853e5e2649328a81a2de20228de5abda08f11..85cd57d8d8a70133f54f1e1970c418c1
                  entitlements='app-entitlements.plist',
                  verify_options=VerifyOptions.DEEP + VerifyOptions.NO_STRICT),
          'framework':
-@@ -84,6 +83,12 @@ def get_parts(config):
+@@ -84,9 +83,16 @@ def get_parts(config):
                  options=CodeSignOptions.RESTRICT +
                  CodeSignOptions.LIBRARY_VALIDATION,
                  verify_options=VerifyOptions.IGNORE_RESOURCES),
@@ -23,3 +23,7 @@ index b56853e5e2649328a81a2de20228de5abda08f11..85cd57d8d8a70133f54f1e1970c418c1
      }
  
      dylibs = (
++        'libchallenge_bypass_ristretto.dylib',
+         'libEGL.dylib',
+         'libGLESv2.dylib',
+         'libswiftshader_libEGL.dylib',


### PR DESCRIPTION
Fixes brave/brave-browser#4694
Uplift request from #2626

Should wait on validation of #2626 before uplifting.