### PR TITLE
Upgrade WebTorrent to 0.105.1 in 0.69.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5415,9 +5415,9 @@
       "dev": true
     },
     "binary-search": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.5.tgz",
-      "integrity": "sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "bitfield": {
       "version": "2.0.0",
@@ -5449,18 +5449,42 @@
       "integrity": "sha512-SYd5H3RbN1ex+TrWAKXkEkASFWxAR7Tk6iLt9tfAT9ehBvZb/Y3AQDVRVJynlrixcWpnmsLYKI7tkRWgp7ORoQ=="
     },
     "bittorrent-protocol": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-3.0.1.tgz",
-      "integrity": "sha512-hnvOzAu9u+2H0OLLL5byoFdz6oz5f3bx5f7R+ItUohTHMq9TgUhEJfcjo7xWtQHSKOVciYWwYTJ4EjczF5RX2A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-3.1.0.tgz",
+      "integrity": "sha512-XPi4PpU8iaHA1HC8ku+3kr+r6TzhG8WFprJs/yUzTE67JSkRcKO5X+XphqeQPj6LkP0syNcUUOp22EDV7Eg4Sg==",
       "requires": {
         "bencode": "^2.0.0",
-        "bitfield": "^2.0.0",
-        "debug": "^3.1.0",
+        "bitfield": "^3.0.0",
+        "debug": "^4.1.1",
         "randombytes": "^2.0.5",
-        "readable-stream": "^2.3.2",
+        "readable-stream": "^3.0.0",
         "speedometer": "^1.0.0",
-        "unordered-array-remove": "^1.0.2",
-        "xtend": "^4.0.0"
+        "unordered-array-remove": "^1.0.2"
+      },
+      "dependencies": {
+        "bitfield": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-3.0.0.tgz",
+          "integrity": "sha512-hJmWKucJQfdSkQPDPBKmWogM9s8+NOSzDT9QVbJbjinXaQ0bJKPu/cn98qRWy3PDNWtKw4XaoUP3XruGRIKEgg=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bittorrent-tracker": {
@@ -5508,13 +5532,23 @@
       "integrity": "sha512-re0AIxakF504MgeMtIyJkVcZ8T5aUxtp/QmTMlmjyb3P44E1BEv5x3LATBGApWAJATyXHtkXRD+gWTmeyYLiQA=="
     },
     "block-stream2": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-1.1.0.tgz",
-      "integrity": "sha1-xzjjqRupd+u14f70MeE8oR2GOeI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-2.0.0.tgz",
+      "integrity": "sha512-1oI+RHHUEo64xomy1ozLgVJetFlHkIfQfJzTBQrj6xWnEMEPooeo2fZoqFjp0yzfHMBrgxwgh70tKp6T17+i3g==",
       "requires": {
-        "defined": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bluebird": {
@@ -5843,7 +5877,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -6132,11 +6167,11 @@
       }
     },
     "chunk-store-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.0.0.tgz",
-      "integrity": "sha512-hmtlqMozj1LbZlEpTBXL3YrBsLz4nJEXVihrSbe6ugfxH/Yae5JvUCXQwpWI7VELjXX0GyZK3ajQDBX/r30zBw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.1.0.tgz",
+      "integrity": "sha512-GjkZ16bFKMFnb8LrGZXAPeRoLXZTLu9ges6LCErJe28bMp6zKLxjWuJ7TYzR0jWq9nwo58hXG3BXZYy66Vze0Q==",
       "requires": {
-        "block-stream2": "^1.0.0",
+        "block-stream2": "^2.0.0",
         "readable-stream": "^3.4.0"
       },
       "dependencies": {
@@ -6314,11 +6349,6 @@
           }
         }
       }
-    },
-    "closest-to": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/closest-to/-/closest-to-2.0.0.tgz",
-      "integrity": "sha1-uyqGDtt3abYtBIIXSK5Q2iTb76o="
     },
     "co": {
       "version": "4.6.0",
@@ -6911,25 +6941,32 @@
       }
     },
     "create-torrent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/create-torrent/-/create-torrent-4.0.0.tgz",
