### PR TITLE
match brave-ui sha in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,8 +1597,8 @@
       }
     },
     "brave-ui": {
-      "version": "github:brave/brave-ui#92a28b05cb771658610f1e44d615473b87d2caa0",
-      "from": "github:brave/brave-ui#92a28b05cb771658610f1e44d615473b87d2caa0",
+      "version": "github:brave/brave-ui#57ed2ffe53706146005a9aea707a0a53eaddd7ba",
+      "from": "github:brave/brave-ui#57ed2ffe53706146005a9aea707a0a53eaddd7ba",
       "dev": true,
       "requires": {
         "@ctrl/tinycolor": "^2.2.1",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5042

version should match package.json https://github.com/brave/brave-core/blob/master/package.json#L280