### PR TITLE
Lazy load WebTorrent component on first load of .torrent or magnet scheme (uplift to 0.71.x)

### DIFF
--- a/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
+++ b/browser/autocomplete/brave_autocomplete_scheme_classifier.cc
@@ -43,7 +43,7 @@ BraveAutocompleteSchemeClassifier::GetInputTypeForScheme(
 
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
   if (base::IsStringASCII(scheme) &&
-      webtorrent::IsWebtorrentEnabled(profile_) &&
+      webtorrent::IsWebtorrentPrefEnabled(profile_) &&
       base::LowerCaseEqualsASCII(scheme, kMagnetScheme)) {
     return metrics::OmniboxInputType::URL;
   }

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -71,6 +71,7 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
 #include "brave/components/brave_webtorrent/browser/content_browser_client_helper.h"
+#include "brave/browser/extensions/brave_webtorrent_navigation_throttle.h"
 #endif
 
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
@@ -363,6 +364,11 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
   throttles.push_back(
       std::make_unique<extensions::BraveWalletNavigationThrottle>(handle));
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
+  throttles.push_back(
+      std::make_unique<extensions::BraveWebTorrentNavigationThrottle>(handle));
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -284,6 +284,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
                        ReverseRewriteTorrentURL) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
+
+  // Used to add the extension
+  ui_test_utils::NavigateToURL(browser(), magnet_url());
+  ASSERT_TRUE(WaitForLoadStop(contents));
+
   ui_test_utils::NavigateToURL(browser(), torrent_extension_url());
   ASSERT_TRUE(WaitForLoadStop(contents));
 
@@ -298,10 +303,19 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
-                       WebTorrentExtensionEnabledByDefault) {
+                       WebTorrentExtensionEnabledAfterLoad) {
   ASSERT_TRUE(browser()->profile()->GetPrefs()->GetBoolean(kWebTorrentEnabled));
+
   extensions::ExtensionRegistry* registry =
       extensions::ExtensionRegistry::Get(browser()->profile());
+  ASSERT_FALSE(
+      registry->enabled_extensions().Contains(brave_webtorrent_extension_id));
+
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  ui_test_utils::NavigateToURL(browser(), magnet_url());
+  WaitForLoadStop(contents);
+
   ASSERT_TRUE(
       registry->enabled_extensions().Contains(brave_webtorrent_extension_id));
 }

--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -93,8 +93,13 @@ source_set("extensions") {
   }
   if (enable_brave_webtorrent) {
     deps += [
+      "//brave/components/brave_webtorrent/browser",
       "//brave/components/brave_webtorrent:generated_resources",
       "//brave/components/brave_webtorrent:static_resources",
+    ]
+    sources += [
+      "brave_webtorrent_navigation_throttle.cc",
+      "brave_webtorrent_navigation_throttle.h",
     ]
   }
 }

--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -97,15 +97,6 @@ void BraveComponentLoader::AddDefaultComponentExtensions(
   }
 #endif
 
-  if (!command_line.HasSwitch(switches::kDisableWebTorrentExtension) &&
-      (!profile_prefs_->FindPreference(kWebTorrentEnabled) ||
-      profile_prefs_->GetBoolean(kWebTorrentEnabled))) {
-    base::FilePath brave_webtorrent_path(FILE_PATH_LITERAL(""));
-    brave_webtorrent_path =
-      brave_webtorrent_path.Append(FILE_PATH_LITERAL("brave_webtorrent"));
-    Add(IDR_BRAVE_WEBTORRENT, brave_webtorrent_path);
-  }
-
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
   // If brave://wallet has been loaded at least once, then load it again.
   if (ExtensionPrefs::Get(profile_)->
@@ -124,5 +115,18 @@ void BraveComponentLoader::AddEthereumRemoteClientExtension() {
   }
 }
 #endif
