### PR TITLE
Uplift "Upgrade WebTorrent forks" to 0.68.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1448,23 +1448,22 @@
       "dev": true
     },
     "binary-search": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.5.tgz",
-      "integrity": "sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "bitfield": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-2.0.0.tgz",
-      "integrity": "sha512-4xM4DYejOHQ/qWBfeqBXNA4mJ12PwcOibFYnH1kYh5U9BHciCqEJBqGNVnMJXUhm8mflujNRLSv7IiVQxovgjw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-3.0.0.tgz",
+      "integrity": "sha512-hJmWKucJQfdSkQPDPBKmWogM9s8+NOSzDT9QVbJbjinXaQ0bJKPu/cn98qRWy3PDNWtKw4XaoUP3XruGRIKEgg=="
     },
     "bittorrent-dht": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-9.0.0.tgz",
-      "integrity": "sha512-X5ax4G/PLtEPfqOUjqDZ2nmPENndWRMK4sT2jcQ4sXor904zhR40r4KqTyTvWYAljh5/hPPqM9DCUUtqWzRXoQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-9.0.2.tgz",
+      "integrity": "sha512-w8JOhuJsdmRc1tlQpwXOmhBy4VwcFr/FDePo97mp0fiBbXQ8CFSemssBL0lSxB1+7sX3vQyZh31YJERNFyPJtA==",
       "requires": {
         "bencode": "^2.0.0",
-        "buffer-equals": "^1.0.3",
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "inherits": "^2.0.1",
         "k-bucket": "^5.0.0",
         "k-rpc": "^5.0.0",
@@ -1472,7 +1471,6 @@
         "lru": "^3.1.0",
         "randombytes": "^2.0.5",
         "record-cache": "^1.0.2",
-        "safe-buffer": "^5.0.1",
         "simple-sha1": "^2.1.0"
       }
     },
@@ -1482,31 +1480,41 @@
       "integrity": "sha512-SYd5H3RbN1ex+TrWAKXkEkASFWxAR7Tk6iLt9tfAT9ehBvZb/Y3AQDVRVJynlrixcWpnmsLYKI7tkRWgp7ORoQ=="
     },
     "bittorrent-protocol": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-3.0.1.tgz",
-      "integrity": "sha512-hnvOzAu9u+2H0OLLL5byoFdz6oz5f3bx5f7R+ItUohTHMq9TgUhEJfcjo7xWtQHSKOVciYWwYTJ4EjczF5RX2A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-3.1.0.tgz",
+      "integrity": "sha512-XPi4PpU8iaHA1HC8ku+3kr+r6TzhG8WFprJs/yUzTE67JSkRcKO5X+XphqeQPj6LkP0syNcUUOp22EDV7Eg4Sg==",
       "requires": {
         "bencode": "^2.0.0",
-        "bitfield": "^2.0.0",
-        "debug": "^3.1.0",
+        "bitfield": "^3.0.0",
+        "debug": "^4.1.1",
         "randombytes": "^2.0.5",
-        "readable-stream": "^2.3.2",
+        "readable-stream": "^3.0.0",
         "speedometer": "^1.0.0",
-        "unordered-array-remove": "^1.0.2",
-        "xtend": "^4.0.0"
+        "unordered-array-remove": "^1.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bittorrent-tracker": {
-      "version": "github:brave/bittorrent-tracker#87cd1bba3ce2f40159210b904db3420e8b237b0a",
-      "from": "github:brave/bittorrent-tracker#87cd1bba3ce2f40159210b904db3420e8b237b0a",
+      "version": "github:brave/bittorrent-tracker#36bccfc97f933ac956b0aed9b09c69c8fb49e713",
+      "from": "github:brave/bittorrent-tracker#36bccfc97f933ac956b0aed9b09c69c8fb49e713",
       "requires": {
         "bencode": "^2.0.0",
         "bittorrent-peerid": "^1.0.2",
-        "bn.js": "^4.4.0",
+        "bn.js": "^5.0.0",
         "bufferutil": "^4.0.0",
         "compact2string": "^1.2.0",
-        "debug": "^3.1.0",
-        "inherits": "^2.0.1",
+        "debug": "^4.0.1",
         "ip": "^1.0.1",
         "lru": "^3.0.0",
         "minimist": "^1.1.1",
@@ -1515,16 +1523,21 @@
         "randombytes": "^2.0.3",
         "run-parallel": "^1.1.2",
         "run-series": "^1.0.2",
-        "safe-buffer": "^5.0.0",
         "simple-get": "^3.0.0",
         "simple-peer": "^9.0.0",
-        "simple-websocket": "^7.0.1",
+        "simple-websocket": "^8.0.0",
         "string2compact": "^1.1.1",
         "uniq": "^1.0.1",
         "unordered-array-remove": "^1.0.2",
         "utf-8-validate": "^5.0.1",
-        "ws": "^6.0.0",
-        "xtend": "^4.0.0"
+        "ws": "^7.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz",
+          "integrity": "sha512-bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A=="
+        }
       }
     },
     "blob-to-buffer": {
@@ -1533,13 +1546,23 @@
       "integrity": "sha512-re0AIxakF504MgeMtIyJkVcZ8T5aUxtp/QmTMlmjyb3P44E1BEv5x3LATBGApWAJATyXHtkXRD+gWTmeyYLiQA=="
     },
     "block-stream2": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-1.1.0.tgz",
