### PR TITLE
Fixes Chromium bluetooth UUID dependency bug.

### DIFF
--- a/patches/extensions-common-BUILD.gn.patch
+++ b/patches/extensions-common-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/extensions/common/BUILD.gn b/extensions/common/BUILD.gn
+index e6bc452c9bc2771c88b32186df1d5676d42f91da..b4f51b6dbefb691fa554a6d628998daf3ca372ff 100644
+--- a/extensions/common/BUILD.gn
++++ b/extensions/common/BUILD.gn
+@@ -325,6 +325,7 @@ if (enable_extensions) {
+       "//components/version_info",
+       "//crypto",
+       "//device/bluetooth",
++      "//device/bluetooth/public/cpp",
+       "//extensions:extensions_resources",
+       "//extensions/common/api",
+       "//extensions/strings",


### PR DESCRIPTION
Fixes brave/brave-browser#5953

In Chromium bluetooth_uuid.* was moved to //device/bluetooth/public/cpp/ (see change below).

Our //test/brave_installer_unittests depends on //chrome/common on Mac, which depends on
//extensions/common which includes bluetooth_manifest_permission.cc that needs BluetoothUUID
from //devices/bluetooth/public/cpp.

//extensions/common already depends on //device/bluetooth which includes
//device/bluetooth/public/cpp as a public_deps, but //device/bluetooth is a component,
so in debug build it creates a shared library that doesn't export symbols from public/cpp.

Consequently, we have to patch //extensions/common to depend on
//devices/bluetooth/public/cpp explicitly.

Chromium change:

https://chromium.googlesource.com/chromium/src/+/47659c4b35f4a5ca96938b56cdaa19c8064f2380

commit 47659c4b35f4a5ca96938b56cdaa19c8064f2380
Author: Jason Majors <jmajors@google.com>
Date:   Mon Jul 8 18:23:28 2019 +0000

    Refactor //device to move bluetooth_uuid.* to //device/bluetooth/public/cpp/ .

    Moving these files to public/cpp to change the dependency structure. Other
    components that need the bluetooth UUID can depend on this new library, without
    having to depend on the entire //device library.
    Moved the bluetooth UUID to //device/bluetooth/public/cpp to prevent dependency
    cycles.

    Bug: 976964

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
