### PR TITLE
allow Shields to block urls with invalid origins

### DIFF
--- a/browser/extensions/api/brave_shields_api_browsertest.cc
+++ b/browser/extensions/api/brave_shields_api_browsertest.cc
@@ -94,6 +94,28 @@ class BraveShieldsAPIBrowserTest : public InProcessBrowserTest {
                                               true);
   }
 
+  void AllowScriptOriginAndDataURLOnce(const std::string& origin,
+      const std::string& dataURL) {
+    scoped_refptr<BraveShieldsAllowScriptsOnceFunction> function(
+        new BraveShieldsAllowScriptsOnceFunction());
+    function->set_extension(extension().get());
+    function->set_has_callback(true);
+
+    const GURL url(embedded_test_server()->GetURL(origin, "/simple.js"));
+    const std::string allow_origin = url.GetOrigin().spec();
+
+    int tabId = extensions::ExtensionTabUtil::GetTabId(active_contents());
+    RunFunctionAndReturnSingleResult(
+        function.get(),
+        "[[\"" + allow_origin + "\",\"" + dataURL + "\"], " +
+        std::to_string(tabId) + "]",
+        browser());
+
+    // reload page with dataURL temporarily allowed
+    active_contents()->GetController().Reload(content::ReloadType::NORMAL,
+                                              true);
+  }
+
  private:
   HostContentSettingsMap* content_settings_;
   scoped_refptr<const extensions::Extension> extension_;
