### PR TITLE
Fix stats updater bug that misidentified Android as Linux

### DIFF
--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -1,8 +1,12 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/brave_stats_updater.h"
+
+#include <string>
+#include <utility>
 
 #include "base/system/sys_info.h"
 #include "brave/browser/brave_stats_updater_params.h"
@@ -64,8 +68,9 @@ GURL GetUpdateURL(const GURL& base_update_url,
                                          GetPlatformIdentifier());
   update_url =
       net::AppendQueryParameter(update_url, "channel", GetChannelName());
-  update_url = net::AppendQueryParameter(update_url, "version",
-                    version_info::GetBraveVersionWithoutChromiumMajorVersion());
+  update_url = net::AppendQueryParameter(
+      update_url, "version",
+      version_info::GetBraveVersionWithoutChromiumMajorVersion());
   update_url = net::AppendQueryParameter(update_url, "daily",
                                          stats_updater_params.GetDailyParam());
   update_url = net::AppendQueryParameter(update_url, "weekly",
@@ -81,7 +86,7 @@ GURL GetUpdateURL(const GURL& base_update_url,
   return update_url;
 }
 
-}
+}  // namespace
 
 namespace brave {
 
@@ -89,11 +94,9 @@ GURL BraveStatsUpdater::g_base_update_url_(
     "https://laptop-updates.brave.com/1/usage/brave-core");
 
 BraveStatsUpdater::BraveStatsUpdater(PrefService* pref_service)
-  : pref_service_(pref_service) {
-}
+    : pref_service_(pref_service) {}
 
-BraveStatsUpdater::~BraveStatsUpdater() {
-}
+BraveStatsUpdater::~BraveStatsUpdater() {}
 
 void BraveStatsUpdater::Start() {
   // Startup timer, only initiated once we've checked for a promo
@@ -207,8 +210,10 @@ void BraveStatsUpdater::SendServerPing() {
             "Not implemented."
         })");
   auto resource_request = std::make_unique<network::ResourceRequest>();
-  auto stats_updater_params = std::make_unique<brave::BraveStatsUpdaterParams>(pref_service_);
-  resource_request->url = GetUpdateURL(g_base_update_url_, *stats_updater_params);
+  auto stats_updater_params =
+      std::make_unique<brave::BraveStatsUpdaterParams>(pref_service_);
+  resource_request->url =
+      GetUpdateURL(g_base_update_url_, *stats_updater_params);
   resource_request->load_flags =
       net::LOAD_DO_NOT_SEND_COOKIES | net::LOAD_DO_NOT_SAVE_COOKIES |
       net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE |
@@ -231,7 +236,8 @@ void BraveStatsUpdater::SetBaseUpdateURLForTest(const GURL& base_update_url) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<BraveStatsUpdater> BraveStatsUpdaterFactory(PrefService* pref_service) {
+std::unique_ptr<BraveStatsUpdater> BraveStatsUpdaterFactory(
+    PrefService* pref_service) {
   return std::make_unique<BraveStatsUpdater>(pref_service);
 }
 

--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -48,6 +48,8 @@ std::string GetPlatformIdentifier() {
     return "winx64-bc";
 #elif defined(OS_MACOSX)
   return "osx-bc";
+#elif defined(OS_ANDROID)
+  return "android-bc";
 #elif defined(OS_LINUX)
   return "linux-bc";
 #else


### PR DESCRIPTION
Fix brave/brave-browser#4361

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Launch Brave with verbose logging set to 1 (or use a network analyzer to monitor traffic)
- Verify that daily ping is sent shortly after startup and looks accurate and contains a platform of `android-bc`

Note that until the server supports Android (see tickets mentioned below), the server will respond with a `400` indicating that `android-bc` is an unrecognized platform. This is expected.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
