### PR TITLE
Disable translate pref in Tor profile.

### DIFF
--- a/browser/profiles/BUILD.gn
+++ b/browser/profiles/BUILD.gn
@@ -8,11 +8,13 @@ source_set("profiles") {
   deps = [
     "//base",
     "//brave/browser/tor",
+    "//brave/browser/translate/buildflags",
     "//brave/common/tor",
     "//brave/components/brave_ads/browser",
     "//brave/components/brave_rewards/browser",
     "//brave/content:browser",
     "//chrome/common",
+    "//components/translate/core/browser",
     "//content/public/common",
     "//ui/base",
   ]

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/tor/buildflags.h"
 #include "brave/browser/tor/tor_profile_service.h"
 #include "brave/browser/tor/tor_profile_service_factory.h"
+#include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/pref_names.h"
 #include "brave/common/tor/pref_names.h"
 #include "brave/common/tor/tor_constants.h"
@@ -31,6 +32,7 @@
 #include "components/prefs/pref_service.h"
 #include "components/safe_browsing/common/safe_browsing_prefs.h"
 #include "components/signin/core/browser/signin_pref_names.h"
+#include "components/translate/core/browser/translate_pref_names.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/url_data_source.h"
 #include "content/public/common/webrtc_ip_handling_policy.h"
@@ -66,6 +68,12 @@ void BraveProfileManager::InitTorProfileUserPrefs(Profile* profile) {
   // https://blog.torproject.org/bittorrent-over-tor-isnt-good-idea
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
   pref_service->SetBoolean(kWebTorrentEnabled, false);
+#endif
+  // Disable the automatic translate bubble in Tor because we currently don't
+  // support extensions in Tor mode and users cannot disable this through
+  // settings page for Tor windows.
+#if BUILDFLAG(ENABLE_BRAVE_TRANSLATE_EXTENSION)
+  pref_service->SetBoolean(prefs::kOfferTranslateEnabled, false);
 #endif
 }
 

--- a/browser/profiles/brave_profile_manager_unittest.cc
+++ b/browser/profiles/brave_profile_manager_unittest.cc
@@ -13,6 +13,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/profiles/tor_unittest_profile_manager.h"
 #include "brave/browser/tor/tor_launcher_factory.h"
+#include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/tor/pref_names.h"
 #include "brave/common/tor/tor_constants.h"
 #include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
@@ -29,6 +30,7 @@
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
 #include "components/safe_browsing/common/safe_browsing_prefs.h"
+#include "components/translate/core/browser/translate_pref_names.h"
 #include "content/public/common/webrtc_ip_handling_policy.h"
 #include "content/public/test/test_browser_thread_bundle.h"
 #include "content/public/test/test_utils.h"
@@ -142,19 +144,23 @@ TEST_F(BraveProfileManagerTest, InitProfileUserPrefs) {
       tor_profile->GetPrefs()->GetInteger(prefs::kProfileAvatarIndex);
   EXPECT_EQ(avatar_index, size_t(0));
   EXPECT_FALSE(
-    tor_profile->GetPrefs()->GetBoolean(prefs::kProfileUsingDefaultName));
+      tor_profile->GetPrefs()->GetBoolean(prefs::kProfileUsingDefaultName));
   EXPECT_FALSE(profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
   EXPECT_TRUE(
-    tor_profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
+      tor_profile->GetPrefs()->GetBoolean(tor::prefs::kProfileUsingTor));
 
   // Check WebRTC IP handling policy.
   EXPECT_EQ(
-    tor_profile->GetPrefs()->GetString(prefs::kWebRTCIPHandlingPolicy),
-    content::kWebRTCIPHandlingDisableNonProxiedUdp);
+      tor_profile->GetPrefs()->GetString(prefs::kWebRTCIPHandlingPolicy),
+      content::kWebRTCIPHandlingDisableNonProxiedUdp);
 
   // Check SafeBrowsing status
   EXPECT_FALSE(
-    tor_profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnabled));
+      tor_profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnabled));
+
+  // Check translate.enabled for translate bubble.
+  EXPECT_FALSE(
+      tor_profile->GetPrefs()->GetBoolean(prefs::kOfferTranslateEnabled));
 }
 
 // This is for tor guest window, remove it when we have persistent tor profiles


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5657
This would prevent showing the translate bubble in Tor mode which we currently ask users if they want to install google translate extension to translate the page.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Make sure google translate extension is not installed.
2. Open tor window and visit https://www.deutschland.de/de, should not show any prompt for asking if users would like to install google translate extension.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
