### PR TITLE
do not show default chrome store url on NTP for any locale

### DIFF
--- a/components/brave_new_tab_ui/api/topSites/grid.ts
+++ b/components/brave_new_tab_ui/api/topSites/grid.ts
@@ -13,14 +13,15 @@ import { debounce } from '../../../common/debounce'
 export const getGridSites = (state: NewTab.State, checkBookmarkInfo?: boolean) => {
   const sizeToCount = { large: 18, medium: 12, small: 6 }
   const count = sizeToCount[state.gridLayoutSize || 'small']
-  const defaultChromeUrl = 'https://chrome.google.com/webstore?hl=en'
+  const defaultChromeWebStoreUrl = 'https://chrome.google.com/webstore'
 
   // Start with top sites with filtered out ignored sites and pinned sites
   let gridSites = state.topSites.slice()
   .filter((site) =>
     !state.ignoredTopSites.find((ignoredSite) => ignoredSite.url === site.url) &&
     !state.pinnedTopSites.find((pinnedSite) => pinnedSite.url === site.url) &&
-    site.url !== defaultChromeUrl
+    // see https://github.com/brave/brave-browser/issues/5376
+    !site.url.startsWith(defaultChromeWebStoreUrl)
   )
 
   // Then add in pinned sites at the specified index, these need to be added in the same


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5376

previous fix referenced the URL locale allowing the tile to still show for locales other than en-US.

## Test Plan:

1. Change your system locale to en-GB
2. Clear profile
3. NTP should not show the default chrome tile

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
