### PR TITLE
Update wrong GOOGLE_CHROME_BUILD usage (uplift to 0.70.x)

### DIFF
--- a/browser/component_updater/brave_component_updater_configurator.cc
+++ b/browser/component_updater/brave_component_updater_configurator.cc
@@ -185,11 +185,7 @@ BraveConfigurator::GetProtocolHandlerFactory() const {
 
 update_client::RecoveryCRXElevator BraveConfigurator::GetRecoveryCRXElevator()
     const {
-#if defined(GOOGLE_CHROME_BUILD) && defined(OS_WIN)
-  return base::BindOnce(&RunRecoveryCRXElevated);
-#else
   return {};
-#endif
 }
 
 }  // namespace component_updater

--- a/browser/extensions/updater/brave_update_client_config.cc
+++ b/browser/extensions/updater/brave_update_client_config.cc
@@ -243,11 +243,7 @@ BraveUpdateClientConfig::GetProtocolHandlerFactory() const {
 
 update_client::RecoveryCRXElevator
 BraveUpdateClientConfig::GetRecoveryCRXElevator() const {
-#if defined(GOOGLE_CHROME_BUILD) && defined(OS_WIN)
-  return base::BindOnce(&RunRecoveryCRXElevated);
-#else
   return {};
-#endif
 }
 
 BraveUpdateClientConfig::~BraveUpdateClientConfig() {}

--- a/chromium_src/chrome/common/media/cdm_host_file_path.cc
+++ b/chromium_src/chrome/common/media/cdm_host_file_path.cc
@@ -10,18 +10,18 @@
 #include "base/logging.h"
 #include "base/path_service.h"
 #include "base/stl_util.h"
+#include "build/branding_buildflags.h"
 #include "build/build_config.h"
 #include "chrome/common/chrome_version.h"
 
 #if defined(OS_MACOSX)
 #include "base/mac/bundle_locations.h"
-#include "chrome/common/buildflags.h"
 #include "chrome/common/chrome_constants.h"
 #endif
 
 // All above headers copied from original cdm_host_file_path.cc are included
 // to prevent below GOOGLE_CHROEM_BUILD affect them.
 
-#define GOOGLE_CHROME_BUILD
+#undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
+#define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
 #include "../../../../../chrome/common/media/cdm_host_file_path.cc"  // NOLINT
-#undef GOOGLE_CHROME_BUILD

--- a/chromium_src/components/metrics/metrics_service_accessor.cc
+++ b/chromium_src/components/metrics/metrics_service_accessor.cc
@@ -1,13 +1,18 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#if defined(BRAVE_CHROMIUM_BUILD)
-#define GOOGLE_CHROME_BUILD
-#endif
+#include "components/metrics/metrics_service_accessor.h"
 
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#include "build/branding_buildflags.h"
+#include "components/metrics/metrics_pref_names.h"
+#include "components/metrics/metrics_service.h"
+#include "components/prefs/pref_service.h"
+#include "components/variations/hashing.h"
+
+#undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
+#define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
 #include "../../../../components/metrics/metrics_service_accessor.cc"
-
-#if defined(BRAVE_CHROMIUM_BUILD)
-#undef GOOGLE_CHROME_BUILD
-#endif

--- a/patches/chrome-installer-util-google_update_settings.cc.patch
+++ b/patches/chrome-installer-util-google_update_settings.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/util/google_update_settings.cc b/chrome/installer/util/google_update_settings.cc
-index 441ed6d50d5cb4edcd665665fca7887f034ff6a0..709c7e5e24518902ae86ab1ef819dd9d86239d1a 100644
+index 441ed6d50d5cb4edcd665665fca7887f034ff6a0..54a22d11c380ee31e12440900cf2a365781fe8d9 100644
 --- a/chrome/installer/util/google_update_settings.cc
 +++ b/chrome/installer/util/google_update_settings.cc
 @@ -29,7 +29,11 @@ using base::win::RegKey;
@@ -14,23 +14,14 @@ index 441ed6d50d5cb4edcd665665fca7887f034ff6a0..709c7e5e24518902ae86ab1ef819dd9d
  const wchar_t GoogleUpdateSettings::kUpdatePolicyValue[] = L"UpdateDefault";
  const wchar_t GoogleUpdateSettings::kDownloadPreferencePolicyValue[] =
      L"DownloadPreference";
-@@ -41,6 +45,11 @@ const wchar_t GoogleUpdateSettings::kCheckPeriodOverrideMinutes[] =
+@@ -41,6 +45,10 @@ const wchar_t GoogleUpdateSettings::kCheckPeriodOverrideMinutes[] =
  const int GoogleUpdateSettings::kCheckPeriodOverrideMinutesMax =
      60 * 24 * 7 * 6;
  
-+
 +#if defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD)
-+#define GOOGLE_CHROME_BUILD
++#undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
++#define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
 +#endif
-+
  const GoogleUpdateSettings::UpdatePolicy
      GoogleUpdateSettings::kDefaultUpdatePolicy =
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
-@@ -836,3 +845,7 @@ bool GoogleUpdateSettings::ReadExperimentLabels(
- 
-   return result == ERROR_SUCCESS;
- }
-+
-+#if defined(BRAVE_CHROMIUM_BUILD) && defined(OFFICIAL_BUILD)
-+#undef GOOGLE_CHROME_BUILD
-+#endif


### PR DESCRIPTION
Uplift of #3718
Fixes https://github.com/brave/brave-browser/issues/6497
Fixes https://github.com/brave/brave-browser/issues/6496

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.