### PR TITLE
Untie more network callbacks from net::URLRequest

### DIFF
--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -336,7 +336,7 @@ void BraveNetworkDelegateBase::RunNextCallback(
       brave::ResponseCallback next_callback =
           base::Bind(&BraveNetworkDelegateBase::RunNextCallback,
                      base::Unretained(this), request, ctx);
-      rv = callback.Run(request, ctx->headers, next_callback, ctx);
+      rv = callback.Run(ctx->headers, next_callback, ctx);
       if (rv == net::ERR_IO_PENDING) {
         return;
       }
@@ -351,7 +351,7 @@ void BraveNetworkDelegateBase::RunNextCallback(
       brave::ResponseCallback next_callback =
           base::Bind(&BraveNetworkDelegateBase::RunNextCallback,
                      base::Unretained(this), request, ctx);
-      rv = callback.Run(request, ctx->original_response_headers,
+      rv = callback.Run(ctx->original_response_headers,
                         ctx->override_response_headers,
                         ctx->allowed_unsafe_redirect_url, next_callback, ctx);
       if (rv == net::ERR_IO_PENDING) {

--- a/browser/net/brave_referrals_network_delegate_helper.cc
+++ b/browser/net/brave_referrals_network_delegate_helper.cc
@@ -16,7 +16,6 @@
 namespace brave {
 
 int OnBeforeStartTransaction_ReferralsWork(
-    net::URLRequest* request,
     net::HttpRequestHeaders* headers,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx) {

--- a/browser/net/brave_referrals_network_delegate_helper.h
+++ b/browser/net/brave_referrals_network_delegate_helper.h
@@ -20,7 +20,6 @@ class URLRequest;
 namespace brave {
 
 int OnBeforeStartTransaction_ReferralsWork(
-    net::URLRequest* request,
     net::HttpRequestHeaders* headers,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_referrals_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_referrals_network_delegate_helper_unittest.cc
@@ -91,7 +91,7 @@ TEST_F(BraveReferralsNetworkDelegateHelperTest,
                                               brave_request_info);
   brave_request_info->referral_headers_list = referral_headers_list;
   int ret = brave::OnBeforeStartTransaction_ReferralsWork(
-      request.get(), &headers, callback, brave_request_info);
+      &headers, callback, brave_request_info);
 
   std::string partner_header;
   headers.GetHeader("X-Brave-Partner", &partner_header);
@@ -125,7 +125,7 @@ TEST_F(BraveReferralsNetworkDelegateHelperTest,
       new brave::BraveRequestInfo());
   brave_request_info->referral_headers_list = referral_headers_list;
   int ret = brave::OnBeforeStartTransaction_ReferralsWork(
-      request.get(), &headers, callback, brave_request_info);
+      &headers, callback, brave_request_info);
 
   EXPECT_FALSE(headers.HasHeader("X-Brave-Partner"));
 

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -72,7 +72,7 @@ void CheckForCookieOverride(const GURL& url, const URLPattern& pattern,
 }
 
 bool IsBlockTwitterSiteHack(std::shared_ptr<BraveRequestInfo> ctx,
-    net::HttpRequestHeaders* headers) {
+                            net::HttpRequestHeaders* headers) {
   URLPattern redirectURLPattern(URLPattern::SCHEME_ALL, kTwitterRedirectURL);
   URLPattern referrerPattern(URLPattern::SCHEME_ALL, kTwitterReferrer);
   if (redirectURLPattern.MatchesURL(ctx->request_url)) {
@@ -85,10 +85,10 @@ bool IsBlockTwitterSiteHack(std::shared_ptr<BraveRequestInfo> ctx,
   return false;
 }
 
-int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
-        net::HttpRequestHeaders* headers,
-        const ResponseCallback& next_callback,
-        std::shared_ptr<BraveRequestInfo> ctx) {
+int OnBeforeStartTransaction_SiteHacksWork(
+    net::HttpRequestHeaders* headers,
+    const ResponseCallback& next_callback,
+    std::shared_ptr<BraveRequestInfo> ctx) {
   CheckForCookieOverride(ctx->request_url,
       URLPattern(URLPattern::SCHEME_ALL, kForbesPattern), headers,
       kForbesExtraCookies);

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -17,7 +17,7 @@ int OnBeforeURLRequest_SiteHacksWork(
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 
-int OnBeforeStartTransaction_SiteHacksWork(net::URLRequest* request,
+int OnBeforeStartTransaction_SiteHacksWork(
     net::HttpRequestHeaders* headers,
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);

--- a/browser/net/brave_site_hacks_network_delegate_helper.h
+++ b/browser/net/brave_site_hacks_network_delegate_helper.h
@@ -1,9 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_H_
-#define BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_H_
+#ifndef BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_HELPER_H_
+#define BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_HELPER_H_
+
+#include <memory>
 
 #include "brave/browser/net/url_context.h"
 
@@ -24,4 +27,4 @@ int OnBeforeStartTransaction_SiteHacksWork(
 
 }  // namespace brave
 
-#endif  // BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_H_
+#endif  // BRAVE_BROWSER_NET_BRAVE_SITE_HACKS_NETWORK_DELEGATE_HELPER_H_

--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -47,7 +47,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithCookieHeader) {
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
       brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
       &headers, callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -68,7 +68,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, ForbesWithoutCookieHeader) {
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
       brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
       &headers, callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -90,7 +90,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NotForbesNoCookieChange) {
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
       brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
       &headers, callback, brave_request_info);
   std::string cookies;
   headers.GetHeader(kCookieHeader, &cookies);
@@ -111,7 +111,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NoScriptTwitterMobileRedirect) {
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
       brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
       &headers, callback, brave_request_info);
   EXPECT_EQ(ret, net::ERR_ABORTED);
 }
@@ -130,7 +130,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest,
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
       brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
       &headers, callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
@@ -148,7 +148,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, TwitterNoCancelWithReferer) {
   brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
       brave_request_info);
   brave::ResponseCallback callback;
-  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+  int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
       &headers, callback, brave_request_info);
   EXPECT_EQ(ret, net::OK);
 }
@@ -187,7 +187,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, UAWhitelistedTest) {
     brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
         brave_request_info);
     brave::ResponseCallback callback;
-    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
         &headers, callback, brave_request_info);
     std::string user_agent;
     headers.GetHeader(kUserAgentHeader, &user_agent);
@@ -219,7 +219,7 @@ TEST_F(BraveSiteHacksNetworkDelegateHelperTest, NOTUAWhitelistedTest) {
     brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
         brave_request_info);
     brave::ResponseCallback callback;
-    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(request.get(),
+    int ret = brave::OnBeforeStartTransaction_SiteHacksWork(
         &headers, callback, brave_request_info);
     std::string user_agent;
     headers.GetHeader(kUserAgentHeader, &user_agent);

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -15,18 +15,24 @@
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
+#include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile_io_data.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/browser/resource_request_info.h"
-#include "extensions/browser/info_map.h"
 #include "net/base/upload_bytes_element_reader.h"
 #include "net/base/upload_data_stream.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
+#include "extensions/browser/info_map.h"
+#endif
 
 namespace brave {
 
 namespace {
+
 bool IsWebTorrentDisabled(content::ResourceContext* resource_context) {
+#if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
   DCHECK(resource_context);
 
   const ProfileIOData* io_data =
@@ -42,6 +48,9 @@ bool IsWebTorrentDisabled(content::ResourceContext* resource_context) {
 
   return !infoMap->extensions().Contains(brave_webtorrent_extension_id) ||
     infoMap->disabled_extensions().Contains(brave_webtorrent_extension_id);
+#else
+  return true;
+#endif  // BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
 }
 
 std::string GetUploadDataFromURLRequest(const net::URLRequest* request) {

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -20,6 +20,8 @@
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/browser/resource_request_info.h"
 #include "extensions/browser/info_map.h"
+#include "net/base/upload_bytes_element_reader.h"
+#include "net/base/upload_data_stream.h"
 
 namespace brave {
 
@@ -41,6 +43,32 @@ bool IsWebTorrentDisabled(content::ResourceContext* resource_context) {
   return !infoMap->extensions().Contains(brave_webtorrent_extension_id) ||
     infoMap->disabled_extensions().Contains(brave_webtorrent_extension_id);
 }
+
+std::string GetUploadDataFromURLRequest(const net::URLRequest* request) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+  if (!request->has_upload())
+    return {};
+
+  const net::UploadDataStream* stream = request->get_upload();
+  if (!stream->GetElementReaders())
+    return {};
+
+  const auto* element_readers = stream->GetElementReaders();
+  if (element_readers->empty())
+    return {};
+
+  std::string upload_data;
+  for (const auto& element_reader : *element_readers) {
+    const net::UploadBytesElementReader* reader =
+        element_reader->AsBytesReader();
+    if (!reader) {
+      return {};
+    }
+    upload_data.append(reader->bytes(), reader->length());
+  }
+  return upload_data;
+}
+
 }  // namespace
 
 BraveRequestInfo::BraveRequestInfo() = default;
@@ -101,6 +129,8 @@ void BraveRequestInfo::FillCTXFromRequest(const net::URLRequest* request,
   ctx->allow_referrers = brave_shields::IsAllowContentSettingFromIO(
       request, ctx->tab_origin, ctx->tab_origin, CONTENT_SETTINGS_TYPE_PLUGINS,
       brave_shields::kReferrers);
+
+  ctx->upload_data = GetUploadDataFromURLRequest(request);
 
   ctx->request = request;
 }

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -131,8 +131,6 @@ void BraveRequestInfo::FillCTXFromRequest(const net::URLRequest* request,
       brave_shields::kReferrers);
 
   ctx->upload_data = GetUploadDataFromURLRequest(request);
-
-  ctx->request = request;
 }
 
 }  // namespace brave

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -67,6 +67,7 @@ struct BraveRequestInfo {
   bool allow_3p_cookies = false;
   bool allow_referrers = false;
   bool allow_google_auth = true;
+  bool is_webtorrent_disabled = false;
   int render_process_id = 0;
   int render_frame_id = 0;
   int frame_tree_node_id = 0;

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -103,9 +103,6 @@ struct BraveRequestInfo {
       std::shared_ptr<brave::BraveRequestInfo> ctx);
   friend class ::BraveNetworkDelegateBase;
 
-  // Don't use this directly after any dispatch
-  // request is deprecated, do not use it.
-  const net::URLRequest* request;
   GURL* new_url = nullptr;
 
   DISALLOW_COPY_AND_ASSIGN(BraveRequestInfo);
@@ -116,12 +113,12 @@ using OnBeforeURLRequestCallback =
     base::Callback<int(const ResponseCallback& next_callback,
         std::shared_ptr<BraveRequestInfo> ctx)>;
 using OnBeforeStartTransactionCallback =
-    base::Callback<int(net::URLRequest* request,
+    base::Callback<int(
         net::HttpRequestHeaders* headers,
         const ResponseCallback& next_callback,
         std::shared_ptr<BraveRequestInfo> ctx)>;
 using OnHeadersReceivedCallback =
-    base::Callback<int(net::URLRequest* request,
+    base::Callback<int(
         const net::HttpResponseHeaders* original_response_headers,
         scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
         GURL* allowed_unsafe_redirect_url,

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -87,6 +87,8 @@ struct BraveRequestInfo {
       static_cast<content::ResourceType>(-1);
   content::ResourceType resource_type = kInvalidResourceType;
 
+  std::string upload_data;
+
   static void FillCTXFromRequest(const net::URLRequest* request,
     std::shared_ptr<brave::BraveRequestInfo> ctx);
 

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -1,4 +1,4 @@
-﻿/* Copyright 2019 The Brave Authors. All rights reserved.
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The Brave Authors. All rights reserved.
+﻿/* Copyright 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -12,9 +12,6 @@
 #include "base/strings/string_util.h"
 #include "brave/common/network_constants.h"
 #include "brave/common/extensions/extension_constants.h"
-#include "chrome/browser/profiles/profile_io_data.h"
-#include "content/public/browser/resource_request_info.h"
-#include "extensions/browser/info_map.h"
 #include "extensions/common/constants.h"
 #include "net/http/http_content_disposition.h"
 #include "net/http/http_response_headers.h"
@@ -39,13 +36,12 @@ bool FileNameMatched(const net::HttpResponseHeaders* headers) {
   return false;
 }
 
-bool URLMatched(net::URLRequest* request) {
-  return base::EndsWith(request->url().spec(), ".torrent",
+bool URLMatched(const GURL& url) {
+  return base::EndsWith(url.spec(), ".torrent",
       base::CompareCase::INSENSITIVE_ASCII);
 }
 
-bool IsTorrentFile(net::URLRequest* request,
-    const net::HttpResponseHeaders* headers) {
+bool IsTorrentFile(const GURL& url, const net::HttpResponseHeaders* headers) {
   std::string mimeType;
   if (!headers->GetMimeType(&mimeType)) {
     return false;
@@ -56,40 +52,16 @@ bool IsTorrentFile(net::URLRequest* request,
   }
 
   if (mimeType == kOctetStreamMimeType &&
-      (URLMatched(request) || FileNameMatched(headers))) {
+      (URLMatched(url) || FileNameMatched(headers))) {
     return true;
   }
 
   return false;
 }
 
-bool IsWebtorrentInitiated(net::URLRequest* request) {
-  return request->initiator().has_value() &&
-    request->initiator()->GetURL().spec() ==
-      base::StrCat({extensions::kExtensionScheme, "://",
-      brave_webtorrent_extension_id, "/"});
-}
-
-bool IsWebTorrentDisabled(net::URLRequest* request) {
-  content::ResourceRequestInfo* resource_info =
-    content::ResourceRequestInfo::ForRequest(request);
-  if (!resource_info || !resource_info->GetContext()) {
-    return false;
-  }
-
-  const ProfileIOData* io_data =
-    ProfileIOData::FromResourceContext(resource_info->GetContext());
-  if (!io_data) {
-    return false;
-  }
-
-  const extensions::InfoMap* infoMap = io_data->GetExtensionInfoMap();
-  if (!infoMap) {
-    return false;
-  }
-
-  return !infoMap->extensions().Contains(brave_webtorrent_extension_id) ||
-    infoMap->disabled_extensions().Contains(brave_webtorrent_extension_id);
+bool IsWebtorrentInitiated(std::shared_ptr<brave::BraveRequestInfo> ctx) {
+  return ctx->initiator_url.scheme() == extensions::kExtensionScheme &&
+      ctx->initiator_url.host() == brave_webtorrent_extension_id;
 }
 
 }  // namespace
@@ -103,10 +75,10 @@ int OnHeadersReceived_TorrentRedirectWork(
     GURL* allowed_unsafe_redirect_url,
     const brave::ResponseCallback& next_callback,
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
-  if (!request || !original_response_headers ||
-      IsWebTorrentDisabled(request) ||
-      IsWebtorrentInitiated(request) ||  // download .torrent, do not redirect
-      !IsTorrentFile(request, original_response_headers)) {
+  if (!original_response_headers ||
+      ctx->is_webtorrent_disabled ||
+      IsWebtorrentInitiated(ctx) ||  // download .torrent, do not redirect
+      !IsTorrentFile(ctx->request_url, original_response_headers)) {
     return net::OK;
   }
 
@@ -119,9 +91,8 @@ int OnHeadersReceived_TorrentRedirectWork(
       base::StrCat({extensions::kExtensionScheme, "://",
       brave_webtorrent_extension_id,
       "/extension/brave_webtorrent.html?",
-      request->url().spec()}));
-  (*override_response_headers)->AddHeader(
-      "Location: " + url.spec());
+      ctx->request_url.spec()}));
+  (*override_response_headers)->AddHeader("Location: " + url.spec());
   *allowed_unsafe_redirect_url = url;
   return net::OK;
 }

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -69,7 +69,6 @@ bool IsWebtorrentInitiated(std::shared_ptr<brave::BraveRequestInfo> ctx) {
 namespace webtorrent {
 
 int OnHeadersReceived_TorrentRedirectWork(
-    net::URLRequest* request,
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
     GURL* allowed_unsafe_redirect_url,

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -1,9 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_NET_BRAVE_TORRENT_REDIRECT_NETWORK_DELEGATE_HELPER_H_
 #define BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_NET_BRAVE_TORRENT_REDIRECT_NETWORK_DELEGATE_HELPER_H_
+
+#include <memory>
 
 #include "brave/browser/net/url_context.h"
 

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -18,7 +18,6 @@ class URLRequest;
 namespace webtorrent {
 
 int OnHeadersReceived_TorrentRedirectWork(
-    net::URLRequest* request,
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
     GURL* allowed_unsafe_redirect_url,

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h
@@ -5,7 +5,6 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_NET_BRAVE_TORRENT_REDIRECT_NETWORK_DELEGATE_HELPER_H_
 #define BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_NET_BRAVE_TORRENT_REDIRECT_NETWORK_DELEGATE_HELPER_H_
 
-#include "chrome/browser/net/chrome_network_delegate.h"
 #include "brave/browser/net/url_context.h"
 
 namespace brave {

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
@@ -99,6 +99,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
@@ -133,6 +135,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
@@ -169,6 +173,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
@@ -210,6 +216,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
@@ -247,6 +255,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
@@ -279,6 +289,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest, MimeTypeNoRedirect) {
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
@@ -314,6 +326,8 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
   GURL allowed_unsafe_redirect_url = GURL::EmptyGURL();
   std::shared_ptr<brave::BraveRequestInfo>
       brave_request_info(new brave::BraveRequestInfo());
+  brave::BraveRequestInfo::FillCTXFromRequest(request.get(),
+                                              brave_request_info);
   brave::ResponseCallback callback;
 
   int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
@@ -103,7 +103,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 
@@ -139,7 +139,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 
@@ -177,7 +177,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 
@@ -220,7 +220,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 
@@ -259,7 +259,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 
@@ -293,7 +293,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest, MimeTypeNoRedirect) {
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 
@@ -330,7 +330,7 @@ TEST_F(BraveTorrentRedirectNetworkDelegateHelperTest,
                                               brave_request_info);
   brave::ResponseCallback callback;
 
-  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(request.get(),
+  int ret = webtorrent::OnHeadersReceived_TorrentRedirectWork(
       orig_response_headers.get(), &overwrite_response_headers,
       &allowed_unsafe_redirect_url, callback, brave_request_info);
 


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
