### PR TITLE
Show bookmark bar on NTP by default

### DIFF
--- a/browser/ui/bookmark/bookmark_prefs_service_factory.cc
+++ b/browser/ui/bookmark/bookmark_prefs_service_factory.cc
@@ -47,5 +47,5 @@ bool BookmarkPrefsServiceFactory::ServiceIsCreatedWithBrowserContext() const {
 
 void BookmarkPrefsServiceFactory::RegisterProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
-  registry->RegisterBooleanPref(kAlwaysShowBookmarkBarOnNTP, false);
+  registry->RegisterBooleanPref(kAlwaysShowBookmarkBarOnNTP, true);
 }

--- a/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc
+++ b/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc
@@ -54,42 +54,44 @@ void AddBookmarkNode(Profile* profile) {
 
 }  // namespace
 
-IN_PROC_BROWSER_TEST_F(BookmarkTabHelperBrowserTest,
-                       BookmarkBarOnNTPToggleTest) {
-  auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
-  EXPECT_TRUE(content::NavigateToURL(contents,
-                                     GURL(chrome::kChromeUINewTabURL)));
-  EXPECT_TRUE(IsNTP(contents));
-  chrome::ToggleBookmarkBar(browser());
-  EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
-
-  AddBookmarkNode(browser()->profile());
-
-  chrome::ToggleBookmarkBar(browser());
-
-  // Check bookmark is still hidden on NTP.
-  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
-}
-
-IN_PROC_BROWSER_TEST_F(BookmarkTabHelperBrowserTest,
-                       AlwaysShowBookmarkBarOnNTPTest) {
+IN_PROC_BROWSER_TEST_F(BookmarkTabHelperBrowserTest, BookmarkBarOnNTPTest) {
   auto* profile = browser()->profile();
-  // Check default is false.
-  EXPECT_FALSE(profile->GetPrefs()->GetBoolean(kAlwaysShowBookmarkBarOnNTP));
+
+  // Check Bookmark bar is hidden by default.
+  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
+
+  // Check default is on.
+  EXPECT_TRUE(profile->GetPrefs()->GetBoolean(kAlwaysShowBookmarkBarOnNTP));
+
+  // Loading NTP.
   auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
   EXPECT_TRUE(content::NavigateToURL(contents,
                                      GURL(chrome::kChromeUINewTabURL)));
   EXPECT_TRUE(IsNTP(contents));
+
+  // Check bookmark bar on NTP is hidden if bookmark bar is empty and
+  // kBookmarkBar is off.
+  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
+
   AddBookmarkNode(profile);
-  profile->GetPrefs()->SetBoolean(kAlwaysShowBookmarkBarOnNTP, true);
 
-  // Check bookmark is visible on NTP.
-  EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
-
-  // Check bookmark is still visible on NTP regardless of kBookmarkBar pref
-  // change.
+  // Check bookmark is visible on NTP after adding bookmark.
   chrome::ToggleBookmarkBar(browser());
   EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
   chrome::ToggleBookmarkBar(browser());
   EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
+
+  // Turn off showing bookmark bar on NTP.
+  profile->GetPrefs()->SetBoolean(kAlwaysShowBookmarkBarOnNTP, false);
+
+  // Check bookmark bar on NTP is hidden.
+  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
+
+  // Check bookmark bar on NTP is visible when kBookmarkBar pref is on.
+  chrome::ToggleBookmarkBar(browser());
+  EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
+
+  // Check bookmark bar on NTP is hidden when kBookmarkBar pref is off.
+  chrome::ToggleBookmarkBar(browser());
+  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5781

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`yarn test brave_browser_tests --filter=*BookmarkBarOnNTPTest*`

1. Launch browser with clean profile
2. Check `Always show bookmarks bar on New Tab page` is on by default

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
