### PR TITLE
Refactor wallet public_key to private_key and remove logging of private key

### DIFF
--- a/vendor/bat-native-confirmations/include/bat/confirmations/wallet_info.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/wallet_info.h
@@ -20,7 +20,7 @@ struct CONFIRMATIONS_EXPORT WalletInfo {
   bool IsValid();
 
   std::string payment_id;
-  std::string public_key;
+  std::string private_key;
 };
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_get_signed_tokens_request_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_get_signed_tokens_request_unittest.cc
@@ -58,7 +58,7 @@ TEST_F(ConfirmationsGetSignedTokensRequestTest, BuildUrl) {
   // Arrange
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   std::string nonce = "716c3381-66e6-46e4-962f-15d01455b5b9";
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -708,7 +708,7 @@ void ConfirmationsImpl::OnStateReset(const Result result) {
 }
 
 void ConfirmationsImpl::SetWalletInfo(std::unique_ptr<WalletInfo> info) {
-  if (info->payment_id.empty() || info->public_key.empty()) {
+  if (info->payment_id.empty() || info->private_key.empty()) {
     return;
   }
 
@@ -716,7 +716,7 @@ void ConfirmationsImpl::SetWalletInfo(std::unique_ptr<WalletInfo> info) {
 
   BLOG(INFO) << "SetWalletInfo:";
   BLOG(INFO) << "  Payment id: " << wallet_info_.payment_id;
-  BLOG(INFO) << "  Public key: " << wallet_info_.public_key;
+  BLOG(INFO) << "  Private key: ********";
 
   NotifyAdsIfConfirmationsIsReady();
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_redeem_payment_tokens_request_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_redeem_payment_tokens_request_unittest.cc
@@ -147,7 +147,7 @@ TEST_F(ConfirmationsRedeemPaymentTokensRequestTest, BuildUrl) {
   // Arrange
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   // Act
   auto url = request_->BuildUrl(wallet_info);
@@ -171,7 +171,7 @@ TEST_F(ConfirmationsRedeemPaymentTokensRequestTest, BuildBody) {
   // Arrange
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   auto unblinded_tokens = GetUnblindedTokens(7);
   unblinded_tokens_->SetTokens(unblinded_tokens);
@@ -192,7 +192,7 @@ TEST_F(ConfirmationsRedeemPaymentTokensRequestTest, CreatePayload) {
   // Arrange
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   // Act
   auto payload = request_->CreatePayload(wallet_info);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_request_signed_tokens_request_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_request_signed_tokens_request_unittest.cc
@@ -100,7 +100,7 @@ TEST_F(ConfirmationsRequestSignedTokensRequestTest, BuildUrl) {
   // Arrange
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   // Act
   auto url = request_->BuildUrl(wallet_info);
@@ -139,7 +139,7 @@ TEST_F(ConfirmationsRequestSignedTokensRequestTest, HeadersCount) {
 
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   // Act
   auto headers = request_->BuildHeaders(body, wallet_info);
@@ -168,7 +168,7 @@ TEST_F(ConfirmationsRequestSignedTokensRequestTest, BuildSignatureHeaderValue) {
 
   WalletInfo wallet_info;
   wallet_info.payment_id = "d4ed0af0-bfa9-464b-abd7-67b29d891b8b";
-  wallet_info.public_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
+  wallet_info.private_key = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
   // Act
   auto header_value = request_->BuildSignatureHeaderValue(body, wallet_info);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_security_helper_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_security_helper_unittest.cc
@@ -59,7 +59,7 @@ TEST_F(ConfirmationsSecurityHelperTest, Sign) {
 
   std::string key_id = "primary";
 
-  std::vector<uint8_t> public_key = {
+  std::vector<uint8_t> private_key = {
       0xe9, 0xb1, 0xab, 0x4f, 0x44, 0xd3, 0x9e, 0xb0, 0x43, 0x23, 0x41, 0x1e,
       0xed, 0x0b, 0x5a, 0x2c, 0xee, 0xdf, 0xf0, 0x12, 0x64, 0x47, 0x4f, 0x86,
       0xe2, 0x9c, 0x70, 0x7a, 0x56, 0x61, 0x56, 0x50, 0x33, 0xce, 0xa0, 0x08,
@@ -69,7 +69,7 @@ TEST_F(ConfirmationsSecurityHelperTest, Sign) {
   };
 
   // Act
-  auto signature = helper::Security::Sign(headers, key_id, public_key);
+  auto signature = helper::Security::Sign(headers, key_id, private_key);
 
   // Assert
   std::string expected_signature = R"(keyId="primary",algorithm="ed25519",headers="digest",signature="m5CxS9uqI7DbZ5UDo51bcLRP2awqcUSU8tfc4t/ysrH47B8OJUG1roQyi6/pjSZj9VJuj296v77c/lxBlCn2DA==")";  // NOLINT
@@ -84,7 +84,7 @@ TEST_F(ConfirmationsSecurityHelperTest, Sign_InvalidPublicKey) {
 
   std::string key_id = "primary";
 
-  std::vector<uint8_t> public_key = {
+  std::vector<uint8_t> private_key = {
       0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
       0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
       0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
@@ -94,7 +94,7 @@ TEST_F(ConfirmationsSecurityHelperTest, Sign_InvalidPublicKey) {
   };
 
   // Act
-  auto signature = helper::Security::Sign(headers, key_id, public_key);
+  auto signature = helper::Security::Sign(headers, key_id, private_key);
 
   // Assert
   std::string expected_signature = "m5CxS9uqI7DbZ5UDo51bcLRP2awqcUSU8tfc4t/ysrH47B8OJUG1roQyi6/pjSZj9VJuj296v77c/lxBlCn2DA==";  // NOLINT

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_string_helper_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_string_helper_unittest.cc
@@ -54,7 +54,7 @@ TEST_F(ConfirmationsStringHelperTest, DecodeHex) {
   // Arrange
   std::string hexadecimal = "e9b1ab4f44d39eb04323411eed0b5a2ceedff01264474f86e29c707a5661565033cea0085cfd551faa170c1dd7f6daaa903cdd3138d61ed5ab2845e224d58144";  // NOLINT
 
-  std::vector<uint8_t> public_key = {
+  std::vector<uint8_t> private_key = {
       0xe9, 0xb1, 0xab, 0x4f, 0x44, 0xd3, 0x9e, 0xb0, 0x43, 0x23, 0x41, 0x1e,
       0xed, 0x0b, 0x5a, 0x2c, 0xee, 0xdf, 0xf0, 0x12, 0x64, 0x47, 0x4f, 0x86,
       0xe2, 0x9c, 0x70, 0x7a, 0x56, 0x61, 0x56, 0x50, 0x33, 0xce, 0xa0, 0x08,
@@ -69,7 +69,7 @@ TEST_F(ConfirmationsStringHelperTest, DecodeHex) {
   // Assert
   unsigned int index = 0;
   for (const auto& byte : bytes) {
-    auto valid_byte = public_key.at(index);
+    auto valid_byte = private_key.at(index);
     if (byte != valid_byte) {
       FAIL();
     }

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.cc
@@ -35,7 +35,7 @@ PayoutTokens::~PayoutTokens() {
 
 void PayoutTokens::Payout(const WalletInfo& wallet_info) {
   DCHECK(!wallet_info.payment_id.empty());
-  DCHECK(!wallet_info.public_key.empty());
+  DCHECK(!wallet_info.private_key.empty());
 
   BLOG(INFO) << "Payout";
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/refill_tokens.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/refill_tokens.cc
@@ -46,7 +46,7 @@ void RefillTokens::Refill(
     const WalletInfo& wallet_info,
     const std::string& public_key) {
   DCHECK(!wallet_info.payment_id.empty());
-  DCHECK(!wallet_info.public_key.empty());
+  DCHECK(!wallet_info.private_key.empty());
   DCHECK(!public_key.empty());
 
   BLOG(INFO) << "Refill";

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/request_signed_tokens_request.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/request_signed_tokens_request.cc
@@ -88,14 +88,14 @@ std::string RequestSignedTokensRequest::BuildSignatureHeaderValue(
     const std::string& body,
     const WalletInfo& wallet_info) const {
   DCHECK(!body.empty());
-  DCHECK(!wallet_info.public_key.empty());
+  DCHECK(!wallet_info.private_key.empty());
 
   auto digest_header_value = BuildDigestHeaderValue(body);
 
-  auto public_key = helper::String::decode_hex(wallet_info.public_key);
+  auto private_key = helper::String::decode_hex(wallet_info.private_key);
 
   return helper::Security::Sign({{"digest", digest_header_value}}, "primary",
-      public_key);
+      private_key);
 }
 
 std::string RequestSignedTokensRequest::GetAcceptHeaderValue() const {

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.cc
@@ -21,10 +21,10 @@ namespace helper {
 std::string Security::Sign(
     const std::map<std::string, std::string>& headers,
     const std::string& key_id,
-    const std::vector<uint8_t>& public_key) {
+    const std::vector<uint8_t>& private_key) {
   DCHECK_NE(headers.size(), 0UL);
   DCHECK(!key_id.empty());
-  DCHECK_NE(public_key.size(), 0UL);
+  DCHECK_NE(private_key.size(), 0UL);
 
   std::string concatenated_header = "";
   std::string concatenated_message = "";
@@ -49,7 +49,7 @@ std::string Security::Sign(
   unsigned long long signed_message_size = 0;  // NOLINT
   crypto_sign(&signed_message.front(), &signed_message_size,
       reinterpret_cast<const unsigned char*>(concatenated_message.c_str()),
-      concatenated_message.length(), &public_key.front());
+      concatenated_message.length(), &private_key.front());
 
   std::vector<uint8_t> signature(crypto_sign_BYTES);
   std::copy(signed_message.begin(), signed_message.begin() +

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/security_helper.h
@@ -22,7 +22,7 @@ class Security {
   static std::string Sign(
       const std::map<std::string, std::string>& headers,
       const std::string& key_id,
-      const std::vector<uint8_t>& public_key);
+      const std::vector<uint8_t>& private_key);
 
   static std::vector<Token> GenerateTokens(const int count);
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/wallet_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/wallet_info.cc
@@ -9,16 +9,16 @@ namespace confirmations {
 
 WalletInfo::WalletInfo() :
     payment_id(""),
-    public_key("") {}
+    private_key("") {}
 
 WalletInfo::WalletInfo(const WalletInfo& info) :
     payment_id(info.payment_id),
-    public_key(info.public_key) {}
+    private_key(info.private_key) {}
 
 WalletInfo::~WalletInfo() = default;
 
 bool WalletInfo::IsValid() {
-  return !payment_id.empty() && !public_key.empty();
+  return !payment_id.empty() && !private_key.empty();
 }
 
 }  // namespace confirmations

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1260,7 +1260,7 @@ const confirmations::WalletInfo LedgerImpl::GetConfirmationsWalletInfo(
   std::vector<uint8_t> secretKey = {};
   braveledger_bat_helper::getPublicKeyFromSeed(seed, &publicKey, &secretKey);
 
-  wallet_info.public_key = braveledger_bat_helper::uint8ToHex(secretKey);
+  wallet_info.private_key = braveledger_bat_helper::uint8ToHex(secretKey);
 
   return wallet_info;
 }


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/4796

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm an Ad and that confirmations are redeemed
- Confirm private key is not logged to the console (Search for `SetWalletInfo:`)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [x] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
