### PR TITLE
Bookmarks resync (toggle off and on)

### DIFF
--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -356,8 +356,10 @@ void BraveProfileSyncServiceImpl::OnSetSyncBookmarks(
       ProfileSyncService::GetUserSettings()->GetSelectedTypes();
   if (sync_bookmarks)
     type_set.Put(syncer::UserSelectableType::kBookmarks);
-  else
+  else {
     type_set.Remove(syncer::UserSelectableType::kBookmarks);
+    brave_sync_prefs_->ClearBookmarksPrefs();
+  }
   ProfileSyncService::GetUserSettings()->SetSelectedTypes(false, type_set);
   if (brave_sync_prefs_->GetSyncBookmarksEnabled() != sync_bookmarks)
     brave_sync_prefs_->SetSyncBookmarksEnabled(sync_bookmarks);

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -210,6 +210,9 @@ class BraveProfileSyncServiceImpl
 
   bool reseting_ = false;
 
+  // counter that prevents sending "fetching bookmarks" to js sync library
+  int  halt_bookmarks_fetch_times_ = -1;
+
   std::string brave_sync_words_;
 
   brave_sync::GetRecordsCallback get_record_cb_;

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -253,12 +253,16 @@ void Prefs::Clear() {
   pref_service_->ClearPref(kSyncBookmarksBaseOrder);
   pref_service_->ClearPref(kSyncSiteSettingsEnabled);
   pref_service_->ClearPref(kSyncHistoryEnabled);
-  pref_service_->ClearPref(kSyncLatestRecordTime);
   pref_service_->ClearPref(kSyncLatestDeviceRecordTime);
   pref_service_->ClearPref(kSyncLastFetchTime);
   pref_service_->ClearPref(kSyncDeviceList);
   pref_service_->ClearPref(kSyncApiVersion);
   pref_service_->ClearPref(kSyncMigrateBookmarksVersion);
+  ClearBookmarksPrefs();
+}
+
+void Prefs::ClearBookmarksPrefs() {
+  pref_service_->ClearPref(kSyncLatestRecordTime);
   pref_service_->ClearPref(kSyncRecordsToResend);
   pref_service_->ClearPref(kSyncRecordsToResendMeta);
 }

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -124,6 +124,7 @@ class Prefs {
                              std::unique_ptr<base::DictionaryValue> meta);
 
   void Clear();
+  void ClearBookmarksPrefs();
 
  private:
   // May be null.

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -611,11 +611,21 @@ TEST_F(BraveSyncServiceTest, OnSetSyncBookmarks) {
       brave_sync::prefs::kSyncBookmarksEnabled));
   EXPECT_CALL(*observer(), OnSyncStateChanged).Times(1);
   sync_service()->OnSetSyncBookmarks(true);
+  brave_sync_prefs()->AddToRecordsToResend(
+      "test_object_id", std::make_unique<base::DictionaryValue>());
+  brave_sync_prefs()->SetRecordToResendMeta(
+      "test_object_id", std::make_unique<base::DictionaryValue>());
+  brave_sync_prefs()->SetLatestRecordTime(base::Time::Now());
   EXPECT_TRUE(profile()->GetPrefs()->GetBoolean(syncer::prefs::kSyncBookmarks));
   EXPECT_TRUE(profile()->GetPrefs()->GetBoolean(
       brave_sync::prefs::kSyncBookmarksEnabled));
   EXPECT_CALL(*observer(), OnSyncStateChanged).Times(1);
   sync_service()->OnSetSyncBookmarks(false);
+  EXPECT_TRUE(brave_sync::tools::IsTimeEmpty(
+      brave_sync_prefs()->GetLatestRecordTime()));
+  EXPECT_TRUE(brave_sync_prefs()->GetRecordsToResend().empty());
+  EXPECT_EQ(brave_sync_prefs()->GetRecordToResendMeta("test_obejct_id"),
+            nullptr);
   EXPECT_FALSE(profile()->GetPrefs()->GetBoolean(
       brave_sync::prefs::kSyncBookmarksEnabled));
   EXPECT_FALSE(


### PR DESCRIPTION
Using existing toggle
<img width="728" alt="Screen Shot 2019-10-30 at 20 32 40" src="https://user-images.githubusercontent.com/11330831/67986784-0ddc3d80-fbe9-11e9-8c4c-5642acb12e76.png">

It will send all local bookmarks preserving original object id and pull
all remote records once

fix https://github.com/brave/brave-browser/issues/6674

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
###  No missing remote records
1. Sync device A and device B
2. Add `A1.com` and `A2.com` on device and wait until they show up in device B
3. Modify `A1.com` to be `A3.com` and `A2.com` to be `A4.com` on device A and wait until they show up in device B
4. Open `chrome://inspect/#extensions` and inspect "Brave Sync" on device A
5. Turn the bookmark toggle off and on on device A
6. There should be `"sync-debug" message="got 4 decrypted records in BOOKMARKS after 0"`
7. And `"sync-debug" message="Sending 2 records" afterward`
8. device A and device B should still have A3.com and A4.com and no duplication

### Simulate missing remote records
1. Sync device A and device B
2. Add `A1.com` and `A2.com` on device and wait until they show up in device B
3. Turn the bookmark toggle off on device A
4. Open `chrome://inspect/#extensions` and inspect "Brave Sync" on device B
5. Modify `A1.com` to be `A3.com` and `A2.com` to be `A4.com` on device B and make sure they are sent on inspected console
6. Add B1.com on device B and make sure it is sent on inspected console
7. Turn the bookmark toggle on device A
8. Wait around 2 minutes
9. device A and device B should have A3.com, A4.com, B1.com and no duplication
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
