### PR TITLE
Network Audit fix for C78

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -29,6 +29,7 @@
 #include "components/omnibox/common/omnibox_features.h"
 #include "components/password_manager/core/common/password_manager_features.h"
 #include "components/unified_consent/feature.h"
+#include "components/sync/driver/sync_driver_switches.h"
 #include "content/public/common/content_features.h"
 #include "extensions/common/extension_features.h"
 #include "services/network/public/cpp/features.h"
@@ -143,6 +144,9 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
       switches::kExtensionContentVerificationEnforceStrict);
   command_line.AppendSwitchASCII(switches::kExtensionsInstallVerification,
       "enforce");
+
+  // Brave's sync protocol does not use the sync service url
+  command_line.AppendSwitchASCII(switches::kSyncServiceURL, "https://no-thanks.invalid");
 
   // Enabled features.
   const std::unordered_set<const char*> enabled_features = {

--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -146,7 +146,8 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
       "enforce");
 
   // Brave's sync protocol does not use the sync service url
-  command_line.AppendSwitchASCII(switches::kSyncServiceURL, "https://no-thanks.invalid");
+  command_line.AppendSwitchASCII(switches::kSyncServiceURL,
+                                 "https://no-thanks.invalid");
 
   // Enabled features.
   const std::unordered_set<const char*> enabled_features = {

--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -46,6 +46,9 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix4);
   static URLPattern crxDownload_pattern(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRXDownloadPrefix);
+  static URLPattern autofill_pattern(
+      URLPattern::SCHEME_HTTPS, kAutofillPrefix);
+
 #if BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
   static URLPattern translate_pattern(URLPattern::SCHEME_HTTPS,
       kTranslateElementJSPattern);
@@ -76,6 +79,13 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
   if (crxDownload_pattern.MatchesURL(request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr("crxdownload.brave.com");
+    *new_url = request_url.ReplaceComponents(replacements);
+    return net::OK;
+  }
+
+  if (autofill_pattern.MatchesURL(request_url)) {
+    replacements.SetSchemeStr("https");
+    replacements.SetHostStr(kBraveStaticProxy);
     *new_url = request_url.ReplaceComponents(replacements);
     return net::OK;
   }

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -19,7 +19,9 @@ const char kBraveReferralsActivityPath[] = "/promo/activity";
 const char kBraveSafeBrowsingFileCheckProxy[] = "sb-ssl.brave.com";
 const char kBraveRedirectorProxy[] = "redirector.brave.com";
 const char kBraveClients4Proxy[] = "clients4.brave.com";
+const char kBraveStaticProxy[] = "static1.brave.com";
 
+const char kAutofillPrefix[] = "https://www.gstatic.com/autofill/*";
 const char kClients4Prefix[] = "*://clients4.google.com/";
 const char kCRXDownloadPrefix[] =
     "*://clients2.googleusercontent.com/crx/blobs/*crx*";

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -15,7 +15,9 @@ extern const char kBraveReferralsActivityPath[];
 extern const char kBraveSafeBrowsingFileCheckProxy[];
 extern const char kBraveRedirectorProxy[];
 extern const char kBraveClients4Proxy[];
+extern const char kBraveStaticProxy[];
 
+extern const char kAutofillPrefix[];
 extern const char kClients4Prefix[];
 extern const char kCRXDownloadPrefix[];
 extern const char kEmptyDataURI[];


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
