### PR TITLE
updated polyfill patterns and google tag manager polyfill content

### DIFF
--- a/app/resources/js/tag_manager_polyfill.js
+++ b/app/resources/js/tag_manager_polyfill.js
@@ -1,1 +1,22 @@
-(function() { var noopfn = function() { ; }; window.ga = window.ga || noopfn; })();
+(function() {
+	var noopfn = function() {
+	};
+	var w = window;
+	w.ga = w.ga || noopfn;
+	var dl = w.dataLayer;
+	if ( dl instanceof Object === false ) { return; }
+	if ( dl.hide instanceof Object && typeof dl.hide.end === 'function' ) {
+		dl.hide.end();
+	}
+	if ( typeof dl.push === 'function' ) {
+		dl.push = function(o) {
+			if (
+				o instanceof Object &&
+				typeof o.eventCallback === 'function'
+			) {
+				setTimeout(o.eventCallback, 1);
+			}
+		};
+	}
+})();
+

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -42,13 +42,13 @@ const char kCRLSetPrefix4[] =
     "*://storage.googleapis.com/update-delta/hfnkpimlhhgieaddgfemjhofmfblmnib"
     "/*crxd";
 const char kGoogleAnalyticsPattern[] =
-    "https://www.google-analytics.com/analytics.js";
+    "https://www.google-analytics.com/analytics.js*";
 const char kChromeCastPrefix[] =
     "*://*.gvt1.com/edgedl/chromewebstore/*pkedcjkdefgpdelpbcmbmeomcjbeemfm*";
 const char kGoogleTagManagerPattern[] =
-    "https://www.googletagmanager.com/gtm.js";
+    "https://www.googletagmanager.com/gtm.js*";
 const char kGoogleTagServicesPattern[] =
-    "https://www.googletagservices.com/tag/js/gpt.js";
+    "https://www.googletagservices.com/tag/js/gpt.js*";
 const char kForbesPattern[] = "https://www.forbes.com/*";
 const char kForbesExtraCookies[] =
     "forbes_ab=true; welcomeAd=true; adblock_session=Off; "


### PR DESCRIPTION
This PR fixes some cases where the google tag manager 4-sec pause still hits, both bc the polyfill was outdated (this PR updates it from uBO) and because the pattern was too narrow (wouldn't catch if there were, for example, query params at the end of the url)