### PR TITLE
Rewards button pre-opt-in badge dismisses after first button press

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -179,7 +179,8 @@ void BraveActionsContainer::AddActionStubForRewards() {
     return;
   }
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
-  actions_[id].view_ = std::make_unique<BraveRewardsActionStubView>(this);
+  actions_[id].view_ = std::make_unique<BraveRewardsActionStubView>(
+      browser_->profile(), this);
   AttachAction(actions_[id]);
 #endif
 }

--- a/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h
+++ b/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h
@@ -8,8 +8,11 @@
 
 #include <memory>
 
+#include "components/prefs/pref_member.h"
 #include "ui/views/controls/button/label_button.h"
 #include "ui/views/view.h"
+
+class Profile;
 
 // A button to take the place of an extension that will be loaded in the future.
 // Call SetImage with the BraveActionIconWithBadgeImageSource
@@ -25,7 +28,7 @@ class BraveRewardsActionStubView : public views::LabelButton,
     ~Delegate() {}
   };
 
-  explicit BraveRewardsActionStubView(Delegate* delegate);
+  explicit BraveRewardsActionStubView(Profile* profile, Delegate* delegate);
   ~BraveRewardsActionStubView() override;
 
   // views::ButtonListener
@@ -41,6 +44,8 @@ class BraveRewardsActionStubView : public views::LabelButton,
  private:
   gfx::Size CalculatePreferredSize() const override;
 
+  StringPrefMember badge_text_pref_;
+  Profile* profile_;
   Delegate* delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveRewardsActionStubView);

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -60,6 +60,7 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterDictionaryPref(prefs::kRewardsExternalWallets);
   registry->RegisterUint64Pref(prefs::kStateServerPublisherListStamp, 0ull);
   registry->RegisterStringPref(prefs::kStateUpholdAnonAddress, "");
+  registry->RegisterStringPref(prefs::kRewardsBadgeText, "1");
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -28,7 +28,7 @@ const char kStateServerPublisherListStamp[] =
     "brave.rewards.server_publisher_list_stamp";
 const char kStateUpholdAnonAddress[] =
     "brave.rewards.uphold_anon_address";
-
+const char kRewardsBadgeText[] = "brave.rewards.badge_text";
 const char kUseRewardsStagingServer[] = "brave.rewards.use_staging_server";
 }  // namespace prefs
 }  // namespace brave_rewards

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -20,6 +20,7 @@ extern const char kRewardsUserHasFunded[];
 extern const char kRewardsAddFundsNotification[];
 extern const char kRewardsNotificationStartupDelay[];
 extern const char kRewardsExternalWallets[];
+extern const char kRewardsBadgeText[];
 
 // Defined in native-ledger
 extern const char kStateServerPublisherListStamp[];


### PR DESCRIPTION
We use a new pref to store the "badge text" value. Whilst we could store a boolean value whose state would be "has dismissed notification" (or not), this method is more future proof for having multiple variations of badge text, especially if or when this button becomes 'native' all the time (i.e. not an extension icon where the badge is controlled via JS).

Fix https://github.com/brave/brave-browser/issues/6691

## Test plan

0. Clean user data directory
1. Launch Brave
2. Create a second profile via App Menu -> Create a New Profile
3. **Expected:** Both profile windows have the rewards icon with the badge text "1"
4. Click the rewards button in the second profile window
5. **Expected:** The second profile window's rewards icon does not have a badge
6. **Expected:** The first profile window's rewards icon does have a badge
7. Quit the browser
8. Start the browser again
9. **Expected:** The rewards icon badge state from each profile window is the same as 5) and 6)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
