### PR TITLE
Contribution code should use doubles for currency, not integers

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -650,7 +650,7 @@ void BraveRewardsGetRecurringTipsFunction::OnGetRecurringTips(
     for (auto const& item : *list) {
       auto tip = std::make_unique<base::DictionaryValue>();
       tip->SetString("publisherKey", item.id);
-      tip->SetInteger("amount", item.weight);
+      tip->SetDouble("amount", item.weight);
       recurringTips->Append(std::move(tip));
     }
   }

--- a/browser/ui/webui/brave_tip_ui.cc
+++ b/browser/ui/webui/brave_tip_ui.cc
@@ -209,7 +209,7 @@ void RewardsTipDOMHandler::OnTip(const base::ListValue* args) {
   CHECK_EQ(3U, args->GetSize());
 
   const std::string publisher_key = args->GetList()[0].GetString();
-  const int amount = args->GetList()[1].GetInt();
+  const double amount = args->GetList()[1].GetDouble();
   const bool recurring = args->GetList()[2].GetBool();
 
   if (publisher_key.empty() || amount < 1) {

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -685,7 +685,7 @@
           },
           {
             "name": "new_amount",
-            "type": "integer"
+            "type": "number"
           }
         ]
       },

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -107,10 +107,10 @@ class MockRewardsService : public RewardsService {
       void(const std::string&,
            brave_rewards::GetPublisherBannerCallback));
   MOCK_METHOD3(OnTip, void(const std::string&,
-                           int,
+                           double,
                            bool));
   MOCK_METHOD4(OnTip, void(const std::string&,
-                           int,
+                           double,
                            bool,
                            std::unique_ptr<brave_rewards::ContentSite>));
   MOCK_METHOD1(RemoveRecurringTipUI, void(const std::string&));
