### PR TITLE
Workaround for `syncer::syncable::ChangeEntryIDAndUpdateChildren` LOG(FATAL) (uplift to 0.70.x)

### DIFF
--- a/chromium_src/components/sync/engine_impl/process_updates_util.cc
+++ b/chromium_src/components/sync/engine_impl/process_updates_util.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// TODO(darkdh): investigate the records flow causing object id not applied to
+// local entry in CommitResponse
+
+#define BRAVE_PROCESS_UPDATE                                   \
+  DCHECK(false) << "Brave object id " << server_id             \
+                << " is not applied to local id " << local_id; \
+  return;
+
+#include "../../../../../components/sync/engine_impl/process_updates_util.cc"  // NOLINT
+#undef BRAVE_PROCESS_UPDATE

--- a/patches/components-sync-engine_impl-process_updates_util.cc.patch
+++ b/patches/components-sync-engine_impl-process_updates_util.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/engine_impl/process_updates_util.cc b/components/sync/engine_impl/process_updates_util.cc
+index 938f9a5ca2d2dd1602c80e6e032e6e5299a0f01f..78cfcaab4fd983cbbec63904fe765d1464f1b612 100644
+--- a/components/sync/engine_impl/process_updates_util.cc
++++ b/components/sync/engine_impl/process_updates_util.cc
+@@ -202,6 +202,7 @@ void ProcessUpdate(const sync_pb::SyncEntity& update,
+   // change the ID now, after we're sure that the update can succeed.
+   if (local_id != server_id) {
+     DCHECK(!update.deleted());
++    BRAVE_PROCESS_UPDATE
+     ChangeEntryIDAndUpdateChildren(trans, &target_entry, server_id);
+     // When IDs change, versions become irrelevant.  Forcing BASE_VERSION
+     // to zero would ensure that this update gets applied, but would indicate


### PR DESCRIPTION
Uplift of #3538
Fixes https://github.com/brave/brave-browser/issues/6091

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.