### PR TITLE
ensure topSites list rendering evaluate to `null` when its hidden

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -174,7 +174,7 @@ class NewTabPage extends React.Component<Props, State> {
               hideWidget={this.toggleShowClock}
               menuPosition={'left'}
             />
-            {this.props.newTabData.gridSites.length && <List
+            {this.props.newTabData.gridSites.length ? <List
               blockNumber={this.props.newTabData.gridSites.length}
               textDirection={newTabData.textDirection}
               showWidget={newTabData.showTopSites}
@@ -200,7 +200,7 @@ class NewTabPage extends React.Component<Props, State> {
                   />
                 )
               }
-            </List>}
+            </List> : null}
             {
               this.props.newTabData.showSiteRemovalNotification
               ? <SiteRemovalNotification actions={actions} />


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5710

There is a rendering issue for topSites that evaluates to false when no topSite is available, which is being coerced to 0 by React. This change ensures it evaluates to null instead, not adding an extraneous output to NTP layout.

## Test Plan:
1. Load NTP
2. Disable background in order to see the bug clearly
3. No `0` should render next to NTP stats (see issue for screenshot)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
