### PR TITLE
Enable Closing all tabs closes Brave option

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -12,6 +12,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java",
   "../../brave/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageView.java",
+  "../../brave/android/java/org/chromium/chrome/browser/partnercustomizations/CloseBraveManager.java",
   "../../brave/android/java/org/chromium/chrome/browser/preferences/BackgroundVideoPlaybackPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/preferences/BraveMainPreferencesBase.java",
   "../../brave/android/java/org/chromium/chrome/browser/preferences/BravePreferenceManager.java",

--- a/android/java/org/chromium/chrome/browser/partnercustomizations/CloseBraveManager.java
+++ b/android/java/org/chromium/chrome/browser/partnercustomizations/CloseBraveManager.java
@@ -1,0 +1,37 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.partnercustomizations;
+
+import android.content.SharedPreferences;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.chrome.browser.ntp.NewTabPage;
+
+public class CloseBraveManager {
+    private static final String CLOSING_ALL_TABS_CLOSES_BRAVE = "closing_all_tabs_closes_brave";
+
+    // When NTP is set as home page, we don't close brave always.
+    // Otherwise, follow option value.
+    public static boolean shouldCloseAppWithZeroTabs() {
+        if (HomepageManager.isHomepageEnabled() &&
+                NewTabPage.isNTPUrl(HomepageManager.getHomepageUri())) {
+            return false;
+        }
+
+        return getClosingAllTabsClosesBraveEnabled();
+    }
+
+    public static boolean getClosingAllTabsClosesBraveEnabled() {
+        return ContextUtils.getAppSharedPreferences().getBoolean(CLOSING_ALL_TABS_CLOSES_BRAVE, false);
+    }
+
+    public static void setClosingAllTabsClosesBraveEnabled(boolean enable) {
+        SharedPreferences.Editor sharedPreferencesEditor =
+            ContextUtils.getAppSharedPreferences().edit();
+        sharedPreferencesEditor.putBoolean(CLOSING_ALL_TABS_CLOSES_BRAVE, enable);
+        sharedPreferencesEditor.apply();
+    }
+}

--- a/android/java/org/chromium/chrome/browser/preferences/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/preferences/BraveMainPreferencesBase.java
@@ -131,6 +131,6 @@ public class BraveMainPreferencesBase extends PreferenceFragmentCompat {
         Preference p = findPreference(PREF_BACKGROUND_VIDEO_PLAYBACK);
         p.setSummary(R.string.prefs_background_video_playback_summary_enabled);
         p = findPreference(PREF_CLOSING_ALL_TABS_CLOSES_BRAVE);
-        p.setSummary(R.string.prefs_closing_all_tabs_closes_brave_summary_enabled);
+        p.setSummary(ClosingAllTabsClosesBravePreference.getPreferenceSummary());
     }
 }

--- a/android/java/org/chromium/chrome/browser/preferences/ClosingAllTabsClosesBravePreference.java
+++ b/android/java/org/chromium/chrome/browser/preferences/ClosingAllTabsClosesBravePreference.java
@@ -1,3 +1,8 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.chromium.chrome.browser.preferences;
 
 import android.os.Bundle;
@@ -6,10 +11,17 @@ import android.support.v7.preference.PreferenceFragmentCompat;
 
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.preferences.ChromeSwitchPreferenceCompat;
+import org.chromium.chrome.browser.partnercustomizations.CloseBraveManager;
 
 public class ClosingAllTabsClosesBravePreference
         extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener {
     private static final String CLOSING_ALL_TABS_CLOSES_BRAVE_KEY = "closing_all_tabs_closes_brave";
+
+    public static int getPreferenceSummary() {
+        return CloseBraveManager.getClosingAllTabsClosesBraveEnabled()
+                ? R.string.prefs_closing_all_tabs_closes_brave_summary_enabled
+                : R.string.prefs_closing_all_tabs_closes_brave_summary_disabled;
+    }
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -18,12 +30,13 @@ public class ClosingAllTabsClosesBravePreference
 
         ChromeSwitchPreferenceCompat pref =
                 (ChromeSwitchPreferenceCompat) findPreference(CLOSING_ALL_TABS_CLOSES_BRAVE_KEY);
-        pref.setChecked(true);
+        pref.setChecked(CloseBraveManager.getClosingAllTabsClosesBraveEnabled());
         pref.setOnPreferenceChangeListener(this);
     }
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
+        CloseBraveManager.setClosingAllTabsClosesBraveEnabled((boolean) newValue);
         return true;
     }
 }

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-partnercustomizations-HomepageManager.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-partnercustomizations-HomepageManager.java.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/HomepageManager.java b/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/HomepageManager.java
+index deb4b5594e41ed3f5f1d2ffb7b2df012d1e522d2..da829ac6616bc1e99a69c4ada39e173e8f5812e2 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/HomepageManager.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/partnercustomizations/HomepageManager.java
+@@ -94,8 +94,9 @@ public class HomepageManager {
+      * @return Whether to close the app when the user has zero tabs.
+      */
+     public static boolean shouldCloseAppWithZeroTabs() {
+-        return HomepageManager.isHomepageEnabled()
+-                && !NewTabPage.isNTPUrl(HomepageManager.getHomepageUri());
++        return CloseBraveManager.shouldCloseAppWithZeroTabs();
++        // return HomepageManager.isHomepageEnabled()
++        //         && !NewTabPage.isNTPUrl(HomepageManager.getHomepageUri());
+     }
+ 
+     /**


### PR DESCRIPTION
When NTP is set as home page, we don't close brave always.
Otherwise, follow option value regardless of homepage settings.

Issue: Issue: https://github.com/brave/brave-browser/issues/6293

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
