### PR TITLE
Add missing deps in importer target (uplift to 0.71.x)

### DIFF
--- a/browser/importer/BUILD.gn
+++ b/browser/importer/BUILD.gn
@@ -20,7 +20,22 @@ source_set("importer") {
 
   deps = [
     "//base",
+    "//brave/common",
+    "//brave/common:pref_names",
+    "//brave/components/brave_rewards/browser",
+    "//chrome/browser/ui",
+    # For buildflags.h included from chrome/browser/browser_process.h, we are
+    # not including chrome/browser here because of circular dependency.
+    # We should refactor this in the future to be able to add chrome/browser
+    # into importer target's deps.
+    "//chrome/common:buildflags",
+    "//chrome/common/importer",
+    "//components/prefs",
+    "//components/search_engines",
     "//content/public/browser",
     "//net",
+    "//services/network/public/mojom",
+    "//ui/base",
+    "//ui/gfx:native_widget_types",
   ]
 }


### PR DESCRIPTION
Issue: https://github.com/brave/brave-browser/issues/6678
Uplift of #3833

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.