### PR TITLE
Issue 6549: Enable password import

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -154,6 +154,7 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
 #if BUILDFLAG(ENABLE_EXTENSIONS)
       extensions_features::kNewExtensionUpdaterService.name,
 #endif
+      password_manager::features::kPasswordImport.name,
     // Enable webui dark theme: @media (prefers-color-scheme: dark) is gated on
     // this feature.
       features::kWebUIDarkMode.name,

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -12,6 +12,7 @@
 #include "components/autofill/core/common/autofill_features.h"
 #include "components/autofill/core/common/autofill_payments_features.h"
 #include "components/omnibox/common/omnibox_features.h"
+#include "components/password_manager/core/common/password_manager_features.h"
 #include "components/sync/driver/sync_driver_switches.h"
 #include "components/unified_consent/feature.h"
 #include "content/public/browser/render_view_host.h"
@@ -63,6 +64,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, EnabledFeatures) {
     &extensions_features::kNewExtensionUpdaterService,
 #endif
     &omnibox::kSimplifyHttpsIndicator,
+    &password_manager::features::kPasswordImport,
   };
 
   for (const auto* feature : enabled_features)


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/6549

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Navigate to https://jumde.github.io/test/password.html
2. Insert a random username and password and click submit
3. When prompted to save password click yes
4. Navigate to brave://settings/passwords and verify the password shows up in Saved Passwords
5. Click on the ... next to the Saved Passwords

<img width="747" alt="Screen Shot 2019-10-17 at 4 27 46 PM" src="https://user-images.githubusercontent.com/1903815/67132015-f69a5a80-f1bb-11e9-8559-b60f81b36482.png">

6. Click export passwords and save it as a CSV
7. Remove the password 
8. Import the password and verify it shows up correctly.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
