### PR TITLE
Fix ad notifications received this month should not include transaction count from server - 0.67.x

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
@@ -291,11 +291,8 @@ void AdsRewards::Update() {
       confirmations_->GetNextTokenRedemptionDateInSeconds());
   uint64_t next_payment_date_in_seconds = next_payment_date.ToDoubleT();
 
-  auto ad_notifications_received_this_month =
-      payments_->GetTransactionCountForMonth(now);
-
   confirmations_->UpdateAdsRewards(estimated_pending_rewards,
-      next_payment_date_in_seconds, ad_notifications_received_this_month);
+      next_payment_date_in_seconds);
 }
 
 double AdsRewards::CalculateEstimatedPendingRewards() const {

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -36,7 +36,6 @@ ConfirmationsImpl::ConfirmationsImpl(
     unblinded_payment_tokens_(std::make_unique<UnblindedTokens>(this)),
     estimated_pending_rewards_(0.0),
     next_payment_date_in_seconds_(0),
-    ad_notifications_received_this_month_(0),
     ads_rewards_(std::make_unique<AdsRewards>(this, confirmations_client)),
     retry_getting_signed_tokens_timer_id_(0),
     refill_tokens_(std::make_unique<RefillTokens>(
@@ -837,8 +836,7 @@ void ConfirmationsImpl::UpdateAdsRewards(const bool should_refresh) {
 
 void ConfirmationsImpl::UpdateAdsRewards(
     const double estimated_pending_rewards,
-    const uint64_t next_payment_date_in_seconds,
-    const uint64_t ad_notifications_received_this_month) {
+    const uint64_t next_payment_date_in_seconds) {
   if (!state_has_loaded_) {
     // We should not update ads rewards until state has successfully loaded
     // otherwise our values will be overwritten
@@ -847,7 +845,6 @@ void ConfirmationsImpl::UpdateAdsRewards(
 
   estimated_pending_rewards_ = estimated_pending_rewards;
   next_payment_date_in_seconds_ = next_payment_date_in_seconds;
-  ad_notifications_received_this_month_ = ad_notifications_received_this_month;
 
   SaveState();
 
@@ -857,13 +854,12 @@ void ConfirmationsImpl::UpdateAdsRewards(
 void ConfirmationsImpl::GetTransactionHistory(
     OnGetTransactionHistory callback) {
   auto unredeemed_transactions = GetUnredeemedTransactions();
-
   double unredeemed_estimated_pending_rewards =
       GetEstimatedPendingRewardsForTransactions(unredeemed_transactions);
 
-  uint64_t unredeemed_ad_notifications_received_this_month =
-      GetAdNotificationsReceivedThisMonthForTransactions(
-          unredeemed_transactions);
+  auto all_transactions = GetTransactions();
+  uint64_t ad_notifications_received_this_month =
+      GetAdNotificationsReceivedThisMonthForTransactions(all_transactions);
 
   auto transactions_info = std::make_unique<TransactionsInfo>();
 
@@ -874,8 +870,7 @@ void ConfirmationsImpl::GetTransactionHistory(
       next_payment_date_in_seconds_;
 
   transactions_info->ad_notifications_received_this_month =
-      ad_notifications_received_this_month_ +
-          unredeemed_ad_notifications_received_this_month;
+      ad_notifications_received_this_month;
 
   auto to_timestamp_in_seconds = Time::NowInSeconds();
   auto transactions = GetTransactionHistory(0, to_timestamp_in_seconds);
@@ -893,9 +888,6 @@ void ConfirmationsImpl::AddTransactionsToPendingRewards(
     const std::vector<TransactionInfo>& transactions) {
   estimated_pending_rewards_ +=
       GetEstimatedPendingRewardsForTransactions(transactions);
-
-  ad_notifications_received_this_month_ +=
-      GetAdNotificationsReceivedThisMonthForTransactions(transactions);
 
   confirmations_client_->ConfirmationsTransactionHistoryDidChange();
 }
@@ -916,7 +908,7 @@ double ConfirmationsImpl::GetEstimatedPendingRewardsForTransactions(
 
 uint64_t ConfirmationsImpl::GetAdNotificationsReceivedThisMonthForTransactions(
     const std::vector<TransactionInfo>& transactions) const {
-  double ad_notifications_received_this_month = 0.0;
+  uint64_t ad_notifications_received_this_month = 0;
 
   auto now = base::Time::Now();
   base::Time::Exploded now_exploded;
@@ -954,6 +946,10 @@ std::vector<TransactionInfo> ConfirmationsImpl::GetTransactionHistory(
   transactions.resize(std::distance(transactions.begin(), it));
 
   return transactions;
+}
+
+std::vector<TransactionInfo> ConfirmationsImpl::GetTransactions() const {
+  return transaction_history_;
 }
 
 std::vector<TransactionInfo> ConfirmationsImpl::GetUnredeemedTransactions() {

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -54,8 +54,7 @@ class ConfirmationsImpl : public Confirmations {
 
   void UpdateAdsRewards(
       const double estimated_pending_rewards,
-      const uint64_t next_payment_date_in_seconds,
-      const uint64_t ad_notifications_received_this_month);
+      const uint64_t next_payment_date_in_seconds);
 
   // Transaction history
   void GetTransactionHistory(
@@ -70,6 +69,7 @@ class ConfirmationsImpl : public Confirmations {
   std::vector<TransactionInfo> GetTransactionHistory(
       const uint64_t from_timestamp_in_seconds,
       const uint64_t to_timestamp_in_seconds);
+  std::vector<TransactionInfo> GetTransactions() const;
   std::vector<TransactionInfo> GetUnredeemedTransactions();
   void AppendTransactionToHistory(
       const double estimated_redemption_value,
@@ -124,7 +124,6 @@ class ConfirmationsImpl : public Confirmations {
   // Ads rewards
   double estimated_pending_rewards_;
   uint64_t next_payment_date_in_seconds_;
-  uint64_t ad_notifications_received_this_month_;
   std::unique_ptr<AdsRewards> ads_rewards_;
 
   // Refill tokens


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5119
Uplift request for https://github.com/brave/brave-core/pull/2851