### PR TITLE
Register prefs in right places

### DIFF
--- a/browser/autoplay/autoplay_permission_context_unittest.cc
+++ b/browser/autoplay/autoplay_permission_context_unittest.cc
@@ -77,8 +77,6 @@ class AutoplayPermissionContextTests : public ChromeRenderViewHostTestHarness {
     auto prefs =
         std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
     RegisterUserProfilePrefs(prefs->registry());
-    prefs->registry()->
-      RegisterBooleanPref(kGoogleLoginControlType, true);
     builder.SetPrefService(std::move(prefs));
     return builder.Build().release();
   }

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -5,10 +5,7 @@
 
 #include "brave/browser/brave_profile_prefs.h"
 
-#include "brave/browser/themes/brave_theme_service.h"
-#include "brave/browser/tor/buildflags.h"
 #include "brave/common/pref_names.h"
-#include "brave/components/brave_rewards/browser/rewards_service.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
 #include "chrome/browser/net/prediction_options.h"
@@ -18,7 +15,6 @@
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/safe_browsing/common/safe_browsing_prefs.h"
 #include "components/signin/core/browser/signin_pref_names.h"
-#include "components/spellcheck/browser/pref_names.h"
 #include "components/sync/base/pref_names.h"
 #include "extensions/buildflags/buildflags.h"
 #include "extensions/common/feature_switch.h"
@@ -32,29 +28,17 @@
 #include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
 #endif
 
-#if BUILDFLAG(ENABLE_TOR)
-#include "brave/browser/tor/tor_profile_service.h"
-#endif
-
 using extensions::FeatureSwitch;
 
 namespace brave {
 
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
-  brave_rewards::RewardsService::RegisterProfilePrefs(registry);
   brave_shields::BraveShieldsWebContentsObserver::RegisterProfilePrefs(
       registry);
 
   // appearance
-#if !defined(OS_ANDROID)
-  BraveThemeService::RegisterProfilePrefs(registry);
-#endif
   registry->RegisterBooleanPref(kLocationBarIsWide, false);
   registry->RegisterBooleanPref(kHideBraveRewardsButton, false);
-
-#if BUILDFLAG(ENABLE_TOR)
-  tor::TorProfileService::RegisterProfilePrefs(registry);
-#endif
 
   registry->RegisterBooleanPref(kWidevineOptedIn, false);
 #if BUILDFLAG(BUNDLE_WIDEVINE_CDM)
@@ -76,11 +60,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   webtorrent::RegisterProfilePrefs(registry);
 #endif
 
-#if defined(OS_LINUX)
-  // Use brave theme by default instead of gtk theme.
-  registry->SetDefaultPrefValue(prefs::kUsesSystemTheme, base::Value(false));
-#endif
-
   // Hangouts
   registry->RegisterBooleanPref(kHangoutsEnabled, true);
 
@@ -96,9 +75,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
       FeatureSwitch::load_media_router_component_extension()->IsEnabled());
 #endif
 
