### PR TITLE
Change date format for Contributions and Tips to match Ads

### DIFF
--- a/components/brave_rewards/resources/ui/components/contributeBox.tsx
+++ b/components/brave_rewards/resources/ui/components/contributeBox.tsx
@@ -282,7 +282,9 @@ class ContributeBox extends React.Component<Props, State> {
           </Select>
         </List>
         <List title={getLocale('contributionNextDate')}>
-          <NextContribution>{new Date(reconcileStamp * 1000).toLocaleDateString()}</NextContribution>
+          <NextContribution>
+            {new Intl.DateTimeFormat('default', { month: 'short', day: 'numeric' }).format(reconcileStamp * 1000)}
+          </NextContribution>
         </List>
         <List title={getLocale('contributionSites')}>
           {getLocale('total')} &nbsp;<Tokens

--- a/components/brave_rewards/resources/ui/components/tipsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/tipsBox.tsx
@@ -238,7 +238,7 @@ class TipBox extends React.Component<Props, State> {
           recurringList && recurringList.length > 0
           ? <List title={getLocale('donationNextDate')}>
             <NextContribution>
-              {new Date(reconcileStamp * 1000).toLocaleDateString()}
+              {new Intl.DateTimeFormat('default', { month: 'short', day: 'numeric' }).format(reconcileStamp * 1000)}
             </NextContribution>
           </List>
           : null


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/4975

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Confirm date format for next Contributions and Tips date is shown in short format, i.e. Jan 5 to match Ads

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
