### PR TITLE
Display brave:// protocol on brave://about page

### DIFF
--- a/patches/chrome-browser-ui-webui-about_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-about_ui.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/chrome/browser/ui/webui/about_ui.cc b/chrome/browser/ui/webui/about_ui.cc
+index 8637fe302a09..8c8b526ab28e 100644
+--- a/chrome/browser/ui/webui/about_ui.cc
++++ b/chrome/browser/ui/webui/about_ui.cc
+@@ -541,16 +541,16 @@ namespace {
+ 
+ std::string ChromeURLs() {
+   std::string html;
+-  AppendHeader(&html, 0, "Chrome URLs");
++  AppendHeader(&html, 0, "Brave URLs");
+   AppendBody(&html);
+-  html += "<h2>List of Chrome URLs</h2>\n<ul>\n";
++  html += "<h2>List of Brave URLs</h2>\n<ul>\n";
+   std::vector<std::string> hosts(
+       chrome::kChromeHostURLs,
+       chrome::kChromeHostURLs + chrome::kNumberOfChromeHostURLs);
+   std::sort(hosts.begin(), hosts.end());
+   for (std::vector<std::string>::const_iterator i = hosts.begin();
+        i != hosts.end(); ++i)
+-    html += "<li><a href='chrome://" + *i + "/'>chrome://" + *i + "</a></li>\n";
++    html += "<li><a href='chrome://" + *i + "/'>brave://" + *i + "</a></li>\n";
+   html += "</ul>\n<h2>For Debug</h2>\n"
+       "<p>The following pages are for debugging purposes only. Because they "
+       "crash or hang the renderer, they're not linked directly; you can type "

--- a/patches/ios-chrome-browser-ui-webui-about_ui.cc.patch
+++ b/patches/ios-chrome-browser-ui-webui-about_ui.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/ios/chrome/browser/ui/webui/about_ui.cc b/ios/chrome/browser/ui/webui/about_ui.cc
+index c1106f426f90..10747a1d57fd 100644
+--- a/ios/chrome/browser/ui/webui/about_ui.cc
++++ b/ios/chrome/browser/ui/webui/about_ui.cc
+@@ -82,15 +82,15 @@ void AppendFooter(std::string* output) {
+ 
+ std::string ChromeURLs() {
+   std::string html;
+-  AppendHeader(&html, 0, "Chrome URLs");
++  AppendHeader(&html, 0, "Brave URLs");
+   AppendBody(&html);
+-  html += "<h2>List of Chrome URLs</h2>\n<ul>\n";
++  html += "<h2>List of Brave URLs</h2>\n<ul>\n";
+   std::vector<std::string> hosts(kChromeHostURLs,
+                                  kChromeHostURLs + kNumberOfChromeHostURLs);
+   std::sort(hosts.begin(), hosts.end());
+   for (std::vector<std::string>::const_iterator i = hosts.begin();
+        i != hosts.end(); ++i)
+-    html += "<li><a href='chrome://" + *i + "/' id='" + *i + "'>chrome://" +
++    html += "<li><a href='chrome://" + *i + "/' id='" + *i + "'>brave://" +
+             *i + "</a></li>\n";
+   html += "</ul>\n";
+   AppendFooter(&html);


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5775.

This is a purely cosmetic patch in a sense that it changes the displayed URLs but not the actual `href`. This is done to ensure that everything works as before.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Open `brave://about` and make sure 
   - the page title has "Brave"in it
   - the list of URLs is titled "List of Brave URLs"
   - all clickable URLs start with `brave://`
2. Click on a few URLs and make sure they lead to wherever is expected
3. All non-clickable URLs (at the end of the page) start with `chrome://` for compatibility.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