-      "integrity": "sha1-xzjjqRupd+u14f70MeE8oR2GOeI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-2.0.0.tgz",
+      "integrity": "sha512-1oI+RHHUEo64xomy1ozLgVJetFlHkIfQfJzTBQrj6xWnEMEPooeo2fZoqFjp0yzfHMBrgxwgh70tKp6T17+i3g==",
       "requires": {
-        "defined": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bluebird": {
@@ -1550,7 +1573,8 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -1753,11 +1777,6 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
-    "buffer-equals": {
-      "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
-      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
-    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -1766,7 +1785,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1959,12 +1979,24 @@
       }
     },
     "chunk-store-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-3.0.1.tgz",
-      "integrity": "sha512-GA1NIFDZKElhkjiO6QOyzfK1QbUt6M3gFhUU/aR05JYaDqXbU5d7U92cLvGKdItJEDfojky6NQefy5VL5PpDBA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.1.0.tgz",
+      "integrity": "sha512-GjkZ16bFKMFnb8LrGZXAPeRoLXZTLu9ges6LCErJe28bMp6zKLxjWuJ7TYzR0jWq9nwo58hXG3BXZYy66Vze0Q==",
       "requires": {
-        "block-stream2": "^1.0.0",
-        "readable-stream": "^2.0.5"
+        "block-stream2": "^2.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "ci-info": {
@@ -2103,9 +2135,9 @@
       "dev": true
     },
     "compact2string": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/compact2string/-/compact2string-1.4.0.tgz",
-      "integrity": "sha1-qZzZbqAAUlaEsmloOuIiLW7qe0k=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/compact2string/-/compact2string-1.4.1.tgz",
+      "integrity": "sha512-3D+EY5nsRhqnOwDxveBv5T8wGo4DEvYxjDtPGmdOX+gfr5gE92c2RC0w2wa+xEefm07QuVqqcF3nZJUZ92l/og==",
       "requires": {
         "ipaddr.js": ">= 0.1.5"
       }
@@ -2192,7 +2224,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -2232,18 +2265,17 @@
       }
     },
     "create-torrent": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/create-torrent/-/create-torrent-3.33.0.tgz",
-      "integrity": "sha512-KMd0KuvwVUg1grlRd5skG9ZkSbBYDDkAjDUMLnvxdRn0rL7ph3IwoOk7I8u1yLX4HYjGiLVlWYO55YWNNPjJFA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/create-torrent/-/create-torrent-4.2.2.tgz",
+      "integrity": "sha512-n6Jjv/Y7LnSI4o3g8Ab7z7fVXOWFx3AQHNlZ/MYnxzLgCEFJQqXR3aoP/1rRjXQnnhrkfY/Kvq5gjmrIfAkT7A==",
       "requires": {
         "bencode": "^2.0.0",
-        "block-stream2": "^1.0.0",
-        "filestream": "^4.0.0",
-        "flatten": "^1.0.2",
+        "block-stream2": "^2.0.0",
+        "filestream": "^5.0.0",
         "is-file": "^1.0.0",
-        "junk": "^2.1.0",
+        "junk": "^3.1.0",
         "minimist": "^1.1.0",
-        "multistream": "^2.0.2",
+        "multistream": "^4.0.0",
         "once": "^1.3.0",
         "piece-length": "^1.0.0",
         "readable-stream": "^3.0.2",
@@ -2252,9 +2284,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2456,9 +2488,9 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2558,11 +2590,6 @@
           }
         }
       }
-    },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3276,14 +3303,24 @@
       }
     },
     "filestream": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/filestream/-/filestream-4.1.3.tgz",
