### PR TITLE
Use different key name for brave channel name in MacOS (uplift to 0.66.x)

### DIFF
--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -85,7 +85,7 @@ def Main(argv):
     output_path = options.plist_output
 
   if options.brave_channel:
-    plist['KSChannelID'] = options.brave_channel
+    plist['BraveChannelID'] = options.brave_channel
 
   plist['CrProductDirName'] = options.brave_product_dir_name
 

--- a/chromium_src/chrome/common/channel_info_mac.mm
+++ b/chromium_src/chrome/common/channel_info_mac.mm
@@ -18,7 +18,7 @@ std::string GetChannelName() {
   // Keystone keys don't live in the framework.
   NSBundle* bundle = base::mac::OuterBundle();
 
-  NSString* channel = [bundle objectForInfoDictionaryKey:@"KSChannelID"];
+  NSString* channel = [bundle objectForInfoDictionaryKey:@"BraveChannelID"];
 
   // Only ever return "", "unknown", "beta", "dev", or "nightly" in an official
   // build.


### PR DESCRIPTION
Uplift of #2634

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.