### PR TITLE
Disable password sign in promo disregarding sync status (uplift to 0.70.x)

### DIFF
--- a/chromium_src/components/password_manager/core/browser/password_bubble_experiment.cc
+++ b/chromium_src/components/password_manager/core/browser/password_bubble_experiment.cc
@@ -1,0 +1,24 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class PrefService;
+namespace syncer {
+class SyncService;
+}  // namespace syncer
+
+namespace password_bubble_experiment {
+
+bool ShouldShowChromeSignInPasswordPromo(
+    PrefService* prefs,
+    const syncer::SyncService* sync_service) {
+  return false;
+}
+
+}  // namespace password_bubble_experiment
+
+#define ShouldShowChromeSignInPasswordPromo \
+  ShouldShowChromeSignInPasswordPromo_ChromiumImpl
+#include "../../../../../../components/password_manager/core/browser/password_bubble_experiment.cc" // NOLINT
+#undef ShouldShowChromeSignInPasswordPromo

--- a/chromium_src/components/password_manager/core/browser/password_bubble_experiment_unittest.cc
+++ b/chromium_src/components/password_manager/core/browser/password_bubble_experiment_unittest.cc
@@ -1,0 +1,73 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/password_manager/core/browser/password_bubble_experiment.h"
+
+#include <ostream>
+
+#include "components/password_manager/core/common/password_manager_pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/sync/driver/test_sync_service.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace password_bubble_experiment {
+
+class PasswordManagerPasswordBubbleExperimentTest : public testing::Test {
+ public:
+  PasswordManagerPasswordBubbleExperimentTest() {
+    RegisterPrefs(pref_service_.registry());
+  }
+
+  PrefService* prefs() { return &pref_service_; }
+
+  syncer::TestSyncService* sync_service() { return &fake_sync_service_; }
+
+ private:
+  syncer::TestSyncService fake_sync_service_;
+  TestingPrefServiceSimple pref_service_;
+};
+
+TEST_F(PasswordManagerPasswordBubbleExperimentTest,
+       ShouldShowChromeSignInPasswordPromo) {
+  // By default the promo is off.
+  EXPECT_FALSE(ShouldShowChromeSignInPasswordPromo(prefs(), nullptr));
+  constexpr struct {
+    bool was_already_clicked;
+    bool is_sync_allowed;
+    bool is_first_setup_complete;
+    int current_shown_count;
+    bool result;
+  } kTestData[] = {
+      {false, true, false, 0, false},   {false, true, false, 5, false},
+      {true, true, false, 0, false},   {true, true, false, 10, false},
+      {false, false, false, 0, false}, {false, true, true, 0, false},
+  };
+  for (const auto& test_case : kTestData) {
+    SCOPED_TRACE(testing::Message("#test_case = ") << (&test_case - kTestData));
+    prefs()->SetBoolean(password_manager::prefs::kWasSignInPasswordPromoClicked,
+                        test_case.was_already_clicked);
+    prefs()->SetInteger(
+        password_manager::prefs::kNumberSignInPasswordPromoShown,
+        test_case.current_shown_count);
+    sync_service()->SetDisableReasons(
+        test_case.is_sync_allowed
+            ? syncer::SyncService::DISABLE_REASON_NONE
+            : syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY);
+    sync_service()->SetFirstSetupComplete(test_case.is_first_setup_complete);
+    sync_service()->SetTransportState(
+        test_case.is_first_setup_complete
+            ? syncer::SyncService::TransportState::ACTIVE
+            : syncer::SyncService::TransportState::
+                  PENDING_DESIRED_CONFIGURATION);
+
+    EXPECT_EQ(test_case.result,
+              ShouldShowChromeSignInPasswordPromo(prefs(), sync_service()));
+  }
+}
+
+}  // namespace password_bubble_experiment

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -78,6 +78,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/chrome/browser/ui/bookmarks/brave_bookmark_context_menu_controller_unittest.cc",
     "//brave/chromium_src/components/metrics/enabled_state_provider_unittest.cc",
+    "//brave/chromium_src/components/password_manager/core/browser/password_bubble_experiment_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc",
     "//brave/chromium_src/components/search_engines/brave_template_url_service_util_unittest.cc",
     "//brave/chromium_src/components/variations/service/field_trial_unittest.cc",


### PR DESCRIPTION
Uplift of #3566
Fixes https://github.com/brave/brave-browser/issues/5849

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.