### PR TITLE
Enable Brave ads for Australia, New Zealand and Ireland

### DIFF
--- a/browser/ui/webui/brave_rewards_ui.cc
+++ b/browser/ui/webui/brave_rewards_ui.cc
@@ -1017,8 +1017,6 @@ void RewardsDOMHandler::SaveAdsSetting(const base::ListValue* args) {
     ads_service_->SetAdsEnabled(value == "true");
   } else if (key == "adsPerHour") {
     ads_service_->SetAdsPerHour(std::stoull(value));
-  } else if (key == "adsEnabledMigrated") {
-    ads_service_->MigrateAdsEnabled(value == "true");
   }
 
   base::ListValue* emptyArgs = nullptr;

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -26,7 +26,6 @@ class AdsService : public KeyedService {
 
   virtual bool IsAdsEnabled() const = 0;
   virtual void SetAdsEnabled(const bool is_enabled) = 0;
-  virtual void MigrateAdsEnabled(const bool is_enabled) = 0;
 
   virtual uint64_t GetAdsPerHour() const = 0;
   virtual void SetAdsPerHour(const uint64_t ads_per_hour) = 0;

--- a/components/brave_ads/browser/ads_service_factory.h
+++ b/components/brave_ads/browser/ads_service_factory.h
@@ -37,8 +37,6 @@ class AdsServiceFactory : public BrowserContextKeyedServiceFactory {
       content::BrowserContext* context) const override;
   bool ServiceIsNULLWhileTesting() const override;
   bool ShouldMigratePrefs(user_prefs::PrefRegistrySyncable* registry) const;
-  bool ShouldMigratePrefsFrom62(
-      user_prefs::PrefRegistrySyncable* registry) const;
 
   DISALLOW_COPY_AND_ASSIGN(AdsServiceFactory);
 };

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -181,9 +181,9 @@ int GetSchemaResourceId(const std::string& name) {
 }
 
 static std::map<std::string, int> g_user_model_resource_ids = {
+  {"en", IDR_ADS_USER_MODEL_EN},
   {"de", IDR_ADS_USER_MODEL_DE},
   {"fr", IDR_ADS_USER_MODEL_FR},
-  {"en", IDR_ADS_USER_MODEL_EN},
 };
 
 int GetUserModelResourceId(const std::string& locale) {
@@ -312,18 +312,15 @@ AdsServiceImpl::AdsServiceImpl(Profile* profile)
       base::BindOnce(&EnsureBaseDirectoryExists, base_path_));
 
   profile_pref_change_registrar_.Init(profile_->GetPrefs());
-  profile_pref_change_registrar_.Add(
-      prefs::kBraveAdsEnabled,
-      base::Bind(&AdsServiceImpl::OnPrefsChanged,
-                 base::Unretained(this)));
-  profile_pref_change_registrar_.Add(
-      brave_rewards::prefs::kBraveRewardsEnabled,
-      base::Bind(&AdsServiceImpl::OnPrefsChanged,
-                 base::Unretained(this)));
-  profile_pref_change_registrar_.Add(
-      prefs::kBraveAdsIdleThreshold,
-      base::Bind(&AdsServiceImpl::OnPrefsChanged,
-                 base::Unretained(this)));
+
+  profile_pref_change_registrar_.Add(prefs::kEnabled,
+      base::Bind(&AdsServiceImpl::OnPrefsChanged, base::Unretained(this)));
+
+  profile_pref_change_registrar_.Add(brave_rewards::prefs::kBraveRewardsEnabled,
+      base::Bind(&AdsServiceImpl::OnPrefsChanged, base::Unretained(this)));
+
+  profile_pref_change_registrar_.Add(prefs::kIdleThreshold,
+      base::Bind(&AdsServiceImpl::OnPrefsChanged, base::Unretained(this)));
 
   MigratePrefs();
 
@@ -378,6 +375,7 @@ void AdsServiceImpl::OnMaybeStartForRegion(
     return;
   }
 
+  MaybeStartFirstLaunchNotificationTimeoutTimer();
   MaybeShowFirstLaunchNotification();
 
   if (IsAdsEnabled()) {
@@ -483,52 +481,23 @@ void AdsServiceImpl::Start() {
 }
 
 void AdsServiceImpl::MaybeShowFirstLaunchNotification() {
-  #if defined(OS_LINUX)
-    auto ads_enabled = true;
-  #else
-    auto ads_enabled =
-        profile_->GetPrefs()->GetBoolean(prefs::kBraveAdsEnabled);
-  #endif
-
-  auto prefs_migrated_from_62 = profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdsPrefsMigratedFrom62);
-
-  if (!ads_enabled ||
-      !prefs_migrated_from_62 ||
-      !ShouldShowFirstLaunchNotification() ||
-      !profile_->GetPrefs()->GetBoolean(
-          brave_rewards::prefs::kBraveRewardsEnabled)) {
-    MaybeStartFirstLaunchNotificationTimer();
+  if (!ShouldShowFirstLaunchNotification()) {
     return;
   }
 
   auto now = static_cast<uint64_t>(
       (base::Time::Now() - base::Time()).InSeconds());
   profile_->GetPrefs()->SetUint64(
-      prefs::kBraveAdsLaunchNotificationTimestamp, now);
+      prefs::kLastShownFirstLaunchNotificationTimestamp, now);
 
   ShowFirstLaunchNotification();
-
-  StartFirstLaunchNotificationTimer();
 }
 
 bool AdsServiceImpl::ShouldShowFirstLaunchNotification() {
-  return profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdShouldShowFirstLaunchNotification);
-}
+  auto should_show = profile_->GetPrefs()->GetBoolean(
+      prefs::kShouldShowFirstLaunchNotification);
 