+
+void BraveComponentLoader::AddWebTorrentExtension() {
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  if (!command_line.HasSwitch(switches::kDisableWebTorrentExtension) &&
+      (!profile_prefs_->FindPreference(kWebTorrentEnabled) ||
+      profile_prefs_->GetBoolean(kWebTorrentEnabled))) {
+    base::FilePath brave_webtorrent_path(FILE_PATH_LITERAL(""));
+    brave_webtorrent_path =
+      brave_webtorrent_path.Append(FILE_PATH_LITERAL("brave_webtorrent"));
+    Add(IDR_BRAVE_WEBTORRENT, brave_webtorrent_path);
+  }
+}
 
 }  // namespace extensions

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -32,6 +32,7 @@ class BraveComponentLoader : public ComponentLoader {
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
   void AddEthereumRemoteClientExtension();
 #endif
+  void AddWebTorrentExtension();
   void OnComponentReady(std::string extension_id,
     bool allow_file_access,
     const base::FilePath& install_dir,

--- a/browser/extensions/brave_webtorrent_navigation_throttle.cc
+++ b/browser/extensions/brave_webtorrent_navigation_throttle.cc
@@ -1,0 +1,117 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/extensions/brave_webtorrent_navigation_throttle.h"
+
+#include "base/bind.h"
+#include "brave/browser/extensions/brave_component_loader.h"
+#include "brave/browser/profiles/profile_util.h"
+#include "brave/common/extensions/extension_constants.h"
+#include "brave/common/pref_names.h"
+#include "brave/common/url_constants.h"
+#include "brave/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper.h"
+#include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
+#include "chrome/browser/extensions/extension_service.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/common/url_constants.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/browser/extension_system.h"
+#include "extensions/common/extension.h"
+
+namespace extensions {
+
+BraveWebTorrentNavigationThrottle::BraveWebTorrentNavigationThrottle(
+        content::NavigationHandle* navigation_handle) :
+    content::NavigationThrottle(navigation_handle),
+    extension_registry_observer_(this),
+    resume_pending_(false) {
+  extension_registry_observer_.Add(
+      ExtensionRegistry::Get(
+          navigation_handle->GetWebContents()->GetBrowserContext()));
+}
+
+BraveWebTorrentNavigationThrottle::~BraveWebTorrentNavigationThrottle() {
+  timer_.Stop();
+}
+
+content::NavigationThrottle::ThrottleCheckResult
+BraveWebTorrentNavigationThrottle::WillStartRequest() {
+  // This handles magnet URLs and .torrent filenames in the URL but not
+  // response headers.
+  return CommonWillProcessRequestResponse();
+}
+
+content::NavigationThrottle::ThrottleCheckResult
+BraveWebTorrentNavigationThrottle::WillProcessResponse() {
+  // This handles response headers with headers that indicate torrent content.
+  // This is not as good as if we catch it in the WillStartRequest section
+  // because the user will need to manually restart the request to make it work.
+  return CommonWillProcessRequestResponse();
+}
+
+content::NavigationThrottle::ThrottleCheckResult
+BraveWebTorrentNavigationThrottle::CommonWillProcessRequestResponse() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  content::WebContents* web_contents = navigation_handle()->GetWebContents();
+
+  // Is this navigation targeting an extension resource?
+  const GURL& url = navigation_handle()->GetURL();
+  // Note, if we use WillProcessResponse we can also use response headers, but
+  // it would be too late to handle the request as WebTorrent in that case.
+  // So the best we can do is via URL pattern match and magnet links.
+  // Headers are null when processing WillStartRequest.
+  auto* headers = navigation_handle()->GetResponseHeaders();
+  bool is_torrent_file = headers ? webtorrent::IsTorrentFile(url, headers) :
+      webtorrent::TorrentURLMatched(url);
+  if (url.SchemeIs(kMagnetScheme) || is_torrent_file) {
+    // If the WebTorrent pref is enabled, but the extension is not,
+    // then enable the extension at this time!
+    content::BrowserContext* browser_context =
+        web_contents->GetBrowserContext();
+    if (webtorrent::IsWebtorrentPrefEnabled(browser_context) &&
+        !webtorrent::IsWebtorrentEnabled(browser_context)) {
+      auto* registry = ExtensionRegistry::Get(browser_context);
+      if (!registry->ready_extensions().GetByID(
+            brave_webtorrent_extension_id)) {
+        resume_pending_ = true;
+        extensions::ExtensionService* service =
+           extensions::ExtensionSystem::Get(
+               browser_context)->extension_service();
+        if (service) {
+          extensions::ComponentLoader* loader = service->component_loader();
+          static_cast<extensions::BraveComponentLoader*>(loader)->
+              AddWebTorrentExtension();
+        }
+        return content::NavigationThrottle::DEFER;
+      }
+    }
+  }
+  return content::NavigationThrottle::PROCEED;
+}
+
+const char* BraveWebTorrentNavigationThrottle::GetNameForLogging() {
+  return "BraveWebTorrentNavigationThrottle";
+}
+
+void BraveWebTorrentNavigationThrottle::OnExtensionReady(
+    content::BrowserContext* browser_context,
+    const Extension* extension) {
+  if (resume_pending_ &&
+      extension->id() == brave_webtorrent_extension_id) {
+    ResumeThrottle();
+  }
+}
+
+void BraveWebTorrentNavigationThrottle::ResumeThrottle() {
+  timer_.Stop();
+  resume_pending_ = false;
+  Resume();
+}
+
+}  // namespace extensions

--- a/browser/extensions/brave_webtorrent_navigation_throttle.h
+++ b/browser/extensions/brave_webtorrent_navigation_throttle.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_EXTENSIONS_BRAVE_WEBTORRENT_NAVIGATION_THROTTLE_H_
+#define BRAVE_BROWSER_EXTENSIONS_BRAVE_WEBTORRENT_NAVIGATION_THROTTLE_H_
+
+#include "base/macros.h"
+#include "base/timer/timer.h"
+#include "content/public/browser/navigation_throttle.h"
+#include "extensions/browser/test_extension_registry_observer.h"
+
+namespace content {
+class NavigationHandle;
+}
+
+namespace extensions {
+
+// This class enables the WebTorrent component when a .torrent
+// or magnet file is loaded.
+class BraveWebTorrentNavigationThrottle : public content::NavigationThrottle,
+                                          public ExtensionRegistryObserver {
+ public:
+  explicit BraveWebTorrentNavigationThrottle(
+      content::NavigationHandle* navigation_handle);
+  ~BraveWebTorrentNavigationThrottle() override;
+
+  // content::NavigationThrottle implementation:
+  ThrottleCheckResult WillStartRequest() override;
+  ThrottleCheckResult WillProcessResponse() override;
+  const char* GetNameForLogging() override;
+
+ private:
+  ThrottleCheckResult CommonWillProcessRequestResponse();
+  void ResumeThrottle();
+
+  // ExtensionRegistryObserver:
+  void OnExtensionReady(content::BrowserContext* browser_context,
+                        const extensions::Extension* extension) override;
+  ScopedObserver<ExtensionRegistry, ExtensionRegistryObserver>
+    extension_registry_observer_;
+  bool resume_pending_;
+  base::OneShotTimer timer_;
+  DISALLOW_COPY_AND_ASSIGN(BraveWebTorrentNavigationThrottle);
+};
+
+}  // namespace extensions
+
+#endif  // BRAVE_BROWSER_EXTENSIONS_BRAVE_WEBTORRENT_NAVIGATION_THROTTLE_H_

--- a/browser/extensions/brave_webtorrent_navigation_throttle_unittest.cc
+++ b/browser/extensions/brave_webtorrent_navigation_throttle_unittest.cc
@@ -1,0 +1,194 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/extensions/brave_webtorrent_navigation_throttle.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "brave/browser/profiles/brave_profile_manager.h"
+#include "brave/browser/profiles/profile_util.h"
+#include "brave/common/extensions/extension_constants.h"
+#include "brave/common/pref_names.h"
+#include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "chrome/test/base/scoped_testing_local_state.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/common/content_client.h"
+#include "content/public/test/mock_navigation_handle.h"
+#include "content/public/test/web_contents_tester.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/common/extension.h"
+#include "extensions/common/extension_builder.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+using content::NavigationThrottle;
+
+namespace extensions {
+
+namespace {
+
+class MockBrowserClient : public content::ContentBrowserClient {
+ public:
+  MockBrowserClient() {}
+  ~MockBrowserClient() override {}
+
+  // Only construct an BraveWebTorrentNavigationThrottle so that we can test it
+  // in isolation.
+  std::vector<std::unique_ptr<NavigationThrottle>> CreateThrottlesForNavigation(
+      content::NavigationHandle* handle) override {
+    std::vector<std::unique_ptr<NavigationThrottle>> throttles;
+    throttles.push_back(
+        std::make_unique<BraveWebTorrentNavigationThrottle>(handle));
+    return throttles;
+  }
+};
+
+GURL magnet_url("magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fbig-buck-bunny.torrent");  // NOLINT
+GURL torrent_url("https://webtorrent.io/torrents/big-buck-bunny.torrent");
+
+}  // namespace
+
+class BraveWebTorrentNavigationThrottleUnitTest
+    : public ChromeRenderViewHostTestHarness {
+ public:
+  BraveWebTorrentNavigationThrottleUnitTest()
+      : local_state_(TestingBrowserProcess::GetGlobal()) {
+  }
+
+  void SetUp() override {
+    original_client_ = content::SetBrowserClientForTesting(&client_);
+    ChromeRenderViewHostTestHarness::SetUp();
+  }
+
+  content::BrowserContext* CreateBrowserContext() override {
+    TestingProfile::Builder builder;
+    auto prefs =
+        std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
+    RegisterUserProfilePrefs(prefs->registry());
+    builder.SetPrefService(std::move(prefs));
+    return builder.Build().release();
+  }
+
+  void TearDown() override {
+    content::SetBrowserClientForTesting(original_client_);
+    ChromeRenderViewHostTestHarness::TearDown();
+  }
+
+  content::RenderFrameHostTester* render_frame_host_tester(
+      content::RenderFrameHost* host) {
+    return content::RenderFrameHostTester::For(host);
+  }
+
+  content::WebContentsTester* web_contents_tester() {
+    return content::WebContentsTester::For(web_contents());
+  }
+
+  void AddExtension() {
+    DictionaryBuilder manifest;
+    manifest.Set("name", "ext")
+        .Set("version", "0.1")
+        .Set("manifest_version", 2);
+    extension_ = ExtensionBuilder()
+                     .SetManifest(manifest.Build())
+                     .SetID(brave_webtorrent_extension_id)
+                     .Build();
+    ASSERT_TRUE(extension_);
+    ExtensionRegistry::Get(browser_context())->AddReady(extension_.get());
+  }
+
+ private:
+  scoped_refptr<const Extension> extension_;
+  MockBrowserClient client_;
+  content::ContentBrowserClient* original_client_;
+  ScopedTestingLocalState local_state_;
+  base::ScopedTempDir temp_dir_;
+  sync_preferences::TestingPrefServiceSyncable prefs_;
+  DISALLOW_COPY_AND_ASSIGN(BraveWebTorrentNavigationThrottleUnitTest);
+};
+
+// Tests the basic case of loading a URL, it should proceed.
+TEST_F(BraveWebTorrentNavigationThrottleUnitTest, ExternalWebPage) {
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* host =
+      render_frame_host_tester(main_rfh())->AppendChild("child");
+  GURL url("http://www.example.com");
+  content::MockNavigationHandle test_handle(url, host);
+  test_handle.set_starting_site_instance(host->GetSiteInstance());
+  auto throttle =
+      std::make_unique<BraveWebTorrentNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << url;
+}
+
+// Tests the case of loading a torrent without having the extension
+// installed. It should defer which it does to install the extension.
+TEST_F(BraveWebTorrentNavigationThrottleUnitTest,
+    WebTorrentUrlNotInstalled) {
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* host =
+      render_frame_host_tester(main_rfh())->AppendChild("child");
+  content::MockNavigationHandle test_handle(torrent_url, host);
+  test_handle.set_starting_site_instance(host->GetSiteInstance());
+  auto throttle =
+      std::make_unique<BraveWebTorrentNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::DEFER, throttle->WillStartRequest().action())
+      << torrent_url;
+}
+
+// Tests the case of loading a torrent without having the extension
+// installed. It should defer which it does to install the extension.
+TEST_F(BraveWebTorrentNavigationThrottleUnitTest,
+    WebTorrentMagnetUrlNotInstalled) {
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* host =
+      render_frame_host_tester(main_rfh())->AppendChild("child");
+  content::MockNavigationHandle test_handle(magnet_url, host);
+  test_handle.set_starting_site_instance(host->GetSiteInstance());
+  auto throttle =
+      std::make_unique<BraveWebTorrentNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::DEFER, throttle->WillStartRequest().action())
+      << magnet_url;
+}
+
+
+// Tests the case of loading a torrent with the extension installed.
+// It should just proceed.
+TEST_F(BraveWebTorrentNavigationThrottleUnitTest, WebTorrentUrlInstalled) {
+  AddExtension();
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* host =
+      render_frame_host_tester(main_rfh())->AppendChild("child");
+  content::MockNavigationHandle test_handle(magnet_url, host);
+  test_handle.set_starting_site_instance(host->GetSiteInstance());
+  auto throttle =
+      std::make_unique<BraveWebTorrentNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
+      << magnet_url;
+}
+
+// Tests the case of loading a torrent when the WebTorrent is explicitly
+// disabled.
+TEST_F(BraveWebTorrentNavigationThrottleUnitTest, WebTorrentDisabledByPref) {
+  profile()->GetPrefs()->SetBoolean(kWebTorrentEnabled, false);
+  web_contents_tester()->NavigateAndCommit(GURL("http://example.com"));
+  content::RenderFrameHost* host =
+      render_frame_host_tester(main_rfh())->AppendChild("child");
+  content::MockNavigationHandle test_handle(magnet_url, host);
+  test_handle.set_starting_site_instance(host->GetSiteInstance());
+  auto throttle =
+      std::make_unique<BraveWebTorrentNavigationThrottle>(&test_handle);
+  EXPECT_EQ(NavigationThrottle::PROCEED,
+      throttle->WillStartRequest().action()) << magnet_url;
+}
+
+}  // namespace extensions

