### PR TITLE
Only match on root README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@ chromium_src/ @bridiver
 script/build-bisect.py @bsclifton
 script/uplift.py @bsclifton
 vendor/brave-ios/ @kylehickinson
-README.md @bsclifton
+/README.md @bsclifton
 Jenkinsfile @mihaiplesa


### PR DESCRIPTION
Update `CODEOWNERS` file

When checking out https://github.com/brave/brave-core/pull/2947#pullrequestreview-263937566, I noticed that it's matching `README` on any directory level. I only want to be an owner for the top level `README` file 😄 