### PR TITLE
Fix 6804: Avoid the OnPreferenceChanged callback when preferences are changed by CookiePrefService

### DIFF
--- a/browser/net/brave_network_delegate_browsertest.cc
+++ b/browser/net/brave_network_delegate_browsertest.cc
@@ -52,21 +52,19 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
   }
 
   void DefaultBlockAllCookies() {
-    brave_shields::SetCookieControlType(browser()->profile(),
-                                        brave_shields::ControlType::BLOCK,
-                                        GURL());
+    brave_shields::SetCookieControlType(
+        browser()->profile(), brave_shields::ControlType::BLOCK, GURL());
   }
 
   void BlockThirdPartyCookies() {
-    brave_shields::SetCookieControlType(browser()->profile(),
-                                        brave_shields::ControlType::BLOCK_THIRD_PARTY,
-                                        GURL());
+    brave_shields::SetCookieControlType(
+        browser()->profile(), brave_shields::ControlType::BLOCK_THIRD_PARTY,
+        GURL());
   }
 
   void AllowAllCookies() {
-    brave_shields::SetCookieControlType(browser()->profile(),
-                                        brave_shields::ControlType::ALLOW,
-                                        GURL());
+    brave_shields::SetCookieControlType(
+        browser()->profile(), brave_shields::ControlType::ALLOW, GURL());
   }
 
   void AllowCookies() {
@@ -82,25 +80,24 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
   }
 
   void ShieldsDown() {
-    brave_shields::SetBraveShieldsEnabled(browser()->profile(),
-                                          false,
+    brave_shields::SetBraveShieldsEnabled(browser()->profile(), false,
                                           top_level_page_url_);
   }
 
-  void NavigateToPageWithFrame(const EmbeddedTestServer *server,
+  void NavigateToPageWithFrame(const EmbeddedTestServer* server,
                                const std::string& host) {
-      ui_test_utils::NavigateToURL(browser(),
-                                   server->GetURL(host, "/cookie_iframe.html"));
+    ui_test_utils::NavigateToURL(browser(),
+                                 server->GetURL(host, "/cookie_iframe.html"));
   }
 
-  void ExpectCookiesOnHost(const EmbeddedTestServer *server,
+  void ExpectCookiesOnHost(const EmbeddedTestServer* server,
                            const std::string& host,
                            const std::string& expected) {
-      EXPECT_EQ(expected, content::GetCookies(browser()->profile(),
-                                              server->GetURL(host, "/")));
+    EXPECT_EQ(expected, content::GetCookies(browser()->profile(),
+                                            server->GetURL(host, "/")));
   }
 
-  void NavigateFrameTo(const EmbeddedTestServer *server,
+  void NavigateFrameTo(const EmbeddedTestServer* server,
                        const std::string& host,
                        const std::string& path) {
     GURL page = server->GetURL(host, path);
@@ -146,7 +143,7 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest, Iframe3PShieldsDown) {
 }
 
 IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
-    Iframe3PShieldsDownOverridesCookieBlock) {
+                       Iframe3PShieldsDownOverridesCookieBlock) {
   // create an explicit override
   BlockCookies();
   ui_test_utils::NavigateToURL(browser(), url_);
@@ -156,8 +153,7 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
 
   ShieldsDown();
   ui_test_utils::NavigateToURL(browser(), url_);
-  cookie =
-      content::GetCookies(browser()->profile(), GURL("http://c.com/"));
+  cookie = content::GetCookies(browser()->profile(), GURL("http://c.com/"));
   EXPECT_FALSE(cookie.empty());
 }
 
@@ -179,15 +175,13 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   EXPECT_FALSE(cookie.empty());
 }
 
-IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
-                       DefaultCookiesBlocked) {
+IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest, DefaultCookiesBlocked) {
   DefaultBlockAllCookies();
   ui_test_utils::NavigateToURL(browser(), nested_iframe_script_url_);
   std::string cookie =
       content::GetCookies(browser()->profile(), GURL("http://c.com/"));
   EXPECT_TRUE(cookie.empty()) << "Actual cookie: " << cookie;
-  cookie =
-      content::GetCookies(browser()->profile(), GURL("http://a.com/"));
+  cookie = content::GetCookies(browser()->profile(), GURL("http://a.com/"));
   EXPECT_TRUE(cookie.empty()) << "Actual cookie: " << cookie;
 }
 
@@ -196,18 +190,15 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultBlockAllCookies();
   BlockThirdPartyCookies();
 
-  EXPECT_TRUE(browser()->profile()->GetPrefs()->
-      GetBoolean(prefs::kBlockThirdPartyCookies));
-  EXPECT_EQ(browser()->profile()->GetPrefs()->
-      GetInteger("profile.default_content_setting_values.cookies"),
-      ContentSetting::CONTENT_SETTING_ALLOW);
+  EXPECT_TRUE(browser()->profile()->GetPrefs()->GetBoolean(
+      prefs::kBlockThirdPartyCookies));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
+                "profile.default_content_setting_values.cookies"),
+            ContentSetting::CONTENT_SETTING_ALLOW);
 
