### PR TITLE
combine trackers blocked and ads blocked on NTP

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -114,8 +114,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
                                                            localized_strings = {
     {
       std::string("newtab"), {
-        { "adsBlocked", IDS_BRAVE_NEW_TAB_TOTAL_ADS_BLOCKED },
-        { "trackersBlocked", IDS_BRAVE_NEW_TAB_TOTAL_TRACKERS_BLOCKED },
+        { "adsTrackersBlocked", IDS_BRAVE_NEW_TAB_TOTAL_ADS_TRACKERS_BLOCKED },
         { "httpsUpgraded", IDS_BRAVE_NEW_TAB_TOTAL_HTTPS_UPGRADES },
         { "estimatedTimeSaved", IDS_BRAVE_NEW_TAB_TOTAL_TIME_SAVED },
         { "thumbRemoved", IDS_BRAVE_NEW_TAB_THUMB_REMOVED },

--- a/components/brave_new_tab_ui/components/default/stats/style.ts
+++ b/components/brave_new_tab_ui/components/default/stats/style.ts
@@ -35,10 +35,7 @@ export const StyledStatsItem = styled<{}, 'li'>('li')`
     color: #FB542B;
   }
   &:nth-child(2) {
-    color: #B02FFB;
-  }
-  &:nth-child(3) {
-    color: #4C54D2;
+    color: #A0A5EB;
   }
   &:last-child {
     color: #FFFFFF;

--- a/components/brave_new_tab_ui/containers/newTab/stats.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/stats.tsx
@@ -62,20 +62,15 @@ class Stats extends React.Component<Props, {}> {
   }
 
   render () {
-    const trackedBlockersCount = this.trackedBlockersCount.toLocaleString()
-    const adblockCount = this.adblockCount.toLocaleString()
+    const trackedBlockersCount = (this.trackedBlockersCount + this.adblockCount).toLocaleString()
     const httpsUpgradedCount = this.httpsUpgradedCount.toLocaleString()
     const timeSaved = this.estimatedTimeSaved
 
     return (
       <StatsContainer>
         <StatsItem
-          description={getLocale('trackersBlocked')}
+          description={getLocale('adsTrackersBlocked')}
           counter={trackedBlockersCount}
-        />
-        <StatsItem
-          description={getLocale('adsBlocked')}
-          counter={adblockCount}
         />
         <StatsItem
           description={getLocale('httpsUpgraded')}

--- a/components/brave_new_tab_ui/stories/default/stats.tsx
+++ b/components/brave_new_tab_ui/stories/default/stats.tsx
@@ -14,8 +14,7 @@ class Stats extends React.PureComponent<{}, {}> {
   render () {
     return (
       <StatsContainer>
-        <StatsItem counter='42' description={getLocale('trackersBlocked')} />
-        <StatsItem counter='105' description={getLocale('adsBlocked')} />
+        <StatsItem counter='42' description={getLocale('adsTrackersBlocked')} />
         <StatsItem counter='0' description={getLocale('httpsUpgrades')} />
         <StatsItem counter='5' text={getLocale('minutes')} description={getLocale('estimatedTimeSaved')} />
       </StatsContainer>

--- a/components/brave_new_tab_ui/stories/fakeLocale.ts
+++ b/components/brave_new_tab_ui/stories/fakeLocale.ts
@@ -4,8 +4,7 @@
 
 const locale: any = {
   // stats
-  trackersBlocked: 'Trackers Blocked',
-  adsBlocked: 'Ads Blocked',
+  adsTrackersBlocked: 'Ads and Trackers Blocked',
   httpsUpgrades: 'HTTPS Upgrades',
   estimatedTimeSaved: 'Estimated Time Saved',
   minutes: 'minutes',

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -118,8 +118,7 @@
   <release seq="1">
     <messages fallback_to_english="true">
       <!-- WebUI newtab resources -->
-      <message name="IDS_BRAVE_NEW_TAB_TOTAL_ADS_BLOCKED" desc="total number of ads blocked">Ads Blocked</message>
-      <message name="IDS_BRAVE_NEW_TAB_TOTAL_TRACKERS_BLOCKED" desc="total number of trackers blocked">Trackers Blocked</message>
+      <message name="IDS_BRAVE_NEW_TAB_TOTAL_ADS_TRACKERS_BLOCKED" desc="total number of ads and trackers blocked">Ads and Trackers Blocked</message>
       <message name="IDS_BRAVE_NEW_TAB_TOTAL_HTTPS_UPGRADES" desc="total number of HTTPS upgrades">HTTPS Upgrades</message>
       <message name="IDS_BRAVE_NEW_TAB_TOTAL_TIME_SAVED" desc="total time saved from blocking ads and trackers">Estimated Time Saved</message>
       <message name="IDS_BRAVE_NEW_TAB_THUMB_REMOVED" desc="Shown when a thumbnail is removed from the new tab page">Top site removed.</message>


### PR DESCRIPTION
close https://github.com/brave/brave-browser/issues/5273

## Test Plan:

1. **Before checking out this branch**, open NTP and check the number of ads and trackers blocked
2. **Check out this branch**, open NTP and assert the current value is the sum of your previous stats of ads and trackers

The combination of ads and trackers is now called "trackers blocked" only, per https://github.com/brave/brave-browser/issues/5273#issuecomment-512562528. 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
