### PR TITLE
WebTorrent: Use friendly URLs for download links

### DIFF
--- a/components/brave_webtorrent/extension/components/torrentFileList.tsx
+++ b/components/brave_webtorrent/extension/components/torrentFileList.tsx
@@ -47,7 +47,7 @@ export default class TorrentFileList extends React.PureComponent<Props, {}> {
     const renderFileLink = (file: File, ix: number, isDownload: boolean) => {
       if (isDownload) {
         if (torrent.serverURL) {
-          const url = torrent.serverURL + '/' + ix
+          const url = `${torrent.serverURL}/${ix}/${file.name}`
           return (
             <a href={url} download={file.name}>
               ⇩


### PR DESCRIPTION
We should link to a friendly filename instead of a file named `/0` or `/1`. This will make the torrent links look less sketchy.

Fixes: https://github.com/brave/brave-browser/issues/5506

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

   1. Go to https://webtorrent.io/free-torrents
   2. Start Big Buck Bunny (torrent)
   3. Start download
   4. Hover over the "Save File" link (looks like a downward-facing arrow)
   5. Confirm that the URL ends with the actual file's name and not a number.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
