### PR TITLE
Disable password sign in promo disregarding sync status

### DIFF
--- a/chromium_src/components/password_manager/core/browser/password_bubble_experiment.cc
+++ b/chromium_src/components/password_manager/core/browser/password_bubble_experiment.cc
@@ -1,0 +1,24 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class PrefService;
+namespace syncer {
+class SyncService;
+}  // namespace syncer
+
+namespace password_bubble_experiment {
+
+bool ShouldShowChromeSignInPasswordPromo(
+    PrefService* prefs,
+    const syncer::SyncService* sync_service) {
+  return false;
+}
+
+}  // namespace password_bubble_experiment
+
+#define ShouldShowChromeSignInPasswordPromo \
+  ShouldShowChromeSignInPasswordPromo_ChromiumImpl
+#include "../../../../../../components/password_manager/core/browser/password_bubble_experiment.cc" // NOLINT
+#undef ShouldShowChromeSignInPasswordPromo

--- a/chromium_src/components/password_manager/core/browser/password_bubble_experiment_unittest.cc
+++ b/chromium_src/components/password_manager/core/browser/password_bubble_experiment_unittest.cc
@@ -1,0 +1,73 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/password_manager/core/browser/password_bubble_experiment.h"
+
+#include <ostream>
+
+#include "components/password_manager/core/common/password_manager_pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/sync/driver/test_sync_service.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace password_bubble_experiment {
+
+class PasswordManagerPasswordBubbleExperimentTest : public testing::Test {
+ public:
+  PasswordManagerPasswordBubbleExperimentTest() {
+    RegisterPrefs(pref_service_.registry());
+  }
+
+  PrefService* prefs() { return &pref_service_; }
+
+  syncer::TestSyncService* sync_service() { return &fake_sync_service_; }
+
+ private:
+  syncer::TestSyncService fake_sync_service_;
+  TestingPrefServiceSimple pref_service_;
+};
+
+TEST_F(PasswordManagerPasswordBubbleExperimentTest,
+       ShouldShowChromeSignInPasswordPromo) {
+  // By default the promo is off.
+  EXPECT_FALSE(ShouldShowChromeSignInPasswordPromo(prefs(), nullptr));
+  constexpr struct {
+    bool was_already_clicked;
+    bool is_sync_allowed;
+    bool is_first_setup_complete;
+    int current_shown_count;
+    bool result;
+  } kTestData[] = {
+      {false, true, false, 0, false},   {false, true, false, 5, false},
+      {true, true, false, 0, false},   {true, true, false, 10, false},
+      {false, false, false, 0, false}, {false, true, true, 0, false},
+  };
+  for (const auto& test_case : kTestData) {
+    SCOPED_TRACE(testing::Message("#test_case = ") << (&test_case - kTestData));
+    prefs()->SetBoolean(password_manager::prefs::kWasSignInPasswordPromoClicked,
+                        test_case.was_already_clicked);
+    prefs()->SetInteger(
+        password_manager::prefs::kNumberSignInPasswordPromoShown,
+        test_case.current_shown_count);
+    sync_service()->SetDisableReasons(
+        test_case.is_sync_allowed
+            ? syncer::SyncService::DISABLE_REASON_NONE
+            : syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY);
+    sync_service()->SetFirstSetupComplete(test_case.is_first_setup_complete);
+    sync_service()->SetTransportState(
+        test_case.is_first_setup_complete
+            ? syncer::SyncService::TransportState::ACTIVE
+            : syncer::SyncService::TransportState::
+                  PENDING_DESIRED_CONFIGURATION);
+
+    EXPECT_EQ(test_case.result,
+              ShouldShowChromeSignInPasswordPromo(prefs(), sync_service()));
+  }
+}
+
+}  // namespace password_bubble_experiment

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -79,6 +79,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
     "//brave/chromium_src/components/autofill/core/browser/autofill_experiments_unittest.cc",
     "//brave/chromium_src/components/metrics/enabled_state_provider_unittest.cc",
+    "//brave/chromium_src/components/password_manager/core/browser/password_bubble_experiment_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/variations/service/field_trial_unittest.cc",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/5849

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Make sure `Offer to save passwords` is enabled in brave://settings/passwords and setup brave sync
2. Login into a website
3. There should be a prompt asking whether to save password, **click Save**
<img width="323" alt="Screen Shot 2019-09-30 at 13 43 47" src="https://user-images.githubusercontent.com/11330831/65915540-7fc22c80-e388-11e9-88d7-0dc5a8dd7a98.png">
4. There shouldn't be any prompt asking to sign in, now click on the key icon, we should see
<img width="319" alt="Screen Shot 2019-09-30 at 13 44 09" src="https://user-images.githubusercontent.com/11330831/65915610-a3857280-e388-11e9-86b2-4e8414a2e58a.png">


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
