### PR TITLE
Fixes Norwegian localization for shields and rewards.

### DIFF
--- a/components/brave_extension/extension/brave_extension/BUILD.gn
+++ b/components/brave_extension/extension/brave_extension/BUILD.gn
@@ -32,8 +32,9 @@ if (is_mac) {
   foreach(locale, locales) {
     bundle_data("brave_extension_framework_bundle_data_${locale}") {
       locale = string_replace(locale, "-", "_")
+      source_locale = string_replace(locale, "nb", "no")
       sources = [
-        "//brave/components/brave_extension/extension/brave_extension/_locales/$locale/messages.json"
+        "//brave/components/brave_extension/extension/brave_extension/_locales/$source_locale/messages.json"
       ]
       outputs = [
         "{{bundle_resources_dir}}/brave_extension/_locales/$locale/{{source_file_part}}"
@@ -50,8 +51,9 @@ if (is_mac) {
   foreach(locale, locales) {
     copy("locales_${locale}") {
       locale = string_replace(locale, "-", "_")
+      source_locale = string_replace(locale, "nb", "no")
       sources = [
-        "//brave/components/brave_extension/extension/brave_extension/_locales/${locale}/messages.json",
+        "//brave/components/brave_extension/extension/brave_extension/_locales/${source_locale}/messages.json",
       ]
       outputs = [
         "$root_out_dir/resources/brave_extension/_locales/${locale}/{{source_file_part}}",

--- a/components/brave_extension/extension/brave_extension/_locales/no/messages.json
+++ b/components/brave_extension/extension/brave_extension/_locales/no/messages.json
@@ -1,50 +1,50 @@
 {
   "appName": {
-    "message": "The Brave Extension",
+    "message": "Brave-utvidelsen",
     "description": "The name of the the extension."
   },
   "shields": {
-    "message": "Shields",
+    "message": "Skjold",
     "description": "The Shields feature name"
   },
   "up": {
-    "message": "up",
+    "message": "Oppe",
     "description": "Message for when shields is enabled"
   },
   "down": {
-    "message": "down",
+    "message": "nede",
     "description": "Message for when shields is disabled"
   },
   "forThisSite": {
-    "message": "for this site",
+    "message": "for denne siden",
     "description": "Partial string for the phrase `shields is up *for this site*`"
   },
   "enabledMessage": {
-    "message": "If a site appears broken, try shields down",
+    "message": "Hvis en side ikke virker, prøv å deaktivere skjold.",
     "description": "Message telling the user to disable shields if a site appears broken"
   },
   "disabledMessage": {
-    "message": "You’re browsing this site without any privacy and security protections.",
+    "message": "Du besøker denne siden uten personvern og sikkerhetsinnstillinger",
     "description": "Message telling the user that shields are disabled"
   },
   "itemsBlocked": {
-    "message": "Items blocked",
+    "message": "Elementer blokkert",
     "description": "Message for the main blocked resources text when there is more than one ad/track/script blocked (plural)"
   },
   "itemBlocked": {
-    "message": "Item blocked",
+    "message": "Element blokkert",
     "description": "Message for the main blocked resources text when there is one ad/track/script blocked (singular)"
   },
   "and": {
-    "message": "and",
+    "message": "og",
     "description": "Message for the `and` conjunction. Used to connect grammatically the `item blocked and connection upgrades` and its variant phrases"
   },
   "connectionsUpgraded": {
-    "message": "connections upgraded",
+    "message": "tilkoblinger oppgradert",
     "description": "Message for the main blocked resources text when there is at least one ad/track/script blocked and more than one connection upgrade (plural)"
   },
   "connectionUpgraded": {
-    "message": "connection upgraded",
+    "message": "tilkobling oppgradert",
     "description": "Message for the main blocked resources text when there is at least one ad/track/script blocked and one connection upgrade (singular)"
   },
   "thirdPartyTrackersBlocked": {
@@ -52,15 +52,15 @@
     "description": "Message for the scripts blocked row label"
   },
   "connectionsUpgradedHTTPS": {
-    "message": "Connections upgraded to HTTPS",
+    "message": "Tilkoblinger oppgradert til HTTPS",
     "description": "Message for the connections upgraded row label and for the main blocked resources text when there is more than one connection upgraded (plural) and no other ads/trackers blocked"
   },
   "connectionUpgradedHTTPS": {
-    "message": "Connection upgraded to HTTPS",
+    "message": "Tilkobling oppgradert til HTTPS",
     "description": "Message for the main blocked resources text when there is one connection upgraded (singular) and no other ads/trackers blocked"
   },
   "scriptsBlocked": {
-    "message": "Scripts blocked",
+    "message": "Skript blokkert",
     "description": "Message for the scripts blocked row label"
   },
   "thirdPartyCookiesBlocked": {
@@ -68,11 +68,11 @@
     "description": "Message for the option in the cookies select field to block all 3rd party cookies"
   },
   "allCookiesBlocked": {
-    "message": "Cookies blocked",
+    "message": "Informasjonskapler er blokkert",
     "description": "Message for the option in the cookies select field to block all cookies"
   },
   "allCookiesAllowed": {
-    "message": "All cookies allowed",
+    "message": "Alle informasjonskapsler er tillatt",
     "description": "Message for the option in the cookies select field to allow all cookies"
   },
   "thirdPartyFingerprintingBlocked": {
@@ -88,35 +88,35 @@
     "description": "Message for the option in the device recognition select field to allow all device recognition attempts"
   },
   "deviceRecognitionAttempts": {
-    "message": "Device recognition attempts",
+    "message": "Forsøk på enhetsgjenkjenning ",
     "description": "Message for the device recognition attempts blocked panel"
   },
   "scriptsOnThisSite": {
-    "message": "Scripts on this site",
+    "message": "Skript på denne siden",
     "description": "Message for the script resources blocked panel"
   },
   "blockedScripts": {
-    "message": "Blocked scripts",
+    "message": "Blokkerte skript",
     "description": "Message for the script resources blocked"
   },
   "allowedScripts": {
-    "message": "Allowed scripts",
+    "message": "Godkjente skript",
     "description": "Message for the script resources allowed"
   },
   "blockAll": {
-    "message": "Block all",
+    "message": "Blokker alle",
     "description": "Message for the resources blocked *block all* option"
   },
   "allowAll": {
-    "message": "Allow all",
+    "message": "Tillat alle",
     "description": "Message for the resources blocked *allow all* option"
   },
   "block": {
-    "message": "Block",
+    "message": "Blokker",
     "description": "Message for the resources blocked *block* option"
   },
   "allow": {
-    "message": "Allow",
+    "message": "Tillat",
     "description": "Message for the resources blocked *allow* option"
   },
   "blockedOnce": {
@@ -132,19 +132,19 @@
     "description": "Message for the shortcut in the main interface to allow all scripts once"
   },
   "cancel": {
-    "message": "Cancel",
+    "message": "Kanseller",
     "description": "Message for the button inside the static list of resources blocked to cancel the operation"
   },
   "goBack": {
-    "message": "Go back",
+    "message": "Gå tilbake",
     "description": "Message for the button inside the static list of resources blocked to go back from the current screen"
   },
   "applyOnce": {
-    "message": "Apply once",
+    "message": "Bruk én gang",
     "description": "Message for action in dynamic list of resources blocked to *apply once*"
   },
   "changeDefaults": {
-    "message": "Change global shield defaults",
+    "message": "Endre globale skjermstandarder",
     "description": "Message for the button action linking to the settings page"
   }
 }

--- a/components/brave_rewards/resources/extension/BUILD.gn
+++ b/components/brave_rewards/resources/extension/BUILD.gn
@@ -56,8 +56,9 @@ if (is_mac) {
   foreach(locale, locales) {
     bundle_data("framework_bundle_data_${locale}") {
       locale = string_replace(locale, "-", "_")
+      source_locale = string_replace(locale, "nb", "no")
       sources = [
-        "brave_rewards/_locales/$locale/messages.json"
+        "brave_rewards/_locales/$source_locale/messages.json"
       ]
       outputs = [
         "{{bundle_resources_dir}}/brave_rewards/_locales/$locale/{{source_file_part}}"
@@ -74,8 +75,9 @@ if (is_mac) {
   foreach(locale, locales) {
     copy("locales_${locale}") {
       locale = string_replace(locale, "-", "_")
+      source_locale = string_replace(locale, "nb", "no")
       sources = [
-        "brave_rewards/_locales/${locale}/messages.json",
+        "brave_rewards/_locales/${source_locale}/messages.json",
       ]
       outputs = [
         "$root_out_dir/resources/brave_rewards/_locales/${locale}/{{source_file_part}}",

--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/no/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/no/messages.json
@@ -1,50 +1,50 @@
 {
   "braveRewards": {
-    "message": "Brave Rewards",
+    "message": "Brave-belønninger",
     "description": "Title in welcome screen for the panel"
   },
   "welcomeButtonTextOne": {
-    "message": "Start Earning Now!",
+    "message": "Begynn å tjene nå!",
     "description": "CTA on welcome screen in the panel, existing users"
   },
   "welcomeButtonTextTwo": {
-    "message": "Join Rewards",
+    "message": "Bli med i Rewards",
     "description": "CTA on welcome screen in the panel, new users"
   },
   "welcomeDescOne": {
-    "message": "Get paid for viewing ads and pay it forward to support your favorite content creators.",
+    "message": "Få betalt for å se på reklame og gi videre for å støtte dine favoritt-tekstforfattere.",
     "description": "Entry text for welcome screen in the panel, existing user"
   },
   "welcomeDescTwo": {
-    "message": "You can now earn tokens for watching privacy-respecting ads.",
+    "message": "Du kan nå tjene tokens for å se på reklame som respekterer personvern.",
     "description": "Entry text for welcome screen in the panel, new user"
   },
   "welcomeFooterTextOne": {
-    "message": "Check out what’s improved",
+    "message": "Sjekk hva som er forbedret",
     "description": "Link in the footer (takes you to rewards settings page) for welcome screen in the panel, existing user"
   },
   "welcomeFooterTextTwo": {
-    "message": "Learn More",
+    "message": "Lær mer",
     "description": "Link in the footer (takes you to rewards settings page) for welcome screen in the panel, new user"
   },
   "welcomeHeaderOne": {
-    "message": "We’ve given Brave Rewards a big upgrade.",
+    "message": "Vi har gitt Brave Rewards en stor oppgradering.",
     "description": "Main header title for welcome screen in the panel, existing user"
   },
   "welcomeHeaderTwo": {
-    "message": "Get ready to experience the next Internet.",
+    "message": "Gjør deg klar til å oppleve et nytt internett. ",
     "description": "Main header title for welcome screen in the panel, new user"
   },
   "yourWallet": {
-    "message": "Your wallet",
+    "message": "Din lommebok",
     "description": "Title of wallet section where we display data about wallet"
   },
   "grants": {
-    "message": "Grants",
+    "message": "Stipend",
     "description": "Title for grant section in wallet summary"
   },
   "on": {
-    "message": "on",
+    "message": "på",
     "description": "The whole string is 'Enable tips on YouTube for like.'"
   },
   "verifiedPublisher": {
@@ -52,23 +52,23 @@
     "description": "Tells user that this particular publisher is a Brave Verified Creator"
   },
   "rewardsContributeAttentionScore": {
-    "message": "Attention",
+    "message": "NB",
     "description": "Label for auto contribute table attention for the publisher"
   },
   "donateMonthly": {
-    "message": "Tip this site monthly",
+    "message": "Gi tips til denne siden hver måned",
     "description": "Label for drop down menu where user select amount for monthly contribution for particular publisher"
   },
   "includeInAuto": {
-    "message": "Include in Auto-Contribute",
+    "message": "Inkluder i auto-bidrag",
     "description": "Label for checkbox that allows user to exclude publishers from auto contribute"
   },
   "donateNow": {
-    "message": "Send a Tip…",
+    "message": "Send tips",
     "description": "CTA for sending tip form site banner"
   },
   "enableTips": {
-    "message": "Enable Tips",
+    "message": "Aktiver Tips",
     "description": "The whole string is 'Enable tips on YouTube for like.'"
   },
   "for": {
@@ -76,7 +76,7 @@
     "description": "The whole string is 'Enable tips on YouTube for like.'"
   },
   "rewardsSummary": {
-    "message": "Rewards Summary",
+    "message": "Sammendrag av belønninger",
     "description": "Section title in wallet panel, which contains monthly rewards summary"
   },
   "monthApr": {
@@ -84,35 +84,35 @@
     "description": "Month"
   },
   "monthAug": {
-    "message": "August",
+    "message": "august",
     "description": "Month"
   },
   "monthDec": {
-    "message": "December",
+    "message": "Desember",
     "description": "Month"
   },
   "monthFeb": {
-    "message": "February",
+    "message": "februar",
     "description": "Month"
   },
   "monthJan": {
-    "message": "January",
+    "message": "Januar",
     "description": "Month"
   },
   "monthJul": {
-    "message": "July",
+    "message": "Juli",
     "description": "Month"
   },
   "monthJun": {
-    "message": "June",
+    "message": "juni",
     "description": "Month"
   },
   "monthMar": {
-    "message": "March",
+    "message": "Mars",
     "description": "Month"
   },
   "monthMay": {
-    "message": "May",
+    "message": "Mai",
     "description": "Month"
   },
   "monthNov": {
@@ -120,7 +120,7 @@
     "description": "Month"
   },
   "monthOct": {
-    "message": "October",
+    "message": "oktober",
     "description": "Month"
   },
   "monthSep": {
@@ -128,35 +128,35 @@
     "description": "Month"
   },
   "tokenGrant": {
-    "message": "Token Grants",
+    "message": "Tilskudd til polletter",
     "description": "Title for grant notification"
   },
   "tokenGrantClaimed": {
-    "message": "Token Grants Claimed",
+    "message": "Tokenstipender gjort krav på",
     "description": "Title for grant section in wallet summary"
   },
   "earningsAds": {
-    "message": "Earnings from Ads",
+    "message": "Opptjente midler fra reklamer",
     "description": "Title for ads section in wallet summary"
   },
   "rewardsContribute": {
-    "message": "Auto-Contribute",
+    "message": "Auto-bidra",
     "description": "Title for auto contribute section in wallet summary"
   },
   "oneTimeDonation": {
-    "message": "One-Time Tips",
+    "message": "Engangstips",
     "description": "Title for one time tips section in wallet summary"
   },
   "expiresOn": {
-    "message": "expires on",
+    "message": "utløper den",
     "description": "Used for grant representation. Whole string is '30.0 BAT expires on 08/05/2022'"
   },
   "recurringDonations": {
-    "message": "Monthly Tips",
+    "message": "Månedlig tips",
     "description": "Title for monthly tips section in wallet summary"
   },
   "off": {
-    "message": "Off",
+    "message": "Av",
     "description": "Label used in toggle indicating that toggle is off"
   },
   "ok": {
@@ -164,23 +164,23 @@
     "description": "Used in notification to dismiss notification"
   },
   "braveAdsLaunchMsg": {
-    "message": "Now you can earn by viewing ads.",
+    "message": "Nå kan du tjene på å se annonser.",
     "description": "Message for ads launch notification"
   },
   "braveAdsLaunchTitle": {
-    "message": "Brave Ads has arrived!",
+    "message": "Brave-annonser er her!",
     "description": "Message used in notification to let users know Ads is available"
   },
   "braveAdsTitle": {
-    "message": "Brave Ads",
+    "message": "Brave-annonser",
     "description": "Notification title when we display info about ads"
   },
   "braveContributeTitle": {
-    "message": "Auto-Contribute",
+    "message": "Auto-bidra",
     "description": "Notification title when we display info about auto contribution"
   },
   "contributeNotificationSuccess": {
-    "message": "You've contributed $amount$ BAT",
+    "message": "Du har bidratt med $amount$ BAT",
     "description": "We show this string in the notification when contribution is successful",
     "placeholders": {
       "amount": {
@@ -190,79 +190,79 @@
     }
   },
   "grantNotification": {
-    "message": "You have a grant waiting for you.",
+    "message": "Du har en tildeling som venter på deg.",
     "description": "Description for new grant notification"
   },
   "backupNow": {
-    "message": "Backup Now",
+    "message": "Sikkerhetskopier nå",
     "description": "Notification button text when we ask user to backup wallet"
   },
   "backupWalletTitle": {
-    "message": "Backup Wallet",
+    "message": "Sikkerhetskopier lommeboken",
     "description": "Notification title when we ask user to backup wallet"
   },
   "backupWalletNotification": {
-    "message": "Please backup your Brave wallet.",
+    "message": "Sikkerhetskopier Brave-lommeboken din.",
     "description": "Description for backup wallet notification"
   },
   "insufficientFundsNotification": {
-    "message": "Your Brave Rewards account is waiting for a deposit.",
+    "message": "Brave Rewards-kontoen din venter på et innskudd.",
     "description": "Description for new insufficient funds notification"
   },
   "insufficientFunds": {
-    "message": "Insufficient Funds",
+    "message": "Utilstrekkelige midler",
     "description": "Title for insufficient funds notification"
   },
   "braveRewardsCreatingText": {
-    "message": "Creating wallet",
+    "message": "Opprettelse av lommebok",
     "description": "Used in a button displaying wallet creation process"
   },
   "contributeNotificationError": {
-    "message": "There was a problem processing your contribution.",
+    "message": "Det oppstod et problem under behandlingen av bidraget ditt.",
     "description": "We show this string in notification when contribution fails"
   },
   "contributeNotificationNotEnoughFunds": {
-    "message": "Your scheduled monthly payment for Auto-Contribute and monthly tips could not be completed due to insufficient funds. We’ll try again in 30 days.",
+    "message": "Den månedlige betalingen din for auto-bidrag og månedlige tips kunne ikke gjennomføres på grunn av utilstrekkelige midler. Vi vil forsøke igjen om 30 dager.",
     "description": "We show this string in the notification when you don't have enough funds for contribution"
   },
   "contributeNotificationTipError": {
-    "message": "Unable to send your tip. Please try again later.",
+    "message": "Kan ikke sende tipsen din. Vennligst prøv igjen senere.",
     "description": "We show this string in notification when tip fails"
   },
   "noActivity": {
-    "message": "No activities yet…",
+    "message": "Ingen aktiviteter enda …",
     "description": "Allows the user to see that there have been no transactions or other activity in their wallet"
   },
   "captchaDrag": {
-    "message": "Drag the BAT Icon on to the",
+    "message": "Dra BAT-ikonet til",
     "description": "Directs the user to drag the BAT icon"
   },
   "captchaProveHuman": {
-    "message": "Prove that you are human!",
+    "message": "Bevis at du er et menneske!",
     "description": "Cosmetic text for captcha prompt"
   },
   "captchaTarget": {
-    "message": "target.",
+    "message": "mål.",
     "description": "Captcha Target"
   },
   "captchaMissedTarget": {
-    "message": "Hmm… Not Quite. Try Again.",
+    "message": "Hmm… det stemmer ikke helt. Prøv på nytt.",
     "description": "Message upon failing captcha"
   },
   "claim": {
-    "message": "Claim",
+    "message": "Gjør krav på",
     "description": "Claim text"
   },
   "newTokenGrant": {
-    "message": "Free Token Grant",
+    "message": "Gratis tokenstipend",
     "description": "Token grant label"
   },
   "grantExpire": {
-    "message": "Grant Expiration Date",
+    "message": "Utløpsdato for stipend",
     "description": "Grant expiry label"
   },
   "grantAlreadyClaimedText": {
-    "message": "Sorry, it appears that this grant has already been claimed.",
+    "message": "Beklager, men det ser ut til at dette stipendet allerede er gjort krav på.",
     "description": "Description of the error when grant is already claimed."
   },
   "grantGeneralErrorButton": {
@@ -270,11 +270,11 @@
     "description": "Button text for clearing the error."
   },
   "grantGeneralErrorText": {
-    "message": "Brave Rewards is having an issue. Please try again later.",
+    "message": "Brave Rewards har et problem. Prøv igjen senere.",
     "description": "Error text when user is having problems claiming a grant."
   },
   "grantGeneralErrorTitle": {
-    "message": "Oops, something is wrong. Please try again later.",
+    "message": "Opp sann, noe er galt. Prøv igjen senere.",
     "description": "Error title when user is having problems claiming a grant."
   },
   "grantGoneButton": {
@@ -282,11 +282,11 @@
     "description": "Button text for clearing the error."
   },
   "grantGoneText": {
-    "message": "Sorry, it appears that this grant has already expired.",
+    "message": "Beklager, men det ser ut til at dette stipendet allerede er utløpt.",
     "description": "Error text when user missed a grant."
   },
   "grantGoneTitle": {
-    "message": "This grant is no longer available.",
+    "message": "Dette stipendet er ikke tilgjengelig lenger.",
     "description": "Error title when user missed a grant."
   },
   "unVerifiedCheck": {
@@ -294,55 +294,55 @@
     "description": "Text of link that allows to check verified status of unverified publisher"
   },
   "unVerifiedPublisher": {
-    "message": "Not yet verified",
+    "message": "Ikke verifisert ennå",
     "description": "Status of the publisher shown in the panel"
   },
   "unVerifiedText": {
-    "message": "This creator has not yet signed up to receive contributions from Brave users. Any tips you send will remain in your wallet until they verify.",
+    "message": "Denne skaperen har ikke registrert seg for å motta bidrag fra Brave-brukere ennå. Eventuell driks du sender, blir værende i lommeboken din til den er verifisert.",
     "description": "Notice about unverified publisher."
   },
   "unVerifiedTextMore": {
-    "message": "Learn more.",
+    "message": "Finn ut mer.",
     "description": "Text for the link that explains more about reserved amount"
   },
   "reservedAmountText": {
-    "message": "You’ve designated {{reservedAmount}} BAT for creators who haven’t yet signed up to receive contributions. Your browser will keep trying to contribute until they verify, or until 90 days have passed.",
+    "message": "Du har tildelt {{reservedAmount}} BAT til skapere som ikke har registrert seg for å motta bidrag ennå. Nettleseren din vil fortsette å prøve å bidra helt til de verifiserer bidraget eller til det har gått 90 dager.",
     "description": "Notification about how much BAT do you have reserved"
   },
   "reservedMoreLink": {
-    "message": "Learn more.",
+    "message": "Finn ut mer.",
     "description": "Text for the link that explains more about reserved amount"
   },
   "disabledPanelOff": {
-    "message": "Off",
+    "message": "Av",
     "description": "Off state text for Panel's disabled state"
   },
   "disabledPanelSettings": {
-    "message": "Settings.",
+    "message": "Innstillinger.",
     "description": "Settings Link for Panel's disabled state"
   },
   "disabledPanelText": {
-    "message": "You are not currently accruing any Rewards benefits while browsing. Turn Rewards back on in",
+    "message": "Du opparbeider deg for tiden ingen Rewards-fordeler mens du surfer. Slå Rewards på igjen",
     "description": "Text for Panel's disabled state"
   },
   "disabledPanelTitle": {
-    "message": "Brave Rewards is",
+    "message": "Brave Rewards er",
     "description": "Title for Panel's disabled state"
   },
   "walletFailedTitle": {
-    "message": "Wallet creation failed",
+    "message": "Opprettelse av lommebok var mislykket",
     "description": "Failure title for wallet creation"
   },
   "walletFailedButton": {
-    "message": "Try again",
+    "message": "Prøv igjen",
     "description": "Button for re-try after wallet creation failed"
   },
   "addFunds": {
-    "message": "Add funds",
+    "message": "Legg til midler",
     "description": "Button for adding funds"
   },
   "rewardsSettings": {
-    "message": "Rewards Settings",
+    "message": "Belønningsinnstillinger",
     "description": "Button for opening settings page"
   },
   "earningsClaimDefault": {
@@ -350,47 +350,47 @@
     "description": "Panel notification text for Ads grant"
   },
   "and": {
-    "message": "and",
+    "message": "og",
     "description": "The word 'and'"
   },
   "braveRewardsSubTitle": {
-    "message": "Get Rewarded for Browsing!",
+    "message": "Bli belønnet for å surfe!",
     "description": "Subtitle for wallet disabled panel"
   },
   "disabledPanelTextTwo": {
-    "message": "Earn by viewing privacy-respecting ads, and pay it forward to support content creators you love.",
+    "message": "Tjen ved å se annonser som respekterer personvernet, og gi det videre for å støtte innholdsskapere du elsker.",
     "description": "Text block for wallet disabled panel"
   },
   "enableRewards": {
-    "message": "Enable Brave Rewards",
+    "message": "Aktiver Brave-belønninger",
     "description": "Subtitle for wallet disabled panel"
   },
   "privacyPolicy": {
-    "message": "Privacy Policy",
+    "message": "Personvernerklæring",
     "description": "Privacy Policy"
   },
   "serviceText": {
-    "message": "By clicking 'Enable Brave Rewards', you indicate that you have read and agree to the",
+    "message": "Ved å klikke 'Aktiver Brave Rewards' indikerer du at du har lest og aksepterer",
     "description": "Terms of service main text"
   },
   "termsOfService": {
-    "message": "Terms of Service",
+    "message": "Brukervilkår",
     "description": "Terms of Service"
   },
   "welcomeBack": {
-    "message": "Welcome Back!",
+    "message": "Velkommen tilbake!",
     "description": "Title message for wallet disabled panel"
   },
   "tipsProcessedNotification": {
-    "message": "Your monthly tips have been processed!",
+    "message": "Dine månedlige tips har blitt behandlet!",
     "description": "Message for monthly tips processed notification"
   },
   "contributionTips": {
-    "message": "Contributions & Tips",
+    "message": "Bidrag og tips",
     "description": "Title for monthly tips processed notification"
   },
   "serviceTextPanelWelcome": {
-    "message": "By clicking ‘Join Rewards’, you indicate that you have read and agree to the",
+    "message": "Ved å klikke 'Aktiver Rewards' indikerer du at du har lest og aksepterer",
     "description": "Terms of service panel opt-in text"
   },
   "bat": {
@@ -398,19 +398,19 @@
     "description": "BAT text for displaying converted tip amount."
   },
   "turnOnAds": {
-    "message": "Turn on Ads",
+    "message": "Slå på annonser",
     "description": "Prompt to turn on Ads via notification"
   },
   "adsEarnings": {
-    "message": "earned from ads",
+    "message": "opptjent fra annonser",
     "description": "Description text for ad grants in grant details"
   },
   "twitterTipsHoverText": {
-    "message": "Tip this tweet",
+    "message": "Tips om denne tweeten",
     "description": "Hover text for Twitter tips action"
   },
   "twitterTipsIconLabel": {
-    "message": "Tip",
+    "message": "Tips",
     "description": "Icon label for Twitter tips"
   },
   "verifiedPublisherNotification": {
@@ -432,15 +432,15 @@
     "description": "Notification title for pending contribution type"
   },
   "grantFinishTitleUGP": {
-    "message": "It’s your lucky day!",
+    "message": "Det er din lykkedag!",
     "description": "Cosmetic text upon captcha success"
   },
   "grantFinishTextUGP": {
-    "message": "Your token grant is on its way.",
+    "message": "Tokenstipendet ditt er på vei.",
     "description": "Cosmetic text indicating grant funds are on the way"
   },
   "grantFinishTokenTitleUGP": {
-    "message": "Free Token Grant",
+    "message": "Gratis tokenstipend",
     "description": "Token title on success screen"
   },
   "grantFinishTitleAds": {


### PR DESCRIPTION
Fixes brave/brave-browser#3425

- Renames Norwegian resources locale from 'nb' back to 'no', so that
  Transifex produces translations for them. When copying these resources
  rename them to 'nb'.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Change your OS locale (or Brave UI language where available) to Norwegian
2. In Brave, click on Rewards extension icon and check that the popup is localized.
3. Navigate to any site, click on Shields extension icon and check that the popup is localized.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
