### PR TITLE
Exempt password managers from the Uphold content script restrictions

### DIFF
--- a/chromium_src/extensions/common/permissions/permissions_data.cc
+++ b/chromium_src/extensions/common/permissions/permissions_data.cc
@@ -9,6 +9,28 @@
 
 namespace extensions {
 
+const char k1PasswordId[] = "aomjjhallfgjeglblehebfpbcfeobpgk";
+const char k1PasswordXId[] = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+const char kBitWardenId[] = "nngceckbapebfimnlniiiahkandclblb";
+const char kDashlaneId[] = "fdjamakpfbbddfjaooikfcpapjohcfmg";
+const char kEnPassId[] = "kmcfomidfpdkfieipokbalgegidffkal";
+const char kKeePassXCId[] = "oboonakemofpalcgghocfoadofidjkkk";
+const char kKeeperId[] = "bfogiafebfohielmmehodmfbbebbbpei";
+const char kLastPassId[] = "hdokiejnpimakedhajhdlcegeplioahd";
+const char kPainFreePasswordsId[] = "hplhaekjfmjfnfdllkpjpeenlbclffgh";
+const char kRoboFormId[] = "pnlccmojcmeohlpggmfnbbiapkmbliob";
+const char kSafeInCloudId[] = "lchdigjbcmdgcfeijpfkpadacbijihjl";
+
+bool IsKnownPasswordManagerExtension(
+    const extensions::ExtensionId& extension_id) {
+  return (extension_id == k1PasswordId) || (extension_id == k1PasswordXId) ||
+         (extension_id == kBitWardenId) || (extension_id == kDashlaneId) ||
+         (extension_id == kEnPassId) || (extension_id == kKeePassXCId) ||
+         (extension_id == kKeeperId) || (extension_id == kLastPassId) ||
+         (extension_id == kPainFreePasswordsId) ||
+         (extension_id == kRoboFormId) || (extension_id == kSafeInCloudId);
+}
+
 bool IsBraveProtectedUrl(const GURL& url) {
   const url::Origin origin = url::Origin::Create(url);
   const base::StringPiece path = url.path_piece();
@@ -36,6 +58,10 @@ bool IsBraveRestrictedUrl(const GURL& document_url,
 
   if (extensions::PermissionsData::CanExecuteScriptEverywhere(extension_id,
                                                               location)) {
+    return false;
+  }
+
+  if (extensions::IsKnownPasswordManagerExtension(extension_id)) {
     return false;
   }
 


### PR DESCRIPTION
This should mitigate some of the bad UX described in brave/brave-browser#6309.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Install the [1 Password X extension](https://chrome.google.com/webstore/detail/1password-x-–-password-ma/aeblfdkhhhdcdjpifhhbdiojplfjncoa).
2. Go into `brave://rewards` and start verifying the wallet with Uphold.
3. On the Uphold account creation / login page, click on the 1Password icon.

If the icon is working (as opposed to being disabled and contained within a circle), then this change is working.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
