### PR TITLE
Reader Mode: remove UI button (0.68.x)

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -79,6 +79,8 @@ source_set("ui") {
       "views/frame/brave_browser_view.h",
       "views/importer/brave_import_lock_dialog_view.cc",
       "views/importer/brave_import_lock_dialog_view.h",
+      "views/reader_mode/brave_reader_mode_icon_view.cc",
+      "views/reader_mode/brave_reader_mode_icon_view.h",
       "views/rounded_separator.cc",
       "views/rounded_separator.h",
       "views/toolbar/bookmark_button.cc",

--- a/browser/ui/views/reader_mode/brave_reader_mode_icon_view.cc
+++ b/browser/ui/views/reader_mode/brave_reader_mode_icon_view.cc
@@ -1,0 +1,11 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/reader_mode/brave_reader_mode_icon_view.h"
+
+bool BraveReaderModeIconView::Update() {
+  SetVisible(false);
+  return false;
+}

--- a/browser/ui/views/reader_mode/brave_reader_mode_icon_view.h
+++ b/browser/ui/views/reader_mode/brave_reader_mode_icon_view.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_READER_MODE_BRAVE_READER_MODE_ICON_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_READER_MODE_BRAVE_READER_MODE_ICON_VIEW_H_
+
+#include "chrome/browser/ui/views/reader_mode/reader_mode_icon_view.h"
+
+
+class BraveReaderModeIconView : public ReaderModeIconView {
+ public:
+    using ReaderModeIconView::ReaderModeIconView;
+ protected:
+    bool Update() override;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveReaderModeIconView);
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_READER_MODE_BRAVE_READER_MODE_ICON_VIEW_H_

--- a/chromium_src/chrome/browser/ui/views/page_action/omnibox_page_action_icon_container_view.cc
+++ b/chromium_src/chrome/browser/ui/views/page_action/omnibox_page_action_icon_container_view.cc
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/reader_mode/brave_reader_mode_icon_view.h"
+
+#define ReaderModeIconView BraveReaderModeIconView
+#include "../../../../../../../chrome/browser/ui/views/page_action/omnibox_page_action_icon_container_view.cc"
+#undef ReaderModeIconView


### PR DESCRIPTION
The Reader Mode feature is not ready yet and whilst a flag exists, we default it to on (unlike Chromium) since we use the backend of the feature as a component for the Brave Ads feature

Address https://github.com/brave/brave-browser/issues/5951 for 0.68.x

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
 - Open a site
 - Reader Button should not be there
 - Change URL
 - Reader Button should still not be there

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
