### PR TITLE
Issue with Ads Payments (August 5)

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.cc
@@ -14,7 +14,9 @@ ConfirmationInfo::ConfirmationInfo() :
     token_info(TokenInfo()),
     payment_token(nullptr),
     blinded_payment_token(nullptr),
-    credential("") {}
+    credential(""),
+    timestamp_in_seconds(0),
+    created(false) {}
 
 ConfirmationInfo::ConfirmationInfo(const ConfirmationInfo& info) :
     id(info.id),
@@ -23,7 +25,9 @@ ConfirmationInfo::ConfirmationInfo(const ConfirmationInfo& info) :
     token_info(info.token_info),
     payment_token(info.payment_token),
     blinded_payment_token(info.blinded_payment_token),
-    credential(info.credential) {}
+    credential(info.credential),
+    timestamp_in_seconds(info.timestamp_in_seconds),
+    created(info.created) {}
 
 ConfirmationInfo::~ConfirmationInfo() {}
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
@@ -6,6 +6,7 @@
 #ifndef BAT_CONFIRMATIONS_INTERNAL_CONFIRMATION_INFO_H_
 #define BAT_CONFIRMATIONS_INTERNAL_CONFIRMATION_INFO_H_
 
+#include <stdint.h>
 #include <string>
 
 #include "bat/confirmations/confirmation_type.h"
@@ -30,6 +31,8 @@ struct ConfirmationInfo {
   Token payment_token;
   BlindedToken blinded_payment_token;
   std::string credential;
+  uint64_t timestamp_in_seconds;
+  bool created;
 };
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -194,6 +194,12 @@ base::Value ConfirmationsImpl::GetConfirmationsAsDictionary(
     confirmation_dictionary.SetKey("credential",
         base::Value(confirmation.credential));
 
+    confirmation_dictionary.SetKey("timestamp_in_seconds",
+        base::Value(std::to_string(confirmation.timestamp_in_seconds)));
+
+    confirmation_dictionary.SetKey("created",
+        base::Value(confirmation.created));
+
     list.GetList().push_back(std::move(confirmation_dictionary));
   }
 
