### PR TITLE
Implment OnRecordsSent and delete resend_records within it

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@13bb40a215248cfbdd87d0a6b425c8397402e9e6",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@800f9d40b7409239ff192e0be634764e747c7a75",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@3c443268bef1675532a472875151a5f053fee82e",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@14682d439b4bbcbf1bad3c6c2442287f1b4b7854",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@45e32155af9897dbe1d5534dd36697ec4728bb75",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@c396fb4eb9e9bf63b89ae5a0ec0b5f201d43c7c5",
 }

--- a/browser/extensions/api/brave_sync_api.cc
+++ b/browser/extensions/api/brave_sync_api.cc
@@ -168,6 +168,24 @@ BraveSyncOnCompactCompleteFunction::Run() {
   return RespondNow(NoArguments());
 }
 
+ExtensionFunction::ResponseAction
+BraveSyncOnRecordsSentFunction::Run() {
+  std::unique_ptr<brave_sync::OnRecordsSent::Params> params(
+      brave_sync::OnRecordsSent::Params::Create(*args_));
+  EXTENSION_FUNCTION_VALIDATE(params.get());
+
+  auto records = std::make_unique<std::vector<::brave_sync::SyncRecordPtr>>();
+  ::brave_sync::ConvertSyncRecords(params->records, records.get());
+
+  BraveSyncService* sync_service = GetSyncService(browser_context());
+  DCHECK(sync_service);
+  sync_service->GetBraveSyncClient()
+      ->sync_message_handler()
+      ->OnRecordsSent(params->category_name, std::move(records));
+
+  return RespondNow(NoArguments());
+}
+
 ExtensionFunction::ResponseAction BraveSyncExtensionInitializedFunction::Run() {
   // Also inform sync client extension started
   BraveSyncService* sync_service = GetSyncService(browser_context());

--- a/browser/extensions/api/brave_sync_api.h
+++ b/browser/extensions/api/brave_sync_api.h
@@ -65,6 +65,12 @@ class BraveSyncOnCompactCompleteFunction : public ExtensionFunction {
   ResponseAction Run() override;
 };
 
+class BraveSyncOnRecordsSentFunction : public ExtensionFunction {
+  ~BraveSyncOnRecordsSentFunction() override {}
+  DECLARE_EXTENSION_FUNCTION("braveSync.onRecordsSent", UNKNOWN)
+  ResponseAction Run() override;
+};
+
 class BraveSyncExtensionInitializedFunction : public ExtensionFunction {
   ~BraveSyncExtensionInitializedFunction() override {}
   DECLARE_EXTENSION_FUNCTION("braveSync.extensionInitialized", UNKNOWN)

--- a/common/extensions/api/brave_sync.json
+++ b/common/extensions/api/brave_sync.json
@@ -418,6 +418,21 @@
             "name": "category_name"
           }
         ]
+      },
+      {
+        "name": "onRecordsSent",
+        "type": "function",
+        "description": "Notify browser that records are successfully uploaded",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "category_name"
+          },
+          {
+            "type": "array", "items": {"$ref": "SyncRecord"},
+            "name": "records"
+          }
+        ]
       }
     ]
   }

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -608,6 +608,17 @@ void BraveProfileSyncServiceImpl::OnCompactComplete(
     brave_sync_prefs_->SetLastCompactTimeBookmarks(base::Time::Now());
 }
 
+void BraveProfileSyncServiceImpl::OnRecordsSent(
+    const std::string& category,
+    std::unique_ptr<brave_sync::RecordsList> records) {
+  for (auto& record : *records) {
+    if (category == kBookmarks) {
+      // Remove Acked sent records
+      brave_sync_prefs_->RemoveFromRecordsToResend(record->objectId);
+    }
+  }
+}
+
 int BraveProfileSyncServiceImpl::GetDisableReasons() const {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
@@ -805,8 +816,6 @@ void BraveProfileSyncServiceImpl::CreateResolveList(
   for (const auto& record : records) {
     // Ignore records from ourselves to avoid mess on merge
     if (record->deviceId == this_device_id) {
-      // Remove Acked sent records
-      brave_sync_prefs_->RemoveFromRecordsToResend(record->objectId);
       continue;
     }
     auto resolved_record = std::make_unique<SyncRecordAndExisting>();

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -31,8 +31,6 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnResetSync);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, ClientOnGetInitData);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnGetInitData);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSaveBookmarksBaseOrder);
-FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnCompactComplete);
-FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnRecordsSent);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSyncPrefsChanged);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSyncDebug);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, StartSyncNonDeviceRecords);
@@ -142,8 +140,6 @@ class BraveProfileSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnResetSync);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, ClientOnGetInitData);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSaveBookmarksBaseOrder);
-  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnCompactComplete);
-  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnRecordsSent);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnGetInitData);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSyncPrefsChanged);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSyncDebug);

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -32,6 +32,7 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, ClientOnGetInitData);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnGetInitData);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSaveBookmarksBaseOrder);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnCompactComplete);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnRecordsSent);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSyncPrefsChanged);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSyncDebug);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, StartSyncNonDeviceRecords);
@@ -96,6 +97,9 @@ class BraveProfileSyncServiceImpl
   void OnDeleteSyncSiteSettings() override;
   void OnSaveBookmarksBaseOrder(const std::string& order) override;
   void OnCompactComplete(const std::string& category_name) override;
+  void OnRecordsSent(
+      const std::string& category_name,
+      std::unique_ptr<brave_sync::RecordsList> records) override;
 
   // syncer::SyncService implementation
   int GetDisableReasons() const override;
@@ -139,6 +143,7 @@ class BraveProfileSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, ClientOnGetInitData);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSaveBookmarksBaseOrder);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnCompactComplete);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnRecordsSent);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnGetInitData);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSyncPrefsChanged);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSyncDebug);

--- a/components/brave_sync/client/brave_sync_client.h
+++ b/components/brave_sync/client/brave_sync_client.h
@@ -53,6 +53,8 @@ class SyncMessageHandler {
   virtual void OnSaveBookmarksBaseOrder(const std::string& order) = 0;
   // COMOACTED_SYNC_CATEGORY
   virtual void OnCompactComplete(const std::string& category_name) = 0;
+  virtual void OnRecordsSent(const std::string &category_name,
+                             std::unique_ptr<RecordsList> records) = 0;
 };
 
 class BraveSyncClient {

--- a/components/brave_sync/extension/background.js
+++ b/components/brave_sync/extension/background.js
@@ -195,6 +195,10 @@ class InjectedObject {
         console.log(`"compacted-sync-category" category=${JSON.stringify(arg1)} `);
         chrome.braveSync.onCompactComplete(arg1/*categoryName*/);
         break;
+      case "sent-sync-records":
+        console.log(`"sent-sync-records" categoryName=${JSON.stringify(arg1)} records=${JSON.stringify(arg2)}`);
+        chrome.braveSync.onRecordsSent(arg1/*categoryName*/, arg2/*records*/);
+        break;
       default:
         console.log('background.js TAGAB InjectedObject.handleMessage unknown message', message, arg1, arg2, arg3, arg4);
         console.log('background.js TAGAB message=' + message);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/6834

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
