### PR TITLE
Fix 32-bit hashing and social blocking for ad-block Rust (uplift to 0.69.x)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@0e980ee0a63d837f3ecad666fabe1f50311baa81",
+  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@2360813922ceed63e3798737a268858c11e24d80",
   "vendor/autoplay-whitelist": "https://github.com/brave/autoplay-whitelist.git@ea527a4d36051daedb34421e129c98eda06cb5d3",
   "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@7843f62e26a23c51336330e220e9d7992680aae9",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@6eab0271d014ff09bd9f38abe1e0c117e13e9aa9",


### PR DESCRIPTION
Uplift of #3160

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.