### PR TITLE
Small fixes

### DIFF
--- a/app/mac/BUILD.gn
+++ b/app/mac/BUILD.gn
@@ -9,11 +9,7 @@ chrome_framework_name = chrome_product_full_name + " Framework"
 chrome_helper_name = chrome_product_full_name + " Helper"
 
 # This must be same value in //chrome/BUILD.gn.
-if (new_mac_bundle_structure) {
-  chrome_framework_version = chrome_version_full
-} else {
-  chrome_framework_version = "A"
-}
+chrome_framework_version = chrome_version_full
 
 # This list must be updated with the two targets' deps list below, and
 # the list of _dsyms in :brave_dsym_archive.

--- a/browser/resources/settings/brave_settings_overrides.html
+++ b/browser/resources/settings/brave_settings_overrides.html
@@ -43,10 +43,8 @@
         align-items: flex-start;
         background: #F1F3F5; /* neutral100 */
       }
-      @media only screen and  (max-width: 815px) {
-        settings-menu {
-          display: none;
-        }
+      #left, #main, #right {
+        flex: unset !important;
       }
       :host-context([dark]) #container {
         background: #1E2127;

--- a/browser/resources/settings/brave_settings_overrides.js
+++ b/browser/resources/settings/brave_settings_overrides.js
@@ -117,17 +117,6 @@ BravePatching.RegisterPolymerComponentBehaviors({
 
 // Templates
 BravePatching.RegisterPolymerTemplateModifications({
-  'settings-ui': (templateContent) => {
-    // Take settings menu out of drawer and put permanently in DOM
-    // TODO(petemill): If this becomes flakey on chromium rebases, consider
-    // making our own settings-ui module template replacement since it's quite simple.
-    const settingsMenuTemplate = templateContent.querySelector('#drawerTemplate')
-    const container = templateContent.querySelector('#container')
-    if (!settingsMenuTemplate || !container) {
-      console.warn('[Brave Settings Overrides] settings-ui: could not find all the required elements for modification', { settingsMenuTemplate, container })
-    }
-    container.insertAdjacentElement('afterbegin', settingsMenuTemplate.content.querySelector('settings-menu'))
-  },
   'settings-menu': (templateContent) => {
     // Add title
     const titleEl = document.createElement('h1')

--- a/browser/ui/brave_dark_mode_observer_browsertest_mac.mm
+++ b/browser/ui/brave_dark_mode_observer_browsertest_mac.mm
@@ -5,7 +5,7 @@
 
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/themes/brave_theme_service.h"
-#include "brave/browser/ui/brave_dark_mode_observer.h"
+#include "brave/ui/native_theme/brave_dark_mode_observer.h"
 #include "brave/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -24,28 +24,30 @@ void SetBraveThemeType(Profile* profile, BraveThemeType type) {
 
 }  // namespace
 
-// Test whether DarkModeObserver observes proper NativeTheme.
-IN_PROC_BROWSER_TEST_F(BraveDarkModeObserverTest,
-                       ObserveProperNativeThemeTest) {
-  if (@available(macOS 10.14, *)) {
-    base::test::ScopedFeatureList features;
-    features.InitAndEnableFeature(features::kWebUIDarkMode);
+namespace ui {
+  // Test whether DarkModeObserver observes proper NativeTheme.
+  IN_PROC_BROWSER_TEST_F(BraveDarkModeObserverTest,
+                         ObserveProperNativeThemeTest) {
+    if (@available(macOS 10.14, *)) {
+      base::test::ScopedFeatureList features;
+      features.InitAndEnableFeature(features::kWebUIDarkMode);
 
-    Profile* profile = browser()->profile();
+      Profile* profile = browser()->profile();
 
-    // Load webui to instantiate BraveDarkModeObserver.
-    AddTabAtIndexToBrowser(
-        browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
+      // Load webui to instantiate BraveDarkModeObserver.
+      AddTabAtIndexToBrowser(
+          browser(), 0, GURL("brave://history"), ui::PAGE_TRANSITION_TYPED, true);
 
-    // Initially set to light.
-    SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
-    EXPECT_EQ(
-        ui::NativeTheme::GetInstanceForNativeUi(),
-        BraveDarkModeObserver::current_native_theme_for_testing_);
+      // Initially set to light.
+      SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_LIGHT);
+      EXPECT_EQ(
+          ui::NativeTheme::GetInstanceForNativeUi(),
+          BraveDarkModeObserver::current_native_theme_for_testing_);
 
-    SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
-    EXPECT_EQ(
-        ui::NativeThemeDarkAura::instance(),
-        BraveDarkModeObserver::current_native_theme_for_testing_);
+      SetBraveThemeType(profile, BraveThemeType::BRAVE_THEME_TYPE_DARK);
+      EXPECT_EQ(
+          ui::NativeThemeDarkAura::instance(),
+          BraveDarkModeObserver::current_native_theme_for_testing_);
+    }
   }
 }

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -54,15 +54,9 @@ if (skip_signing) {
       chrome_framework_name = chrome_product_full_name + " Framework"
       target_app_path = "$root_out_dir/$chrome_product_full_name.app"
 
-      if (new_mac_bundle_structure) {
-        brave_version_path = "$target_app_path/Contents/Frameworks/$chrome_framework_name.framework/Versions/$chrome_version_full"
-        framework_file = "$brave_version_path/$chrome_framework_name"
-        signature_file = "$brave_version_path/Resources/$chrome_framework_name.sig"
-      } else {
-        brave_version_path = "$target_app_path/Contents/Versions/$chrome_version_full"
-        framework_file = "$brave_version_path/$chrome_framework_name.framework/Versions/Current/$chrome_framework_name"
-        signature_file = "$brave_version_path/Widevine Resources.bundle/Contents/Resources/$chrome_framework_name.sig"
-      }
+      brave_version_path = "$target_app_path/Contents/Frameworks/$chrome_framework_name.framework/Versions/$chrome_version_full"
+      framework_file = "$brave_version_path/$chrome_framework_name"
+      signature_file = "$brave_version_path/Resources/$chrome_framework_name.sig"
 
       flags = 1  # blessed binary
 

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -109,6 +109,12 @@ source_set("brave_cookie_blocking") {
     "brave_cookie_blocking.cc",
     "brave_cookie_blocking.h",
   ]
+
+  if (is_mac) {
+    deps = [
+      "//base:logging_buildflags",
+    ]
+  }
 }
 
 source_set("shield_exceptions") {


### PR DESCRIPTION
- fix compilation errors on macOS (see https://chromium.googlesource.com/chromium/src/+/d24fe6f65d3e2fe6f214f007c7b9d4cc5c347065 for deprecation of `new_mac_bundle_structure`)
- Fix the double `settings-menu` instances on settings page (cc: @petemill)

I basically ran through these:
- compile/link 👍 
- unit tests (1 failure)
   ```
   [416/416] HistoryUtilsTest.VariousURLTest (27 ms)
   1 test failed:
       HistoryUtilsTest.VariousURLTest 
   (../../brave/chromium_src/chrome/browser/history/history_utils_unittest.cc:23)
   Tests took 1 seconds.
   ```
- browser tests (34 failed)
   ```
    [221/221] AdBlockServiceTest.ResetPreservesTags (TIMED OUT)
    Too many failing tests (34), skipping retries.
    11 tests failed:
        BraveRewardsBrowserTest.HandleFlagsMultipleFlags (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1348)
        BraveRewardsBrowserTest.HandleFlagsSingleArg (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1237)
        BraveRewardsBrowserTest.HandleFlagsWrongInput (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1369)
        BraveRewardsBrowserTest.PrefsTestInPrivateWindow (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2055)
        BraveRewardsBrowserTest.RedditTipsInjectedOnReddit (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1736)
        BraveRewardsBrowserTest.RedditTipsNotInjectedOnNonReddit (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1765)
        BraveRewardsBrowserTest.RenderWelcome (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1094)
        BraveRewardsBrowserTest.ToggleAutoContribute (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1151)
        BraveRewardsBrowserTest.TwitterTipsInjectedOnTwitter (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1691)
        BraveRewardsBrowserTest.TwitterTipsNotInjectedOnNonTwitter (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1721)
        SearchEngineProviderServiceTest.GuestWindowControllerTest (../../brave/browser/search_engines/search_engine_provider_service_browsertest.cc:178)
    17 tests timed out:
        AdBlockServiceTest.ResetPreservesTags (../../brave/components/brave_shields/browser/ad_block_service_browsertest.cc:724)
        BraveRewardsBrowserTest.AutoContribution (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1521)
        BraveRewardsBrowserTest.ClaimGrantViaPanel (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1407)
        BraveRewardsBrowserTest.ClaimGrantViaSettingsPage (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1391)
        BraveRewardsBrowserTest.ContributionWithLowAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1659)
        BraveRewardsBrowserTest.InsufficientNotificationForVerifiedsDefaultAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1931)
        BraveRewardsBrowserTest.InsufficientNotificationForVerifiedsInsufficientAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2013)
        BraveRewardsBrowserTest.InsufficientNotificationForVerifiedsSufficientAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1971)
        BraveRewardsBrowserTest.InsufficientNotificationForVerifiedsZeroAmountZeroPublishers (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1904)
        BraveRewardsBrowserTest.PendingContributionTip (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1781)
        BraveRewardsBrowserTest.ProcessPendingContributions (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2067)
        BraveRewardsBrowserTest.RecurringTipForUnverifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1637)
        BraveRewardsBrowserTest.RecurringTipForVerifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1615)
        BraveRewardsBrowserTest.TipUnverifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1595)
        BraveRewardsBrowserTest.TipVerifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1575)
        BraveRewardsBrowserTest.VisitUnverifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1505)
        BraveRewardsBrowserTest.VisitVerifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1489)
    6 tests crashed:
        BraveContentSettingsObserverBrowserTest.AllowReferrer (../../brave/renderer/brave_content_settings_observer_browsertest.cc:577)
        BraveRewardsBrowserTest.ActivateSettingsModal (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1212)
        BraveRewardsBrowserTest.AddFunds (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1842)
        BraveRewardsBrowserTest.AddFundsCountryLimited (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1871)
        BraveRewardsBrowserTest.PanelShowsCorrectPublisherData (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1424)
        BraveRewardsBrowserTest.ToggleRewards (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:1102)
   ```