### PR TITLE
Sync: never show service error status in browser UI

### DIFF
--- a/chromium_src/chrome/browser/sync/sync_ui_util.cc
+++ b/chromium_src/chrome/browser/sync/sync_ui_util.cc
@@ -1,0 +1,23 @@
+// Copyright 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#define GetMessagesForAvatarSyncError \
+    GetMessagesForAvatarSyncError_ChromiumImpl
+#include "../../../../../chrome/browser/sync/sync_ui_util.cc"
+#undef GetMessagesForAvatarSyncError
+
+namespace sync_ui_util {
+
+AvatarSyncErrorType GetMessagesForAvatarSyncError(
+    Profile* profile,
+    int* content_string_id,
+    int* button_string_id) {
+  // Brave Sync works differently in that there is no sign-in
+  // and nothing to prompt the user to manage once their sync
+  // chain is setup.
+  return NO_SYNC_ERROR;
+}
+
+}  // namespace sync_ui_util


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5839

According to discussion, we never want to display any prompts for Sync because Brave will never have a prompt for user action once sync is already setup. Whether we have a prompt for users to _initially_ setup sync is another matter that can have an issue created for it if necessary.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
See issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
