### PR TITLE
Fixing missing ads box on brave://rewards (0.70)

### DIFF
--- a/components/brave_rewards/resources/ui/components/adsBox.tsx
+++ b/components/brave_rewards/resources/ui/components/adsBox.tsx
@@ -280,11 +280,8 @@ class AdsBox extends React.Component<Props, State> {
     const toggle = !(!enabledMain || !adsUIEnabled || !adsIsSupported)
     const showDisabled = firstLoad !== false || !toggle || !adsEnabled || !adsIsSupported
 
-    if (!adsHistory) {
-      return null
-    }
-
-    const rows = this.getAdHistoryData(adsHistory, savedOnly)
+    const historyEntries = adsHistory || []
+    const rows = this.getAdHistoryData(historyEntries, savedOnly)
     const notEmpty = rows && rows.length !== 0
 
     return (


### PR DESCRIPTION
Uplift of: https://github.com/brave/brave-core/pull/3536
Fixes: https://github.com/brave/brave-browser/issues/6148