### PR TITLE
Adding state for unsupported ads regions to ntp rewards widget (0.71)

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -1081,5 +1081,24 @@ void BraveRewardsGetWalletExistsFunction::OnGetWalletExists(
   Respond(OneArgument(std::make_unique<base::Value>(exists)));
 }
 
+BraveRewardsGetAdsSupportedFunction::
+~BraveRewardsGetAdsSupportedFunction() {
+}
+
+ExtensionFunction::ResponseAction
+BraveRewardsGetAdsSupportedFunction::Run() {
+  Profile* profile = Profile::FromBrowserContext(browser_context());
+  AdsService* ads_service_ =
+      AdsServiceFactory::GetForProfile(profile);
+
+  if (!ads_service_) {
+    return RespondNow(Error("Ads service is not initialized"));
+  }
+
+  const bool supported = ads_service_->IsSupportedRegion();
+  return RespondNow(
+      OneArgument(std::make_unique<base::Value>(supported)));
+}
+
 }  // namespace api
 }  // namespace extensions

--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -430,6 +430,16 @@ class BraveRewardsGetWalletExistsFunction
   void OnGetWalletExists(const bool exists);
 };
 
+class BraveRewardsGetAdsSupportedFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("braveRewards.getAdsSupported", UNKNOWN)
+
+ protected:
+  ~BraveRewardsGetAdsSupportedFunction() override;
+
+  ResponseAction Run() override;
+};
+
 }  // namespace api
 }  // namespace extensions
 

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -204,6 +204,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "rewardsWidgetEnableTitle", IDS_REWARDS_WIDGET_ENABLE_TITLE },
         { "rewardsWidgetReEnableSubTitle", IDS_REWARDS_WIDGET_REENABLE_SUBTITLE },        // NOLINT
         { "rewardsWidgetEnableSubTitle", IDS_REWARDS_WIDGET_ENABLE_SUBTITLE },            // NOLINT
