### PR TITLE
Disable download protection remote lookups (brave/brave-browser#4341)

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -8,6 +8,8 @@ source_set("net") {
   sources = [
     "brave_ad_block_tp_network_delegate_helper.cc",
     "brave_ad_block_tp_network_delegate_helper.h",
+    "brave_block_safebrowsing_urls.cc",
+    "brave_block_safebrowsing_urls.h",
     "brave_common_static_redirect_network_delegate_helper.cc",
     "brave_common_static_redirect_network_delegate_helper.h",
     "brave_httpse_network_delegate_helper.cc",

--- a/browser/net/brave_block_safebrowsing_urls.cc
+++ b/browser/net/brave_block_safebrowsing_urls.cc
@@ -1,0 +1,46 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/brave_block_safebrowsing_urls.h"
+
+#include <vector>
+
+#include "extensions/common/url_pattern.h"
+#include "net/base/net_errors.h"
+#include "url/gurl.h"
+
+namespace brave {
+
+const char kDummyUrl[] = "https://no-thanks.invalid";
+
+bool IsSafeBrowsingReportingURL(const GURL& gurl) {
+  static const std::vector<URLPattern> reporting_patterns({
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://sb-ssl.google.com/safebrowsing/clientreport/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://safebrowsing.google.com/safebrowsing/clientreport/*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://safebrowsing.google.com/safebrowsing/report*"),
+      URLPattern(URLPattern::SCHEME_HTTPS,
+                 "https://safebrowsing.google.com/safebrowsing/uploads/*"),
+  });
+  return std::any_of(
+      reporting_patterns.begin(), reporting_patterns.end(),
+      [&gurl](URLPattern pattern) { return pattern.MatchesURL(gurl); });
+}
+
+int OnBeforeURLRequest_BlockSafeBrowsingReportingURLs(const GURL& request_url,
+                                                      GURL* new_url) {
+  DCHECK(new_url);
+
+  if (IsSafeBrowsingReportingURL(request_url)) {
+    *new_url = GURL(kDummyUrl);
+    return net::ERR_ABORTED;
+  }
+
+  return net::OK;
+}
+
+}  // namespace brave

--- a/browser/net/brave_block_safebrowsing_urls.h
+++ b/browser/net/brave_block_safebrowsing_urls.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_NET_BRAVE_BLOCK_SAFEBROWSING_URLS_H_
+#define BRAVE_BROWSER_NET_BRAVE_BLOCK_SAFEBROWSING_URLS_H_
+
+class GURL;
+
+namespace brave {
+
+int OnBeforeURLRequest_BlockSafeBrowsingReportingURLs(const GURL& url,
+                                                      GURL* new_url);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_NET_BRAVE_BLOCK_SAFEBROWSING_URLS_H_

--- a/browser/net/brave_block_safebrowsing_urls_unittest.cc
+++ b/browser/net/brave_block_safebrowsing_urls_unittest.cc
@@ -1,0 +1,91 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/brave_block_safebrowsing_urls.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "brave/browser/net/url_context.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
+#include "net/url_request/url_request_test_util.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+namespace {
+
+const char kInvalidUrl[] = "https://no-thanks.invalid";
+
+class BraveBlockReportingUrlsHelperTest : public testing::Test {
+ public:
+  BraveBlockReportingUrlsHelperTest()
+      : thread_bundle_(content::TestBrowserThreadBundle::IO_MAINLOOP),
+        context_(new net::TestURLRequestContext(true)) {}
+  ~BraveBlockReportingUrlsHelperTest() override {}
+  void SetUp() override { context_->Init(); }
+  net::TestURLRequestContext* context() { return context_.get(); }
+  void CheckUrl(const std::string& test_url,
+                const char* expected_url,
+                int expected_error);
+
+ private:
+  content::TestBrowserThreadBundle thread_bundle_;
+  std::unique_ptr<net::TestURLRequestContext> context_;
+};
+
+void BraveBlockReportingUrlsHelperTest::CheckUrl(const std::string& test_url,
+                                                 const char* expected_url,
+                                                 int expected_error) {
+  net::TestDelegate test_delegate;
+  GURL url(test_url);
+  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+      new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              before_url_context);
+  brave::ResponseCallback callback;
+  GURL new_url;
+  int ret =
+      brave::OnBeforeURLRequest_BlockSafeBrowsingReportingURLs(url, &new_url);
+  EXPECT_EQ(new_url, GURL(expected_url));
+  EXPECT_EQ(ret, expected_error);
+}
+
+TEST_F(BraveBlockReportingUrlsHelperTest, PreserveNormalUrls) {
+  const std::vector<const std::string> normalUrls({
+      "https://brave.com/",
+      "https://safebrowsing.google.com/safebrowsing",
+      "https://safebrowsing.googleapis.com/v4",
+  });
+
+  for (const auto& url : normalUrls) {
+    CheckUrl(url, "", net::OK);
+  }
+}
+
+TEST_F(BraveBlockReportingUrlsHelperTest, CancelReportingUrl) {
+  const std::vector<const std::string> reportingUrls({
+      "https://sb-ssl.google.com/safebrowsing/clientreport/download",
+      "https://sb-ssl.google.com/safebrowsing/clientreport/chrome-reset",
+      "https://sb-ssl.google.com/safebrowsing/clientreport/incident",
+      "https://sb-ssl.google.com/safebrowsing/clientreport/login",
+      "https://sb-ssl.google.com/safebrowsing/clientreport/phishing",
+      "https://sb-ssl.google.com/safebrowsing/clientreport/malware-check",
+      "https://safebrowsing.google.com/safebrowsing/uploads/webprotect",
+      "https://safebrowsing.google.com/safebrowsing/report",
+      "https://safebrowsing.google.com/safebrowsing/clientreport/malware",
+      "https://safebrowsing.google.com/safebrowsing/uploads/chrome",
+      "https://safebrowsing.google.com/safebrowsing/clientreport/crx-list-info",
+  });
+
+  for (const auto& url : reportingUrls) {
+    CheckUrl(url, kInvalidUrl, net::ERR_ABORTED);
+  }
+}
+
+}  // namespace

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -64,8 +64,12 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
   }
 
   if (safebrowsingfilecheck_pattern.MatchesHost(request_url)) {
-    replacements.SetHostStr(kBraveSafeBrowsingFileCheckProxy);
-    *new_url = request_url.ReplaceComponents(replacements);
+    // TODO(@fmarier): Re-enable download protection once we have
+    // truncated the list of metadata that it sends to the server
+    // (brave/brave-browser#6267).
+    //
+    // replacements.SetHostStr(kBraveSafeBrowsingFileCheckProxy);
+    // *new_url = request_url.ReplaceComponents(replacements);
     return net::OK;
   }
 

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -284,26 +284,31 @@ TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, ModifySafeBrowsingURLV5) {
   EXPECT_EQ(ret, net::OK);
 }
 
