### PR TITLE
[0.69.x] allow shields read-only view to show actual resources blocked

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/adsTrackersControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/adsTrackersControl.tsx
@@ -28,7 +28,7 @@ import {
   getToggleStateViaEventTarget,
   getTabIndexValueBasedOnProps,
   blockedResourcesSize,
-  maybeDisableResourcesRow
+  shouldDisableResourcesRow
 } from '../../../helpers/shieldsUtils'
 
 // Types
@@ -83,8 +83,8 @@ export default class AdsTrackersControl extends React.PureComponent<Props, State
     return maybeBlockResource(ads) && maybeBlockResource(trackers)
   }
 
-  get maybeDisableResourcesRow (): boolean {
-    return maybeDisableResourcesRow(this.totalAdsTrackersBlocked)
+  get shouldDisableResourcesRow (): boolean {
+    return shouldDisableResourcesRow(this.totalAdsTrackersBlocked)
   }
 
   get tabIndex (): number {
@@ -122,7 +122,7 @@ export default class AdsTrackersControl extends React.PureComponent<Props, State
       <>
         <BlockedInfoRow id='adsTrackersControl'>
           <BlockedInfoRowData
-            disabled={this.maybeDisableResourcesRow}
+            disabled={this.shouldDisableResourcesRow}
             tabIndex={this.tabIndex}
             onClick={this.onOpen3rdPartyTrackersBlocked}
             onKeyDown={this.onOpen3rdPartyTrackersBlockedViaKeyboard}

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/deviceRecognitionControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/deviceRecognitionControl.tsx
@@ -21,7 +21,7 @@ import { getLocale } from '../../../background/api/localeAPI'
 
 // Helpers
 import {
-  maybeDisableResourcesRow,
+  shouldDisableResourcesRow,
   getTabIndexValueBasedOnProps,
   blockedResourcesSize
 } from '../../../helpers/shieldsUtils'
@@ -36,14 +36,14 @@ interface CommonProps {
   setBlockedListOpen: () => void
 }
 
-interface HTTPSUpgradesProps {
+interface DeviceRecognitionProps {
   fingerprinting: BlockFPOptions
   fingerprintingBlocked: number
   fingerprintingBlockedResources: Array<string>
   blockFingerprinting: (event: string) => void
 }
 
-export type Props = CommonProps & HTTPSUpgradesProps
+export type Props = CommonProps & DeviceRecognitionProps
 
 interface State {
   deviceRecognitionOpen: boolean
@@ -62,9 +62,9 @@ export default class DeviceRecognitionControl extends React.PureComponent<Props,
     return blockedResourcesSize(fingerprintingBlocked)
   }
 
-  get maybeDisableResourcesRow (): boolean {
+  get shouldDisableResourcesRow (): boolean {
     const { fingerprintingBlocked } = this.props
-    return maybeDisableResourcesRow(fingerprintingBlocked)
+    return shouldDisableResourcesRow(fingerprintingBlocked)
   }
 
   get tabIndex (): number {
@@ -108,7 +108,7 @@ export default class DeviceRecognitionControl extends React.PureComponent<Props,
       <>
         <BlockedInfoRowForSelect id='deviceRecognitionControl'>
           <BlockedInfoRowDataForSelect
-            disabled={this.maybeDisableResourcesRow}
+            disabled={this.shouldDisableResourcesRow}
             tabIndex={this.tabIndex}
             onClick={this.onOpenDeviceRecognition}
             onKeyDown={this.onOpenDeviceRecognitionViaKeyboard}

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/httpsUpgradesControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/httpsUpgradesControl.tsx
@@ -23,7 +23,7 @@ import { getLocale } from '../../../background/api/localeAPI'
 // Helpers
 import {
   maybeBlockResource,
-  maybeDisableResourcesRow,
+  shouldDisableResourcesRow,
   getTabIndexValueBasedOnProps,
   blockedResourcesSize,
   getToggleStateViaEventTarget
@@ -59,9 +59,9 @@ export default class HTTPSUpgradesControl extends React.PureComponent<Props, Sta
     this.state = { connectionsUpgradedOpen: false }
   }
 
-  get maybeDisableResourcesRow (): boolean {
+  get shouldDisableResourcesRow (): boolean {
     const { httpsRedirected } = this.props
-    return maybeDisableResourcesRow(httpsRedirected)
+    return shouldDisableResourcesRow(httpsRedirected)
   }
 
   get httpsRedirectedDisplay (): string {
@@ -109,7 +109,7 @@ export default class HTTPSUpgradesControl extends React.PureComponent<Props, Sta
       <>
         <BlockedInfoRow id='httpsUpgradesControl'>
           <BlockedInfoRowData
-            disabled={this.maybeDisableResourcesRow}
+            disabled={this.shouldDisableResourcesRow}
             tabIndex={this.tabIndex}
             onClick={this.onOpenConnectionsUpgradedToHTTPS}
             onKeyDown={this.onOpenConnectionsUpgradedToHTTPSViaKeyboard}

--- a/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/controls/scriptsControl.tsx
@@ -23,7 +23,7 @@ import { getLocale } from '../../../background/api/localeAPI'
 
 // Helpers
 import {
-  maybeDisableResourcesRow,
+  shouldDisableResourcesRow,
   blockedResourcesSize,
   maybeBlockResource,
   getTabIndexValueBasedOnProps,
@@ -71,14 +71,12 @@ interface State {
 export default class ScriptsControls extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props)
-    this.state = {
-      scriptsBlockedOpen: false
-    }
+    this.state = { scriptsBlockedOpen: false }
   }
 
-  get maybeDisableResourcesRow (): boolean {
+  get shouldDisableResourcesRow (): boolean {
     const { javascriptBlocked } = this.props
-    return maybeDisableResourcesRow(javascriptBlocked)
+    return shouldDisableResourcesRow(javascriptBlocked)
   }
 
   get javascriptBlockedDisplay (): string {
@@ -142,7 +140,7 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
       <>
         <BlockedInfoRow id='scriptsControl' extraColumn={true}>
           <BlockedInfoRowData
-            disabled={this.maybeDisableResourcesRow}
+            disabled={this.shouldDisableResourcesRow}
             tabIndex={this.tabIndex}
             onClick={this.onOpenScriptsBlocked}
             onKeyDown={this.onOpenScriptsBlockedViaKeyboard}
@@ -152,7 +150,7 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
             <BlockedInfoRowText>{getLocale('scriptsBlocked')}</BlockedInfoRowText>
           </BlockedInfoRowData>
           {
-            this.maybeDisableResourcesRow === false
+            this.shouldDisableResourcesRow === false
               && (
                 <LinkAction
                   size='small'

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/adsTrackersControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/adsTrackersControl.tsx
@@ -13,45 +13,86 @@ import {
   ArrowUpIcon,
   ArrowDownIcon,
   BlockedInfoRowStats,
-  BlockedListStatic,
-  dummyData
+  BlockedListStatic
 } from 'brave-ui/features/shields'
 
 // Group components
 import StaticResourcesList from '../../shared/resourcesBlockedList/staticResourcesList'
 
-// Helpers
+// Locale
 import { getLocale } from '../../../background/api/localeAPI'
 
-interface State {
-  dummyThirdPartyTrackersBlockedOpen: boolean
+// Helpers
+import {
+  sumAdsAndTrackers,
+  blockedResourcesSize,
+  shouldDisableResourcesRow,
+  mergeAdsAndTrackersResources
+} from '../../../helpers/shieldsUtils'
+
+// Types
+import { BlockOptions } from '../../../types/other/blockTypes'
+
+interface Props {
+  ads: BlockOptions
+  adsBlocked: number
+  adsBlockedResources: Array<string>
+  trackers: BlockOptions
+  trackersBlocked: number
+  trackersBlockedResources: Array<string>
 }
 
-export default class AdsTrackersControl extends React.PureComponent<{}, State> {
-  constructor (props: {}) {
+interface State {
+  trackersBlockedOpen: boolean
+}
+
+export default class AdsTrackersControl extends React.PureComponent<Props, State> {
+  constructor (props: Props) {
     super(props)
-    this.state = { dummyThirdPartyTrackersBlockedOpen: false }
+    this.state = { trackersBlockedOpen: false }
   }
-  onClickFakeThirdPartyTrackersBlocked = () => {
-    this.setState({ dummyThirdPartyTrackersBlockedOpen: !this.state.dummyThirdPartyTrackersBlockedOpen })
+
+  get totalAdsTrackersBlocked (): number {
+    const { adsBlocked, trackersBlocked } = this.props
+    return sumAdsAndTrackers(adsBlocked, trackersBlocked)
   }
+
+  get totalAdsTrackersBlockedDisplay (): string {
+    return blockedResourcesSize(this.totalAdsTrackersBlocked)
+  }
+
+  get totalAdsTrackersBlockedList (): Array<string> {
+    const { adsBlockedResources, trackersBlockedResources } = this.props
+    return mergeAdsAndTrackersResources(adsBlockedResources, trackersBlockedResources)
+  }
+
+  get shouldDisableResourcesRow (): boolean {
+    return shouldDisableResourcesRow(this.totalAdsTrackersBlocked)
+  }
+
+  triggerOpen3rdPartyTrackersBlocked = () => {
+    if (!this.shouldDisableResourcesRow) {
+      this.setState({ trackersBlockedOpen: !this.state.trackersBlockedOpen })
+    }
+  }
+
   render () {
-    const { dummyThirdPartyTrackersBlockedOpen } = this.state
+    const { trackersBlockedOpen } = this.state
     return (
       <BlockedInfoRowDetails>
-        <BlockedInfoRowSummary onClick={this.onClickFakeThirdPartyTrackersBlocked}>
-          <BlockedInfoRowData disabled={false}>
+        <BlockedInfoRowSummary onClick={this.triggerOpen3rdPartyTrackersBlocked}>
+          <BlockedInfoRowData disabled={this.shouldDisableResourcesRow}>
             {
-              dummyThirdPartyTrackersBlockedOpen
+              trackersBlockedOpen
                 ? <ArrowUpIcon />
                 : <ArrowDownIcon />
             }
-            <BlockedInfoRowStats>{2}</BlockedInfoRowStats>
+            <BlockedInfoRowStats>{this.totalAdsTrackersBlockedDisplay}</BlockedInfoRowStats>
             <BlockedInfoRowText>{getLocale('thirdPartyTrackersBlocked')}</BlockedInfoRowText>
           </BlockedInfoRowData>
         </BlockedInfoRowSummary>
         <BlockedListStatic>
-          <StaticResourcesList list={dummyData.otherBlockedResources} />
+          <StaticResourcesList list={this.totalAdsTrackersBlockedList} />
         </BlockedListStatic>
       </BlockedInfoRowDetails>
     )

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/deviceRecognitionControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/deviceRecognitionControl.tsx
@@ -13,48 +13,76 @@ import {
   BlockedInfoRowForSelectSummary,
   BlockedInfoRowDataForSelect,
   BlockedListStatic,
-  BlockedInfoRowText,
-  dummyData
+  BlockedInfoRowText
 } from 'brave-ui/features/shields'
 
 // Group components
 import StaticResourcesList from '../../shared/resourcesBlockedList/staticResourcesList'
 
-// Helpers
+// Locale
 import { getLocale } from '../../../background/api/localeAPI'
 
-interface State {
-  dummyThirdPartyFingerprintingBlockedOpen: boolean
+// Helpers
+import {
+  blockedResourcesSize,
+  shouldDisableResourcesRow
+} from '../../../helpers/shieldsUtils'
+
+// Types
+import { BlockFPOptions } from '../../../types/other/blockTypes'
+
+interface Props {
+  fingerprinting: BlockFPOptions
+  fingerprintingBlocked: number
+  fingerprintingBlockedResources: Array<string>
 }
 
-export default class AdsTrackersControl extends React.PureComponent<{}, State> {
-  constructor (props: {}) {
+interface State {
+  deviceRecognitionOpen: boolean
+}
+
+export default class DeviceRecognitionControl extends React.PureComponent<Props, State> {
+  constructor (props: Props) {
     super(props)
-    this.state = { dummyThirdPartyFingerprintingBlockedOpen: false }
+    this.state = { deviceRecognitionOpen: false }
   }
 
-  onClickFakeThirdPartyFingerprintingBlocked = () => {
-    this.setState({ dummyThirdPartyFingerprintingBlockedOpen: !this.state.dummyThirdPartyFingerprintingBlockedOpen })
+  get totalDeviceRecognitonAttemptsDisplay (): string {
+    const { fingerprintingBlocked } = this.props
+    return blockedResourcesSize(fingerprintingBlocked)
   }
+
+  get shouldDisableResourcesRow (): boolean {
+    const { fingerprintingBlocked } = this.props
+    return shouldDisableResourcesRow(fingerprintingBlocked)
+  }
+
+  triggerOpenDeviceRecognition = () => {
+    if (!this.shouldDisableResourcesRow) {
+      this.setState({ deviceRecognitionOpen: !this.state.deviceRecognitionOpen })
+    }
+  }
+
   render () {
-    const { dummyThirdPartyFingerprintingBlockedOpen } = this.state
+    const { deviceRecognitionOpen } = this.state
+    const { fingerprintingBlockedResources } = this.props
     return (
       <BlockedInfoRowDetails>
-        <BlockedInfoRowForSelectSummary onClick={this.onClickFakeThirdPartyFingerprintingBlocked}>
-          <BlockedInfoRowDataForSelect disabled={false}>
+        <BlockedInfoRowForSelectSummary onClick={this.triggerOpenDeviceRecognition}>
+          <BlockedInfoRowDataForSelect disabled={this.shouldDisableResourcesRow}>
             {
-              dummyThirdPartyFingerprintingBlockedOpen
+              deviceRecognitionOpen
                 ? <ArrowUpIcon />
                 : <ArrowDownIcon />
             }
-            <BlockedInfoRowStats>{2}</BlockedInfoRowStats>
+            <BlockedInfoRowStats>{this.totalDeviceRecognitonAttemptsDisplay}</BlockedInfoRowStats>
             <BlockedInfoRowText>
               <span>{getLocale('thirdPartyFingerprintingBlocked')}</span>
             </BlockedInfoRowText>
           </BlockedInfoRowDataForSelect>
         </BlockedInfoRowForSelectSummary>
         <BlockedListStatic>
-          <StaticResourcesList list={dummyData.otherBlockedResources} />
+          <StaticResourcesList list={fingerprintingBlockedResources} />
         </BlockedListStatic>
       </BlockedInfoRowDetails>
     )

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/httpsUpgradesControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/httpsUpgradesControl.tsx
@@ -13,47 +13,75 @@ import {
   ArrowUpIcon,
   ArrowDownIcon,
   BlockedInfoRowStats,
-  BlockedListStatic,
-  dummyData
+  BlockedListStatic
 } from 'brave-ui/features/shields'
 
 // Group components
 import StaticResourcesList from '../../shared/resourcesBlockedList/staticResourcesList'
 
-// Helpers
+// Locale
 import { getLocale } from '../../../background/api/localeAPI'
 
-interface State {
-  dummyConnectionsUpgradedHTTPSOpen: boolean
+// Helpers
+import {
+  blockedResourcesSize,
+  shouldDisableResourcesRow
+} from '../../../helpers/shieldsUtils'
+
+// Types
+import { BlockOptions } from '../../../types/other/blockTypes'
+
+interface Props {
+  httpsRedirected: number
+  httpUpgradableResources: BlockOptions
+  httpsRedirectedResources: Array<string>
 }
 
-export default class AdsTrackersControl extends React.PureComponent<{}, State> {
-  constructor (props: {}) {
+interface State {
+  connectionsUpgradedOpen: boolean
+}
+
+export default class AdsTrackersControl extends React.PureComponent<Props, State> {
+  constructor (props: Props) {
     super(props)
-    this.state = { dummyConnectionsUpgradedHTTPSOpen: false }
+    this.state = { connectionsUpgradedOpen: false }
   }
 
-  onClickFakeConnectionsUpgradedHTTPS = () => {
-    this.setState({ dummyConnectionsUpgradedHTTPSOpen: !this.state.dummyConnectionsUpgradedHTTPSOpen })
+  get shouldDisableResourcesRow (): boolean {
+    const { httpsRedirected } = this.props
+    return shouldDisableResourcesRow(httpsRedirected)
+  }
+
+  get httpsRedirectedDisplay (): string {
+    const { httpsRedirected } = this.props
+    return blockedResourcesSize(httpsRedirected)
+  }
+
+  triggerConnectionsUpgradedToHTTPS = () => {
+    if (!this.shouldDisableResourcesRow) {
+      this.setState({ connectionsUpgradedOpen: !this.state.connectionsUpgradedOpen })
+    }
   }
 
   render () {
-    const { dummyConnectionsUpgradedHTTPSOpen } = this.state
+    const { connectionsUpgradedOpen } = this.state
+    const { httpsRedirectedResources } = this.props
+
     return (
       <BlockedInfoRowDetails>
-        <BlockedInfoRowSummary onClick={this.onClickFakeConnectionsUpgradedHTTPS}>
-          <BlockedInfoRowData disabled={false}>
+        <BlockedInfoRowSummary onClick={this.triggerConnectionsUpgradedToHTTPS}>
+          <BlockedInfoRowData disabled={this.shouldDisableResourcesRow}>
             {
-              dummyConnectionsUpgradedHTTPSOpen
+              connectionsUpgradedOpen
                 ? <ArrowUpIcon />
                 : <ArrowDownIcon />
             }
-            <BlockedInfoRowStats>{2}</BlockedInfoRowStats>
+            <BlockedInfoRowStats>{this.httpsRedirectedDisplay}</BlockedInfoRowStats>
             <BlockedInfoRowText>{getLocale('connectionsUpgradedHTTPS')}</BlockedInfoRowText>
           </BlockedInfoRowData>
         </BlockedInfoRowSummary>
         <BlockedListStatic>
-          <StaticResourcesList list={dummyData.otherBlockedResources} />
+          <StaticResourcesList list={httpsRedirectedResources} />
         </BlockedListStatic>
       </BlockedInfoRowDetails>
     )

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/controls/scriptsControl.tsx
@@ -13,51 +13,78 @@ import {
   ArrowUpIcon,
   ArrowDownIcon,
   BlockedInfoRowStats,
-  BlockedListStatic,
-  dummyData
+  BlockedListStatic
 } from 'brave-ui/features/shields'
 
 // Group components
 import StaticResourcesList from '../../shared/resourcesBlockedList/staticResourcesList'
 
-// Helpers
+// Locale
 import { getLocale } from '../../../background/api/localeAPI'
-import { generateNoScriptInfoDataStructure } from '../../../helpers/noScriptUtils'
 
-interface State {
-  dummyScriptsBlockedOpen: boolean
+// Helpers
+import {
+  blockedResourcesSize,
+  shouldDisableResourcesRow
+} from '../../../helpers/shieldsUtils'
+
+// Types
+import { BlockJSOptions } from '../../../types/other/blockTypes'
+import { NoScriptInfo } from '../../../types/other/noScriptInfo'
+
+interface Props {
+  javascript: BlockJSOptions
+  javascriptBlocked: number
+  noScriptInfo: NoScriptInfo
 }
 
-export default class AdsTrackersControl extends React.PureComponent<{}, State> {
-  constructor (props: {}) {
+interface State {
+  scriptsBlockedOpen: boolean
+}
+
+export default class AdsTrackersControl extends React.PureComponent<Props, State> {
+  constructor (props: Props) {
     super(props)
-    this.state = { dummyScriptsBlockedOpen: false }
+    this.state = { scriptsBlockedOpen: false }
   }
-  get generateNoScriptInfo () {
-    return generateNoScriptInfoDataStructure(dummyData.noScriptsResouces)
+
+  get shouldDisableResourcesRow (): boolean {
+    const { javascriptBlocked } = this.props
+    return shouldDisableResourcesRow(javascriptBlocked)
   }
-  onClickFakeScriptsBlocked = () => {
-    this.setState({ dummyScriptsBlockedOpen: !this.state.dummyScriptsBlockedOpen })
+
+  get javascriptBlockedDisplay (): string {
+    const { javascriptBlocked } = this.props
+    return blockedResourcesSize(javascriptBlocked)
   }
+
+  triggerOpenScriptsBlocked = () => {
+    if (!this.shouldDisableResourcesRow) {
+      this.setState({ scriptsBlockedOpen: !this.state.scriptsBlockedOpen })
+    }
+  }
+
   render () {
-    const { dummyScriptsBlockedOpen } = this.state
+    const { scriptsBlockedOpen } = this.state
+    const { noScriptInfo } = this.props
+
     return (
       <BlockedInfoRowDetails>
-        <BlockedInfoRowSummary onClick={this.onClickFakeScriptsBlocked}>
-          <BlockedInfoRowData disabled={false}>
+        <BlockedInfoRowSummary onClick={this.triggerOpenScriptsBlocked}>
+          <BlockedInfoRowData disabled={this.shouldDisableResourcesRow}>
             {
-              dummyScriptsBlockedOpen
+              scriptsBlockedOpen
                 ? <ArrowUpIcon />
                 : <ArrowDownIcon />
             }
-            <BlockedInfoRowStats>{2}</BlockedInfoRowStats>
+            <BlockedInfoRowStats>{this.javascriptBlockedDisplay}</BlockedInfoRowStats>
             <BlockedInfoRowText>
               <span>{getLocale('scriptsBlocked')}</span>
             </BlockedInfoRowText>
           </BlockedInfoRowData>
         </BlockedInfoRowSummary>
         <BlockedListStatic>
-          <StaticResourcesList list={dummyData.otherBlockedResources} />
+          <StaticResourcesList list={Object.keys(noScriptInfo)} />
         </BlockedListStatic>
       </BlockedInfoRowDetails>
     )

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/index.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/index.tsx
@@ -52,8 +52,29 @@ export default class ShieldsReadOnlyView extends React.PureComponent<Props, {}> 
         </StaticHeader>
         <StaticResourcesControls>
           <StaticResourcesContainer>
-            <InterfaceControls />
-            <PrivacyControls />
+          <InterfaceControls
+            // Ads/Trackers
+            ads={shieldsPanelTabData.ads}
+            adsBlocked={shieldsPanelTabData.adsBlocked}
+            adsBlockedResources={shieldsPanelTabData.adsBlockedResources}
+            trackers={shieldsPanelTabData.trackers}
+            trackersBlocked={shieldsPanelTabData.trackersBlocked}
+            trackersBlockedResources={shieldsPanelTabData.trackersBlockedResources}
+            // HTTPS Upgrades
+            httpsRedirected={shieldsPanelTabData.httpsRedirected}
+            httpUpgradableResources={shieldsPanelTabData.httpUpgradableResources}
+            httpsRedirectedResources={shieldsPanelTabData.httpsRedirectedResources}
+          />
+          <PrivacyControls
+            // JavaScript
+            javascript={shieldsPanelTabData.javascript}
+            javascriptBlocked={shieldsPanelTabData.javascriptBlocked}
+            noScriptInfo={shieldsPanelTabData.noScriptInfo}
+            // Fingerprinting
+            fingerprinting={shieldsPanelTabData.fingerprinting}
+            fingerprintingBlocked={shieldsPanelTabData.fingerprintingBlocked}
+            fingerprintingBlockedResources={shieldsPanelTabData.fingerprintingBlockedResources}
+          />
           </StaticResourcesContainer>
         </StaticResourcesControls>
         <BlockedListFooter>

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/interfaceControls.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/interfaceControls.tsx
@@ -8,12 +8,43 @@ import * as React from 'react'
 import AdsTrackersControl from './controls/adsTrackersControl'
 import HTTPSUpgradesControl from './controls/httpsUpgradesControl'
 
-export default class InterfaceControls extends React.PureComponent<{}, {}> {
+// Types
+import { BlockOptions } from '../../types/other/blockTypes'
+
+interface AdsTrackersProps {
+  ads: BlockOptions
+  adsBlocked: number
+  adsBlockedResources: Array<string>
+  trackers: BlockOptions
+  trackersBlocked: number
+  trackersBlockedResources: Array<string>
+}
+
+interface HTTPSUpgradesProps {
+  httpsRedirected: number
+  httpUpgradableResources: BlockOptions
+  httpsRedirectedResources: Array<string>
+}
+
+export type Props = AdsTrackersProps & HTTPSUpgradesProps
+
+export default class InterfaceControls extends React.PureComponent<Props, {}> {
   render () {
     return (
       <>
-        <AdsTrackersControl />
-        <HTTPSUpgradesControl />
+        <AdsTrackersControl
+          ads={this.props.ads}
+          adsBlocked={this.props.adsBlocked}
+          adsBlockedResources={this.props.adsBlockedResources}
+          trackers={this.props.trackers}
+          trackersBlocked={this.props.trackersBlocked}
+          trackersBlockedResources={this.props.trackersBlockedResources}
+        />
+        <HTTPSUpgradesControl
+          httpsRedirected={this.props.httpsRedirected}
+          httpUpgradableResources={this.props.httpUpgradableResources}
+          httpsRedirectedResources={this.props.httpsRedirectedResources}
+        />
       </>
     )
   }

--- a/components/brave_extension/extension/brave_extension/components/readOnlyView/privacyControls.tsx
+++ b/components/brave_extension/extension/brave_extension/components/readOnlyView/privacyControls.tsx
@@ -9,13 +9,39 @@ import ScriptsControl from './controls/scriptsControl'
 import CookiesControl from './controls/cookiesControl'
 import DeviceRecognitionControl from './controls/deviceRecognitionControl'
 
-export default class PrivacyControls extends React.PureComponent<{}, {}> {
+// Types
+import { NoScriptInfo } from '../../types/other/noScriptInfo'
+import { BlockJSOptions, BlockFPOptions } from '../../types/other/blockTypes'
+
+interface JavaScriptProps {
+  javascript: BlockJSOptions
+  javascriptBlocked: number
+  noScriptInfo: NoScriptInfo
+}
+
+interface FingerprintingProps {
+  fingerprinting: BlockFPOptions
+  fingerprintingBlocked: number
+  fingerprintingBlockedResources: Array<string>
+}
+
+export type Props = JavaScriptProps & FingerprintingProps
+
+export default class PrivacyControls extends React.PureComponent<Props, {}> {
   render () {
     return (
       <>
-        <ScriptsControl />
+        <ScriptsControl
+          javascript={this.props.javascript}
+          javascriptBlocked={this.props.javascriptBlocked}
+          noScriptInfo={this.props.noScriptInfo}
+        />
         <CookiesControl />
-        <DeviceRecognitionControl />
+        <DeviceRecognitionControl
+          fingerprintingBlocked={this.props.fingerprintingBlocked}
+          fingerprinting={this.props.fingerprinting}
+          fingerprintingBlockedResources={this.props.fingerprintingBlockedResources}
+        />
       </>
     )
   }

--- a/components/brave_extension/extension/brave_extension/helpers/shieldsUtils.ts
+++ b/components/brave_extension/extension/brave_extension/helpers/shieldsUtils.ts
@@ -66,7 +66,7 @@ export const maybeBlockResource = (resouce: BlockOptions) => {
   return resouce !== 'allow'
 }
 
-export const maybeDisableResourcesRow = (resource: number) => {
+export const shouldDisableResourcesRow = (resource: number) => {
   return resource === 0
 }
 


### PR DESCRIPTION
uplift request for https://github.com/brave/brave-core/pull/2987 so bug https://github.com/brave/brave-browser/issues/5355 could land in 0.69.x.