### PR TITLE
Use different key name for brave channel name in MacOS

### DIFF
--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -85,7 +85,7 @@ def Main(argv):
     output_path = options.plist_output
 
   if options.brave_channel:
-    plist['KSChannelID'] = options.brave_channel
+    plist['BraveChannelID'] = options.brave_channel
 
   plist['CrProductDirName'] = options.brave_product_dir_name
 

--- a/chromium_src/chrome/common/channel_info_mac.mm
+++ b/chromium_src/chrome/common/channel_info_mac.mm
@@ -18,7 +18,7 @@ std::string GetChannelName() {
   // Keystone keys don't live in the framework.
   NSBundle* bundle = base::mac::OuterBundle();
 
-  NSString* channel = [bundle objectForInfoDictionaryKey:@"KSChannelID"];
+  NSString* channel = [bundle objectForInfoDictionaryKey:@"BraveChannelID"];
 
   // Only ever return "", "unknown", "beta", "dev", or "nightly" in an official
   // build.


### PR DESCRIPTION
After recent chromium bumping, KSChannelID is disappeared.
This is strange because we add that key by `brave_app_plist`.
I suspect chromium code could remove that key from Info.plist because
we use same key name with chrome's `KeystoneRegistration.framework` and `chrome_app_plist`
target has code that removes that key from Info.plist.
In theory, I think `chrome_app_plist` could not remove it because `chrome_app_list`
is evaluated first and then `brave_app_plist` is evaluated.

This PR is workaround by using another key name and I think using different key name is more safer.

Fix https://github.com/brave/brave-browser/issues/4753

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
