### PR TITLE
Fix WebTorrent instant streaming playback links

### DIFF
--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -41,6 +41,16 @@ bool URLMatched(const GURL& url) {
       base::CompareCase::INSENSITIVE_ASCII);
 }
 
+/**
+ * Returns true if the URL contains a URL fragment that starts with "ix=". For
+ * example, https://webtorrent.io/torrents/big-buck-bunny.torrent#ix=1.
+ * Otherwise, returns false.
+ */
+bool IsViewerURL(const GURL& url) {
+  return base::StartsWith(url.ref(), "ix=",
+      base::CompareCase::INSENSITIVE_ASCII);
+}
+
 bool IsTorrentFile(const GURL& url, const net::HttpResponseHeaders* headers) {
   std::string mimeType;
   if (!headers->GetMimeType(&mimeType)) {
@@ -76,7 +86,8 @@ int OnHeadersReceived_TorrentRedirectWork(
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
   if (!original_response_headers ||
       ctx->is_webtorrent_disabled ||
-      IsWebtorrentInitiated(ctx) ||  // download .torrent, do not redirect
+      // download .torrent, do not redirect
+      (IsWebtorrentInitiated(ctx) && !IsViewerURL(ctx->request_url)) ||
       !IsTorrentFile(ctx->request_url, original_response_headers)) {
     return net::OK;
   }

--- a/components/brave_webtorrent/extension/components/torrentFileList.tsx
+++ b/components/brave_webtorrent/extension/components/torrentFileList.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export default class TorrentFileList extends React.PureComponent<Props, {}> {
   render () {
-    const { torrent } = this.props
+    const { torrent, torrentId } = this.props
     if (!torrent || !torrent.files) {
       return (
         <div className='torrentSubhead'>
@@ -45,8 +45,6 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
     ]
 
     const renderFileLink = (file: File, ix: number, isDownload: boolean) => {
-      const { torrentId, torrent } = this.props
-      if (!torrent) return null
       if (isDownload) {
         if (torrent.serverURL) {
           const url = torrent.serverURL + '/' + ix


### PR DESCRIPTION
In short, this PR does not redirect URL requests with `#ix=` to the .torrent file.

When the user clicks on a file in the torrent file list, a new tab opens which points to the .torrent file, but with a file fragment appended. For example, the torrent https://webtorrent.io/torrents/big-buck-bunny.torrent would have a link to https://webtorrent.io/torrents/big-buck-bunny.torrent#ix=1 for the 2nd file in the torrent.

Without this PR, this request passes the `IsWebtorrentInitiated(ctx)` condition and is therefore allowed to reach the network. Instead, we should confirm that the request is not for an individual file before letting it go to the network. That's what this PR does.

Fixes: https://github.com/brave/brave-browser/issues/3966

Branched from this PR: https://github.com/brave/brave-core/pull/2989 (so merge after that one is merged)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Go to https://webtorrent.io/free-torrents
- Click on Big Buck Bunny (torrent file)
- Start download
- Click on the .mp4 file (second file)
- Confirm that it opens a new tab, and a video player shows up.
- Confirm that the video plays Big Buck Bunny when it is clicked.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
