### PR TITLE
Fixes ad notifications are not displayed on macOS Catalina

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -116,6 +116,7 @@ source_set("browser_process") {
     "//base",
     "//brave/browser/tor",
     "//brave/browser/translate/buildflags",
+    "//brave/browser/notifications",
     "//brave/common",
     "//brave/components/brave_ads/browser",
     "//brave/components/brave_component_updater/browser",

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -64,6 +64,7 @@ class BraveBrowserProcessImpl : public BrowserProcessImpl {
   // BrowserProcess implementation.
 
   ProfileManager* profile_manager() override;
+  NotificationPlatformBridge* notification_platform_bridge() override;
 
   void StartBraveServices();
   brave_shields::AdBlockService* ad_block_service();
@@ -93,6 +94,7 @@ class BraveBrowserProcessImpl : public BrowserProcessImpl {
 
  private:
   void CreateProfileManager();
+  void CreateNotificationPlatformBridge();
 
   BraveComponent::Delegate* brave_component_updater_delegate();
 

--- a/browser/notifications/BUILD.gn
+++ b/browser/notifications/BUILD.gn
@@ -1,0 +1,19 @@
+source_set("notifications") {
+  if (is_mac) {
+    sources = [
+      "brave_alert_dispatcher_mac.mm",
+      "brave_alert_dispatcher_mac.h",
+      "brave_notification_platform_bridge_mac.mm",
+      "brave_notification_platform_bridge.h",
+    ]
+
+    deps = [
+      "//base",
+      "//chrome/browser/ui/cocoa/notifications:common",
+      "//ui/message_center/public/cpp",
+      "//skia",
+    ]
+
+    libs = [ "Foundation.framework" ]
+  }
+}

--- a/browser/notifications/brave_alert_dispatcher_mac.h
+++ b/browser/notifications/brave_alert_dispatcher_mac.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2019 The Brave Software Team. Distributed under the MPL2
+ * license. This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_NOTIFICATIONS_BRAVE_ALERT_DISPATCHER_MAC_H_
+#define BRAVE_BROWSER_NOTIFICATIONS_BRAVE_ALERT_DISPATCHER_MAC_H_
+
+#import <Foundation/Foundation.h>
+
+#include <string>
+
+#include "chrome/browser/notifications/alert_dispatcher_mac.h"
+
+@interface BraveAlertDispatcherMac : NSObject<AlertDispatcher>
+
+- (void)dispatchNotification:(NSDictionary *)data;                               // NOLINT
+
+- (void)closeNotificationWithId:(NSString *)notificationId                       // NOLINT
+                  withProfileId:(NSString *)profileId;                           // NOLINT
+
+- (void)closeAllNotifications;
+
+- (void)
+getDisplayedAlertsForProfileId:(NSString *)profileId                             // NOLINT
+                     incognito:(BOOL)incognito
+            notificationCenter:(NSUserNotificationCenter *)notificationCenter    // NOLINT
+                      callback:(GetDisplayedNotificationsCallback)callback;      // NOLINT
+
+@end
+
+#endif  // BRAVE_BROWSER_NOTIFICATIONS_BRAVE_ALERT_DISPATCHER_MAC_H_

--- a/browser/notifications/brave_alert_dispatcher_mac.mm
+++ b/browser/notifications/brave_alert_dispatcher_mac.mm
@@ -1,0 +1,76 @@
+/* Copyright (c) 2019 The Brave Software Team. Distributed under the MPL2
+ * license. This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import "brave/browser/notifications/brave_alert_dispatcher_mac.h"
+
+#include <memory>
+#include <set>
+#include <string>
+
+#include "base/callback.h"
+#include "base/mac/scoped_nsobject.h"
+#include "base/strings/sys_string_conversions.h"
+#include "chrome/browser/ui/cocoa/notifications/notification_constants_mac.h"
+#include "chrome/browser/ui/cocoa/notifications/notification_builder_mac.h"
+
+@implementation BraveAlertDispatcherMac {
+  base::scoped_nsobject<NSMutableArray> alerts_;
+}
+
+- (void)dispatchNotification:(NSDictionary *)data {
+  base::scoped_nsobject<NotificationBuilder> builder(
+      [[NotificationBuilder alloc] initWithDictionary:data]);
+
+  NSUserNotification * toast = [builder buildUserNotification];
+  [[NSUserNotificationCenter defaultUserNotificationCenter]
+      deliverNotification: toast];
+}
+
+- (void)closeNotificationWithId:(NSString *)notificationId
+                  withProfileId:(NSString *)profileId {
+  NSUserNotificationCenter * notificationCenter =
+      [NSUserNotificationCenter defaultUserNotificationCenter];
+  for (NSUserNotification * candidate in
+       [notificationCenter deliveredNotifications]) {
+    NSString* candidateId = [candidate.userInfo
+        objectForKey: notification_constants::kNotificationId];
+
+    NSString* candidateProfileId = [candidate.userInfo
+        objectForKey: notification_constants::kNotificationProfileId];
+
+    if ([candidateId isEqualToString: notificationId] &&
+        [profileId isEqualToString: candidateProfileId]) {
+      [notificationCenter removeDeliveredNotification:candidate];
+      break;
+    }
+  }
+}
+
+- (void)closeAllNotifications {
+  [[NSUserNotificationCenter defaultUserNotificationCenter]
+      removeAllDeliveredNotifications];
+}
+
+- (void)
+getDisplayedAlertsForProfileId:(NSString *)profileId
+                     incognito:(BOOL)incognito
+            notificationCenter:(NSUserNotificationCenter*)notificationCenter
+                      callback:(GetDisplayedNotificationsCallback)callback {
+  std::set<std::string> displayedNotifications;
+  for (NSUserNotification * toast in
+      [notificationCenter deliveredNotifications]) {
+    NSString * toastProfileId = [toast.userInfo
+        objectForKey:notification_constants::kNotificationProfileId];
+    if ([toastProfileId isEqualToString:profileId]) {
+      displayedNotifications.insert(base::SysNSStringToUTF8([toast.userInfo
+          objectForKey: notification_constants::kNotificationId]));
+    }
+  }
+
+  std::move(callback).Run(std::move(displayedNotifications),
+                          true /* supports_synchronization */);
+}
+
+@end

--- a/browser/notifications/brave_notification_platform_bridge.h
+++ b/browser/notifications/brave_notification_platform_bridge.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_NOTIFICATIONS_BRAVE_NOTIFICATION_PLATFORM_BRIDGE_H_
+#define BRAVE_BROWSER_NOTIFICATIONS_BRAVE_NOTIFICATION_PLATFORM_BRIDGE_H_
+
+#include <memory>
+
+#include "base/macros.h"
+
+class NotificationPlatformBridge;
+
+class BraveNotificationPlatformBridge {
+ public:
+  static std::unique_ptr<NotificationPlatformBridge> Create();
+
+ private:
+  BraveNotificationPlatformBridge() = default;
+  ~BraveNotificationPlatformBridge() = default;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveNotificationPlatformBridge);
+};
+
+#endif  // BRAVE_BROWSER_NOTIFICATIONS_BRAVE_NOTIFICATION_PLATFORM_BRIDGE_H_