@@ -140,7 +140,7 @@ class MockRewardsService : public RewardsService {
       void(brave_rewards::GetTransactionHistoryCallback));
   MOCK_METHOD3(SaveRecurringTipUI,
       void(const std::string&,
-           const int,
+           const double,
            brave_rewards::SaveRecurringTipCallback));
   MOCK_METHOD2(RefreshPublisher, void(const std::string&,
                                       brave_rewards::RefreshPublisherCallback));

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -180,9 +180,9 @@ class RewardsService : public KeyedService {
   virtual void GetPublisherBanner(const std::string& publisher_id,
                                   GetPublisherBannerCallback callback) = 0;
   virtual void OnTip(const std::string& publisher_key,
-                     int amount,
+                     double amount,
                      bool recurring) = 0;
-  virtual void OnTip(const std::string& publisher_key, int amount,
+  virtual void OnTip(const std::string& publisher_key, double amount,
       bool recurring, std::unique_ptr<brave_rewards::ContentSite> site) = 0;
   virtual void RemoveRecurringTipUI(const std::string& publisher_key) = 0;
   virtual void GetRecurringTipsUI(GetRecurringTipsCallback callback) = 0;
@@ -235,7 +235,7 @@ class RewardsService : public KeyedService {
   static void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
   virtual void SaveRecurringTipUI(const std::string& publisher_key,
-                                  const int amount,
+                                  const double amount,
                                   SaveRecurringTipCallback callback) = 0;
 
   virtual const RewardsNotificationService::RewardsNotificationsMap&

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -1129,7 +1129,8 @@ class BraveRewardsBrowserTest :
     const size_t size = probi.size();
     std::string amount = "0";
     if (size > 18) {
-      amount = probi.substr(0, size - 18);
+      amount = probi;
+      amount.insert(size - 18, ".");
     }
 
     double amount_double = std::stod(amount);

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -2509,6 +2509,47 @@ IN_PROC_BROWSER_TEST_F(
   rewards_service_->RemoveObserver(this);
 }
 
+// Ensure that we can make a one-time tip of a non-integral amount.
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, TipNonIntegralAmount) {
+  rewards_service()->AddObserver(this);
+
+  EnableRewards();
+
+  const bool use_panel = true;
+  ClaimGrant(use_panel);
+
+  // TODO(jhoneycutt): Test that this works through the tipping UI.
+  rewards_service()->OnTip("duckduckgo.com", 2.5, false);
+  WaitForTipReconcileCompleted();
+  ASSERT_EQ(tip_reconcile_status_, ledger::Result::LEDGER_OK);
+
+  ASSERT_EQ(reconciled_tip_total_, 2.5);
+
+  rewards_service_->RemoveObserver(this);
+}
+
+// Ensure that we can make a recurring tip of a non-integral amount.
+IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest, RecurringTipNonIntegralAmount) {
+  rewards_service()->AddObserver(this);
+
+  EnableRewards();
+
+  const bool use_panel = true;
+  ClaimGrant(use_panel);
+
+  const bool verified = true;
+  VisitPublisher("duckduckgo.com", verified);
+
+  rewards_service()->OnTip("duckduckgo.com", 2.5, true);
+  rewards_service()->StartMonthlyContributionForTest();
+  WaitForTipReconcileCompleted();
+  ASSERT_EQ(tip_reconcile_status_, ledger::Result::LEDGER_OK);
+
+  ASSERT_EQ(reconciled_tip_total_, 2.5);
+
+  rewards_service_->RemoveObserver(this);
+}
+
 IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
     RecurringAndPartialAutoContribution) {
   // Observe the Rewards service

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2344,7 +2344,7 @@ void RewardsServiceImpl::OnTipPublisherInfoSaved(const ledger::Result result,
 }
 
 void RewardsServiceImpl::OnTip(const std::string& publisher_key,
-                               int amount,
+                               double amount,
                                bool recurring,
                                ledger::PublisherInfoPtr publisher_info) {
   if (recurring) {
@@ -2429,7 +2429,7 @@ void RewardsServiceImpl::OnSaveRecurringTipUI(
 
 void RewardsServiceImpl::SaveRecurringTipUI(
     const std::string& publisher_key,
-    const int amount,
+    const double amount,
     SaveRecurringTipCallback callback) {
   ledger::ContributionInfoPtr info = ledger::ContributionInfo::New();
   info->publisher = publisher_key;
@@ -2952,7 +2952,7 @@ void RewardsServiceImpl::GetRewardsInternalsInfo(
 
 void RewardsServiceImpl::OnTip(
     const std::string& publisher_key,
-    int amount,
+    double amount,
     bool recurring) {
   OnTip(publisher_key, amount, recurring,
       static_cast<ledger::PublisherInfoPtr>(nullptr));
@@ -2960,7 +2960,7 @@ void RewardsServiceImpl::OnTip(
 
 void RewardsServiceImpl::OnTip(
     const std::string& publisher_key,
-    const int amount,
+    const double amount,
     const bool recurring,
     std::unique_ptr<brave_rewards::ContentSite> site) {
 

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -220,7 +220,7 @@ class RewardsServiceImpl : public RewardsService,
       const ledger::Result result);
   void SaveRecurringTipUI(
       const std::string& publisher_key,
-      const int amount,
+      const double amount,
       SaveRecurringTipCallback callback) override;
 
   const RewardsNotificationService::RewardsNotificationsMap&
@@ -255,12 +255,12 @@ class RewardsServiceImpl : public RewardsService,
   void RemoveAllPendingContributionsUI() override;
 
   void OnTip(const std::string& publisher_key,
-             int amount,
+             double amount,
              bool recurring) override;
 
   void OnTip(
       const std::string& publisher_key,
-      const int amount,
+      const double amount,
       const bool recurring,
       std::unique_ptr<brave_rewards::ContentSite> site) override;
 
@@ -354,7 +354,7 @@ class RewardsServiceImpl : public RewardsService,
   void OnTipPublisherInfoSaved(const ledger::Result result,
                                ledger::PublisherInfoPtr info);
   void OnTip(const std::string& publisher_key,
-             int amount,
+             double amount,
              bool recurring,
              ledger::PublisherInfoPtr publisher_info);
   void OnResetTheWholeState(base::Callback<void(bool)> callback,

--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -454,7 +454,7 @@ export class Panel extends React.Component<Props, State> {
   }
 
   onContributionAmountChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const newValue = parseInt(event.target.value, 10)
+    const newValue = parseFloat(event.target.value)
     const publisher: RewardsExtension.Publisher | undefined = this.getPublisher()
 
     if (!publisher || !publisher.publisher_key) {

--- a/components/brave_rewards/resources/tip/components/siteBanner.tsx
+++ b/components/brave_rewards/resources/tip/components/siteBanner.tsx
@@ -77,7 +77,7 @@ class Banner extends React.Component<Props, State> {
     const { total } = balance
     const publisher = this.props.publisher
 
-    if (publisher.publisherKey && total >= parseInt(amount, 10)) {
+    if (publisher.publisherKey && total >= parseFloat(amount)) {
       this.actions.onTip(publisher.publisherKey, amount, recurring)
     } else {
       // TODO return error

--- a/components/brave_rewards/resources/tip/reducers/tip_reducer.ts
+++ b/components/brave_rewards/resources/tip/reducers/tip_reducer.ts
@@ -63,7 +63,7 @@ const publishersReducer: Reducer<RewardsTip.State> = (state: RewardsTip.State = 
     }
     case types.ON_TIP: {
       if (payload.publisherKey && payload.amount > 0) {
-        let amount = parseInt(payload.amount, 10)
+        let amount = parseFloat(payload.amount)
         chrome.send('brave_rewards_tip.onTip', [
           payload.publisherKey,
           amount,

--- a/components/services/bat_ledger/bat_ledger_impl.cc
+++ b/components/services/bat_ledger/bat_ledger_impl.cc
@@ -430,7 +430,7 @@ void BatLedgerImpl::OnDoDirectTip(
 }
 
 void BatLedgerImpl::DoDirectTip(const std::string& publisher_id,
-                                int32_t amount,
+                                double amount,
                                 const std::string& currency,
                                 DoDirectTipCallback callback) {
   // deleted in OnDoDirectTip

--- a/components/services/bat_ledger/bat_ledger_impl.h
+++ b/components/services/bat_ledger/bat_ledger_impl.h
@@ -125,7 +125,7 @@ class BatLedgerImpl : public mojom::BatLedger,
       GetPublisherBannerCallback callback) override;
 
   void DoDirectTip(const std::string& publisher_id,
-                   int32_t amount,
+                   double amount,
                    const std::string& currency,
                    DoDirectTipCallback callback) override;
 

--- a/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
+++ b/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
@@ -99,7 +99,7 @@ interface BatLedger {
       (ledger.mojom.PublisherBanner? banner);
 
   DoDirectTip(string publisher_id,
-              int32 amount,
+              double amount,
               string currency) => (ledger.mojom.Result result);
 
   RemoveRecurringTip(string publisher_key) => (ledger.mojom.Result result);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -197,7 +197,7 @@ test("brave_unit_tests") {
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_util_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_helper_unittest.cc",
-      "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_helper_unittest.h",
+      "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/publisher/publisher_unittest.cc",
       "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/test/niceware_partial_unittest.cc",
       "//brave/components/brave_rewards/browser/database/publisher_info_database_unittest.cc",

--- a/vendor/bat-native-ledger/BUILD.gn
+++ b/vendor/bat-native-ledger/BUILD.gn
@@ -87,6 +87,8 @@ source_set("ledger") {
   output_name = "bat_native_ledger"
 
   sources = [
+    "src/bat/ledger/internal/bat_util.cc",
+    "src/bat/ledger/internal/bat_util.h",
     "src/bat/ledger/internal/bat_helper.cc",
     "src/bat/ledger/internal/bat_helper.h",
     "src/bat/ledger/internal/bat_state.cc",

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -86,7 +86,7 @@ class LEDGER_EXPORT Ledger {
                             CreateWalletCallback callback) = 0;
 
   virtual void DoDirectTip(const std::string& publisher_key,
-                           int amount,
+                           double amount,
                            const std::string& currency,
                            ledger::DoDirectTipCallback callback) = 0;
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_helper_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_helper_unittest.cc
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "bat/ledger/internal/bat_helper.h"
+#include "bat/ledger/internal/rapidjson_bat_helper.h"
 #include "bat/ledger/ledger.h"
 #include "testing/gtest/include/gtest/gtest.h"
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/strings/string_split.h"
+#include "bat/ledger/internal/bat_util.h"
+
+namespace braveledger_bat_util {
+
+std::string ConvertToProbi(const std::string& amount) {
+  if (amount.empty()) {
+    return "0";
+  }
+
+  auto vec = base::SplitString(
+      amount, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+
+  const std::string probi = "000000000000000000";
+
+  if (vec.size() == 1) {
+    return vec.at(0) + probi;
+  }
+
+  const auto before_dot = vec.at(0);
+  const auto after_dot = vec.at(1);
+  const auto rest_probi = probi.substr(after_dot.size());
+
+  return before_dot + after_dot + rest_probi;
+}
+
+}  // namespace braveledger_bat_util

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVELEDGER_BAT_UTIL_H_
+#define BRAVELEDGER_BAT_UTIL_H_
+
+#include <string>
+
+namespace braveledger_bat_util {
+
+std::string ConvertToProbi(const std::string& amount);
+
+}  // namespace braveledger_bat_util
+
+#endif  // BRAVELEDGER_BAT_UTIL_H_

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bat_util_unittest.cc
@@ -1,0 +1,34 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ledger/internal/bat_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BatUtilTest.*
+
+class BatUtilTest : public testing::Test {
+};
+
+TEST(BatUtilTest, ConvertToProbi) {
+  // empty string
+  std::string result = braveledger_bat_util::ConvertToProbi("");
+  ASSERT_EQ(result, "0");
+
+  // single dig int
+  result = braveledger_bat_util::ConvertToProbi("5");
+  ASSERT_EQ(result, "5000000000000000000");
+
+  // two dig int
+  result = braveledger_bat_util::ConvertToProbi("15");
+  ASSERT_EQ(result, "15000000000000000000");
+
+  // single dig decimal
+  result = braveledger_bat_util::ConvertToProbi("5.4");
+  ASSERT_EQ(result, "5400000000000000000");
+
+  // two dig decimal
+  result = braveledger_bat_util::ConvertToProbi("5.45");
+  ASSERT_EQ(result, "5450000000000000000");
+}

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.cc
@@ -13,6 +13,7 @@
 
 #include "base/time/time.h"
 #include "bat/ledger/global_constants.h"
+#include "bat/ledger/internal/bat_util.h"
 #include "bat/ledger/internal/common/bind_util.h"
 #include "bat/ledger/internal/contribution/contribution.h"
 #include "bat/ledger/internal/contribution/contribution_util.h"
@@ -901,7 +902,7 @@ void Contribution::OnExternalWalletServerPublisherInfo(
   const auto reconcile = ledger_->GetReconcileById(viewing_id);
   if (!info) {
     const auto probi =
-        braveledger_uphold::ConvertToProbi(std::to_string(amount));
+        braveledger_bat_util::ConvertToProbi(std::to_string(amount));
     ledger_->OnReconcileComplete(
         ledger::Result::LEDGER_ERROR,
         viewing_id,

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.cc
@@ -593,7 +593,7 @@ void Contribution::StartPhaseTwo(const std::string& viewing_id) {
 
 void Contribution::DoDirectTip(
     const std::string& publisher_key,
-    int amount,
+    double amount,
     const std::string& currency,
     ledger::DoDirectTipCallback callback) {
   if (publisher_key.empty()) {
@@ -636,7 +636,7 @@ void Contribution::SavePendingContribution(
 void Contribution::OnDoDirectTipServerPublisher(
     ledger::ServerPublisherInfoPtr server_info,
     const std::string& publisher_key,
-    int amount,
+    double amount,
     const std::string& currency,
     ledger::DoDirectTipCallback callback) {
   auto status = ledger::PublisherStatus::NOT_VERIFIED;
@@ -648,7 +648,7 @@ void Contribution::OnDoDirectTipServerPublisher(
   if (status == ledger::PublisherStatus::NOT_VERIFIED) {
     SavePendingContribution(
         publisher_key,
-        static_cast<double>(amount),
+        amount,
         ledger::RewardsType::ONE_TIME_TIP,
         callback);
     return;
@@ -897,7 +897,7 @@ void Contribution::OnExternalWallets(
 void Contribution::OnExternalWalletServerPublisherInfo(
     ledger::ServerPublisherInfoPtr info,
     const std::string& viewing_id,
-    int amount,
+    double amount,
     const ledger::ExternalWallet& wallet) {
   const auto reconcile = ledger_->GetReconcileById(viewing_id);
   if (!info) {
@@ -918,7 +918,7 @@ void Contribution::OnExternalWalletServerPublisherInfo(
   if (info->status != ledger::PublisherStatus::VERIFIED) {
     SavePendingContribution(
         info->publisher_key,
-        static_cast<double>(amount),
+        amount,
         static_cast<ledger::RewardsType>(reconcile.type_),
         [](const ledger::Result _){});
     return;
@@ -927,7 +927,7 @@ void Contribution::OnExternalWalletServerPublisherInfo(
   uphold_->StartContribution(
       viewing_id,
       info->address,
-      static_cast<double>(amount),
+      amount,
       ledger::ExternalWallet::New(wallet));
 }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.h
@@ -180,7 +180,7 @@ class Contribution {
 
   void DoDirectTip(
       const std::string& publisher_key,
-      int amount,
+      double amount,
       const std::string& currency,
       ledger::DoDirectTipCallback callback);
 
@@ -244,7 +244,7 @@ class Contribution {
   void OnDoDirectTipServerPublisher(
     ledger::ServerPublisherInfoPtr server_info,
     const std::string& publisher_key,
-    int amount,
+    double amount,
     const std::string& currency,
     ledger::DoDirectTipCallback callback);
 
@@ -273,7 +273,7 @@ class Contribution {
   void OnExternalWalletServerPublisherInfo(
       ledger::ServerPublisherInfoPtr info,
       const std::string& viewing_id,
-      int amount,
+      double amount,
       const ledger::ExternalWallet& wallet);
 
   void OnUpholdAC(ledger::Result result,

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/phase_one.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/phase_one.cc
@@ -8,6 +8,7 @@
 #include "anon/anon.h"
 #include "bat/ledger/internal/contribution/phase_one.h"
 #include "bat/ledger/internal/contribution/phase_two.h"
+#include "bat/ledger/internal/bat_util.h"
 #include "bat/ledger/internal/ledger_impl.h"
 #include "net/http/http_status_code.h"
 
@@ -280,7 +281,8 @@ void PhaseOne::ReconcilePayloadCallback(
   transaction.contribution_rates_ = reconcile.rates_;
 
   if (ledger::is_testing) {
-    transaction.contribution_probi_ = reconcile.amount_ + "000000000000000000";
+    transaction.contribution_probi_ =
+        braveledger_bat_util::ConvertToProbi(reconcile.amount_);
   }
 
   braveledger_bat_helper::Transactions transactions =

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -714,7 +714,7 @@ void LedgerImpl::SaveUnverifiedContribution(
 }
 
 void LedgerImpl::DoDirectTip(const std::string& publisher_key,
-                             int amount,
+                             double amount,
                              const std::string& currency,
                              ledger::DoDirectTipCallback callback) {
   bat_contribution_->DoDirectTip(publisher_key, amount, currency, callback);

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -105,7 +105,7 @@ class LedgerImpl : public ledger::Ledger,
                            ledger::PublisherInfoListCallback callback) override;
 
   void DoDirectTip(const std::string& publisher_key,
-                   int amount,
+                   double amount,
                    const std::string& currency,
                    ledger::DoDirectTipCallback callback) override;
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold.cc
@@ -10,6 +10,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/string_number_conversions.h"
 #include "bat/ledger/global_constants.h"
+#include "bat/ledger/internal/bat_util.h"
 #include "bat/ledger/internal/uphold/uphold.h"
 #include "bat/ledger/internal/uphold/uphold_authorization.h"
 #include "bat/ledger/internal/uphold/uphold_card.h"
@@ -83,7 +84,8 @@ void Uphold::ContributionCompleted(
     const double fee,
     const ledger::ExternalWallet& wallet) {
   const auto reconcile = ledger_->GetReconcileById(viewing_id);
-  const auto amount = ConvertToProbi(std::to_string(reconcile.fee_));
+  const auto amount =
+      braveledger_bat_util::ConvertToProbi(std::to_string(reconcile.fee_));
 
   if (result == ledger::Result::LEDGER_OK) {
     const auto current_time_seconds = base::Time::Now().ToDoubleT();

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.cc
@@ -7,7 +7,6 @@
 
 #include "base/base64.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"
 #include "bat/ledger/global_constants.h"
 #include "bat/ledger/internal/uphold/uphold_util.h"
@@ -48,27 +47,6 @@ std::string GetFeeAddress() {
   return ledger::is_production
       ? kFeeAddressProduction
       : kFeeAddressStaging;
-}
-
-std::string ConvertToProbi(const std::string& amount) {
-  if (amount.empty()) {
-    return "0";
-  }
-
-  auto vec = base::SplitString(
-      amount, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-
-  const std::string probi = "000000000000000000";
-
-  if (vec.size() == 1) {
-    return vec.at(0) + probi;
-  }
-
-  const auto before_dot = vec.at(0);
-  const auto after_dot = vec.at(1);
-  const auto rest_probi = probi.substr(after_dot.size());
-
-  return before_dot + after_dot + rest_probi;
 }
 
 std::string GetVerifyUrl(const std::string& state) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util.h
@@ -36,8 +36,6 @@ std::string GetAPIUrl(const std::string& path);
 
 std::string GetFeeAddress();
 
-std::string ConvertToProbi(const std::string& amount);
-
 std::string GetVerifyUrl(const std::string& state);
 
 std::string GetAddUrl(const std::string& address);

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc
@@ -71,28 +71,6 @@ TEST(UpholdUtilTest, GetFeeAddress) {
   ASSERT_EQ(result, kFeeAddressStaging);
 }
 
-TEST(UpholdUtilTest, ConvertToProbi) {
-  // empty string
-  std::string result = braveledger_uphold::ConvertToProbi("");
-  ASSERT_EQ(result, "0");
-
-  // single dig int
-  result = braveledger_uphold::ConvertToProbi("5");
-  ASSERT_EQ(result, "5000000000000000000");
-
-  // two dig int
-  result = braveledger_uphold::ConvertToProbi("15");
-  ASSERT_EQ(result, "15000000000000000000");
-
-  // single dig decimal
-  result = braveledger_uphold::ConvertToProbi("5.4");
-  ASSERT_EQ(result, "5400000000000000000");
-
-  // two dig decimal
-  result = braveledger_uphold::ConvertToProbi("5.45");
-  ASSERT_EQ(result, "5450000000000000000");
-}
-
 TEST(UpholdUtilTest, GetVerifyUrl) {
   // production
   ledger::is_production = true;

--- a/vendor/brave-ios/Ledger/BATBraveLedger.h
+++ b/vendor/brave-ios/Ledger/BATBraveLedger.h
@@ -161,7 +161,7 @@ NS_SWIFT_NAME(BraveLedger)
 - (void)listOneTimeTips:(void (NS_NOESCAPE ^)(NSArray<BATPublisherInfo *> *))completion;
 
 - (void)tipPublisherDirectly:(BATPublisherInfo *)publisher
-                      amount:(int)amount
+                      amount:(double)amount
                     currency:(NSString *)currency
                   completion:(void (^)(BATResult result))completion;
 

--- a/vendor/brave-ios/Ledger/BATBraveLedger.mm
+++ b/vendor/brave-ios/Ledger/BATBraveLedger.mm
@@ -532,7 +532,7 @@ BATLedgerReadonlyBridge(double, defaultContributionAmount, GetDefaultContributio
   });
 }
 
-- (void)tipPublisherDirectly:(BATPublisherInfo *)publisher amount:(int)amount currency:(NSString *)currency completion:(void (^)(BATResult result))completion
+- (void)tipPublisherDirectly:(BATPublisherInfo *)publisher amount:(double)amount currency:(NSString *)currency completion:(void (^)(BATResult result))completion
 {
   ledger->DoDirectTip(std::string(publisher.id.UTF8String), amount, std::string(currency.UTF8String), ^(ledger::Result result) {
     completion(static_cast<BATResult>(result));


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/6481

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
This does not currently have a user-facing impact.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
