### PR TITLE
Remove fail-safe WaitableEvent::TimedWait() because (uplift to 0.70.x)

### DIFF
--- a/chromium_src/components/sync/engine_impl/syncer.cc
+++ b/chromium_src/components/sync/engine_impl/syncer.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/bind.h"
-#include "base/time/time.h"
 
 #include "../../../../../components/sync/engine_impl/syncer.cc"  // NOLINT
 
@@ -29,12 +28,7 @@ void Syncer::DownloadBraveRecords(SyncCycle* cycle) {
       base::BindOnce(&Syncer::OnGetRecords, base::Unretained(this));
   base::WaitableEvent wevent;
   cycle->delegate()->OnPollSyncCycle(std::move(on_get_records), &wevent);
-  // Make sure OnGetRecords will be the next task on sync thread
-  // it will timeout in 3 mins to prevent sync thread from being blocked as
-  // fail-safe
-  bool result = wevent.TimedWait(base::TimeDelta::FromMinutes(3));
-  if (!result)
-    LOG(WARNING) << "WaitableEvent timed out";
+  wevent.Wait();
 }
 
 }  // namespace syncer


### PR DESCRIPTION
Uplift of #3636
Fixes https://github.com/brave/brave-browser/issues/6367

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.