### PR TITLE
Ad notifications do not close when clicking the close or view buttons or after the notification times out - 0.72

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1903,6 +1903,7 @@ bool AdsServiceImpl::ShouldShowNotifications() const {
 
 void AdsServiceImpl::CloseNotification(
     const std::string& id) {
+#if defined(OS_ANDROID)
   // we might want to close Brave ads notification
   // between browser sessions and
   // NotificationPlatformBridgeAndroid::regenerated_notification_infos_
@@ -1910,6 +1911,9 @@ void AdsServiceImpl::CloseNotification(
   std::string prefixed_id(kBraveAdsUrlPrefix);
   prefixed_id += id;
   display_service_->Close(NotificationHandler::Type::BRAVE_ADS, prefixed_id);
+#else
+  display_service_->Close(NotificationHandler::Type::BRAVE_ADS, id);
+#endif
 }
 
 void AdsServiceImpl::SetCatalogIssuers(


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/6748
Uplift of: https://github.com/brave/brave-core/pull/3869