### PR TITLE
Generate widevine sig file during the app signing

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -81,11 +81,7 @@ action("create_pkg") {
     "unsigned/$brave_pkg",
   ]
 
-  if (enable_widevine_cdm_host_verification) {
-    deps = [ ":sign_chrome_framework_for_widevine" ]
-  } else {
-    deps = [":sign_app"]
-  }
+  deps = [":sign_app"]
 }
 
 action("sign_pkg") {
@@ -129,11 +125,7 @@ action("create_dmg") {
     "--symlink", "/Applications",
   ]
 
-  if (enable_widevine_cdm_host_verification) {
-    deps = [ ":sign_chrome_framework_for_widevine" ]
-  } else {
-    deps = [":sign_app"]
-  }
+  deps = [":sign_app"]
 }
 
 action("create_unsigned_dmg") {

--- a/patches/chrome-installer-mac-signing-signing.py.patch
+++ b/patches/chrome-installer-mac-signing-signing.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mac/signing/signing.py b/chrome/installer/mac/signing/signing.py
-index b56853e5e2649328a81a2de20228de5abda08f11..b0e4a28355f410efb2105273f423d4f38d1425c5 100644
+index b56853e5e2649328a81a2de20228de5abda08f11..4ab7212746a03f88b7000654fcbfebd65f0735de 100644
 --- a/chrome/installer/mac/signing/signing.py
 +++ b/chrome/installer/mac/signing/signing.py
 @@ -42,7 +42,6 @@ def get_parts(config):
@@ -27,3 +27,22 @@ index b56853e5e2649328a81a2de20228de5abda08f11..b0e4a28355f410efb2105273f423d4f3
          'libEGL.dylib',
          'libGLESv2.dylib',
          'libswiftshader_libEGL.dylib',
+@@ -143,7 +149,7 @@ def sign_part(paths, config, part):
+         part: The |model.CodeSignedProduct| to sign. The product's |path| must
+             be in |paths.work|.
+     """
+-    command = ['codesign', '--sign', config.identity]
++    command = ['codesign', '--force', '--sign', config.identity]
+     if part.sign_with_identifier:
+         command.extend(['--identifier', part.identifier])
+     reqs = part.requirements_string(config)
+@@ -233,6 +239,9 @@ def sign_chrome(paths, config):
+ 
+     # Sign the framework bundle.
+     sign_part(paths, config, parts['framework'])
++    from signing_helper import GenerateWidevineSigFile
++    GenerateWidevineSigFile(paths, config, parts['framework'])
++    sign_part(paths, config, parts['framework'])
+ 
+     provisioning_profile_basename = config.provisioning_profile_basename
+     if provisioning_profile_basename:

--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2019 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import os
+import subprocess
+import sys
+
+sign_widevine_cert = os.environ.get('SIGN_WIDEVINE_CERT')
+sign_widevine_key = os.environ.get('SIGN_WIDEVINE_KEY')
+sign_widevine_passwd = os.environ.get('SIGN_WIDEVINE_PASSPHRASE')
+sig_generator_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+sig_generator_path = os.path.realpath(
+    os.path.join(sig_generator_path, os.pardir, os.pardir, 'third_party',
+                 'widevine', 'scripts', 'signature_generator.py'))
+
+
+def file_exists(path):
+    return os.path.exists(path)
+
+
+def run_command(args, **kwargs):
+    print('Running command: {}'.format(args))
+    subprocess.check_call(args, **kwargs)
+
+
+def GenerateWidevineSigFile(paths, config, part):
+    if sign_widevine_key and sign_widevine_key and sign_widevine_passwd and file_exists(sig_generator_path):
+        chrome_framework_name = config.app_product + ' Framework'
+        chrome_framework_version_path = os.path.join(paths.work, part.path, 'Versions', config.version)
+        sig_source_file = os.path.join(chrome_framework_version_path, chrome_framework_name)
+        sig_target_file = os.path.join(chrome_framework_version_path, 'Resources', chrome_framework_name + '.sig')
+        assert file_exists(sig_source_file), 'Wrong source path for sig generation'
+
+        command = ['python', sig_generator_path, '--input_file', sig_source_file,
+                   '--output_file', sig_target_file, '--flags', '1',
+                   '--certificate', sign_widevine_cert,
+                   '--private_key', sign_widevine_key,
+                   '--private_key_passphrase', sign_widevine_passwd]
+
+        run_command(command)
+        assert file_exists(sig_target_file), 'No sig file'


### PR DESCRIPTION
Framework bundle will be signed twice for widevine vmp.
To get proper sig file, it needs signed framework dylib.
So sig file is generated and it is inserted framework bundle after first signing.
Then framework is signed again to make proper signing with additional sig file in framework bundle.
To make signing twice, `--force` option is added for `codesign`.
With that, `codesign` will sign again.

`sign_chrome_framework_for_widevine` target is only used for unsigned dmg.
When signing is enabled, sig file generation is done during the `sign_app` target.

To test this PR works or not, image from release builder is needed.
We can't test signed dmg from CI builder or local for now.

Fix https://github.com/brave/brave-browser/issues/4905

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
