### PR TITLE
update webtorrent storybook

### DIFF
--- a/components/brave_webtorrent/stories/story.tsx
+++ b/components/brave_webtorrent/stories/story.tsx
@@ -7,6 +7,7 @@ import { storiesOf } from '@storybook/react'
 
 // Components
 import TorrentViewer from '../extension/components/torrentViewer'
+import { TorrentState } from '../extension/constants/webtorrentState'
 // Storybook
 const fullPageStoryStyles: object = {
   width: '-webkit-fill-available',
@@ -47,6 +48,11 @@ const sampleTorrent = {
   tabClients: new Set([1, 2, 4, 5])
 }
 
+const torrentState: TorrentState = {
+  tabId: 1,
+  torrentId: 'id'
+}
+
 // Storybook UI
 storiesOf('WebTorrent', module)
   .addDecorator(FullPageStory)
@@ -54,9 +60,8 @@ storiesOf('WebTorrent', module)
     return (
       <TorrentViewer
         actions={consoleLog}
-        torrentId={'Torrent Id'}
-        tabId={1}
         name={'Fake Torrent with really long title'}
+        torrentState={torrentState}
       />
     )
   })
@@ -64,10 +69,9 @@ storiesOf('WebTorrent', module)
     return (
       <TorrentViewer
         actions={consoleLog}
-        torrentId={'Fake Torrent'}
         torrent={sampleTorrent}
-        tabId={1}
         name={'Sample Torrent Name'}
+        torrentState={torrentState}
       />
     )
   })


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5662

storybook went broken after https://github.com/brave/brave-core/pull/3146.
this PR fixes it by updating webtorrent's props in storybook.

## Test Plan:
```
npm run storybook
```

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
