### PR TITLE
add polyfill for dev visual optimizer

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -447,6 +447,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <include name="IDR_BRAVE_GOOGLE_ANALYTICS_POLYFILL" file="resources/js/google_analytics_polyfill.js" type="BINDATA" />
       <include name="IDR_BRAVE_TAG_SERVICES_POLYFILL" file="resources/js/tag_services_polyfill.js" type="BINDATA" />
       <include name="IDR_BRAVE_TAG_MANAGER_POLYFILL" file="resources/js/tag_manager_polyfill.js" type="BINDATA" />
+      <include name="IDR_BRAVE_DEV_VISUAL_OPTIMIZER_POLYFILL" file="resources/js/dev_visual_optimizer_polyfill.js" type="BINDATA" />
     </includes>
   </release>
 </grit>

--- a/app/resources/js/dev_visual_optimizer_polyfill.js
+++ b/app/resources/js/dev_visual_optimizer_polyfill.js
@@ -1,0 +1,1 @@
+(function () { if (window._vwo_code && window._vwo_code.finish) { window._vwo_code.finish(); })());

--- a/app/resources/js/dev_visual_optimizer_polyfill.js
+++ b/app/resources/js/dev_visual_optimizer_polyfill.js
@@ -1,1 +1,1 @@
-(function () { if (window._vwo_code && window._vwo_code.finish) { window._vwo_code.finish(); })());
+(function () { if (window._vwo_code && window._vwo_code.finish) { window._vwo_code.finish(); } })();

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -69,6 +69,19 @@ std::string GetGoogleTagServicesPolyfillJS() {
   return base64_output;
 }
 
+std::string GetDevVisualOptimizerPolyfillJS() {
+  static std::string base64_output;
+  if (base64_output.length() != 0)  {
+    return base64_output;
+  }
+  std::string str = ui::ResourceBundle::GetSharedInstance().GetRawDataResource(
+    IDR_BRAVE_DEV_VISUAL_OPTIMIZER_POLYFILL).as_string();
+  Base64UrlEncode(str, base::Base64UrlEncodePolicy::OMIT_PADDING,
+      &base64_output);
+  base64_output = std::string(kJSDataURLPrefix) + base64_output;
+  return base64_output;
+}
+
 bool GetPolyfillForAdBlock(bool allow_brave_shields, bool allow_ads,
     const GURL& tab_origin, const GURL& gurl, std::string* new_url_spec) {
   // Polyfills which are related to adblock should only apply when shields
@@ -83,6 +96,8 @@ bool GetPolyfillForAdBlock(bool allow_brave_shields, bool allow_ads,
       kGoogleTagManagerPattern);
   static URLPattern tag_services(URLPattern::SCHEME_ALL,
       kGoogleTagServicesPattern);
+  static URLPattern visual_optimizer(URLPattern::SCHEME_ALL,
+      kDevVisualWebsiteOptimizerPattern);
   if (analytics.MatchesURL(gurl)) {
     std::string&& data_url = GetGoogleAnalyticsPolyfillJS();
     *new_url_spec = data_url;
@@ -97,6 +112,12 @@ bool GetPolyfillForAdBlock(bool allow_brave_shields, bool allow_ads,
 
   if (tag_services.MatchesURL(gurl)) {
     std::string&& data_url = GetGoogleTagServicesPolyfillJS();
+    *new_url_spec = data_url;
+    return true;
+  }
+
+  if (visual_optimizer.MatchesURL(gurl)) {
+    std::string&& data_url = GetDevVisualOptimizerPolyfillJS();
     *new_url_spec = data_url;
     return true;
   }

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -128,6 +128,7 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, GetPolyfill) {
   GURL google_analytics_url(kGoogleAnalyticsPattern);
   GURL tag_manager_url(kGoogleTagManagerPattern);
   GURL tag_services_url(kGoogleTagServicesPattern);
+  GURL dev_visual_optimizer_url(kDevVisualWebsiteOptimizerPattern);
   GURL normal_url("https://a.com");
   std::string out_url_spec;
   // Shields up, block ads, google analytics should get polyfill
@@ -139,6 +140,9 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, GetPolyfill) {
   // Shields up, block ads, tag services should get polyfill
   ASSERT_TRUE(GetPolyfillForAdBlock(true, false, tab_origin, tag_services_url,
       &out_url_spec));
+  // Shields up, block ads, dev.visiualoptimizer.com should get polyfill
+  ASSERT_TRUE(GetPolyfillForAdBlock(true, false, tab_origin,
+      dev_visual_optimizer_url, &out_url_spec));
   // Shields up, block ads, normal URL should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(true, false, tab_origin, normal_url,
       &out_url_spec));
@@ -152,6 +156,9 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, GetPolyfill) {
   // Shields up, allow ads, tag services should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(true, true, tab_origin, tag_services_url,
       &out_url_spec));
+  // Shields up, allow ads, dev.visiualoptimizer.com should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(true, true, tab_origin,
+      dev_visual_optimizer_url, &out_url_spec));
   // Shields up, allow ads, normal URL should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(true, true, tab_origin, normal_url,
       &out_url_spec));
@@ -165,6 +172,9 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, GetPolyfill) {
   // Shields down, allow ads, tag services should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(false, true, tab_origin, tag_services_url,
       &out_url_spec));
+  // Shields down, allow ads, dev.visiualoptimizer.com should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, true, tab_origin,
+      dev_visual_optimizer_url, &out_url_spec));
   // Shields down, allow ads, normal URL should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(false, true, tab_origin, normal_url,
       &out_url_spec));
@@ -178,6 +188,9 @@ TEST_F(BraveAdBlockTPNetworkDelegateHelperTest, GetPolyfill) {
   // Shields down, block ads, tag services should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(false, false, tab_origin,
       tag_services_url, &out_url_spec));
+  // Shields down, block ads, dev.visiualoptimizer.com should NOT get polyfill
+  ASSERT_FALSE(GetPolyfillForAdBlock(false, false, tab_origin,
+      dev_visual_optimizer_url, &out_url_spec));
   // Shields down, block ads, normal URL should NOT get polyfill
   ASSERT_FALSE(GetPolyfillForAdBlock(false, false, tab_origin, normal_url,
       &out_url_spec));

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -44,6 +44,8 @@ const char kGoogleTagManagerPattern[] =
     "https://www.googletagmanager.com/gtm.js";
 const char kGoogleTagServicesPattern[] =
     "https://www.googletagservices.com/tag/js/gpt.js";
+const char kDevVisualWebsiteOptimizerPattern[] =
+    "https://dev.visualwebsiteoptimizer.com/j.php?*";
 const char kForbesPattern[] = "https://www.forbes.com/*";
 const char kForbesExtraCookies[] =
     "forbes_ab=true; welcomeAd=true; adblock_session=Off; "

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -22,6 +22,7 @@ extern const char kGeoLocationsPattern[];
 extern const char kGoogleAnalyticsPattern[];
 extern const char kGoogleTagManagerPattern[];
 extern const char kGoogleTagServicesPattern[];
+extern const char kDevVisualWebsiteOptimizerPattern[];
 extern const char kForbesPattern[];
 extern const char kForbesExtraCookies[];
 extern const char kSafeBrowsingPrefix[];


### PR DESCRIPTION
Adds a polyfil for working around a "blank the page for a bit while the tracking happens" style issue.

Won't be needed once uBO resources are in place