### PR TITLE
WebTorrent: Support rendering images, PDFs, more media formats, and text-like files

### DIFF
--- a/components/brave_webtorrent/extension/background/webtorrent.ts
+++ b/components/brave_webtorrent/extension/background/webtorrent.ts
@@ -30,7 +30,7 @@ export const createServer = (torrent: WebTorrent.Torrent, cb: (serverURL: string
     origin: window.location.origin,
     // Use hostname option to mitigate DNS rebinding
     // Ref: https://github.com/brave/browser-laptop/issues/12616
-    hostname: 'localhost'
+    hostname: '127.0.0.1'
   }
   const server = torrent.createServer(opts)
   if (!server) return

--- a/components/brave_webtorrent/extension/manifest.json
+++ b/components/brave_webtorrent/extension/manifest.json
@@ -20,6 +20,6 @@
       "listen": "*:*"
     }
   },
-  "content_security_policy": "default-src 'self'; connect-src 'self' http: https:; font-src 'self' data:; script-src 'self'; media-src 'self' http://127.0.0.1:*; form-action 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self' http://127.0.0.1:*;",
+  "content_security_policy": "default-src 'self'; connect-src 'self' http: https:; font-src 'self' data:; script-src 'self'; media-src 'self' http://127.0.0.1:*; form-action 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: http://127.0.0.1:*; object-src 'self' http://127.0.0.1:*; frame-src 'self' http://127.0.0.1:*;",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArfOx1MW/cb3YPNlmT37CuISYgRbtR1SIdgnx/cfTyXO/PuD1VVsQWLDmrZGDmYVCzZvP36t75uhpJH4IoXL58U16yhdXZeSlb0LKcgMZB6cMNyjznV4NTEeY+tLnwGaB1TVdkJgSlY09psyfvcdzQd8xz9CNE6CXDzEq8+uMSaoAyEJ3nP78yV33nBrMj3jbjTi1fr2QsrpoISql/pJ9Zr5V0QbK4wIqln20ly96KuAO5c1DM9z9VnoYFdirEZBfkT/4gB7pBfyd4ScoMhXuaa9w53N8Espu1bC0RGmaKB679rGQdaBTrEUGF+PNfsucjnyrsnup6GMVhc91CXTDjQIDAQAB"
 }

--- a/components/styles/webtorrent.css
+++ b/components/styles/webtorrent.css
@@ -78,7 +78,7 @@ a {
   margin: 0 0 18px;
 }
 
-#video, #audio {
+#video, #audio, #image, #object, #iframe {
   position: absolute;
   top: 0px;
   right: 0px;
@@ -87,4 +87,13 @@ a {
   max-height: 100%;
   max-width: 100%;
   margin: auto;
+}
+
+#object, #iframe {
+  width: 100%;
+  height: 100%;
+}
+
+#iframe {
+  border: 0;
 }

--- a/components/test/brave_webtorrent/components/mediaViewer_test.tsx
+++ b/components/test/brave_webtorrent/components/mediaViewer_test.tsx
@@ -48,7 +48,7 @@ describe('mediaViewer component', () => {
       expect(assertion.length).toBe(1)
     })
 
-    it('renders iframe for other ext', () => {
+    it('renders img for image', () => {
       const files = [ { name: 'file.jpg', length: 500 } ]
       const torrentWithJpgFile = { ...torrentObj, files, serverURL }
       const wrapper = shallow(
@@ -57,7 +57,33 @@ describe('mediaViewer component', () => {
           ix={ix}
         />
       )
-      const assertion = wrapper.find('#other')
+      const assertion = wrapper.find('#image')
+      expect(assertion.length).toBe(1)
+    })
+
+    it('renders object for PDF file', () => {
+      const files = [ { name: 'file.pdf', length: 500 } ]
+      const torrentWithPdfFile = { ...torrentObj, files, serverURL }
+      const wrapper = shallow(
+        <MediaViewer
+          torrent={torrentWithPdfFile}
+          ix={ix}
+        />
+      )
+      const assertion = wrapper.find('#object')
+      expect(assertion.length).toBe(1)
+    })
+
+    it('renders iframe for text file', () => {
+      const files = [ { name: 'file.txt', length: 500 } ]
+      const torrentWithTxtFile = { ...torrentObj, files, serverURL }
+      const wrapper = shallow(
+        <MediaViewer
+          torrent={torrentWithTxtFile}
+          ix={ix}
+        />
+      )
+      const assertion = wrapper.find('#iframe')
       expect(assertion.length).toBe(1)
     })
   })


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/5326

Previously, images and PDFs would not render at all. Other formats would render in a very tiny iframe which was unusable. Unsupported formats would render as gibberish text.

Now, we properly support images, centered, with a black background behind them, just like for audio and video.

For PDFs, we use the native built-in PDF viewer and render at 100% width and height.

For text-like files, we render them in a full-screen iframe with the default white page background.

For audio, we now support FLAC, M4B, M4P, and OGA formats. The browser still has to support the specific codec used within the file, but we'll render an <audio> tag and at least attempt to play it.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Visit this URL: https://ia800301.us.archive.org/14/items/art_of_war_librivox/art_of_war_librivox_archive.torrent
2. Start the torrent download
3. Click on file 1 "ArtOfWar-64kb_librivox.m4b" and confirm that the audio file plays.
4. Click on file 2 "Art_War_1107.jpg" and confirm that an image shows up.
5. Click on file 3 "Art_War_1107.pdf" and confirm that the PDF viewer loads with a PDF inside.
6. Click on file 11 "art_of_war_01-02_sun_tzu.ogg" and confirm that the audio file plays.
7. Click on file 12 "art_of_war_01-02_sun_tzu.png" and confirm that the image shows up.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
