### PR TITLE
Issue 5952: Add X-Brave-Partner to CORS safelisted request headers (uplift to 0.71.x)

### DIFF
--- a/chromium_src/services/network/public/cpp/cors/cors_unittest.cc
+++ b/chromium_src/services/network/public/cpp/cors/cors_unittest.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "services/network/public/cpp/cors/cors.h"
+
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+
+namespace network {
+namespace cors {
+namespace {
+
+typedef testing::Test CorsTest;
+
+TEST_F(CorsTest, SafelistedHeader) {
+  EXPECT_TRUE(IsCorsSafelistedHeader("accept", "foo"));
+  EXPECT_FALSE(IsCorsSafelistedHeader("foo", "bar"));
+  EXPECT_FALSE(IsCorsSafelistedHeader("user-agent", "foo"));
+  EXPECT_TRUE(IsCorsSafelistedHeader("x-brave-partner", "foo"));
+}
+
+}  // namespace
+}  // namespace cors
+}  // namespace network

--- a/patches/services-network-public-cpp-cors-cors.cc.patch
+++ b/patches/services-network-public-cpp-cors-cors.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/services/network/public/cpp/cors/cors.cc b/services/network/public/cpp/cors/cors.cc
+index e0345d08067946debe655bf7ba2a85c70f29e93b..e63e251173b81493e66c4072f83f4027141fa1c0 100644
+--- a/services/network/public/cpp/cors/cors.cc
++++ b/services/network/public/cpp/cors/cors.cc
+@@ -412,6 +412,7 @@ bool IsCorsSafelistedHeader(const std::string& name, const std::string& value) {
+       "sec-ch-ua-platform",
+       "sec-ch-ua-arch",
+       "sec-ch-ua-model",
++      "x-brave-partner", // Prevent Allow-Cross-Origin-Request-Header failures
+   };
+   const std::string lower_name = base::ToLowerASCII(name);
+   if (std::find(std::begin(safe_names), std::end(safe_names), lower_name) ==

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -86,6 +86,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/extensions/browser/sandboxed_unpacker_unittest.cc",
     "//brave/chromium_src/extensions/common/permissions/permissions_data_unittest.cc",
     "//brave/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc",
+    "//brave/chromium_src/services/network/public/cpp/cors/cors_unittest.cc",
     "//brave/common/brave_content_client_unittest.cc",
     "//brave/common/importer/brave_mock_importer_bridge.cc",
     "//brave/common/importer/brave_mock_importer_bridge.h",


### PR DESCRIPTION
Uplift of #3434

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.