### PR TITLE
Update rustup dependencies to 0.1.2 (uplift to 0.68.x)

### DIFF
--- a/script/rust_deps_config.py
+++ b/script/rust_deps_config.py
@@ -8,4 +8,4 @@
 # it now breaks because of urllib2 and SSL/TLS incompatibility when using Fastly
 # RUST_DEPS_PACKAGES_URL = "https://rust-pkg-brave-core.s3.brave.com"
 RUST_DEPS_PACKAGES_URL = "https://s3-us-west-2.amazonaws.com/rust-pkg-brave-core"
-RUST_DEPS_PACKAGE_VERSION = "0.1.1"
+RUST_DEPS_PACKAGE_VERSION = "0.1.2"


### PR DESCRIPTION
Uplift of #2844

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.