### PR TITLE
ensure dashboard settings menu has a title attribute

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -68,7 +68,7 @@ export default class Settings extends React.PureComponent<Props, {}> {
       onClick
     } = this.props
     return (
-      <SettingsWrapper innerRef={this.settingsMenuRef}>
+      <SettingsWrapper title={getLocale('dashboardSettingsTitle')} innerRef={this.settingsMenuRef}>
         <IconButton onClick={onClick} onKeyDown={this.onKeyPressSettings}><SettingsIcon/></IconButton>
         {showSettingsMenu &&
           <SettingsMenu textDirection={textDirection}>


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5797

## Test Plan:

1. Open NTP
2. Hover over settings dashboard
3. Should show a title attribute

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