-      "integrity": "sha1-lI/KregiH3FfXsrdxUhi+qrMkyU=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/filestream/-/filestream-5.0.0.tgz",
+      "integrity": "sha512-5H3RqSaJp12THfZiNWodYM7TiKfQvrpX+EIOrB1XvCceTys4yvfEIl8wDp+/yI8qj6Bxym8m0NYWwVXDAet/+A==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5",
-        "typedarray-to-buffer": "^3.0.0",
-        "xtend": "^4.0.1"
+        "readable-stream": "^3.4.0",
+        "typedarray-to-buffer": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -3352,11 +3389,6 @@
         }
       }
     },
-    "flatten": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -3421,11 +3453,10 @@
       }
     },
     "fs-chunk-store": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-1.7.0.tgz",
-      "integrity": "sha512-KhjJmZAs2eqfhCb6PdPx4RcZtheGTz86tpTC5JTvqBn/xda+Nb+0C7dCyjOSN7T76H6a56LvH0SVXQMchLXDRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-2.0.0.tgz",
+      "integrity": "sha512-zTlXr5CE9Ad+Jyse3SB57AbRfgt+QO8T9vG1B7G2eNCxxx/WqeMt0NBWfjjgUnmxfwlbB85vICAvJJMHoT3FvA==",
       "requires": {
-        "mkdirp": "^0.5.1",
         "random-access-file": "^2.0.1",
         "randombytes": "^2.0.3",
         "rimraf": "^2.4.2",
@@ -4027,9 +4058,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -4495,17 +4526,17 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-set": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ip-set/-/ip-set-1.0.1.tgz",
-      "integrity": "sha1-Yztm0L1sjQ3paNBTJjyRINO2cn4=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ip-set/-/ip-set-1.0.2.tgz",
+      "integrity": "sha512-Mb6kv78bTi4RNAIIWL8Bbre7hXOR2pNUi3j8FaQkLaitf/ZWxkq3/iIwXNYk2ACO3IMfdVdQrOkUtwZblO7uBA==",
       "requires": {
         "ip": "^1.1.3"
       }
     },
     "ipaddr.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -4748,7 +4779,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -5534,9 +5566,9 @@
       }
     },
     "junk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz",
-      "integrity": "sha1-9DG0t/By3FAKXxDOf07HGTDnATQ="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
+      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ=="
     },
     "just-extend": {
       "version": "4.0.2",
@@ -5553,36 +5585,21 @@
       }
     },
     "k-rpc": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.0.0.tgz",
-      "integrity": "sha512-vCH2rQdfMOS+MlUuTSuar1pS2EMrltURf9LmAR9xR6Jik0XPlMX3vEixgqMn17wKmFVCublJqSJ4hJIP7oKZ3Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
+      "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
       "requires": {
-        "buffer-equals": "^1.0.3",
-        "k-bucket": "^4.0.0",
+        "k-bucket": "^5.0.0",
         "k-rpc-socket": "^1.7.2",
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "k-bucket": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
-          "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "randombytes": "^2.0.3"
-          }
-        }
+        "randombytes": "^2.0.5"
       }
     },
     "k-rpc-socket": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.8.0.tgz",
-      "integrity": "sha512-f/9TynsO8YYjZ6JjNNtSSH7CJcIHcio1buy3zqByGxb/GX8AWLdL6FZEWTrN8V3/J7W4/E0ZTQQ+Jt2rVq7ELg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.9.0.tgz",
+      "integrity": "sha512-0SEtwKDVLOIoR0mh+ncJuryC4FM9fgcwc7Xa6AaLA4i0dBoLfKojIjr8KKw4CPwzgkpdfJArsYW7OQugYILkgQ==",
       "requires": {
-        "bencode": "^2.0.0",
-        "buffer-equals": "^1.0.4",
-        "safe-buffer": "^5.1.1"
+        "bencode": "^2.0.0"
       }
     },
     "kind-of": {
@@ -5912,9 +5929,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5990,9 +6007,9 @@
       }
     },
     "mime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
       "version": "1.38.0",
@@ -6120,25 +6137,33 @@
       }
     },
     "mp4-box-encoding": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mp4-box-encoding/-/mp4-box-encoding-1.3.0.tgz",
