### PR TITLE
New Tab Page: when initialized from JS, force send updated data

### DIFF
--- a/browser/ui/webui/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/brave_new_tab_message_handler.cc
@@ -81,6 +81,17 @@ void BraveNewTabMessageHandler::RegisterMessages() {
 
 void BraveNewTabMessageHandler::HandleInitialized(const base::ListValue* args) {
   AllowJavascript();
+  // Force all the data to update in order to resolve a timing / singleton
+  // issue where the JS does not have access to the WebUIProperty data set
+  // on render_view_host in the WebUIController (BraveNewTabUI)
+  // (see https://github.com/brave/brave-browser/issues/5249).
+  // TODO(petemill): However, to properly resolve this, we may want to
+  // use loadTimeData directly in this MessageHandler to set the initial
+  // properties for all renders of the WebUI and then send the updated data
+  // in the event fire.
+  OnStatsChanged();
+  OnPrivatePropertiesChanged();
+  OnPreferencesChanged();
 }
 
 void BraveNewTabMessageHandler::HandleToggleAlternativeSearchEngineProvider(
@@ -124,15 +135,24 @@ void BraveNewTabMessageHandler::HandleSaveNewTabPagePref(
 }
 
 void BraveNewTabMessageHandler::OnPrivatePropertiesChanged() {
+  // TODO(petemill): This is a bit of a layer violation as we're
+  // calling the controller from the message handler.
+  // Instead, we can send the updated data along with the event.
   new_tab_web_ui_->OnPrivatePropertiesChanged();
 }
 
 void BraveNewTabMessageHandler::OnStatsChanged() {
+  // TODO(petemill): This is a bit of a layer violation as we're
+  // calling the controller from the message handler.
+  // Instead, we can send the updated data along with the event.
   new_tab_web_ui_->OnStatsChanged();
   FireWebUIListener("stats-updated");
 }
 
 void BraveNewTabMessageHandler::OnPreferencesChanged() {
+  // TODO(petemill): This is a bit of a layer violation as we're
+  // calling the controller from the message handler.
+  // Instead, we can send the updated data along with the event.
   new_tab_web_ui_->OnPreferencesChanged();
   FireWebUIListener("preferences-changed");
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5249

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Specified in issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
