### PR TITLE
0.68.x [brave-extension] prevent `allow scripts once` button from visible in resources overlay

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/components/controls/scriptsControl.tsx
@@ -157,6 +157,12 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
                 <LinkAction
                   size='small'
                   onClick={this.onClickAllowScriptsOnce}
+                  style={{
+                    // TODO: cezaraugusto re-visit shields components.
+                    // this should be defined in the component itself and not inlined,
+                    // and ideally in a logic that is not bounded to a reusable component such as this one.
+                    zIndex: 1
+                  }}
                 >
                   {getLocale('allowScriptsOnce')}
                 </LinkAction>


### PR DESCRIPTION
[brave-extension] prevent `allow scripts once` button from being visible in resources overlay

uplift request for https://github.com/brave/brave-browser/issues/5486