### PR TITLE
Remove fail-safe WaitableEvent::TimedWait() because

### DIFF
--- a/chromium_src/components/sync/engine_impl/syncer.cc
+++ b/chromium_src/components/sync/engine_impl/syncer.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/bind.h"
-#include "base/time/time.h"
 
 #include "../../../../../components/sync/engine_impl/syncer.cc"  // NOLINT
 
@@ -29,12 +28,7 @@ void Syncer::DownloadBraveRecords(SyncCycle* cycle) {
       base::BindOnce(&Syncer::OnGetRecords, base::Unretained(this));
   base::WaitableEvent wevent;
   cycle->delegate()->OnPollSyncCycle(std::move(on_get_records), &wevent);
-  // Make sure OnGetRecords will be the next task on sync thread
-  // it will timeout in 3 mins to prevent sync thread from being blocked as
-  // fail-safe
-  bool result = wevent.TimedWait(base::TimeDelta::FromMinutes(3));
-  if (!result)
-    LOG(WARNING) << "WaitableEvent timed out";
+  wevent.Wait();
 }
 
 }  // namespace syncer


### PR DESCRIPTION
BraveProfileSyncServiceImpl::SignalWaitableEvent() will hold invalid memory address
after WaitableEvent timed out and goes out of scope.
OnConnectionChanged(), Shutdown() and ResetSyncInternal() already handle
the cases when we might not have `resolve-sync-records` callback from js
sync library

fix https://github.com/brave/brave-browser/issues/6367

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Establish sync chain
2. Open chrome://inspect#extensions, make sure you see `"sync-debug" message="success"`
3. Make OS goes offline for 3-4 minutes or more until you see ` "Uncaught (in promise) TypeError: Failed to fetch",` from inspector console
4. Make OS goes online
5. Wait for around 1-2 minutes, you should see `"fetch-sync-records" category_names=["BOOKMARKS"]...` from inspector console

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [x] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
