### PR TITLE
Fixed ad notifications are not delivered on Android unless browser enters the background and then becomes active

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -141,15 +141,19 @@ void AdsImpl::InitializeStep4(
 
   BLOG(INFO) << "Successfully initialized ads";
 
-  initialize_callback_(SUCCESS);
-
   is_foreground_ = ads_client_->IsForeground();
 
   ads_client_->SetIdleThreshold(kIdleThresholdInSeconds);
 
+  initialize_callback_(SUCCESS);
+
   NotificationAllowedCheck(false);
 
   client_->UpdateAdUUID();
+
+  if (IsMobile()) {
+    StartDeliveringNotifications();
+  }
 
   if (_is_debug) {
     StartCollectingActivity(kDebugOneHourInSeconds);
@@ -244,6 +248,10 @@ bool AdsImpl::GetNotificationForId(
 }
 
 void AdsImpl::OnForeground() {
+  if (!IsInitialized()) {
+    return;
+  }
+
   is_foreground_ = true;
   GenerateAdReportingForegroundEvent();
 
@@ -253,6 +261,10 @@ void AdsImpl::OnForeground() {
 }
 
 void AdsImpl::OnBackground() {
+  if (!IsInitialized()) {
+    return;
+  }
+
   is_foreground_ = false;
   GenerateAdReportingBackgroundEvent();
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5879

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm Ads are delivered on Android after 30 minutes (if set to 2 ads per hour)
- Confirm Ads are delivered on Android (if set to 2 ads per hour) and the browser is closed after 15 minutes and then reopened after a further 15 minutes (ads will be delivered after 1 min of reopening the app)
- Confirm Ads are delivered on Android after 30 minutes (if set to 2 ads per hour) and the browser is backgrounded for 15 minutes then brought to the foreground after a further 5 minutes
- Confirm Ads are delivered on Android after 30 minutes (if set to 2 ads per hour) and the browser is backgrounded for 15 minutes then brought to the foreground after a further 30 minutes
- Confirm Ads are delivered on Desktop

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