-void AdsServiceImpl::RemoveFirstLaunchNotification() {
-  KillTimer(ads_launch_id_);
-
-  auto* rewards_service =
-      brave_rewards::RewardsServiceFactory::GetForProfile(profile_);
-  auto* rewards_notification_service =
-      rewards_service->GetNotificationService();
-  rewards_notification_service->DeleteNotification(
-      kRewardsNotificationAdsLaunch);
-
-  profile_->GetPrefs()->SetBoolean(
-    prefs::kBraveAdsHasRemovedFirstLaunchNotification, true);
+  return !IsAdsEnabled() && should_show;
 }
 
 void AdsServiceImpl::ShowFirstLaunchNotification() {
@@ -544,28 +513,29 @@ void AdsServiceImpl::ShowFirstLaunchNotification() {
       args, kRewardsNotificationAdsLaunch);
 
   profile_->GetPrefs()->SetBoolean(
-    prefs::kBraveAdShouldShowFirstLaunchNotification, false);
+      prefs::kShouldShowFirstLaunchNotification, false);
+
+  StartFirstLaunchNotificationTimeoutTimer();
 }
 
-void AdsServiceImpl::MaybeStartFirstLaunchNotificationTimer() {
-  bool has_removed_notification =
-      profile_->GetPrefs()->GetBoolean(
-          prefs::kBraveAdsHasRemovedFirstLaunchNotification);
+void AdsServiceImpl::MaybeStartFirstLaunchNotificationTimeoutTimer() {
+  bool has_removed = profile_->GetPrefs()->GetBoolean(
+      prefs::kHasRemovedFirstLaunchNotification);
 
-  if (has_removed_notification) {
+  if (has_removed) {
     return;
   }
 
-  StartFirstLaunchNotificationTimer();
+  StartFirstLaunchNotificationTimeoutTimer();
 }
 
-void AdsServiceImpl::StartFirstLaunchNotificationTimer() {
+void AdsServiceImpl::StartFirstLaunchNotificationTimeoutTimer() {
   uint64_t timer_offset_in_seconds;
 
   if (HasFirstLaunchNotificationExpired()) {
     timer_offset_in_seconds = base::Time::kSecondsPerMinute;
   } else {
-    timer_offset_in_seconds = GetFirstLaunchNotificationTimerOffset();
+    timer_offset_in_seconds = GetFirstLaunchNotificationTimeoutTimerOffset();
   }
 
   auto timer_offset = base::TimeDelta::FromSeconds(timer_offset_in_seconds);
@@ -580,22 +550,16 @@ void AdsServiceImpl::StartFirstLaunchNotificationTimer() {
           timer_id));
 }
 
-uint64_t AdsServiceImpl::GetFirstLaunchNotificationTimeout() {
-  const base::CommandLine& command_line =
-      *base::CommandLine::ForCurrentProcess();
-  auto timeout_in_seconds =
-      command_line.HasSwitch(switches::kDebug)
-      ? (5 * base::Time::kSecondsPerMinute)
-      : (base::Time::kMicrosecondsPerWeek /
-         base::Time::kMicrosecondsPerSecond);
-  return timeout_in_seconds;
+void AdsServiceImpl::OnFirstLaunchNotificationTimedOut(uint32_t timer_id) {
+  timers_.erase(timer_id);
+  RemoveFirstLaunchNotification();
 }
 
-uint64_t AdsServiceImpl::GetFirstLaunchNotificationTimerOffset() {
+uint64_t AdsServiceImpl::GetFirstLaunchNotificationTimeoutTimerOffset() {
   auto timeout_in_seconds = GetFirstLaunchNotificationTimeout();
 
   auto timestamp_in_seconds = profile_->GetPrefs()->GetUint64(
-      prefs::kBraveAdsLaunchNotificationTimestamp);
+      prefs::kLastShownFirstLaunchNotificationTimestamp);
 
   auto now_in_seconds = static_cast<uint64_t>(
       (base::Time::Now() - base::Time()).InSeconds());
@@ -610,7 +574,7 @@ bool AdsServiceImpl::HasFirstLaunchNotificationExpired() {
   auto timeout_in_seconds = GetFirstLaunchNotificationTimeout();
 
   auto timestamp_in_seconds = profile_->GetPrefs()->GetUint64(
-      prefs::kBraveAdsLaunchNotificationTimestamp);
+      prefs::kLastShownFirstLaunchNotificationTimestamp);
 
   auto now_in_seconds = static_cast<uint64_t>(
       (base::Time::Now() - base::Time()).InSeconds());
@@ -622,9 +586,46 @@ bool AdsServiceImpl::HasFirstLaunchNotificationExpired() {
   return true;
 }
 
-void AdsServiceImpl::OnFirstLaunchNotificationTimedOut(uint32_t timer_id) {
-  timers_.erase(timer_id);
-  RemoveFirstLaunchNotification();
+uint64_t AdsServiceImpl::GetFirstLaunchNotificationTimeout() {
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  auto timeout_in_seconds =
+      command_line.HasSwitch(switches::kDebug)
+      ? (5 * base::Time::kSecondsPerMinute)
+      : (base::Time::kMicrosecondsPerWeek /
+         base::Time::kMicrosecondsPerSecond);
+  return timeout_in_seconds;
+}
+
+void AdsServiceImpl::RemoveFirstLaunchNotification() {
+  bool has_removed = profile_->GetPrefs()->GetBoolean(
+      prefs::kHasRemovedFirstLaunchNotification);
+
+  if (has_removed) {
+    return;
+  }
+
+  KillTimer(ads_launch_id_);
+
+  auto* rewards_service =
+      brave_rewards::RewardsServiceFactory::GetForProfile(profile_);
+
+  if (!rewards_service) {
+    return;
+  }
+
+  auto* rewards_notification_service =
+      rewards_service->GetNotificationService();
+
+  if (!rewards_notification_service) {
+    return;
+  }
+
+  rewards_notification_service->DeleteNotification(
+      kRewardsNotificationAdsLaunch);
+
+  profile_->GetPrefs()->SetBoolean(
+      prefs::kHasRemovedFirstLaunchNotification, true);
 }
 
 void AdsServiceImpl::Stop() {
@@ -686,7 +687,7 @@ void AdsServiceImpl::Shutdown() {
 
 void AdsServiceImpl::MigratePrefs() const {
   auto source_version = GetPrefsVersion();
-  auto dest_version = prefs::kBraveAdsPrefsCurrentVersion;
+  auto dest_version = prefs::kCurrentVersionNumber;
 
   if (!MigratePrefs(source_version, dest_version, true)) {
     // Migration dry-run failed, so do not migrate preferences
@@ -722,7 +723,8 @@ bool AdsServiceImpl::MigratePrefs(
   static std::map<std::pair<int, int>, void (AdsServiceImpl::*)() const>
       mappings {
     // {{from version, to version}, function}
-    {{1, 2}, &AdsServiceImpl::MigratePrefsVersion1To2}
+    {{1, 2}, &AdsServiceImpl::MigratePrefsVersion1To2},
+    {{2, 3}, &AdsServiceImpl::MigratePrefsVersion2To3}
   };
 
   // Cycle through migration paths, i.e. if upgrading from version 2 to 5 we
@@ -744,9 +746,6 @@ bool AdsServiceImpl::MigratePrefs(
           << from_version << " to " << to_version;
 
       (this->*(mapping->second))();
-
-      profile_->GetPrefs()->SetInteger(prefs::kBraveAdsPrefsVersion,
-          to_version);
     }
 
     from_version++;
@@ -756,6 +755,8 @@ bool AdsServiceImpl::MigratePrefs(
   } while (from_version != to_version);
 
   if (!is_dry_run) {
+    profile_->GetPrefs()->SetInteger(prefs::kVersion, dest_version);
+
     LOG(INFO) << "Successfully migrated Ads preferences from version "
         << source_version << " to " << dest_version;
   }
@@ -766,31 +767,93 @@ bool AdsServiceImpl::MigratePrefs(
 void AdsServiceImpl::MigratePrefsVersion1To2() const {
   DCHECK_EQ(1, GetPrefsVersion()) << "Invalid migration path";
 
-  // Unlike Muon, Ads per day are not configurable in the UI so we can safely
+  // Unlike Muon, ads per day are not configurable in the UI so we can safely
   // migrate to the new value
 
   #if defined(OS_ANDROID)
-    profile_->GetPrefs()->SetUint64(prefs::kBraveAdsPerDay, 12);
+    profile_->GetPrefs()->SetUint64(prefs::kAdsPerDay, 12);
   #else
-    profile_->GetPrefs()->SetUint64(prefs::kBraveAdsPerDay, 20);
+    profile_->GetPrefs()->SetUint64(prefs::kAdsPerDay, 20);
   #endif
 }
 
+void AdsServiceImpl::MigratePrefsVersion2To3() const {
+  DCHECK_EQ(2, GetPrefsVersion()) << "Invalid migration path";
+
+  auto locale = GetAdsLocale();
+  auto region = ads::Ads::GetRegion(locale);
+
+  // Disable ads for unsupported legacy regions due to a bug where ads were
+  // enabled even if the users region was not supported
+  std::vector<std::string> legacy_regions = {
+    "US",  // United States of America
+    "CA",  // Canada
+    "GB",  // United Kingdom (Great Britain and Northern Ireland)
+    "DE",  // Germany
+    "FR"   // France
+  };
+
+  DisableAdsForUnsupportedRegion(region, legacy_regions);
+
+  // On-board users for newly supported regions
+  std::vector<std::string> new_regions = {
+    "AU",  // Australia
+    "NZ",  // New Zealand
+    "IE"   // Ireland
+  };
+
+  MayBeShowFirstLaunchNotificationForSupportedRegion(region, new_regions);
+}
+
 int AdsServiceImpl::GetPrefsVersion() const {
-  return profile_->GetPrefs()->GetInteger(prefs::kBraveAdsPrefsVersion);
+  return profile_->GetPrefs()->GetInteger(prefs::kVersion);
 }
 
 void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
-  if (pref == prefs::kBraveAdsEnabled ||
+  if (pref == prefs::kEnabled ||
       pref == brave_rewards::prefs::kBraveRewardsEnabled) {
     if (IsAdsEnabled()) {
+      RemoveFirstLaunchNotification();
+
       MaybeStart(false);
     } else {
       Stop();
     }
-  } else if (pref == prefs::kBraveAdsIdleThreshold) {
+  } else if (pref == prefs::kIdleThreshold) {
     ResetTimer();
   }
+}
+
+void AdsServiceImpl::DisableAdsForUnsupportedRegion(
+    const std::string& region,
+    const std::vector<std::string>& supported_regions) const {
+  if (std::find(supported_regions.begin(), supported_regions.end(), region)
+      != supported_regions.end()) {
+    return;
+  }
+
+  profile_->GetPrefs()->SetBoolean(prefs::kEnabled, false);
+}
+
+void AdsServiceImpl::MayBeShowFirstLaunchNotificationForSupportedRegion(
+    const std::string& region,
+    const std::vector<std::string>& supported_regions) const {
+  if (IsAdsEnabled()) {
+    return;
+  }
+
+  auto* prefs = profile_->GetPrefs();
+  prefs->SetBoolean(prefs::kHasRemovedFirstLaunchNotification, false);
+  prefs->SetUint64(prefs::kLastShownFirstLaunchNotificationTimestamp, 0);
+
+  if (std::find(supported_regions.begin(), supported_regions.end(), region)
+      == supported_regions.end()) {
+    // Do not show first launch notification for unsupported region
+  prefs->SetBoolean(prefs::kShouldShowFirstLaunchNotification, false);
+    return;
+  }
+
+  prefs->SetBoolean(prefs::kShouldShowFirstLaunchNotification, true);
 }
 
 bool AdsServiceImpl::IsSupportedRegion() const {
@@ -798,61 +861,23 @@ bool AdsServiceImpl::IsSupportedRegion() const {
 }
 
 bool AdsServiceImpl::IsAdsEnabled() const {
-  auto ads_enabled = profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdsEnabled);
-
-  auto prefs_migrated_from_62 = profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdsPrefsMigratedFrom62);
-
-  if (ads_enabled && prefs_migrated_from_62) {
-    // Disable Ads by default when upgrading from 0.62.x to 0.63.x
-    ads_enabled = false;
-
-    profile_->GetPrefs()->SetBoolean(
-        prefs::kBraveAdsEnabled, ads_enabled);
-
-    profile_->GetPrefs()->SetBoolean(
-        prefs::kBraveAdsPrefsMigratedFrom62, false);
-  }
-
-  auto rewards_enabled = profile_->GetPrefs()->GetBoolean(
-      brave_rewards::prefs::kBraveRewardsEnabled);
-
-  return IsSupportedRegion() && ads_enabled && rewards_enabled;
+  return profile_->GetPrefs()->GetBoolean(prefs::kEnabled);
 }
 
 void AdsServiceImpl::SetAdsEnabled(const bool is_enabled) {
-  if (is_enabled) {
-    profile_->GetPrefs()->SetBoolean(
-        prefs::kBraveAdsPrefsMigratedFrom62, false);
-
-    RemoveFirstLaunchNotification();
-  }
-
-  profile_->GetPrefs()->SetBoolean(prefs::kBraveAdsEnabled, is_enabled);
-}
-
-void AdsServiceImpl::MigrateAdsEnabled(const bool is_enabled) {
-  if (profile_->GetPrefs()->GetBoolean(
-      prefs::kBraveAdsEnabledMigrated)) {
-    return;
-  }
-
-  SetAdsEnabled(is_enabled);
-
-  profile_->GetPrefs()->SetBoolean(prefs::kBraveAdsEnabledMigrated, true);
+  profile_->GetPrefs()->SetBoolean(prefs::kEnabled, is_enabled);
 }
 
 uint64_t AdsServiceImpl::GetAdsPerHour() const {
-  return profile_->GetPrefs()->GetUint64(prefs::kBraveAdsPerHour);
+  return profile_->GetPrefs()->GetUint64(prefs::kAdsPerHour);
 }
 
 void AdsServiceImpl::SetAdsPerHour(const uint64_t ads_per_hour) {
-  profile_->GetPrefs()->SetUint64(prefs::kBraveAdsPerHour, ads_per_hour);
+  profile_->GetPrefs()->SetUint64(prefs::kAdsPerHour, ads_per_hour);
 }
 
 uint64_t AdsServiceImpl::GetAdsPerDay() const {
-  return profile_->GetPrefs()->GetUint64(prefs::kBraveAdsPerDay);
+  return profile_->GetPrefs()->GetUint64(prefs::kAdsPerDay);
 }
 
 bool AdsServiceImpl::IsForeground() const {
@@ -894,11 +919,11 @@ void AdsServiceImpl::ClassifyPage(const std::string& url,
 }
 
 int AdsServiceImpl::GetIdleThreshold() {
-  return profile_->GetPrefs()->GetInteger(prefs::kBraveAdsIdleThreshold);
+  return profile_->GetPrefs()->GetInteger(prefs::kIdleThreshold);
 }
 
 void AdsServiceImpl::SetIdleThreshold(const int threshold) {
-  profile_->GetPrefs()->SetInteger(prefs::kBraveAdsIdleThreshold, threshold);
+  profile_->GetPrefs()->SetInteger(prefs::kIdleThreshold, threshold);
 }
 
 bool AdsServiceImpl::IsNotificationsAvailable() const {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -65,7 +65,6 @@ class AdsServiceImpl : public AdsService,
   bool IsSupportedRegion() const override;
 
   void SetAdsEnabled(const bool is_enabled) override;
-  void MigrateAdsEnabled(const bool is_enabled) override;
 
   void SetAdsPerHour(const uint64_t ads_per_hour) override;
 
@@ -190,14 +189,24 @@ class AdsServiceImpl : public AdsService,
   void OnSaved(const ads::OnSaveCallback& callback, bool success);
   void OnReset(const ads::OnResetCallback& callback, bool success);
   void OnTimer(uint32_t timer_id);
+
   void MigratePrefs() const;
   bool MigratePrefs(
       const int source_version,
       const int dest_version,
       const bool is_dry_run = false) const;
   void MigratePrefsVersion1To2() const;
+  void MigratePrefsVersion2To3() const;
   int GetPrefsVersion() const;
   void OnPrefsChanged(const std::string& pref);
+
+  void DisableAdsForUnsupportedRegion(
+    const std::string& region,
+    const std::vector<std::string>& regions) const;
+  void MayBeShowFirstLaunchNotificationForSupportedRegion(
+    const std::string& region,
+    const std::vector<std::string>& regions) const;
+
   void OnCreate();
   void OnInitialize();
   void MaybeStart(bool should_restart);
@@ -207,16 +216,17 @@ class AdsServiceImpl : public AdsService,
   void NotificationTimedOut(
       uint32_t timer_id,
       const std::string& notification_id);
+
   void MaybeShowFirstLaunchNotification();
   bool ShouldShowFirstLaunchNotification();
-  void RemoveFirstLaunchNotification();
   void ShowFirstLaunchNotification();
-  void MaybeStartFirstLaunchNotificationTimer();
-  void StartFirstLaunchNotificationTimer();
-  uint64_t GetFirstLaunchNotificationTimeout();
-  uint64_t GetFirstLaunchNotificationTimerOffset();
-  bool HasFirstLaunchNotificationExpired();
+  void MaybeStartFirstLaunchNotificationTimeoutTimer();
+  void StartFirstLaunchNotificationTimeoutTimer();
   void OnFirstLaunchNotificationTimedOut(uint32_t timer_id);
+  uint64_t GetFirstLaunchNotificationTimeoutTimerOffset();
+  bool HasFirstLaunchNotificationExpired();
+  uint64_t GetFirstLaunchNotificationTimeout();
+  void RemoveFirstLaunchNotification();
 
   uint32_t next_timer_id();
 

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -9,26 +9,22 @@ namespace brave_ads {
 
 namespace prefs {
 
-const char kBraveAdsEnabled[] = "brave.brave_ads.enabled";
+const char kEnabled[] = "brave.brave_ads.enabled";
 
-const char kBraveAdsPerHour[] = "brave.brave_ads.ads_per_hour";
-const char kBraveAdsPerDay[] = "brave.brave_ads.ads_per_day";
-const char kBraveAdsIdleThreshold[] = "brave.brave_ads.idle_threshold";
+const char kAdsPerHour[] = "brave.brave_ads.ads_per_hour";
+const char kAdsPerDay[] = "brave.brave_ads.ads_per_day";
 
-const char kBraveAdShouldShowFirstLaunchNotification[] =
+const char kIdleThreshold[] = "brave.brave_ads.idle_threshold";
+
+const char kShouldShowFirstLaunchNotification[] =
     "brave.brave_ads.should_show_first_launch_notification";
-const char kBraveAdsLaunchNotificationTimestamp[] =
-    "brave.brave_ads.launch_notification_timestamp";
-const char kBraveAdsHasRemovedFirstLaunchNotification[] =
+const char kHasRemovedFirstLaunchNotification[] =
     "brave.brave_ads.has_removed_first_launch_notification";
+const char kLastShownFirstLaunchNotificationTimestamp[] =
+    "brave.brave_ads.launch_notification_timestamp";
 
-const int kBraveAdsPrefsDefaultVersion = 1;
-const int kBraveAdsPrefsCurrentVersion = 2;
-const char kBraveAdsPrefsVersion[] = "brave.brave_ads.prefs.version";
-const char kBraveAdsPrefsMigratedFrom62[] =
-    "brave.brave_ads.prefs.migrated.from_0_62.x";
-const char kBraveAdsEnabledMigrated[] =
-    "brave.brave_ads.prefs.enabled_migrated";
+const int kCurrentVersionNumber = 3;
+const char kVersion[] = "brave.brave_ads.prefs.version";
 
 }  // namespace prefs
 

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -10,20 +10,19 @@ namespace brave_ads {
 
 namespace prefs {
 
-extern const char kBraveAdsEnabled[];
-extern const char kBraveAdsPerHour[];
-extern const char kBraveAdsPerDay[];
-extern const char kBraveAdsIdleThreshold[];
+extern const char kEnabled[];
 
-extern const char kBraveAdShouldShowFirstLaunchNotification[];
-extern const char kBraveAdsLaunchNotificationTimestamp[];
-extern const char kBraveAdsHasRemovedFirstLaunchNotification[];
+extern const char kAdsPerHour[];
+extern const char kAdsPerDay[];
 
-extern const int kBraveAdsPrefsDefaultVersion;
-extern const int kBraveAdsPrefsCurrentVersion;
-extern const char kBraveAdsPrefsVersion[];
-extern const char kBraveAdsPrefsMigratedFrom62[];
-extern const char kBraveAdsEnabledMigrated[];
+extern const char kIdleThreshold[];
+
+extern const char kShouldShowFirstLaunchNotification[];
+extern const char kHasRemovedFirstLaunchNotification[];
+extern const char kLastShownFirstLaunchNotificationTimestamp[];
+
+extern const int kCurrentVersionNumber;
+extern const char kVersion[];
 
 }  // namespace prefs
 

--- a/vendor/bat-native-ads/README.md
+++ b/vendor/bat-native-ads/README.md
@@ -36,6 +36,12 @@ static bool IsSupportedRegion(
     const std::string& locale)
 ```
 
+`GetRegion` should be called to get the region for the specified locale
+```
+static std::string GetRegion(
+    const std::string& locale)
+```
+
 `OnForeground` should be called when the browser enters the foreground
 ```
 void OnForeground()

--- a/vendor/bat-native-ads/include/bat/ads/ads.h
+++ b/vendor/bat-native-ads/include/bat/ads/ads.h
@@ -41,6 +41,9 @@ class ADS_EXPORT Ads {
   // Should be called to determine if Ads are supported for the specified locale
   static bool IsSupportedRegion(const std::string& locale);
 
+  // Should be called to get the region for the specified locale
+  static std::string GetRegion(const std::string& locale);
+
   // Should be called when Ads are enabled or disabled on the Client
   virtual void Initialize() = 0;
 

--- a/vendor/bat-native-ads/resources/bat_ads_resources.grd
+++ b/vendor/bat-native-ads/resources/bat_ads_resources.grd
@@ -11,9 +11,9 @@
       <include name="IDR_ADS_CATALOG_SCHEMA" file="catalog-schema.json" type="BINDATA" />
       <include name="IDR_ADS_BUNDLE_SCHEMA" file="bundle-schema.json" type="BINDATA" />
       <include name="IDR_ADS_SAMPLE_BUNDLE" file="sample_bundle.json" type="BINDATA" />
+      <include name="IDR_ADS_USER_MODEL_EN" file="locales/en/user_model.json" type="BINDATA" />
       <include name="IDR_ADS_USER_MODEL_DE" file="locales/de/user_model.json" type="BINDATA" />
       <include name="IDR_ADS_USER_MODEL_FR" file="locales/fr/user_model.json" type="BINDATA" />
-      <include name="IDR_ADS_USER_MODEL_EN" file="locales/en/user_model.json" type="BINDATA" />
     </includes>
   </release>
 </grit>

--- a/vendor/bat-native-ads/src/bat/ads/ads.cc
+++ b/vendor/bat-native-ads/src/bat/ads/ads.cc
@@ -27,13 +27,26 @@ Ads* Ads::CreateInstance(AdsClient* ads_client) {
 bool Ads::IsSupportedRegion(const std::string& locale) {
   auto region = helper::Locale::GetCountryCode(locale);
 
-  auto supported_regions = {"US", "CA", "DE", "FR", "GB"};
-  if (std::find(supported_regions.begin(), supported_regions.end(), region)
-      == supported_regions.end()) {
+  std::vector<std::string> regions = {
+    "US",  // United States of America
+    "CA",  // Canada
+    "GB",  // United Kingdom (Great Britain and Northern Ireland)
+    "DE",  // Germany
+    "FR",  // France
+    "AU",  // Australia
+    "NZ",  // New Zealand
+    "IE"   // Ireland
+  };
+
+  if (std::find(regions.begin(), regions.end(), region) == regions.end()) {
     return false;
   }
 
   return true;
+}
+
+std::string Ads::GetRegion(const std::string& locale) {
+  return helper::Locale::GetCountryCode(locale);
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -82,7 +82,8 @@ void AdsImpl::Initialize() {
 void AdsImpl::InitializeStep2() {
   client_->SetLocales(ads_client_->GetLocales());
 
-  LoadUserModel();
+  auto locale = ads_client_->GetAdsLocale();
+  ChangeLocale(locale);
 }
 
 void AdsImpl::InitializeStep3() {
@@ -148,35 +149,39 @@ bool AdsImpl::IsInitialized() {
 
 void AdsImpl::LoadUserModel() {
   auto locale = client_->GetLocale();
+
   auto callback = std::bind(&AdsImpl::OnUserModelLoaded, this, _1, _2);
   ads_client_->LoadUserModelForLocale(locale, callback);
 }
 
 void AdsImpl::OnUserModelLoaded(const Result result, const std::string& json) {
-  if (result != SUCCESS) {
-    BLOG(ERROR) << "Failed to load user model";
+  auto locale = client_->GetLocale();
 
+  if (result != SUCCESS) {
+    BLOG(ERROR) << "Failed to load user model for " << locale << " locale";
     return;
   }
 
-  BLOG(INFO) << "Successfully loaded user model";
+  BLOG(INFO) << "Successfully loaded user model for " << locale << " locale";
 
-  InitializeUserModel(json);
+  InitializeUserModel(json, locale);
 
   if (!IsInitialized()) {
     InitializeStep3();
   }
 }
 
-void AdsImpl::InitializeUserModel(const std::string& json) {
+void AdsImpl::InitializeUserModel(
+    const std::string& json,
+    const std::string& locale) {
   // TODO(Terry Mancey): Refactor function to use callbacks
 
-  BLOG(INFO) << "Initializing user model";
+  BLOG(INFO) << "Initializing \"" << locale << "\" user model";
 
   user_model_.reset(usermodel::UserModel::CreateInstance());
   user_model_->InitializePageClassifier(json);
 
-  BLOG(INFO) << "Initialized user model";
+  BLOG(INFO) << "Initialized \"" << locale << "\" user model";
 }
 
 bool AdsImpl::IsMobile() const {
@@ -348,29 +353,18 @@ void AdsImpl::SetConfirmationsIsReady(const bool is_ready) {
 }
 
 void AdsImpl::ChangeLocale(const std::string& locale) {
-  if (!IsInitialized()) {
-    BLOG(WARNING) << "Failed to change locale as not initialized";
-    return;
-  }
+  auto language_code = helper::Locale::GetLanguageCode(locale);
 
   auto locales = ads_client_->GetLocales();
-
-  if (std::find(locales.begin(), locales.end(), locale) != locales.end()) {
-    BLOG(INFO) << "Change Localed to " << locale;
-    client_->SetLocale(locale);
+  if (std::find(locales.begin(), locales.end(), language_code)
+      != locales.end()) {
+    BLOG(INFO) << "Changed locale to " << language_code;
+    client_->SetLocale(language_code);
   } else {
-    std::string closest_match_for_locale = "";
-    auto language_code = helper::Locale::GetLanguageCode(locale);
-    if (std::find(locales.begin(), locales.end(),
-        language_code) != locales.end()) {
-      closest_match_for_locale = language_code;
-    } else {
-      closest_match_for_locale = kDefaultLanguageCode;
-    }
+    BLOG(INFO) << language_code << " locale not found, so changed locale to "
+        << kDefaultLanguageCode;
 
-    BLOG(INFO) << "Locale not found, so changed Locale to closest match: "
-        << closest_match_for_locale;
-    client_->SetLocale(closest_match_for_locale);
+    client_->SetLocale(kDefaultLanguageCode);
   }
 
   LoadUserModel();
@@ -696,9 +690,6 @@ void AdsImpl::ServeAdFromCategory(const std::string& category) {
 
     return;
   }
-
-  auto locale = ads_client_->GetAdsLocale();
-  auto region = helper::Locale::GetCountryCode(locale);
 
   auto callback = std::bind(&AdsImpl::OnGetAds, this, _1, _2, _3);
   ads_client_->GetAds(category, callback);

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
@@ -49,7 +49,7 @@ class AdsImpl : public Ads {
 
   void LoadUserModel();
   void OnUserModelLoaded(const Result result, const std::string& json);
-  void InitializeUserModel(const std::string& json);
+  void InitializeUserModel(const std::string& json, const std::string& region);
 
   bool IsMobile() const;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/locale_helper.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/locale_helper.cc
@@ -15,14 +15,24 @@
 namespace helper {
 
 const std::string Locale::GetLanguageCode(const std::string& locale) {
-  std::vector<std::string> locale_components = base::SplitString(locale, "_",
+  std::vector<std::string> locale_components = base::SplitString(locale, ".",
       base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 
   if (locale_components.size() == 0) {
     return ads::kDefaultLanguageCode;
   }
 
-  auto language_code = locale_components.front();
+  auto normalized_locale = locale_components.front();
+  std::replace(normalized_locale.begin(), normalized_locale.end(), '-', '_');
+
+  std::vector<std::string> components = base::SplitString(
+      normalized_locale, "_", base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
+
+  if (components.size() == 0) {
+    return ads::kDefaultLanguageCode;
+  }
+
+  auto language_code = components.front();
   return language_code;
 }
 
@@ -37,14 +47,14 @@ const std::string Locale::GetCountryCode(const std::string& locale) {
   auto normalized_locale = locale_components.front();
   std::replace(normalized_locale.begin(), normalized_locale.end(), '-', '_');
 
-  std::vector<std::string> country_code_components = base::SplitString(
+  std::vector<std::string> components = base::SplitString(
       normalized_locale, "_", base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
 
-  if (country_code_components.size() != 2) {
+  if (components.size() != 2) {
     return ads::kDefaultCountryCode;
   }
 
-  auto country_code = country_code_components.at(1);
+  auto country_code = components.at(1);
   return country_code;
 }
 

--- a/vendor/bat-native-ads/test/data/client.json
+++ b/vendor/bat-native-ads/test/data/client.json
@@ -1,27 +1,30 @@
 {
-  "adsShownHistory": [
-  ],
-  "adUUID": "",
-  "adsUUIDSeen": {
-  },
-  "available": false,
-  "lastSearchTime": 0,
-  "lastShopTime": 0,
-  "lastUserActivity": 0,
   "lastUserIdleStopTime": 0,
-  "locale": "en",
+  "creativeSetHistory": {
+  },
+  "lastShopTime": 0,
+  "campaignHistory": {
+  },
+  "last_page_classification": "",
   "locales": [
+    "en",
+    "de",
+    "fr"
   ],
   "pageScoreHistory": [
   ],
-  "creativeSetHistory": {
+  "adsUUIDSeen": {
   },
-  "campaignHistory": {
-  },
-  "score": 0,
+  "adUUID": "",
+  "locale": "en",
+  "lastUserActivity": 0,
   "searchActivity": false,
   "searchUrl": "",
+  "lastSearchTime": 0,
   "shopActivity": false,
+  "available": true,
   "shopUrl": "",
-  "status": ""
+  "adsShownHistory": [
+  ],
+  "score": 0
 }


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5153

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm Brave ads work as expected in the United States of America, Canada, United Kingdom, Germany, France, Australia, New Zealand and Ireland
- Confirm Brave ads are not supported in all other regions
- Confirm Ads switch and "Brave Ads have arrived!" on-boarding notification are working as expected for upgrade paths from 0.62.x where Rewards and Ads are both disabled
- Confirm Ads switch and "Brave Ads have arrived!" on-boarding notification are working as expected for upgrade paths from 0.62.x where Rewards and Ads are both enabled
- Confirm Ads switch and "Brave Ads have arrived!" on-boarding notification are working as expected for upgrade paths from 0.62.x where Rewards is enabled and Ads is disabled
- Confirm Ads switch and "Brave Ads have arrived!" on-boarding notification are working as expected for upgrade paths from 0.68.x where Rewards and Ads are both disabled
- Confirm Ads switch and "Brave Ads have arrived!" on-boarding notification are working as expected for upgrade paths from 0.68.x where Rewards and Ads are both enabled
- Confirm Ads switch and "Brave Ads have arrived!" on-boarding notification are working as expected for upgrade paths from 0.68.x where Rewards is enabled and Ads is disabled

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
