### PR TITLE
Brave syncer ordering

### DIFF
--- a/chromium_src/components/sync_bookmarks/bookmark_change_processor.cc
+++ b/chromium_src/components/sync_bookmarks/bookmark_change_processor.cc
@@ -119,7 +119,7 @@ void BookmarkChangeProcessor::MakeRepositionAndUpdateSyncNodes(
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_BOOKMARK_NODE_MOVED_1 \
   ScopedPauseObserver pause(bookmark_model_, this); \
-  brave_sync::AddBraveMetaInfo(child, model, old_parent != new_parent); \
+  brave_sync::AddBraveMetaInfo(child, model); \
   SetSyncNodeMetaInfo(child, &sync_node);
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_BOOKMARK_NODE_MOVED_2 \
@@ -129,7 +129,7 @@ void BookmarkChangeProcessor::MakeRepositionAndUpdateSyncNodes(
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_CHILDREN_REORDERED \
       ScopedPauseObserver pause(bookmark_model_, this); \
-      brave_sync::AddBraveMetaInfo(child, model, false); \
+      brave_sync::AddBraveMetaInfo(child, model); \
       SetSyncNodeMetaInfo(child, &sync_child);
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL \

--- a/components/brave_sync/bookmark_order_util.cc
+++ b/components/brave_sync/bookmark_order_util.cc
@@ -1,6 +1,7 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/brave_sync/bookmark_order_util.h"
 
@@ -8,6 +9,17 @@
 #include "base/strings/string_split.h"
 
 namespace brave_sync {
+
+namespace {
+
+bool CompareOrder(const std::vector<int>& vec_left,
+    const std::vector<int>& vec_right) {
+  // Use C++ stdlib
+  return std::lexicographical_compare(vec_left.begin(), vec_left.end(),
+    vec_right.begin(), vec_right.end());
+}
+
+}  // namespace
 
 std::vector<int> OrderToIntVect(const std::string& s) {
   std::vector<std::string> vec_s = SplitString(
@@ -21,20 +33,142 @@ std::vector<int> OrderToIntVect(const std::string& s) {
     int output = 0;
     bool b = base::StringToInt(vec_s[i], &output);
     CHECK(b);
-    CHECK(output >= 0);
+    CHECK_GE(output, 0);
     vec_int.emplace_back(output);
   }
   return vec_int;
 }
 
+std::string ToOrderString(const std::vector<int> &vec_int) {
+  std::string ret;
+  for (size_t i = 0; i < vec_int.size(); ++i) {
+    if (vec_int[i] < 0) {
+      return "";
+    }
+    ret += std::to_string(vec_int[i]);
+    if (i != vec_int.size() - 1) {
+      ret += ".";
+    }
+  }
+  return ret;
+}
+
 bool CompareOrder(const std::string& left, const std::string& right) {
   // Return: true if left <  right
-  // Split each and use C++ stdlib
+  // Split each and compare as int vectors
   std::vector<int> vec_left = OrderToIntVect(left);
   std::vector<int> vec_right = OrderToIntVect(right);
 
-  return std::lexicographical_compare(vec_left.begin(), vec_left.end(),
-    vec_right.begin(), vec_right.end());
+  return CompareOrder(vec_left, vec_right);
 }
 
-} // namespace brave_sync
+namespace {
+
+std::string GetNextOrderFromPrevOrder(std::vector<int>* vec_prev) {
+  DCHECK_GT(vec_prev->size(), 2u);
+  int last_number = vec_prev->at(vec_prev->size() - 1);
+  DCHECK_GT(last_number, 0);
+  if (last_number <= 0) {
+    return "";
+  } else {
+    vec_prev->at(vec_prev->size() - 1)++;
+    return ToOrderString(*vec_prev);
+  }
+}
+
+std::string GetPrevOrderFromNextOrder(std::vector<int>* vec_next) {
+  DCHECK_GT(vec_next->size(), 2u);
+  int last_number = vec_next->at(vec_next->size() - 1);
+  DCHECK_GT(last_number, 0);
+  vec_next->resize(vec_next->size() - 1);
+  if (last_number <= 0) {
+    return "";
+  } else if (last_number == 1) {
+    return ToOrderString(*vec_next) + ".0.1";
+  } else {
+    vec_next->push_back(last_number - 1);
+    return ToOrderString(*vec_next);
+  }
+}
+
+}  // namespace
+
+// Inspired by https://github.com/brave/sync/blob/staging/client/bookmarkUtil.js
+std::string GetOrder(const std::string& prev, const std::string& next,
+    const std::string& parent) {
+  if (prev.empty() && next.empty()) {
+    DCHECK(!parent.empty());
+    return parent + ".1";
+  } else if (!prev.empty() && next.empty()) {
+    std::vector<int> vec_prev = OrderToIntVect(prev);
+    DCHECK_GT(vec_prev.size(), 2u);
+    // Just increase the last number, as we don't have next
+    return GetNextOrderFromPrevOrder(&vec_prev);
+  } else if (prev.empty() && !next.empty()) {
+    std::vector<int> vec_next = OrderToIntVect(next);
+    DCHECK_GT(vec_next.size(), 2u);
+    // Just decrease the last number or substitute with 0.1,
+    // as we don't have prev
+    return GetPrevOrderFromNextOrder(&vec_next);
+  } else {
+    DCHECK(!prev.empty() && !next.empty());
+    std::vector<int> vec_prev = OrderToIntVect(prev);
+    DCHECK_GT(vec_prev.size(), 2u);
+    std::vector<int> vec_next = OrderToIntVect(next);
+    DCHECK_GT(vec_next.size(), 2u);
+    DCHECK(CompareOrder(prev, next));
+
+    // Assume prev looks as a.b.c.d
+    // result candidates are:
+    // a.b.c.(d+1)
+    // a.b.c.d.1
+    // a.b.c.d.0.1
+    // a.b.c.d.0.0.1
+    // ...
+    // each of them is greater than prev
+
+    // Length of result in worse case can be one segment longer
+    // than length of next
+    // And result should be < next
+
+    std::vector<int> vec_result;
+    vec_result = vec_prev;
+    vec_result[vec_result.size() - 1]++;
+
+    // Case a.b.c.(d+1)
+    DCHECK(CompareOrder(vec_prev, vec_result));
+    if (CompareOrder(vec_result, vec_next)) {
+      return ToOrderString(vec_result);
+    }
+
+    vec_result = vec_prev;
+    vec_result.push_back(1);
+    // Case a.b.c.d.1
+    DCHECK(CompareOrder(vec_prev, vec_result));
+    if (CompareOrder(vec_result, vec_next)) {
+      return ToOrderString(vec_result);
+    }
+
+    size_t insert_at = vec_prev.size();
+    size_t try_until_size = vec_next.size() + 1;
+    // Cases a.b.c.d.0....0.1
+    while (vec_result.size() < try_until_size) {
+      vec_result.insert(vec_result.begin() + insert_at, 0);
+      DCHECK(CompareOrder(vec_prev, vec_result));
+      if (CompareOrder(vec_result, vec_next)) {
+        return ToOrderString(vec_result);
+      }
+    }
+
+    NOTREACHED() << "[BraveSync] " << __func__ << " prev=" << prev <<
+        " next=" << next << " terminated with " << ToOrderString(vec_result);
+  }
+
+  NOTREACHED() << "[BraveSync] " << __func__ <<
+      " condition is not handled prev.empty()=" << prev.empty() <<
+      " next.empty()=" << next.empty();
+
+  return "";
+}
+
+}  // namespace brave_sync

--- a/components/brave_sync/bookmark_order_util.h
+++ b/components/brave_sync/bookmark_order_util.h
@@ -1,6 +1,7 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_BRAVE_SYNC_BOOKMARK_ORDER_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_SYNC_BOOKMARK_ORDER_UTIL_H_
@@ -11,8 +12,11 @@
 namespace brave_sync {
 
   std::vector<int> OrderToIntVect(const std::string& s);
+  std::string ToOrderString(const std::vector<int> &vec_int);
   bool CompareOrder(const std::string& left, const std::string& right);
+  std::string GetOrder(const std::string& prev, const std::string& next,
+      const std::string& parent);
 
-} // namespace brave_sync
+}  // namespace brave_sync
 
-#endif // BRAVE_COMPONENTS_BRAVE_SYNC_BOOKMARK_ORDER_UTIL_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_BOOKMARK_ORDER_UTIL_H_

--- a/components/brave_sync/bookmark_order_util_unittest.cc
+++ b/components/brave_sync/bookmark_order_util_unittest.cc
@@ -39,6 +39,13 @@ TEST(BookmarkOrderUtilTest, OrderToIntVect_SemiWrongValue) {
   EXPECT_EQ(result.at(0), 5);
 }
 
+TEST(BookmarkOrderUtilTest, ToOrderString) {
+  EXPECT_EQ(ToOrderString({}), "");
+  EXPECT_EQ(ToOrderString({1}), "1");
+  EXPECT_EQ(ToOrderString({1, 2, 3}), "1.2.3");
+  EXPECT_EQ(ToOrderString({-1, 2, 3}), "");
+}
+
 TEST(BookmarkOrderUtilTest, CompareOrder) {
   EXPECT_FALSE(CompareOrder("", ""));
   EXPECT_TRUE(CompareOrder("1", "2"));
@@ -53,6 +60,55 @@ TEST(BookmarkOrderUtilTest, CompareOrder) {
   EXPECT_TRUE(CompareOrder("1.7.0.1", "1.7.1"));
   EXPECT_TRUE(CompareOrder("1.7.0.1", "1.7.0.2"));
   EXPECT_FALSE(CompareOrder("1.7.0.2", "1.7.0.1"));
+
+  EXPECT_TRUE(CompareOrder("2.0.8", "2.0.8.0.1"));
+  EXPECT_TRUE(CompareOrder("2.0.8.0.1", "2.0.8.1"));
+
+  EXPECT_TRUE(CompareOrder("2.0.8", "2.0.8.0.0.1"));
+  EXPECT_TRUE(CompareOrder("2.0.8.0.0.1", "2.0.8.0.1"));
+
+  EXPECT_TRUE(CompareOrder("2.0.8.10", "2.0.8.10.1"));
+  EXPECT_TRUE(CompareOrder("2.0.8.10.1", "2.0.8.11.1"));
+
+  EXPECT_TRUE(CompareOrder("2.0.0.1", "2.0.1"));
+
+  EXPECT_TRUE(CompareOrder("2.5.6.3", "2.5.7.8.2"));
+  EXPECT_TRUE(CompareOrder("2.5.6.3", "2.5.6.4"));
+  EXPECT_TRUE(CompareOrder("2.5.6.4", "2.5.7.8.2"));
+
+  EXPECT_TRUE(CompareOrder("2.0.8.10", "2.0.8.11"));
+  EXPECT_TRUE(CompareOrder("2.0.8.11", "2.0.8.11.1"));
+}
+
+TEST(BookmarkOrderUtilTest, GetOrder) {
+  // Ported from https://github.com/brave/sync/blob/staging/test/client/bookmarkUtil.js
+  EXPECT_EQ(GetOrder("", "2.0.1", ""), "2.0.0.1");
+
+  EXPECT_EQ(GetOrder("", "2.0.9", ""), "2.0.8");
+  EXPECT_EQ(GetOrder("2.0.8", "", ""), "2.0.9");
+  EXPECT_EQ(GetOrder("2.0.8", "2.0.9", ""), "2.0.8.1");
+
+  EXPECT_EQ(GetOrder("2.0.8", "2.0.8.1", ""), "2.0.8.0.1");
+  EXPECT_EQ(GetOrder("2.0.8", "2.0.8.0.1", ""), "2.0.8.0.0.1");
+  EXPECT_EQ(GetOrder("2.0.8", "2.0.8.0.0.1", ""), "2.0.8.0.0.0.1");
+
+  EXPECT_EQ(GetOrder("2.0.8.1", "2.0.9", ""), "2.0.8.2");
+  EXPECT_EQ(GetOrder("2.0.8.1", "2.0.10", ""), "2.0.8.2");
+  EXPECT_EQ(GetOrder("2.0.8.10", "2.0.8.15", ""), "2.0.8.11");
+
+  EXPECT_EQ(GetOrder("2.0.8.10", "2.0.8.15.1", ""), "2.0.8.11");
+  EXPECT_EQ(GetOrder("2.0.8.10", "2.0.8.11.1", ""), "2.0.8.11");
+
+  EXPECT_EQ(GetOrder("2.0.8.11", "2.0.8.11.1", ""), "2.0.8.11.0.1");
+
+  EXPECT_EQ(GetOrder("2.0.8.10.0.1", "2.0.8.15.1", ""), "2.0.8.10.0.2");
+  EXPECT_EQ(GetOrder("", "", "2.0.9"), "2.0.9.1");
+
+  EXPECT_EQ(GetOrder("2.5.6.3", "2.5.7.8.2", ""), "2.5.6.4");
+  EXPECT_EQ(GetOrder("2.5.6.35", "2.5.7.8.2", ""), "2.5.6.36");
+
+  EXPECT_EQ(GetOrder("1.1.1.2", "1.1.1.2.1", ""), "1.1.1.2.0.1");
+  EXPECT_EQ(GetOrder("1.1.1.2.1", "1.1.1.3", ""), "1.1.1.2.2");
 }
 
 }   // namespace brave_sync

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -590,6 +590,7 @@ int BraveProfileSyncServiceImpl::GetDisableReasons() const {
   // kSyncManaged is set by Brave so it will contain
   // DISABLE_REASON_ENTERPRISE_POLICY and
   // SaveCardBubbleControllerImpl::ShouldShowSignInPromo will return false.
+  // kSyncManaged is disabled by us
   return ProfileSyncService::GetDisableReasons();
 }
 

--- a/components/brave_sync/syncer_helper.h
+++ b/components/brave_sync/syncer_helper.h
@@ -26,6 +26,16 @@ void RepositionOnApplyChangesFromSyncModel(
   bookmarks::BookmarkModel* bookmark_model,
   const std::multimap<int, const bookmarks::BookmarkNode*>& to_reposition);
 
+// Exported for test only
+void RepositionRespectOrder(
+    bookmarks::BookmarkModel* bookmark_model,
+    const bookmarks::BookmarkNode* node);
+
+uint64_t GetIndexByCompareOrderStartFrom(
+    const bookmarks::BookmarkNode* parent,
+    const bookmarks::BookmarkNode* src,
+    int index);
+
 }   // namespace brave_sync
 
 #endif  // BRAVE_COMPONENTS_BRAVE_SYNC_SYNCER_HELPER_H_

