### PR TITLE
Rewards button pre-opt-in badge dismisses after first button press (uplift to 0.72.x)

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -179,7 +179,8 @@ void BraveActionsContainer::AddActionStubForRewards() {
     return;
   }
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
-  actions_[id].view_ = std::make_unique<BraveRewardsActionStubView>(this);
+  actions_[id].view_ = std::make_unique<BraveRewardsActionStubView>(
+      browser_->profile(), this);
   AttachAction(actions_[id]);
 #endif
 }

--- a/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h
+++ b/browser/ui/views/brave_actions/brave_rewards_action_stub_view.h
@@ -8,8 +8,11 @@
 
 #include <memory>
 
+#include "components/prefs/pref_member.h"
 #include "ui/views/controls/button/label_button.h"
 #include "ui/views/view.h"
+
+class Profile;
 
 // A button to take the place of an extension that will be loaded in the future.
 // Call SetImage with the BraveActionIconWithBadgeImageSource
@@ -25,7 +28,7 @@ class BraveRewardsActionStubView : public views::LabelButton,
     ~Delegate() {}
   };
 
-  explicit BraveRewardsActionStubView(Delegate* delegate);
+  explicit BraveRewardsActionStubView(Profile* profile, Delegate* delegate);
   ~BraveRewardsActionStubView() override;
 
   // views::ButtonListener
@@ -41,6 +44,8 @@ class BraveRewardsActionStubView : public views::LabelButton,
  private:
   gfx::Size CalculatePreferredSize() const override;
 
+  StringPrefMember badge_text_pref_;
+  Profile* profile_;
   Delegate* delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveRewardsActionStubView);

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -60,6 +60,7 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterDictionaryPref(prefs::kRewardsExternalWallets);
   registry->RegisterUint64Pref(prefs::kStateServerPublisherListStamp, 0ull);
   registry->RegisterStringPref(prefs::kStateUpholdAnonAddress, "");
+  registry->RegisterStringPref(prefs::kRewardsBadgeText, "1");
 }
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -28,7 +28,7 @@ const char kStateServerPublisherListStamp[] =
     "brave.rewards.server_publisher_list_stamp";
 const char kStateUpholdAnonAddress[] =
     "brave.rewards.uphold_anon_address";
-
+const char kRewardsBadgeText[] = "brave.rewards.badge_text";
 const char kUseRewardsStagingServer[] = "brave.rewards.use_staging_server";
 }  // namespace prefs
 }  // namespace brave_rewards

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -20,6 +20,7 @@ extern const char kRewardsUserHasFunded[];
 extern const char kRewardsAddFundsNotification[];
 extern const char kRewardsNotificationStartupDelay[];
 extern const char kRewardsExternalWallets[];
+extern const char kRewardsBadgeText[];
 
 // Defined in native-ledger
 extern const char kStateServerPublisherListStamp[];


### PR DESCRIPTION
Uplift of #3898
Fixes https://github.com/brave/brave-browser/issues/6691

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.