### PR TITLE
Add missing deps in importer target

### DIFF
--- a/browser/importer/BUILD.gn
+++ b/browser/importer/BUILD.gn
@@ -22,7 +22,22 @@ source_set("importer") {
 
   deps = [
     "//base",
+    "//brave/common",
+    "//brave/common:pref_names",
+    "//brave/components/brave_rewards/browser",
+    "//chrome/browser/ui",
+    # For buildflags.h included from chrome/browser/browser_process.h, we are
+    # not including chrome/browser here because of circular dependency.
+    # We should refactor this in the future to be able to add chrome/browser
+    # into importer target's deps.
+    "//chrome/common:buildflags",
+    "//chrome/common/importer",
+    "//components/prefs",
+    "//components/search_engines",
     "//content/public/browser",
     "//net",
+    "//services/network/public/mojom",
+    "//ui/base",
+    "//ui/gfx:native_widget_types",
   ]
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/6678

Add missing deps in importer target, `chrome/browser` is not added because of circular dependency, will create a follow up issue to break this and then importer target could include it as deps normally.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
