### PR TITLE
Fix widevine loading failure due to different TeamID (uplift to 0.68.x)

### DIFF
--- a/app/helper-entitlements.plist
+++ b/app/helper-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -114,7 +114,8 @@ if (skip_signing) {
 
     deps = [
       "//brave:chrome_app",
-      "//chrome/installer/mac"
+      "//chrome/installer/mac",
+      ":copies",
     ]
 
     if (is_official_build) {
@@ -149,6 +150,18 @@ if (skip_signing) {
       rebase_path(provisioning_profile, root_out_dir),
       keychain_db,
       mac_signing_identifier,
+    ]
+  }
+
+  copy("copies") {
+    visibility = [ ":sign_app" ]
+
+    sources = [
+      "//brave/app/helper-entitlements.plist",
+    ]
+
+    outputs = [
+      "$packaging_dir/{{source_file_part}}"
     ]
   }
 

--- a/patches/chrome-installer-mac-signing-signing.py.patch
+++ b/patches/chrome-installer-mac-signing-signing.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/mac/signing/signing.py b/chrome/installer/mac/signing/signing.py
-index 9a425e757229484755a2f656f8a7758c7538b676..17bd52c0c0bd0f7cc1abc405bfd24d05fa6a592a 100644
+index 9a425e757229484755a2f656f8a7758c7538b676..af54f97b7e3913f0846750bcdcd591679722e953 100644
 --- a/chrome/installer/mac/signing/signing.py
 +++ b/chrome/installer/mac/signing/signing.py
 @@ -11,6 +11,7 @@ import os.path
@@ -10,17 +10,7 @@ index 9a425e757229484755a2f656f8a7758c7538b676..17bd52c0c0bd0f7cc1abc405bfd24d05
  
  _PROVISIONPROFILE_EXT = '.provisionprofile'
  _PROVISIONPROFILE_DEST = 'embedded.provisionprofile'
-@@ -76,7 +77,8 @@ def get_parts(config):
-                 '{0.framework_dir}/Helpers/{0.product} Helper.app'.format(
-                     config),
-                 '{}.helper'.format(uncustomized_bundle_id),
--                options=full_hardened_runtime_options,
-+                options=CodeSignOptions.RESTRICT + CodeSignOptions.KILL +
-+                CodeSignOptions.HARDENED_RUNTIME,
-                 verify_options=VerifyOptions.DEEP),
-         'helper-renderer-app':
-             CodeSignedProduct(
-@@ -136,6 +138,7 @@ def get_parts(config):
+@@ -136,6 +137,7 @@ def get_parts(config):
              library_basename.replace('.dylib', ''),
              verify_options=VerifyOptions.DEEP)
  
@@ -28,7 +18,7 @@ index 9a425e757229484755a2f656f8a7758c7538b676..17bd52c0c0bd0f7cc1abc405bfd24d05
      return parts
  
  
-@@ -180,7 +183,7 @@ def sign_part(paths, config, part):
+@@ -180,7 +182,7 @@ def sign_part(paths, config, part):
          part: The |model.CodeSignedProduct| to sign. The product's |path| must
              be in |paths.work|.
      """
@@ -37,7 +27,7 @@ index 9a425e757229484755a2f656f8a7758c7538b676..17bd52c0c0bd0f7cc1abc405bfd24d05
      if config.notary_user:
          # Assume if the config has notary authentication information that the
          # products will be notarized, which requires a secure timestamp.
-@@ -272,6 +275,7 @@ def sign_chrome(paths, config, sign_framework=False):
+@@ -272,6 +274,7 @@ def sign_chrome(paths, config, sign_framework=False):
                  continue
              sign_part(paths, config, part)
  

--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -63,7 +63,7 @@ def GenerateBraveWidevineSigFile(paths, config, part):
 
 
 def AddBravePartsForSigning(parts, config):
-    from signing.model import CodeSignedProduct, VerifyOptions
+    from signing.model import CodeSignedProduct, VerifyOptions, CodeSignOptions
 
     # Add libs
     brave_dylibs = (
@@ -83,6 +83,10 @@ def AddBravePartsForSigning(parts, config):
         '{.framework_dir}/Frameworks/Sparkle.framework'.format(config),
         'org.sparkle-project.Sparkle',
         verify_options=VerifyOptions.DEEP + VerifyOptions.NO_STRICT)
+
+    # Overwrite to avoid TeamID mismatch with widevine dylib.
+    parts['helper-app'].entitlements = 'helper-entitlements.plist'
+    parts['helper-app'].options = CodeSignOptions.RESTRICT + CodeSignOptions.KILL + CodeSignOptions.HARDENED_RUNTIME
 
 
 def GetBraveSigningConfig(config_class, development):


### PR DESCRIPTION
Uplift of #3061

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.