### PR TITLE
only enable sparkle by default for official builds on mac

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -519,15 +519,14 @@ if (is_mac) {
     extra_configs = [ "//build/config/compiler:wexit_time_destructors" ]
 
     deps = [
-      "//brave/vendor/sparkle:sparkle_resources_bundle_data",
       "//chrome:chrome_app_strings_bundle_data",
       "//chrome:chrome_resources",
       "//chrome:chrome_versioned_bundle_data",
       "//chrome/common:version_header",
     ]
 
-    if (is_chrome_branded) {
-      deps += [ "chrome:chrome_helpers" ]
+    if (enable_sparkle) {
+      deps += [ "//brave/vendor/sparkle:sparkle_resources_bundle_data" ]
     }
 
     if (enable_stripping) {

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -2,6 +2,7 @@ import("//brave/build/config.gni")
 import("//brave/browser/tor/buildflags/buildflags.gni")
 import("//brave/components/brave_ads/browser/buildflags/buildflags.gni")
 import("//brave/components/brave_webtorrent/browser/buildflags/buildflags.gni")
+import("//build/buildflag_header.gni")
 import("//build/config/features.gni")
 import("//extensions/buildflags/buildflags.gni")
 import("//third_party/widevine/cdm/widevine.gni")
@@ -80,8 +81,6 @@ source_set("browser_process") {
   ]
 
   if (enable_sparkle) {
-    defines = [ "ENABLE_SPARKLE" ]
-
     sources += [
       "mac/sparkle_glue.mm",
       "mac/sparkle_glue.h",
@@ -90,6 +89,7 @@ source_set("browser_process") {
   }
 
   deps = [
+    ":sparkle_buildflags",
     ":version_info",
     "autoplay",
     "download",
@@ -189,6 +189,13 @@ source_set("browser_process") {
       "//google_update",
     ]
   }
+}
+
+buildflag_header("sparkle_buildflags") {
+  header = "sparkle_buildflags.h"
+  flags = [
+    "ENABLE_SPARKLE=$enable_sparkle",
+  ]
 }
 
 source_set("version_info") {

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -61,9 +61,6 @@ source_set("browser_process") {
     "content_settings/brave_cookie_settings_factory.h",
     "geolocation/brave_geolocation_permission_context.cc",
     "geolocation/brave_geolocation_permission_context.h",
-    "mac/sparkle_glue.mm",
-    "mac/sparkle_glue.h",
-    "mac/su_updater.h",
     "metrics/metrics_reporting_util.cc",
     "metrics/metrics_reporting_util.h",
     "search_engines/guest_window_search_engine_provider_service.cc",
@@ -81,6 +78,16 @@ source_set("browser_process") {
     "update_util.cc",
     "update_util.h",
   ]
+
+  if (enable_sparkle) {
+    defines = [ "ENABLE_SPARKLE" ]
+
+    sources += [
+      "mac/sparkle_glue.mm",
+      "mac/sparkle_glue.h",
+      "mac/su_updater.h",
+    ]
+  }
 
   deps = [
     ":version_info",
@@ -208,7 +215,7 @@ source_set("browser") {
   deps = [
     "//chrome/browser",
   ]
-  if (is_mac) {
+  if (enable_sparkle) {
     deps += [
       "//brave/vendor/sparkle:sparkle_framework_bundle_data"
     ]

--- a/browser/brave_browser_main_parts_mac.mm
+++ b/browser/brave_browser_main_parts_mac.mm
@@ -9,6 +9,8 @@
 void BraveBrowserMainPartsMac::PreMainMessageLoopStart() {
   ChromeBrowserMainPartsMac::PreMainMessageLoopStart();
 
+#if defined(ENABLE_SPARKLE)
   // It would be no-op if udpate is disabled.
   [[SparkleGlue sharedSparkleGlue] registerWithSparkle];
+#endif
 }

--- a/browser/brave_browser_main_parts_mac.mm
+++ b/browser/brave_browser_main_parts_mac.mm
@@ -4,14 +4,16 @@
 
 #include "brave/browser/brave_browser_main_parts_mac.h"
 
-#if defined(ENABLE_SPARKLE)
+#include "brave/browser/sparkle_buildflags.h"
+
+#if BUILDFLAG(ENABLE_SPARKLE)
 #import "brave/browser/mac/sparkle_glue.h"
 #endif
 
 void BraveBrowserMainPartsMac::PreMainMessageLoopStart() {
   ChromeBrowserMainPartsMac::PreMainMessageLoopStart();
 
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
   // It would be no-op if udpate is disabled.
   [[SparkleGlue sharedSparkleGlue] registerWithSparkle];
 #endif

--- a/browser/brave_browser_main_parts_mac.mm
+++ b/browser/brave_browser_main_parts_mac.mm
@@ -4,7 +4,9 @@
 
 #include "brave/browser/brave_browser_main_parts_mac.h"
 
+#if defined(ENABLE_SPARKLE)
 #import "brave/browser/mac/sparkle_glue.h"
+#endif
 
 void BraveBrowserMainPartsMac::PreMainMessageLoopStart() {
   ChromeBrowserMainPartsMac::PreMainMessageLoopStart();

--- a/browser/mac/sparkle_glue.h
+++ b/browser/mac/sparkle_glue.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -25,7 +26,8 @@
 - (void)relaunch;
 
 - (AutoupdateStatus)recentStatus;
-- (NSNotification*)recentNotification;
+
+- (NSNotification*)recentNotification;  // NOLINT - not sure how to fix this
 
 // Returns YES if an asynchronous operation is pending: if an update check or
 // installation attempt is currently in progress.

--- a/browser/mac/sparkle_glue.h
+++ b/browser/mac/sparkle_glue.h
@@ -6,42 +6,11 @@
 #define BRAVE_BROWSER_MAC_SPARKLE_GLUE_H_
 
 #include "base/strings/string16.h"
+#import "chrome/browser/mac/keystone_glue.h"
 
 #if defined(__OBJC__)
 
 #import <Foundation/Foundation.h>
-
-// Possible outcomes of various operations.  A version may accompany some of
-// these, but beware: a version is never required.  For statuses that can be
-// accompanied by a version, the comment indicates what version is referenced.
-// A notification posted containing an asynchronous status will always be
-// followed by a notification with a terminal status.
-enum AutoupdateStatus {
-  kAutoupdateNone = 0,        // no version (initial state only)
-  kAutoupdateRegistering,     // no version (asynchronous operation in progress)
-  kAutoupdateRegistered,      // no version
-  kAutoupdateChecking,        // no version (asynchronous operation in progress)
-  kAutoupdateCurrent,         // version of the running application
-  kAutoupdateAvailable,       // version of the update that is available
-  kAutoupdateInstalling,      // no version (asynchronous operation in progress)
-  kAutoupdateInstalled,       // version of the update that was installed
-  kAutoupdateRegisterFailed,  // no version
-  kAutoupdateCheckFailed,     // no version
-  kAutoupdateInstallFailed,   // no version
-};
-
-// kBraveAutoupdateStatusNotification is the name of the notification posted
-// when -checkForUpdate and -installUpdate complete.  This notification will be
-// sent with with its sender object set to the SparkleGlue instance sending
-// the notification.  Its userInfo dictionary will contain an AutoupdateStatus
-// value as an intValue at key kBraveAutoupdateStatusStatus.  If a version is
-// available (see AutoupdateStatus), it will be present at key
-// kBraveAutoupdateStatusVersion.  If any error messages were supplied by
-// Sparkle, they will be present at key kBraveAutoupdateStatusErrorMessages.
-extern NSString* const kBraveAutoupdateStatusNotification;
-extern NSString* const kBraveAutoupdateStatusStatus;
-extern NSString* const kBraveAutoupdateStatusVersion;
-extern NSString* const kBraveAutoupdateStatusErrorMessages;
 
 @interface SparkleGlue : NSObject
 

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -81,11 +81,6 @@ class PerformBridge : public base::RefCountedThreadSafe<PerformBridge> {
 
 }  // namespace
 
-NSString* const kBraveAutoupdateStatusNotification = @"AutoupdateStatusNotification";
-NSString* const kBraveAutoupdateStatusStatus = @"status";
-NSString* const kBraveAutoupdateStatusVersion = @"version";
-NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
-
 @implementation SparkleGlue
 {
   SUUpdater* su_updater_;
@@ -98,7 +93,7 @@ NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
   NSString* new_version_;
 
   std::string channel_;
-  // The most recent kBraveAutoupdateStatusNotification notification posted.
+  // The most recent kAutoupdateStatusNotification notification posted.
   base::scoped_nsobject<NSNotification> recentNotification_;
 }
 
@@ -241,16 +236,16 @@ NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
   NSNumber* statusNumber = [NSNumber numberWithInt:status];
   NSMutableDictionary* dictionary =
       [NSMutableDictionary dictionaryWithObject:statusNumber
-                                         forKey:kBraveAutoupdateStatusStatus];
+                                         forKey:kAutoupdateStatusStatus];
   if ([version length]) {
-    [dictionary setObject:version forKey:kBraveAutoupdateStatusVersion];
+    [dictionary setObject:version forKey:kAutoupdateStatusVersion];
   }
   if ([error length]) {
-    [dictionary setObject:error forKey:kBraveAutoupdateStatusErrorMessages];
+    [dictionary setObject:error forKey:kAutoupdateStatusErrorMessages];
   }
 
   NSNotification* notification =
-      [NSNotification notificationWithName:kBraveAutoupdateStatusNotification
+      [NSNotification notificationWithName:kAutoupdateStatusNotification
                                     object:self
                                   userInfo:dictionary];
   recentNotification_.reset([notification retain]);
@@ -301,7 +296,7 @@ NSString* const kBraveAutoupdateStatusErrorMessages = @"errormessages";
 - (AutoupdateStatus)recentStatus {
   NSDictionary* dictionary = [recentNotification_ userInfo];
   NSNumber* status = base::mac::ObjCCastStrict<NSNumber>(
-      [dictionary objectForKey:kBraveAutoupdateStatusStatus]);
+      [dictionary objectForKey:kAutoupdateStatusStatus]);
   return static_cast<AutoupdateStatus>([status intValue]);
 }
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -50,11 +50,16 @@ source_set("ui") {
       "webui/navigation_bar_data_provider.h",
       "webui/settings/brave_privacy_handler.cc",
       "webui/settings/brave_privacy_handler.h",
-      "webui/settings/brave_relaunch_handler_mac.mm",
-      "webui/settings/brave_relaunch_handler_mac.h",
       "webui/settings/default_brave_shields_handler.cc",
       "webui/settings/default_brave_shields_handler.h",
     ]
+
+    if (enable_sparkle) {
+      sources += [
+        "webui/settings/brave_relaunch_handler_mac.mm",
+        "webui/settings/brave_relaunch_handler_mac.h",
+      ]
+    }
   }
 
   if (toolkit_views) {
@@ -71,9 +76,14 @@ source_set("ui") {
       "views/rounded_separator.h",
       "views/toolbar/bookmark_button.cc",
       "views/toolbar/bookmark_button.h",
-      "views/update_recommended_message_box_mac.mm",
-      "views/update_recommended_message_box_mac.h",
     ]
+
+    if (enable_sparkle) {
+      sources += [
+        "views/update_recommended_message_box_mac.mm",
+        "views/update_recommended_message_box_mac.h",
+      ]
+    }
   }
 
   if (is_win || is_mac || is_desktop_linux) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -128,6 +128,7 @@ source_set("ui") {
     "//brave/components/brave_sync:static_resources",
     "//brave/components/brave_sync:generated_resources",
     "//brave/components/brave_welcome_ui:generated_resources",
+    "//brave/browser:sparkle_buildflags",
     "//brave/browser/devtools",
     "//brave/browser/tor",
     "//brave/browser/resources/settings:resources",

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -13,7 +14,8 @@
 #endif
 
 void BraveBrowserView::SetStarredState(bool is_starred) {
-  BookmarkButton* button = ((BraveToolbarView *)toolbar())->bookmark_button();
+  BookmarkButton* button =
+      static_cast<BraveToolbarView*>(toolbar())->bookmark_button();
   if (button)
     button->SetToggled(is_starred);
 }

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -7,7 +7,7 @@
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 
-#if defined(OS_MACOSX)
+#if defined(ENABLE_SPARKLE)
 #include "brave/browser/ui/views/update_recommended_message_box_mac.h"
 #endif
 
@@ -18,7 +18,7 @@ void BraveBrowserView::SetStarredState(bool is_starred) {
 }
 
 void BraveBrowserView::ShowUpdateChromeDialog() {
-#if defined(OS_MACOSX)
+#if defined(ENABLE_SPARKLE)
   // On mac, sparkle frameworks's relaunch api is used.
   UpdateRecommendedMessageBoxMac::Show(GetNativeWindow());
 #else

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -4,10 +4,11 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 
+#include "brave/browser/sparkle_buildflags.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
 #include "brave/browser/ui/views/update_recommended_message_box_mac.h"
 #endif
 
@@ -18,7 +19,7 @@ void BraveBrowserView::SetStarredState(bool is_starred) {
 }
 
 void BraveBrowserView::ShowUpdateChromeDialog() {
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
   // On mac, sparkle frameworks's relaunch api is used.
   UpdateRecommendedMessageBoxMac::Show(GetNativeWindow());
 #else

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -6,10 +6,12 @@
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 
 #include <string>
+
 #include "base/command_line.h"
 #include "brave/browser/extensions/brave_component_loader.h"
 #include "brave/browser/resources/settings/grit/brave_settings_resources.h"
 #include "brave/browser/resources/settings/grit/brave_settings_resources_map.h"
+#include "brave/browser/sparkle_buildflags.h"
 #include "brave/browser/ui/webui/settings/brave_default_extensions_handler.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/browser/ui/webui/settings/default_brave_shields_handler.h"
@@ -20,7 +22,7 @@
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
 #include "content/public/browser/web_ui_data_source.h"
 
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
 #include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
 #endif
 
@@ -32,7 +34,7 @@ BraveSettingsUI::BraveSettingsUI(content::WebUI* web_ui,
   web_ui->AddMessageHandler(std::make_unique<BravePrivacyHandler>());
   web_ui->AddMessageHandler(std::make_unique<DefaultBraveShieldsHandler>());
   web_ui->AddMessageHandler(std::make_unique<BraveDefaultExtensionsHandler>());
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
   // Use sparkle's relaunch api for browser relaunch on update.
   web_ui->AddMessageHandler(std::make_unique<BraveRelaunchHandler>());
 #endif

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -20,7 +20,7 @@
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
 #include "content/public/browser/web_ui_data_source.h"
 
-#if defined(OS_MACOSX)
+#if defined(ENABLE_SPARKLE)
 #include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
 #endif
 
@@ -32,7 +32,7 @@ BraveSettingsUI::BraveSettingsUI(content::WebUI* web_ui,
   web_ui->AddMessageHandler(std::make_unique<BravePrivacyHandler>());
   web_ui->AddMessageHandler(std::make_unique<DefaultBraveShieldsHandler>());
   web_ui->AddMessageHandler(std::make_unique<BraveDefaultExtensionsHandler>());
-#if defined(OS_MACOSX)
+#if defined(ENABLE_SPARKLE)
   // Use sparkle's relaunch api for browser relaunch on update.
   web_ui->AddMessageHandler(std::make_unique<BraveRelaunchHandler>());
 #endif

--- a/build/config.gni
+++ b/build/config.gni
@@ -10,6 +10,7 @@ declare_args() {
   brave_channel = ""
   is_release_channel = true
   base_sparkle_update_url = ""
+  enable_sparkle = is_official_build && is_mac
 
   brave_dsa_file = "dsa_pub.pem"
 

--- a/chromium_src/chrome/browser/mac/keystone_glue.mm
+++ b/chromium_src/chrome/browser/mac/keystone_glue.mm
@@ -1,0 +1,29 @@
+#if defined(ENABLE_SPARKLE)
+#include "brave/browser/mac/sparkle_glue.h"
+#endif
+
+#define KeystoneEnabled KeystoneEnabled_ChromiumImpl
+#define CurrentlyInstalledVersion CurrentlyInstalledVersion_ChromiumImpl
+#include "../../../../../chrome/browser/mac/keystone_glue.mm"  // NOLINT
+#undef KeystoneEnabled
+#undef CurrentlyInstalledVersion
+
+namespace keystone_glue {
+
+bool KeystoneEnabled() {
+#if defined(ENABLE_SPARKLE)
+  return sparkle_glue::SparkleEnabled();
+#else
+  return false;
+#endif
+}
+
+base::string16 CurrentlyInstalledVersion() {
+#if defined(ENABLE_SPARKLE)
+  return sparkle_glue::CurrentlyInstalledVersion();
+#else
+  return base::string16();
+#endif
+}
+
+}  // namespace keystone_glue

--- a/chromium_src/chrome/browser/mac/keystone_glue.mm
+++ b/chromium_src/chrome/browser/mac/keystone_glue.mm
@@ -1,4 +1,6 @@
-#if defined(ENABLE_SPARKLE)
+#include "brave/browser/sparkle_buildflags.h"
+
+#if BUILDFLAG(ENABLE_SPARKLE)
 #include "brave/browser/mac/sparkle_glue.h"
 #endif
 
@@ -11,7 +13,7 @@
 namespace keystone_glue {
 
 bool KeystoneEnabled() {
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
   return sparkle_glue::SparkleEnabled();
 #else
   return false;
@@ -19,7 +21,7 @@ bool KeystoneEnabled() {
 }
 
 base::string16 CurrentlyInstalledVersion() {
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
   return sparkle_glue::CurrentlyInstalledVersion();
 #else
   return base::string16();

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -7,6 +7,7 @@
 #include "base/mac/foundation_util.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/strings/utf_string_conversions.h"
+#include "brave/browser/sparkle_buildflags.h"
 #include "chrome/browser/mac/keystone_glue.h"
 #include "chrome/browser/obsolete_system/obsolete_system.h"
 #include "chrome/grit/chromium_strings.h"
@@ -73,7 +74,7 @@ void VersionUpdaterMac::CheckForUpdate(
     const PromoteCallback& promote_callback) {
   status_callback_ = status_callback;
 
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
   if (SparkleGlue* sparkle_glue = [SparkleGlue sharedSparkleGlue]) {
     AutoupdateStatus recent_status = [sparkle_glue recentStatus];
     if ([sparkle_glue asyncOperationPending] ||
@@ -135,7 +136,7 @@ void VersionUpdaterMac::UpdateStatus(NSDictionary* dictionary) {
     case kAutoupdateRegistered:
       // Go straight into an update check. Return immediately, this routine
       // will be re-entered shortly with kAutoupdateChecking.
-#if defined(ENABLE_SPARKLE)
+#if BUILDFLAG(ENABLE_SPARKLE)
       [[SparkleGlue sharedSparkleGlue] checkForUpdates];
 #endif
       return;

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -7,7 +7,7 @@
 #include "base/mac/foundation_util.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/strings/utf_string_conversions.h"
-#import "brave/browser/mac/sparkle_glue.h"
+#include "chrome/browser/mac/keystone_glue.h"
 #include "chrome/browser/obsolete_system/obsolete_system.h"
 #include "chrome/grit/chromium_strings.h"
 #include "chrome/grit/generated_resources.h"

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -15,6 +15,10 @@
 #include "net/base/escape.h"
 #include "ui/base/l10n/l10n_util.h"
 
+#if BUILDFLAG(ENABLE_SPARKLE)
+#import "brave/browser/mac/sparkle_glue.h"
+#endif
+
 // KeystoneObserver is a simple notification observer for Keystone status
 // updates. It will be created and managed by VersionUpdaterMac.
 @interface KeystoneObserver : NSObject {

--- a/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
+++ b/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
@@ -1,30 +1,8 @@
 diff --git a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
-index 4392e660c64821767c8b408a327259fbf1f767f5..8ebd18485542d26f2d36eaa5d0b5663839a925cf 100644
+index 4392e660c64821767c8b408a327259fbf1f767f5..e2b98cc07762418841dc6f21d5407c283979e2e6 100644
 --- a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
 +++ b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
-@@ -45,6 +45,9 @@
- #include "chrome/installer/util/install_util.h"
- #elif defined(OS_MACOSX)
- #include "chrome/browser/mac/keystone_glue.h"
-+#if defined(BRAVE_CHROMIUM_BUILD)
-+#include "brave/browser/mac/sparkle_glue.h"
-+#endif
- #endif
- 
- namespace {
-@@ -124,7 +127,11 @@ base::Version GetCurrentlyInstalledVersionImpl(base::Version* critical_update) {
-     *critical_update = InstallUtil::GetCriticalUpdateVersion();
- #elif defined(OS_MACOSX)
-   installed_version = base::Version(
-+#if defined(BRAVE_CHROMIUM_BUILD)
-+      base::UTF16ToASCII(sparkle_glue::CurrentlyInstalledVersion()));
-+#else
-       base::UTF16ToASCII(keystone_glue::CurrentlyInstalledVersion()));
-+#endif
- #elif defined(OS_POSIX)
-   // POSIX but not Mac OS X: Linux, etc.
-   base::CommandLine command_line(*base::CommandLine::ForCurrentProcess());
-@@ -220,7 +227,7 @@ UpgradeDetectorImpl::UpgradeDetectorImpl(const base::Clock* clock,
+@@ -220,7 +220,7 @@ UpgradeDetectorImpl::UpgradeDetectorImpl(const base::Clock* clock,
  #if defined(OS_WIN)
  // Only enable upgrade notifications for Google Chrome builds. Chromium does not
  // use an auto-updater.
@@ -33,20 +11,16 @@ index 4392e660c64821767c8b408a327259fbf1f767f5..8ebd18485542d26f2d36eaa5d0b56638
    // There might be a policy/enterprise environment preventing updates, so
    // validate updatability and then call StartTimerForUpgradeCheck
    // appropriately. Skip this step if a past attempt has been made to enable
-@@ -240,7 +247,11 @@ UpgradeDetectorImpl::UpgradeDetectorImpl(const base::Clock* clock,
+@@ -240,7 +240,7 @@ UpgradeDetectorImpl::UpgradeDetectorImpl(const base::Clock* clock,
  #else   // defined(OS_WIN)
  #if defined(OS_MACOSX)
    // Only enable upgrade notifications if the updater (Keystone) is present.
 -  if (!keystone_glue::KeystoneEnabled()) {
-+#if defined(BRAVE_CHROMIUM_BUILD)
-+  if (!sparkle_glue::SparkleEnabled()) {
-+#else
 +   if (!keystone_glue::KeystoneEnabled()) {
-+#endif
      is_auto_update_enabled_ = false;
      return;
    }
-@@ -556,7 +567,7 @@ void UpgradeDetectorImpl::OnRelaunchNotificationPeriodPrefChanged() {
+@@ -556,7 +556,7 @@ void UpgradeDetectorImpl::OnRelaunchNotificationPeriodPrefChanged() {
      NotifyOnUpgrade();
  }
  

--- a/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
+++ b/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
-index 4392e660c64821767c8b408a327259fbf1f767f5..e2b98cc07762418841dc6f21d5407c283979e2e6 100644
+index 4392e660c64821767c8b408a327259fbf1f767f5..83a848760a2c8355c636a504a669524b0920d67a 100644
 --- a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
 +++ b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
 @@ -220,7 +220,7 @@ UpgradeDetectorImpl::UpgradeDetectorImpl(const base::Clock* clock,
@@ -11,15 +11,6 @@ index 4392e660c64821767c8b408a327259fbf1f767f5..e2b98cc07762418841dc6f21d5407c28
    // There might be a policy/enterprise environment preventing updates, so
    // validate updatability and then call StartTimerForUpgradeCheck
    // appropriately. Skip this step if a past attempt has been made to enable
-@@ -240,7 +240,7 @@ UpgradeDetectorImpl::UpgradeDetectorImpl(const base::Clock* clock,
- #else   // defined(OS_WIN)
- #if defined(OS_MACOSX)
-   // Only enable upgrade notifications if the updater (Keystone) is present.
--  if (!keystone_glue::KeystoneEnabled()) {
-+   if (!keystone_glue::KeystoneEnabled()) {
-     is_auto_update_enabled_ = false;
-     return;
-   }
 @@ -556,7 +556,7 @@ void UpgradeDetectorImpl::OnRelaunchNotificationPeriodPrefChanged() {
      NotifyOnUpgrade();
  }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/4908

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