-      "integrity": "sha512-U4pMLpjT/UzB8d36dxj6Mf1bG9xypEvgbuRIa1fztRXNKKTCAtRxsnFZhNOd7YDFOKtjBgssYGvo4H/Q3ZY1MA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mp4-box-encoding/-/mp4-box-encoding-1.4.1.tgz",
+      "integrity": "sha512-2/PRtGGiqPc/VEhbm7xAQ+gbb7yzHjjMAv6MpAifr5pCpbh3fQUdj93uNgwPiTppAGu8HFKe3PeU+OdRyAxStA==",
       "requires": {
-        "buffer-alloc": "^1.2.0",
-        "buffer-from": "^1.1.0",
         "uint64be": "^2.0.2"
       }
     },
     "mp4-stream": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mp4-stream/-/mp4-stream-2.0.3.tgz",
-      "integrity": "sha512-5NzgI0+bGakoZEwnIYINXqB3mnewkt3Y7jcvkXsTubnCNUSdM8cpP0Vemxf6FLg0qUN8fydTgNMVAc3QU8B92g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mp4-stream/-/mp4-stream-3.1.0.tgz",
+      "integrity": "sha512-ZQQjf0VEiqPucwRvmT3e0pfZfMSE3nc5ngGUiN1+2VMxCtrInrlAjZ2K6jpNmxSZ/roiQne/ovYJYTeOvZDXPw==",
       "requires": {
-        "buffer-alloc": "^1.1.0",
-        "inherits": "^2.0.1",
-        "mp4-box-encoding": "^1.1.0",
+        "mp4-box-encoding": "^1.3.0",
         "next-event": "^1.0.0",
-        "readable-stream": "^2.0.3"
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "ms": {
@@ -6147,12 +6172,23 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multistream": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz",
-      "integrity": "sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-4.0.0.tgz",
+      "integrity": "sha512-t0C8MAtH/d3Y+5nooEtUMWli92lVw9Jhx4uOhRl5GAwS5vc+YTmp/VXNJNsCBAMeEyK/6zhbk6x9JE3AiCvo4g==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "mz": {
@@ -6722,13 +6758,13 @@
       "dev": true
     },
     "parse-torrent": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-6.1.2.tgz",
-      "integrity": "sha512-Z/vig84sHwtrTEbOzisT4xnYTFlOgAaLQccPruMPgRahZUppVE/BUXzAos3jZM7c64o0lfukQdQ4ozWa5lN39w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-7.0.0.tgz",
+      "integrity": "sha512-i/Y9CNp2xn+moDrNWApBZ5rW9xRY6x6z4A71Lw886UKx7E/DkVAzuvA7efVtcPgdY3iI9ea0thaoqeMN3GZBOA==",
       "requires": {
         "bencode": "^2.0.0",
         "blob-to-buffer": "^1.2.6",
-        "get-stdin": "^6.0.0",
+        "get-stdin": "^7.0.0",
         "magnet-uri": "^5.1.3",
         "simple-get": "^3.0.1",
         "simple-sha1": "^2.0.0",
@@ -7005,7 +7041,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "promise": {
       "version": "7.3.1",
@@ -7156,18 +7193,18 @@
       }
     },
     "random-access-file": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.0.tgz",
-      "integrity": "sha512-W2hY3DboLETMclybTVzyqCNVKx1MjqUwZPzkpkkMD2t9mbGEtkV2SKWPqAJ/FTrAtnWB7aGwl0NDUS82da0KdQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.3.tgz",
+      "integrity": "sha512-AE0Z1ywR5gIkzACMC1lCsR6LP8g4ynNm7oYWYdKPSSU6Y3H+mGDJxBqfcV9B9KstfHNemhfX3nYmx99ZC9f/yg==",
       "requires": {
         "mkdirp": "^0.5.1",
         "random-access-storage": "^1.1.1"
       }
     },
     "random-access-storage": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
-      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.0.tgz",
+      "integrity": "sha512-7oszloM/+PdqWp/oFGyL6SeI14liqo8AAisHAZQGkWdHISyAnngKjNPL0JYIazeLxbHPY6oed2yUffowdq/o6A==",
       "requires": {
         "inherits": "^2.0.3"
       }
@@ -7196,9 +7233,9 @@
       }
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "range-slice-stream": {
       "version": "2.0.0",
@@ -7209,9 +7246,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -7372,6 +7409,7 @@
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7467,15 +7505,15 @@
       "dev": true
     },
     "render-media": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/render-media/-/render-media-3.1.3.tgz",
-      "integrity": "sha512-K7ziKKlIcgYpAovRsABDiSaNn7TzDDyyuFGpRwM52cloNcajInB6sCxFPUEzOuTJUeyvKCqT/k5INOjpKLCjhQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/render-media/-/render-media-3.3.0.tgz",
+      "integrity": "sha512-IWz+3KbUxFaxke8v/TJE0nZlhoNTTqSYS3hh284R+6rgqwahR4hA+5dAAyb0A1t4M4oLwePaGlHllfQiS2ItWQ==",
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "is-ascii": "^1.0.0",
         "mediasource": "^2.1.0",
         "stream-to-blob-url": "^2.0.0",
