### PR TITLE
[brave-extension] improve tests on shields

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/api/shieldsAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/shieldsAPI.ts
@@ -76,6 +76,7 @@ export const requestShieldPanelData = (tabId: number) =>
     .then((details: ShieldDetails) => {
       actions.shieldsPanelDataUpdated(details)
     })
+    .catch((error: any) => console.error('[Shields]: Can\'t request shields panel data.', error))
 
 /**
  * Changes the brave shields setting at origin to be allowed or blocked.

--- a/components/test/brave_extension/actions/cosmeticFilterActions_test.ts
+++ b/components/test/brave_extension/actions/cosmeticFilterActions_test.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Types
 import * as types from '../../../brave_extension/extension/brave_extension/constants/cosmeticFilterTypes'
+
+// Actions
 import * as actions from '../../../brave_extension/extension/brave_extension/actions/cosmeticFilterActions'
 
 describe('cosmeticFilterActions', () => {

--- a/components/test/brave_extension/actions/shieldsPanelActions_test.ts
+++ b/components/test/brave_extension/actions/shieldsPanelActions_test.ts
@@ -14,19 +14,20 @@ import {
 // Actions
 import * as actions from '../../../brave_extension/extension/brave_extension/actions/shieldsPanelActions'
 
+const details: ShieldDetails = {
+  ads: 'allow',
+  trackers: 'block',
+  httpUpgradableResources: 'allow',
+  origin: 'https://www.brave.com',
+  hostname: 'www.brave.com',
+  id: 1,
+  javascript: 'allow',
+  fingerprinting: 'allow',
+  cookies: 'allow'
+}
+
 describe('shieldsPanelActions', () => {
   it('shieldsPanelDataUpdated', () => {
-    const details: ShieldDetails = {
-      ads: 'allow',
-      trackers: 'block',
-      httpUpgradableResources: 'allow',
-      origin: 'https://www.brave.com',
-      hostname: 'www.brave.com',
-      id: 1,
-      javascript: 'allow',
-      fingerprinting: 'allow',
-      cookies: 'allow'
-    }
     expect(actions.shieldsPanelDataUpdated(details)).toEqual({
       type: types.SHIELDS_PANEL_DATA_UPDATED,
       details

--- a/components/test/brave_extension/actions/tabActions_test.ts
+++ b/components/test/brave_extension/actions/tabActions_test.ts
@@ -1,4 +1,3 @@
-/* global describe, it */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -6,10 +5,25 @@
 import * as types from '../../../brave_extension/extension/brave_extension/constants/tabTypes'
 import * as actions from '../../../brave_extension/extension/brave_extension/actions/tabActions'
 
