### PR TITLE
Ignore favicon changes for sync update

### DIFF
--- a/chromium_src/components/sync_bookmarks/bookmark_change_processor.cc
+++ b/chromium_src/components/sync_bookmarks/bookmark_change_processor.cc
@@ -36,28 +36,6 @@ class ScopedPauseObserver {
   BookmarkModelObserver* observer_;  // Not owned
 };
 
-bool IsFirstLoadedFavicon(BookmarkChangeProcessor* bookmark_change_processor,
-                          BookmarkModel* bookmark_model,
-                          const BookmarkNode* node) {
-  // Avoid sending duplicate records right after applying CREATE records,
-  // BookmarkChangeProcessor::SetBookmarkFavicon, put favicon data into database
-  // BookmarkNode::favicon() and BookmarkNode::icon_url() are available only
-  // after first successfuly BookmarkModel::GetFavicon() which means
-  // BookmarkModel::OnFaviconDataAvailable has image result available.
-  // So we set metainfo to know if it is first time favicon load after create
-  // node from remote record
-  std::string FirstLoadedFavicon;
-  if (node->GetMetaInfo("FirstLoadedFavicon", &FirstLoadedFavicon)) {
-    if (!node->icon_url())
-      return true;
-    ScopedPauseObserver pause(bookmark_model, bookmark_change_processor);
-    BookmarkNode* mutable_node = const_cast<BookmarkNode*>(node);
-    mutable_node->DeleteMetaInfo("FirstLoadedFavicon");
-    return true;
-  }
-  return false;
-}
-
 }  // namespace
 
 namespace sync_bookmarks {
@@ -91,7 +69,6 @@ void BookmarkChangeProcessor::MoveSyncNode(
 }  // namespace sync_bookmarks
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_BOOKMARK_NODE_FAVICON_CHANGED \
-  if (IsFirstLoadedFavicon(this, bookmark_model_, node))              \
     return;
 
 #define BRAVE_BOOKMARK_CHANGE_PROCESSOR_UPDATE_SYNC_NODE_PROPERTIES \
@@ -107,10 +84,7 @@ void BookmarkChangeProcessor::MoveSyncNode(
   brave_sync::AddBraveMetaInfo(child, model);              \
   SetSyncNodeMetaInfo(child, &sync_child);
 
-#define BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_1 \
-  bookmark_model_->SetNodeMetaInfo(dst, "FirstLoadedFavicon", "true");
-
-#define BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_2   \
+#define BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL   \
   int new_index =                                                         \
       brave_sync::GetIndexByCompareOrderStartFrom(parent, it->second, 0); \
   if (it->first != new_index) {                                           \
@@ -123,5 +97,4 @@ void BookmarkChangeProcessor::MoveSyncNode(
 #undef BRAVE_BOOKMARK_CHANGE_PROCESSOR_UPDATE_SYNC_NODE_PROPERTIES
 #undef BRAVE_BOOKMARK_CHANGE_PROCESSOR_BOOKMARK_NODE_MOVED
 #undef BRAVE_BOOKMARK_CHANGE_PROCESSOR_CHILDREN_REORDERED
-#undef BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_1
-#undef BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_2
+#undef BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL

--- a/patches/components-sync_bookmarks-bookmark_change_processor.cc.patch
+++ b/patches/components-sync_bookmarks-bookmark_change_processor.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/sync_bookmarks/bookmark_change_processor.cc b/components/sync_bookmarks/bookmark_change_processor.cc
-index 4363d682a7467ac0f501a06032d711278ab82b26..a9fa6d26854a32f526870a43441e631db6f28128 100644
+index 4363d682a7467ac0f501a06032d711278ab82b26..f655c50e84fd5ff1cd994577eff2eaf86a954544 100644
 --- a/components/sync_bookmarks/bookmark_change_processor.cc
 +++ b/components/sync_bookmarks/bookmark_change_processor.cc
 @@ -87,6 +87,7 @@ void BookmarkChangeProcessor::UpdateSyncNodeProperties(
@@ -42,19 +42,11 @@ index 4363d682a7467ac0f501a06032d711278ab82b26..a9fa6d26854a32f526870a43441e631d
        if (!PlaceSyncNode(MOVE, node, i, &trans, &sync_child,
                           model_associator_)) {
          syncer::SyncError error(FROM_HERE,
-@@ -720,6 +723,7 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
-                    << src.GetBookmarkSpecifics().url();
-         continue;
-       }
-+      BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_1
-       model_associator_->Associate(dst, src);
-     }
- 
-@@ -732,6 +736,7 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
+@@ -732,6 +735,7 @@ void BookmarkChangeProcessor::ApplyChangesFromSyncModel(
    // sync order, left to right, moving them into their proper positions.
    for (auto it = to_reposition.begin(); it != to_reposition.end(); ++it) {
      const BookmarkNode* parent = it->second->parent();
-+    BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL_2
++    BRAVE_BOOKMARK_CHANGE_PROCESSOR_APPLY_CHANGES_FROM_SYNC_MODEL
      model->Move(it->second, parent, size_t{it->first});
    }
  


### PR DESCRIPTION
Previously, we tried to ignore favicon changes after applying CREATE
sync record.
https://github.com/brave/brave-core/pull/2010/commits/2b431d6e787b0ebbc212d0c7a3d4807095d4f0d5
Right now we ignore all the favicon changes because we don't send
favicon image date in our sync record. favicon url is only used by muon.

fix https://github.com/brave/brave-browser/issues/6158

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Open `chrome://inspect/#extensions` on device A and device B
2. Sync device A and device B and inspect "Brave Sync" extension from step 1
3. After both devices are linked, bookmark "brave.com" on device A
4. Make sure device B apply record with action 0 and doesn't send extra update with action 1
5. Click the bookmark on device A or device B should not trigger any send event

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
