### PR TITLE
Override menu item colors on old macOS

### DIFF
--- a/chromium_src/ui/native_theme/native_theme_mac.mm
+++ b/chromium_src/ui/native_theme/native_theme_mac.mm
@@ -1,0 +1,37 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ui/native_theme/native_theme.h"
+
+namespace ui {
+bool ShouldOverride(NativeTheme::ColorId color_id) {
+  // This override only targets for old macOS like high sierra that doesn't
+  // support dark mode. We are using dark mode on old macOS but some below
+  // colors are fetched from system color and they are not dark mode aware.
+  // So, we should replace those colors with dark mode aware aura color.
+  if (@available(macOS 10.14, *))
+    return false;
+
+  switch (color_id) {
+    case NativeTheme::kColorId_EnabledMenuItemForegroundColor:
+    case NativeTheme::kColorId_DisabledMenuItemForegroundColor:
+    case NativeTheme::kColorId_LabelTextSelectionBackgroundFocused:
+    case NativeTheme::kColorId_TextfieldSelectionBackgroundFocused:
+    case NativeTheme::kColorId_FocusedBorderColor:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+#define GET_BRAVE_COLOR(color_id)                                          \
+  if (ShouldOverride(color_id)) {                                          \
+    return GetAuraColor(color_id, NativeTheme::GetInstanceForNativeUi());  \
+  }
+
+}  // namespace ui
+
+#include "../../../../ui/native_theme/native_theme_mac.mm"  // NOLINT

--- a/patches/ui-native_theme-native_theme_mac.mm.patch
+++ b/patches/ui-native_theme-native_theme_mac.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/native_theme/native_theme_mac.mm b/ui/native_theme/native_theme_mac.mm
+index 9881259e8a9650e22a7d3a7a82af0598e0da299e..5500cd52d58d217612f13604c3f2feafa9cd91cb 100644
+--- a/ui/native_theme/native_theme_mac.mm
++++ b/ui/native_theme/native_theme_mac.mm
+@@ -199,6 +199,7 @@ SkColor NativeThemeMac::GetSystemColor(ColorId color_id) const {
+   }
+   // Even with --secondary-ui-md, menus use the platform colors and styling, and
+   // Mac has a couple of specific color overrides, documented below.
++  GET_BRAVE_COLOR(color_id)
+   switch (color_id) {
+     case kColorId_EnabledMenuItemForegroundColor:
+       return NSSystemColorToSkColor([NSColor controlTextColor]);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5423

We also support dark mode on old macOS.
However, some colors are fetched from system color.
If system doesn't support dark mode, fetched system color is only
suitable with light mode.
So, we should override those colors that fetched from system color
with aura color that dark mode aware color.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
