### PR TITLE
Removes Crypto Wallets menu item in official builds

### DIFF
--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -1,11 +1,11 @@
 import("//tools/grit/grit_rule.gni")
 import("//ui/webui/webui_features.gni")
-import("//build/config/features.gni")
+import("//brave/components/brave_wallet/browser/buildflags/buildflags.gni")
 
 grit("resources") {
   defines = [
     "optimize_webui=$optimize_webui",
-    "is_official_build=$is_official_build"
+    "brave_wallet_enabled=$brave_wallet_enabled"
   ]
   source = "brave_webui_resources.grd"
 

--- a/ui/webui/resources/br_elements/br_toolbar/br_toolbar.html
+++ b/ui/webui/resources/br_elements/br_toolbar/br_toolbar.html
@@ -163,7 +163,7 @@
             <span class="nav-item_text">[[downloadsTitle]]</span>
           </a>
         </li>
-        <if expr="not is_official_build">
+        <if expr="brave_wallet_enabled">
           <li class="nav-items_list-item" title="[[walletsTitle]]">
             <a class="nav-item" href="chrome://wallet">
               <span class="nav-item_icon">


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/5383

Uses `brave_wallet_enabled` over `is_official_build`. Should be uplifted to Dev

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
