### PR TITLE
stylesheet injection for cosmetic filtering

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
@@ -31,8 +31,9 @@ export const applySiteFilters = (hostname: string) => {
         if (process.env.NODE_ENV === 'shields_development') {
           console.log('applying rule', rule)
         }
-        chrome.tabs.insertCSS({
-          code: `${rule} {display: none;}`,
+        chrome.tabs.insertCSS({ // https://github.com/brave/brave-browser/wiki/Cosmetic-Filtering
+          code: `${rule} {display: none !important;}`,
+          cssOrigin: 'user',
           runAt: 'document_start'
         })
       })

--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -86,7 +86,8 @@ export function onSelectorReturned (response: any) {
 
   if (rule.selector && rule.selector.length > 0) {
     chrome.tabs.insertCSS({
-      code: `${rule.selector} {display: none;}`
+      code: `${rule.selector} {display: none !important;}`,
+      cssOrigin: 'user'
     })
     cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
   }

--- a/components/test/brave_extension/background/api/cosmeticFilterAPI_test.ts
+++ b/components/test/brave_extension/background/api/cosmeticFilterAPI_test.ts
@@ -208,7 +208,8 @@ describe('cosmeticFilterTestSuite', () => {
       })
       cosmeticFilterAPI.applySiteFilters('brave.com')
       expect(insertCSSStub.getCall(0).args[0]).toEqual({
-        code: `${ filter } {display: none;}`,
+        code: `${ filter } {display: none !important;}`,
+        cssOrigin: 'user',
         runAt: 'document_start'
       })
     })
@@ -220,11 +221,13 @@ describe('cosmeticFilterTestSuite', () => {
       })
       cosmeticFilterAPI.applySiteFilters('brave.com')
       expect(insertCSSStub.getCall(0).args[0]).toEqual({
-        code: `${ filter } {display: none;}`,
+        code: `${filter } {display: none !important;}`,
+        cssOrigin: 'user',
         runAt: 'document_start'
       })
       expect(insertCSSStub.getCall(1).args[0]).toEqual({
-        code: `${ filter2 } {display: none;}`,
+        code: `${ filter2 } {display: none !important;}`,
+        cssOrigin: 'user',
         runAt: 'document_start'
       })
 

--- a/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
+++ b/components/test/brave_extension/background/events/cosmeticFilterEvents_test.ts
@@ -148,7 +148,8 @@ describe('cosmeticFilterEvents events', () => {
           selectorToReturn = '#test_selector'
           cosmeticFilterEvents.onSelectorReturned(selectorToReturn)
           let returnObj = {
-            'code': '#test_selector {display: none;}'
+            'code': '#test_selector {display: none !important;}',
+            'cssOrigin': 'user'
           }
           expect(insertCssSpy).toBeCalledWith(returnObj)
         })


### PR DESCRIPTION
## Submitter Checklist:

closes https://github.com/brave/brave-browser/issues/3041, https://github.com/brave/brave-browser/issues/4348, https://github.com/brave/brave-browser/issues/4338

and https://github.com/brave/brave-browser/issues/94#issuecomment-445516002

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Block element with !important html tag or is asynchronously added to the webpage (ex. reddit/facebook with filters added) and see that those ads are blocked.

1. 
- 1. Visit http://raymondhill.net/ublock/adbox.html (mirror: https://jsfiddle.net/fbdagveq/)
- 2. Right click, add `.ADBox` filter
- 3. master will not be able to block the 2nd red highlighted element (because of `!important`), PR will.


2.

- 1. Visit https://new.reddit.com/
- 2. add `.promotedlink` to filter
- 3. scroll down to see promoted links/advertisements (master will not be able to block the promoted links, but this PR will)


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
