### PR TITLE
New Tabs Page: Enable NTP to be theme aware

### DIFF
--- a/common/extensions/api/_api_features.json
+++ b/common/extensions/api/_api_features.json
@@ -105,7 +105,8 @@
     "contexts": ["webui"],
     "matches": [
       "chrome://welcome/*",
-      "chrome://settings/*"
+      "chrome://settings/*",
+      "chrome://newtab/*"
     ]
   }]
 }

--- a/components/brave_new_tab_ui/brave_new_tab.tsx
+++ b/components/brave_new_tab_ui/brave_new_tab.tsx
@@ -7,7 +7,8 @@ import * as React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import Theme from 'brave-ui/theme/brave-default'
-import { ThemeProvider } from 'brave-ui/theme'
+import DarkTheme from 'brave-ui/theme/brave-dark'
+import BraveCoreThemeProvider from '../common/BraveCoreThemeProvider'
 import wireAPIEventsToStore from './apiEventsToStore'
 
 // Components
@@ -24,15 +25,24 @@ import '../fonts/muli.css'
 function initialize () {
   console.timeStamp('loaded')
   // Get rendering going
-  render(
-    <Provider store={store}>
-      <ThemeProvider theme={Theme}>
-        <App />
-      </ThemeProvider>
-    </Provider>,
-    document.getElementById('root'),
-    () => console.timeStamp('first react render')
-  )
+  new Promise(resolve => chrome.braveTheme.getBraveThemeType(resolve))
+  .then((themeType: chrome.braveTheme.ThemeType) => {
+    render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider
+          initialThemeType={themeType}
+          dark={DarkTheme}
+          light={Theme}
+        >
+          <App />
+        </BraveCoreThemeProvider>
+      </Provider>,
+      document.getElementById('root'),
+      () => console.timeStamp('first react render'))
+  })
+  .catch((error) => {
+    console.error('Problem mounting brave new tab', error)
+  })
   window.i18nTemplate.process(window.document, window.loadTimeData)
 }
 


### PR DESCRIPTION
Closes https://github.com/brave/brave-browser/issues/5014
Themes/Styling were pre-built in an earlier PR for storybook (https://github.com/brave/brave-ui/pull/485)
Quick view:
![ntp-theme](https://user-images.githubusercontent.com/9125231/62888054-64756200-bcf3-11e9-98cc-874d4c5a3eda.gif)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1 Set theme settings to 'Light'/'Dark'/'Same as OSX' from brave://settings
2 Open NTP's customization menu 
3 Menu should be themed accordingly
4. Menu should dynamically update theme when if "Same as OS theme"* is set 

*Assuming native OS supports dark mode - otherwise this option wouldn't be available from settings
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
