### PR TITLE
[0.71.x] Make NTP widget size to fit content

### DIFF
--- a/components/brave_new_tab_ui/components/default/widget/styles.ts
+++ b/components/brave_new_tab_ui/components/default/widget/styles.ts
@@ -13,7 +13,8 @@ interface WidgetContainerProps {
 export const StyledWidgetContainer = styled<WidgetContainerProps, 'div'>('div')`
   display: ${p => p.showWidget ? 'flex' : 'none'};
   align-items: center;
-  flex-direction: ${p => p.menuPosition === 'right' ? 'row' : 'row-reverse'}
+  flex-direction: ${p => p.menuPosition === 'right' ? 'row' : 'row-reverse'};
+  height: fit-content;
 
   @media screen and (max-width: 1150px) {
     flex-direction: row;


### PR DESCRIPTION
fix brave/brave-browser#6746 for 0.71.x

Sibling PRs #3916, #3938, https://github.com/brave/brave-core/pull/3941