### PR TITLE
Fix ad notifications received this month should not include transaction count from server - 0.68.x

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
@@ -290,11 +290,8 @@ void AdsRewards::Update() {
       confirmations_->GetNextTokenRedemptionDateInSeconds());
   uint64_t next_payment_date_in_seconds = next_payment_date.ToDoubleT();
 
-  auto ad_notifications_received_this_month =
-      payments_->GetTransactionCountForMonth(now);
-
   confirmations_->UpdateAdsRewards(estimated_pending_rewards,
-      next_payment_date_in_seconds, ad_notifications_received_this_month);
+      next_payment_date_in_seconds);
 }
 
 double AdsRewards::CalculateEstimatedPendingRewards() const {

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -55,8 +55,7 @@ class ConfirmationsImpl : public Confirmations {
 
   void UpdateAdsRewards(
       const double estimated_pending_rewards,
-      const uint64_t next_payment_date_in_seconds,
-      const uint64_t ad_notifications_received_this_month);
+      const uint64_t next_payment_date_in_seconds);
 
   // Transaction history
   void GetTransactionHistory(
@@ -71,6 +70,7 @@ class ConfirmationsImpl : public Confirmations {
   std::vector<TransactionInfo> GetTransactionHistory(
       const uint64_t from_timestamp_in_seconds,
       const uint64_t to_timestamp_in_seconds);
+  std::vector<TransactionInfo> GetTransactions() const;
   std::vector<TransactionInfo> GetUnredeemedTransactions();
   void AppendTransactionToHistory(
       const double estimated_redemption_value,
@@ -124,7 +124,6 @@ class ConfirmationsImpl : public Confirmations {
   // Ads rewards
   double estimated_pending_rewards_;
   uint64_t next_payment_date_in_seconds_;
-  uint64_t ad_notifications_received_this_month_;
   std::unique_ptr<AdsRewards> ads_rewards_;
 
   // Refill tokens


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5119
Uplift request for https://github.com/brave/brave-core/pull/2851