### PR TITLE
Rewards Extension: delay loading until enabled

### DIFF
--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -78,6 +78,7 @@ source_set("extensions") {
 
   if (brave_rewards_enabled) {
     deps += [
+      "//brave/components/brave_rewards/browser",
       "//brave/components/brave_rewards/resources/extension:extension_generated_resources",
       "//brave/components/brave_rewards/resources/extension:static_resources",
     ]

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -9,9 +9,18 @@
 #include <string>
 
 #include "base/files/file_path.h"
+#include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/browser/buildflags/buildflags.h"
 #include "chrome/browser/extensions/component_loader.h"
 #include "components/prefs/pref_change_registrar.h"
+
+class PrefService;
+class Profile;
+
+namespace brave_rewards {
+class RewardsService;
+}
+
 
 namespace extensions {
 
@@ -29,6 +38,9 @@ class BraveComponentLoader : public ComponentLoader {
   void AddDefaultComponentExtensions(bool skip_session_components) override;
   void OnComponentRegistered(std::string extension_id);
 
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  void AddRewardsExtension();
+#endif
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
   void AddEthereumRemoteClientExtension();
 #endif
@@ -48,9 +60,13 @@ class BraveComponentLoader : public ComponentLoader {
   void AddHangoutServicesExtension() override;
 #endif  // BUILDFLAG(ENABLE_HANGOUT_SERVICES_EXTENSION)
 
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  void HandleRewardsEnabledStatus();
+#endif
+
   Profile* profile_;
   PrefService* profile_prefs_;
-  PrefChangeRegistrar registrar_;
+  PrefChangeRegistrar pref_change_registrar_;
   std::string ethereum_remote_client_manifest_;
   base::FilePath ethereum_remote_client_install_dir_;
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -187,7 +187,7 @@ source_set("ui") {
     deps += [ "//brave/app:brave_generated_resources_grit" ]
   }
 
-  if (enable_extensions) {
+  if (enable_extensions && toolkit_views) {
     sources += [
       "brave_actions/brave_action_icon_with_badge_image_source.cc",
       "brave_actions/brave_action_icon_with_badge_image_source.h",
@@ -214,6 +214,13 @@ source_set("ui") {
       "webui/settings/brave_default_extensions_handler.cc",
       "webui/settings/brave_default_extensions_handler.h",
     ]
+
+    if (brave_rewards_enabled) {
+      sources += [
+        "views/brave_actions/brave_rewards_action_stub_view.cc",
+        "views/brave_actions/brave_rewards_action_stub_view.h",
+      ]
+    }
 
     deps += [
       "//brave/browser/resources/extensions:resources",

--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -9,14 +9,21 @@
 #include <string>
 #include <utility>
 
+#include "base/command_line.h"
 #include "base/one_shot_event.h"
+#include "brave/browser/extensions/brave_component_loader.h"
 #include "brave/browser/ui/brave_actions/brave_action_view_controller.h"
+#include "brave/browser/ui/brave_actions/constants.h"
 #include "brave/browser/ui/views/brave_actions/brave_action_view.h"
+#include "brave/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h"
 #include "brave/browser/ui/views/rounded_separator.h"
+#include "brave/common/brave_switches.h"
 #include "brave/common/extensions/extension_constants.h"
 #include "brave/common/pref_names.h"
+#include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "chrome/browser/extensions/extension_action_manager.h"
+#include "chrome/browser/extensions/extension_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/layout_constants.h"
@@ -47,6 +54,7 @@ void BraveActionsContainer::BraveActionInfo::Reset() {
 BraveActionsContainer::BraveActionsContainer(Browser* browser, Profile* profile)
     : views::View(),
       browser_(browser),
+      extension_system_(extensions::ExtensionSystem::Get(profile)),
       extension_action_api_(extensions::ExtensionActionAPI::Get(profile)),
       extension_registry_(extensions::ExtensionRegistry::Get(profile)),
       extension_action_manager_(
@@ -55,7 +63,7 @@ BraveActionsContainer::BraveActionsContainer(Browser* browser, Profile* profile)
       extension_action_observer_(this),
       weak_ptr_factory_(this) {
   // Handle when the extension system is ready
-  extensions::ExtensionSystem::Get(profile)->ready().Post(
+  extension_system_->ready().Post(
       FROM_HERE, base::Bind(&BraveActionsContainer::OnExtensionSystemReady,
                             weak_ptr_factory_.GetWeakPtr()));
 }
@@ -118,20 +126,26 @@ bool BraveActionsContainer::ShouldAddAction(const std::string& id) const {
 }
 
 bool BraveActionsContainer::ShouldAddBraveRewardsAction() const {
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  if (command_line.HasSwitch(switches::kDisableBraveRewardsExtension)) {
+    return false;
+  }
   const PrefService* prefs = browser_->profile()->GetPrefs();
   return prefs->GetBoolean(brave_rewards::prefs::kBraveRewardsEnabled) ||
          !prefs->GetBoolean(kHideBraveRewardsButton);
 }
 
-void BraveActionsContainer::AddAction(const extensions::Extension* extension,
-                                      int pos) {
+void BraveActionsContainer::AddAction(const extensions::Extension* extension) {
   DCHECK(extension);
   if (!ShouldAddAction(extension->id()))
     return;
   VLOG(1) << "AddAction (" << extension->id() << "), was already loaded: "
           << static_cast<bool>(actions_[extension->id()].view_);
-  if (!actions_[extension->id()].view_) {
+  if (!actions_[extension->id()].view_controller_) {
     const auto& id = extension->id();
+    // Remove existing stub view, if present
+    actions_[id].Reset();
     // Create a ExtensionActionViewController for the extension
     // Passing |nullptr| instead of ToolbarActionsBar since we
     // do not require that logic.
@@ -144,30 +158,59 @@ void BraveActionsContainer::AddAction(const extensions::Extension* extension,
     // The button view
     actions_[id].view_ = std::make_unique<BraveActionView>(
         actions_[id].view_controller_.get(), this);
-    // Add extension view after separator view
-    // `AddChildView` should be called first, so that changes that modify
-    // layout (e.g. preferred size) are forwarded to its parent
-    if (actions_[id].position_ != ACTION_ANY_POSITION) {
-      DCHECK_GT(actions_[id].position_, 0);
-      AddChildViewAt(actions_[id].view_.get(), actions_[id].position_);
-    } else {
-      AddChildView(actions_[id].view_.get());
+    AttachAction(actions_[id]);
+    // Handle if we are in a continuing pressed state for this extension.
+    if (is_rewards_pressed_ && id == brave_rewards_extension_id) {
+      is_rewards_pressed_ = false;
+      actions_[id].view_controller_->ExecuteAction(true);
     }
-    // we control destruction
-    actions_[id].view_->set_owned_by_client();
-    // Sets overall size of button but not image graphic. We set a large width
-    // in order to give space for the bubble.
-    actions_[id].view_->SetPreferredSize(gfx::Size(34, 24));
-    Update();
   }
 }
 
-void BraveActionsContainer::AddAction(const std::string& id, int pos) {
+void BraveActionsContainer::AddActionStubForRewards() {
+  const std::string id = brave_rewards_extension_id;
+  if (!ShouldAddAction(id)) {
+    return;
+  }
+  if (actions_[id].view_) {
+    return;
+  }
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  actions_[id].view_ = std::make_unique<BraveRewardsActionStubView>(this);
+  AttachAction(actions_[id]);
+#endif
+}
+
+void BraveActionsContainer::AttachAction(BraveActionInfo &action) {
+  // Add extension view after separator view
+  // `AddChildView` should be called first, so that changes that modify
+  // layout (e.g. preferred size) are forwarded to its parent
+  if (action.position_ != ACTION_ANY_POSITION) {
+    DCHECK_GT(action.position_, 0);
+    AddChildViewAt(action.view_.get(), action.position_);
+  } else {
+    AddChildView(action.view_.get());
+  }
+  // we control destruction
+  action.view_->set_owned_by_client();
+  Update();
+}
+
+void BraveActionsContainer::AddAction(const std::string& id) {
   DCHECK(extension_registry_);
   const extensions::Extension* extension =
       extension_registry_->enabled_extensions().GetByID(id);
-  if (extension)
-    AddAction(extension, pos);
+  if (extension) {
+    AddAction(extension);
+    return;
+  }
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  if (id == brave_rewards_extension_id) {
+    AddActionStubForRewards();
+    return;
+  }
+#endif
+  LOG(ERROR) << "Extension not found for Brave Action: " << id;
 }
 
 void BraveActionsContainer::RemoveAction(const std::string& id) {
@@ -240,10 +283,9 @@ views::LabelButton* BraveActionsContainer::GetOverflowReferenceView() const {
 
 // ToolbarActionView::Delegate members
 gfx::Size BraveActionsContainer::GetToolbarActionSize() {
-  // Shields icon should be square, and full-height
-  gfx::Rect rect(gfx::Size(height(), height()));
-  rect.Inset(-GetLayoutInsets(LOCATION_BAR_ICON_INTERIOR_PADDING));
-  return rect.size();
+  // Width > Height to give space for a large bubble (especially for shields).
+  // TODO(petemill): Generate based on toolbar size.
+  return gfx::Size(34, 24);
 }
 
 void BraveActionsContainer::WriteDragDataForView(View* sender,
@@ -264,20 +306,34 @@ bool BraveActionsContainer::CanStartDragForView(View* sender,
 }
 // end ToolbarActionView::Delegate members
 
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+// BraveRewardsActionStubView::Delegate members
+void BraveActionsContainer::OnRewardsStubButtonClicked() {
+  // Keep button state visually pressed until new extension button
+  // takes over.
+  actions_[brave_rewards_extension_id].view_->SetState(
+      views::Button::STATE_PRESSED);
+  extensions::ExtensionService* service =
+           extension_system_->extension_service();
+  if (service) {
+    is_rewards_pressed_ = true;
+    extensions::ComponentLoader* loader = service->component_loader();
+          static_cast<extensions::BraveComponentLoader*>(loader)->
+              AddRewardsExtension();
+  }
+}
+// end BraveRewardsActionStubView::Delegate members
+#endif
+
 void BraveActionsContainer::OnExtensionSystemReady() {
   // observe changes in extension system
   extension_registry_observer_.Add(extension_registry_);
   extension_action_observer_.Add(extension_action_api_);
-  // Check if brave extension already loaded
-  const extensions::Extension* extension =
-          extension_registry_->enabled_extensions().GetByID(brave_extension_id);
-  if (extension)
-    AddAction(extension);
-  // Check if brave rewards extension already loaded
-  extension = extension_registry_->enabled_extensions().GetByID(
-      brave_rewards_extension_id);
-  if (extension)
-    AddAction(extension);
+  // Check if extensions already loaded
+  AddAction(brave_extension_id);
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  AddAction(brave_rewards_extension_id);
+#endif
 }
 
 // ExtensionRegistry::Observer

--- a/browser/ui/views/brave_actions/brave_rewards_action_stub_view.cc
+++ b/browser/ui/views/brave_actions/brave_rewards_action_stub_view.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h"
+
+#include <string>
+#include <memory>
+#include <utility>
+
+#include "brave/browser/ui/brave_actions/brave_action_icon_with_badge_image_source.h"  // NOLINT
+#include "brave/browser/ui/brave_actions/constants.h"
+#include "brave/components/brave_rewards/resources/extension/grit/brave_rewards_extension_resources.h"  // NOLINT
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_action_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_ink_drop_util.h"
+#include "ui/base/resource/resource_bundle.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/image/canvas_image_source.h"
+#include "ui/gfx/image/image_skia_source.h"
+#include "ui/views/view.h"
+#include "ui/views/view_class_properties.h"
+#include "ui/views/animation/ink_drop_impl.h"
+#include "ui/views/controls/button/label_button_border.h"
+
+namespace {
+  constexpr SkColor kRewardsBadgeBg = SkColorSetRGB(0xfb, 0x54, 0x2b);
+  const std::string kRewardsInitialBadgeText = "1";
+}
+
+BraveRewardsActionStubView::BraveRewardsActionStubView(
+    BraveRewardsActionStubView::Delegate* delegate)
+    : LabelButton(this, base::string16()),
+      delegate_(delegate) {
+  SetInkDropMode(InkDropMode::ON);
+  set_has_ink_drop_action_on_click(true);
+  SetHorizontalAlignment(gfx::ALIGN_CENTER);
+  set_ink_drop_visible_opacity(kToolbarInkDropVisibleOpacity);
+  // Create badge-and-image source like an extension icon would
+  auto preferred_size = GetPreferredSize();
+  ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
+  std::unique_ptr<IconWithBadgeImageSource> image_source(
+      new BraveActionIconWithBadgeImageSource(preferred_size));
+  // Set icon on badge using actual extension icon resource
+  const auto image = gfx::Image(
+      rb.GetImageNamed(IDR_BRAVE_REWARDS_ICON_64).AsImageSkia()
+          .DeepCopy());
+  image_source->SetIcon(image);
+  // Set text on badge
+  std::unique_ptr<IconWithBadgeImageSource::Badge> badge;
+  badge.reset(new IconWithBadgeImageSource::Badge(
+          kRewardsInitialBadgeText,
+          SK_ColorWHITE,
+          kRewardsBadgeBg));
+  image_source->SetBadge(std::move(badge));
+  image_source->set_paint_page_action_decoration(false);
+  gfx::ImageSkia icon(gfx::Image(
+      gfx::ImageSkia(
+          std::move(image_source),
+          preferred_size))
+      .AsImageSkia());
+  // Use badge-and-icon source for button's image in all states
+  SetImage(views::Button::STATE_NORMAL, icon);
+  // Set the highlight path for the toolbar button,
+  // making it inset so that the badge can show outside it in the
+  // fake margin on the right that we are creating.
+  gfx::Insets highlight_insets(0, 0, 0, brave_actions::kBraveActionRightMargin);
+  gfx::Rect rect(preferred_size);
+  rect.Inset(highlight_insets);
+  const int radii = ChromeLayoutProvider::Get()->GetCornerRadiusMetric(
+      views::EMPHASIS_MAXIMUM, rect.size());
+  auto path = std::make_unique<SkPath>();
+  path->addRoundRect(gfx::RectToSkRect(rect), radii, radii);
+  SetProperty(views::kHighlightPathKey, path.release());
+}
+
+BraveRewardsActionStubView::~BraveRewardsActionStubView() {}
+
+void BraveRewardsActionStubView::ButtonPressed(
+    Button* sender, const ui::Event& event) {
+  delegate_->OnRewardsStubButtonClicked();
+}
+
+gfx::Size BraveRewardsActionStubView::CalculatePreferredSize() const {
+  return delegate_->GetToolbarActionSize();
+}
+
+std::unique_ptr<views::LabelButtonBorder> BraveRewardsActionStubView::
+    CreateDefaultBorder() const {
+  std::unique_ptr<views::LabelButtonBorder> border =
+      LabelButton::CreateDefaultBorder();
+  border->set_insets(
+      gfx::Insets(0, 0, 0, 0));
+  return border;
+}
+
+SkColor BraveRewardsActionStubView::GetInkDropBaseColor() const {
+  return GetToolbarInkDropBaseColor(this);
+}
+
+std::unique_ptr<views::InkDropHighlight>
+BraveRewardsActionStubView::CreateInkDropHighlight() const {
+  return CreateToolbarInkDropHighlight(this);
+}

--- a/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h
+++ b/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_ACTIONS_BRAVE_REWARDS_ACTION_STUB_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_ACTIONS_BRAVE_REWARDS_ACTION_STUB_VIEW_H_
+
+#include <memory>
+
+#include "ui/views/controls/button/label_button.h"
+#include "ui/views/view.h"
+
+// A button to take the place of an extension that will be loaded in the future.
+// Call SetImage with the BraveActionIconWithBadgeImageSource
+// Call highlight etc from ToolbarActionView
+class BraveRewardsActionStubView : public views::LabelButton,
+                                   public views::ButtonListener {
+ public:
+  class Delegate {
+   public:
+    virtual void OnRewardsStubButtonClicked() = 0;
+    virtual gfx::Size GetToolbarActionSize() = 0;
+   protected:
+    ~Delegate() {}
+  };
+
+  explicit BraveRewardsActionStubView(Delegate* delegate);
+  ~BraveRewardsActionStubView() override;
+
+  // views::ButtonListener
+  void ButtonPressed(Button* sender, const ui::Event& event) override;
+
+  // views::LabelButton:
+  std::unique_ptr<views::LabelButtonBorder> CreateDefaultBorder()
+      const override;
+  SkColor GetInkDropBaseColor() const override;
+  std::unique_ptr<views::InkDropHighlight> CreateInkDropHighlight()
+      const override;
+
+ private:
+  gfx::Size CalculatePreferredSize() const override;
+
+  Delegate* delegate_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveRewardsActionStubView);
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_ACTIONS_BRAVE_REWARDS_ACTION_STUB_VIEW_H_

--- a/chromium_src/chrome/browser/extensions/extension_action_manager.cc
+++ b/chromium_src/chrome/browser/extensions/extension_action_manager.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/common/extensions/extension_constants.h"
+#include "brave/browser/ui/brave_actions/constants.h"
+
+// Avoid a jump from small image to large image when the non-default
+// image is set.
+#define BRAVE_GET_EXTENSION_ACTION \
+  if (action->default_icon() && ( \
+      extension.id() == brave_rewards_extension_id || \
+      extension.id() == brave_extension_id)) { \
+    action->SetDefaultIconImage(std::make_unique<IconImage>( \
+        profile_, &extension, *action->default_icon(), \
+        brave_actions::kBraveActionGraphicSize, \
+        ExtensionAction::FallbackIcon().AsImageSkia(), nullptr)); \
+  }
+#include "../../../../../chrome/browser/extensions/extension_action_manager.cc"
+#undef BRAVE_GET_EXTENSION_ACTION

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -697,14 +697,6 @@ class BraveRewardsBrowserTest :
     // Wait for grant to finish
     WaitForGrantFinished();
 
-    // Goes to final step
-    if (use_panel) {
-      ASSERT_TRUE(ExecJs(contents,
-                         "document.getElementsByTagName('button')[0].click();",
-                         content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
-                         content::ISOLATED_WORLD_ID_CONTENT_END));
-    }
-
     // Ensure that grant looks as expected
     EXPECT_STREQ(grant_.altcurrency.c_str(), "BAT");
     EXPECT_STREQ(grant_.probi.c_str(), "30000000000000000000");

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -439,6 +439,34 @@ class BraveRewardsBrowserTest :
     wait_for_insufficient_notification_loop_->Run();
   }
 
+  void WaitForSelector(content::WebContents* contents,
+      const std::string& selector) const {
+    auto script = content::JsReplace(
+        "new Promise((resolve) => {"
+        "  let count = 20;"
+        "  let interval = setInterval(function() {"
+        "    if (count == 0) {"
+        "      clearInterval(interval);"
+        "      resolve(false);"
+        "    } else {"
+        "      count -= 1;"
+        "    }"
+        "    const element = document.querySelector($1);"
+        "    if (element) {"
+        "      clearInterval(interval);"
+        "      resolve(true);"
+        "    }"
+        "  }, 500);"
+        "});",
+        selector);
+    auto js_result = EvalJs(
+        contents,
+        script,
+        content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+        content::ISOLATED_WORLD_ID_CONTENT_END);
+    ASSERT_TRUE(js_result.ExtractBool());
+  }
+
   void GetReconcileTime() {
     rewards_service()->GetReconcileTime(
         base::Bind(&BraveRewardsBrowserTest::OnGetReconcileTime,
@@ -487,6 +515,7 @@ class BraveRewardsBrowserTest :
         static_cast<const content::Source<content::WebContents>&>(
             popup_observer.source());
 
+    WaitForSelector(source.ptr(), "#panel-slider");
     return source.ptr();
   }
 

--- a/components/brave_rewards/resources/extension/brave_rewards/background.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background.ts
@@ -34,28 +34,7 @@ chrome.tabs.query({
   rewardsPanelActions.init(tabs)
 })
 
-chrome.runtime.onInstalled.addListener(function (details) {
-  if (details.reason === 'install') {
-    const initialNotificationDismissed = 'false'
-    chrome.storage.local.set({
-      'is_dismissed': initialNotificationDismissed
-    }, function () {
-      chrome.browserAction.setBadgeText({
-        text: '1'
-      })
-    })
-  }
-})
-
 chrome.runtime.onStartup.addListener(function () {
-  chrome.storage.local.get(['is_dismissed'], function (result) {
-    if (result && result['is_dismissed'] === 'false') {
-      chrome.browserAction.setBadgeText({
-        text: '1'
-      })
-    }
-  })
-
   chrome.runtime.onConnect.addListener(function (externalPort) {
     chrome.storage.local.set({
       'rewards_panel_open': 'true'
@@ -66,17 +45,6 @@ chrome.runtime.onStartup.addListener(function () {
         'rewards_panel_open': 'false'
       })
     })
-  })
-})
-
-chrome.runtime.onConnect.addListener(function () {
-  chrome.storage.local.get(['is_dismissed'], function (result) {
-    if (result && result['is_dismissed'] === 'false') {
-      chrome.browserAction.setBadgeText({
-        text: ''
-      })
-      chrome.storage.local.remove(['is_dismissed'])
-    }
   })
 })
 

--- a/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
@@ -4,22 +4,6 @@
 
 import rewardsPanelActions from '../actions/rewardsPanelActions'
 
-// Fetch initial data required to refresh state, keeping in mind
-// that the extension process be restarted at any time.
-// TODO(petemill): Move to initializer function or single 'init' action.
-chrome.braveRewards.getRewardsMainEnabled((enabledMain: boolean) => {
-  rewardsPanelActions.onEnabledMain(enabledMain)
-  if (enabledMain) {
-    chrome.braveRewards.getWalletProperties()
-    chrome.braveRewards.fetchBalance((balance: RewardsExtension.Balance) => {
-      rewardsPanelActions.onBalance(balance)
-    })
-    chrome.braveRewards.getAllNotifications((list: RewardsExtension.Notification[]) => {
-      rewardsPanelActions.onAllNotifications(list)
-    })
-  }
-})
-
 // Handle all rewards events and pass to actions
 chrome.braveRewards.onWalletInitialized.addListener((result: RewardsExtension.Result) => {
   rewardsPanelActions.onWalletInitialized(result)
@@ -127,6 +111,23 @@ chrome.braveRewards.onDisconnectWallet.addListener((properties: {result: number,
 
     chrome.braveRewards.fetchBalance((balance: RewardsExtension.Balance) => {
       rewardsPanelActions.onBalance(balance)
+    })
+  }
+})
+
+// Fetch initial data required to refresh state, keeping in mind
+// that the extension process be restarted at any time.
+// TODO(petemill): Move to initializer function or single 'init' action.
+chrome.braveRewards.getRewardsMainEnabled((enabledMain: boolean) => {
+  rewardsPanelActions.onEnabledMain(enabledMain)
+  if (enabledMain) {
+    chrome.braveRewards.getWalletProperties()
+    chrome.braveRewards.getGrants()
+    chrome.braveRewards.fetchBalance((balance: RewardsExtension.Balance) => {
+      rewardsPanelActions.onBalance(balance)
+    })
+    chrome.braveRewards.getAllNotifications((list: RewardsExtension.Notification[]) => {
+      rewardsPanelActions.onAllNotifications(list)
     })
   }
 })

--- a/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/events/rewardsEvents.ts
@@ -4,10 +4,23 @@
 
 import rewardsPanelActions from '../actions/rewardsPanelActions'
 
-chrome.braveRewards.getAllNotifications((list: RewardsExtension.Notification[]) => {
-  rewardsPanelActions.onAllNotifications(list)
+// Fetch initial data required to refresh state, keeping in mind
+// that the extension process be restarted at any time.
+// TODO(petemill): Move to initializer function or single 'init' action.
+chrome.braveRewards.getRewardsMainEnabled((enabledMain: boolean) => {
+  rewardsPanelActions.onEnabledMain(enabledMain)
+  if (enabledMain) {
+    chrome.braveRewards.getWalletProperties()
+    chrome.braveRewards.fetchBalance((balance: RewardsExtension.Balance) => {
+      rewardsPanelActions.onBalance(balance)
+    })
+    chrome.braveRewards.getAllNotifications((list: RewardsExtension.Notification[]) => {
+      rewardsPanelActions.onAllNotifications(list)
+    })
+  }
 })
 
+// Handle all rewards events and pass to actions
 chrome.braveRewards.onWalletInitialized.addListener((result: RewardsExtension.Result) => {
   rewardsPanelActions.onWalletInitialized(result)
 })

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -130,8 +130,14 @@ export const rewardsPanelReducer = (state: RewardsExtension.State | undefined, a
       chrome.braveRewards.getWalletProperties()
       break
     case types.ON_WALLET_PROPERTIES: {
-      state = { ...state }
-      state.walletProperties = payload.properties
+      state = {
+        ...state,
+        walletCreated: true,
+        walletCreateFailed: false,
+        walletCreating: false,
+        walletCorrupted: false,
+        walletProperties: payload.properties
+      }
       break
     }
     case types.GET_CURRENT_REPORT:

--- a/patches/chrome-browser-extensions-extension_action_manager.cc.patch
+++ b/patches/chrome-browser-extensions-extension_action_manager.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/extensions/extension_action_manager.cc b/chrome/browser/extensions/extension_action_manager.cc
+index 90884f9916494778fc182c49ac7709bc91f536b9..0b099db863682c226da5f6e2f67e684ed56da3ef 100644
+--- a/chrome/browser/extensions/extension_action_manager.cc
++++ b/chrome/browser/extensions/extension_action_manager.cc
+@@ -109,6 +109,7 @@ ExtensionAction* ExtensionActionManager::GetExtensionAction(
+         ExtensionAction::ActionIconSize(),
+         ExtensionAction::FallbackIcon().AsImageSkia(), nullptr));
+   }
++  BRAVE_GET_EXTENSION_ACTION
+ 
+   ExtensionAction* raw_action = action.get();
+   actions_[extension.id()] = std::move(action);


### PR DESCRIPTION
Replaces the rewards toolbar icon with a non-extension-related Button. When the button is clicked, the Rewards extension will be loaded. The extension browser action button will replace the previous 'stub' button and the popup will automatically open.

If the profile starts with rewards already enabled then the extension is immediately started.

Fix https://github.com/brave/brave-browser/issues/3436

 - [x] Delay extension loading until rewards is enabled
 - [x] Implement 'stub' native button
 - [x] Open popup when extension is installed after 'stub' button click
 - [x] Fix extension data is out of sync because it doesn't 'sync' state at startup (see related issues).
 - [x] Verify disable-rewards cli flag
 - [x] Badge text '1' and image scaling
 - [ ] Rewards team to verify that panel does not need to 'sync' more data to state, and fix any impacted browser tests due to extension install delay.

Related but (probably) not blocking:
 - Rewards extension can't handle any gap in events. <-- should be fixed in this PR, please check @NejcZdovc @ryanml.
 - Rewards extension UI should get neccessary data (publisher, currency and settings for current tab) when panel opens, and not constantly in the background for every tab.
 - Rewards background script should only get data which is required for the badge (i.e. when a publisher has been found for a tab, or the notification count changes). The badge does not need to be updated every time active tab or window changes.
 - Rewards extension should not concern itself with active tab or active windows. It is unneccessary processing, code complexity, and can become out of sync.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


### 1. Panel works on fresh data directory
1. Fresh user data directory
2. Toolbar Rewards button and icon should be visible
3. Button should have badge with "1" text content (extension is not loaded)
4. Clicking button once should open Rewards extension panel (extension has loaded)
_Can also verify extension loaded status in Brave Task Manager_

### 2. Existing rewards profile
1. Existing data directory with 1 profile with rewards enabled
2. Toolbar Rewards icon should be visible
3. Toolbar Rewards icon should not have "1" in badge
4. Clicking rewards icon should open panel, which should show wallet and active tab publisher

### Additional profiles in same data directory
Verify 1. and 2. but with new profiles in the same browser session. (App Menu -> Create New Profile). Each profile should have or not have its own copy of the brave rewards extension, and behave as per test 1. and 2.

### cli flag to disable
1. Fresh profile
2. Launch with `--disable-brave-rewards-extension`
3. Rewards toolbar button is not visible
4. Go to brave://rewards
5. Enable rewards
6. Rewards toolbar button is still not visible


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
