### PR TITLE
respect region time format on NTP

### DIFF
--- a/components/brave_new_tab_ui/components/default/clock/index.tsx
+++ b/components/brave_new_tab_ui/components/default/clock/index.tsx
@@ -25,7 +25,9 @@ class Clock extends React.PureComponent<{}, ClockState> {
   }
 
   get dateTimeFormat (): any {
-    return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
+    // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+    const options = { hour: 'numeric', minute: 'numeric' }
+    return new Intl.DateTimeFormat(undefined, options)
   }
 
   get formattedTime () {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1308

this change allows users with 24-hour format to see time on NTP the same way their system defined. defaults to whichever locale user defined on their system settings.

## Test Plan:

1. Go to NTP and assert time there is on the same time format (12-hour or 24-hour) as your system
2. Change your system locale to a language that defaults to the opposite time format (en-US uses the 12-hour system, pt-BR uses the 24-hour system) 
3. Relaunch Brave
4. NTP should follow the change

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
