### PR TITLE
Hide google microphone from https://github.com/brave/brave-browser/issues/2690

### DIFF
--- a/components/brave_extension/extension/brave_extension/assets/siteHack-googlemic.js
+++ b/components/brave_extension/extension/brave_extension/assets/siteHack-googlemic.js
@@ -1,3 +1,10 @@
 // Stop the google mic from showing up.
 // https://github.com/brave/brave-browser/issues/2690
-document.querySelector('[aria-label="Search by voice"]').style.visibility = 'hidden';
+
+var selection = document.querySelector('[aria-label="Search by voice"]')!== null;
+if (selection) {
+  document.querySelector('[aria-label="Search by voice"]').style.visibility = 'hidden';
+} else {
+  console.warn('The element aria-label does not exist in the page.');
+}
+

--- a/components/brave_extension/extension/brave_extension/assets/siteHack-googlemic.js
+++ b/components/brave_extension/extension/brave_extension/assets/siteHack-googlemic.js
@@ -1,0 +1,3 @@
+// Stop the google mic from showing up.
+// https://github.com/brave/brave-browser/issues/2690
+document.querySelector('[aria-label="Search by voice"]').style.visibility = 'hidden';

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -75,6 +75,13 @@
       "js": [
         "assets/siteHack-glennbeck.com.js"
       ]
+    }, {
+      "run_at": "document_start",
+      "all_frames": true,
+      "matches": ["https://www.google.*"],
+      "js": [
+        "assets/siteHack-googlemic.js"
+      ]
     }
   ],
   "permissions": [ "contentSettings", "settingsPrivate", "management", "tabs", "storage", "webNavigation", "contextMenus", "cookies", "*://*/*", "chrome://favicon/*" ],


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/2690

Since the google microphone doesn't work, the microphone is hidden on Firefox (possibly a user agent checks by google)

This patch will hide the microphone icon on all google regional sites, tested on `www.google.com`, `www.google.co.nz`, `www.google.com.au`, `www.google.co.uk`, `www.google.de`  This patch works both in desktop and mobile versions of google.

- [x] Main home page, microphone hidden
- [x] When google searching, microphone hidden

