### PR TITLE
WebTorrent: torrent name improvements

### DIFF
--- a/components/brave_webtorrent/extension/background/reducers/webtorrent_reducer.ts
+++ b/components/brave_webtorrent/extension/background/reducers/webtorrent_reducer.ts
@@ -182,7 +182,7 @@ const updateProgress = (state: TorrentsState, torrent: Torrent) => {
 
 const updateInfo = (state: TorrentsState, torrent: Torrent) => {
   const { torrentStateMap, torrentObjMap } = state
-  const { downloaded, uploaded, downloadSpeed, uploadSpeed, progress, ratio,
+  const { name, downloaded, uploaded, downloadSpeed, uploadSpeed, progress, ratio,
     numPeers, timeRemaining, infoHash } = torrent
   let length: number = 0
   const files: File[] = torrent.files.map((file) => {
@@ -199,7 +199,7 @@ const updateInfo = (state: TorrentsState, torrent: Torrent) => {
     )
 
   torrentObjMap[torrent.infoHash] = { ...torrentObjMap[torrent.infoHash],
-    files, downloaded, uploaded, downloadSpeed, uploadSpeed, progress, ratio,
+    files, name, downloaded, uploaded, downloadSpeed, uploadSpeed, progress, ratio,
     numPeers, timeRemaining, length, tabClients }
 
   return { ...state, torrentStateMap, torrentObjMap }

--- a/components/brave_webtorrent/extension/brave_webtorrent.html
+++ b/components/brave_webtorrent/extension/brave_webtorrent.html
@@ -1,14 +1,15 @@
+<!doctype html>
 <html>
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width">
-<title>Webtorrent</title>
-<script src="/extension/out/brave_webtorrent.bundle.js"></script>
-<style>
-  #root { height: 100%; }
-</style>
-</head>
-<body>
-<div id="root"></div>
-</body>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>WebTorrent</title>
+    <script src="/extension/out/brave_webtorrent.bundle.js"></script>
+    <style>
+      #root { height: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
 </html>

--- a/components/brave_webtorrent/extension/components/app.tsx
+++ b/components/brave_webtorrent/extension/components/app.tsx
@@ -43,6 +43,16 @@ export class BraveWebtorrentPage extends React.Component<Props, {}> {
 
     if (!torrentState) return null
 
+    let name = torrentObj && torrentObj.name
+      ? torrentObj.name
+      : torrentState && torrentState.name
+      ? torrentState.name
+      : undefined
+
+    document.title = name
+      ? name + ' – WebTorrent'
+      : 'WebTorrent'
+
     if (torrentObj && typeof torrentState.ix === 'number') {
       return <MediaViewer torrent={torrentObj} ix={torrentState.ix} />
     }
@@ -50,7 +60,7 @@ export class BraveWebtorrentPage extends React.Component<Props, {}> {
     return (
       <TorrentViewer
         actions={actions}
-        name={torrentState.name}
+        name={name}
         torrentId={torrentState.torrentId}
         errorMsg={torrentState.errorMsg}
         torrent={torrentObj}

--- a/components/brave_webtorrent/extension/constants/webtorrentState.ts
+++ b/components/brave_webtorrent/extension/constants/webtorrentState.ts
@@ -55,6 +55,7 @@ export interface TorrentState {
 }
 
 export interface TorrentObj {
+  name?: string,
   files?: File[]
   serverURL?: string
   timeRemaining: number

--- a/components/brave_webtorrent/extension/manifest.json
+++ b/components/brave_webtorrent/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
-  "name": "Brave Webtorrent",
+  "name": "Brave WebTorrent",
   "manifest_version": 2,
-  "description": "Webtorrent extension",
+  "description": "WebTorrent extension",
   "background" : {
     "scripts": ["extension/out/brave_webtorrent_background.bundle.js"],
     "persistent": true

--- a/components/test/brave_webtorrent/components/torrentViewerHeader_test.tsx
+++ b/components/test/brave_webtorrent/components/torrentViewerHeader_test.tsx
@@ -43,5 +43,21 @@ describe('torrentViewerHeader component', () => {
       )
       expect(wrapper.html()).toEqual(expect.stringContaining('Stop Torrent'))
     })
+
+    it('renders the component with torrent title', () => {
+      const wrapper = shallow(
+        <TestThemeProvider>
+          <TorrentViewerHeader
+            tabId={tabId}
+            torrentId={torrentId}
+            torrent={torrentObj}
+            name={torrentObj.name}
+            onStartTorrent={startTorrentMock}
+            onStopDownload={stopDownloadMock}
+          />
+        </TestThemeProvider>
+      )
+      expect(wrapper.html()).toEqual(expect.stringContaining(torrentObj.name))
+    })
   })
 })

--- a/components/test/brave_webtorrent/testData.ts
+++ b/components/test/brave_webtorrent/testData.ts
@@ -13,6 +13,7 @@ export const torrentState: TorrentState = {
 }
 
 export const torrentObj: TorrentObj = {
+  name: 'A Torrent Name',
   timeRemaining: 0,
   downloaded: 0,
   uploaded: 0,


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/5351

- Properly capitalize WebTorrent in interface
- Show torrent name in <title>

Before:

![Screen Shot 2019-07-23 at 1 03 55 PM](https://user-images.githubusercontent.com/121766/61743547-5f537180-ad4a-11e9-9019-4dfdbae01a0b.png)

After:

![Screen Shot 2019-07-23 at 1 03 48 PM](https://user-images.githubusercontent.com/121766/61743557-65e1e900-ad4a-11e9-8e2b-2e56ffb568f2.png)

- Show torrent name in TorrentViewer header
  - Previously, we showed the torrent file name (big-buck-bunny.torrent) but now we attempt to show the torrent name (e.g. Big Buck Bunny) when it is available which is usually once the torrent has been started and metadata has been fetched transfer has started.

Before:

![Screen Shot 2019-07-23 at 1 03 45 PM](https://user-images.githubusercontent.com/121766/61743577-74300500-ad4a-11e9-8d4e-1fcd7c9b95e1.png)

After:

![Screen Shot 2019-07-23 at 1 03 40 PM](https://user-images.githubusercontent.com/121766/61743584-77c38c00-ad4a-11e9-8f9b-bc9594cdcfc0.png)

- Indent page HTML and add doctype

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Visit https://webtorrent.io/free-torrents
- Click Big Buck Bunny torrent file
- Start download
- Confirm that torrent name (Big Buck Bunny) shows up instead of torrent file name (big-buck-bunny.torrent)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