--- a/browser/notifications/brave_notification_platform_bridge_mac.mm
+++ b/browser/notifications/brave_notification_platform_bridge_mac.mm
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019 The Brave Software Team. Distributed under the MPL2
+ * license. This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/notifications/brave_notification_platform_bridge.h"
+
+#include <memory>
+
+#include "brave/browser/notifications/brave_alert_dispatcher_mac.h"
+#include "chrome/browser/notifications/notification_platform_bridge_mac.h"
+#include "ui/message_center/public/cpp/notification.h"
+#include "ui/message_center/public/cpp/notification_types.h"
+
+@class NSUserNotificationCenter;
+
+// static
+std::unique_ptr<NotificationPlatformBridge>
+BraveNotificationPlatformBridge::Create() {
+  base::scoped_nsobject<BraveAlertDispatcherMac> alert_dispatcher(
+      [[BraveAlertDispatcherMac alloc] init]);
+  return std::make_unique<NotificationPlatformBridgeMac>(
+      [NSUserNotificationCenter defaultUserNotificationCenter],
+          alert_dispatcher.get());
+}

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -98,6 +98,9 @@ def Main(argv):
   # Explicitly disable profiling
   plist['SUEnableSystemProfiling'] = False
 
+  # Explicitly change notifications from banner to alert
+  plist['NSUserNotificationAlertStyle'] = 'alert'
+
   # Now that all keys have been mutated, rewrite the file.
   with tempfile.NamedTemporaryFile() as temp_info_plist:
     plistlib.writePlist(plist, temp_info_plist.name)

