### PR TITLE
[brave-extension] prevent `allow scripts once` button from being visible in resources overlay

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
@@ -159,6 +159,12 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
                 <LinkAction
                   size='small'
                   onClick={this.onClickAllowScriptsOnce}
+                  style={{
+                    // TODO: cezaraugusto re-visit shields components.
+                    // this should be defined in the component itself and not inlined,
+                    // and ideally in a logic that is not bounded to a reusable component such as this one.
+                    zIndex: 1
+                  }}
                 >
                   {getLocale('allowScriptsOnce')}
                 </LinkAction>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5486

Note: this inline style is a temp hack until https://github.com/brave/brave-core/pull/2944 is ready. 

## Test Plan:

Stolen from (https://github.com/brave/brave-browser/issues/5486#issue-475281452).

   1. Clean profile 0.68.114
   2. Open buzzfeed.com in a new tab
   3. Click on shield panel
   4. Turn ON scripts
   5. Click on `Cross-site trackers blocked`
   6. `Allow scripts once` is reflected in cross-site trackers list

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
