### PR TITLE
Remove redundant obsolete brave/tracking-protection (Uplift to 0.68.x)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -2,10 +2,9 @@ use_relative_paths = True
 
 deps = {
   "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@0e980ee0a63d837f3ecad666fabe1f50311baa81",
-  "vendor/autoplay-whitelist": "https://github.com/brave/autoplay-whitelist.git@f39d83788cd12b883bfe6561cc7166b176ab9d9d",
-  "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@aa74a1bc29ced176e50db9f54946f28d82dfc795",
-  "vendor/tracking-protection": "https://github.com/brave/tracking-protection.git@3de744d4698b2f8fac1f52579d39f9ad154d1ec2",
-  "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@4b55fe39bb25bb0d8b11a43d547d75f00c6c46fb",
+  "vendor/autoplay-whitelist": "https://github.com/brave/autoplay-whitelist.git@ea527a4d36051daedb34421e129c98eda06cb5d3",
+  "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@7843f62e26a23c51336330e220e9d7992680aae9",
+  "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@6eab0271d014ff09bd9f38abe1e0c117e13e9aa9",
   "vendor/bloom-filter-cpp": "https://github.com/brave/bloom-filter-cpp.git@9be5c63b14e094156e00c8b28f205e7794f0b92c",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -19,7 +19,6 @@
 #include "brave/components/brave_shields/browser/ad_block_service.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
-#include "brave/components/brave_shields/browser/tracking_protection_service.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "content/public/browser/browser_thread.h"
@@ -133,22 +132,12 @@ void OnBeforeURLRequestAdBlockTP(
                                        tab_host, &did_match_exception,
                                        &ctx->cancel_request_explicitly)) {
     ctx->blocked_by = kAdBlocked;
-  } else if (!did_match_exception &&
-             !g_brave_browser_process->tracking_protection_service()
-                  ->ShouldStartRequest(ctx->request_url, ctx->resource_type,
-                                       tab_host, &did_match_exception,
-                                       &ctx->cancel_request_explicitly)) {
-    ctx->blocked_by = kTrackerBlocked;
   }
 
   if (ctx->blocked_by == kAdBlocked) {
     brave_shields::DispatchBlockedEventFromIO(ctx->request_url,
         ctx->render_frame_id, ctx->render_process_id, ctx->frame_tree_node_id,
         brave_shields::kAds);
-  } else if (ctx->blocked_by == kTrackerBlocked) {
-    brave_shields::DispatchBlockedEventFromIO(ctx->request_url,
-        ctx->render_frame_id, ctx->render_process_id, ctx->frame_tree_node_id,
-        brave_shields::kTrackers);
   }
 }
 

--- a/browser/net/brave_network_delegate_base.cc
+++ b/browser/net/brave_network_delegate_base.cc
@@ -379,8 +379,7 @@ void BraveNetworkDelegateBase::RunNextCallback(
         IsRequestIdentifierValid(ctx->request_identifier)) {
       *ctx->new_url = GURL(ctx->new_url_spec);
     }
