### PR TITLE
Issue 5070: MediaRouterEnabled should return false  if kLoadMediaRouterComponentExtensionFlag is disabled

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -61,6 +61,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // Hangouts
   registry->RegisterBooleanPref(kHangoutsEnabled, true);
 
+  // Media Router
+  registry->SetDefaultPrefValue(prefs::kEnableMediaRouter, base::Value(false));
+
   // No sign into Brave functionality
   registry->SetDefaultPrefValue(prefs::kSigninAllowed, base::Value(false));
 

--- a/chromium_src/chrome/browser/media/router/media_router_feature.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/media/router/media_router_feature.h"
+
+#include "chrome/common/pref_names.h"
+#include "extensions/common/feature_switch.h"
+
+#define MediaRouterEnabled MediaRouterEnabled_ChromiumImpl
+#include "../../../../../../chrome/browser/media/router/media_router_feature.cc"  // NOLINT
+#undef MediaRouterEnabled
+
+namespace media_router {
+
+// Media router pref can be toggled using kLoadMediaRouterComponentExtension
+// on Desktop
+void UpdateMediaRouterPref(content::BrowserContext* context) {
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  user_prefs::UserPrefs::Get(context)->SetBoolean(
+      ::prefs::kEnableMediaRouter,
+      extensions::FeatureSwitch::load_media_router_component_extension()
+          ->IsEnabled());
+#endif
+}
+
+bool MediaRouterEnabled(content::BrowserContext* context) {
+#if defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS)
+  UpdateMediaRouterPref(context);
+  const PrefService::Preference* pref = GetMediaRouterPref(context);
+  bool allowed = false;
+  CHECK(pref->GetValue()->GetAsBoolean(&allowed));
+
+  // The component extension cannot be loaded in guest sessions.
+  // crbug.com/756243
+  return allowed && !Profile::FromBrowserContext(context)->IsGuestSession();
+#else   // !(defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS))
+  return false;
+#endif  // defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS)
+}
+
+}  // namespace media_router

--- a/chromium_src/chrome/browser/media/router/media_router_feature_browsertest.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature_browsertest.cc
@@ -1,0 +1,60 @@
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/media/router/media_router_feature.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/common/pref_names.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
+#include "extensions/common/feature_switch.h"
+
+using extensions::FeatureSwitch;
+
+class MediaRouterTest : public InProcessBrowserTest {
+ protected:
+  MediaRouterTest() {}
+  ~MediaRouterTest() override {}
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterDefaults) {
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+  EXPECT_FALSE(
+      FeatureSwitch::load_media_router_component_extension()->IsEnabled());
+}
+
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterEnabled) {
+  FeatureSwitch::ScopedOverride load_media_router_component_extension(
+      FeatureSwitch::load_media_router_component_extension(), true);
+  EXPECT_TRUE(media_router::MediaRouterEnabled(browser()->profile()));
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+}
+
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterToggle) {
+  FeatureSwitch::ScopedOverride enabled_override_(
+      FeatureSwitch::load_media_router_component_extension(), true);
+  EXPECT_TRUE(media_router::MediaRouterEnabled(browser()->profile()));
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+
+  FeatureSwitch::ScopedOverride disabled_override_(
+      FeatureSwitch::load_media_router_component_extension(), false);
+  EXPECT_FALSE(media_router::MediaRouterEnabled(browser()->profile()));
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+}
+
+// Test to confirm that setting the pref to false disables MediaRouterEnabled
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterDisabled) {
+  browser()->profile()->GetPrefs()->SetBoolean(prefs::kEnableMediaRouter,
+                                               false);
+  EXPECT_FALSE(media_router::MediaRouterEnabled(browser()->profile()));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -361,6 +361,7 @@ test("brave_browser_tests") {
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/browser/ui/toolbar/brave_app_menu_model_browsertest.cc",
+    "//brave/chromium_src/chrome/browser/media/router/media_router_feature_browsertest.cc",
     "//brave/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",


### PR DESCRIPTION
Fix: https://github.com/brave/brave-browser/issues/5070

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [x] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Install Windows Network Monitor/Wireshark
2. Start a network capture
3. Run Brave
4. Verify that no SSDP requests are sent by default (use filter `udp.port == 1900`) with data:

```
ST: urn:dial-multiscreen-org:service:dial:1
Brave Browser <channel>/75.0.69.22 Mac OS X
```

1. Navigate to brave://flags
2. Switch the media router flag from `Default` to `Enabled`
3. Verify that SSDP requests are sent after restart
4. Toggle it back to `Disabled` 
5. Verify no SSDP requests are seen after restart

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