-      "integrity": "sha512-16JQRuPJWAntC4p+k6EFMxKatqzQOKv037aAun6Comomizlg9fOoBiIhxC/QCQfJFmGIfnT6HMOEa6da5xUmsg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/create-torrent/-/create-torrent-4.3.0.tgz",
+      "integrity": "sha512-zcKfxN61zvaiKBrREZSx6K7mu1JsFPT7uzP2JThlpd0JwXtlmMcM4zpCh7mVF/OYkK6sxLLSNWqWSQ3YTd42Ng==",
       "requires": {
         "bencode": "^2.0.0",
-        "block-stream2": "^1.0.0",
-        "filestream": "^4.0.0",
-        "flatten": "^1.0.2",
+        "block-stream2": "^2.0.0",
+        "filestream": "^5.0.0",
         "is-file": "^1.0.0",
         "junk": "^3.1.0",
         "minimist": "^1.1.0",
-        "multistream": "^3.0.0",
+        "multistream": "^4.0.0",
         "once": "^1.3.0",
-        "piece-length": "^1.0.0",
+        "piece-length": "^2.0.1",
         "readable-stream": "^3.0.2",
         "run-parallel": "^1.0.0",
         "simple-sha1": "^2.0.0"
       },
       "dependencies": {
+        "multistream": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multistream/-/multistream-4.0.0.tgz",
+          "integrity": "sha512-t0C8MAtH/d3Y+5nooEtUMWli92lVw9Jhx4uOhRl5GAwS5vc+YTmp/VXNJNsCBAMeEyK/6zhbk6x9JE3AiCvo4g==",
+          "requires": {
+            "readable-stream": "^3.4.0"
+          }
+        },
         "readable-stream": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
@@ -7295,11 +7332,6 @@
           }
         }
       }
-    },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -8448,14 +8480,24 @@
       "dev": true
     },
     "filestream": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/filestream/-/filestream-4.1.3.tgz",
-      "integrity": "sha1-lI/KregiH3FfXsrdxUhi+qrMkyU=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/filestream/-/filestream-5.0.0.tgz",
+      "integrity": "sha512-5H3RqSaJp12THfZiNWodYM7TiKfQvrpX+EIOrB1XvCceTys4yvfEIl8wDp+/yI8qj6Bxym8m0NYWwVXDAet/+A==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5",
-        "typedarray-to-buffer": "^3.0.0",
-        "xtend": "^4.0.1"
+        "readable-stream": "^3.4.0",
+        "typedarray-to-buffer": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -8561,11 +8603,6 @@
           }
         }
       }
-    },
-    "flatten": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -8757,7 +8794,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8778,12 +8816,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8798,17 +8838,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8925,7 +8968,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8937,6 +8981,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8951,6 +8996,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8958,12 +9004,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8982,6 +9030,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9062,7 +9111,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9074,6 +9124,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9159,7 +9210,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9195,6 +9247,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9214,6 +9267,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9257,12 +9311,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12074,22 +12130,18 @@
       }
     },
     "mp4-box-encoding": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mp4-box-encoding/-/mp4-box-encoding-1.3.0.tgz",
-      "integrity": "sha512-U4pMLpjT/UzB8d36dxj6Mf1bG9xypEvgbuRIa1fztRXNKKTCAtRxsnFZhNOd7YDFOKtjBgssYGvo4H/Q3ZY1MA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mp4-box-encoding/-/mp4-box-encoding-1.4.1.tgz",
+      "integrity": "sha512-2/PRtGGiqPc/VEhbm7xAQ+gbb7yzHjjMAv6MpAifr5pCpbh3fQUdj93uNgwPiTppAGu8HFKe3PeU+OdRyAxStA==",
       "requires": {
-        "buffer-alloc": "^1.2.0",
-        "buffer-from": "^1.1.0",
         "uint64be": "^2.0.2"
       }
     },
     "mp4-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mp4-stream/-/mp4-stream-3.0.0.tgz",
-      "integrity": "sha512-UCvsZaEP2b+Tl2mJOmb+TXdA2f24ggNUadgQkpgvaNDZQNGs6/O8ivFcj9ogf4Bj4R6dbqv18VXUdp16BhXk/A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mp4-stream/-/mp4-stream-3.1.0.tgz",
+      "integrity": "sha512-ZQQjf0VEiqPucwRvmT3e0pfZfMSE3nc5ngGUiN1+2VMxCtrInrlAjZ2K6jpNmxSZ/roiQne/ovYJYTeOvZDXPw==",
       "requires": {
-        "buffer-alloc": "^1.1.0",
-        "inherits": "^2.0.1",
         "mp4-box-encoding": "^1.3.0",
         "next-event": "^1.0.0",
         "readable-stream": "^3.0.6"
@@ -12113,9 +12165,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multistream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/multistream/-/multistream-3.0.0.tgz",
-      "integrity": "sha512-v1Fx9uhHEpTB725/Kj8YpRCvrLhb20LeABFLw+0dkBkKUUAbDCY6CUUNzGQsJ94ji/p50wBPsRjIQXN1iOwZYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-3.1.0.tgz",
+      "integrity": "sha512-zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^3.4.0"
@@ -12973,12 +13025,9 @@
       "dev": true
     },
     "piece-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/piece-length/-/piece-length-1.0.0.tgz",
