### PR TITLE
Whitelist schemes by TorNavigationThrottle

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -15,7 +15,6 @@
 #include "brave/browser/brave_browser_main_extra_parts.h"
 #include "brave/browser/brave_browser_process_impl.h"
 #include "brave/browser/extensions/brave_tor_client_updater.h"
-#include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/tor/buildflags.h"
 #include "brave/common/webui_url_constants.h"
 #include "brave/components/brave_ads/browser/buildflags/buildflags.h"
@@ -358,11 +357,12 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
   throttles.push_back(
       std::make_unique<extensions::BraveWalletNavigationThrottle>(handle));
 #endif
+
 #if BUILDFLAG(ENABLE_TOR)
-  Profile* profile = Profile::FromBrowserContext(
-      handle->GetWebContents()->GetBrowserContext());
-  if (brave::IsTorProfile(profile))
-    throttles.push_back(std::make_unique<tor::TorNavigationThrottle>(handle));
+  std::unique_ptr<content::NavigationThrottle> tor_navigation_throttle =
+    tor::TorNavigationThrottle::MaybeCreateThrottleFor(handle);
+  if (tor_navigation_throttle)
+    throttles.push_back(std::move(tor_navigation_throttle));
 #endif
 
   return throttles;

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/brave_browser_main_extra_parts.h"
 #include "brave/browser/brave_browser_process_impl.h"
 #include "brave/browser/extensions/brave_tor_client_updater.h"
+#include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/tor/buildflags.h"
 #include "brave/common/webui_url_constants.h"
 #include "brave/components/brave_ads/browser/buildflags/buildflags.h"
@@ -77,6 +78,7 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
+#include "brave/browser/tor/tor_navigation_throttle.h"
 #include "brave/browser/tor/tor_profile_service_factory.h"
 #include "brave/common/tor/switches.h"
 #include "brave/components/services/tor/public/cpp/manifest.h"
@@ -355,6 +357,12 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
   throttles.push_back(
       std::make_unique<extensions::BraveWalletNavigationThrottle>(handle));
+#endif
+#if BUILDFLAG(ENABLE_TOR)
+  Profile* profile = Profile::FromBrowserContext(
+      handle->GetWebContents()->GetBrowserContext());
+  if (brave::IsTorProfile(profile))
+    throttles.push_back(std::make_unique<tor::TorNavigationThrottle>(handle));
 #endif
 
   return throttles;

--- a/browser/profiles/brave_profile_manager_unittest.cc
+++ b/browser/profiles/brave_profile_manager_unittest.cc
@@ -118,38 +118,43 @@ TEST_F(BraveProfileManagerTest, GetTorProfilePath) {
 }
 
 TEST_F(BraveProfileManagerTest, InitProfileUserPrefs) {
-  base::FilePath dest_path = temp_dir_.GetPath();
-  dest_path = dest_path.Append(tor::kTorProfileDir);
+  base::FilePath dest_path =
+    temp_dir_.GetPath().AppendASCII(TestingProfile::kTestUserProfileDir);
+  base::FilePath tor_dest_path =
+    temp_dir_.GetPath().Append(tor::kTorProfileDir);
 
   ProfileManager* profile_manager = g_browser_process->profile_manager();
 
-  Profile* profile;
-
-  // Successfully create the profile
-  profile = profile_manager->GetProfile(dest_path);
+  // Successfully create test profile and tor profile
+  Profile* profile = profile_manager->GetProfile(dest_path);
+  Profile* tor_profile = profile_manager->GetProfile(tor_dest_path);
   ASSERT_TRUE(profile);
+  ASSERT_TRUE(tor_profile);
 
-  // Check that the profile name is non empty
+  // Check that the tor_profile name is non empty
   std::string profile_name =
-      profile->GetPrefs()->GetString(prefs::kProfileName);
+      tor_profile->GetPrefs()->GetString(prefs::kProfileName);
   EXPECT_EQ(profile_name,
             l10n_util::GetStringUTF8(IDS_PROFILES_TOR_PROFILE_NAME));
 
-  // Check that the profile avatar index is valid
+  // Check that the tor_profile avatar index is valid
   size_t avatar_index =
-      profile->GetPrefs()->GetInteger(prefs::kProfileAvatarIndex);
+      tor_profile->GetPrefs()->GetInteger(prefs::kProfileAvatarIndex);
   EXPECT_EQ(avatar_index, size_t(0));
   EXPECT_FALSE(
-    profile->GetPrefs()->GetBoolean(prefs::kProfileUsingDefaultName));
-  EXPECT_TRUE(profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
+    tor_profile->GetPrefs()->GetBoolean(prefs::kProfileUsingDefaultName));
+  EXPECT_FALSE(profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
+  EXPECT_TRUE(
+    tor_profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
 
   // Check WebRTC IP handling policy.
   EXPECT_EQ(
-    profile->GetPrefs()->GetString(prefs::kWebRTCIPHandlingPolicy),
+    tor_profile->GetPrefs()->GetString(prefs::kWebRTCIPHandlingPolicy),
     content::kWebRTCIPHandlingDisableNonProxiedUdp);
 
   // Check SafeBrowsing status
-  EXPECT_FALSE(profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnabled));
+  EXPECT_FALSE(
+    tor_profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnabled));
 }
 
 // This is for tor guest window, remove it when we have persistent tor profiles