-        "videostream": "^2.5.1"
+        "videostream": "^3.2.0"
       }
     },
     "repeat-element": {
@@ -7846,45 +7884,58 @@
       }
     },
     "simple-peer": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.2.1.tgz",
-      "integrity": "sha512-NDAQefJCcmpni/csZgBEBDyDglTMBJOoZSl3pUQTWud+jqy02CX8LMz8Ys9qVLmm1D4IW/NP24pM9vKK0MRgXQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.5.0.tgz",
+      "integrity": "sha512-3tROq3nBo/CIZI8PWlXGbAxQIlQF6KQ/zcd4lQ2pAC4+rPiV7E721hI22nTO54uw/nzb2HKbvmDtZ4Wr173+vA==",
       "requires": {
         "debug": "^4.0.1",
         "get-browser-rtc": "^1.0.0",
         "inherits": "^2.0.1",
         "randombytes": "^2.0.3",
-        "readable-stream": "^2.3.4"
+        "readable-stream": "^3.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
     },
     "simple-sha1": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
-      "integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.2.tgz",
+      "integrity": "sha512-TQl9rm4rdKAVmhO++sXAb8TNN0D6JAD5iyI1mqEPNpxUzTRrtm4aOG1pDf/5W/qCFihiaoK6uuL9rvQz1x1VKw==",
       "requires": {
         "rusha": "^0.8.1"
       }
     },
     "simple-websocket": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-7.2.0.tgz",
-      "integrity": "sha512-wdxFg1fHw1yqFKWDcw+yNb4VIYqtl+vknZMlpLhvZSlR6l7/iVuwozqo+Qtl73mB1IH5QnXzonD1S+hAaLNTvQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.0.0.tgz",
+      "integrity": "sha512-DwBEoqOq8gvnblarMPkhZD6AWituWbVfTil/UflowYm/Bu5SK23BDKGxrVwgQXGKydzxlSiYva7LC3/hXSRLIw==",
       "requires": {
-        "debug": "^3.1.0",
-        "inherits": "^2.0.1",
+        "debug": "^4.1.1",
         "randombytes": "^2.0.3",
-        "readable-stream": "^2.0.5",
-        "ws": "^6.0.0"
+        "readable-stream": "^3.1.1",
+        "ws": "^7.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "sinon": {
@@ -8244,25 +8295,32 @@
       "dev": true
     },
     "stream-to-blob": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.1.tgz",
-      "integrity": "sha512-aRy4neA4rf+qMtLT9fCRLPGWdrsIKtCx4kUdNTIPgPQ2hkHkdxbViVAvABMx9oRM6yCWfngHx6pwXfbYkVuPuw==",
-      "requires": {
-        "once": "^1.3.3"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-2.0.0.tgz",
+      "integrity": "sha512-E+YitTtIHo7RQ4Cmgl+EzlMpqvLroTynRgt4t0pI4y5oz/piqlBQB8NFXLIWcjGOsKw+THnImrdpWcOCVxK25Q=="
     },
     "stream-to-blob-url": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-2.1.1.tgz",
-      "integrity": "sha512-DKJPEmCmIZoBfGVle9IhSfERiWaN5cuOtmfPxP2dZbLDRZxkBWZ4QbYxEJOSALk1Kf+WjBgedAMO6qkkf7Lmrg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-2.1.2.tgz",
+      "integrity": "sha512-dpfeYUYNodazv7rU+B9DOBj8u+dueXKOWqCy1lzPBxqeVIqq93jVTn68DZoBPLiYXSdsY9AW8D1l1BuxvghqEA==",
       "requires": {
         "stream-to-blob": "^1.0.0"
+      },
+      "dependencies": {
+        "stream-to-blob": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.2.tgz",
+          "integrity": "sha512-ryeEu3DGMt/095uTShIYGzLbbhZ+tHQtgp5HWEhXALSoc4U1iLSvpReZUdysahnJ3tki80wBBgryqqBzFZ0KaA==",
+          "requires": {
+            "once": "^1.3.3"
+          }
+        }
       }
     },
     "stream-with-known-length-to-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-with-known-length-to-buffer/-/stream-with-known-length-to-buffer-1.0.2.tgz",