--- a/components/brave_webtorrent/browser/BUILD.gn
+++ b/components/brave_webtorrent/browser/BUILD.gn
@@ -9,6 +9,7 @@ source_set("browser") {
     "//base",
     "//brave/common",
     "//components/pref_registry",
+    "//components/prefs",
     "//content/public/browser",
     "//extensions/browser",
     "//extensions/common",

--- a/components/brave_webtorrent/browser/net/BUILD.gn
+++ b/components/brave_webtorrent/browser/net/BUILD.gn
@@ -7,6 +7,7 @@ source_set("net") {
   deps = [
     "//base",
     "//brave/common",
+    "//brave/components/brave_webtorrent/browser",
     "//extensions/browser",
     "//net",
   ]

--- a/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
+++ b/components/brave_webtorrent/browser/net/brave_torrent_redirect_network_delegate_helper_unittest.cc
@@ -44,14 +44,14 @@ class BraveTorrentRedirectNetworkDelegateHelperTest: public testing::Test {
 
     torrent_extension_url_ = GURL(
         "chrome-extension://lgjmpdmojkpocjcopdikifhejkkjglho/extension/"
-        "brave_webtorrent.html?https://webtorrent.io/torrents/sintel.torrent");
+        "brave_webtorrent2.html?https://webtorrent.io/torrents/sintel.torrent");
     torrent_viewer_extension_url_ = GURL(
         "chrome-extension://lgjmpdmojkpocjcopdikifhejkkjglho/extension/"
-        "brave_webtorrent.html?https://webtorrent.io/torrents/sintel.torrent"
+        "brave_webtorrent2.html?https://webtorrent.io/torrents/sintel.torrent"
         "#ix=0");
     non_torrent_extension_url_ = GURL(
         "chrome-extension://lgjmpdmojkpocjcopdikifhejkkjglho/extension/"
-        "brave_webtorrent.html?https://webtorrent.io/torrents/sintel");
+        "brave_webtorrent2.html?https://webtorrent.io/torrents/sintel");
   }
 
   void TearDown() override {

--- a/components/brave_webtorrent/browser/webtorrent_util.h
+++ b/components/brave_webtorrent/browser/webtorrent_util.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_WEBTORRENT_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_WEBTORRENT_BROWSER_WEBTORRENT_UTIL_H_
 
+class GURL;
+
 namespace content {
 class BrowserContext;
 }
@@ -14,10 +16,17 @@ namespace user_prefs {
 class PrefRegistrySyncable;
 }
 
+namespace net {
+class HttpResponseHeaders;
+}
+
 namespace webtorrent {
 
 bool IsWebtorrentEnabled(content::BrowserContext* browser_context);
+bool IsWebtorrentPrefEnabled(content::BrowserContext* browser_context);
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
+bool IsTorrentFile(const GURL& url, const net::HttpResponseHeaders* headers);
+bool TorrentURLMatched(const GURL& url);
 
 }  // webtorrent
 

--- a/components/brave_webtorrent/extension/brave_webtorrent.tsx
+++ b/components/brave_webtorrent/extension/brave_webtorrent.tsx
@@ -16,6 +16,15 @@ import App from './components/app'
 // Constants
 import { TorrentsState } from './constants/webtorrentState'
 
+// This is a hack that's needed for lazy loading
+// Basically we need the browser to restart the navigation, so we redirect first
+// to brave_webtorrent2.html and have that rewrite the URL to
+// brave_webtorrent.html
+if (window.location.pathname === '/extension/brave_webtorrent2.html') {
+  window.location.href =
+    window.location.href.replace('brave_webtorrent2.html', 'brave_webtorrent.html')
+}
+
 const store: Store<TorrentsState> = new Store({
   portName: 'WEBTORRENT'
 })

--- a/components/brave_webtorrent/extension/brave_webtorrent2.html
+++ b/components/brave_webtorrent/extension/brave_webtorrent2.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>WebTorrent</title>
+    <script src="/extension/out/brave_webtorrent.bundle.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/components/brave_webtorrent/extension/manifest.json
+++ b/components/brave_webtorrent/extension/manifest.json
@@ -8,7 +8,8 @@
     "persistent": true
   },
   "web_accessible_resources": [
-    "extension/brave_webtorrent.html"
+    "extension/brave_webtorrent.html",
+    "extension/brave_webtorrent2.html"
   ],
   "permissions": ["downloads", "dns", "tabs", "windows", "<all_urls>"],
   "sockets": {

--- a/components/brave_webtorrent/resources.grd
+++ b/components/brave_webtorrent/resources.grd
@@ -12,6 +12,7 @@
     <includes first_id="37500">
       <include name="IDR_BRAVE_WEBTORRENT" file="brave_webtorrent/extension/manifest.json" type="BINDATA" />
       <include name="IDR_BRAVE_WEBTORRENT_HTML" file="brave_webtorrent/extension/brave_webtorrent.html" type="BINDATA" />
+      <include name="IDR_BRAVE_WEBTORRENT2_HTML" file="brave_webtorrent/extension/brave_webtorrent2.html" type="BINDATA" />
     </includes>
   </release>
 </grit>

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -59,6 +59,7 @@ test("brave_unit_tests") {
     "//brave/browser/brave_resources_util_unittest.cc",
     "//brave/browser/brave_stats_updater_unittest.cc",
     "//brave/browser/download/brave_download_item_model_unittest.cc",
+    "//brave/browser/extensions/brave_webtorrent_navigation_throttle_unittest.cc",
     "//brave/browser/metrics/metrics_reporting_util_unittest_linux.cc",
     "//brave/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc",
     "//brave/browser/net/brave_common_static_redirect_network_delegate_helper_unittest.cc",


### PR DESCRIPTION
Uplift of #3616

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.