### PR TITLE
Override CFBundleVersion string to prepare update on MacOS after major version (uplift to 0.73.x)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -473,6 +473,7 @@ if (is_mac) {
       "--brave_product_dir_name=" + brave_product_dir_name,
       "--brave_feed_url=" + brave_feed_url,
       "--brave_dsa_file=" + brave_dsa_file,
+      "--brave_version=" + brave_version,
     ]
 
     deps = [

--- a/script/lib/omaha.py
+++ b/script/lib/omaha.py
@@ -92,6 +92,14 @@ def get_app_info(appinfo, args):
     chrome_major = get_chrome_version().split('.')[0]
     chrome_minor = get_chrome_version().split('.')[1]
 
+    # The Sparkle CFBundleVersion is no longer tied to the Chrome version,
+    # instead we derive it from the package.json['version'] string. The 2nd
+    # digit is adjusted, and then we utilize that combined with the 3rd digit as
+    # the CFBundleVersion. (This is also used in build/mac/tweak_info_plist.py)
+    version_values = get_upload_version().split('.')
+    if int(version_values[0]) >= 1:
+        adjusted_minor = int(version_values[1]) + (100 * int(version_values[0]))
+
     appinfo['appguid'] = get_appguid(release_channel(), appinfo['platform'])
     appinfo['channel'] = release_channel()
     appinfo['chrome_version'] = get_chrome_version()
@@ -104,8 +112,8 @@ def get_app_info(appinfo, args):
         appinfo['version'] = chrome_major + '.' + get_upload_version()
     if appinfo['platform'] in 'darwin':
         appinfo['short_version'] = chrome_major + '.' + get_upload_version()
-        appinfo['version'] = appinfo['short_version'].split('.')[2] + \
-            '.' + appinfo['short_version'].split('.')[3]
+        appinfo['version'] = str(adjusted_minor) + \
+            '.' + version_values[2]
     appinfo['release_notes'] = 'Brave Browser version: {}\n\n<a href="{}">Brave Changelog</a>'\
         .format(appinfo['version'] if appinfo['platform'] in 'win32' else appinfo['short_version'],
                 changelog_url)


### PR DESCRIPTION
Uplift of #3797
Fixes https://github.com/brave/brave-browser/issues/6465

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.