@@ -135,6 +157,28 @@ IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, AllowScriptsOnce) {
   EXPECT_TRUE(WaitForLoadStop(active_contents()));
   EXPECT_EQ(active_contents()->GetAllFrames().size(), 1u)
       << "All script loadings should be blocked after navigating away.";
+}
+
+IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, AllowScriptsOnceDataURL) {
+  EXPECT_TRUE(
+      NavigateToURLUntilLoadStop("a.com", "/load_js_from_origins.html"));
+  EXPECT_EQ(active_contents()->GetAllFrames().size(), 4u)
+      << "All script loadings should not be blocked by default.";
+
+  BlockScripts();
+  EXPECT_TRUE(
+      NavigateToURLUntilLoadStop("a.com", "/load_js_from_origins.html"));
+  EXPECT_EQ(active_contents()->GetAllFrames().size(), 1u)
+      << "All script loadings should be blocked.";
+
+  AllowScriptOriginAndDataURLOnce("a.com",
+      "data:application/javascript;base64,"
+      "dmFyIGZyYW1lID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnaWZyYW1lJyk7CmRvY3VtZW"
+      "50LmJvZHkuYXBwZW5kQ2hpbGQoZnJhbWUpOw==");
+
+  EXPECT_TRUE(WaitForLoadStop(active_contents()));
+  EXPECT_EQ(active_contents()->GetAllFrames().size(), 3u)
+      << "Scripts from a.com and data URL should be temporarily allowed.";
 }
 
 IN_PROC_BROWSER_TEST_F(BraveShieldsAPIBrowserTest, AllowScriptsOnceIframe) {

--- a/components/brave_extension/extension/brave_extension/helpers/noScriptUtils.ts
+++ b/components/brave_extension/extension/brave_extension/helpers/noScriptUtils.ts
@@ -9,7 +9,7 @@ import { NoScriptInfo, NoScriptEntry } from '../types/other/noScriptInfo'
 import { getLocale } from '../background/api/localeAPI'
 
 // Helpers
-import { getOrigin } from './urlUtils'
+import { getOrigin, isHttpOrHttps } from './urlUtils'
 
 /**
  * Filter resources by origin to be used for generating NoScriptInfo.
@@ -121,5 +121,5 @@ export const getBlockScriptText = (haveUserInteracted: boolean, isBlocked: boole
 export const getAllowedScriptsOrigins = (modifiedNoScriptInfo: NoScriptInfo): Array<string> => {
   const getAllowedOrigins = Object.entries(modifiedNoScriptInfo)
     .filter(url => url[1].actuallyBlocked === false)
-  return getAllowedOrigins.map(url => getOrigin(url[0]) + '/')
+  return getAllowedOrigins.map(url => isHttpOrHttps(url[0]) ? getOrigin(url[0]) + '/' : url[0])
 }

--- a/components/brave_extension/extension/brave_extension/helpers/urlUtils.ts
+++ b/components/brave_extension/extension/brave_extension/helpers/urlUtils.ts
@@ -13,13 +13,27 @@ export const isHttpOrHttps = (url?: string) => {
  * Get the URL origin via Web API
  * @param {string} url - The URL to get the origin from
  */
-export const getOrigin = (url: string) => new window.URL(url).origin
+export const getOrigin = (url: string) => {
+  // for URLs such as blob:// and data:// that doesn't have a
+  // valid origin, return the full url.
+  if (!isHttpOrHttps(url)) {
+    return url
+  }
+  return new window.URL(url).origin
+}
 
 /**
  * Get the URL hostname via Web API
  * @param {string} url - The URL to get the origin from
  */
-export const getHostname = (url: string) => new window.URL(url).hostname
+export const getHostname = (url: string) => {
+  // for URLs such as blob:// and data:// that doesn't have a
+  // valid origin, return the full url.
+  if (!isHttpOrHttps(url)) {
+    return url
+  }
+  return new window.URL(url).hostname
+}
 
 /**
  * Strip http/https protocol

--- a/components/test/brave_extension/helpers/urlUtils_test.ts
+++ b/components/test/brave_extension/helpers/urlUtils_test.ts
@@ -49,11 +49,19 @@ describe('urlUtils test', () => {
       const url = 'https://pokemons-invading-tests-breaking-stuff.com/you-knew-that.js'
       expect(getOrigin(url)).toBe('https://pokemons-invading-tests-breaking-stuff.com')
     })
+    it('returns the full URL if origin is not valid', () => {
+      const url = 'data:application/javascript;base64,c3z4r4vgvst0n00b'
+      expect(getOrigin(url)).toBe('data:application/javascript;base64,c3z4r4vgvst0n00b')
+    })
   })
   describe('getHostname', () => {
     it('properly gets the hostname from an URL', () => {
       const url = 'https://pokemons-invading-tests-breaking-stuff.com/you-knew-that.js'
       expect(getHostname(url)).toBe('pokemons-invading-tests-breaking-stuff.com')
+    })
+    it('returns the full URL if origin is not valid', () => {
+      const url = 'data:application/javascript;base64,c3z4r4vgvst0n00b'
+      expect(getHostname(url)).toBe('data:application/javascript;base64,c3z4r4vgvst0n00b')
     })
   })
   describe('stripProtocolFromUrl', () => {

--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -65,10 +65,12 @@ void BraveContentSettingsObserver::DidCommitProvisionalLoad(
 
 bool BraveContentSettingsObserver::IsScriptTemporilyAllowed(
     const GURL& script_url) {
-  // check if scripts from this origin are temporily allowed or not
-  return base::ContainsKey(temporarily_allowed_scripts_,
-      script_url.GetOrigin().spec()) ||
-      base::ContainsKey(temporarily_allowed_scripts_, script_url.spec());
+  // Check if scripts from this origin are temporily allowed or not.
+  // Also matches the full script URL to support data URL cases which we use
+  // the full URL to allow it.
+  return base::ContainsKey(
+      temporarily_allowed_scripts_, script_url.GetOrigin().spec()) ||
+    base::ContainsKey(temporarily_allowed_scripts_, script_url.spec());
 }
 
 void BraveContentSettingsObserver::BraveSpecificDidBlockJavaScript(

--- a/renderer/brave_content_settings_observer.cc
+++ b/renderer/brave_content_settings_observer.cc
@@ -67,7 +67,8 @@ bool BraveContentSettingsObserver::IsScriptTemporilyAllowed(
     const GURL& script_url) {
   // check if scripts from this origin are temporily allowed or not
   return base::ContainsKey(temporarily_allowed_scripts_,
-      script_url.GetOrigin().spec());
+      script_url.GetOrigin().spec()) ||
+      base::ContainsKey(temporarily_allowed_scripts_, script_url.spec());
 }
 
 void BraveContentSettingsObserver::BraveSpecificDidBlockJavaScript(

--- a/renderer/brave_content_settings_observer_browsertest.cc
+++ b/renderer/brave_content_settings_observer_browsertest.cc
@@ -689,7 +689,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest, AllowScripts) {
 
   EXPECT_TRUE(
       NavigateToURLUntilLoadStop("a.com", "/load_js_from_origins.html"));
-  EXPECT_EQ(contents()->GetAllFrames().size(), 3u);
+  EXPECT_EQ(contents()->GetAllFrames().size(), 4u);
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
@@ -699,7 +699,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,
 
   EXPECT_TRUE(
       NavigateToURLUntilLoadStop("a.com", "/load_js_from_origins.html"));
-  EXPECT_EQ(contents()->GetAllFrames().size(), 3u);
+  EXPECT_EQ(contents()->GetAllFrames().size(), 4u);
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsObserverBrowserTest,

--- a/test/data/load_js_from_origins.html
+++ b/test/data/load_js_from_origins.html
@@ -6,6 +6,7 @@
   See comments here <https://cs.chromium.org/chromium/src/content/public/test/browser_test_utils.h?l=434>
   for more details on how CrossSiteRedirector works.
 -->
+<script src="data:application/javascript;base64,dmFyIGZyYW1lID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnaWZyYW1lJyk7CmRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQoZnJhbWUpOw=="></script>
 <script src="/cross-site/a.com/create_iframe.js"></script>
 <script src="/cross-site/b.com/create_iframe.js"></script>
 </body></html>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5346
fix https://github.com/brave/brave-browser/issues/5483

shields can't manually block urls with invalid origins, making blob:// and data:// scripts impossible to allow once, for example.

### Test Plan

See https://github.com/brave/brave-browser/issues/5346 and https://github.com/brave/brave-browser/issues/5483.

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
