### PR TITLE
Update sync nodes index only when we are about to moving the nodes from end to proper position

### DIFF
--- a/chromium_src/components/sync_bookmarks/bookmark_change_processor.cc
+++ b/chromium_src/components/sync_bookmarks/bookmark_change_processor.cc
@@ -112,10 +112,10 @@ void BookmarkChangeProcessor::MoveSyncNode(
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_2   \
   int new_index =                                                         \
-      brave_sync::GetIndexByCompareOrderStartFrom(dst->parent(), dst, 0); \
-  if (src.GetPositionIndex() != new_index) {                              \
-    to_reposition.insert(std::make_pair(new_index, dst));                 \
-    MoveSyncNode(new_index, dst, trans);                                  \
+      brave_sync::GetIndexByCompareOrderStartFrom(parent, it->second, 0); \
+  if (it->first != new_index) {                                           \
+    model->Move(it->second, parent, new_index);                           \
+    MoveSyncNode(new_index, it->second, trans);                           \
   } else  // NOLINT
 
 #include "../../../../components/sync_bookmarks/bookmark_change_processor.cc"  // NOLINT

--- a/patches/components-sync_bookmarks-bookmark_change_processor.cc.patch
+++ b/patches/components-sync_bookmarks-bookmark_change_processor.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/sync_bookmarks/bookmark_change_processor.cc b/components/sync_bookmarks/bookmark_change_processor.cc
-index 35a73a07bbcdd8aeba13acf37c6754aadb039768..67cb25e20a9c2eb1f70661de4e03c956b7a6a6bc 100644
+index 35a73a07bbcdd8aeba13acf37c6754aadb039768..ce1af3e95e3745bf3cb06ecd5a94ed29b3ec4355 100644
 --- a/components/sync_bookmarks/bookmark_change_processor.cc
 +++ b/components/sync_bookmarks/bookmark_change_processor.cc
 @@ -87,6 +87,7 @@ void BookmarkChangeProcessor::UpdateSyncNodeProperties(
@@ -42,7 +42,7 @@ index 35a73a07bbcdd8aeba13acf37c6754aadb039768..67cb25e20a9c2eb1f70661de4e03c956
        if (!PlaceSyncNode(MOVE, node, i, &trans, &sync_child,
                           model_associator_)) {
          syncer::SyncError error(FROM_HERE,
-@@ -718,9 +721,11 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
+@@ -718,6 +721,7 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
                     << src.GetBookmarkSpecifics().url();
          continue;
        }
@@ -50,7 +50,11 @@ index 35a73a07bbcdd8aeba13acf37c6754aadb039768..67cb25e20a9c2eb1f70661de4e03c956
        model_associator_->Associate(dst, src);
      }
  
+@@ -730,6 +734,7 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
+   // sync order, left to right, moving them into their proper positions.
+   for (auto it = to_reposition.begin(); it != to_reposition.end(); ++it) {
+     const BookmarkNode* parent = it->second->parent();
 +    BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_2
-     to_reposition.insert(std::make_pair(src.GetPositionIndex(), dst));
-     bookmark_model_->SetNodeSyncTransactionVersion(dst, model_version);
+     model->Move(it->second, parent, it->first);
    }
+ 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5770

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Specified in the issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