--- a/components/brave_sync/syncer_helper.h
+++ b/components/brave_sync/syncer_helper.h
@@ -17,9 +17,7 @@ class BookmarkNode;
 namespace brave_sync {
 
 void AddBraveMetaInfo(const bookmarks::BookmarkNode* node,
-                      bookmarks::BookmarkModel* bookmark_model,
-                      bool has_new_parent);
-
+                      bookmarks::BookmarkModel* bookmark_model);
 
 // |src| is the node which is about to be inserted into |parent|
 uint64_t GetIndex(const bookmarks::BookmarkNode* parent,

--- a/components/brave_sync/syncer_helper_unittest.cc
+++ b/components/brave_sync/syncer_helper_unittest.cc
@@ -84,7 +84,7 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoCreateOrUpdate) {
   std::string sync_timestamp;
   const auto* folder1 = model()->AddFolder(model()->bookmark_bar_node(), 0,
                                            base::ASCIIToUTF16("Folder1"));
-  AddBraveMetaInfo(folder1, model(), false);
+  AddBraveMetaInfo(folder1, model());
   folder1->GetMetaInfo("order", &order);
   EXPECT_EQ(order, "1.0.1.1");
   std::string folder1_id;
@@ -101,7 +101,7 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoCreateOrUpdate) {
                                        GURL("https://a.com/"));
   order.clear();
   sync_timestamp.clear();
