### PR TITLE
Add quick text replacement hack for duckduckgo.com brave/brave-browser#3096

### DIFF
--- a/components/brave_extension/extension/brave_extension/assets/siteHack-duckduckgo.com.js
+++ b/components/brave_extension/extension/brave_extension/assets/siteHack-duckduckgo.com.js
@@ -1,0 +1,5 @@
+var tag = document.getElementsByTagName("span");
+  for(var i = 0, l = tag.length; i < l; i++) {
+      var el = tag[i];
+      el.innerHTML = el.innerHTML.replace(/ Chrome/gi, ' Brave');
+}

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -75,6 +75,13 @@
       "js": [
         "assets/siteHack-glennbeck.com.js"
       ]
+    }, {
+      "run_at": "document_start",
+      "all_frames": true,
+      "matches": ["https://duckduckgo.com/*"],
+      "js": [
+        "assets/siteHack-duckduckgo.com.js"
+      ]
     }
   ],
   "permissions": [ "contentSettings", "management", "tabs", "storage", "webNavigation", "contextMenus", "cookies", "*://*/*", "chrome://favicon/*" ],


### PR DESCRIPTION
Was a quick text replacement hack to fix https://github.com/brave/brave-browser/issues/3096

Tested via userjs, doesn't affect search elements. But can make more specific if need be.