### PR TITLE
WebUI: Turn off search feature via html "hidden" attribute instead of polymer dom-if template

### DIFF
--- a/ui/webui/resources/br_elements/br_toolbar/br_toolbar.html
+++ b/ui/webui/resources/br_elements/br_toolbar/br_toolbar.html
@@ -176,14 +176,12 @@
           </a>
         </li>
       </ul>
-      <template id="searchIf" is="dom-if" if="[[!noSearch]]">
         <br-toolbar-search-field id="search"
           narrow="[[narrow]]"
           label="[[searchPrompt]]" clear-label="[[clearLabel]]"
           spinner-active="[[spinnerActive]]"
           showing-search="{{showingSearch_}}"
         ></br-toolbar-search-field>
-      </template>
       <div class="toolbar-extra">
         <slot></slot>
       </div>

--- a/ui/webui/resources/br_elements/br_toolbar/br_toolbar.js
+++ b/ui/webui/resources/br_elements/br_toolbar/br_toolbar.js
@@ -64,6 +64,7 @@ Polymer({
     closeMenuPromo: String,
 
     noSearch: {
+      observer: 'noSearchChanged_',
       type: Boolean,
       // boolean props on html attributes must default to false
       value: false
@@ -82,9 +83,7 @@ Polymer({
 
   /** @return {!CrToolbarSearchFieldElement} */
   getSearchField: function() {
-    // make sure conditional has run
-    this.$.searchIf.render()
-    return this.$$('#search');
+    return this.$.search;
   },
 
   /** @private */
@@ -102,6 +101,16 @@ Polymer({
     console.debug('[br_toolbar] Not Implemented: possiblyShowMenuPromo')
   },
 
+  /** @private */
+  noSearchChanged_: function () {
+    this.updateSearchDisplayed_()
+  },
+
+  /** @private */
+  updateSearchDisplayed_: function () {
+    this.$.search.hidden = this.noSearch
+  },
+
   /**
    * @param {string} title
    * @param {boolean} showMenuPromo
@@ -110,8 +119,6 @@ Polymer({
   titleIfNotShowMenuPromo_: function(title, showMenuPromo) {
     return showMenuPromo ? '' : title;
   },
-
-
 
   getNavItemSelectedClassName: function(itemName) {
     // which navigation item is the current page?

--- a/ui/webui/resources/br_elements/br_toolbar/br_toolbar_search_field.html
+++ b/ui/webui/resources/br_elements/br_toolbar/br_toolbar_search_field.html
@@ -15,9 +15,12 @@
         right: 0;
         top: 0;
         color: inherit;
-        display: flex;
         flex-direction: row;
         align-items: stretch;
+      }
+
+      :host:not([hidden]) {
+        display: flex;
       }
 
       .page-search_toggle {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5330

This fixes the issue with the downloads page due to a timing issue with the download item list rendering. That list uses iron-list via downloads/manager.html. The list will not render if the list component's element does not have either a width or a height (via flex, explicit css, or otherwise). In the course of the page load, there is specific timing where the page has width *just* before the items that are provided to the iron-list are rendered. This timing could definitely be improved upstream.

The download page asks the toolbar whether the search field is clear or not (so that the download page knew to render the entire list of downloads, or one filtered to the search term).

Somehow having an extra polymer template to ensure had rendered before our toolbar would return the correct value for this caused this timing to be off, and so when the iron-list was first rendered it did not do anything because there was no width or height to the element. At any time later, forcing the iron-list to re-evaluate it's rendering ability by resizing the window (since it subscribes directly to this event), or running `downloadsList.fire('iron-resize')` directly, would caus the list to render successfully.

Interestingly, there is an attempt in the upstream code to force firing of this event to prevent this issue, but it actually happens too early, or rather it does not listen to all the properties that could cause this issue: https://cs.chromium.org/chromium/src/chrome/browser/resources/downloads/manager.js?rcl=044ab765751f0d98b0758a6de98265797ee67793&l=122

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
As well as verifying the downloads page list is fixed via https://github.com/brave/brave-browser/issues/5330, we should also verify that the search box still hides / shows appropriately:

### Search shows
1. open `brave://settings`
2. verify -> Search icon shows and search switches to input when pressing <kbd>/</kbd> or clicking the search icon

### Search does not show
1. open `brave://rewards`
2. verify -> Search icon does not show and does switch to input when pressing <kbd>/</kbd>

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
