### PR TITLE
Toolbar: hide the profile button if there is only 1 user profile

### DIFF
--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -6,12 +6,15 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_
 
+#include "base/scoped_observer.h"
+#include "chrome/browser/profiles/profile_attributes_storage.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "components/prefs/pref_member.h"
 
 class BookmarkButton;
 
-class BraveToolbarView : public ToolbarView {
+class BraveToolbarView : public ToolbarView,
+                         public ProfileAttributesStorage::Observer {
  public:
   explicit BraveToolbarView(Browser* browser, BrowserView* browser_view);
   ~BraveToolbarView() override;
@@ -32,12 +35,20 @@ class BraveToolbarView : public ToolbarView {
   void ResetLocationBarBounds();
   void ResetBookmarkButtonBounds();
 
+  // ProfileAttributesStorage::Observer:
+  void OnProfileAdded(const base::FilePath& profile_path) override;
+  void OnProfileWasRemoved(const base::FilePath& profile_path,
+      const base::string16& profile_name) override;
+
   BookmarkButton* bookmark_ = nullptr;
   // Tracks the preference to determine whether bookmark editing is allowed.
   BooleanPrefMember edit_bookmarks_enabled_;
   BooleanPrefMember location_bar_is_wide_;
   // Whether this toolbar has been initialized.
   bool brave_initialized_ = false;
+  // Tracks profile count to determine whether profile switcher should be shown.
+  ScopedObserver<ProfileAttributesStorage, BraveToolbarView>
+      profile_observer_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -1,0 +1,129 @@
+// Copyright 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/chrome_notification_types.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/profiles/profile_window.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/search_test_utils.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/test/test_utils.h"
+#include "ui/views/view.h"
+
+// An observer that returns back to test code after a new profile is
+// initialized.
+void OnUnblockOnProfileCreation(base::RunLoop* run_loop,
+                                Profile* profile,
+                                Profile::CreateStatus status) {
+  if (status == Profile::CREATE_STATUS_INITIALIZED)
+    run_loop->Quit();
+}
+
+class BraveToolbarViewTest : public InProcessBrowserTest {
+ public:
+  BraveToolbarViewTest() = default;
+  ~BraveToolbarViewTest() override = default;
+
+  void SetUpOnMainThread() override {
+    Init(browser());
+  }
+
+  void Init(Browser* browser) {
+    BrowserView* browser_view =
+      BrowserView::GetBrowserViewForBrowser(browser);
+    ASSERT_NE(browser_view, nullptr);
+    toolbar_view_ = browser_view->toolbar();
+    ASSERT_NE(toolbar_view_, nullptr);
+  }
+
+ protected:
+  bool is_avatar_button_shown() {
+    views::View* button = toolbar_view_->GetAvatarToolbarButton();
+    DCHECK(button);
+    return button->GetVisible();
+  }
+
+ private:
+  ToolbarView* toolbar_view_;
+  DISALLOW_COPY_AND_ASSIGN(BraveToolbarViewTest);
+};
+
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
+    AvatarButtonNotShownSingleProfile) {
+  EXPECT_EQ(false, is_avatar_button_shown());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest, AvatarButtonIsShownGuestProfile) {
+  // Open a Guest window.
+  EXPECT_EQ(1U, BrowserList::GetInstance()->size());
+  content::WindowedNotificationObserver browser_creation_observer(
+      chrome::NOTIFICATION_BROWSER_OPENED,
+      content::NotificationService::AllSources());
+  profiles::SwitchToGuestProfile(ProfileManager::CreateCallback());
+  base::RunLoop().RunUntilIdle();
+  browser_creation_observer.Wait();
+  EXPECT_EQ(2U, BrowserList::GetInstance()->size());
+
+  // Retrieve the new Guest profile.
+  Profile* guest = g_browser_process->profile_manager()->GetProfileByPath(
+      ProfileManager::GetGuestProfilePath());
+
+  // Access the browser with the Guest profile and re-init test for it.
+  Browser* browser = chrome::FindAnyBrowser(guest, true);
+  EXPECT_TRUE(browser);
+  Init(browser);
+  EXPECT_EQ(true, is_avatar_button_shown());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
+    AvatarButtonIsShownMultipleProfiles) {
+  // Should not be shown in first profile, at first
+  EXPECT_EQ(false, is_avatar_button_shown());
+
+  // Create an additional profile.
+  ProfileManager* profile_manager = g_browser_process->profile_manager();
+  ProfileAttributesStorage& storage =
+      profile_manager->GetProfileAttributesStorage();
+  base::FilePath current_profile_path = browser()->profile()->GetPath();
+  base::FilePath new_path = profile_manager->GenerateNextProfileDirectoryPath();
+  base::RunLoop run_loop;
+  profile_manager->CreateProfileAsync(
+      new_path, base::Bind(&OnUnblockOnProfileCreation, &run_loop),
+      base::string16(), std::string());
+  run_loop.Run();
+  ASSERT_EQ(2u, storage.GetNumberOfProfiles());
+  Profile* new_profile = profile_manager->GetProfileByPath(new_path);
+
+  // check it's now shown in first profile
+  EXPECT_EQ(true, is_avatar_button_shown());
+
+  // Open the new profile
+  EXPECT_EQ(1U, BrowserList::GetInstance()->size());
+  content::WindowedNotificationObserver browser_creation_observer(
+      chrome::NOTIFICATION_BROWSER_OPENED,
+      content::NotificationService::AllSources());
+  profiles::OpenBrowserWindowForProfile(
+    ProfileManager::CreateCallback(),
+    false, true, true,
+    new_profile,
+    Profile::CREATE_STATUS_INITIALIZED);
+  base::RunLoop().RunUntilIdle();
+  browser_creation_observer.Wait();
+  EXPECT_EQ(2U, BrowserList::GetInstance()->size());
+
+  // Check it's shown in second profile
+  Browser* browser = chrome::FindAnyBrowser(new_profile, true);
+  EXPECT_TRUE(browser);
+  Init(browser);
+  EXPECT_EQ(true, is_avatar_button_shown());
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -386,6 +386,7 @@ test("brave_browser_tests") {
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",
     "//brave/browser/ui/views/profiles/brave_profile_chooser_view_browsertest.cc",
+    "//brave/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc",
     "//brave/browser/ui/webui/brave_new_tab_ui_browsertest.cc",
     "//brave/browser/ui/webui/brave_welcome_ui_browsertest.cc",
     "//brave/browser/ui/toolbar/brave_app_menu_model_browsertest.cc",


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5091

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

_New automated browser tests also cover most of the following..._

0. Fresh profle
1. Open 1 or more windows
 --> Profile button is now shown
2. Open the guest window
 --> Profile button is shown

3. Open incognito / tor window
 --> Profile button is shown

4. Create a new profile (on macos use the System menu, on other OS wait until https://github.com/brave/brave-core/pull/3096 provides the app menu action!)
 ---> Profile button is shown on original profile window
 ---> Profile button is shown on new profile window

5. Delete profile (click on profile button, then Manage profiles, then the menu button on one of the profiles, then remove profile, then confirm!)
 ---> Profile button is not shown on existing remaining profile window

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