-      "integrity": "sha512-UxSISjxmguvfYzZdq6d4XAjc3gAocqTIOS1CjgwkDkkGT/LMTsIYiV8agIw42IHFFHf8k4lPOoroCCf4W9oqzg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-with-known-length-to-buffer/-/stream-with-known-length-to-buffer-1.0.3.tgz",
+      "integrity": "sha512-4Wi2v47HMkNdRWrlFJNlIsrhV6z6nCyVKVAIiq14MAnc7wILEAINmn96IiPWTcXzT8y2S6yfBoX++MUxqiovag==",
       "requires": {
         "once": "^1.3.3"
       }
@@ -8595,7 +8653,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -8682,27 +8740,26 @@
       }
     },
     "torrent-discovery": {
-      "version": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
-      "from": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
+      "version": "github:brave/torrent-discovery#b8e96e25949fa63b5edce3ad8a80322f57c547e3",
+      "from": "github:brave/torrent-discovery#b8e96e25949fa63b5edce3ad8a80322f57c547e3",
       "requires": {
         "bittorrent-dht": "^9.0.0",
         "bittorrent-tracker": "^9.0.0",
-        "debug": "^3.1.0",
+        "debug": "^4.0.0",
         "run-parallel": "^1.1.2"
       },
       "dependencies": {
         "bittorrent-tracker": {
-          "version": "9.10.1",
-          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.10.1.tgz",
-          "integrity": "sha512-n5zTL/g6Wt0rb2EnkiyiaGYhth7I/N0/xMqGUpvGX/7g1scDGBVPhJnXR8lfp3/OMj681fv40o4q/otECMtZSA==",
+          "version": "9.13.0",
+          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.13.0.tgz",
+          "integrity": "sha512-mQGpnRX0vBMAYIeuEUR0M/aIC7s+QbO+7aGcrs5wdGTrXWa22RRr+50BYw5HZcA8Raez8DREi0FZIBFp/Nq0Qg==",
           "requires": {
             "bencode": "^2.0.0",
             "bittorrent-peerid": "^1.0.2",
-            "bn.js": "^4.4.0",
+            "bn.js": "^5.0.0",
             "bufferutil": "^4.0.0",
             "compact2string": "^1.2.0",
-            "debug": "^3.1.0",
-            "inherits": "^2.0.1",
+            "debug": "^4.0.1",
             "ip": "^1.0.1",
             "lru": "^3.0.0",
             "minimist": "^1.1.1",
@@ -8711,17 +8768,20 @@
             "randombytes": "^2.0.3",
             "run-parallel": "^1.1.2",
             "run-series": "^1.0.2",
-            "safe-buffer": "^5.0.0",
             "simple-get": "^3.0.0",
             "simple-peer": "^9.0.0",
-            "simple-websocket": "^7.0.1",
+            "simple-websocket": "^8.0.0",
             "string2compact": "^1.1.1",
             "uniq": "^1.0.1",
             "unordered-array-remove": "^1.0.2",
             "utf-8-validate": "^5.0.1",
-            "ws": "^6.0.0",
-            "xtend": "^4.0.0"
+            "ws": "^7.0.0"
           }
+        },
+        "bn.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz",
+          "integrity": "sha512-bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A=="
         }
       }
     },
@@ -9165,24 +9225,23 @@
       "dev": true
     },
     "ut_metadata": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ut_metadata/-/ut_metadata-3.3.0.tgz",
-      "integrity": "sha512-IK+ke9yL6a4oPLz/3oSW9TW7m9Wr4RG+5kW5aS2YulzEU1QDGAtago/NnOlno91fo3fSO7mnsqzn3NXNXdv8nA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ut_metadata/-/ut_metadata-3.4.0.tgz",
+      "integrity": "sha512-/Igrr2rPD0NH/dNx493alpHxGBF/XREu68bZU4zigrYiQMQpYL68sKbNo9ND5DcmbMp0lNppw4mOhSSONgUYKw==",
       "requires": {
         "bencode": "^2.0.0",
-        "bitfield": "^2.0.0",
-        "debug": "^3.1.0",
+        "bitfield": "^3.0.0",
+        "debug": "^4.0.0",
         "simple-sha1": "^2.0.0"
       }
     },
     "ut_pex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ut_pex/-/ut_pex-1.2.1.tgz",
