### PR TITLE
Ads should not display on touch of mouse post long idle or after unlocking device

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -349,6 +349,11 @@ void AdsImpl::OnUnIdle() {
     return;
   }
 
+  if (idle_time > kMaximumIdleThresholdInSeconds) {
+    BLOG(INFO) << "Notification not made: Exceeded maximum idle time";
+    return;
+  }
+
   MaybeServeAdNotification(true);
 }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/static_values.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/static_values.h
@@ -23,6 +23,7 @@ namespace ads {
 #define GETSTATE_PATH "/v5/getstate"
 
 const int kIdleThresholdInSeconds = 15;
+const int kMaximumIdleThresholdInSeconds = 120;
 
 const uint64_t kMaximumPageProbabilityHistoryEntries = 5;
 const int kTopWinningCategoryCountForServingAds = 3;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5029
Fixes https://github.com/brave/brave-browser/issues/5090

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm ads are not shown if user idles for longer than 2 minutes
- Confirm ads are not shown if user idles for less than 15 seconds
- Confirm ads are not shown if the user unlocks their device (supports desktop only)
- Confirm ads are shown if the user un-idles between 15 seconds and 2 minutes (and all other criteria is met)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
