### PR TITLE
Sync: never show service error status in browser UI (uplift to 0.71.x)

### DIFF
--- a/chromium_src/chrome/browser/sync/sync_ui_util.cc
+++ b/chromium_src/chrome/browser/sync/sync_ui_util.cc
@@ -1,0 +1,23 @@
+// Copyright 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#define GetMessagesForAvatarSyncError \
+    GetMessagesForAvatarSyncError_ChromiumImpl
+#include "../../../../../chrome/browser/sync/sync_ui_util.cc"
+#undef GetMessagesForAvatarSyncError
+
+namespace sync_ui_util {
+
+AvatarSyncErrorType GetMessagesForAvatarSyncError(
+    Profile* profile,
+    int* content_string_id,
+    int* button_string_id) {
+  // Brave Sync works differently in that there is no sign-in
+  // and nothing to prompt the user to manage once their sync
+  // chain is setup.
+  return NO_SYNC_ERROR;
+}
+
+}  // namespace sync_ui_util


### PR DESCRIPTION
Uplift of #3357
Fixes https://github.com/brave/brave-browser/issues/5839

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.