### PR TITLE
add exception for socket.io endpoint on sliver.tv

### DIFF
--- a/common/shield_exceptions.cc
+++ b/common/shield_exceptions.cc
@@ -59,7 +59,13 @@ bool IsWhitelistedCookieException(const GURL& firstPartyOrigin,
   }
 
   // 1st-party-dependent whitelist
-  static std::map<GURL, std::vector<URLPattern> > whitelist_patterns = {};
+  static std::map<GURL, std::vector<URLPattern> > whitelist_patterns = {
+    {
+      GURL("https://www.sliver.tv/"),
+      std::vector<URLPattern>({URLPattern(URLPattern::SCHEME_ALL,
+            "https://*.thetatoken.org:8700/*")})
+    }
+  };
   std::map<GURL, std::vector<URLPattern> >::iterator i =
       whitelist_patterns.find(firstPartyOrigin);
   if (i == whitelist_patterns.end()) {


### PR DESCRIPTION
This fixes a problem with socket.io integration for sliver.tv by allowing 3p cookies on `https://*.thetatoken.org:8700/`.