### PR TITLE
WebTorrent: UI improvements

### DIFF
--- a/components/brave_webtorrent/extension/components/torrentFileList.tsx
+++ b/components/brave_webtorrent/extension/components/torrentFileList.tsx
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import { Table } from 'brave-ui/components'
+import { Heading, Table } from 'brave-ui/components'
 import { Cell, Row } from 'brave-ui/components/dataTables/table/index'
 import { LoaderIcon } from 'brave-ui/components/icons'
 import * as prettierBytes from 'prettier-bytes'
@@ -22,9 +22,8 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
     if (!torrent || !torrent.files) {
       return (
         <div className='torrentSubhead'>
-          <p>
-            Click "Start Torrent" to begin your download. WebTorrent can be
-            disabled from the extensions panel in Settings.
+          <p className='starterText'>
+            Click "Start Torrent" to begin your download.
           </p>
         </div>
       )
@@ -94,6 +93,7 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
 
     return (
       <div>
+        <Heading children='Files' level={2} className='torrentHeading' />
         <Table header={header} rows={rows}>
           <div className='loadingContainer'>
             <div className='__icon'>

--- a/components/brave_webtorrent/extension/components/torrentStatus.tsx
+++ b/components/brave_webtorrent/extension/components/torrentStatus.tsx
@@ -4,10 +4,14 @@
 
 import * as React from 'react'
 import * as prettierBytes from 'prettier-bytes'
-import { Column, Grid, Heading } from 'brave-ui/components'
+import { Heading } from 'brave-ui/components'
 
 // Constants
 import { TorrentObj } from '../constants/webtorrentState'
+
+const TorrentStatDivider = () => (
+  <span className='torrentStatDivider'>•</span>
+ )
 
 interface Props {
   torrent?: TorrentObj
@@ -27,39 +31,64 @@ export default class TorrentStatus extends React.PureComponent<Props, {}> {
     }
 
     const renderStatus = () => {
-      const status = torrent.progress < 1 ? 'Downloading' : 'Seeding'
-      return <Column size={2}> {status} </Column>
+      const status = torrent.progress < 1
+        ? 'Downloading'
+        : 'Seeding'
+      return <span className='torrentStat'>{status}</span>
     }
 
     const renderPercentage = () => {
-      const percentage =
-        torrent.progress < 1 ? (torrent.progress * 100).toFixed(1) : '100'
-      return <Column size={2}> {percentage}% </Column>
+      const percentage = torrent.progress < 1
+        ? (torrent.progress * 100).toFixed(1)
+        : '100'
+      return (
+        <>
+          <TorrentStatDivider />
+          <span className='torrentStat'>{percentage}%</span>
+        </>
+      )
     }
 
-    const renderSpeeds = () => {
-      let str = ''
-      if (torrent.downloadSpeed > 0) {
-        str += ' ↓ ' + prettierBytes(torrent.downloadSpeed) + '/s'
-      }
-      if (torrent.uploadSpeed > 0) {
-        str += ' ↑ ' + prettierBytes(torrent.uploadSpeed) + '/s'
-      }
-      if (str === '') return
-      return <Column size={2}> {str} </Column>
+    const renderDownloadSpeed = () => {
+      if (torrent.downloadSpeed === 0) return
+      return (
+        <>
+          <TorrentStatDivider />
+          <span className='torrentStat'>
+            ↓ {prettierBytes(torrent.downloadSpeed)}/s
+          </span>
+        </>
+      )
+    }
+
+    const renderUploadSpeed = () => {
+      if (torrent.uploadSpeed === 0) return
+      return (
+        <>
+          <TorrentStatDivider />
+          <span className='torrentStat'>
+            ↑ {prettierBytes(torrent.uploadSpeed)}/s
+          </span>
+        </>
+      )
     }
 
     const renderTotalProgress = () => {
       const downloaded = prettierBytes(torrent.downloaded)
       const total = prettierBytes(torrent.length || 0)
       if (downloaded === total) {
-        return <Column size={2}> {downloaded} </Column>
+        return (
+          <>
+            <TorrentStatDivider />
+            <span className='torrentStat'>{downloaded}</span>
+          </>
+        )
       } else {
         return (
-          <Column size={2}>
-            {' '}
-            {downloaded} / {total}{' '}
-          </Column>
+          <>
+            <TorrentStatDivider />
+            <span className='torrentStat'>{downloaded} / {total}</span>
+          </>
         )
       }
     }
@@ -68,10 +97,12 @@ export default class TorrentStatus extends React.PureComponent<Props, {}> {
       if (torrent.numPeers === 0) return
       const count = torrent.numPeers === 1 ? 'peer' : 'peers'
       return (
-        <Column size={2}>
-          {' '}
-          {torrent.numPeers} {count}{' '}
-        </Column>
+        <>
+          <TorrentStatDivider />
+          <span className='torrentStat'>
+            {torrent.numPeers} {count}
+          </span>
+        </>
       )
     }
 
@@ -93,23 +124,27 @@ export default class TorrentStatus extends React.PureComponent<Props, {}> {
       const secondsStr = seconds + 's'
 
       return (
-        <div className='__column'>
-          {hoursStr} {minutesStr} {secondsStr} remaining
-        </div>
+        <>
+          <TorrentStatDivider />
+          <span className='torrentStat'>
+            {hoursStr} {minutesStr} {secondsStr} remaining
+          </span>
+        </>
       )
     }
 
     return (
       <div className='torrentSubhead'>
-        <Heading children='Torrent Status' level={3} />
-        <Grid className='gridFix'>
+        <Heading children='Torrent Stats' level={2} className='torrentHeading' />
+        <div className='torrentStatus'>
           {renderStatus()}
           {renderPercentage()}
-          {renderSpeeds()}
+          {renderDownloadSpeed()}
+          {renderUploadSpeed()}
           {renderTotalProgress()}
           {renderPeers()}
           {renderEta()}
-        </Grid>
+        </div>
       </div>
     )
   }

--- a/components/brave_webtorrent/extension/components/torrentViewerFooter.tsx
+++ b/components/brave_webtorrent/extension/components/torrentViewerFooter.tsx
@@ -22,21 +22,27 @@ export default class TorrentViewerFooter extends React.PureComponent<
   render () {
     const { torrent } = this.props
 
-    return torrent ? (
-      <Anchor
-        href='https://webtorrent.io'
-        text='Powered By WebTorrent'
-        target='_blank'
-        id='webTorrentCredit'
-      />
-    ) : (
-      <div className='privacyNotice'>
-        Privacy Warning: When you click "Start Torrent" Brave will begin
-        downloading pieces of the torrent file from other users and uploading to
-        them in turn. This action will share that you're downloading this file.
-        Others may be able to see what you're downloading and/or determine your
-        public IP address.
-      </div>
-    )
+    if (torrent) {
+      return (
+        <Anchor
+          href='https://webtorrent.io'
+          text='Powered By WebTorrent'
+          target='_blank'
+          id='webTorrentCredit'
+        />
+      )
+    } else {
+      return (
+        <div className='footerNotice'>
+          Privacy Warning: When you click "Start Torrent" Brave will begin
+          downloading pieces of the torrent file from other users and uploading to
+          them in turn. This action will share that you're downloading this file.
+          Others may be able to see what you're downloading and/or determine your
+          public IP address.
+          <br /><br />
+          The WebTorrent extension can be disabled from Brave settings.
+        </div>
+      )
+    }
   }
 }

--- a/components/brave_webtorrent/extension/components/torrentViewerHeader.tsx
+++ b/components/brave_webtorrent/extension/components/torrentViewerHeader.tsx
@@ -64,6 +64,7 @@ export default class TorrentViewerHeader extends React.PureComponent<
         <div className='__column'>
           <Button
             type='accent'
+            level={!torrent ? 'primary' : 'secondary'}
             text={mainButtonText}
             onClick={this.onClick}
             className='__button'

--- a/components/styles/webtorrent.css
+++ b/components/styles/webtorrent.css
@@ -32,34 +32,39 @@ a {
 }
 
 .torrentSubhead {
-  padding: 18px 0;
   border-top: solid 1px #c8c8d5;
+  margin: 16px 0;
 }
 
-.torrentSubhead p {
-  font-size: 18px;
-}
-
-.torrentSubhead h3 {
+.starterText {
   font-size: 20px;
-  margin: 24px 0;
+  margin: 32px 0;
+}
+
+.torrentHeading {
+  font-size: 20px;
+  margin: 32px 0 16px 0;
   font-weight: 500;
   color: #fb542b;
 }
 
-.privacyNotice {
+.torrentStatus {
+  font-size: 16px;
+}
+
+.torrentStat, .torrentStatDivider {
+  margin-right: 15px;
+}
+
+.footerNotice {
   padding: 18px 0;
   border-top: solid 1px #c8c8d5;
-  color: #ababbf;
-  line-height: 24px;
+  color: #8b8b9f;
+  line-height: 18px;
 }
 
 #webTorrentCredit {
-  color: #c8c8d5;
-}
-
-.gridFix {
-  grid-template-columns: repeat(auto-fill, 50px);
+  color: #8b8b9f;
 }
 
 .loadingContainer {

--- a/components/test/brave_webtorrent/components/torrentViewerFooter_test.tsx
+++ b/components/test/brave_webtorrent/components/torrentViewerFooter_test.tsx
@@ -24,7 +24,7 @@ describe('torrentViewerFooter component', () => {
       const wrapper = shallow(
         <TorrentViewerFooter />
       )
-      const assertion = wrapper.find('.privacyNotice')
+      const assertion = wrapper.find('.footerNotice')
       expect(assertion.length).toBe(1)
     })
   })


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/5353

- Fixes torrent stats layout issues https://github.com/brave/brave-browser/issues/5353
  - Removed the `<Grid>` component which only allowed for a fixed size for each stat item. Instead, we just have one line of text, with stats separated by a mid-dot (•)
- Add 'Files' table heading
- Display 'Stop Torrent' button as a secondary button
  - Once user has started the torrent, their likely next step is to click on a file name and the primary 'Stop Torrent' button was drawing too much attention.
- Move disable instructions to footer
  - It seemed odd to have the instructions for disabling WebTorrent so prominently in the UI when the user first lands on this page. Especially for new users who haven't even tried the WebTorrent extension yet.

Before:

![Screen Shot 2019-07-24 at 4 10 25 PM](https://user-images.githubusercontent.com/121766/61834659-a36b7280-ae2d-11e9-9706-d4ee37a0d196.png)

After:

![Screen Shot 2019-07-24 at 4 10 33 PM](https://user-images.githubusercontent.com/121766/61834661-a6666300-ae2d-11e9-9168-ccbbc8214aed.png)

Before:

![Screen Shot 2019-07-24 at 4 10 40 PM](https://user-images.githubusercontent.com/121766/61834666-ab2b1700-ae2d-11e9-834b-912f14fed9a4.png)

After:

![Screen Shot 2019-07-24 at 4 10 47 PM](https://user-images.githubusercontent.com/121766/61834668-ae260780-ae2d-11e9-9170-f60f2f84ecef.png)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

   1. Visit https://webtorrent.io/free-torrents
   2. Click Big Buck Bunny (torrent file)
   3. Start downloading torrent
   4. Look at the stats

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
