### PR TITLE
fixing error of not handled enum AUTOPLAY in switch

### DIFF
--- a/chromium_src/android_webview/browser/aw_permission_manager.cc
+++ b/chromium_src/android_webview/browser/aw_permission_manager.cc
@@ -1,0 +1,11 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "content/public/browser/permission_type.h"
+
+#define BRAVE_PERMISSION_TYPES \
+    case PermissionType::AUTOPLAY:
+#include "../../../../android_webview/browser/aw_permission_manager.cc"
+#undef BRAVE_PERMISSION_TYPES

--- a/patches/android_webview-browser-aw_permission_manager.cc.patch
+++ b/patches/android_webview-browser-aw_permission_manager.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/android_webview/browser/aw_permission_manager.cc b/android_webview/browser/aw_permission_manager.cc
+index f1979fdcc078f31d8caad5da6cd68906b138f263..4d0f05ae1f14f7e6533398456bdebac7d04ba5ba 100644
+--- a/android_webview/browser/aw_permission_manager.cc
++++ b/android_webview/browser/aw_permission_manager.cc
+@@ -335,6 +335,7 @@ int AwPermissionManager::RequestPermissions(
+       case PermissionType::BACKGROUND_FETCH:
+       case PermissionType::IDLE_DETECTION:
+       case PermissionType::PERIODIC_BACKGROUND_SYNC:
++      BRAVE_PERMISSION_TYPES
+         NOTIMPLEMENTED() << "RequestPermissions is not implemented for "
+                          << static_cast<int>(permissions[i]);
+         pending_request_raw->SetPermissionStatus(permissions[i],
+@@ -536,6 +537,7 @@ void AwPermissionManager::CancelPermissionRequest(int request_id) {
+       case PermissionType::BACKGROUND_FETCH:
+       case PermissionType::IDLE_DETECTION:
+       case PermissionType::PERIODIC_BACKGROUND_SYNC:
++      BRAVE_PERMISSION_TYPES
+         NOTIMPLEMENTED() << "CancelPermission not implemented for "
+                          << static_cast<int>(permission);
+         break;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5750

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues/5998) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [X] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
After https://github.com/brave/brave-browser/pull/5995 is merged or cherry-picked:
run npm run init -- --target_os=android --target_arch=x64
run npm run build -- --target_os=android --target_arch=x64

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
