### PR TITLE
Accounting for AC in NTP widget contrib totals

### DIFF
--- a/components/brave_new_tab_ui/rewards-utils.ts
+++ b/components/brave_new_tab_ui/rewards-utils.ts
@@ -1,17 +1,31 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { tipsTotal } from '../brave_rewards/resources/page/utils'
 
-export const getTotalContributions = (reports: Record<string, NewTab.RewardsReport>) => {
+import BigNumber from 'bignumber.js'
+
+const getReportIndex = () => {
   const currentTime = new Date()
   const year = currentTime.getFullYear()
   const month = (currentTime.getMonth() + 1)
-  const report: NewTab.RewardsReport = reports[`${year}_${month}`]
 
-  if (!report) {
+  return `${year}_${month}`
+}
+
+export const getTotalContributions = (reports: Record<string, NewTab.RewardsReport>) => {
+  const reportIndex = getReportIndex()
+
+  if (!reports.hasOwnProperty(reportIndex)) {
     return '0.0'
   }
 
-  return tipsTotal(report)
+  const report = reports[reportIndex]
+  const tips = new BigNumber(report.tips)
+  const contribute = new BigNumber(report.contribute)
+
+  return new BigNumber(report.donation)
+    .plus(tips)
+    .plus(contribute)
+    .dividedBy('1e18')
+    .toFixed(1, BigNumber.ROUND_DOWN)
 }


### PR DESCRIPTION
Fixes brave/brave-browser#6740

The previously utilized `tipsTotal` from `brave://rewards` page utils did not account for a-c in the balance report.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Defined in issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