-  AddBraveMetaInfo(node_a, model(), false);
+  AddBraveMetaInfo(node_a, model());
   node_a->GetMetaInfo("order", &order);
   EXPECT_EQ(order, "1.0.1.1.1");
   std::string node_a_id;
@@ -118,7 +118,7 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoCreateOrUpdate) {
   node_a_id.clear();
   node_a_parent_id.clear();
   model()->SetURL(node_a, GURL("https://a-m.com/"));
-  AddBraveMetaInfo(node_a, model(), false);
+  AddBraveMetaInfo(node_a, model());
   node_a->GetMetaInfo("order", &order);
   EXPECT_EQ(order, "1.0.1.1.1");
   node_a->GetMetaInfo("object_id", &node_a_id);
@@ -133,13 +133,13 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoCreateOrUpdate) {
 TEST_F(SyncerHelperTest, AddBraveMetaInfoNodeMoved) {
   const auto* folder1 = model()->AddFolder(model()->bookmark_bar_node(), 0,
                                            base::ASCIIToUTF16("Folder1"));
-  AddBraveMetaInfo(folder1, model(), false);
+  AddBraveMetaInfo(folder1, model());
   const auto *node_a = model()->AddURL(folder1, 0,
                                        base::ASCIIToUTF16("A.com - title"),
                                        GURL("https://a.com/"));
-  AddBraveMetaInfo(node_a, model(), false);
+  AddBraveMetaInfo(node_a, model());
   model()->Move(node_a, model()->bookmark_bar_node(), 1);
-  AddBraveMetaInfo(node_a, model(), true);
+  AddBraveMetaInfo(node_a, model());
 
   std::string order;
   node_a->GetMetaInfo("order", &order);
@@ -159,15 +159,22 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoNodeChildrenReordered) {
   const auto *node_a = model()->AddURL(model()->bookmark_bar_node(), 0,
                                        base::ASCIIToUTF16("A.com - title"),
                                        GURL("https://a.com/"));
-  AddBraveMetaInfo(node_a, model(), false);
+  AddBraveMetaInfo(node_a, model());
   const auto *node_b = model()->AddURL(model()->bookmark_bar_node(), 1,
                                        base::ASCIIToUTF16("B.com - title"),
                                        GURL("https://b.com/"));
-  AddBraveMetaInfo(node_b, model(), false);
+  AddBraveMetaInfo(node_b, model());
   const auto *node_c = model()->AddURL(model()->bookmark_bar_node(), 2,
                                        base::ASCIIToUTF16("C.com - title"),
                                        GURL("https://c.com/"));
-  AddBraveMetaInfo(node_c, model(), false);
+  AddBraveMetaInfo(node_c, model());
+
+  // Expecting to have initially:
+  // 'Bookmarks Bar'   1.0.1
+  //  |-A.com          1.0.1.1
+  //  |-B.com          1.0.1.2
+  //  |-C.com          1.0.1.3
+
   std::string order_a;
   std::string order_b;
   std::string order_c;
@@ -179,38 +186,49 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoNodeChildrenReordered) {
   EXPECT_EQ(order_c, "1.0.1.3");
 
   model()->Move(node_c, model()->bookmark_bar_node(), 0);
-  AddBraveMetaInfo(node_a, model(), false);
-  AddBraveMetaInfo(node_b, model(), false);
-  AddBraveMetaInfo(node_c, model(), false);
+  AddBraveMetaInfo(node_c, model());
+
+  // After move to have:
+  // 'Bookmarks Bar'   1.0.1
+  //  |-C.com          1.0.1.0.1
+  //  |-A.com          1.0.1.1
+  //  |-B.com          1.0.1.2
 
   order_a.clear();
   order_b.clear();
   order_c.clear();
 
   node_a->GetMetaInfo("order", &order_a);
-  EXPECT_EQ(order_a, "1.0.1.2");
+  EXPECT_EQ(order_a, "1.0.1.1");
   node_b->GetMetaInfo("order", &order_b);
-  EXPECT_EQ(order_b, "1.0.1.3");
+  EXPECT_EQ(order_b, "1.0.1.2");
   node_c->GetMetaInfo("order", &order_c);
-  EXPECT_EQ(order_c, "1.0.1.1");
+  EXPECT_EQ(order_c, "1.0.1.0.1");
 }
 
 TEST_F(SyncerHelperTest, AddBraveMetaInfoNodeMovedReordered) {
   const auto *node_a = model()->AddURL(model()->bookmark_bar_node(), 0,
                                        base::ASCIIToUTF16("A.com - title"),
                                        GURL("https://a.com/"));
-  AddBraveMetaInfo(node_a, model(), false);
+  AddBraveMetaInfo(node_a, model());
   const auto* folder1 = model()->AddFolder(model()->bookmark_bar_node(), 1,
                                            base::ASCIIToUTF16("Folder1"));
-  AddBraveMetaInfo(folder1, model(), false);
+  AddBraveMetaInfo(folder1, model());
   const auto *node_b = model()->AddURL(folder1, 0,
                                        base::ASCIIToUTF16("B.com - title"),
                                        GURL("https://b.com/"));
-  AddBraveMetaInfo(node_b, model(), false);
+  AddBraveMetaInfo(node_b, model());
   const auto *node_c = model()->AddURL(folder1, 1,
                                        base::ASCIIToUTF16("C.com - title"),
                                        GURL("https://c.com/"));
-  AddBraveMetaInfo(node_c, model(), false);
+  AddBraveMetaInfo(node_c, model());
+
+  // Expecting here to have:
+  // 'Bookmarks Bar'   1.0.1
+  //  |-A.com          1.0.1.1
+  //  |-Folder1        1.0.1.2
+  //    |-B.com        1.0.1.2.1
+  //    |-C.com        1.0.1.2.2
 
   std::string order_a;
   std::string order_b;
@@ -226,24 +244,28 @@ TEST_F(SyncerHelperTest, AddBraveMetaInfoNodeMovedReordered) {
   EXPECT_EQ(order_folder1, "1.0.1.2");
 
   model()->Move(node_a, folder1, 0);
-  AddBraveMetaInfo(node_a, model(), true);
-  AddBraveMetaInfo(folder1, model(), false);
-  AddBraveMetaInfo(node_b, model(), false);
-  AddBraveMetaInfo(node_c, model(), false);
+  AddBraveMetaInfo(node_a, model());
 
   order_a.clear();
   order_b.clear();
   order_c.clear();
   order_folder1.clear();
 
+  // After move expecting have:
+  // 'Bookmarks Bar'   1.0.1       (kept)
+  //  |-Folder1        1.0.1.2     (kept)
+  //    |-A.com        1.0.1.2.0.1 (re-calculated)
+  //    |-B.com        1.0.1.2.1   (kept)
+  //    |-C.com        1.0.1.2.2   (kept)
+
   node_a->GetMetaInfo("order", &order_a);
-  EXPECT_EQ(order_a, "1.0.1.1.1");
+  EXPECT_EQ(order_a, "1.0.1.2.0.1");
   node_b->GetMetaInfo("order", &order_b);
-  EXPECT_EQ(order_b, "1.0.1.1.2");
+  EXPECT_EQ(order_b, "1.0.1.2.1");
   node_c->GetMetaInfo("order", &order_c);
-  EXPECT_EQ(order_c, "1.0.1.1.3");
+  EXPECT_EQ(order_c, "1.0.1.2.2");
   folder1->GetMetaInfo("order", &order_folder1);
-  EXPECT_EQ(order_folder1, "1.0.1.1");
+  EXPECT_EQ(order_folder1, "1.0.1.2");
 }
 
 TEST_F(SyncerHelperTest, GetIndexInPermanentNodes) {

--- a/patches/chrome-browser-resources-bookmarks-api_listener.js.patch
+++ b/patches/chrome-browser-resources-bookmarks-api_listener.js.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/browser/resources/bookmarks/api_listener.js b/chrome/browser/resources/bookmarks/api_listener.js
+index 7bc20ec28e9faebc14dba26c277ea07db0940ed7..b1bafab103435383bbfa27338b8064aae38c1c44 100644
+--- a/chrome/browser/resources/bookmarks/api_listener.js
++++ b/chrome/browser/resources/bookmarks/api_listener.js
+@@ -135,6 +135,7 @@ cr.define('bookmarks.ApiListener', function() {
+    */
+   function onImportBegan() {
+     chrome.bookmarks.onCreated.removeListener(onBookmarkCreated);
++    chrome.bookmarks.onMoved.removeListener(onBookmarkMoved);
+   }
+ 
+   function onImportEnded() {
+@@ -143,6 +144,7 @@ cr.define('bookmarks.ApiListener', function() {
+           bookmarks.util.normalizeNodes(results[0])));
+     });
+     chrome.bookmarks.onCreated.addListener(onBookmarkCreated);
++    chrome.bookmarks.onMoved.addListener(onBookmarkMoved);
+   }
+ 
+   /**

--- a/patches/components-sync_bookmarks-bookmark_change_processor.cc.patch
+++ b/patches/components-sync_bookmarks-bookmark_change_processor.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/components/sync_bookmarks/bookmark_change_processor.cc b/components/sync_bookmarks/bookmark_change_processor.cc
-index 35a73a07bbcdd8aeba13acf37c6754aadb039768..f00db7611ccf75b66d8f4bf2db20566d45711f60 100644
+index 35a73a07bbcdd8aeba13acf37c6754aadb039768..52483687b7929da553b10f26423486597b1ed240 100644
 --- a/components/sync_bookmarks/bookmark_change_processor.cc
 +++ b/components/sync_bookmarks/bookmark_change_processor.cc
 @@ -87,6 +87,7 @@ void BookmarkChangeProcessor::UpdateSyncNodeProperties(
    bookmark_specifics.set_creation_time_us(src->date_added().ToInternalValue());
    dst->SetBookmarkSpecifics(bookmark_specifics);
    SetSyncNodeFavicon(src, model, dst);
-+  brave_sync::AddBraveMetaInfo(src, model, false);
++  brave_sync::AddBraveMetaInfo(src, model);
    SetSyncNodeMetaInfo(src, dst);
  }
  
@@ -43,12 +43,10 @@ index 35a73a07bbcdd8aeba13acf37c6754aadb039768..f00db7611ccf75b66d8f4bf2db20566d
    CreateOrUpdateSyncNode(node);
  }
  
-@@ -489,7 +493,8 @@ void BookmarkChangeProcessor::BookmarkNodeChildrenReordered(
-       }
+@@ -490,6 +494,7 @@ void BookmarkChangeProcessor::BookmarkNodeChildrenReordered(
        DCHECK_EQ(sync_child.GetParentId(),
                  model_associator_->GetSyncIdFromChromeId(node->id()));
--
-+ 
+ 
 +      BRAVE_BOOKMARK_CHANGE_PROCESSOR_CHILDREN_REORDERED
        if (!PlaceSyncNode(MOVE, node, i, &trans, &sync_child,
                           model_associator_)) {


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