-TEST_F(BraveStaticRedirectNetworkDelegateHelperTest,
-       ModifySafeBrowsingFileCheckURL) {
-  net::TestDelegate test_delegate;
-  GURL url(
-      "https://sb-ssl.google.com/safebrowsing/clientreport/download?"
-      "key=DUMMY_KEY");
-  std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
-      url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
-  std::shared_ptr<brave::BraveRequestInfo> before_url_context(
-      new brave::BraveRequestInfo());
-  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
-                                              before_url_context);
-  brave::ResponseCallback callback;
-  GURL expected_url(
-      "https://sb-ssl.brave.com/safebrowsing/clientreport/download?"
-      "key=DUMMY_KEY");
-  int ret = OnBeforeURLRequest_StaticRedirectWork(callback, before_url_context);
-  EXPECT_EQ(before_url_context->new_url_spec, expected_url);
-  EXPECT_EQ(ret, net::OK);
-}
+// TODO(@fmarier): Re-enable download protection once we have
+// truncated the list of metadata that it sends to the server
+// (brave/brave-browser#6267).
+//
+// TEST_F(BraveStaticRedirectNetworkDelegateHelperTest,
+//        ModifySafeBrowsingFileCheckURL) {
+//   net::TestDelegate test_delegate;
+//   GURL url(
+//       "https://sb-ssl.google.com/safebrowsing/clientreport/download?"
+//       "key=DUMMY_KEY");
+//   std::unique_ptr<net::URLRequest> request = context()->CreateRequest(
+//       url, net::IDLE, &test_delegate, TRAFFIC_ANNOTATION_FOR_TESTS);
+//   std::shared_ptr<brave::BraveRequestInfo> before_url_context(
+//       new brave::BraveRequestInfo());
+//   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+//                                               before_url_context);
+//   brave::ResponseCallback callback;
+//   GURL expected_url(
+//       "https://sb-ssl.brave.com/safebrowsing/clientreport/download?"
+//       "key=DUMMY_KEY");
+//   int ret = OnBeforeURLRequest_StaticRedirectWork(callback,
+//                                                   before_url_context);
+//   EXPECT_EQ(before_url_context->new_url_spec, expected_url);
+//   EXPECT_EQ(ret, net::OK);
+// }
 
 #if BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
 TEST_F(BraveStaticRedirectNetworkDelegateHelperTest, RedirectTranslate) {

--- a/browser/net/brave_system_request_handler.cc
+++ b/browser/net/brave_system_request_handler.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/net/brave_system_request_handler.h"
 
+#include "brave/browser/net/brave_block_safebrowsing_urls.h"
 #include "brave/browser/net/brave_common_static_redirect_network_delegate_helper.h"
 #include "brave/browser/net/brave_static_redirect_network_delegate_helper.h"
 #include "services/network/public/cpp/resource_request.h"
@@ -15,6 +16,8 @@ namespace brave {
 network::ResourceRequest OnBeforeSystemRequest(
     const network::ResourceRequest& url_request) {
   GURL new_url;
+  brave::OnBeforeURLRequest_BlockSafeBrowsingReportingURLs(url_request.url,
+                                                           &new_url);
   brave::OnBeforeURLRequest_StaticRedirectWorkForGURL(url_request.url,
                                                       &new_url);
   brave::OnBeforeURLRequest_CommonStaticRedirectWorkForGURL(url_request.url,

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -61,6 +61,7 @@ test("brave_unit_tests") {
     "//brave/browser/download/brave_download_item_model_unittest.cc",
     "//brave/browser/metrics/metrics_reporting_util_unittest_linux.cc",
     "//brave/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc",
+    "//brave/browser/net/brave_block_safebrowsing_urls_unittest.cc",
     "//brave/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_httpse_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_network_delegate_base_unittest.cc",


### PR DESCRIPTION
Fixes brave/brave-browser#4341.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

To test that remote lookups are no longer done, go to https://testsafebrosing.appspot.com and verify that none of the Download Warnings files get blocked. Ideally, do this while looking at a MITM proxy to ensure that nothing is sent to `sb-ssl.google.com` or `sb-ssl.brave.com`.

To test that the "bad binary" list is still used against the download URL, I made a build which always flags download URLs as dangerous:

```
--- a/chrome/browser/safe_browsing/download_protection/download_url_sb_client.cc
+++ b/chrome/browser/safe_browsing/download_protection/download_url_sb_client.cc
@@ -58,7 +58,7 @@ void DownloadUrlSBClient::StartCheck() {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
   if (!database_manager_.get() ||
       database_manager_->CheckDownloadUrl(url_chain_, this)) {
-    CheckDone(SB_THREAT_TYPE_SAFE);
+    CheckDone(SB_THREAT_TYPE_URL_BINARY_MALWARE);
   } else {
     // Add a reference to this object to prevent it from being destroyed
     // before url checking result is returned.
@@ -74,7 +74,7 @@ bool DownloadUrlSBClient::IsDangerous(SBThreatType threat_type) const {
 void DownloadUrlSBClient::OnCheckDownloadUrlResult(
     const std::vector<GURL>& url_chain,
     SBThreatType threat_type) {
-  CheckDone(threat_type);
+  CheckDone(SB_THREAT_TYPE_URL_BINARY_MALWARE);
   UMA_HISTOGRAM_TIMES("SB2.DownloadUrlCheckDuration",
                       base::TimeTicks::Now() - start_time_);
   Release();
```

and then verified that any download would be blocked.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
- [ ] Update https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)