### PR TITLE
shields: ensure event target exist before blur happens

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/adsTrackersControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/adsTrackersControl.tsx
@@ -95,7 +95,9 @@ export default class AdsTrackersControl extends React.PureComponent<Props, State
   triggerOpen3rdPartyTrackersBlocked = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ trackersBlockedOpen: !this.state.trackersBlockedOpen })
   }

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/deviceRecognitionControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/deviceRecognitionControl.tsx
@@ -75,7 +75,9 @@ export default class DeviceRecognitionControl extends React.PureComponent<Props,
   triggerOpenDeviceRecognition = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ deviceRecognitionOpen: !this.state.deviceRecognitionOpen })
   }

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/httpsUpgradesControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/httpsUpgradesControl.tsx
@@ -82,7 +82,9 @@ export default class HTTPSUpgradesControl extends React.PureComponent<Props, Sta
   triggerConnectionsUpgradedToHTTPS = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ connectionsUpgradedOpen: !this.state.connectionsUpgradedOpen })
   }

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
@@ -99,7 +99,9 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
   triggerOpenScriptsBlocked = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ scriptsBlockedOpen: !this.state.scriptsBlockedOpen })
   }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5338

## Test Plan:

1. Visit a website
2. Open Shields
3. Block scripts
4. Click to see which scripts blocked
5. Click `Go back`
6. Should go back

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
