### PR TITLE
Workaround for `syncer::syncable::ChangeEntryIDAndUpdateChildren` LOG(FATAL) 

### DIFF
--- a/chromium_src/components/sync/engine_impl/process_updates_util.cc
+++ b/chromium_src/components/sync/engine_impl/process_updates_util.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// TODO(darkdh): investigate the records flow causing object id not applied to
+// local entry in CommitResponse
+
+#define BRAVE_PROCESS_UPDATE                                   \
+  DCHECK(false) << "Brave object id " << server_id             \
+                << " is not applied to local id " << local_id; \
+  return;
+
+#include "../../../../../components/sync/engine_impl/process_updates_util.cc"  // NOLINT
+#undef BRAVE_PROCESS_UPDATE

--- a/patches/components-sync-engine_impl-process_updates_util.cc.patch
+++ b/patches/components-sync-engine_impl-process_updates_util.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/engine_impl/process_updates_util.cc b/components/sync/engine_impl/process_updates_util.cc
+index 938f9a5ca2d2dd1602c80e6e032e6e5299a0f01f..78cfcaab4fd983cbbec63904fe765d1464f1b612 100644
+--- a/components/sync/engine_impl/process_updates_util.cc
++++ b/components/sync/engine_impl/process_updates_util.cc
+@@ -202,6 +202,7 @@ void ProcessUpdate(const sync_pb::SyncEntity& update,
+   // change the ID now, after we're sure that the update can succeed.
+   if (local_id != server_id) {
+     DCHECK(!update.deleted());
++    BRAVE_PROCESS_UPDATE
+     ChangeEntryIDAndUpdateChildren(trans, &target_entry, server_id);
+     // When IDs change, versions become irrelevant.  Forcing BASE_VERSION
+     // to zero would ensure that this update gets applied, but would indicate


### PR DESCRIPTION
because there is already a successfully applied object_id
entry but there is also an entry contains originator_client_item_id as
Id. That is why the entry cannot be updated by new id and cause the
conflict.

local_id should always equal to server_id in brave sync

resolve https://github.com/brave/brave-browser/issues/6091

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
