### PR TITLE
[0.71.x] ensure topSites list rendering evaluate to `null` when its hidden

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -174,7 +174,7 @@ class NewTabPage extends React.Component<Props, State> {
               hideWidget={this.toggleShowClock}
               menuPosition={'left'}
             />
-            {this.props.newTabData.gridSites.length && <List
+            {this.props.newTabData.gridSites.length ? <List
               blockNumber={this.props.newTabData.gridSites.length}
               textDirection={newTabData.textDirection}
               showWidget={newTabData.showTopSites}
@@ -200,7 +200,7 @@ class NewTabPage extends React.Component<Props, State> {
                   />
                 )
               }
-            </List>}
+            </List> : null}
             {
               this.props.newTabData.showSiteRemovalNotification
               ? <SiteRemovalNotification actions={actions} />


### PR DESCRIPTION
uplift request for https://github.com/brave/brave-core/pull/3297
fix https://github.com/brave/brave-browser/issues/5710 on 0.71.x