### PR TITLE
[Security] Mitigate DNS rebinding flaw

### DIFF
--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.cc
@@ -75,7 +75,7 @@ bool IsWebtorrentInitiated(std::shared_ptr<brave::BraveRequestInfo> ctx) {
       ctx->initiator_url.host() == brave_webtorrent_extension_id;
 }
 
-/*
+/**
  * Returns true if the resource type is a frame (i.e. a top level page) or a
  * subframe (i.e. a frame or iframe). For all other resource types (stylesheet,
  * script, XHR request, etc.), returns false.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17411,8 +17411,8 @@
       "dev": true
     },
     "webtorrent": {
-      "version": "github:brave/webtorrent#6dae42cba71de26124c78f378a77aec0859b142b",
-      "from": "github:brave/webtorrent#6dae42cba71de26124c78f378a77aec0859b142b",
+      "version": "github:brave/webtorrent#423f1faca0f45c2aa0d199e224178ebc6733bf78",
+      "from": "github:brave/webtorrent#423f1faca0f45c2aa0d199e224178ebc6733bf78",
       "requires": {
         "addr-to-ip-port": "^1.4.2",
         "bitfield": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -344,6 +344,6 @@
     "throttleit": "^1.0.0",
     "torrent-discovery": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
     "unique-selector": "^0.4.1",
-    "webtorrent": "github:brave/webtorrent#6dae42cba71de26124c78f378a77aec0859b142b"
+    "webtorrent": "github:brave/webtorrent#423f1faca0f45c2aa0d199e224178ebc6733bf78"
   }
 }


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Go to https://webtorrent.io/free-torrents
2. Select Sintel (magnet link)
3. Start the download
4. Hover your mouse over the download link (the downward-facing arrow) and observe the link's port number. It should be something like e.g. 58630.
5. Run the following command in Terminal (tested on Mac): `cat <(echo -en 'GET / HTTP/1.1\r\nHost: attacker.com\r\n\r\n') - | nc localhost 58630`. Note: be sure to replace `58630` in the command with the actual port number you observed in Step 4.
6. The command should hang without outputting anything to Terminal at all. If you see an HTTP response or HTML, then this is *broken*. Nothing should be output from the command.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