--- a/browser/profiles/tor_unittest_profile_manager.cc
+++ b/browser/profiles/tor_unittest_profile_manager.cc
@@ -24,10 +24,7 @@ Profile* TorUnittestProfileManager::CreateProfileHelper(
     if (!base::CreateDirectory(path))
       return nullptr;
   }
-  if (path == BraveProfileManager::GetTorProfilePath())
-    return CreateTorProfile(path, nullptr);
-  else
-    return new TestingProfile(path, nullptr);
+  return CreateProfile(path, nullptr);
 }
 
 Profile* TorUnittestProfileManager::CreateProfileAsyncHelper(
@@ -38,10 +35,7 @@ Profile* TorUnittestProfileManager::CreateProfileAsyncHelper(
       FROM_HERE,
       base::BindOnce(base::IgnoreResult(&base::CreateDirectory), path));
 
-  if (path == BraveProfileManager::GetTorProfilePath())
-    return CreateTorProfile(path, this);
-  else
-    return new TestingProfile(path, this);
+  return CreateProfile(path, this);
 }
 
 void TorUnittestProfileManager::InitProfileUserPrefs(Profile* profile) {
@@ -52,7 +46,7 @@ void TorUnittestProfileManager::InitProfileUserPrefs(Profile* profile) {
   }
 }
 
