### PR TITLE
WebTorrent: Wait for media metadata before attempting autoplay

### DIFF
--- a/components/brave_webtorrent/extension/components/mediaViewer.tsx
+++ b/components/brave_webtorrent/extension/components/mediaViewer.tsx
@@ -48,6 +48,14 @@ interface Props {
 export default class MediaViewer extends React.PureComponent<Props, {}> {
   ref = (elem: HTMLMediaElement | null) => {
     if (!elem) return
+    if (elem.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+      this.play(elem)
+    } else {
+      elem.addEventListener('loadeddata', () => this.play(elem), { once: true })
+    }
+  }
+
+  play (elem: HTMLMediaElement) {
     elem.play().catch(err => console.error('Autoplay failed', err))
   }
 


### PR DESCRIPTION
Fix: https://github.com/brave/brave-browser/issues/5471

If the media element does not have metadata available immediately when the media viewer loads, then autoplay will fail with a `DOMException`.

So, we now wait for the metadata to be loaded before calling `play()`.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

   1. Load the torrent from https://ia802608.us.archive.org/18/items/gd1975-06-17.aud.unknown.87560.flac16/gd1975-06-17.aud.unknown.87560.flac16_archive.torrent
   2. Start the download. 
   3. Scroll to the bottom of the file list and select the last MP3 file in the list (file number 111). (This is so that the file data is not likely to be downloaded by webtorrent yet.)
   4. The file should eventually start playing. There should be no warning that autoplay was blocked.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
