### PR TITLE
Override menu item colors on old macOS (uplift to 0.69.x)

### DIFF
--- a/chromium_src/ui/native_theme/native_theme_mac.mm
+++ b/chromium_src/ui/native_theme/native_theme_mac.mm
@@ -1,0 +1,37 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ui/native_theme/native_theme.h"
+
+namespace ui {
+bool ShouldOverride(NativeTheme::ColorId color_id) {
+  // This override only targets for old macOS like high sierra that doesn't
+  // support dark mode. We are using dark mode on old macOS but some below
+  // colors are fetched from system color and they are not dark mode aware.
+  // So, we should replace those colors with dark mode aware aura color.
+  if (@available(macOS 10.14, *))
+    return false;
+
+  switch (color_id) {
+    case NativeTheme::kColorId_EnabledMenuItemForegroundColor:
+    case NativeTheme::kColorId_DisabledMenuItemForegroundColor:
+    case NativeTheme::kColorId_LabelTextSelectionBackgroundFocused:
+    case NativeTheme::kColorId_TextfieldSelectionBackgroundFocused:
+    case NativeTheme::kColorId_FocusedBorderColor:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+#define GET_BRAVE_COLOR(color_id)                                          \
+  if (ShouldOverride(color_id)) {                                          \
+    return GetAuraColor(color_id, NativeTheme::GetInstanceForNativeUi());  \
+  }
+
+}  // namespace ui
+
+#include "../../../../ui/native_theme/native_theme_mac.mm"  // NOLINT

--- a/patches/ui-native_theme-native_theme_mac.mm.patch
+++ b/patches/ui-native_theme-native_theme_mac.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/native_theme/native_theme_mac.mm b/ui/native_theme/native_theme_mac.mm
+index 9881259e8a9650e22a7d3a7a82af0598e0da299e..5500cd52d58d217612f13604c3f2feafa9cd91cb 100644
+--- a/ui/native_theme/native_theme_mac.mm
++++ b/ui/native_theme/native_theme_mac.mm
+@@ -199,6 +199,7 @@ SkColor NativeThemeMac::GetSystemColor(ColorId color_id) const {
+   }
+   // Even with --secondary-ui-md, menus use the platform colors and styling, and
+   // Mac has a couple of specific color overrides, documented below.
++  GET_BRAVE_COLOR(color_id)
+   switch (color_id) {
+     case kColorId_EnabledMenuItemForegroundColor:
+       return NSSystemColorToSkColor([NSColor controlTextColor]);


### PR DESCRIPTION
Uplift of #3266

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.