-Profile* TorUnittestProfileManager::CreateTorProfile(
+Profile* TorUnittestProfileManager::CreateProfile(
     const base::FilePath& path, Delegate* delegate) {
   TestingProfile::Builder profile_builder;
   sync_preferences::PrefServiceMockFactory factory;

--- a/browser/profiles/tor_unittest_profile_manager.h
+++ b/browser/profiles/tor_unittest_profile_manager.h
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -22,7 +23,7 @@ class TorUnittestProfileManager : public ProfileManagerWithoutInit {
   void InitProfileUserPrefs(Profile* profile) override;
 
  private:
-  Profile* CreateTorProfile(const base::FilePath& path, Delegate* delegate);
+  Profile* CreateProfile(const base::FilePath& path, Delegate* delegate);
 };
 
 #endif  // BRAVE_BROWSER_PROFILES_TOR_UNITTEST_PROFILE_MANAGER_H_

--- a/browser/tor/BUILD.gn
+++ b/browser/tor/BUILD.gn
@@ -16,13 +16,9 @@ source_set("tor") {
   deps = [
     "//base",
     "//brave/common/tor",
-    "//brave/components/services/tor/public/interfaces",
     "//components/keyed_service/content",
     "//components/keyed_service/core",
-
-    # for profile.h
     "//content/public/browser",
-    "//services/service_manager",
   ]
 
   public_deps = [
@@ -33,10 +29,19 @@ source_set("tor") {
     sources += [
       "tor_launcher_factory.cc",
       "tor_launcher_factory.h",
+      "tor_navigation_throttle.cc",
+      "tor_navigation_throttle.h",
       "tor_profile_service.cc",
       "tor_profile_service.h",
       "tor_profile_service_impl.cc",
       "tor_profile_service_impl.h",
+    ]
+
+    deps += [
+      "//brave/components/services/tor/public/interfaces",
+      "//content/public/common",
+      "//extensions/common:common_constants",
+      "//services/service_manager",
     ]
   }
 }

--- a/browser/tor/tor_navigation_throttle.cc
+++ b/browser/tor/tor_navigation_throttle.cc
@@ -5,11 +5,25 @@
 
 #include "brave/browser/tor/tor_navigation_throttle.h"
 
+#include "brave/browser/profiles/profile_util.h"
+#include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/common/url_constants.h"
 #include "extensions/common/constants.h"
 
 namespace tor {
+
+// static
+std::unique_ptr<TorNavigationThrottle>
+TorNavigationThrottle::MaybeCreateThrottleFor(
+    content::NavigationHandle* navigation_handle) {
+  Profile* profile = Profile::FromBrowserContext(
+      navigation_handle->GetWebContents()->GetBrowserContext());
+  if (!brave::IsTorProfile(profile))
+    return nullptr;
+  return std::make_unique<TorNavigationThrottle>(navigation_handle);
+}
 
 TorNavigationThrottle::TorNavigationThrottle(
     content::NavigationHandle* navigation_handle)

--- a/browser/tor/tor_navigation_throttle.cc
+++ b/browser/tor/tor_navigation_throttle.cc
@@ -1,0 +1,35 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/tor/tor_navigation_throttle.h"
+
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/common/url_constants.h"
+#include "extensions/common/constants.h"
+
+namespace tor {
+
+TorNavigationThrottle::TorNavigationThrottle(
+    content::NavigationHandle* navigation_handle)
+    : content::NavigationThrottle(navigation_handle) {}
+
+TorNavigationThrottle::~TorNavigationThrottle() = default;
+
+content::NavigationThrottle::ThrottleCheckResult
+TorNavigationThrottle::WillStartRequest() {
+  GURL url = navigation_handle()->GetURL();
+  if (url.SchemeIsHTTPOrHTTPS() ||
+      url.SchemeIs(content::kChromeUIScheme) ||
+      url.SchemeIs(extensions::kExtensionScheme) ||
+      url.SchemeIs(content::kChromeDevToolsScheme))
+    return content::NavigationThrottle::PROCEED;
+  return content::NavigationThrottle::BLOCK_REQUEST;
+}
+
+const char* TorNavigationThrottle::GetNameForLogging() {
+  return "TorNavigationThrottle";
+}
+
+}  // namespace tor

--- a/browser/tor/tor_navigation_throttle.h
+++ b/browser/tor/tor_navigation_throttle.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_TOR_TOR_NAVIGATION_THROTTLE_H_
 #define BRAVE_BROWSER_TOR_TOR_NAVIGATION_THROTTLE_H_
 
+#include <memory>
+
 #include "content/public/browser/navigation_throttle.h"
 
 namespace content {
@@ -16,6 +18,8 @@ namespace tor {
 
 class TorNavigationThrottle : public content::NavigationThrottle {
  public:
+  static std::unique_ptr<TorNavigationThrottle>
+    MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle);
   explicit TorNavigationThrottle(content::NavigationHandle* navigation_handle);
   ~TorNavigationThrottle() override;
 

--- a/browser/tor/tor_navigation_throttle.h
+++ b/browser/tor/tor_navigation_throttle.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_TOR_TOR_NAVIGATION_THROTTLE_H_
+#define BRAVE_BROWSER_TOR_TOR_NAVIGATION_THROTTLE_H_
+
+#include "content/public/browser/navigation_throttle.h"
+
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
+namespace tor {
+
+class TorNavigationThrottle : public content::NavigationThrottle {
+ public:
+  explicit TorNavigationThrottle(content::NavigationHandle* navigation_handle);
+  ~TorNavigationThrottle() override;
+
+  // content::NavigationThrottle implementation:
+  ThrottleCheckResult WillStartRequest() override;
+  const char* GetNameForLogging() override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TorNavigationThrottle);
+};
+
+}  // namespace tor
+
+#endif  // BRAVE_BROWSER_TOR_TOR_NAVIGATION_THROTTLE_H_

--- a/browser/tor/tor_navigation_throttle_unittest.cc
+++ b/browser/tor/tor_navigation_throttle_unittest.cc
@@ -1,0 +1,136 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/tor/tor_navigation_throttle.h"
+
+#include <utility>
+
+#include "brave/common/tor/pref_names.h"
+#include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/prefs/pref_service.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/test/mock_navigation_handle.h"
+#include "content/public/test/web_contents_tester.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+using content::NavigationThrottle;
+
+namespace tor {
+
+class TorNavigationThrottleUnitTest
+    : public ChromeRenderViewHostTestHarness {
+ public:
+  TorNavigationThrottleUnitTest() = default;
+  ~TorNavigationThrottleUnitTest() override = default;
+
+  void SetUp() override {
+    ChromeRenderViewHostTestHarness::SetUp();
+  }
+
+  void TearDown() override {
+    ChromeRenderViewHostTestHarness::TearDown();
+  }
+
+  content::BrowserContext* CreateBrowserContext() override {
+    TestingProfile::Builder builder;
+    auto prefs =
+        std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
+    RegisterUserProfilePrefs(prefs->registry());
+    prefs->registry()->
+      RegisterBooleanPref(prefs::kProfileUsingTor, false);
+    builder.SetPrefService(std::move(prefs));
+    return builder.Build().release();
+  }
+
+  content::RenderFrameHostTester* render_frame_host_tester(
+      content::RenderFrameHost* host) {
+    return content::RenderFrameHostTester::For(host);
+  }
+
+  content::WebContentsTester* web_contents_tester() {
+    return content::WebContentsTester::For(web_contents());
+  }
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TorNavigationThrottleUnitTest);
+};
+
+// Tests TorNavigationThrottle::MaybeCreateThrottleFor with tor enabled/disabled
+TEST_F(TorNavigationThrottleUnitTest, Instantiation) {
+  profile()->GetPrefs()->SetBoolean(prefs::kProfileUsingTor, true);
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* rfh = main_rfh();
+  GURL url("http://www.example.com");
+  content::MockNavigationHandle test_handle(url, rfh);
+  std::unique_ptr<TorNavigationThrottle> throttle =
+    TorNavigationThrottle::MaybeCreateThrottleFor(&test_handle);
+  EXPECT_TRUE(throttle != nullptr);
+  profile()->GetPrefs()->SetBoolean(prefs::kProfileUsingTor, false);
+  std::unique_ptr<TorNavigationThrottle> throttle2 =
+    TorNavigationThrottle::MaybeCreateThrottleFor(&test_handle);
+  EXPECT_TRUE(throttle2 == nullptr);
+}
+
+TEST_F(TorNavigationThrottleUnitTest, WhitelistedScheme) {
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* rfh = main_rfh();
+  GURL url("http://www.example.com");
+  content::MockNavigationHandle test_handle(url, rfh);
+  std::unique_ptr<TorNavigationThrottle> throttle =
+    std::make_unique<TorNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << url;
+
+  GURL url2("https://www.example.com");
+  test_handle.set_url(url2);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << url2;
+
+  GURL url3("chrome://settings");
+  test_handle.set_url(url3);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << url3;
+
+  GURL url4("chrome-extension://cldoidikboihgcjfkhdeidbpclkineef");
+  test_handle.set_url(url4);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << url4;
+
+  // chrome-devtools migrates to devtools
+  GURL url5("devtools://devtools/bundled/inspector.html");
+  test_handle.set_url(url5);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << url5;
+}
+
+// Every schemes other than whitelisted scheme, no matter it is internal or
+// external scheme
+TEST_F(TorNavigationThrottleUnitTest, BlockedScheme) {
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* rfh = main_rfh();
+  GURL url("ftp://ftp.example.com");
+  content::MockNavigationHandle test_handle(url, rfh);
+  std::unique_ptr<TorNavigationThrottle> throttle =
+    std::make_unique<TorNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::BLOCK_REQUEST,
+            throttle->WillStartRequest().action()) << url;
+
+  GURL url2("mailto:example@www.example.com");
+  test_handle.set_url(url2);
+  EXPECT_EQ(NavigationThrottle::BLOCK_REQUEST,
+            throttle->WillStartRequest().action()) << url2;
+
+  GURL url3("magnet:?xt=urn:btih:***.torrent");
+  test_handle.set_url(url3);
+  EXPECT_EQ(NavigationThrottle::BLOCK_REQUEST,
+            throttle->WillStartRequest().action()) << url3;
+}
+
+}  // namespace tor

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -174,6 +174,7 @@ test("brave_unit_tests") {
     sources += [
       "//brave/browser/profiles/tor_unittest_profile_manager.cc",
       "//brave/browser/profiles/tor_unittest_profile_manager.h",
+      "//brave/browser/tor/tor_navigation_throttle_unittest.cc",
       "//brave/common/tor/tor_test_constants.cc",
       "//brave/common/tor/tor_test_constants.h",
       "//brave/net/proxy_resolution/proxy_config_service_tor_unittest.cc",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/4461
fix https://github.com/brave/brave-browser/issues/5357

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
a. Blocked protocols
1. Paste `mailto:press@brave.com` in non-tor window, it will open your email handler
2. Paste `mailto:press@brave.com` in tor window, the request will be blocked
3. Paste `ftp://ftp.uni-erlangen.de/mirrors/ubuntu-releases/` in non-tor window, it will accessing through ftp protocol
4. Paste `ftp://ftp.uni-erlangen.de/mirrors/ubuntu-releases/`, in tor window, the request will be blocked
5. Click any magnet link of https://webtorrent.io/free-torrents in non-tor window, it will open webtorrent or your torrent handler
6. Click any magnet link of https://webtorrent.io/free-torrents in tor window, the request will be blocked

b. Whitelisted protocols
1. Go to any http/https sites in tor and non-tor window, everything should work fine.
2. We should be able to visit `chrome://settings/` in tor and non-tor window
3. ~We should be able to visit any extension page starting with `chrome-extension://` in tor and non-tor window~ We can only verify this after tor profile rework, currently extension is disabled in guest window
4. We should be able to visit `devtools://devtools/bundled/inspector.html` in tor and non-tor window

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
