### PR TITLE
Remove items from profile menu

### DIFF
--- a/browser/ui/views/profiles/brave_profile_chooser_view.cc
+++ b/browser/ui/views/profiles/brave_profile_chooser_view.cc
@@ -46,6 +46,8 @@ void BraveProfileChooserView::Reset() {
   tor_profile_button_ = nullptr;
 }
 
+void BraveProfileChooserView::AddAutofillHomeView() { }
+
 void BraveProfileChooserView::AddDiceSyncErrorView(
     const AvatarMenu::Item& avatar_item,
     sync_ui_util::AvatarSyncErrorType error,

--- a/browser/ui/views/profiles/brave_profile_chooser_view.cc
+++ b/browser/ui/views/profiles/brave_profile_chooser_view.cc
@@ -20,9 +20,7 @@
 
 void BraveProfileChooserView::ButtonPressed(views::Button* sender,
                                             const ui::Event& event) {
-  if (sender == tor_profile_button_) {
-    profiles::SwitchToTorProfile(ProfileManager::CreateCallback());
-  } else if (sender == users_button_ &&
+  if (sender == users_button_ &&
              browser()->profile()->IsGuestSession()) {
     if (brave::IsTorProfile(browser()->profile()))
       profiles::CloseTorProfileWindows();
@@ -31,19 +29,6 @@ void BraveProfileChooserView::ButtonPressed(views::Button* sender,
   } else {
     ProfileChooserView::ButtonPressed(sender, event);
   }
-}
-
-void BraveProfileChooserView::AddTorButton() {
-  if (brave::ShouldShowTorProfileButton(browser()->profile())) {
-    tor_profile_button_ = CreateAndAddButton(
-        brave::CreateTorProfileButtonIcon(),
-        brave::CreateTorProfileButtonText());
-  }
-}
-
-void BraveProfileChooserView::Reset() {
-  ProfileChooserView::Reset();
-  tor_profile_button_ = nullptr;
 }
 
 void BraveProfileChooserView::AddAutofillHomeView() { }

--- a/browser/ui/views/profiles/brave_profile_chooser_view.h
+++ b/browser/ui/views/profiles/brave_profile_chooser_view.h
@@ -20,6 +20,7 @@ class BraveProfileChooserView : public ProfileChooserView {
 
   void Reset() override;
 
+  void AddAutofillHomeView() override;
   void AddDiceSyncErrorView(const AvatarMenu::Item& avatar_item,
                             sync_ui_util::AvatarSyncErrorType error,
                             int button_string_id) override;

--- a/browser/ui/views/profiles/brave_profile_chooser_view.h
+++ b/browser/ui/views/profiles/brave_profile_chooser_view.h
@@ -18,16 +18,10 @@ class BraveProfileChooserView : public ProfileChooserView {
   // views::ButtonListener:
   void ButtonPressed(views::Button* sender, const ui::Event& event) override;
 
-  void Reset() override;
-
   void AddAutofillHomeView() override;
   void AddDiceSyncErrorView(const AvatarMenu::Item& avatar_item,
                             sync_ui_util::AvatarSyncErrorType error,
                             int button_string_id) override;
-
-  void AddTorButton();
-
-  views::Button* tor_profile_button_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveProfileChooserView);
 };

--- a/chromium_src/chrome/browser/ui/views/profiles/profile_chooser_view.cc
+++ b/chromium_src/chrome/browser/ui/views/profiles/profile_chooser_view.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/ui/views/profiles/brave_profile_chooser_view.h"
 #define ADD_TOR_EXIT_BUTTON_ \
-  static_cast<BraveProfileChooserView*>(this)->AddTorButton(); \
   if (brave::IsTorProfile(browser()->profile())) \
     text = l10n_util::GetStringUTF16(IDS_PROFILES_EXIT_TOR);
 #include "../../../../../../../chrome/browser/ui/views/profiles/profile_chooser_view.cc"  // NOLINT

--- a/patches/chrome-browser-ui-views-profiles-profile_chooser_view.h.patch
+++ b/patches/chrome-browser-ui-views-profiles-profile_chooser_view.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/profiles/profile_chooser_view.h b/chrome/browser/ui/views/profiles/profile_chooser_view.h
-index 165a396a2a1a54286a6c4be1d659567e3b0c0d0c..bea6295b25944251c1b78a8f6e7155e617411b18 100644
+index 165a396a2a1a54286a6c4be1d659567e3b0c0d0c..ffeb6d116dfa05bb84130e9aedc969a9b5804e1a 100644
 --- a/chrome/browser/ui/views/profiles/profile_chooser_view.h
 +++ b/chrome/browser/ui/views/profiles/profile_chooser_view.h
 @@ -45,6 +45,8 @@ class ProfileChooserView : public ProfileMenuViewBase,
@@ -20,7 +20,15 @@ index 165a396a2a1a54286a6c4be1d659567e3b0c0d0c..bea6295b25944251c1b78a8f6e7155e6
  
    // Shows the bubble with the |view_to_display|.
    void ShowView(profiles::BubbleViewMode view_to_display,
-@@ -115,6 +117,7 @@ class ProfileChooserView : public ProfileMenuViewBase,
+@@ -93,6 +95,7 @@ class ProfileChooserView : public ProfileMenuViewBase,
+   void AddGuestProfileView();
+   void AddOptionsView(bool display_lock, AvatarMenu* avatar_menu);
+   void AddSupervisedUserDisclaimerView();
++  virtual
+   void AddAutofillHomeView();
+ #if defined(GOOGLE_CHROME_BUILD)
+   void AddManageGoogleAccountButton();
+@@ -115,6 +118,7 @@ class ProfileChooserView : public ProfileMenuViewBase,
  
    // Adds a view showing the profile associated with |avatar_item| and an error
    // button below, when dice is enabled.

--- a/patches/chrome-browser-ui-views-profiles-profile_chooser_view.h.patch
+++ b/patches/chrome-browser-ui-views-profiles-profile_chooser_view.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/profiles/profile_chooser_view.h b/chrome/browser/ui/views/profiles/profile_chooser_view.h
-index 165a396a2a1a54286a6c4be1d659567e3b0c0d0c..ffeb6d116dfa05bb84130e9aedc969a9b5804e1a 100644
+index 165a396a2a1a54286a6c4be1d659567e3b0c0d0c..c532c6a7dd35dfe1e435f06f5fa5eeb98c67daf9 100644
 --- a/chrome/browser/ui/views/profiles/profile_chooser_view.h
 +++ b/chrome/browser/ui/views/profiles/profile_chooser_view.h
 @@ -45,6 +45,8 @@ class ProfileChooserView : public ProfileMenuViewBase,
@@ -11,15 +11,6 @@ index 165a396a2a1a54286a6c4be1d659567e3b0c0d0c..ffeb6d116dfa05bb84130e9aedc969a9
    friend class ProfileChooserViewExtensionsTest;
  
    typedef std::vector<size_t> Indexes;
-@@ -74,7 +76,7 @@ class ProfileChooserView : public ProfileMenuViewBase,
-   // Tests set this to "false" for more consistent operation.
-   static bool close_on_deactivate_for_testing_;
- 
--  void Reset();
-+  virtual void Reset();
- 
-   // Shows the bubble with the |view_to_display|.
-   void ShowView(profiles::BubbleViewMode view_to_display,
 @@ -93,6 +95,7 @@ class ProfileChooserView : public ProfileMenuViewBase,
    void AddGuestProfileView();
    void AddOptionsView(bool display_lock, AvatarMenu* avatar_menu);


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5213

- Removes profile-related autofill items (passwords, credit cards, addresses)
- Removes 'Open Tor Window' item

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
