### PR TITLE
Brave Ads still show when app are in full-screen mode

### DIFF
--- a/components/brave_ads/browser/notification_helper_linux.cc
+++ b/components/brave_ads/browser/notification_helper_linux.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/browser/notification_helper_linux.h"
 
+#include "chrome/browser/fullscreen.h"
+
 namespace brave_ads {
 
 NotificationHelperLinux::NotificationHelperLinux() = default;
@@ -12,9 +14,7 @@ NotificationHelperLinux::NotificationHelperLinux() = default;
 NotificationHelperLinux::~NotificationHelperLinux() = default;
 
 bool NotificationHelperLinux::ShouldShowNotifications() const {
-  // Unable to find a way of detecting if notifications are enabled within the
-  // operating system so always return true
-  return true;
+  return !IsFullScreenMode();
 }
 
 bool NotificationHelperLinux::ShowMyFirstAdNotification() const {

--- a/components/brave_ads/browser/notification_helper_mac.cc
+++ b/components/brave_ads/browser/notification_helper_mac.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/browser/notification_helper_mac.h"
 
+#include "chrome/browser/fullscreen.h"
+
 namespace brave_ads {
 
 NotificationHelperMac::NotificationHelperMac() = default;
@@ -12,7 +14,7 @@ NotificationHelperMac::NotificationHelperMac() = default;
 NotificationHelperMac::~NotificationHelperMac() = default;
 
 bool NotificationHelperMac::ShouldShowNotifications() const {
-  return true;
+  return !IsFullScreenMode();
 }
 
 bool NotificationHelperMac::ShowMyFirstAdNotification() const {

--- a/components/brave_ads/browser/notification_helper_win.cc
+++ b/components/brave_ads/browser/notification_helper_win.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/browser/notification_helper_win.h"
 
+#include "chrome/browser/fullscreen.h"
+
 namespace brave_ads {
 
 NotificationHelperWin::NotificationHelperWin() = default;
@@ -12,7 +14,7 @@ NotificationHelperWin::NotificationHelperWin() = default;
 NotificationHelperWin::~NotificationHelperWin() = default;
 
 bool NotificationHelperWin::ShouldShowNotifications() const {
-  return true;
+  return !IsFullScreenMode();
 }
 
 bool NotificationHelperWin::ShowMyFirstAdNotification() const {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5559

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm Ads are not shown in fullscreen mode for macOS
- Confirm Ads are not shown in fullscreen mode for Windows
- Confirm Ads are not shown in fullscreen mode for Linux
- Confirm Ads are shown in non fullscreen mode for macOS
- Confirm Ads are shown in non fullscreen mode for Winows
- Confirm Ads are shown in non fullscreen mode for Linux

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
