### PR TITLE
Fix profile avatars getting button style overrides instead of avatar circles

### DIFF
--- a/ui/webui/resources/polymer_overriding.html
+++ b/ui/webui/resources/polymer_overriding.html
@@ -35,7 +35,11 @@
         }
       }
       /* Default button */
-      :host {
+      /* Ignore buttons with style attribute as they are most likely
+          buttons that are copmletely overriding the default button
+          style, e.g. avatar icons. See
+          https://github.com/brave/brave-browser/issues/5977. */
+      :host(:not([style])) {
         font-family: Muli !important;
         border-radius: 20px !important;
         border: 1px solid;
@@ -43,20 +47,20 @@
         color: var(--brave-text-color) !important;
         outline: none;
       }
-      :host-context(.focus-outline-visible):host(:focus) {
+      :host-context(.focus-outline-visible):host(:not([style]):focus) {
         box-shadow: 0 0 0 3px var(--brave-focus-outline) !important;
       }
       /* Action button */
-      :host(.action-button) {
+      :host(:not([style]).action-button) {
         background-color: var(--brave-brand-color) !important;
         color: #ffffff !important;
         border: none !important;
       }
-      :host(.action-button:hover) {
+      :host(:not([style]).action-button:hover) {
         background: var(--brave-primary-hover) !important;
       }
       /* Not-action button */
-      :host(:not(.action-button):hover) {
+      :host(:not(.action-button, [style]):hover) {
         background: none !important;
         border-color: var(--brave-brand-color) !important;
         color: var(--brave-brand-color) !important;


### PR DESCRIPTION
This restricts our button style overrides to only buttons without a style attribute.

Fix https://github.com/brave/brave-browser/issues/5977

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
On https://github.com/brave/brave-browser/issues/5977

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