+const windowId = 1
+const tabId = 1
+const changeInfo = {}
+
+const tab: chrome.tabs.Tab = {
+  id: 1,
+  index: 1,
+  pinned: false,
+  highlighted: false,
+  windowId: 1,
+  active: true,
+  incognito: false,
+  selected: false,
+  discarded: false,
+  autoDiscardable: false
+}
+
 describe('tabActions', () => {
   it('activeTabChanged', () => {
-    const windowId = 1
-    const tabId = 1
     expect(actions.activeTabChanged(windowId, tabId)).toEqual({
       type: types.ACTIVE_TAB_CHANGED,
       windowId: windowId,
@@ -18,17 +32,6 @@ describe('tabActions', () => {
   })
 
   it('tabCreated', () => {
-    const tab: chrome.tabs.Tab = {
-      id: 1,
-      index: 1,
-      pinned: false,
-      highlighted: false,
-      windowId: 1,
-      active: true,
-      incognito: false,
-      selected: false
-    }
-
     expect(actions.tabCreated(tab)).toEqual({
       type: types.TAB_CREATED,
       tab
@@ -36,18 +39,6 @@ describe('tabActions', () => {
   })
 
   it('tabDataChanged', () => {
-    const tabId = 1
-    const changeInfo = {}
-    const tab: chrome.tabs.Tab = {
-      id: 1,
-      index: 1,
-      pinned: false,
-      highlighted: false,
-      windowId: 1,
-      active: true,
-      incognito: false,
-      selected: false
-    }
     expect(actions.tabDataChanged(tabId, changeInfo, tab)).toEqual({
       type: types.TAB_DATA_CHANGED,
       tabId,

--- a/components/test/brave_extension/actions/windowActions_test.ts
+++ b/components/test/brave_extension/actions/windowActions_test.ts
@@ -3,7 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Types
 import * as types from '../../../brave_extension/extension/brave_extension/constants/windowTypes'
+
+// Actions
 import * as actions from '../../../brave_extension/extension/brave_extension/actions/windowActions'
 
 describe('windowActions', () => {

--- a/components/test/brave_extension/background/api/cosmeticFilterAPI_test.ts
+++ b/components/test/brave_extension/background/api/cosmeticFilterAPI_test.ts
@@ -6,7 +6,7 @@
 import * as sinon from 'sinon'
 import * as cosmeticFilterAPI from '../../../../brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI'
 
-describe('cosmeticFilterTestSuite', () => {
+describe('cosmeticFilter API', () => {
   describe('addSiteCosmeticFilter', () => {
     const url = 'https://www.brave.com'
     const filter = '#cssFilter'
@@ -233,7 +233,6 @@ describe('cosmeticFilterTestSuite', () => {
         cssOrigin: 'user',
         runAt: 'document_start'
       })
-
     })
     // chrome.local.storage.get() always returns an empty object if nothing exists
     it('doesn\'t apply filters if storage for host is implicitly undefined', () => {

--- a/components/test/brave_extension/background/api/shieldsAPI_test.ts
+++ b/components/test/brave_extension/background/api/shieldsAPI_test.ts
@@ -5,7 +5,7 @@
 import actions from '../../../../brave_extension/extension/brave_extension/background/actions/shieldsPanelActions'
 import * as shieldsAPI from '../../../../brave_extension/extension/brave_extension/background/api/shieldsAPI'
 import { activeTabData } from '../../../testData'
-// import { Tab as TabType } from '../../../types/state/shieldsPannelState'
+import { ShieldDetails } from '../../../../brave_extension/extension/brave_extension/types/actions/shieldsPanelActions'
 
 describe('Shields API', () => {
   describe('getShieldSettingsForTabData', () => {
@@ -26,7 +26,9 @@ describe('Shields API', () => {
         windowId: 1,
         active: true,
         incognito: false,
-        selected: false
+        selected: false,
+        discarded: false,
+        autoDiscardable: false
       }
 
       expect.assertions(1)
@@ -91,15 +93,13 @@ describe('Shields API', () => {
       spy.mockRestore()
     })
     it('resolves and calls requestShieldPanelData', (cb) => {
-      const tab = {
-        url: 'https://www.brave.com/test',
-        origin: 'https://www.brave.com',
-        hostname: 'www.brave.com',
-        id: 2,
-        braveShields: 'block',
+      const details: ShieldDetails = {
         ads: 'block',
         trackers: 'block',
         httpUpgradableResources: 'block',
+        origin: 'https://www.brave.com',
+        hostname: 'www.brave.com',
+        id: 2,
         javascript: 'block',
         fingerprinting: 'block',
         cookies: 'block'
@@ -109,7 +109,11 @@ describe('Shields API', () => {
       shieldsAPI.requestShieldPanelData(tabId)
         .then(() => {
           expect(spy).toBeCalledTimes(1)
-          expect(spy.mock.calls[0][0]).toEqual(tab)
+          expect(spy.mock.calls[0][0]).toEqual({
+            ...details,
+            url: 'https://www.brave.com/test',
+            braveShields: 'block'
+          })
           cb()
         })
         .catch((e: Error) => {

--- a/components/test/brave_extension/background/events/runtimeEvents_test.ts
+++ b/components/test/brave_extension/background/events/runtimeEvents_test.ts
@@ -5,6 +5,8 @@
 import '../../../../brave_extension/extension/brave_extension/background/events/runtimeEvents'
 import windowActions from '../../../../brave_extension/extension/brave_extension/background/actions/windowActions'
 import tabActions from '../../../../brave_extension/extension/brave_extension/background/actions/tabActions'
+import * as windowTypes from '../../../../brave_extension/extension/brave_extension/constants/windowTypes'
+import * as tabTypes from '../../../../brave_extension/extension/brave_extension/constants/tabTypes'
 import { ChromeEvent } from '../../../testData'
 
 interface InputWindows {
@@ -41,12 +43,36 @@ describe('runtimeEvents events', () => {
     const p = new Promise((resolve, reject) => {
       deferred = resolve
     })
+    const window: chrome.windows.Window = {
+      id: 1,
+      state: 'normal',
+      focused: true,
+      alwaysOnTop: false,
+      incognito: false,
+      type: 'normal'
+    }
+    const tab: chrome.tabs.Tab = {
+      id: 3,
+      index: 0,
+      pinned: false,
+      highlighted: false,
+      windowId: 1,
+      active: true,
+      incognito: false,
+      selected: true,
+      discarded: false,
+      autoDiscardable: false
+    }
     let windowCreatedSpy: jest.SpyInstance
     let tabCreatedSpy: jest.SpyInstance
     let windowGetAllSpy: jest.SpyInstance
     beforeEach((cb) => {
       windowCreatedSpy = jest.spyOn(windowActions, 'windowCreated')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: windowTypes.WINDOW_CREATED, window })
       tabCreatedSpy = jest.spyOn(tabActions, 'tabCreated')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: tabTypes.TAB_CREATED, tab })
       windowGetAllSpy = jest.spyOn(chrome.windows, 'getAllAsync').mockImplementation(() => {
         deferred(inputWindows)
         return p

--- a/components/test/brave_extension/background/events/tabsEvents_test.ts
+++ b/components/test/brave_extension/background/events/tabsEvents_test.ts
@@ -4,6 +4,7 @@
 
 import '../../../../brave_extension/extension/brave_extension/background/events/tabsEvents'
 import actions from '../../../../brave_extension/extension/brave_extension/background/actions/tabActions'
+import * as types from '../../../../brave_extension/extension/brave_extension/constants/tabTypes'
 
 interface TabActivatedEvent extends chrome.events.Event<(activeInfo: chrome.tabs.TabActiveInfo) => void> {
   emit: (detail: chrome.tabs.TabActiveInfo) => void
@@ -22,6 +23,8 @@ describe('tabsEvents events', () => {
     let spy: jest.SpyInstance
     beforeEach(() => {
       spy = jest.spyOn(actions, 'activeTabChanged')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: types.ACTIVE_TAB_CHANGED, windowId: 1, tabId: 2 })
     })
     afterEach(() => {
       spy.mockRestore()
@@ -43,7 +46,7 @@ describe('tabsEvents events', () => {
   })
   describe('chrome.tabs.onCreated', () => {
     let spy: jest.SpyInstance
-    const inputTab = {
+    const inputTab: chrome.tabs.Tab = {
       id: 3,
       index: 0,
       pinned: false,
@@ -51,10 +54,14 @@ describe('tabsEvents events', () => {
       windowId: 1,
       active: true,
       incognito: false,
-      selected: true
+      selected: true,
+      discarded: false,
+      autoDiscardable: false
     }
     beforeEach(() => {
       spy = jest.spyOn(actions, 'tabCreated')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: types.TAB_CREATED, tab: inputTab })
     })
     afterEach(() => {
       spy.mockRestore()
@@ -76,7 +83,7 @@ describe('tabsEvents events', () => {
     let spy: jest.SpyInstance
     const inputTabId = 3
     const inputChangeInfo = {}
-    const inputTab = {
+    const inputTab: chrome.tabs.Tab = {
       id: 3,
       index: 0,
       pinned: false,
@@ -84,10 +91,19 @@ describe('tabsEvents events', () => {
       windowId: 1,
       active: true,
       incognito: false,
-      selected: true
+      selected: true,
+      discarded: false,
+      autoDiscardable: false
     }
     beforeEach(() => {
       spy = jest.spyOn(actions, 'tabDataChanged')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({
+          type: types.TAB_DATA_CHANGED,
+          tab: inputTab,
+          tabId: inputTabId,
+          changeInfo: inputChangeInfo
+        })
     })
     afterEach(() => {
       spy.mockRestore()

--- a/components/test/brave_extension/background/events/windowsEvents_test.ts
+++ b/components/test/brave_extension/background/events/windowsEvents_test.ts
@@ -4,6 +4,7 @@
 
 import '../../../../brave_extension/extension/brave_extension/background/events/windowsEvents'
 import actions from '../../../../brave_extension/extension/brave_extension/background/actions/windowActions'
+import * as types from '../../../../brave_extension/extension/brave_extension/constants/windowTypes'
 
 interface WindowIdEvent extends chrome.events.Event<(windowId: number) => void> {
   emit: (windowId: number) => void
@@ -18,6 +19,8 @@ describe('windowsEvents events', () => {
     let spy: jest.SpyInstance
     beforeEach(() => {
       spy = jest.spyOn(actions, 'windowFocusChanged')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: types.WINDOW_FOCUS_CHANGED, windowId: 1 })
     })
     afterEach(() => {
       spy.mockRestore()
@@ -35,7 +38,7 @@ describe('windowsEvents events', () => {
   })
   describe('chrome.windows.onCreated', () => {
     let spy: jest.SpyInstance
-    const window = {
+    const window: chrome.windows.Window = {
       id: 1,
       state: 'normal',
       focused: true,
@@ -45,6 +48,8 @@ describe('windowsEvents events', () => {
     }
     beforeEach(() => {
       spy = jest.spyOn(actions, 'windowCreated')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: types.WINDOW_CREATED, window })
     })
     afterEach(() => {
       spy.mockRestore()
@@ -65,6 +70,8 @@ describe('windowsEvents events', () => {
     let spy: jest.SpyInstance
     beforeEach(() => {
       spy = jest.spyOn(actions, 'windowRemoved')
+        // ensure return value is also mocked so a warning about lack of tabId is not thrown
+        .mockReturnValue({ type: types.WINDOW_REMOVED, windowId: 1 })
     })
     afterEach(() => {
       spy.mockRestore()

--- a/components/test/brave_extension/state/shieldsPanelState_test.ts
+++ b/components/test/brave_extension/state/shieldsPanelState_test.ts
@@ -16,11 +16,26 @@ const state: State = deepFreeze({
   tabs: {
     2: {
       id: 2,
+      hostname: 'https://brave.com',
+      origin: 'https://brave.com',
+      url: 'https://brave.com',
       ads: 'block',
+      adsBlocked: 0,
+      adsBlockedResources: [],
+      braveShields: 'allow',
+      controlsOpen: true,
       trackers: 'block',
+      trackersBlocked: 0,
+      trackersBlockedResources: [],
       httpUpgradableResources: 'block',
+      httpsRedirected: 0,
+      httpsRedirectedResources: [],
       javascript: 'block',
+      javascriptBlocked: 0,
+      noScriptInfo: {},
       fingerprinting: 'block',
+      fingerprintingBlocked: 0,
+      fingerprintingBlockedResources: [],
       cookies: 'block'
     },
     3: {
@@ -44,15 +59,7 @@ describe('shieldsPanelState test', () => {
   })
   describe('getActiveTabData', () => {
     it('', () => {
-      expect(shieldsPanelState.getActiveTabData(state)).toEqual({
-        id: 2,
-        ads: 'block',
-        trackers: 'block',
-        httpUpgradableResources: 'block',
-        javascript: 'block',
-        fingerprinting: 'block',
-        cookies: 'block'
-      })
+      expect(shieldsPanelState.getActiveTabData(state)).toEqual(state.tabs[2])
     })
   })
   describe('isShieldsActive', () => {
@@ -110,58 +117,18 @@ describe('shieldsPanelState test', () => {
   describe('updateActiveTab', () => {
     it('can update focused window', () => {
       expect(shieldsPanelState.updateActiveTab(state, 1, 4)).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
-        tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block'
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
-          }
-        },
+        ...state,
         windows: {
-          1: 4,
-          2: 3
+          ...state.windows,
+          1: 4
         }
       })
     })
     it('can update a window which is not focused', () => {
       expect(shieldsPanelState.updateActiveTab(state, 2, 4)).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
-        tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block'
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
-          }
-        },
+        ...state,
         windows: {
-          1: 2,
+          ...state.windows,
           2: 4
         }
       })
@@ -170,27 +137,7 @@ describe('shieldsPanelState test', () => {
   describe('removeWindowInfo', () => {
     it('can remove the focused window', () => {
       expect(shieldsPanelState.removeWindowInfo(state, 1)).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
-        tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block'
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
-          }
-        },
+        ...state,
         windows: {
           2: 3
         }
@@ -198,27 +145,7 @@ describe('shieldsPanelState test', () => {
     })
     it('can remove a window which is not focused', () => {
       expect(shieldsPanelState.removeWindowInfo(state, 2)).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
-        tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block'
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
-          }
-        },
+        ...state,
         windows: {
           1: 2
         }
@@ -228,31 +155,8 @@ describe('shieldsPanelState test', () => {
   describe('updateFocusedWindow', () => {
     it('updates the currentWindowId', () => {
       expect(shieldsPanelState.updateFocusedWindow(state, 2)).toEqual({
-        currentWindowId: 2,
-        persistentData: {
-          isFirstAccess: true
-        },
-        tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block'
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
-          }
-        },
-        windows: {
-          1: 2,
-          2: 3
-        }
+        ...state,
+        currentWindowId: 2
       })
     })
   })
@@ -267,42 +171,18 @@ describe('shieldsPanelState test', () => {
         fingerprinting: 'allow',
         cookies: 'allow'
       })).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            id: 2,
+          ...state.tabs,
+          [this.tabId]: {
+            ...state.tabs[this.tabId],
             ads: 'allow',
             trackers: 'allow',
             httpUpgradableResources: 'allow',
             javascript: 'allow',
             fingerprinting: 'allow',
-            cookies: 'allow',
-            controlsOpen: true,
-            braveShields: 'allow',
-            adsBlocked: 0,
-            trackersBlocked: 0,
-            httpsRedirected: 0,
-            javascriptBlocked: 0,
-            fingerprintingBlocked: 0,
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
+            cookies: 'allow'
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       })
     })
@@ -311,87 +191,28 @@ describe('shieldsPanelState test', () => {
     it('sets the specified stats back to 0 for the active tab', () => {
       this.tabId = 2
       const stateWithStats: State = {
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block',
+          [this.tabId]: {
+            ...state.tabs[this.tabId],
+            braveShields: 'block',
             adsBlocked: 3,
             trackersBlocked: 4444,
             httpsRedirected: 5,
             javascriptBlocked: 5,
-            fingerprintingBlocked: 5,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
+            fingerprintingBlocked: 5
+
           },
           3: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
+            ...state.tabs[2],
             id: 3,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
+            braveShields: 'block'
           },
           4: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
+            ...state.tabs[2],
             id: 4,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
+            braveShields: 'block'
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       }
 
@@ -401,259 +222,43 @@ describe('shieldsPanelState test', () => {
       stateWithStats.tabs[this.tabId].javascriptBlocked = 6
       stateWithStats.tabs[this.tabId].fingerprintingBlocked = 7
       expect(shieldsPanelState.resetBlockingStats(stateWithStats, this.tabId)).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block',
-            adsBlocked: 0,
-            trackersBlocked: 0,
-            httpsRedirected: 0,
-            javascriptBlocked: 0,
-            fingerprintingBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          3: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
-            id: 3,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          4: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
-            id: 4,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          }
-        },
-        windows: {
-          1: 2,
-          2: 3
+          ...state.tabs,
+          2: { ...state.tabs[2], braveShields: 'block' },
+          3: { ...state.tabs[2], id: 3, braveShields: 'block' },
+          4: { ...state.tabs[2], id: 4, braveShields: 'block' }
         }
       })
     })
     it('sets the specified stats back to 0 for the a non active tab', () => {
       this.tabId = 4
       const stateWithStats: State = {
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
-            id: 2,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          3: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
-            id: 3,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          4: {
-            ads: 'block',
-            adsBlocked: 3,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 5,
+          ...state.tabs,
+          [this.tabId]: {
+            ...state.tabs[2],
             id: 4,
-            javascript: 'block',
-            javascriptBlocked: 5,
-            origin: 'https://brave.com',
             braveShields: 'block',
-            trackers: 'block',
+            adsBlocked: 3,
+            httpsRedirected: 5,
+            javascriptBlocked: 5,
             trackersBlocked: 4444,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 5,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
+            fingerprintingBlocked: 5
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       }
 
       expect(shieldsPanelState.resetBlockingStats(stateWithStats, this.tabId)).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
-            id: 2,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          3: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
-            id: 3,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
-          },
-          4: {
-            ads: 'block',
-            adsBlocked: 0,
-            controlsOpen: true,
-            hostname: 'https://brave.com',
-            httpUpgradableResources: 'block',
-            httpsRedirected: 0,
+          ...state.tabs,
+          [this.tabId]: {
+            ...state.tabs[2],
             id: 4,
-            javascript: 'block',
-            javascriptBlocked: 0,
-            origin: 'https://brave.com',
-            braveShields: 'block',
-            trackers: 'block',
-            trackersBlocked: 0,
-            fingerprinting: 'block',
-            cookies: 'block',
-            fingerprintingBlocked: 0,
-            url: 'https://brave.com',
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            trackersBlockedResources: [],
-            httpsRedirectedResources: [],
-            fingerprintingBlockedResources: []
+            braveShields: 'block'
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       })
     })
@@ -662,270 +267,97 @@ describe('shieldsPanelState test', () => {
     it('can update ads blocked count', () => {
       this.tabId = 2
       expect(shieldsPanelState.updateResourceBlocked(state, this.tabId, 'ads', 'https://test.brave.com')).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block',
+          ...state.tabs,
+          [this.tabId]: {
+            ...state.tabs[this.tabId],
             adsBlocked: 1,
-            trackersBlocked: 0,
-            httpsRedirected: 0,
-            javascriptBlocked: 0,
-            fingerprintingBlocked: 0,
-            noScriptInfo: {},
-            adsBlockedResources: [ 'https://test.brave.com' ],
-            fingerprintingBlockedResources: [],
-            httpsRedirectedResources: [],
-            trackersBlockedResources: []
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
+            adsBlockedResources: [
+              'https://test.brave.com'
+            ]
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       })
     })
     it('can update tracking protection blocked count', () => {
       this.tabId = 2
-      expect(shieldsPanelState.updateResourceBlocked(state, this.tabId, 'trackers', 'https://test.brave.com')).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+      expect(shieldsPanelState.updateResourceBlocked(state, this.tabId, 'trackers', 'https://test.brave.com'))
+      .toEqual({
+        ...state,
         tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block',
-            adsBlocked: 0,
+          ...state.tabs,
+          [this.tabId]: {
+            ...state.tabs[this.tabId],
             trackersBlocked: 1,
-            httpsRedirected: 0,
-            javascriptBlocked: 0,
-            fingerprintingBlocked: 0,
-            noScriptInfo: {},
-            adsBlockedResources: [],
-            fingerprintingBlockedResources: [],
-            httpsRedirectedResources: [],
-            trackersBlockedResources: [ 'https://test.brave.com' ]
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
+            trackersBlockedResources: [
+              'https://test.brave.com'
+            ]
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       })
     })
     it('can update javascript blocked count and noScriptInfo', () => {
       this.tabId = 2
       expect(shieldsPanelState.updateResourceBlocked(state, this.tabId, 'javascript', 'https://test.brave.com')).toEqual({
-        currentWindowId: 1,
-        persistentData: {
-          isFirstAccess: true
-        },
+        ...state,
         tabs: {
-          2: {
-            id: 2,
-            ads: 'block',
-            trackers: 'block',
-            httpUpgradableResources: 'block',
-            javascript: 'block',
-            fingerprinting: 'block',
-            cookies: 'block',
-            adsBlocked: 0,
-            trackersBlocked: 0,
-            httpsRedirected: 0,
+          ...state.tabs,
+          [this.tabId]: {
+            ...state.tabs[this.tabId],
             javascriptBlocked: 1,
-            fingerprintingBlocked: 0,
             noScriptInfo: {
               'https://test.brave.com': { actuallyBlocked: true, willBlock: true, userInteracted: false }
-            },
-            adsBlockedResources: [],
-            fingerprintingBlockedResources: [],
-            httpsRedirectedResources: [],
-            trackersBlockedResources: []
-          },
-          3: {
-            id: 3
-          },
-          4: {
-            id: 4
+            }
           }
-        },
-        windows: {
-          1: 2,
-          2: 3
         }
       })
     })
   })
   describe('resetNoScriptInfo', () => {
     const stateWithAllowedScriptOrigins: State = {
-      currentWindowId: 1,
-      persistentData: {
-        isFirstAccess: true
-      },
+      ...state,
       tabs: {
+        ...state.tabs,
         2: {
-          id: 2,
-          ads: 'block',
-          adsBlocked: 0,
-          controlsOpen: true,
-          hostname: 'https://brave.com',
-          httpUpgradableResources: 'block',
-          httpsRedirected: 0,
-          javascript: 'block',
-          javascriptBlocked: 0,
-          origin: 'https://brave.com',
-          braveShields: 'block',
-          trackers: 'block',
-          trackersBlocked: 0,
-          fingerprinting: 'block',
-          cookies: 'block',
-          fingerprintingBlocked: 0,
-          url: 'https://brave.com',
+          ...state.tabs[2],
           noScriptInfo: {
             'https://a.com': { actuallyBlocked: true, willBlock: true, userInteracted: false },
             'https://b.com': { actuallyBlocked: true, willBlock: false, userInteracted: false }
-          },
-          adsBlockedResources: [],
-          trackersBlockedResources: [],
-          httpsRedirectedResources: [],
-          fingerprintingBlockedResources: []
+          }
         },
         3: {
+          ...state.tabs[2],
           id: 3,
-          ads: 'block',
-          adsBlocked: 0,
-          controlsOpen: true,
-          hostname: 'https://brave.com',
-          httpUpgradableResources: 'block',
-          httpsRedirected: 0,
-          javascript: 'block',
-          javascriptBlocked: 0,
-          origin: 'https://brave.com',
-          braveShields: 'block',
-          trackers: 'block',
-          trackersBlocked: 0,
-          fingerprinting: 'block',
-          cookies: 'block',
-          fingerprintingBlocked: 0,
-          url: 'https://brave.com',
           noScriptInfo: {
             'https://a.com': { actuallyBlocked: true, willBlock: true, userInteracted: false },
             'https://b.com': { actuallyBlocked: false, willBlock: false, userInteracted: false }
-          },
-          adsBlockedResources: [],
-          trackersBlockedResources: [],
-          httpsRedirectedResources: [],
-          fingerprintingBlockedResources: []
+          }
         }
-      },
-      windows: {
-        1: 2,
-        2: 3
       }
     }
     it('reset noScriptInfo for a specific tab without navigating away', () => {
       this.tabId = 2
       expect(noScriptState.resetNoScriptInfo(
         stateWithAllowedScriptOrigins, this.tabId, 'https://brave.com')).toEqual({
-          currentWindowId: 1,
-          persistentData: {
-            isFirstAccess: true
-          },
+          ...state,
           tabs: {
-            2: {
-              id: 2,
-              ads: 'block',
-              adsBlocked: 0,
-              controlsOpen: true,
-              hostname: 'https://brave.com',
-              httpUpgradableResources: 'block',
-              httpsRedirected: 0,
-              javascript: 'block',
-              javascriptBlocked: 0,
-              origin: 'https://brave.com',
-              braveShields: 'block',
-              trackers: 'block',
-              trackersBlocked: 0,
-              fingerprinting: 'block',
-              cookies: 'block',
-              fingerprintingBlocked: 0,
-              url: 'https://brave.com',
+            ...state.tabs,
+            [this.tabId]: {
+              ...state.tabs[this.tabId],
               noScriptInfo: {
-                'https://a.com': {
-                  actuallyBlocked: true,
-                  userInteracted: false,
-                  willBlock: true
-                },
-                'https://b.com': {
-                  actuallyBlocked: true,
-                  userInteracted: false,
-                  willBlock: false
-                }
-              },
-              adsBlockedResources: [],
-              trackersBlockedResources: [],
-              httpsRedirectedResources: [],
-
-              fingerprintingBlockedResources: []
+                'https://a.com': { actuallyBlocked: true, willBlock: true, userInteracted: false },
+                'https://b.com': { actuallyBlocked: true, willBlock: false, userInteracted: false }
+              }
             },
             3: {
+              ...state.tabs[2],
               id: 3,
-              ads: 'block',
-              adsBlocked: 0,
-              controlsOpen: true,
-              hostname: 'https://brave.com',
-              httpUpgradableResources: 'block',
-              httpsRedirected: 0,
-              javascript: 'block',
-              javascriptBlocked: 0,
-              origin: 'https://brave.com',
-              braveShields: 'block',
-              trackers: 'block',
-              trackersBlocked: 0,
-              fingerprinting: 'block',
-              cookies: 'block',
-              fingerprintingBlocked: 0,
-              url: 'https://brave.com',
               noScriptInfo: {
                 'https://a.com': { actuallyBlocked: true, willBlock: true, userInteracted: false },
                 'https://b.com': { actuallyBlocked: false, willBlock: false, userInteracted: false }
-              },
-              adsBlockedResources: [],
-              trackersBlockedResources: [],
-              httpsRedirectedResources: [],
-
-              fingerprintingBlockedResources: []
+              }
             }
-          },
-          windows: {
-            1: 2,
-            2: 3
           }
         })
     })
@@ -933,68 +365,17 @@ describe('shieldsPanelState test', () => {
       this.tabId = 2
       expect(noScriptState.resetNoScriptInfo(
         stateWithAllowedScriptOrigins, this.tabId, 'https://test.brave.com')).toEqual({
-          currentWindowId: 1,
-          persistentData: {
-            isFirstAccess: true
-          },
+          ...state,
           tabs: {
-            2: {
-              id: 2,
-              ads: 'block',
-              adsBlocked: 0,
-              controlsOpen: true,
-              hostname: 'https://brave.com',
-              httpUpgradableResources: 'block',
-              httpsRedirected: 0,
-              javascript: 'block',
-              javascriptBlocked: 0,
-              origin: 'https://brave.com',
-              braveShields: 'block',
-              trackers: 'block',
-              trackersBlocked: 0,
-              fingerprinting: 'block',
-              cookies: 'block',
-              fingerprintingBlocked: 0,
-              url: 'https://brave.com',
-              noScriptInfo: {},
-              adsBlockedResources: [],
-              trackersBlockedResources: [],
-              httpsRedirectedResources: [],
-
-              fingerprintingBlockedResources: []
-            },
+            ...state.tabs,
             3: {
+              ...state.tabs[2],
               id: 3,
-              ads: 'block',
-              adsBlocked: 0,
-              controlsOpen: true,
-              hostname: 'https://brave.com',
-              httpUpgradableResources: 'block',
-              httpsRedirected: 0,
-              javascript: 'block',
-              javascriptBlocked: 0,
-              origin: 'https://brave.com',
-              braveShields: 'block',
-              trackers: 'block',
-              trackersBlocked: 0,
-              fingerprinting: 'block',
-              cookies: 'block',
-              fingerprintingBlocked: 0,
-              url: 'https://brave.com',
               noScriptInfo: {
                 'https://a.com': { actuallyBlocked: true, willBlock: true, userInteracted: false },
                 'https://b.com': { actuallyBlocked: false, willBlock: false, userInteracted: false }
-              },
-              adsBlockedResources: [],
-              trackersBlockedResources: [],
-              httpsRedirectedResources: [],
-
-              fingerprintingBlockedResources: []
+              }
             }
-          },
-          windows: {
-            1: 2,
-            2: 3
           }
         })
     })
@@ -1099,6 +480,9 @@ describe('shieldsPanelState test', () => {
     let updateShieldsIconSpy: jest.SpyInstance
     let consoleWarnSpy: jest.SpyInstance
     beforeEach(() => {
+      // avoid printing warn logs to the test console.
+      // this warn is also tested at the end of this `describe`
+      console.warn = () => ''
       requestShieldPanelDataSpy = jest.spyOn(shieldsAPI, 'requestShieldPanelData')
       updateShieldsIconSpy = jest.spyOn(shieldsPanelState, 'updateShieldsIcon')
       consoleWarnSpy = jest.spyOn(global.console, 'warn')
@@ -1141,7 +525,8 @@ describe('shieldsPanelState test', () => {
       requestShieldPanelDataSpy.mockRestore()
     })
     it('calls requestShieldPanelData', () => {
-      shieldsPanelState.requestDataAndUpdateActiveTab(state, state.windows['1'], state.tabs['2'])
+      shieldsPanelState.requestDataAndUpdateActiveTab(state, state.windows[1], 2)
+
       expect(requestShieldPanelDataSpy).toHaveBeenCalled()
       expect(requestShieldPanelDataSpy.mock.calls[0][0]).toEqual(state)
     })


### PR DESCRIPTION
close https://github.com/brave/brave-browser/issues/5609

this change fix all uncatched promises, warnings and error logs related to tests in Shields, replace boilerplate code with the spread operator whenever possible and type errors spotted by vscode.


## Test Plan:

`npm run test-unit`

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [x] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
