### PR TITLE
Issue 5070: MediaRouterEnabled should return false  if kLoadMediaRouterComponentExtensionFlag is disabled (uplift to 0.67.x)

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -60,6 +60,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // Hangouts
   registry->RegisterBooleanPref(kHangoutsEnabled, true);
 
+  // Media Router
+  registry->SetDefaultPrefValue(prefs::kEnableMediaRouter, base::Value(false));
+
   // No sign into Brave functionality
   registry->SetDefaultPrefValue(prefs::kSigninAllowed, base::Value(false));
 

--- a/chromium_src/chrome/browser/media/router/media_router_feature.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/media/router/media_router_feature.h"
+
+#include "chrome/common/pref_names.h"
+#include "extensions/common/feature_switch.h"
+
+#define MediaRouterEnabled MediaRouterEnabled_ChromiumImpl
+#include "../../../../../../chrome/browser/media/router/media_router_feature.cc"  // NOLINT
+#undef MediaRouterEnabled
+
+namespace media_router {
+
+// Media router pref can be toggled using kLoadMediaRouterComponentExtension
+// on Desktop
+void UpdateMediaRouterPref(content::BrowserContext* context) {
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  user_prefs::UserPrefs::Get(context)->SetBoolean(
+      ::prefs::kEnableMediaRouter,
+      extensions::FeatureSwitch::load_media_router_component_extension()
+          ->IsEnabled());
+#endif
+}
+
+bool MediaRouterEnabled(content::BrowserContext* context) {
+#if defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS)
+  UpdateMediaRouterPref(context);
+  const PrefService::Preference* pref = GetMediaRouterPref(context);
+  bool allowed = false;
+  CHECK(pref->GetValue()->GetAsBoolean(&allowed));
+
+  // The component extension cannot be loaded in guest sessions.
+  // crbug.com/756243
+  return allowed && !Profile::FromBrowserContext(context)->IsGuestSession();
+#else   // !(defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS))
+  return false;
+#endif  // defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS)
+}
+
+}  // namespace media_router

--- a/chromium_src/chrome/browser/media/router/media_router_feature_browsertest.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature_browsertest.cc
@@ -1,0 +1,60 @@
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/media/router/media_router_feature.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/common/pref_names.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
+#include "extensions/common/feature_switch.h"
+
+using extensions::FeatureSwitch;
+
+class MediaRouterTest : public InProcessBrowserTest {
+ protected:
+  MediaRouterTest() {}
+  ~MediaRouterTest() override {}
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterDefaults) {
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+  EXPECT_FALSE(
+      FeatureSwitch::load_media_router_component_extension()->IsEnabled());
+}
+
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterEnabled) {
+  FeatureSwitch::ScopedOverride load_media_router_component_extension(
+      FeatureSwitch::load_media_router_component_extension(), true);
+  EXPECT_TRUE(media_router::MediaRouterEnabled(browser()->profile()));
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+}
+
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterToggle) {
+  FeatureSwitch::ScopedOverride enabled_override_(
+      FeatureSwitch::load_media_router_component_extension(), true);
+  EXPECT_TRUE(media_router::MediaRouterEnabled(browser()->profile()));
+  EXPECT_TRUE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+
+  FeatureSwitch::ScopedOverride disabled_override_(
+      FeatureSwitch::load_media_router_component_extension(), false);
+  EXPECT_FALSE(media_router::MediaRouterEnabled(browser()->profile()));
+  EXPECT_FALSE(
+      browser()->profile()->GetPrefs()->GetBoolean(prefs::kEnableMediaRouter));
+}
+
+// Test to confirm that setting the pref to false disables MediaRouterEnabled
+IN_PROC_BROWSER_TEST_F(MediaRouterTest, MediaRouterDisabled) {
+  browser()->profile()->GetPrefs()->SetBoolean(prefs::kEnableMediaRouter,
+                                               false);
+  EXPECT_FALSE(media_router::MediaRouterEnabled(browser()->profile()));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -345,6 +345,7 @@ test("brave_browser_tests") {
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/browser/ui/toolbar/brave_app_menu_model_browsertest.cc",
+    "//brave/chromium_src/chrome/browser/media/router/media_router_feature_browsertest.cc",
     "//brave/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",
     "//brave/components/brave_shields/browser/ad_block_service_browsertest.cc",


### PR DESCRIPTION
Uplift of #2836
Fixes https://github.com/brave/brave-browser/issues/5070

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.