-      "integrity": "sha1-TbcWcVf9af7xTK9yYs058YmyRQg=",
-      "requires": {
-        "closest-to": "~2.0.0"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/piece-length/-/piece-length-2.0.1.tgz",
+      "integrity": "sha512-dBILiDmm43y0JPISWEmVGKBETQjwJe6mSU9GND+P9KW0SJGUwoU/odyH1nbalOP9i8WSYuqf1lQnaj92Bhw+Ug=="
     },
     "pify": {
       "version": "3.0.0",
@@ -14541,14 +14590,14 @@
       "dev": true
     },
     "render-media": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/render-media/-/render-media-3.2.0.tgz",
-      "integrity": "sha512-JuV0z+jCWxNO2hYX2dE67G4eiKkXaSR+Nep1ya2AOuXF4ht9t6WLkWT2fq3XbbBre+jFYsZB2jZOIX+rRut9aQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/render-media/-/render-media-3.3.1.tgz",
+      "integrity": "sha512-kabvYrlpPmQtraUAPjBI5hyK3vM/TJah+wnlKJPc27bo0POMU3x26db/zDuMqha6JXz8lLu/pI+ORDlwJmJtFQ==",
       "requires": {
         "debug": "^4.1.1",
         "is-ascii": "^1.0.0",
         "mediasource": "^2.1.0",
-        "stream-to-blob-url": "^2.0.0",
+        "stream-to-blob-url": "^3.0.0",
         "videostream": "^3.2.0"
       },
       "dependencies": {
@@ -14558,6 +14607,19 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "stream-to-blob": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-2.0.0.tgz",
+          "integrity": "sha512-E+YitTtIHo7RQ4Cmgl+EzlMpqvLroTynRgt4t0pI4y5oz/piqlBQB8NFXLIWcjGOsKw+THnImrdpWcOCVxK25Q=="
+        },
+        "stream-to-blob-url": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-3.0.0.tgz",
+          "integrity": "sha512-Mu1iPvbBkzdUPCZ+J+XBr/oagjOBfj4vpErHRIe08QzWeILSDtF5LXo6v44HeQFpx7dfqcBKjGUbSNCJ+38zqQ==",
+          "requires": {
+            "stream-to-blob": "^2.0.0"
           }
         }
       }
@@ -16953,14 +17015,29 @@
       "dev": true
     },
     "ut_metadata": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ut_metadata/-/ut_metadata-3.3.0.tgz",
-      "integrity": "sha512-IK+ke9yL6a4oPLz/3oSW9TW7m9Wr4RG+5kW5aS2YulzEU1QDGAtago/NnOlno91fo3fSO7mnsqzn3NXNXdv8nA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ut_metadata/-/ut_metadata-3.4.0.tgz",
+      "integrity": "sha512-/Igrr2rPD0NH/dNx493alpHxGBF/XREu68bZU4zigrYiQMQpYL68sKbNo9ND5DcmbMp0lNppw4mOhSSONgUYKw==",
       "requires": {
         "bencode": "^2.0.0",
-        "bitfield": "^2.0.0",
-        "debug": "^3.1.0",
+        "bitfield": "^3.0.0",
+        "debug": "^4.0.0",
         "simple-sha1": "^2.0.0"
+      },
+      "dependencies": {
+        "bitfield": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-3.0.0.tgz",
+          "integrity": "sha512-hJmWKucJQfdSkQPDPBKmWogM9s8+NOSzDT9QVbJbjinXaQ0bJKPu/cn98qRWy3PDNWtKw4XaoUP3XruGRIKEgg=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "ut_pex": {
@@ -17108,9 +17185,9 @@
       }
     },
     "videostream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/videostream/-/videostream-3.2.0.tgz",
