### PR TITLE
bravify webstore

### DIFF
--- a/components/brave_extension/extension/brave_extension/BUILD.gn
+++ b/components/brave_extension/extension/brave_extension/BUILD.gn
@@ -8,6 +8,7 @@ transpile_web_ui("brave_extension") {
     ["brave_extension", rebase_path("braveShieldsPanel.tsx")],
     ["brave_extension_background", rebase_path("background.ts")],
     ["content", rebase_path("content.ts")],
+    ["webstore", rebase_path("webstore.ts")],
   ]
 
   # what is the directory / pack name

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -33,6 +33,15 @@
       "run_at": "document_start",
       "all_frames": true
     }, {
+      "matches": [
+        "https://chrome.google.com/webstore/detail/*"
+      ],
+      "js": [
+        "out/webstore.bundle.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true
+    }, {
       "run_at": "document_start",
       "all_frames": true,
       "matches": [

--- a/components/brave_extension/extension/brave_extension/webstore.ts
+++ b/components/brave_extension/extension/brave_extension/webstore.ts
@@ -1,0 +1,19 @@
+const config = { attributes: true, childList: true, subtree: true }
+const textToMatch: Array<string> = ['Add to Chrome', 'Remove from Chrome']
+
+const callback = (mutationsList: MutationRecord[], observer: MutationObserver) => {
+  const buttons: NodeListOf<Element> = document.querySelectorAll('div.webstore-test-button-label')
+
+  buttons.forEach((button: Element) => {
+    const text: string = button.innerHTML
+    if (textToMatch.includes(text)) {
+      button.innerHTML = text.replace('Chrome', 'Brave')
+    }
+  })
+}
+
+const observer: MutationObserver = new MutationObserver(callback)
+
+window.onload = () => {
+  observer.observe(document, config)
+}


### PR DESCRIPTION
Change the buttons labels from "Add to Chrome" and "Remove from Chrome" to "Add to Brave" and "Remove from Brave" respectively. 

Fixes https://github.com/brave/brave-browser/issues/790

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
  - [ ] Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
