### PR TITLE
Re-enable BraveLayoutProvider for c78

### DIFF
--- a/chromium_src/chrome/browser/ui/views/chrome_layout_provider.cc
+++ b/chromium_src/chrome/browser/ui/views/chrome_layout_provider.cc
@@ -1,4 +1,19 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
 #include "brave/browser/ui/views/brave_layout_provider.h"
-#define MaterialRefreshLayoutProvider BraveLayoutProvider
-#include "../../../../../chrome/browser/ui/views/chrome_layout_provider.cc"
-#undef MaterialRefreshLayoutProvider
+
+// Replace LayoutProvider creation with our own function.
+// The definition is provided similarly by the override of
+// the header file.
+#define CreateLayoutProvider CreateLayoutProvider_ChromiumImpl
+#include "../../../../../../chrome/browser/ui/views/chrome_layout_provider.cc"
+#undef CreateLayoutProvider
+
+// static
+std::unique_ptr<views::LayoutProvider>
+ChromeLayoutProvider::CreateLayoutProvider() {
+  return std::make_unique<BraveLayoutProvider>();
+}

--- a/chromium_src/chrome/browser/ui/views/chrome_layout_provider.h
+++ b/chromium_src/chrome/browser/ui/views/chrome_layout_provider.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_CHROME_LAYOUT_PROVIDER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_CHROME_LAYOUT_PROVIDER_H_
+
+#define CreateLayoutProvider             \
+    CreateLayoutProvider_ChromiumImpl(); \
+    static std::unique_ptr<views::LayoutProvider> CreateLayoutProvider
+#include "../../../../../../chrome/browser/ui/views/chrome_layout_provider.h"
+#undef CreateLayoutProvider
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_CHROME_LAYOUT_PROVIDER_H_


### PR DESCRIPTION
Fixes border radius 'emphasis' levels being at Chromium values and not Brave.

It goes to show that `#define` overrides can be completely missed at build-time since if they go unused, an error will not be shown. The underlying chromium file no longer used the word "MaterialRefreshLayoutProvider" and so our replacement never happened.

In that type of case we should probably have a browser test to make sure the right side effect occurs.

In this new case, however, we should get a build error if they change the keyword `CreateLayoutProvider` since our function definition will no longer have a matching header declaration.

Fix https://github.com/brave/brave-browser/issues/6426

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
