### PR TITLE
remove invalid shields tests because the default for "shields up/down…

### DIFF
--- a/components/brave_shields/browser/brave_shields_util.cc
+++ b/components/brave_shields/browser/brave_shields_util.cc
@@ -120,6 +120,8 @@ void SetBraveShieldsEnabled(Profile* profile,
   if (url.is_valid() && !url.SchemeIsHTTPOrHTTPS())
     return;
 
+  DCHECK(!url.is_empty()) << "url for shields setting cannot be blank";
+
   auto primary_pattern = GetPatternFromURL(url, true);
 
   if (!primary_pattern.IsValid())

--- a/components/brave_shields/browser/brave_shields_util_unittest.cc
+++ b/components/brave_shields/browser/brave_shields_util_unittest.cc
@@ -117,58 +117,6 @@ TEST_F(BraveShieldsUtilTest, ControlTypeFromString) {
 }
 
 /* BRAVE_SHIELDS CONTROL */
-TEST_F(BraveShieldsUtilTest, SetBraveShieldsEnabled_Default) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(profile());
-  // settings should be default
-  auto setting =
-      map->GetContentSetting(GURL(), GURL(), CONTENT_SETTINGS_TYPE_PLUGINS,
-                             brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_DEFAULT, setting);
-  setting = map->GetContentSetting(GURL("http://brave.com"), GURL(),
-                                   CONTENT_SETTINGS_TYPE_PLUGINS,
-                                   brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_DEFAULT, setting);
-
-  /* enabled */
-  brave_shields::SetBraveShieldsEnabled(profile(), true, GURL());
-  setting =
-      map->GetContentSetting(GURL(), GURL(), CONTENT_SETTINGS_TYPE_PLUGINS,
-                             brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_ALLOW, setting);
-
-  // override should apply to all origins
-  setting = map->GetContentSetting(GURL("http://brave.com"), GURL(),
-                                   CONTENT_SETTINGS_TYPE_PLUGINS,
-                                   brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_ALLOW, setting);
-
-  /* disabled */
-  brave_shields::SetBraveShieldsEnabled(profile(), false, GURL());
-  setting =
-      map->GetContentSetting(GURL(), GURL(), CONTENT_SETTINGS_TYPE_PLUGINS,
-                             brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_BLOCK, setting);
-
-  // override should apply to all origins
-  setting = map->GetContentSetting(GURL("http://brave.com"), GURL(),
-                                   CONTENT_SETTINGS_TYPE_PLUGINS,
-                                   brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_BLOCK, setting);
-
-  /* DEFAULT */
-  brave_shields::ResetBraveShieldsEnabled(profile(), GURL());
-  setting =
-      map->GetContentSetting(GURL(), GURL(), CONTENT_SETTINGS_TYPE_PLUGINS,
-                             brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_DEFAULT, setting);
-
-  // override should apply to all origins
-  setting = map->GetContentSetting(GURL("http://brave.com"), GURL(),
-                                   CONTENT_SETTINGS_TYPE_PLUGINS,
-                                   brave_shields::kBraveShields);
-  EXPECT_EQ(CONTENT_SETTING_DEFAULT, setting);
-}
-
 TEST_F(BraveShieldsUtilTest, SetBraveShieldsEnabled_ForOrigin) {
   auto* map = HostContentSettingsMapFactory::GetForProfile(profile());
 
@@ -213,29 +161,6 @@ TEST_F(BraveShieldsUtilTest, SetBraveShieldsEnabled_IsNotHttpHttps) {
   EXPECT_EQ(false, setting);
 }
 
-TEST_F(BraveShieldsUtilTest, GetBraveShieldsEnabled_Default) {
-  auto* map = HostContentSettingsMapFactory::GetForProfile(profile());
-
-  auto setting = brave_shields::GetBraveShieldsEnabled(profile(), GURL());
-  EXPECT_EQ(true, setting);
-
-  /* BLOCK */
-  map->SetContentSettingCustomScope(
-      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
-      CONTENT_SETTINGS_TYPE_PLUGINS, brave_shields::kBraveShields,
-      CONTENT_SETTING_BLOCK);
-  setting = brave_shields::GetBraveShieldsEnabled(profile(), GURL());
-  EXPECT_EQ(false, setting);
-
-  /* ALLOW */
-  map->SetContentSettingCustomScope(
-      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
-      CONTENT_SETTINGS_TYPE_PLUGINS, brave_shields::kBraveShields,
-      CONTENT_SETTING_ALLOW);
-  setting = brave_shields::GetBraveShieldsEnabled(profile(), GURL());
-  EXPECT_EQ(true, setting);
-}
-
 TEST_F(BraveShieldsUtilTest, GetBraveShieldsEnabled_ForOrigin) {
   auto* map = HostContentSettingsMapFactory::GetForProfile(profile());
 
@@ -263,38 +188,6 @@ TEST_F(BraveShieldsUtilTest, GetBraveShieldsEnabled_ForOrigin) {
   // default is unchanged
   setting = brave_shields::GetBraveShieldsEnabled(profile(), GURL());
   EXPECT_EQ(true, setting);
-
-  /* ALLOW */
-  // change default to block
-  map->SetContentSettingCustomScope(
-      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
-      CONTENT_SETTINGS_TYPE_PLUGINS, brave_shields::kBraveShields,
-      CONTENT_SETTING_BLOCK);
-  setting = brave_shields::GetBraveShieldsEnabled(profile(),
-                                                  GURL("http://brave.com"));
-  EXPECT_EQ(false, setting);
-  setting = brave_shields::GetBraveShieldsEnabled(profile(),
-                                                  GURL("https://brave.com"));
-  EXPECT_EQ(false, setting);
-  setting = brave_shields::GetBraveShieldsEnabled(profile(), GURL());
-  EXPECT_EQ(false, setting);
-
-  // set override to allow
-  map->SetContentSettingCustomScope(
-      ContentSettingsPattern::FromString("http://brave.com/*"),
-      ContentSettingsPattern::Wildcard(), CONTENT_SETTINGS_TYPE_PLUGINS,
-      brave_shields::kBraveShields, CONTENT_SETTING_ALLOW);
-  setting = brave_shields::GetBraveShieldsEnabled(profile(),
-                                                  GURL("http://brave.com"));
-  EXPECT_EQ(true, setting);
-
-  // https in unchanged
-  setting = brave_shields::GetBraveShieldsEnabled(profile(),
-                                                  GURL("https://brave.com"));
-  EXPECT_EQ(false, setting);
-  // default is unchanged
-  setting = brave_shields::GetBraveShieldsEnabled(profile(), GURL());
-  EXPECT_EQ(false, setting);
 }
 
 TEST_F(BraveShieldsUtilTest, GetBraveShieldsEnabled_IsNotHttpHttps) {


### PR DESCRIPTION
…" is not changeable, only the individual settings are

fix https://github.com/brave/brave-browser/issues/6494

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
