### PR TITLE
[brave-extension] do not show advanced view option when Shields is off

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/advancedView/footer.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/footer.tsx
@@ -14,6 +14,7 @@ import * as tabsAPI from '../../background/api/tabsAPI'
 import { getLocale } from '../../background/api/localeAPI'
 
 export interface Props {
+  enabled: boolean
   isBlockedListOpen: boolean
   toggleAdvancedView: () => void
 }
@@ -25,12 +26,12 @@ export default class Footer extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { isBlockedListOpen, toggleAdvancedView } = this.props
+    const { enabled, isBlockedListOpen, toggleAdvancedView } = this.props
     return (
       <MainFooter>
-        <Link disabled={isBlockedListOpen} onClick={toggleAdvancedView}>
+        {enabled && <Link disabled={isBlockedListOpen} onClick={toggleAdvancedView}>
           {getLocale('simpleView')}
-        </Link>
+        </Link>}
         <Link
           id='braveShieldsFooter'
           onClick={this.openSettings}

--- a/components/brave_extension/extension/brave_extension/components/advancedView/index.tsx
+++ b/components/brave_extension/extension/brave_extension/components/advancedView/index.tsx
@@ -157,6 +157,7 @@ export default class Shields extends React.PureComponent<Props, State> {
           )
         }
         <Footer
+          enabled={this.isShieldsEnabled}
           isBlockedListOpen={isBlockedListOpen}
           toggleAdvancedView={toggleAdvancedView}
         />

--- a/components/brave_extension/extension/brave_extension/components/simpleView/footer.tsx
+++ b/components/brave_extension/extension/brave_extension/components/simpleView/footer.tsx
@@ -14,6 +14,7 @@ import * as tabsAPI from '../../background/api/tabsAPI'
 import { getLocale } from '../../background/api/localeAPI'
 
 export interface Props {
+  enabled: boolean
   toggleAdvancedView: () => void
 }
 
@@ -24,12 +25,13 @@ export default class Footer extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { toggleAdvancedView } = this.props
+    const { enabled, toggleAdvancedView } = this.props
     return (
       <MainFooter>
+        {enabled &&
         <Link onClick={toggleAdvancedView}>
           {getLocale('advancedView')}
-        </Link>
+        </Link>}
         <Link id='braveShieldsFooter' onClick={this.openSettings}>
           {getLocale('changeDefaults')}
         </Link>

--- a/components/brave_extension/extension/brave_extension/components/simpleView/index.tsx
+++ b/components/brave_extension/extension/brave_extension/components/simpleView/index.tsx
@@ -79,6 +79,7 @@ export default class ShieldsSimpleView extends React.PureComponent<Props, {}> {
           toggleReadOnlyView={toggleReadOnlyView}
         />
         <Footer
+          enabled={this.isShieldsEnabled}
           toggleAdvancedView={toggleAdvancedView}
         />
       </ShieldsPanel>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5438

## Test Plan:

when Shields panel is disabled, both advanced and simple panels should not have an option to toggle views. this is an interface-only change.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