@@ -527,6 +533,24 @@ bool ConfirmationsImpl::GetConfirmationsFromDictionary(
       // Credential missing, skip confirmation
       DCHECK(false) << "Confirmation missing credential";
       continue;
+    }
+
+    // Timestamp
+    auto* timestamp_in_seconds_value =
+        confirmation_dictionary->FindKey("timestamp_in_seconds");
+    if (timestamp_in_seconds_value) {
+      auto timestamp_in_seconds =
+          std::stoull(timestamp_in_seconds_value->GetString());
+
+      confirmation_info.timestamp_in_seconds = timestamp_in_seconds;
+    }
+
+    // Created
+    auto* created_value = confirmation_dictionary->FindKey("created");
+    if (created_value) {
+      confirmation_info.created = created_value->GetBool();
+    } else {
+      confirmation_info.created = true;
     }
 
     confirmations->push_back(confirmation_info);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -46,7 +46,6 @@ class ConfirmationsImpl : public Confirmations {
 
   // Confirmations
   void AppendConfirmationToQueue(const ConfirmationInfo& confirmation_info);
-  void RemoveConfirmationFromQueue(const ConfirmationInfo& confirmation_info);
   void StartRetryingFailedConfirmations(const uint64_t start_timer_in);
   bool IsRetryingFailedConfirmations() const;
 
@@ -108,7 +107,8 @@ class ConfirmationsImpl : public Confirmations {
 
   // Confirmations
   uint32_t retry_failed_confirmations_timer_id_;
-  void RetryFailedConfirmations() const;
+  void RemoveConfirmationFromQueue(const ConfirmationInfo& confirmation_info);
+  void RetryFailedConfirmations();
   void StopRetryingFailedConfirmations();
   std::vector<ConfirmationInfo> confirmations_;
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.h
@@ -46,8 +46,7 @@ class ConfirmationsImpl : public Confirmations {
 
   // Confirmations
   void AppendConfirmationToQueue(const ConfirmationInfo& confirmation_info);
-  void StartRetryingFailedConfirmations(const uint64_t start_timer_in);
-  bool IsRetryingFailedConfirmations() const;
+  void StartRetryingFailedConfirmations();
 
   // Ads rewards
   void UpdateAdsRewards(const bool should_refresh) override;
@@ -79,8 +78,8 @@ class ConfirmationsImpl : public Confirmations {
   bool OnTimer(const uint32_t timer_id) override;
 
   // Refill tokens
-  void RefillTokensIfNecessary() const;
   void StartRetryingToGetRefillSignedTokens(const uint64_t start_timer_in);
+  void RefillTokensIfNecessary() const;
 
   // Redeem unblinded tokens
   void ConfirmAd(std::unique_ptr<NotificationInfo> info) override;
@@ -108,6 +107,8 @@ class ConfirmationsImpl : public Confirmations {
   // Confirmations
   uint32_t retry_failed_confirmations_timer_id_;
   void RemoveConfirmationFromQueue(const ConfirmationInfo& confirmation_info);
+  void StartRetryingFailedConfirmations(const uint64_t start_timer_in);
+  bool IsRetryingFailedConfirmations() const;
   void RetryFailedConfirmations();
   void StopRetryingFailedConfirmations();
   std::vector<ConfirmationInfo> confirmations_;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
@@ -70,6 +70,8 @@ void RedeemToken::Redeem(
   BLOG(INFO) << "Redeem";
 
   CreateConfirmation(confirmation_info);
+
+  confirmations_->RefillTokensIfNecessary();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -416,23 +418,6 @@ void RedeemToken::OnRedeem(
         << " confirmation id with " << confirmation_info.creative_instance_id
         << " creative instance id for " << std::string(confirmation_info.type);
   }
-
-  if (!confirmations_->IsRetryingFailedConfirmations()) {
-    ScheduleNextRetryForFailedConfirmations();
-  }
-}
-
-void RedeemToken::ScheduleNextRetryForFailedConfirmations() const {
-  auto start_timer_in = CalculateTimerForNextRetryForFailedConfirmations();
-  confirmations_->StartRetryingFailedConfirmations(start_timer_in);
-}
-
-uint64_t RedeemToken::CalculateTimerForNextRetryForFailedConfirmations() const {
-  auto start_timer_in = kRetryFailedConfirmationsAfterSeconds;
-  auto rand_delay = brave_base::random::Geometric(start_timer_in);
-  start_timer_in = rand_delay;
-
-  return start_timer_in;
 }
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
@@ -69,9 +69,6 @@ class RedeemToken {
       const ConfirmationInfo& confirmation_info,
       const bool should_retry = true);
 
-  void ScheduleNextRetryForFailedConfirmations() const;
-  uint64_t CalculateTimerForNextRetryForFailedConfirmations() const;
-
   ConfirmationsImpl* confirmations_;  // NOT OWNED
   ConfirmationsClient* confirmations_client_;  // NOT OWNED
   UnblindedTokens* unblinded_tokens_;  // NOT OWNED

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
@@ -69,6 +69,9 @@ class RedeemToken {
       const ConfirmationInfo& confirmation_info,
       const bool should_retry = true);
 
+  bool Verify(
+    const ConfirmationInfo& confirmation_info) const;
+
   ConfirmationsImpl* confirmations_;  // NOT OWNED
   ConfirmationsClient* confirmations_client_;  // NOT OWNED
   UnblindedTokens* unblinded_tokens_;  // NOT OWNED

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
@@ -39,11 +39,11 @@ class RedeemToken {
       const std::string& creative_instance_id,
       const ConfirmationType confirmation_type);
   void Redeem(
-    const ConfirmationInfo& confirmation_info);
+    const ConfirmationInfo& confirmation);
 
  private:
   void CreateConfirmation(
-      const ConfirmationInfo& confirmation_info);
+      const ConfirmationInfo& confirmation);
   void CreateConfirmation(
       const std::string& creative_instance_id,
       const TokenInfo& token_info,
@@ -53,24 +53,24 @@ class RedeemToken {
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers,
-      const ConfirmationInfo& confirmation_info);
+      const ConfirmationInfo& confirmation);
 
   void FetchPaymentToken(
-      const ConfirmationInfo& confirmation_info);
+      const ConfirmationInfo& confirmation);
   void OnFetchPaymentToken(
       const std::string& url,
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers,
-      const ConfirmationInfo& confirmation_info);
+      const ConfirmationInfo& confirmation);
 
   void OnRedeem(
       const Result result,
-      const ConfirmationInfo& confirmation_info,
+      const ConfirmationInfo& confirmation,
       const bool should_retry = true);
 
   bool Verify(
-    const ConfirmationInfo& confirmation_info) const;
+    const ConfirmationInfo& confirmation) const;
 
   ConfirmationsImpl* confirmations_;  // NOT OWNED
   ConfirmationsClient* confirmations_client_;  // NOT OWNED


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5548

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm on slow networks when viewing, and then immediately clicking an ad that `Response status code: 404` (with exception of when migrating from fail confirmations added to the queue before this fix) are not shown  in the diagnostic logs (also allow multiple ad notifications to appear in the Notification Center and click the notifications as quickly as possible).

- Confirm when failed confirmations are retried that `Response status code: 400` does not appear in the diagnostic logs

- Confirm failed confirmations from older builds are retried after upgrading and added to the `Estimated pending rewards` and `Ad notifications received this month` totals

- Confirm failed confirmations are retried every ~5 minutes until the queue is empty

- Confirm failed confirmations are retried if the queue is empty and a confirmation fails

**NOTES: You can use Network Link Conditioner on macOS to change latency to +~30s**

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