-  NavigateToPageWithFrame(embedded_test_server(),
-                          "a.com");
+  NavigateToPageWithFrame(embedded_test_server(), "a.com");
 
-  NavigateFrameTo(embedded_test_server(),
-                  "b.com",
-                  "/set-cookie?name=Good");
+  NavigateFrameTo(embedded_test_server(), "b.com", "/set-cookie?name=Good");
 
   ExpectCookiesOnHost(embedded_test_server(), "a.com", "name=Good");
   ExpectCookiesOnHost(embedded_test_server(), "b.com", "");
@@ -218,18 +209,15 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultBlockAllCookies();
   AllowAllCookies();
 
-  EXPECT_FALSE(browser()->profile()->GetPrefs()->
-      GetBoolean(prefs::kBlockThirdPartyCookies));
-  EXPECT_EQ(browser()->profile()->GetPrefs()->
-      GetInteger("profile.default_content_setting_values.cookies"),
-      ContentSetting::CONTENT_SETTING_ALLOW);
+  EXPECT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(
+      prefs::kBlockThirdPartyCookies));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
+                "profile.default_content_setting_values.cookies"),
+            ContentSetting::CONTENT_SETTING_ALLOW);
 
-  NavigateToPageWithFrame(embedded_test_server(),
-                          "a.com");
+  NavigateToPageWithFrame(embedded_test_server(), "a.com");
 
-  NavigateFrameTo(embedded_test_server(),
-                  "b.com",
-                  "/set-cookie?name=Good");
+  NavigateFrameTo(embedded_test_server(), "b.com", "/set-cookie?name=Good");
 
   ExpectCookiesOnHost(embedded_test_server(), "a.com", "name=Good");
   ExpectCookiesOnHost(embedded_test_server(), "b.com", "name=Good");
@@ -240,18 +228,15 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   BlockThirdPartyCookies();
   AllowAllCookies();
 
-  EXPECT_FALSE(browser()->profile()->GetPrefs()->
-      GetBoolean(prefs::kBlockThirdPartyCookies));
-  EXPECT_EQ(browser()->profile()->GetPrefs()->
-      GetInteger("profile.default_content_setting_values.cookies"),
-      ContentSetting::CONTENT_SETTING_ALLOW);
+  EXPECT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(
+      prefs::kBlockThirdPartyCookies));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
+                "profile.default_content_setting_values.cookies"),
+            ContentSetting::CONTENT_SETTING_ALLOW);
 
-  NavigateToPageWithFrame(embedded_test_server(),
-                          "a.com");
+  NavigateToPageWithFrame(embedded_test_server(), "a.com");
 
-  NavigateFrameTo(embedded_test_server(),
-                  "b.com",
-                  "/set-cookie?name=Good");
+  NavigateFrameTo(embedded_test_server(), "b.com", "/set-cookie?name=Good");
 
   ExpectCookiesOnHost(embedded_test_server(), "a.com", "name=Good");
   ExpectCookiesOnHost(embedded_test_server(), "b.com", "name=Good");