+        { "rewardsWidgetAdsNotSupported", IDS_BRAVE_REWARDS_LOCAL_ADS_NOT_SUPPORTED },    // NOLINT
         { "rewardsWidgetNotificationTitle", IDS_REWARDS_WIDGET_NOTIFICATION_TITLE },      // NOLINT
         { "rewardsWidgetNotificationTextAds", IDS_REWARDS_WIDGET_NOTIFICATION_TEXT_ADS }, // NOLINT
         { "rewardsWidgetNotificationTextUGP", IDS_REWARDS_WIDGET_NOTIFICATION_TEXT_UGP }  // NOLINT

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -653,6 +653,23 @@
         ]
       },
       {
+        "name": "getAdsSupported",
+        "type": "function",
+        "description": "Gets whether ads is supported in the user's region",
+        "parameters": [
+          {
+            "type": "function",
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "supported",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "name": "getAdsEstimatedEarnings",
         "type": "function",
         "description": "Gets estimated ads earnings for the current month",

--- a/components/brave_new_tab_ui/api/initialData.ts
+++ b/components/brave_new_tab_ui/api/initialData.ts
@@ -17,6 +17,7 @@ export type InitialData = {
 
 export type PreInitialRewardsData = {
   enabledAds: boolean
+  adsSupported: boolean
   enabledMain: boolean
 }
 
@@ -54,10 +55,14 @@ export async function getRewardsPreInitialData (): Promise<PreInitialRewardsData
   try {
     const [
       enabledAds,
+      adsSupported,
       enabledMain
     ] = await Promise.all([
       new Promise(resolve => chrome.braveRewards.getAdsEnabled((enabledAds: boolean) => {
         resolve(enabledAds)
+      })),
+      new Promise(resolve => chrome.braveRewards.getAdsSupported((adsSupported: boolean) => {
+        resolve(adsSupported)
       })),
       new Promise(resolve => chrome.braveRewards.getRewardsMainEnabled((enabledMain: boolean) => {
         resolve(enabledMain)
@@ -65,6 +70,7 @@ export async function getRewardsPreInitialData (): Promise<PreInitialRewardsData
     ])
     return {
       enabledAds,
+      adsSupported,
       enabledMain
     } as PreInitialRewardsData
   } catch (err) {

--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -26,7 +26,8 @@ import {
   Amount,
   ConvertedAmount,
   LearnMoreLink,
-  TurnOnAdsButton
+  TurnOnAdsButton,
+  UnsupportedMessage
 } from './style'
 import Notification from './notification'
 import { BatColorIcon } from 'brave-ui/components/icons'
@@ -43,6 +44,7 @@ export interface RewardsProps {
   walletCorrupted: boolean
   adsEstimatedEarnings: number
   onlyAnonWallet?: boolean
+  adsSupported?: boolean
   onCreateWallet: () => void
   onEnableAds: () => void
   onEnableRewards: () => void
@@ -135,11 +137,12 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
       onEnableAds,
       adsEstimatedEarnings,
       onlyAnonWallet,
-      totalContribution
+      totalContribution,
+      adsSupported
     } = this.props
 
     const rates = balance.rates || {}
-    const showEnableAds = type === AmountItemType.ADS && !enabledAds
+    const showEnableAds = type === AmountItemType.ADS && !enabledAds && adsSupported
     const amount = type === AmountItemType.TIPS
       ? totalContribution
       : adsEstimatedEarnings.toFixed(1)
@@ -147,7 +150,14 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
     const batFormatString = onlyAnonWallet ? getLocale('rewardsWidgetBatPoints') : getLocale('rewardsWidgetBat')
 
     return (
-      <AmountItem>
+      <AmountItem isLast={type === AmountItemType.TIPS}>
+        <AmountDescription>
+          {
+            type === AmountItemType.ADS
+            ? getLocale('rewardsWidgetEstimatedEarnings')
+            : getLocale('rewardsWidgetMonthlyTips')
+          }
+        </AmountDescription>
         {
           showEnableAds
           ? <TurnOnAdsButton onClick={onEnableAds}>
@@ -156,7 +166,7 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
           : null
         }
         {
-          !showEnableAds
+          !showEnableAds && !(type === AmountItemType.ADS && !adsSupported)
           ? <AmountInformation data-test-id={`widget-amount-total-${type}`}>
               <Amount>{amount}</Amount>
               <ConvertedAmount>
@@ -165,13 +175,13 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
             </AmountInformation>
           : null
         }
-        <AmountDescription>
-          {
-            type === AmountItemType.ADS
-            ? getLocale('rewardsWidgetEstimatedEarnings')
-            : getLocale('rewardsWidgetMonthlyTips')
-          }
-        </AmountDescription>
+        {
+          type === AmountItemType.ADS && !adsSupported
+          ? <UnsupportedMessage>
+              {getLocale('rewardsWidgetAdsNotSupported')}
+            </UnsupportedMessage>
+          : null
+        }
       </AmountItem>
     )
   }

--- a/components/brave_new_tab_ui/components/default/rewards/style.ts
+++ b/components/brave_new_tab_ui/components/default/rewards/style.ts
@@ -5,6 +5,10 @@
 import styled from 'styled-components'
 import palette from 'brave-ui/theme/colors'
 
+interface StyleProps {
+  isLast?: boolean
+}
+
 export const WidgetWrapper = styled<{}, 'div'>('div')`
   color: white;
   padding: 10px 15px;
@@ -93,16 +97,17 @@ export const TurnOnButton = styled<{}, 'button'>('button')`
 
 export const TurnOnAdsButton = styled(TurnOnButton)`
   width: 100%;
-  margin-bottom: 5px;
+  margin-top: 8px;
   display: block;
 `
 
-export const AmountItem = styled<{}, 'div'>('div')`
-  margin-top: 10px;
+export const AmountItem = styled<StyleProps, 'div'>('div')`
+  margin-top: ${p => p.isLast ? 20 : 10}px;
+  margin-bottom: ${p => p.isLast ? -10 : 0}px;
 `
 
 export const AmountInformation = styled<{}, 'div'>('div')`
-  margin-bottom: 5px;
+  margin-top: 5px;
 `
 
 export const Amount = styled<{}, 'span'>('span')`
@@ -118,6 +123,7 @@ export const ConvertedAmount = styled<{}, 'span'>('span')`
 export const AmountDescription = styled<{}, 'span'>('span')`
   font-size: 14px;
   color: #fff;
+  margin-bottom: 5px;
 `
 
 export const NotificationWrapper = styled(WidgetWrapper)`
@@ -150,4 +156,11 @@ export const CloseIcon = styled<{}, 'div'>('div')`
   height: 20px;
   float: right;
   cursor: pointer;
+`
+
+export const UnsupportedMessage = styled<{}, 'div'>('div')`
+  color: rgba(255, 255, 255, 0.70);
+  font-size: 14px;
+  max-width: 235px;
+  margin-top: 8px;
 `

--- a/components/brave_new_tab_ui/reducers/new_tab_reducer.tsx
+++ b/components/brave_new_tab_ui/reducers/new_tab_reducer.tsx
@@ -377,6 +377,7 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
         rewardsState: {
           ...state.rewardsState,
           enabledAds: preInitialRewardsDataPayload.enabledAds,
+          adsSupported: preInitialRewardsDataPayload.adsSupported,
           enabledMain: preInitialRewardsDataPayload.enabledMain
         }
       }

--- a/components/brave_new_tab_ui/storage.ts
+++ b/components/brave_new_tab_ui/storage.ts
@@ -40,6 +40,7 @@ const defaultState: NewTab.State = {
     },
     dismissedNotifications: [],
     enabledAds: false,
+    adsSupported: false,
     enabledMain: false,
     grants: [],
     onlyAnonWallet: false,

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -101,6 +101,7 @@ declare namespace chrome.braveRewards {
     addListener: (callback: (enabledMain: boolean) => void) => void
   }
   const getAdsEnabled: (callback: (enabled: boolean) => void) => {}
+  const getAdsSupported: (callback: (supported: boolean) => void) => {}
   const getBalanceReports: (callback: (reports: Record<string, Rewards.Report>) => void) => {}
   const getAdsEstimatedEarnings: (callback: (amount: number) => void) => {}
   const getRewardsMainEnabled: (callback: (enabled: boolean) => void) => {}

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -69,6 +69,7 @@ declare namespace NewTab {
 
   export interface RewardsWidgetState {
     adsEstimatedEarnings: number
+    adsSupported?: boolean
     balance: RewardsBalance
     dismissedNotifications: string[]
     enabledAds: boolean


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6759
Uplifts: https://github.com/brave/brave-core/pull/3876