### PR TITLE
[0.69.x] shields: ensure event target exist before blur happens

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/adsTrackersControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/adsTrackersControl.tsx
@@ -95,7 +95,9 @@ export default class AdsTrackersControl extends React.PureComponent<Props, State
   triggerOpen3rdPartyTrackersBlocked = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ trackersBlockedOpen: !this.state.trackersBlockedOpen })
   }

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/deviceRecognitionControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/deviceRecognitionControl.tsx
@@ -75,7 +75,9 @@ export default class DeviceRecognitionControl extends React.PureComponent<Props,
   triggerOpenDeviceRecognition = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ deviceRecognitionOpen: !this.state.deviceRecognitionOpen })
   }

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/httpsUpgradesControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/httpsUpgradesControl.tsx
@@ -82,7 +82,9 @@ export default class HTTPSUpgradesControl extends React.PureComponent<Props, Sta
   triggerConnectionsUpgradedToHTTPS = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ connectionsUpgradedOpen: !this.state.connectionsUpgradedOpen })
   }

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
@@ -99,7 +99,9 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
   triggerOpenScriptsBlocked = (
     event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    event.currentTarget.blur()
+    if (event) {
+      event.currentTarget.blur()
+    }
     this.props.setBlockedListOpen()
     this.setState({ scriptsBlockedOpen: !this.state.scriptsBlockedOpen })
   }


### PR DESCRIPTION
this is an uplift request of https://github.com/brave/brave-core/pull/3034 since bug https://github.com/brave/brave-browser/issues/5338 was reported in 0.69.x.

cc @tomlowenthal 