-      "integrity": "sha512-8+EY2dBxpJti9OBWUHtTn8wZEzyUwX7ldm/rwz8LKsgK+ccGVbTug9F6nyBOehLhifXALCs6Ca+CeYPVGBwobg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/videostream/-/videostream-3.2.1.tgz",
+      "integrity": "sha512-Z4EcsX9aYNJZD1M+0jCeQ0t+5ETlHE88B2SF1fCuVxfn+XxHGJVec6tbHGqpULk4esOOLJEipAScOCDGHk+teQ==",
       "requires": {
         "binary-search": "^1.3.4",
         "mediasource": "^2.2.2",
@@ -17353,8 +17430,8 @@
       "dev": true
     },
     "webtorrent": {
-      "version": "github:brave/webtorrent#ed433c35ba6f4e1e15d62c1a9a7a9241a7504e66",
-      "from": "github:brave/webtorrent#ed433c35ba6f4e1e15d62c1a9a7a9241a7504e66",
+      "version": "github:brave/webtorrent#6dae42cba71de26124c78f378a77aec0859b142b",
+      "from": "github:brave/webtorrent#6dae42cba71de26124c78f378a77aec0859b142b",
       "requires": {
         "addr-to-ip-port": "^1.4.2",
         "bitfield": "^2.0.0",
@@ -17399,14 +17476,15 @@
       },
       "dependencies": {
         "bittorrent-tracker": {
-          "version": "9.11.0",
-          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.11.0.tgz",
-          "integrity": "sha512-T1zvW/kSeEnWT4I3JE+6c7aZbO5jtleZyQe911SyzIxFF9DvtUNWXud3p5ZUkXaoI2xXwfpvlks5VFj5SKEB+A==",
+          "version": "9.14.4",
+          "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.14.4.tgz",
+          "integrity": "sha512-2Y/MNRjYhysD6t4r38z7l1WTT7g23IAqRWZRsj7xnnpciFn4xE4qiKmyFwA4gtbFGAZ14K3DdaqZbiQsC3PEfQ==",
           "requires": {
             "bencode": "^2.0.0",
             "bittorrent-peerid": "^1.0.2",
-            "bn.js": "^4.4.0",
+            "bn.js": "^5.0.0",
             "bufferutil": "^4.0.0",
+            "chrome-dgram": "^3.0.2",
             "compact2string": "^1.2.0",
             "debug": "^4.0.1",
             "ip": "^1.0.1",
@@ -17417,15 +17495,28 @@
             "randombytes": "^2.0.3",
             "run-parallel": "^1.1.2",
             "run-series": "^1.0.2",
-            "safe-buffer": "^5.0.0",
             "simple-get": "^3.0.0",
             "simple-peer": "^9.0.0",
-            "simple-websocket": "^7.0.1",
+            "simple-websocket": "^8.0.0",
             "string2compact": "^1.1.1",
             "uniq": "^1.0.1",
             "unordered-array-remove": "^1.0.2",
             "utf-8-validate": "^5.0.1",
-            "ws": "^6.0.0"
+            "ws": "^7.0.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz",
+          "integrity": "sha512-bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A=="
+        },
+        "chrome-dgram": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.2.tgz",
+          "integrity": "sha512-Ay741EHF/Ib18un+LUtBNK43NrabD6GOuwVaka7uUbV0gFRLEPULm2Q05YSzRNBtSrbaO4eErmDdniiy/u8Lig==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "run-series": "^1.1.2"
           }
         },
         "debug": {
@@ -17446,25 +17537,34 @@
             "util-deprecate": "^1.0.1"
           }
         },
+        "simple-websocket": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.0.1.tgz",
+          "integrity": "sha512-2QKSRjf+tqFXLVmOQjf95gHeKhuyx2k1ouDjtnE0uKCYw84HfN85HsXo+GmPH+2PIh5BQql++g2AIbHgGAZU4w==",
+          "requires": {
+            "debug": "^4.1.1",
+            "randombytes": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "ws": "^7.0.0"
+          }
+        },
         "torrent-discovery": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.1.1.tgz",
-          "integrity": "sha512-3mHf+bxVCVLrlkPJdAoMbPMY1hpTZVeWw5hNc2pPFm+HCc2DS0HgVFTBTSWtB8vQPWA1hSEZpqJ+3QfdXxDE1g==",
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.2.1.tgz",
+          "integrity": "sha512-bjKkbTEkcoZTXF8nhcRu6UWqbkpUsehd/6umoZqjgj/dM8nD3O7wNkPZrmls+vVf+2LT9ejZMlNUvZCqSe8cqg==",
           "requires": {
             "bittorrent-dht": "^9.0.0",
             "bittorrent-tracker": "^9.0.0",
-            "debug": "^3.1.0",
+            "debug": "^4.0.0",
             "run-parallel": "^1.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
+          }
+        },
+        "ws": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+          "requires": {
+            "async-limiter": "^1.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -344,6 +344,6 @@
     "throttleit": "^1.0.0",
     "torrent-discovery": "github:brave/torrent-discovery#b565f40278c1cb910722ceb027a739d9173d587a",
     "unique-selector": "^0.4.1",
-    "webtorrent": "github:brave/webtorrent#ed433c35ba6f4e1e15d62c1a9a7a9241a7504e66"
+    "webtorrent": "github:brave/webtorrent#6dae42cba71de26124c78f378a77aec0859b142b"
   }
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5882 in 0.69.x.
0.69.x is the only milestone that's on WebTorrent 0.105.0 which has the undefined URL constructor described in https://github.com/brave/brave-browser/issues/5358.
This PR is to upgrade to WebTorrent 0.105.1 in 0.69.x which has the fix for above.

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.