-      "integrity": "sha512-ZrxMCbffYtxQDqvREN9kBXK2CB9tPnd5PylHoqQX9ai+3HV9/S39FnA5JnhLOC82dxIQQg0nTN2wmhtAdGNtOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ut_pex/-/ut_pex-2.0.0.tgz",
+      "integrity": "sha512-Uc0IxXGlES1DfeG+ITUISAvCF4Uldj7tt/n7s3TBt0KyXqDViOO26X5WfwXtUpEwn8fyZyerzf/YOK4rIZ2S3Q==",
       "requires": {
         "bencode": "^2.0.0",
         "compact2string": "^1.2.0",
-        "inherits": "^2.0.1",
         "string2compact": "^1.2.5"
       }
     },
@@ -9253,16 +9312,14 @@
       }
     },
     "videostream": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/videostream/-/videostream-2.6.0.tgz",
-      "integrity": "sha512-nSsullx1BYClJxVSt4Fa+Ulsv0Cf7UwaHq+4LQdLkAUdmqNhY1DlGxXDWVY2gui5XV4FvDiSbXmSbGryMrrUCQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/videostream/-/videostream-3.2.1.tgz",
+      "integrity": "sha512-Z4EcsX9aYNJZD1M+0jCeQ0t+5ETlHE88B2SF1fCuVxfn+XxHGJVec6tbHGqpULk4esOOLJEipAScOCDGHk+teQ==",
       "requires": {
         "binary-search": "^1.3.4",
-        "inherits": "^2.0.1",
         "mediasource": "^2.2.2",
         "mp4-box-encoding": "^1.3.0",
-        "mp4-stream": "^2.0.0",
-        "multistream": "^2.0.2",
+        "mp4-stream": "^3.0.0",
         "pump": "^3.0.0",
         "range-slice-stream": "^2.0.0"
       }
@@ -9412,41 +9469,40 @@
       }
     },
     "webtorrent": {
-      "version": "github:brave/webtorrent#7742597c9cee74100dcd1f241e1a55aff93adf5c",
-      "from": "github:brave/webtorrent#7742597c9cee74100dcd1f241e1a55aff93adf5c",
+      "version": "github:brave/webtorrent#652fbeecd6c05076fdfd0f1e64ccb3957d51e21f",
+      "from": "github:brave/webtorrent#652fbeecd6c05076fdfd0f1e64ccb3957d51e21f",
       "requires": {
         "addr-to-ip-port": "^1.4.2",
-        "bitfield": "^2.0.0",
+        "bitfield": "^3.0.0",
         "bittorrent-dht": "^9.0.0",
         "bittorrent-protocol": "^3.0.0",
-        "chunk-store-stream": "^3.0.1",
-        "create-torrent": "^3.33.0",
-        "debug": "^4.0.1",
+        "chunk-store-stream": "^4.0.0",
+        "create-torrent": "^4.0.0",
+        "debug": "^4.1.0",
         "end-of-stream": "^1.1.0",
-        "fs-chunk-store": "^1.6.2",
+        "fs-chunk-store": "^2.0.0",
         "immediate-chunk-store": "^2.0.0",
         "load-ip-set": "^2.1.0",
         "memory-chunk-store": "^1.2.0",
-        "mime": "^2.2.0",
-        "multistream": "^2.0.5",
+        "mime": "^2.4.0",
+        "multistream": "^4.0.0",
         "package-json-versionify": "^1.0.2",
         "parse-numeric-range": "^0.0.2",
-        "parse-torrent": "^6.1.2",
+        "parse-torrent": "^7.0.0",
         "pump": "^3.0.0",
         "random-iterate": "^1.0.1",
         "randombytes": "^2.0.3",
         "range-parser": "^1.2.0",
-        "readable-stream": "^3.0.2",
+        "readable-stream": "^3.0.6",
         "render-media": "^3.0.0",
         "run-parallel": "^1.1.6",
         "run-parallel-limit": "^1.0.3",
-        "safe-buffer": "^5.0.1",
         "simple-concat": "^1.0.0",
         "simple-get": "^3.0.1",
         "simple-peer": "^9.0.0",
         "simple-sha1": "^2.0.8",
         "speedometer": "^1.0.0",
-        "stream-to-blob": "^1.0.0",
+        "stream-to-blob": "^2.0.0",
         "stream-to-blob-url": "^2.1.0",
         "stream-with-known-length-to-buffer": "^1.0.0",
         "torrent-discovery": "^9.1.1",
@@ -9454,21 +9510,20 @@
         "uniq": "^1.0.1",
         "unordered-array-remove": "^1.0.2",
         "ut_metadata": "^3.3.0",
-        "ut_pex": "^1.1.1"
+        "ut_pex": "^2.0.0"
       },
       "dependencies": {
         "bittorrent-tracker": {
-          "version": "9.10.1",
-          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.10.1.tgz",
-          "integrity": "sha512-n5zTL/g6Wt0rb2EnkiyiaGYhth7I/N0/xMqGUpvGX/7g1scDGBVPhJnXR8lfp3/OMj681fv40o4q/otECMtZSA==",
+          "version": "9.13.0",
+          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.13.0.tgz",
+          "integrity": "sha512-mQGpnRX0vBMAYIeuEUR0M/aIC7s+QbO+7aGcrs5wdGTrXWa22RRr+50BYw5HZcA8Raez8DREi0FZIBFp/Nq0Qg==",
           "requires": {
             "bencode": "^2.0.0",
             "bittorrent-peerid": "^1.0.2",
-            "bn.js": "^4.4.0",
+            "bn.js": "^5.0.0",
             "bufferutil": "^4.0.0",
             "compact2string": "^1.2.0",
-            "debug": "^3.1.0",
-            "inherits": "^2.0.1",
+            "debug": "^4.0.1",
             "ip": "^1.0.1",
             "lru": "^3.0.0",
             "minimist": "^1.1.1",
@@ -9477,40 +9532,25 @@
             "randombytes": "^2.0.3",
             "run-parallel": "^1.1.2",
             "run-series": "^1.0.2",
-            "safe-buffer": "^5.0.0",
             "simple-get": "^3.0.0",
             "simple-peer": "^9.0.0",
-            "simple-websocket": "^7.0.1",
+            "simple-websocket": "^8.0.0",
             "string2compact": "^1.1.1",
             "uniq": "^1.0.1",
             "unordered-array-remove": "^1.0.2",
             "utf-8-validate": "^5.0.1",
-            "ws": "^6.0.0",
-            "xtend": "^4.0.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
+            "ws": "^7.0.0"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
+        "bn.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz",
+          "integrity": "sha512-bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A=="
         },
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -9518,24 +9558,14 @@
           }
         },
         "torrent-discovery": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.1.1.tgz",
-          "integrity": "sha512-3mHf+bxVCVLrlkPJdAoMbPMY1hpTZVeWw5hNc2pPFm+HCc2DS0HgVFTBTSWtB8vQPWA1hSEZpqJ+3QfdXxDE1g==",
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.1.2.tgz",
+          "integrity": "sha512-LW5CZEWwmlnK0iDwiV8glDI9jWQ1OhL1hGnyn5/ystOSa2+cZO1d2xcKemghf1tlG0C3ytmLE4rnM5yXR5eN3A==",
           "requires": {
             "bittorrent-dht": "^9.0.0",
             "bittorrent-tracker": "^9.0.0",
-            "debug": "^3.1.0",
+            "debug": "^4.0.0",
             "run-parallel": "^1.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
           }
         }
       }