--- a/chromium_src/chrome/browser/notifications/notification_platform_bridge_mac.mm
+++ b/chromium_src/chrome/browser/notifications/notification_platform_bridge_mac.mm
@@ -1,0 +1,72 @@
+#include "chrome/browser/notifications/notification_platform_bridge_mac.h"
+
+#import <Foundation/Foundation.h>
+
+@interface NotificationTimeoutMac : NSObject
+
+- (void)startTimer:(NSUserNotification *)notification;
+
+@end
+
+@implementation NotificationTimeoutMac {
+  NSMutableArray<NSTimer *> * timers_;
+}
+
+- (id)init {
+  if (self = [super init]) {
+    timers_ = [[NSMutableArray alloc] init];
+  }
+
+  return self;
+}
+
+- (void)dealloc {
+  for (NSTimer * timer in timers_) {
+    [timer invalidate];
+    timer = nil;
+  }
+
+  [timers_ removeAllObjects];
+
+  [timers_ release];
+  timers_ = nil;
+
+  [super dealloc];
+}
+
+- (void)startTimer:(NSUserNotification *)notification {
+  NSTimer * timer =
+      [NSTimer scheduledTimerWithTimeInterval:5.0
+                                       target:self
+                                     selector:@selector(timerFired:)
+                                     userInfo:[notification retain]
+                                      repeats:NO];
+    [timers_ addObject:timer];
+}
+
+- (void)timerFired:(NSTimer *)timer {
+  NSUserNotification* notification = timer.userInfo;
+  if (!notification) {
+    return;
+  }
+
+  auto* notification_center =
+      [NSUserNotificationCenter defaultUserNotificationCenter];
+  [notification_center removeDeliveredNotification:notification];
+
+  [notification release];
+  notification = nil;
+
+  [timers_ removeObject:timer];
+}
+
+@end
+
+static NotificationTimeoutMac*
+    g_notification_platform_bridge_notification_timeout =
+        [[[NotificationTimeoutMac alloc] init] retain];
+
+#define BRAVE_DISPLAY_ \
+  [g_notification_platform_bridge_notification_timeout startTimer:toast];
+
+#include "../../../../../chrome/browser/notifications/notification_platform_bridge_mac.mm"  // NOLINT

--- a/patches/chrome-browser-notifications-notification_platform_bridge_mac.mm.patch
+++ b/patches/chrome-browser-notifications-notification_platform_bridge_mac.mm.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/notifications/notification_platform_bridge_mac.mm b/chrome/browser/notifications/notification_platform_bridge_mac.mm
-index f4e3046614e13837050edf3862d66bccee3cc9e1..e982932589cbb24d486b41fb02e031abaf59f15f 100644
+index f4e3046614e13837050edf3862d66bccee3cc9e1..724e1a39cdfe950d6ce933f630195a273f35c7e8 100644
 --- a/chrome/browser/notifications/notification_platform_bridge_mac.mm
 +++ b/chrome/browser/notifications/notification_platform_bridge_mac.mm
 @@ -226,6 +226,7 @@ void NotificationPlatformBridgeMac::Display(
@@ -10,3 +10,11 @@ index f4e3046614e13837050edf3862d66bccee3cc9e1..e982932589cbb24d486b41fb02e031ab
                               IDS_NOTIFICATION_BUTTON_SETTINGS)]);
  
    [builder
+@@ -300,6 +301,7 @@ void NotificationPlatformBridgeMac::Display(
+   } else {
+     NSUserNotification* toast = [builder buildUserNotification];
+     [notification_center_ deliverNotification:toast];
++    BRAVE_DISPLAY_
+   }
+ }
+ 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/6466

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm ad native notifications are shown on all supported macOS versions including Catalina and timeout after 2 minutes
- Confirm web notifications appear as expected and timeout after 5 seconds
- Confirm Google Calendar notifications appear as expected

NOTE: Due to the temporary workaround until a better solution is found, notifications will not be added to the Notification Center

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