-    if (ctx->blocked_by == brave::kAdBlocked ||
-        ctx->blocked_by == brave::kTrackerBlocked) {
+    if (ctx->blocked_by == brave::kAdBlocked) {
       // We are going to intercept this request and block it later in the
       // network stack.
       if (ctx->cancel_request_explicitly) {

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -43,7 +43,6 @@ enum BraveNetworkDelegateEventType {
 enum BlockedBy {
   kNotBlocked ,
   kAdBlocked,
-  kTrackerBlocked,
   kOtherBlocked
 };
 

--- a/browser/ui/webui/brave_adblock_ui.cc
+++ b/browser/ui/webui/brave_adblock_ui.cc
@@ -130,7 +130,8 @@ void BraveAdblockUI::CustomizeWebUIProperties(
   PrefService* prefs = profile->GetPrefs();
   if (render_view_host) {
     render_view_host->SetWebUIProperty(
-        "adsBlockedStat", std::to_string(prefs->GetUint64(kAdsBlocked)));
+        "adsBlockedStat", std::to_string(prefs->GetUint64(kAdsBlocked) +
+            prefs->GetUint64(kTrackersBlocked)));
   }
 }
 

--- a/browser/ui/webui/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/brave_new_tab_message_handler.cc
@@ -29,9 +29,6 @@ void BraveNewTabMessageHandler::OnJavascriptAllowed() {
   pref_change_registrar_.Add(kAdsBlocked,
     base::Bind(&BraveNewTabMessageHandler::OnStatsChanged,
     base::Unretained(this)));
-  pref_change_registrar_.Add(kTrackersBlocked,
-    base::Bind(&BraveNewTabMessageHandler::OnStatsChanged,
-    base::Unretained(this)));
   pref_change_registrar_.Add(kHttpsUpgrades,
     base::Bind(&BraveNewTabMessageHandler::OnStatsChanged,
     base::Unretained(this)));

--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -49,10 +49,8 @@ void BraveNewTabUI::SetStatsWebUIProperties(
   if (render_view_host) {
     render_view_host->SetWebUIProperty(
         "adsBlockedStat",
-        std::to_string(prefs->GetUint64(kAdsBlocked)));
-    render_view_host->SetWebUIProperty(
-        "trackersBlockedStat",
-        std::to_string(prefs->GetUint64(kTrackersBlocked)));
+        std::to_string(prefs->GetUint64(kAdsBlocked) +
+            prefs->GetUint64(kTrackersBlocked)));
     render_view_host->SetWebUIProperty(
         "javascriptBlockedStat",
         std::to_string(prefs->GetUint64(kJavascriptBlocked)));

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -6,6 +6,8 @@
 #include "brave/common/pref_names.h"
 
 const char kAdsBlocked[] = "brave.stats.ads_blocked";
+// We no longer update this pref, but we keep it around for now because it's
+// added to kAdsBlocked when being displayed.
 const char kTrackersBlocked[] = "brave.stats.trackers_blocked";
 const char kJavascriptBlocked[] = "brave.stats.javascript_blocked";
 const char kHttpsUpgrades[] = "brave.stats.https_upgrades";

--- a/components/brave_new_tab_ui/components/newTab/stats.tsx
+++ b/components/brave_new_tab_ui/components/newTab/stats.tsx
@@ -17,10 +17,6 @@ export default class Stats extends React.Component<Props, {}> {
     return 50
   }
 
-  get trackedBlockersCount () {
-    return this.props.stats.trackersBlockedStat || 0
-  }
-
   get adblockCount () {
     return this.props.stats.adsBlockedStat || 0
   }
@@ -30,7 +26,7 @@ export default class Stats extends React.Component<Props, {}> {
   }
 
   get estimatedTimeSaved () {
-    const estimatedMillisecondsSaved = (this.adblockCount + this.trackedBlockersCount) * this.millisecondsPerItem || 0
+    const estimatedMillisecondsSaved = this.adblockCount * this.millisecondsPerItem || 0
     const hours = estimatedMillisecondsSaved < 1000 * 60 * 60 * 24
     const minutes = estimatedMillisecondsSaved < 1000 * 60 * 60
     const seconds = estimatedMillisecondsSaved < 1000 * 60
@@ -62,17 +58,12 @@ export default class Stats extends React.Component<Props, {}> {
   }
 
   render () {
-    const trackedBlockersCount = this.trackedBlockersCount.toLocaleString()
     const adblockCount = this.adblockCount.toLocaleString()
     const httpsUpgradedCount = this.httpsUpgradedCount.toLocaleString()
     const timeSaved = this.estimatedTimeSaved
 
     return (
       <StatsContainer>
-        <StatsItem
-          description={getLocale('trackersBlocked')}
-          counter={trackedBlockersCount}
-        />
         <StatsItem
           description={getLocale('adsBlocked')}
           counter={adblockCount}

--- a/components/brave_new_tab_ui/storage.ts
+++ b/components/brave_new_tab_ui/storage.ts
@@ -24,7 +24,6 @@ const defaultState: NewTab.State = {
   bookmarks: {},
   stats: {
     adsBlockedStat: 0,
-    trackersBlockedStat: 0,
     javascriptBlockedStat: 0,
     httpsUpgradesStat: 0,
     fingerprintingBlockedStat: 0
@@ -34,7 +33,7 @@ const defaultState: NewTab.State = {
 export const getLoadTimeData = (state: NewTab.State) => {
   state = { ...state }
   state.stats = defaultState.stats
-  ;['adsBlockedStat', 'trackersBlockedStat', 'javascriptBlockedStat',
+  ;['adsBlockedStat', 'javascriptBlockedStat',
     'httpsUpgradesStat', 'fingerprintingBlockedStat'].forEach((stat) => {
       state.stats[stat] = parseInt(chrome.getVariableValue(stat), 10) || 0
     })

--- a/components/brave_shields/browser/BUILD.gn
+++ b/components/brave_shields/browser/BUILD.gn
@@ -51,7 +51,6 @@ source_set("brave_shields") {
     "//brave/components/brave_component_updater/browser",
     "//brave/content:common",
     "//brave/vendor/adblock_rust_ffi:adblock_ffi",
-    "//brave/vendor/tracking-protection/brave:tracking-protection",
     "//brave/vendor/autoplay-whitelist/brave:autoplay-whitelist",
     "//chrome/common",
     "//components/prefs",

--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -547,60 +547,6 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
 
-// Load a page that references a tracker from an untrusted domain, but
-// has no specific exception rule in ad-block.
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
-    TrackerReferencedFromUntrustedDomain) {
-  SetDefaultComponentIdAndBase64PublicKeyForTest(
-      kDefaultAdBlockComponentTestId,
-      kDefaultAdBlockComponentTestBase64PublicKey);
-  InitTrackingProtectionService();
-  ASSERT_TRUE(InstallTrackingProtectionExtension());
-  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kTrackersBlocked),
-      0ULL);
-  GURL url = embedded_test_server()->GetURL("google.com", kAdBlockTestPage);
-  ui_test_utils::NavigateToURL(browser(), url);
-  content::WebContents* contents =
-      browser()->tab_strip_model()->GetActiveWebContents();
-  GURL test_url = embedded_test_server()->GetURL("365dm.com", "/logo.png");
-  bool as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-      base::StringPrintf(
-          "setExpectations(0, 1, 0, 0, 0, 0);"
-          "addImage('%s')",
-      test_url.spec().c_str()),
-      &as_expected));
-  EXPECT_TRUE(as_expected);
-  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kTrackersBlocked),
-      1ULL);
-}
-
-// Load a page that references a tracker from an untrusted domain, but
-// has a specific exception rule in ad-block.
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
-    TrackerReferencedFromUntrustedDomainWithException) {
-  InitTrackingProtectionService();
-  UpdateAdBlockInstanceWithRules("||365dm.com\n@@logo.png");
-  ASSERT_TRUE(InstallTrackingProtectionExtension());
-  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kTrackersBlocked),
-      0ULL);
-  GURL url = embedded_test_server()->GetURL("google.com", kAdBlockTestPage);
-  ui_test_utils::NavigateToURL(browser(), url);
-  content::WebContents* contents =
-      browser()->tab_strip_model()->GetActiveWebContents();
-  GURL test_url = embedded_test_server()->GetURL("365dm.com", "/logo.png");
-  bool as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(contents,
-      base::StringPrintf(
-          "setExpectations(1, 0, 0, 0, 0, 0);"
-          "addImage('%s')",
-      test_url.spec().c_str()),
-      &as_expected));
-  EXPECT_TRUE(as_expected);
-  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kTrackersBlocked),
-      0ULL);
-}
-
 // Make sure the third-party flag is passed into the ad-block library properly
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdBlockThirdPartyWorksByETLDP1) {
   UpdateAdBlockInstanceWithRules("||a.com$third-party");

--- a/components/brave_shields/browser/brave_shields_web_contents_observer.cc
+++ b/components/brave_shields/browser/brave_shields_web_contents_observer.cc
@@ -245,9 +245,6 @@ void BraveShieldsWebContentsObserver::DispatchBlockedEvent(
 
       if (block_type == kAds) {
         prefs->SetUint64(kAdsBlocked, prefs->GetUint64(kAdsBlocked) + 1);
-      } else if (block_type == kTrackers) {
-        prefs->SetUint64(kTrackersBlocked,
-            prefs->GetUint64(kTrackersBlocked) + 1);
       } else if (block_type == kHTTPUpgradableResources) {
         prefs->SetUint64(kHttpsUpgrades, prefs->GetUint64(kHttpsUpgrades) + 1);
       } else if (block_type == kJavaScript) {

--- a/components/brave_shields/browser/tracking_protection_service.h
+++ b/components/brave_shields/browser/tracking_protection_service.h
@@ -23,7 +23,6 @@
 #include "content/public/common/resource_type.h"
 #include "url/gurl.h"
 
-class CTPParser;
 class HostContentSettingsMap;
 class TrackingProtectionServiceTest;
 
@@ -39,9 +38,6 @@ namespace brave_shields {
 // The brave shields service in charge of tracking protection and init.
 class TrackingProtectionService : public LocalDataFilesObserver {
  public:
-  using GetDATFileDataResult =
-      brave_component_updater::LoadDATFileDataResult<CTPParser>;
-
   explicit TrackingProtectionService(
       LocalDataFilesService* local_data_files_service);
   ~TrackingProtectionService() override;
@@ -111,18 +107,11 @@ class TrackingProtectionService : public LocalDataFilesObserver {
 #endif
 
  private:
-  void OnGetDATFileData(GetDATFileDataResult result);
-  void UpdateTrackingProtectionClient(
-      std::unique_ptr<CTPParser> tracking_protection_client,
-      brave_component_updater::DATFileDataBuffer);
-  std::vector<std::string> GetThirdPartyHosts(const std::string& base_host);
-
 #if BUILDFLAG(BRAVE_STP_ENABLED)
   base::flat_set<std::string> first_party_storage_trackers_;
   std::map<RenderFrameIdKey, GURL> render_frame_key_to_starting_site_url;
 #endif
 
-  std::unique_ptr<CTPParser> tracking_protection_client_;
   std::vector<std::string> third_party_base_hosts_;
   std::map<std::string, std::vector<std::string>> third_party_hosts_cache_;
   base::Lock third_party_hosts_lock_;

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -25,7 +25,6 @@ declare namespace NewTab {
 
   export interface Stats {
     adsBlockedStat: number
-    trackersBlockedStat: number
     javascriptBlockedStat: number
     httpsUpgradesStat: number
     fingerprintingBlockedStat: number

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -167,7 +167,7 @@
       <!-- WebUI adblock resources -->
       <message name="IDS_ADBLOCK_ADDITIONAL_FILTERS_TITLE" desc="Title for additional filters section">Additional Filters</message>
       <message name="IDS_ADBLOCK_ADDITIONAL_FILTERS_WARNING" desc="Warning for additional filters section">Warning: Turning on too many filters will degrade performance</message>
-      <message name="IDS_ADBLOCK_TOTAL_ADS_BLOCKED" desc="total number of ads blocked">Total Ads Blocked:</message>
+      <message name="IDS_ADBLOCK_TOTAL_ADS_BLOCKED" desc="total number of ads blocked">Total ads and trackers blocked:</message>
       <message name="IDS_ADBLOCK_CUSTOM_FILTERS_TITLE" desc="Title for custom filters section">Custom Filters</message>
       <message name="IDS_ADBLOCK_CUSTOM_FILTERS_INSTRUCTIONS" desc="Instructions for custom filters section">One per line, a filter is described in Adblock Plus filter syntax</message>
 

--- a/components/test/testData.ts
+++ b/components/test/testData.ts
@@ -55,7 +55,6 @@ export const newTabInitialState: NewTab.ApplicationState = {
     bookmarks: {},
     stats: {
       adsBlockedStat: 0,
-      trackersBlockedStat: 0,
       javascriptBlockedStat: 0,
       httpsUpgradesStat: 0,
       fingerprintingBlockedStat: 0

--- a/test/data/tracking.html
+++ b/test/data/tracking.html
@@ -1,4 +1,0 @@
-<html>
-<head></head>
-<body>Tracking image inserted here:</body>
-</html>


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/2971