@@ -9651,11 +9681,11 @@
       }
     },
     "ws": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-      "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
+      "integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "xml-name-validator": {
@@ -9667,7 +9697,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     "@types/parse-torrent": "^5.8.2",
     "@types/webtorrent": "^0.98.4",
     "bignumber.js": "^7.2.1",
-    "bittorrent-tracker": "github:brave/bittorrent-tracker#87cd1bba3ce2f40159210b904db3420e8b237b0a",
+    "bittorrent-tracker": "github:brave/bittorrent-tracker#36bccfc97f933ac956b0aed9b09c69c8fb49e713",
     "bluebird": "^3.5.1",
     "chrome-dgram": "^3.0.1",
     "chrome-net": "^3.3.1",
@@ -327,8 +327,8 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "throttleit": "^1.0.0",
-    "torrent-discovery": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
+    "torrent-discovery": "github:brave/torrent-discovery#b8e96e25949fa63b5edce3ad8a80322f57c547e3",
     "unique-selector": "^0.4.1",
-    "webtorrent": "github:brave/webtorrent#7742597c9cee74100dcd1f241e1a55aff93adf5c"
+    "webtorrent": "github:brave/webtorrent#652fbeecd6c05076fdfd0f1e64ccb3957d51e21f"
   }
 }


### PR DESCRIPTION
Issue: brave/brave-browser#5581
Original PR: #3114

Issues that would be fixed because of updating WebTorrent to its latest version:
brave/brave-browser#5460
brave/brave-browser#5489
brave/brave-browser#5358 (This is actually not introduced in 0.69.x and 0.68.x yet since these two are using an older version of WebTorrent (less than v0.105.1) before this uplift PR.)