### PR TITLE
Fix ad notifications received this month should not include transaction count from server

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
@@ -290,11 +290,8 @@ void AdsRewards::Update() {
       confirmations_->GetNextTokenRedemptionDateInSeconds());
   uint64_t next_payment_date_in_seconds = next_payment_date.ToDoubleT();
 
-  auto ad_notifications_received_this_month =
-      payments_->GetTransactionCountForMonth(now);
-
   confirmations_->UpdateAdsRewards(estimated_pending_rewards,
-      next_payment_date_in_seconds, ad_notifications_received_this_month);
+      next_payment_date_in_seconds);
 }
 
 double AdsRewards::CalculateEstimatedPendingRewards() const {

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -55,8 +55,7 @@ class ConfirmationsImpl : public Confirmations {
 
   void UpdateAdsRewards(
       const double estimated_pending_rewards,
-      const uint64_t next_payment_date_in_seconds,
-      const uint64_t ad_notifications_received_this_month);
+      const uint64_t next_payment_date_in_seconds);
 
   // Transaction history
   void GetTransactionHistory(
@@ -71,6 +70,7 @@ class ConfirmationsImpl : public Confirmations {
   std::vector<TransactionInfo> GetTransactionHistory(
       const uint64_t from_timestamp_in_seconds,
       const uint64_t to_timestamp_in_seconds);
+  std::vector<TransactionInfo> GetTransactions() const;
   std::vector<TransactionInfo> GetUnredeemedTransactions();
   void AppendTransactionToHistory(
       const double estimated_redemption_value,
@@ -124,7 +124,6 @@ class ConfirmationsImpl : public Confirmations {
   // Ads rewards
   double estimated_pending_rewards_;
   uint64_t next_payment_date_in_seconds_;
-  uint64_t ad_notifications_received_this_month_;
   std::unique_ptr<AdsRewards> ads_rewards_;
 
   // Refill tokens


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5119

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Confirm "Ad notifications received this month" is calculated from ads which have been seen in that month, i.e. view 3 ads in July then fast-forward the clock to August and the count should be 0. Quit browser and set clock back to July and the count should be 3. If a user deletes their user profile the count will be lost.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