@@ -262,18 +247,15 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   BlockThirdPartyCookies();
   DefaultBlockAllCookies();
 
-  EXPECT_FALSE(browser()->profile()->GetPrefs()->
-      GetBoolean(prefs::kBlockThirdPartyCookies));
-  EXPECT_EQ(browser()->profile()->GetPrefs()->
-      GetInteger("profile.default_content_setting_values.cookies"),
-      ContentSetting::CONTENT_SETTING_BLOCK);
+  EXPECT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(
+      prefs::kBlockThirdPartyCookies));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
+                "profile.default_content_setting_values.cookies"),
+            ContentSetting::CONTENT_SETTING_BLOCK);
 
-  NavigateToPageWithFrame(embedded_test_server(),
-                          "a.com");
+  NavigateToPageWithFrame(embedded_test_server(), "a.com");
 
-  NavigateFrameTo(embedded_test_server(),
-                  "b.com",
-                  "/set-cookie?name=Good");
+  NavigateFrameTo(embedded_test_server(), "b.com", "/set-cookie?name=Good");
 
   ExpectCookiesOnHost(embedded_test_server(), "a.com", "");
   ExpectCookiesOnHost(embedded_test_server(), "b.com", "");
@@ -284,18 +266,15 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   AllowAllCookies();
   BlockThirdPartyCookies();
 
-  EXPECT_TRUE(browser()->profile()->GetPrefs()->
-      GetBoolean(prefs::kBlockThirdPartyCookies));
-  EXPECT_EQ(browser()->profile()->GetPrefs()->
-      GetInteger("profile.default_content_setting_values.cookies"),
-      ContentSetting::CONTENT_SETTING_ALLOW);
+  EXPECT_TRUE(browser()->profile()->GetPrefs()->GetBoolean(
+      prefs::kBlockThirdPartyCookies));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
+                "profile.default_content_setting_values.cookies"),
+            ContentSetting::CONTENT_SETTING_ALLOW);
 
-  NavigateToPageWithFrame(embedded_test_server(),
-                          "a.com");
+  NavigateToPageWithFrame(embedded_test_server(), "a.com");
 
-  NavigateFrameTo(embedded_test_server(),
-                  "b.com",
-                  "/set-cookie?name=Good");
+  NavigateFrameTo(embedded_test_server(), "b.com", "/set-cookie?name=Good");
 
   ExpectCookiesOnHost(embedded_test_server(), "a.com", "name=Good");
   ExpectCookiesOnHost(embedded_test_server(), "b.com", "");
@@ -306,18 +285,15 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   AllowAllCookies();
   DefaultBlockAllCookies();
 
-  EXPECT_FALSE(browser()->profile()->GetPrefs()->
-      GetBoolean(prefs::kBlockThirdPartyCookies));
-  EXPECT_EQ(browser()->profile()->GetPrefs()->
-      GetInteger("profile.default_content_setting_values.cookies"),
-      ContentSetting::CONTENT_SETTING_BLOCK);
+  EXPECT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(
+      prefs::kBlockThirdPartyCookies));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
+                "profile.default_content_setting_values.cookies"),
+            ContentSetting::CONTENT_SETTING_BLOCK);
 
-  NavigateToPageWithFrame(embedded_test_server(),
-                          "a.com");
+  NavigateToPageWithFrame(embedded_test_server(), "a.com");
 
-  NavigateFrameTo(embedded_test_server(),
-                  "b.com",
-                  "/set-cookie?name=Good");
+  NavigateFrameTo(embedded_test_server(), "b.com", "/set-cookie?name=Good");
 
   ExpectCookiesOnHost(embedded_test_server(), "a.com", "");
   ExpectCookiesOnHost(embedded_test_server(), "b.com", "");

