### PR TITLE
WebTorrent: intercept only top-level frame requests for .torrent files

### DIFF
--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -10,8 +10,9 @@
 
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
-#include "brave/common/network_constants.h"
 #include "brave/common/extensions/extension_constants.h"
+#include "brave/common/network_constants.h"
+#include "content/public/common/resource_type.h"
 #include "extensions/common/constants.h"
 #include "net/http/http_content_disposition.h"
 #include "net/http/http_response_headers.h"
@@ -74,6 +75,16 @@ bool IsWebtorrentInitiated(std::shared_ptr<brave::BraveRequestInfo> ctx) {
       ctx->initiator_url.host() == brave_webtorrent_extension_id;
 }
 
+/*
+ * Returns true if the resource type is a frame (i.e. a top level page) or a
+ * subframe (i.e. a frame or iframe). For all other resource types (stylesheet,
+ * script, XHR request, etc.), returns false.
+ */
+
+bool IsFrameResource(std::shared_ptr<brave::BraveRequestInfo> ctx) {
+  return content::IsResourceTypeFrame(ctx->resource_type);
+}
+
 }  // namespace
 
 namespace webtorrent {
@@ -85,6 +96,7 @@ int OnHeadersReceived_TorrentRedirectWork(
     const brave::ResponseCallback& next_callback,
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
   if (!original_response_headers ||
+      !IsFrameResource(ctx) ||
       ctx->is_webtorrent_disabled ||
       // download .torrent, do not redirect
       (IsWebtorrentInitiated(ctx) && !IsViewerURL(ctx->request_url)) ||

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -41,6 +41,16 @@ bool URLMatched(const GURL& url) {
       base::CompareCase::INSENSITIVE_ASCII);
 }
 
+/**
+ * Returns true if the URL contains a URL fragment that starts with "ix=". For
+ * example, https://webtorrent.io/torrents/big-buck-bunny.torrent#ix=1.
+ * Otherwise, returns false.
+ */
+bool IsViewerURL(const GURL& url) {
+  return base::StartsWith(url.ref(), "ix=",
+      base::CompareCase::INSENSITIVE_ASCII);
+}
+
 bool IsTorrentFile(const GURL& url, const net::HttpResponseHeaders* headers) {
   std::string mimeType;
   if (!headers->GetMimeType(&mimeType)) {
@@ -76,7 +86,8 @@ int OnHeadersReceived_TorrentRedirectWork(
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
   if (!original_response_headers ||
       ctx->is_webtorrent_disabled ||
-      IsWebtorrentInitiated(ctx) ||  // download .torrent, do not redirect
+      // download .torrent, do not redirect
+      (IsWebtorrentInitiated(ctx) && !IsViewerURL(ctx->request_url)) ||
       !IsTorrentFile(ctx->request_url, original_response_headers)) {
     return net::OK;
   }

--- a/components/brave_webtorrent/extension/components/torrentFileList.tsx
+++ b/components/brave_webtorrent/extension/components/torrentFileList.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export default class TorrentFileList extends React.PureComponent<Props, {}> {
   render () {
-    const { torrent } = this.props
+    const { torrent, torrentId } = this.props
     if (!torrent || !torrent.files) {
       return (
         <div className='torrentSubhead'>
@@ -45,8 +45,6 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
     ]
 
     const renderFileLink = (file: File, ix: number, isDownload: boolean) => {
-      const { torrentId, torrent } = this.props
-      if (!torrent) return null
       if (isDownload) {
         if (torrent.serverURL) {
           const url = torrent.serverURL + '/' + ix


### PR DESCRIPTION
If a web page embeds the WebTorrent client-side JS library and attempts to load a .torrent file using an XHR request or fetch, Brave will intercept the .torrent file load and replace it with the chrome-extension HTML, breaking the site. This is true not just for the WebTorrent JS library but for any request to fetch a .torrent file.

Fixes: brave/brave-browser#5361
Fixes: brave/brave-browser#3164
Fixes: brave/brave-browser#1436

(Rebased on top of this unmerged PR (https://github.com/brave/brave-core/pull/2990) to avoid merge conflicts later. So no need to review anything but the last commit)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

There are three test plans, see these issues:

- brave/brave-browser#5361
- brave/brave-browser#3164
- brave/brave-browser#1436


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
