### PR TITLE
Override CFBundleVersion string to prepare update on MacOS after major version

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -473,6 +473,7 @@ if (is_mac) {
       "--brave_product_dir_name=" + brave_product_dir_name,
       "--brave_feed_url=" + brave_feed_url,
       "--brave_dsa_file=" + brave_dsa_file,
+      "--brave_version=" + brave_version,
     ]
 
     deps = [

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -44,14 +44,17 @@ def _RemoveKeys(plist, *keys):
 
 
 def _OverrideVersionKey(plist, brave_version):
-  """ minor.build version string is used for update.
-  When we start to 1.0 version era, brave version string will be 1.0.0 and
-  0.0 is used for update check. With it, update will be failed because 0.0 is lower
-  version from 7x.xx. To make higher version from 7x.xx, add 100 magic number to
-  minor version and set it to `CFBundleVersion`."""
+  """ `minor.build` version string is used for update.
+  When we begin to use the Major version component, Brave version string will
+  be `1.0.0` for example and `Minor.Build` (`0.0`) would be used for update
+  check. Without modifying these numbers, update will fail as `0.0` is lower
+  than `70.121` for example.
+
+  To ensure minor version is higher than existing minor versions, we can
+  multiply the major version by 100 and set it to `CFBundleVersion`."""
   version_values = brave_version.split('.')
   if int(version_values[0]) >= 1:
-    adjusted_minor = int(version_values[1]) + 100
+    adjusted_minor = int(version_values[1]) + (100 * int(version_values[0]))
     plist['CFBundleVersion'] = str(adjusted_minor) + '.' + version_values[2]
 
 

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -43,6 +43,18 @@ def _RemoveKeys(plist, *keys):
       pass
 
 
+def _OverrideVersionKey(plist, brave_version):
+  """ minor.build version string is used for update.
+  When we start to 1.0 version era, brave version string will be 1.0.0 and
+  0.0 is used for update check. With it, update will be failed because 0.0 is lower
+  version from 7x.xx. To make higher version from 7x.xx, add 100 magic number to
+  minor version and set it to `CFBundleVersion`."""
+  version_values = brave_version.split('.')
+  if int(version_values[0]) >= 1:
+    adjusted_minor = int(version_values[1]) + 100
+    plist['CFBundleVersion'] = str(adjusted_minor) + '.' + version_values[2]
+
+
 def Main(argv):
   parser = optparse.OptionParser('%prog [options]')
   parser.add_option('--plist', dest='plist_path', action='store',
@@ -59,6 +71,8 @@ def Main(argv):
       type='string', default=None, help='Target url for update feed')
   parser.add_option('--brave_dsa_file', dest='brave_dsa_file', action='store',
       type='string', default=None, help='Public DSA file for update')
+  parser.add_option('--brave_version', dest='brave_version', action='store',
+      type='string', default=None, help='brave version string')
   parser.add_option('--format', choices=('binary1', 'xml1', 'json'),
       default='xml1', help='Format to use when writing property list '
           '(default: %(default)s)')
@@ -94,6 +108,8 @@ def Main(argv):
 
   if options.brave_dsa_file:
     plist['SUPublicDSAKeyFile'] = options.brave_dsa_file
+
+  _OverrideVersionKey(plist, options.brave_version)
 
   # Explicitly disable profiling
   plist['SUEnableSystemProfiling'] = False

--- a/script/lib/omaha.py
+++ b/script/lib/omaha.py
@@ -92,6 +92,14 @@ def get_app_info(appinfo, args):
     chrome_major = get_chrome_version().split('.')[0]
     chrome_minor = get_chrome_version().split('.')[1]
 
+    # The Sparkle CFBundleVersion is no longer tied to the Chrome version,
+    # instead we derive it from the package.json['version'] string. The 2nd
+    # digit is adjusted, and then we utilize that combined with the 3rd digit as
+    # the CFBundleVersion. (This is also used in build/mac/tweak_info_plist.py)
+    version_values = get_upload_version().split('.')
+    if int(version_values[0]) >= 1:
+        adjusted_minor = int(version_values[1]) + (100 * int(version_values[0]))
+
     appinfo['appguid'] = get_appguid(release_channel(), appinfo['platform'])
     appinfo['channel'] = release_channel()
     appinfo['chrome_version'] = get_chrome_version()
@@ -104,8 +112,8 @@ def get_app_info(appinfo, args):
         appinfo['version'] = chrome_major + '.' + get_upload_version()
     if appinfo['platform'] in 'darwin':
         appinfo['short_version'] = chrome_major + '.' + get_upload_version()
-        appinfo['version'] = appinfo['short_version'].split('.')[2] + \
-            '.' + appinfo['short_version'].split('.')[3]
+        appinfo['version'] = str(adjusted_minor) + \
+            '.' + version_values[2]
     appinfo['release_notes'] = 'Brave Browser version: {}\n\n<a href="{}">Brave Changelog</a>'\
         .format(appinfo['version'] if appinfo['platform'] in 'win32' else appinfo['short_version'],
                 changelog_url)


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/6465

To make update work after moving to 1.0, CFBundleVersion should be
always higher version than old one.
If we start to use 1.0.0, CFBundleVersion(combination of brave minor and build version) will be 0.0
and it is lower than previous one such as 71.103 from 0.71.103.
With this, update will not work.
So, we should adjust CFBundleVersion string after we move to 1.0.

In this PR, 100 is addded to brave minor version number.
With this, CFBundleVersion will be 100.0 from 1.0.0 and it's always higher
than previous one.

I think this is work-around fix but simplest fix instead of modifying sparkle itself and omaha server.
Also, I can't find this `CFBundleVersion` is exported via UI.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