--- a/components/brave_shields/browser/cookie_pref_service.cc
+++ b/components/brave_shields/browser/cookie_pref_service.cc
@@ -77,8 +77,7 @@ void CookiePrefService::Lock::Release() {
 CookiePrefService::CookiePrefService(
     HostContentSettingsMap* host_content_settings_map,
     PrefService* prefs)
-    : host_content_settings_map_(host_content_settings_map),
-      prefs_(prefs) {
+    : host_content_settings_map_(host_content_settings_map), prefs_(prefs) {
   SetCookiePrefDefaults(host_content_settings_map, prefs);
   host_content_settings_map_->AddObserver(this);
   pref_change_registrar_.Init(prefs_);
@@ -112,10 +111,10 @@ void CookiePrefService::OnContentSettingChanged(
       secondary_pattern == ContentSettingsPattern::Wildcard() &&
       content_type == CONTENT_SETTINGS_TYPE_PLUGINS &&
       resource_identifier == brave_shields::kCookies) {
-     if (lock_.Try()) {
-       SetCookiePrefDefaults(host_content_settings_map_, prefs_);
-       lock_.Release();
-     }
+    if (lock_.Try()) {
+      SetCookiePrefDefaults(host_content_settings_map_, prefs_);
+      lock_.Release();
+    }
   }
 }
 

--- a/components/brave_shields/browser/cookie_pref_service.h
+++ b/components/brave_shields/browser/cookie_pref_service.h
@@ -9,8 +9,8 @@
 #include <string>
 
 #include "base/macros.h"
-#include "components/keyed_service/core/keyed_service.h"
 #include "components/content_settings/core/browser/content_settings_observer.h"
+#include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_change_registrar.h"
 
 class HostContentSettingsMap;
@@ -22,9 +22,8 @@ namespace brave_shields {
 class CookiePrefService : public KeyedService,
                           public content_settings::Observer {
  public:
-  explicit CookiePrefService(
-      HostContentSettingsMap* host_content_settings_map,
-      PrefService* prefs);
+  explicit CookiePrefService(HostContentSettingsMap* host_content_settings_map,
+                             PrefService* prefs);
   ~CookiePrefService() override;
 
  private:
@@ -34,6 +33,7 @@ class CookiePrefService : public KeyedService,
     ~Lock();
     bool Try();
     void Release();
+
    private:
     bool locked_;
     DISALLOW_COPY_AND_ASSIGN(Lock);
@@ -42,11 +42,10 @@ class CookiePrefService : public KeyedService,
   void OnPreferenceChanged();
 
   // content_settings::Observer overrides:
-  void OnContentSettingChanged(
-    const ContentSettingsPattern& primary_pattern,
-    const ContentSettingsPattern& secondary_pattern,
-    ContentSettingsType content_type,
-    const std::string& resource_identifier) override;
+  void OnContentSettingChanged(const ContentSettingsPattern& primary_pattern,
+                               const ContentSettingsPattern& secondary_pattern,
+                               ContentSettingsType content_type,
+                               const std::string& resource_identifier) override;
 
   Lock lock_;
   HostContentSettingsMap* host_content_settings_map_;

--- a/components/brave_shields/browser/cookie_pref_service.h
+++ b/components/brave_shields/browser/cookie_pref_service.h
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include "base/macros.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/content_settings/core/browser/content_settings_observer.h"
 #include "components/prefs/pref_change_registrar.h"
@@ -27,6 +28,17 @@ class CookiePrefService : public KeyedService,
   ~CookiePrefService() override;
 
  private:
+  class Lock {
+   public:
+    Lock();
+    ~Lock();
+    bool Try();
+    void Release();
+   private:
+    bool locked_;
+    DISALLOW_COPY_AND_ASSIGN(Lock);
+  };
+
   void OnPreferenceChanged();
 
   // content_settings::Observer overrides:
@@ -36,9 +48,12 @@ class CookiePrefService : public KeyedService,
     ContentSettingsType content_type,
     const std::string& resource_identifier) override;
 
+  Lock lock_;
   HostContentSettingsMap* host_content_settings_map_;
   PrefService* prefs_;
   PrefChangeRegistrar pref_change_registrar_;
+
+  DISALLOW_COPY_AND_ASSIGN(CookiePrefService);
 };
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/cookie_pref_service_browsertest.cc
+++ b/components/brave_shields/browser/cookie_pref_service_browsertest.cc
@@ -72,6 +72,12 @@ IN_PROC_BROWSER_TEST_F(CookiePrefServiceTest, CookieControlType_Preference) {
   EXPECT_EQ(ControlType::ALLOW,
             brave_shields::GetCookieControlType(profile(), GURL()));
 
+  /* BLOCK_THIRD_PARTY */
+  SetCookiePref(CONTENT_SETTING_ALLOW);
+  SetThirdPartyCookiePref(true);
+  EXPECT_EQ(ControlType::BLOCK_THIRD_PARTY,
+            brave_shields::GetCookieControlType(profile(), GURL()));
+
   // Preserve CONTENT_SETTING_SESSION_ONLY
   SetCookiePref(CONTENT_SETTING_BLOCK);
   EXPECT_EQ(ControlType::BLOCK,

--- a/components/brave_shields/browser/cookie_pref_service_browsertest.cc
+++ b/components/brave_shields/browser/cookie_pref_service_browsertest.cc
@@ -9,6 +9,7 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/content_settings/core/common/content_settings.h"
+#include "components/content_settings/core/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 
@@ -24,6 +25,11 @@ class CookiePrefServiceTest : public InProcessBrowserTest {
   ContentSetting GetCookiePref() {
     return IntToContentSetting(profile()->GetPrefs()->GetInteger(
         "profile.default_content_setting_values.cookies"));
+  }
+
+  void SetThirdPartyCookiePref(bool setting) {
+    profile()->GetPrefs()->SetBoolean(
+        prefs::kBlockThirdPartyCookies, setting);
   }
 
   void SetCookiePref(ContentSetting setting) {
@@ -62,6 +68,7 @@ IN_PROC_BROWSER_TEST_F(CookiePrefServiceTest, CookieControlType_Preference) {
 
   /* ALLOW */
   SetCookiePref(CONTENT_SETTING_ALLOW);
+  SetThirdPartyCookiePref(false);
   EXPECT_EQ(ControlType::ALLOW,
             brave_shields::GetCookieControlType(profile(), GURL()));
 
@@ -70,9 +77,11 @@ IN_PROC_BROWSER_TEST_F(CookiePrefServiceTest, CookieControlType_Preference) {
   EXPECT_EQ(ControlType::BLOCK,
             brave_shields::GetCookieControlType(profile(), GURL()));
   SetCookiePref(CONTENT_SETTING_SESSION_ONLY);
+  SetThirdPartyCookiePref(false);
   EXPECT_EQ(ControlType::ALLOW,
             brave_shields::GetCookieControlType(profile(), GURL()));
   SetCookiePref(CONTENT_SETTING_ALLOW);
+  SetThirdPartyCookiePref(false);
   EXPECT_EQ(ControlType::ALLOW,
             brave_shields::GetCookieControlType(profile(), GURL()));
 }

--- a/test/data/cookie_iframe.html
+++ b/test/data/cookie_iframe.html
@@ -1,0 +1,5 @@
+<html><head><title>iframe test</title></head>
+<body>
+<script src="/cross-site/a.com/script_cookies.js"></script>
+<iframe src="simple.html" id="test"></iframe>
+</body></html>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/6804

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Navigate to brave://settings/shields
2. Toggle `Cookie` settings from `Only block only cross-site cookies` to `Block All Cookies`
3. Refresh and verify the setting remains the same
4. Toggle the setting to `Block-Cross site cookies` and refresh
5. Verify the setting remains the same
6. Navigate to https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled and verify that third party cookies are blocked
7. Toggle the setting to `Block all cookies` -> `Allow all cookies`
8. Navigate to https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled and verify that all cookies are allowed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
