### PR TITLE
Fix crash in GetShortcutProperties when opening Tor window on Windows

### DIFF
--- a/browser/profiles/BUILD.gn
+++ b/browser/profiles/BUILD.gn
@@ -11,6 +11,14 @@ source_set("profiles") {
     "profile_util.cc",
     "profile_util.h",
   ]
+
+  if (is_win) {
+    sources += [
+      "brave_profile_shortcut_manager_win.cc",
+      "brave_profile_shortcut_manager_win.h",
+    ]
+  }
+
   deps = [
     "//base",
     "//brave/browser/gcm_driver",

--- a/browser/profiles/brave_profile_shortcut_manager_win.cc
+++ b/browser/profiles/brave_profile_shortcut_manager_win.cc
@@ -1,0 +1,44 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/profiles/brave_profile_shortcut_manager_win.h"
+
+#include "brave/browser/profiles/profile_util.h"
+#include "chrome/browser/profiles/profile_attributes_storage.h"
+#include "chrome/browser/profiles/profile_manager.h"
+
+BraveProfileShortcutManagerWin::BraveProfileShortcutManagerWin(
+    ProfileManager* manager)
+    : ProfileShortcutManagerWin(manager),
+      profile_manager_(manager) {}
+
+void BraveProfileShortcutManagerWin::GetShortcutProperties(
+    const base::FilePath& profile_path,
+    base::CommandLine* command_line,
+    base::string16* name,
+    base::FilePath* icon_path) {
+  // Session profiles are currently not added into storage because they will
+  // return early in ProfileManager::AddProfileToStorage because of the profile
+  // path is not directly under user_data_dir. To avoid DCHECK(has_entry) in
+  // chromium's GetShortcutProperties and invalid access to the entry, return
+  // early here when entry cannot be found.
+  //
+  // TODO(jocelyn): Properly add session profiles into the storage and remove
+  // this override.
+  if (brave::IsSessionProfilePath(profile_path)) {
+    ProfileAttributesStorage& storage =
+        profile_manager_->GetProfileAttributesStorage();
+    ProfileAttributesEntry* entry;
+    bool has_entry =
+        storage.GetProfileAttributesWithPath(profile_path, &entry);
+    if (!has_entry)
+      return;
+  }
+
+  ProfileShortcutManagerWin::GetShortcutProperties(profile_path,
+                                                   command_line,
+                                                   name,
+                                                   icon_path);
+}

--- a/browser/profiles/brave_profile_shortcut_manager_win.h
+++ b/browser/profiles/brave_profile_shortcut_manager_win.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_PROFILES_BRAVE_PROFILE_SHORTCUT_MANAGER_WIN_H_
+#define BRAVE_BROWSER_PROFILES_BRAVE_PROFILE_SHORTCUT_MANAGER_WIN_H_
+
+#include "chrome/browser/profiles/profile_shortcut_manager_win.h"
+
+class BraveProfileShortcutManagerWin : public ProfileShortcutManagerWin {
+ public:
+  explicit BraveProfileShortcutManagerWin(ProfileManager* manager);
+  ~BraveProfileShortcutManagerWin() override = default;
+
+  void GetShortcutProperties(const base::FilePath& profile_path,
+                             base::CommandLine* command_line,
+                             base::string16* name,
+                             base::FilePath* icon_path) override;
+
+ private:
+  ProfileManager* profile_manager_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveProfileShortcutManagerWin);
+};
+
+#endif  // BRAVE_BROWSER_PROFILES_BRAVE_PROFILE_SHORTCUT_MANAGER_WIN_H_

--- a/chromium_src/chrome/browser/profiles/profile_shortcut_manager_win.cc
+++ b/chromium_src/chrome/browser/profiles/profile_shortcut_manager_win.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/profiles/brave_profile_shortcut_manager_win.h"
+#include "../../../../../chrome/browser/profiles/profile_shortcut_manager_win.cc"

--- a/patches/chrome-browser-profiles-profile_shortcut_manager_win.cc.patch
+++ b/patches/chrome-browser-profiles-profile_shortcut_manager_win.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/profiles/profile_shortcut_manager_win.cc b/chrome/browser/profiles/profile_shortcut_manager_win.cc
+index b81775384af11a28086e35ba645c36f65122092c..4922d2ed199f4438b76261701bc488f2c10daad1 100644
+--- a/chrome/browser/profiles/profile_shortcut_manager_win.cc
++++ b/chrome/browser/profiles/profile_shortcut_manager_win.cc
+@@ -726,7 +726,7 @@ bool ProfileShortcutManager::IsFeatureEnabled() {
+ // static
+ std::unique_ptr<ProfileShortcutManager> ProfileShortcutManager::Create(
+     ProfileManager* manager) {
+-  return std::make_unique<ProfileShortcutManagerWin>(manager);
++  return std::make_unique<BraveProfileShortcutManagerWin>(manager);
+ }
+ 
+ ProfileShortcutManagerWin::ProfileShortcutManagerWin(ProfileManager* manager)


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/6617

On Windows, we crashed in `GetShortcutProperties` because `has_entry` is false but chromium does not return early in that case and it continues to access entry which is invalid.
`has_entry` is false because session profiles are currently not added into `ProfileAttributesStorage` because the path we're using will be returned early in https://cs.chromium.org/chromium/src/chrome/browser/profiles/profile_manager.cc?type=cs&q=AddProfile&sq=package:chromium&g=0&l=1577-1580.
This PR is a short term fix to address this crash, will create a follow-up issue to properly add tor profile into the storage as a long term fix.

## Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
