### PR TITLE
set wildcard last so content settings observer picks up the right value (uplift to 0.70.x)

### DIFF
--- a/browser/net/brave_network_delegate_browsertest.cc
+++ b/browser/net/brave_network_delegate_browsertest.cc
@@ -47,6 +47,12 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
     return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
   }
 
+  void DefaultBlockAllCookies() {
+    brave_shields::SetCookieControlType(browser()->profile(),
+                                        brave_shields::ControlType::BLOCK,
+                                        GURL());
+  }
+
   void AllowCookies() {
     brave_shields::SetCookieControlType(browser()->profile(),
                                         brave_shields::ControlType::ALLOW,
@@ -97,4 +103,16 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   const std::string cookie =
       content::GetCookies(browser()->profile(), GURL("http://c.com/"));
   EXPECT_FALSE(cookie.empty());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
+                       DefaultCookiesBlocked) {
+  DefaultBlockAllCookies();
+  ui_test_utils::NavigateToURL(browser(), nested_iframe_script_url_);
+  std::string cookie =
+      content::GetCookies(browser()->profile(), GURL("http://c.com/"));
+  EXPECT_TRUE(cookie.empty()) << "Actual cookie: " << cookie;
+  cookie =
+      content::GetCookies(browser()->profile(), GURL("http://a.com/"));
+  EXPECT_TRUE(cookie.empty()) << "Actual cookie: " << cookie;
 }

--- a/components/brave_shields/browser/brave_shields_util.cc
+++ b/components/brave_shields/browser/brave_shields_util.cc
@@ -210,16 +210,16 @@ void SetCookieControlType(HostContentSettingsMap* map,
                                     CONTENT_SETTINGS_TYPE_PLUGINS, kReferrers,
                                     GetDefaultBlockFromControlType(type));
 
-  map->SetContentSettingCustomScope(primary_pattern,
-                                    ContentSettingsPattern::Wildcard(),
-                                    CONTENT_SETTINGS_TYPE_PLUGINS, kCookies,
-                                    GetDefaultBlockFromControlType(type));
-
   map->SetContentSettingCustomScope(
       primary_pattern,
       ContentSettingsPattern::FromString("https://firstParty/*"),
       CONTENT_SETTINGS_TYPE_PLUGINS, kCookies,
       GetDefaultAllowFromControlType(type));
+
+  map->SetContentSettingCustomScope(primary_pattern,
+                                    ContentSettingsPattern::Wildcard(),
+                                    CONTENT_SETTINGS_TYPE_PLUGINS, kCookies,
+                                    GetDefaultBlockFromControlType(type));
 }
 
 ControlType GetCookieControlType(HostContentSettingsMap* map, const GURL& url) {

--- a/test/data/nested_iframe_script.html
+++ b/test/data/nested_iframe_script.html
@@ -1,5 +1,6 @@
 <html><head><title>nested iframe script test</title></head>
 <body>
+<script src="/cross-site/a.com/script_cookies.js"></script>
 <iframe src="/cross-site/c.com/iframe_script_cookie.html" id="nested_iframe_script"></iframe>
 </body></html>
 


### PR DESCRIPTION
Uplift of #3694 (squashed) to beta
Fixes https://github.com/brave/brave-browser/issues/6389