### PR TITLE
Sync prefs redo issue 6504

### DIFF
--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -3,8 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/brave_profile_prefs.h"
 #include "brave/browser/brave_local_state_prefs.h"
+#include "brave/browser/brave_profile_prefs.h"
+#include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
@@ -23,5 +24,7 @@ void MigrateObsoleteProfilePrefs(Profile* profile) {
   // Added 11/2019.
   MigrateWidevinePrefs(profile);
 #endif
+  // Added 11/2019.
+  MigrateBraveSyncPrefs(profile);
 }
 

--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -35,8 +35,8 @@ if (enable_brave_sync) {
       "//components/prefs",
       "//components/prefs",
       "//components/signin/public/identity_manager",
-      "//components/sync/driver:driver",
       "//components/sync:rest_of_sync",
+      "//components/sync/driver:driver",
       "//content/public/browser",
       "//extensions/browser",
       "//net",
@@ -72,6 +72,7 @@ source_set("prefs") {
 
   deps = [
     "//components/prefs",
+    "//content/public/browser",
   ]
 }
 
@@ -100,9 +101,7 @@ source_set("crypto") {
   ]
 
   if (is_android) {
-    deps += [
-      "//third_party/android_sdk:cpu_features",
-    ]
+    deps += [ "//third_party/android_sdk:cpu_features" ]
   }
 }
 

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -78,9 +78,9 @@ std::string GetDeviceName() {
 }
 
 RecordsListPtr CreateDeviceRecord(const std::string& device_name,
-                                           const std::string& object_id,
-                                           const SyncRecord::Action& action,
-                                           const std::string& device_id) {
+                                  const std::string& object_id,
+                                  const SyncRecord::Action& action,
+                                  const std::string& device_id) {
   RecordsListPtr records = std::make_unique<RecordsList>();
 
   SyncRecordPtr record = std::make_unique<SyncRecord>();
@@ -426,16 +426,8 @@ void BraveProfileSyncServiceImpl::OnSaveInitData(const Uint8Array& seed,
   std::string seed_str = StrFromUint8Array(seed);
   std::string device_id_str = StrFromUint8Array(device_id);
 
-  std::string prev_seed_str = brave_sync_prefs_->GetPrevSeed();
-
   seed_.clear();
   DCHECK(!seed_str.empty());
-
-  if (prev_seed_str == seed_str) {  // reconnecting to previous sync chain
-    brave_sync_prefs_->SetPrevSeed(std::string());
-  } else if (!prev_seed_str.empty()) {  // connect/create to new sync chain
-    brave_sync_prefs_->SetPrevSeed(std::string());
-  }
 
   brave_sync_prefs_->SetSeed(seed_str);
   brave_sync_prefs_->SetThisDeviceId(device_id_str);
@@ -650,7 +642,6 @@ void BraveProfileSyncServiceImpl::NotifyHaveSyncWords(
 
 void BraveProfileSyncServiceImpl::ResetSyncInternal() {
   SignalWaitableEvent();
-  brave_sync_prefs_->SetPrevSeed(brave_sync_prefs_->GetSeed());
   brave_sync_prefs_->Clear();
 
   brave_sync_ready_ = false;
@@ -845,9 +836,9 @@ void BraveProfileSyncServiceImpl::SendDeviceSyncRecord(
     const std::string& device_id,
     const std::string& object_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  RecordsListPtr records = CreateDeviceRecord(
-      device_name, object_id, static_cast<SyncRecord::Action>(action),
-      device_id);
+  RecordsListPtr records =
+      CreateDeviceRecord(device_name, object_id,
+                         static_cast<SyncRecord::Action>(action), device_id);
   SendSyncRecords(SyncRecordType_PREFERENCES, std::move(records));
 }
 

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -320,7 +320,11 @@ void BraveProfileSyncServiceImpl::GetSettingsAndDevices(
 void BraveProfileSyncServiceImpl::GetSyncWords() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   Uint8Array seed = Uint8ArrayFromString(brave_sync_prefs_->GetSeed());
-  NotifyHaveSyncWords(crypto::PassphraseFromBytes32(seed));
+  if (!seed.empty()) {
+    NotifyHaveSyncWords(crypto::PassphraseFromBytes32(seed));
+  } else {
+    NotifyHaveSyncWords("TEST DEBUG");
+  }
 }
 
 std::string BraveProfileSyncServiceImpl::GetSeed() {

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -9,9 +9,17 @@
 
 #include "brave/components/brave_sync/settings.h"
 #include "brave/components/brave_sync/sync_devices.h"
+#include "chrome/browser/profiles/profile.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
+#include "content/public/browser/browser_thread.h"
+
+void MigrateBraveSyncPrefs(Profile* profile) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  PrefService* prefs = profile->GetPrefs();
+  prefs->ClearPref(brave_sync::prefs::kSyncPrevSeed);
+}
 
 namespace brave_sync {
 namespace prefs {
@@ -73,14 +81,6 @@ std::string Prefs::GetSeed() const {
 void Prefs::SetSeed(const std::string& seed) {
   DCHECK(!seed.empty());
   pref_service_->SetString(kSyncSeed, seed);
-}
-
-std::string Prefs::GetPrevSeed() const {
-  return pref_service_->GetString(kSyncPrevSeed);
-}
-
-void Prefs::SetPrevSeed(const std::string& seed) {
-  pref_service_->SetString(kSyncPrevSeed, seed);
 }
 
 std::string Prefs::GetThisDeviceId() const {

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -24,6 +24,8 @@ namespace user_prefs {
 class PrefRegistrySyncable;
 }
 
+void MigrateBraveSyncPrefs(Profile* profile);
+
 namespace brave_sync {
 
 class Settings;
@@ -37,6 +39,7 @@ extern const char kSyncDeviceId[];
 // like "145,58,125,111,85,164,236,38,204,67,40,31,182,114,14,152,242,..."
 extern const char kSyncSeed[];
 // For storing previous seed after reset. It won't be cleared by Clear()
+// Now is deprecated.
 extern const char kSyncPrevSeed[];
 // String of current device namefor sync
 extern const char kSyncDeviceName[];
@@ -78,8 +81,6 @@ class Prefs {
 
   std::string GetSeed() const;
   void SetSeed(const std::string& seed);
-  std::string GetPrevSeed() const;
-  void SetPrevSeed(const std::string& seed);
   std::string GetThisDeviceId() const;
   void SetThisDeviceId(const std::string& device_id);
   std::string GetThisDeviceName() const;

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -398,11 +398,9 @@ TEST_F(BraveSyncServiceTest, GetSeed) {
   // Service gets seed from client via BraveSyncServiceImpl::OnSaveInitData
   const auto binary_seed = brave_sync::Uint8Array(16, 77);
 
-  EXPECT_TRUE(brave_sync_prefs()->GetPrevSeed().empty());
   sync_service()->OnSaveInitData(binary_seed, {0});
   std::string expected_seed = brave_sync::StrFromUint8Array(binary_seed);
   EXPECT_EQ(sync_service()->GetSeed(), expected_seed);
-  EXPECT_TRUE(brave_sync_prefs()->GetPrevSeed().empty());
 }
 
 TEST_F(BraveSyncServiceTest, OnDeleteDevice) {
@@ -489,8 +487,7 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenOneDevice) {
   EXPECT_TRUE(DevicesContains(devices_semi_final.get(), "1", "device1"));
 }
 
-TEST_F(BraveSyncServiceTest,
-       OnDeleteDeviceWhenSelfDeleted) {
+TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
   brave_sync_prefs()->SetThisDeviceId("1");
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
@@ -693,8 +690,7 @@ TEST_F(BraveSyncServiceTest, OnBraveSyncPrefsChanged) {
   sync_service()->OnBraveSyncPrefsChanged(brave_sync::prefs::kSyncEnabled);
 }
 
-void OnGetRecordsStub(std::unique_ptr<RecordsList> records) {
-}
+void OnGetRecordsStub(std::unique_ptr<RecordsList> records) {}
 
 TEST_F(BraveSyncServiceTest, SetThisDeviceCreatedTime) {
   EXPECT_TRUE(brave_sync::tools::IsTimeEmpty(
@@ -1008,4 +1004,11 @@ TEST_F(BraveSyncServiceTest, SendCompact) {
   EXPECT_CALL(*sync_client(), SendCompact(kBookmarks)).Times(0);
   EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
   sync_service()->FetchSyncRecords(true, false, true, 1000);
+}
+
+TEST_F(BraveSyncServiceTest, MigratePrevSeed) {
+  profile()->GetPrefs()->SetString(brave_sync::prefs::kSyncPrevSeed, "1,2,3");
+  MigrateBraveSyncPrefs(profile());
+  EXPECT_EQ(profile()->GetPrefs()->GetString(brave_sync::prefs::kSyncPrevSeed),
+            "");
 }

--- a/components/brave_sync/brave_sync_service_unittest.cc
+++ b/components/brave_sync/brave_sync_service_unittest.cc
@@ -229,7 +229,6 @@ class BraveSyncServiceTest : public testing::Test {
   // When this is set, class should not install any other MessageLoops, like
   // base::test::ScopedTaskEnvironment
   content::TestBrowserThreadBundle thread_bundle_;
-
   std::unique_ptr<Profile> profile_;
   BraveProfileSyncServiceImpl* sync_service_;
   MockBraveSyncClient* sync_client_;
@@ -248,8 +247,7 @@ TEST_F(BraveSyncServiceTest, SetSyncEnabled) {
   sync_service()->OnSetSyncEnabled(true);
   EXPECT_TRUE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
-  EXPECT_FALSE(sync_service()->IsBraveSyncInitialized());
-  EXPECT_FALSE(sync_service()->IsBraveSyncConfigured());
+  EXPECT_FALSE(sync_service()->brave_sync_ready_);
 }
 
 TEST_F(BraveSyncServiceTest, SetSyncDisabled) {
@@ -264,24 +262,46 @@ TEST_F(BraveSyncServiceTest, SetSyncDisabled) {
   sync_service()->OnSetSyncEnabled(false);
   EXPECT_FALSE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
-  EXPECT_FALSE(sync_service()->IsBraveSyncInitialized());
-  EXPECT_FALSE(sync_service()->IsBraveSyncConfigured());
+  EXPECT_FALSE(sync_service()->brave_sync_ready_);
 }
 
-TEST_F(BraveSyncServiceTest, IsSyncConfiguredOnNewProfile) {
-  EXPECT_FALSE(sync_service()->IsBraveSyncConfigured());
+TEST_F(BraveSyncServiceTest, IsSyncReadyOnNewProfile) {
+  EXPECT_FALSE(sync_service()->brave_sync_ready_);
 }
 
-TEST_F(BraveSyncServiceTest, IsSyncInitializedOnNewProfile) {
-  EXPECT_FALSE(sync_service()->IsBraveSyncInitialized());
-}
+const char kTestWords1[] =
+    "absurd avoid scissors anxiety gather lottery category door "
+    "army half long cage bachelor another expect people blade "
+    "school educate curtain scrub monitor lady beyond";
 
 TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCode) {
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged);
   // Expecting sync state changed twice: for enabled state and for device name
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(2);
-  sync_service()->OnSetupSyncHaveCode("word1 word2 word3", "test_device");
+  sync_service()->OnSetupSyncHaveCode(kTestWords1, "test_device");
   EXPECT_TRUE(
+      profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
+}
+
+TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCodeIncorrectCode) {
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(0);
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(0);
+  EXPECT_CALL(*observer(),
+              OnSyncSetupError(sync_service(), "ERR_SYNC_WRONG_WORDS"))
+      .Times(1);
+  sync_service()->OnSetupSyncHaveCode("wrong code", "test_device");
+  EXPECT_FALSE(
+      profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
+}
+
+TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCodeEmptyCode) {
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(0);
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(0);
+  EXPECT_CALL(*observer(),
+              OnSyncSetupError(sync_service(), "ERR_SYNC_WRONG_WORDS"))
+      .Times(1);
+  sync_service()->OnSetupSyncHaveCode("", "test_device");
+  EXPECT_FALSE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
 }
 
@@ -289,7 +309,7 @@ TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCodeEmptyDeviceName) {
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged);
   // Expecting sync state changed twice: for enabled state and for device name
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(2);
-  sync_service()->OnSetupSyncHaveCode("word1 word2 word3", "");
+  sync_service()->OnSetupSyncHaveCode(kTestWords1, "");
   EXPECT_TRUE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
   EXPECT_EQ(
@@ -408,6 +428,7 @@ TEST_F(BraveSyncServiceTest, OnDeleteDevice) {
                               ContainsDeviceRecord(SyncRecord::Action::A_DELETE,
                                                    "device3")))
       .Times(1);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, _, _));
   sync_service()->OnDeleteDevice("3");
 
   RecordsList resolved_records;
@@ -446,6 +467,7 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenOneDevice) {
   EXPECT_TRUE(DevicesContains(devices.get(), "2", "device2"));
 
   EXPECT_CALL(*sync_client(), SendSyncRecords).Times(1);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, _, _));
   sync_service()->OnDeleteDevice("2");
 
   RecordsList resolved_records;
@@ -455,34 +477,24 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenOneDevice) {
   // Expecting to be called one time to set the new devices list
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
 
-  EXPECT_CALL(*sync_client(), SendSyncRecords).Times(1);
+  EXPECT_CALL(*sync_client(), SendSyncRecords).Times(0);
+
+  // Still enabled
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(0);
 
   sync_service()->OnResolvedPreferences(resolved_records);
 
   auto devices_semi_final = brave_sync_prefs()->GetSyncDevices();
   EXPECT_FALSE(DevicesContains(devices_semi_final.get(), "2", "device2"));
   EXPECT_TRUE(DevicesContains(devices_semi_final.get(), "1", "device1"));
-
-  // Enabled->Disabled
-  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
-
-  // Emulate sending DELETE for this device
-  RecordsList resolved_records2;
-  auto resolved_record2 = SyncRecord::Clone(*records.at(0));
-  resolved_record2->action = SyncRecord::Action::A_DELETE;
-  resolved_records2.push_back(std::move(resolved_record2));
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(3);
-
-  sync_service()->OnResolvedPreferences(resolved_records2);
-
-  auto devices_final = brave_sync_prefs()->GetSyncDevices();
-  EXPECT_FALSE(DevicesContains(devices_final.get(), "1", "device1"));
-  EXPECT_FALSE(DevicesContains(devices_final.get(), "2", "device2"));
-  EXPECT_FALSE(sync_service()->IsBraveSyncConfigured());
 }
 
-TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
+TEST_F(BraveSyncServiceTest,
+       OnDeleteDeviceWhenSelfDeleted) {
   brave_sync_prefs()->SetThisDeviceId("1");
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
+  brave_sync_prefs()->SetSyncEnabled(true);
   RecordsList records;
   records.push_back(
       SimpleDeviceRecord(SyncRecord::Action::A_CREATE, "1", "device1"));
@@ -501,11 +513,11 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
                               ContainsDeviceRecord(SyncRecord::Action::A_DELETE,
                                                    "device1")))
       .Times(1);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, _, _));
   sync_service()->OnDeleteDevice("1");
 
   // Enabled->Disabled
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
-
   RecordsList resolved_records;
   auto resolved_record = SyncRecord::Clone(*records.at(0));
   resolved_record->action = SyncRecord::Action::A_DELETE;
@@ -514,11 +526,11 @@ TEST_F(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted) {
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(3);
   sync_service()->OnResolvedPreferences(resolved_records);
 
+  EXPECT_FALSE(brave_sync_prefs()->GetSyncEnabled());
+
   auto devices_final = brave_sync_prefs()->GetSyncDevices();
   EXPECT_FALSE(DevicesContains(devices_final.get(), "1", "device1"));
   EXPECT_FALSE(DevicesContains(devices_final.get(), "2", "device2"));
-
-  EXPECT_FALSE(sync_service()->IsBraveSyncConfigured());
 }
 
 TEST_F(BraveSyncServiceTest, OnResetSync) {
@@ -549,11 +561,13 @@ TEST_F(BraveSyncServiceTest, OnResetSync) {
                                                    "this_device")))
       .Times(1);
 
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords);
   sync_service()->OnResetSync();
   RecordsList resolved_records;
   auto resolved_record = SyncRecord::Clone(*records.at(0));
   resolved_record->action = SyncRecord::Action::A_DELETE;
   resolved_records.push_back(std::move(resolved_record));
+
   sync_service()->OnResolvedPreferences(resolved_records);
 
   auto devices_final = brave_sync_prefs()->GetSyncDevices();
@@ -598,8 +612,7 @@ TEST_F(BraveSyncServiceTest, OnResetSync) {
       profile()->GetPrefs()->GetString(brave_sync::prefs::kSyncApiVersion),
       "0");
 
-  EXPECT_FALSE(sync_service()->IsBraveSyncInitialized());
-  EXPECT_FALSE(sync_service()->IsBraveSyncConfigured());
+  EXPECT_FALSE(sync_service()->brave_sync_ready_);
 
   EXPECT_FALSE(sync_prefs()->IsSyncRequested());
   EXPECT_FALSE(
@@ -680,25 +693,27 @@ TEST_F(BraveSyncServiceTest, OnBraveSyncPrefsChanged) {
   sync_service()->OnBraveSyncPrefsChanged(brave_sync::prefs::kSyncEnabled);
 }
 
-TEST_F(BraveSyncServiceTest, StartSyncNonDeviceRecords) {
-  EXPECT_FALSE(sync_service()->IsBraveSyncInitialized());
-  sync_service()->OnSetSyncEnabled(true);
-  profile()->GetPrefs()->SetString(brave_sync::prefs::kSyncBookmarksBaseOrder,
-                                   "1.1.");
-  profile()->GetPrefs()->SetBoolean(brave_sync::prefs::kSyncBookmarksEnabled,
-                                    true);
-  EXPECT_FALSE(
-      profile()->GetPrefs()->GetBoolean(syncer::prefs::kSyncBookmarks));
+void OnGetRecordsStub(std::unique_ptr<RecordsList> records) {
+}
+
+TEST_F(BraveSyncServiceTest, SetThisDeviceCreatedTime) {
+  EXPECT_TRUE(brave_sync::tools::IsTimeEmpty(
+      sync_service()->this_device_created_time_));
+
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  EXPECT_CALL(*observer(), OnSyncStateChanged);
+  brave_sync_prefs()->SetSyncEnabled(true);
   brave_sync_prefs()->SetThisDeviceId("1");
-  RecordsList records;
-  records.push_back(
-      SimpleDeviceRecord(SyncRecord::Action::A_CREATE, "1", "device1"));
-  records.push_back(
-      SimpleDeviceRecord(SyncRecord::Action::A_CREATE, "2", "device2"));
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
-  sync_service()->OnResolvedPreferences(records);
-  EXPECT_TRUE(
-      !brave_sync::tools::IsTimeEmpty(sync_service()->chain_created_time_));
+
+  brave_sync::GetRecordsCallback on_get_records =
+      base::BindOnce(&OnGetRecordsStub);
+  base::WaitableEvent we;
+  EXPECT_CALL(*sync_client(), SendSyncRecords("PREFERENCES", _));
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords);
+  sync_service()->OnPollSyncCycle(std::move(on_get_records), &we);
+
+  EXPECT_FALSE(brave_sync::tools::IsTimeEmpty(
+      sync_service()->this_device_created_time_));
 }
 
 TEST_F(BraveSyncServiceTest, OnSyncReadyNewToSync) {
@@ -737,6 +752,8 @@ TEST_F(BraveSyncServiceTest, GetDisableReasons) {
   EXPECT_EQ(sync_service()->GetDisableReasons(),
             syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY |
                 syncer::SyncService::DISABLE_REASON_USER_CHOICE);
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnSetSyncEnabled(true);
   EXPECT_EQ(sync_service()->GetDisableReasons(),
             syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY |
@@ -744,17 +761,18 @@ TEST_F(BraveSyncServiceTest, GetDisableReasons) {
   brave_sync_prefs()->SetMigratedBookmarksVersion(2);
   EXPECT_EQ(sync_service()->GetDisableReasons(),
             syncer::SyncService::DISABLE_REASON_NONE);
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnSetSyncEnabled(false);
   EXPECT_TRUE(sync_service()->HasDisableReason(
       syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY));
 }
 
 TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCode_Reset_SetupAgain) {
-  EXPECT_FALSE(sync_service()->GetResettingForTest());
   EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
   // Expecting sync state changed twice: for enabled state and for device name
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(2);
-  sync_service()->OnSetupSyncHaveCode("word1 word2 word3", "test_device");
+  sync_service()->OnSetupSyncHaveCode(kTestWords1, "test_device");
   EXPECT_TRUE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
 
@@ -778,37 +796,34 @@ TEST_F(BraveSyncServiceTest, OnSetupSyncHaveCode_Reset_SetupAgain) {
                               ContainsDeviceRecord(SyncRecord::Action::A_DELETE,
                                                    "this_device")))
       .Times(1);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords);
   sync_service()->OnResetSync();
-  // Here we have marked service as in resetting state
+
   // Actual kSyncEnabled will go to false after receiving confirmation of
   // this_device DELETE
   EXPECT_TRUE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
 
-  EXPECT_TRUE(sync_service()->GetResettingForTest());
+  // Emulating resolved with DELETE
+  records.at(0)->action = SyncRecord::Action::A_DELETE;
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  // Sync state is changed 4 times:
+  // 1) we do save updated devices list
+  // 2,3,4) we do ResetSyncInternal() which clears this device name,
+  //        sync enabled and devices list
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(4);
+  sync_service()->OnResolvedPreferences(records);
 
-  // OnSyncStateChanged actually is invoked 9 times:
-  // ForceCompleteReset
-  //    ResetSyncInternal
-  //        brave_sync::Prefs::Clear()
-  //            device_name
-  //            enabled => false
-  //            bookmarks_enabled
-  //            site_settings_enabled
-  //            history_enabled
-  //            device_list
-  //       enabled => false
-  // OnSetupSyncHaveCode()
-  //     device_name
-  //     enabled => true
+  EXPECT_FALSE(
+      profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
 
-  // OnSyncEnabledChanged is actually invoked 3 times:
-  // see preference enabled in abobe list
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service()))
-      .Times(AtLeast(1));
-  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(AtLeast(1));
-  sync_service()->OnSetupSyncHaveCode("word1 word2 word5", "test_device");
-  EXPECT_FALSE(sync_service()->GetResettingForTest());
+  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(2);
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  sync_service()->OnSetupSyncHaveCode(
+      "anxiety path library anxiety gather lottery category door army half "
+      "long cage bachelor another expect people blade school "
+      "educate curtain scrub monitor lady arctic",
+      "test_device");
 
   EXPECT_TRUE(
       profile()->GetPrefs()->GetBoolean(brave_sync::prefs::kSyncEnabled));
@@ -908,15 +923,28 @@ TEST_F(BraveSyncServiceTest, ExponentialResend) {
 TEST_F(BraveSyncServiceTest, GetDevicesWithFetchSyncRecords) {
   using brave_sync::jslib_const::kPreferences;
 
+  EXPECT_CALL(*sync_client(), OnSyncEnabledChanged).Times(1);
+  EXPECT_CALL(*observer(), OnSyncStateChanged);
+  brave_sync_prefs()->SetSyncEnabled(true);
+  brave_sync_prefs()->SetThisDeviceId("1");
+
   // Expecting SendFetchSyncRecords will be invoked
+  // after sync_service()->OnPollSyncCycle
   EXPECT_EQ(brave_sync_prefs()->GetLastFetchTime(), base::Time());
   EXPECT_EQ(brave_sync_prefs()->GetLatestDeviceRecordTime(), base::Time());
-  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, base::Time(), _))
-      .Times(1);
-  sync_service()->FetchDevices();
+
+  using brave_sync::tools::IsTimeEmpty;
+  EXPECT_TRUE(IsTimeEmpty(sync_service()->this_device_created_time_));
+
+  brave_sync::GetRecordsCallback on_get_records =
+      base::BindOnce(&OnGetRecordsStub);
+  base::WaitableEvent we;
+  EXPECT_CALL(*sync_client(), SendSyncRecords("PREFERENCES", _));
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, base::Time(), _));
+  sync_service()->OnPollSyncCycle(std::move(on_get_records), &we);
+  EXPECT_FALSE(IsTimeEmpty(sync_service()->this_device_created_time_));
 
   // Emulate we received this device
-  brave_sync_prefs()->SetThisDeviceId("1");
   auto records = std::make_unique<brave_sync::RecordsList>();
   records->push_back(
       SimpleDeviceRecord(SyncRecord::Action::A_CREATE, "1", "device1"));
@@ -935,27 +963,7 @@ TEST_F(BraveSyncServiceTest, GetDevicesWithFetchSyncRecords) {
   EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
   sync_service()->OnResolvedSyncRecords(kPreferences, std::move(records));
 
-  // When there is only on device in chain, expect fetching sync records with
-  // start_at==0
-  ASSERT_EQ(brave_sync_prefs()->GetSyncDevices()->size(), 1u);
-  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, base::Time(), _))
-      .Times(1);
-  sync_service()->FetchDevices();
-
-  // If number of devices becomes 2 or more we should next 70 sec use s3
-  // with epmty start_at_time and then switch to sqs with non-empty
-  // start_at_time
-  records = std::make_unique<brave_sync::RecordsList>();
-  records->push_back(
-      SimpleDeviceRecord(SyncRecord::Action::A_CREATE, "2", "device2"));
-  EXPECT_CALL(*observer(), OnSyncStateChanged(sync_service())).Times(1);
-  sync_service()->OnResolvedSyncRecords(kPreferences, std::move(records));
-
-  // Chain has been created but 70 sec not yet passed
-  ASSERT_EQ(brave_sync_prefs()->GetSyncDevices()->size(), 2u);
-  EXPECT_CALL(*sync_client(), SendFetchSyncRecords(_, base::Time(), _))
-      .Times(1);
-  sync_service()->FetchDevices();
+  EXPECT_FALSE(IsTimeEmpty(sync_service()->this_device_created_time_));
 
   // Less than 70 seconds have passed, we should fetch with empty start_at
   {
@@ -979,20 +987,25 @@ TEST_F(BraveSyncServiceTest, SendCompact) {
   using brave_sync::jslib_const::kBookmarks;
   EXPECT_EQ(brave_sync_prefs()->GetLastCompactTimeBookmarks(), base::Time());
   EXPECT_CALL(*sync_client(), SendCompact(kBookmarks)).Times(1);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
   sync_service()->FetchSyncRecords(true, false, true, 1000);
   // timestamp is not writtend until we get CompactedSyncCategory
   EXPECT_CALL(*sync_client(), SendCompact(kBookmarks)).Times(1);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
   sync_service()->FetchSyncRecords(true, false, true, 1000);
   sync_service()->OnCompactComplete(kBookmarks);
   EXPECT_CALL(*sync_client(), SendCompact(kBookmarks)).Times(0);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
   sync_service()->FetchSyncRecords(true, false, true, 1000);
   {
     auto time_override = OverrideForTimeDelta(base::TimeDelta::FromDays(
         sync_service()->GetCompactPeriodInDaysForTests()));
     EXPECT_CALL(*sync_client(), SendCompact(kBookmarks)).Times(1);
+    EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
     sync_service()->FetchSyncRecords(true, false, true, 1000);
     sync_service()->OnCompactComplete(kBookmarks);
   }
   EXPECT_CALL(*sync_client(), SendCompact(kBookmarks)).Times(0);
+  EXPECT_CALL(*sync_client(), SendFetchSyncRecords).Times(1);
   sync_service()->FetchSyncRecords(true, false, true, 1000);
 }

--- a/components/brave_sync/ui/components/app.tsx
+++ b/components/brave_sync/ui/components/app.tsx
@@ -39,7 +39,7 @@ export class SyncPage extends React.PureComponent<Props, {}> {
     return (
       <div id='syncPage'>
         {
-          syncData.isSyncConfigured && syncData.devices.length > 1
+          syncData.isSyncConfigured
             ? <EnabledContent syncData={syncData} actions={actions} />
             : <DisabledContent syncData={syncData} actions={actions} />
         }

--- a/components/brave_sync/ui/components/modals/enterSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/enterSyncCode.tsx
@@ -53,8 +53,7 @@ export default class EnterSyncCodeModal extends React.PureComponent<Props, State
       (
         this.state.willCreateNewSyncChainFromCode &&
         prevProps.syncData.isSyncConfigured !==
-        this.props.syncData.isSyncConfigured &&
-        this.props.syncData.devices.length > 1
+        this.props.syncData.isSyncConfigured
       )
     ) {
       this.setState({ willCreateNewSyncChainFromCode: false })
@@ -87,8 +86,8 @@ export default class EnterSyncCodeModal extends React.PureComponent<Props, State
   }
 
   onClickConfirmSyncCode = () => {
-    const { error, thisDeviceName } = this.props.syncData
-    if (thisDeviceName !== '' || error) {
+    const { error } = this.props.syncData
+    if (error) {  // Important for the STR
       return
     }
     const { passphrase } = this.state

--- a/components/brave_sync/ui/components/modals/removeDevice.tsx
+++ b/components/brave_sync/ui/components/modals/removeDevice.tsx
@@ -59,12 +59,7 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, St
   }
 
   onClickConfirmRemoveDeviceButton = () => {
-    const { syncData, deviceName, deviceId } = this.props
-    // if there aren't enough devices, reset sync
-    if (syncData.devices.length < 2) {
-      this.props.actions.onSyncReset()
-      return
-    }
+    const { deviceName, deviceId } = this.props
     this.props.actions.onRemoveDevice(Number(deviceId), deviceName)
     this.setState({ willRemoveDevice: true })
   }

--- a/components/brave_sync/ui/components/modals/scanCode.tsx
+++ b/components/brave_sync/ui/components/modals/scanCode.tsx
@@ -52,7 +52,6 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
 
   componentDidUpdate (prevProps: Readonly<Props>) {
     if (
-        this.props.syncData.devices.length > 1 &&
         prevProps.syncData.devices.length !==
         this.props.syncData.devices.length
     ) {
@@ -78,10 +77,10 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
   }
 
   onDismissModal = () => {
-    const { devices, isSyncConfigured } = this.props.syncData
+    const { isSyncConfigured } = this.props.syncData
     // if user is still trying to build a sync chain,
     // open the confirmation modal. otherwise close it
-    isSyncConfigured && devices.length < 2
+    isSyncConfigured
       ? this.setState({ willCancelScanCode: true })
       : this.dismissAllModals()
   }
@@ -91,12 +90,12 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
   }
 
   onConfirmDismissModal = () => {
-    const { devices, isSyncConfigured } = this.props.syncData
+    const { isSyncConfigured } = this.props.syncData
     // sync is enabled when at least 2 devices are in the chain.
     // this modal works both with sync enabled and disabled states.
     // in case user opens it in the enabled content screen,
     // check there are 2 devices in chain before reset
-    if (isSyncConfigured && devices.length < 2) {
+    if (isSyncConfigured) {
       this.props.actions.onSyncReset()
       this.dismissAllModals()
     }

--- a/components/brave_sync/ui/components/modals/viewSyncCode.tsx
+++ b/components/brave_sync/ui/components/modals/viewSyncCode.tsx
@@ -48,7 +48,6 @@ export default class ViewSyncCodeModal extends React.PureComponent<Props, State>
 
   componentDidUpdate (prevProps: Readonly<Props>) {
     if (
-        this.props.syncData.devices.length > 1 &&
         prevProps.syncData.devices.length !==
         this.props.syncData.devices.length
     ) {
@@ -74,10 +73,10 @@ export default class ViewSyncCodeModal extends React.PureComponent<Props, State>
   }
 
   onDismissModal = () => {
-    const { devices, isSyncConfigured } = this.props.syncData
+    const { isSyncConfigured } = this.props.syncData
     // if user is still trying to build a sync chain,
     // open the confirmation modal. otherwise close it
-    isSyncConfigured && devices.length < 2
+    isSyncConfigured
       ? this.setState({ willCancelViewCode: true })
       : this.dismissAllModals()
   }
@@ -87,12 +86,12 @@ export default class ViewSyncCodeModal extends React.PureComponent<Props, State>
   }
 
   onConfirmDismissModal = () => {
-    const { devices, isSyncConfigured } = this.props.syncData
+    const { isSyncConfigured } = this.props.syncData
     // sync is enabled when at least 2 devices are in the chain.
     // this modal works both with sync enabled and disabled states.
     // in case user opens it in the enabled content screen,
     // check there are 2 devices in chain before reset
-    if (isSyncConfigured && devices.length < 2) {
+    if (isSyncConfigured) {
       this.props.actions.onSyncReset()
       this.dismissAllModals()
     }


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/6504

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
Seeing not related with PR fails at:
```
13 tests failed:
    BraveRewardsBrowserTest.AutoContribution (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2052)
    BraveRewardsBrowserTest.ContributionWithLowAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2218)
    BraveRewardsBrowserTest.InsufficientNotificationForInsufficientAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2533)
    BraveRewardsBrowserTest.InsufficientNotificationForVerifiedInsufficientAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2568)
    BraveRewardsBrowserTest.MultipleRecurringOverBudgetAndPartialAutoContribution (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2964)
    BraveRewardsBrowserTest.PendingContributionTip (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2415)
    BraveRewardsBrowserTest.RecurringAndPartialAutoContribution (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2917)
    BraveRewardsBrowserTest.RecurringTipForUnverifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2197)
    BraveRewardsBrowserTest.RecurringTipForVerifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2176)
    BraveRewardsBrowserTest.TipConnectedPublisherAnonAndConnected (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2792)
    BraveRewardsBrowserTest.TipNonIntegralAmount (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2876)
    BraveRewardsBrowserTest.TipUnverifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2156)
    BraveRewardsBrowserTest.TipVerifiedPublisher (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2137)
1 test timed out:
    BraveRewardsBrowserTest.ProcessPendingContributions (../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:2615)
```
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Please see the next message

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
