### PR TITLE
Switch python-patch to our fork of it

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ deps = {
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@9be5c63b14e094156e00c8b28f205e7794f0b92c",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
-  "vendor/python-patch": "https://github.com/techtonik/python-patch@2148d5408fafd5c05ac6854dd7deb4e8a4ca4a49",
+  "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
   "vendor/omaha":  "https://github.com/brave/omaha.git@22dec7e124881ba2c7e8f331d18d9c4dd40ed207",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",


### PR DESCRIPTION
This will prevent silent errors when `.orig` files already exist and interfere with `npm run apply_patches`.

See techtonik/python-patch#60.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

I started by running this using the old python-patch:

```
$ touch src/content/browser/frame_host/navigation_request.cc.orig
$ cd src
$ git reset --hard
$ cd ..
$ npm run apply_patches
$ npm run update_patches
```

and then swapped to the new one and got the following (as expected):

```
$ cd src
$ git reset --hard
$ cd ..
$ npm run apply_patches

> brave@0.69.31 apply_patches /home/francois/devel/brave-browser
> node ./scripts/sync.js --run_hooks

undefined: python /home/francois/devel/brave-browser/src/brave/script/apply-patches.py

content-browser-frame_host-navigation_request.cc.patch failed to apply
```

before doing the following:

```
$ rm src/content/browser/frame_host/navigation_request.cc.orig
$ npm run update_patches
```
and confirming that the patches are the same as before.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
