### PR TITLE
Issue 6541: BraveServiceKey for testing fetched should be fetched from the system request handler

### DIFF
--- a/browser/net/brave_system_request_handler.cc
+++ b/browser/net/brave_system_request_handler.cc
@@ -22,6 +22,10 @@ const char kBraveServicesKeyHeader[] = "BraveServiceKey";
 
 namespace brave {
 
+std::string BraveServicesKeyForTesting() {
+  return BRAVE_SERVICES_KEY;
+}
+
 void AddBraveServicesKeyHeader(network::ResourceRequest* url_request) {
   static URLPattern proxy_pattern(URLPattern::SCHEME_HTTPS,
                                   kBraveProxyPattern);

--- a/browser/net/brave_system_request_handler.h
+++ b/browser/net/brave_system_request_handler.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_SYSTEM_REQUEST_HANDLER_H_
 #define BRAVE_BROWSER_NET_BRAVE_SYSTEM_REQUEST_HANDLER_H_
 
+#include <string>
+
 namespace network {
 struct ResourceRequest;
 }
@@ -13,6 +15,8 @@ struct ResourceRequest;
 extern const char kBraveServicesKeyHeader[];
 
 namespace brave {
+
+std::string BraveServicesKeyForTesting();
 
 void AddBraveServicesKeyHeader(network::ResourceRequest* url_request);
 

--- a/browser/net/brave_system_request_handler_unittest.cc
+++ b/browser/net/brave_system_request_handler_unittest.cc
@@ -10,10 +10,6 @@
 #include "services/network/public/cpp/resource_request.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !defined(BRAVE_SERVICES_KEY)
-#define BRAVE_SERVICES_KEY "dummytoken"
-#endif
-
 namespace brave {
 
 TEST(BraveSystemRequestHandlerTest, AddBraveServiceKeyHeader) {
@@ -24,7 +20,7 @@ TEST(BraveSystemRequestHandlerTest, AddBraveServiceKeyHeader) {
     brave::AddBraveServicesKeyHeader(&request);
     std::string key;
     EXPECT_TRUE(request.headers.GetHeader(kBraveServicesKeyHeader, &key));
-    EXPECT_EQ(key, BRAVE_SERVICES_KEY);
+    EXPECT_EQ(key, BraveServicesKeyForTesting());
 }
 
 TEST(BraveSystemRequestHandlerTest, DontAddBraveServiceKeyHeader) {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/6541

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
