### PR TITLE
Check if WaitableEvent is already Signaled before signal it (uplift to 0.70.x)

### DIFF
--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -977,7 +977,7 @@ void BraveProfileSyncServiceImpl::OnPollSyncCycle(GetRecordsCallback cb,
 
 void BraveProfileSyncServiceImpl::SignalWaitableEvent() {
   std::move(get_record_cb_);
-  if (wevent_) {
+  if (wevent_ && !wevent_->IsSignaled()) {
     wevent_->Signal();
     wevent_ = nullptr;
   }


### PR DESCRIPTION
Uplift of #3528
Fixes https://github.com/brave/brave-browser/issues/6169

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.