-  // No sign into Brave functionality
-  registry->SetDefaultPrefValue(prefs::kSigninAllowed, base::Value(false));
-
   // Restore last profile on restart
   registry->SetDefaultPrefValue(
       prefs::kRestoreOnStartup,
@@ -110,10 +86,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   // Not using chrome's web service for resolving navigation errors
   registry->SetDefaultPrefValue(prefs::kAlternateErrorPagesEnabled,
                                 base::Value(false));
-
-  // Disable spell check service
-  registry->SetDefaultPrefValue(
-      spellcheck::prefs::kSpellCheckUseSpellingService, base::Value(false));
 
   // Disable safebrowsing reporting
   registry->SetDefaultPrefValue(
@@ -130,12 +102,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   // Make sync managed to dsiable some UI after password saving.
   registry->SetDefaultPrefValue(syncer::prefs::kSyncManaged, base::Value(true));
-
-  // Make sure sign into Brave is not enabled
-  // The older kSigninAllowed is deprecated and only in use in Android until
-  // C71.
-  registry->SetDefaultPrefValue(prefs::kSigninAllowedOnNextStartup,
-                                base::Value(false));
 
   // Disable cloud print
   // Cloud Print: Don't allow this browser to act as Cloud Print server

--- a/browser/profiles/tor_unittest_profile_manager.cc
+++ b/browser/profiles/tor_unittest_profile_manager.cc
@@ -12,8 +12,6 @@
 #include "base/threading/thread_task_runner_handle.h"
 #include "brave/browser/profiles/brave_profile_manager.h"
 #include "brave/browser/tor/tor_profile_service.h"
-#include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
-#include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
 #include "chrome/browser/prefs/browser_prefs.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/test/base/testing_profile.h"
@@ -63,9 +61,6 @@ Profile* TorUnittestProfileManager::CreateTorProfile(
       factory.CreateSyncable(registry.get()));
   RegisterUserProfilePrefs(registry.get());
   tor::TorProfileService::RegisterProfilePrefs(registry.get());
-#if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
-  webtorrent::RegisterProfilePrefs(registry.get());
-#endif
   profile_builder.SetPrefService(std::move(prefs));
   profile_builder.SetPath(path);
   profile_builder.SetDelegate(delegate);

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -1,2 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_profile_prefs.h"
 #include "brave/browser/brave_local_state_prefs.h"
 #include "../../../../chrome/browser/prefs/browser_prefs.cc"

--- a/chromium_src/chrome/browser/profiles/pref_service_builder_utils.cc
+++ b/chromium_src/chrome/browser/profiles/pref_service_builder_utils.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/profiles/pref_service_builder_utils.h"
+
+#define RegisterProfilePrefs RegisterProfilePrefs_ChromiumImpl
+#include "../../../../../chrome/browser/profiles/pref_service_builder_utils.cc"
+#undef RegisterProfilePrefs
+
+#include "brave/browser/brave_profile_prefs.h"
+#include "brave/browser/themes/brave_theme_service.h"
+#include "brave/browser/tor/buildflags.h"
+#include "brave/common/pref_names.h"
+#include "brave/components/brave_rewards/browser/rewards_service.h"
+#include "chrome/common/pref_names.h"
+#include "components/spellcheck/browser/pref_names.h"
+
+#if BUILDFLAG(ENABLE_TOR)
+#include "brave/browser/tor/tor_profile_service.h"
+#endif
+
+// Prefs for KeyedService
+void RegisterProfilePrefs(bool is_signin_profile,
+                          const std::string& locale,
+                          user_prefs::PrefRegistrySyncable* registry) {
+  RegisterProfilePrefs_ChromiumImpl(is_signin_profile, locale, registry);
+
+  // appearance
+#if !defined(OS_ANDROID)
+  BraveThemeService::RegisterProfilePrefs(registry);
+#endif
+
+#if BUILDFLAG(ENABLE_TOR)
+  tor::TorProfileService::RegisterProfilePrefs(registry);
+#endif
+
+  brave_rewards::RewardsService::RegisterProfilePrefs(registry);
+
+  // Disable spell check service
+  registry->SetDefaultPrefValue(
+      spellcheck::prefs::kSpellCheckUseSpellingService, base::Value(false));
+
+  // Make sure sign into Brave is not enabled
+  // The older kSigninAllowed is deprecated and only in use in Android until
+  // C71.
+  registry->SetDefaultPrefValue(prefs::kSigninAllowedOnNextStartup,
+                                base::Value(false));
+
+#if defined(OS_LINUX)
+  // Use brave theme by default instead of gtk theme.
+  registry->SetDefaultPrefValue(prefs::kUsesSystemTheme, base::Value(false));
+#endif
+}

--- a/chromium_src/chrome/common/pref_names.h
+++ b/chromium_src/chrome/common/pref_names.h
@@ -1,4 +1,12 @@
-#include "../../../chrome/common/pref_names.h"
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_COMMON_PREF_NAMES_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_COMMON_PREF_NAMES_H_
+
+#include "../../../../chrome/common/pref_names.h"
 
 namespace prefs {
 
@@ -8,3 +16,5 @@ extern const char kImportDialogLedger[];
 extern const char kImportDialogWindows[];
 
 }  // namespace prefs
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_COMMON_PREF_NAMES_H_

--- a/patches/chrome-browser-prefs-browser_prefs.cc.patch
+++ b/patches/chrome-browser-prefs-browser_prefs.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/prefs/browser_prefs.cc b/chrome/browser/prefs/browser_prefs.cc
-index 50312cdb0324e3dad18c77c96e5e609bfb259541..ed0ab71e9e08494abb5016bcb4e1fce6f852ea24 100644
+index 50312cdb0324e3dad18c77c96e5e609bfb259541..2298f9b60d2718d82e721dc8483b114931a30d0d 100644
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
 @@ -658,6 +658,7 @@ void RegisterLocalState(PrefRegistrySimple* registry) {
@@ -10,3 +10,11 @@ index 50312cdb0324e3dad18c77c96e5e609bfb259541..ed0ab71e9e08494abb5016bcb4e1fce6
  }
  
  // Register prefs applicable to all profiles.
+@@ -908,6 +909,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry,
+ #endif
+ 
+   RegisterProfilePrefsForMigration(registry);
++  brave::RegisterProfilePrefs(registry);
+ }
+ 
+ void RegisterUserProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {

--- a/patches/chrome-browser-profiles-profile_impl.cc.patch
+++ b/patches/chrome-browser-profiles-profile_impl.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/profiles/profile_impl.cc b/chrome/browser/profiles/profile_impl.cc
-index 71619ca3d5271b0f813110dce0e5570b6eebdda7..a9c1f8ec99aafa581c7fc8261e470261323c6492 100644
+index 71619ca3d5271b0f813110dce0e5570b6eebdda7..97003f2bc6f1141ae49dc2a2ac58e5f861fd0615 100644
 --- a/chrome/browser/profiles/profile_impl.cc
 +++ b/chrome/browser/profiles/profile_impl.cc
 @@ -34,6 +34,7 @@
@@ -10,13 +10,3 @@ index 71619ca3d5271b0f813110dce0e5570b6eebdda7..a9c1f8ec99aafa581c7fc8261e470261
  #include "build/build_config.h"
  #include "chrome/browser/background/background_contents_service_factory.h"
  #include "chrome/browser/background_fetch/background_fetch_delegate_factory.h"
-@@ -508,6 +509,9 @@ ProfileImpl::ProfileImpl(
-   LoadPrefsForNormalStartup(async_prefs);
- #endif
- 
-+// Done here instead of browser_prefs.cc so it can override default prefs
-+brave::RegisterProfilePrefs(pref_registry_.get());
-+
-   content::BrowserContext::Initialize(this, path_);
- 
-   // Register on BrowserContext.


### PR DESCRIPTION
1. Prefs used by keyed service must be registered or set default in
RegisterProfilePrefs of pref_service_builder_utils
2. RegisterProfilePrefs or RegisterLocalStatePrefs depends on scope

fix https://github.com/brave/brave-browser/issues/5414

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
