### PR TITLE
Tightens up spacing in grant captcha panel

### DIFF
--- a/components/brave_rewards/resources/ui/components/grantCaptcha/style.ts
+++ b/components/brave_rewards/resources/ui/components/grantCaptcha/style.ts
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 
 export const StyledWrapper = styled<{}, 'div'>('div')`
   text-align: center;
-  margin: 15px 0 0 -32px;
+  margin: 10px 0 0 -32px;
   width: 333px;
 `
 

--- a/components/brave_rewards/resources/ui/components/grantWrapper/style.ts
+++ b/components/brave_rewards/resources/ui/components/grantWrapper/style.ts
@@ -81,13 +81,13 @@ export const StyledText = styled<{}, 'div'>('div')`
 export const StyledGrantIcon = styled<{}, 'img'>('img')`
   height: 53px;
   width: 53px;
-  margin: 25px auto 15px;
+  margin: 20px auto 10px;
 `
 
 export const StyledPanelText = styled<{}, 'div'>('div')`
   padding: 7px;
   font-size: 12px;
-  margin: 7px auto 0px;
+  margin: 5px auto 0px;
   background: rgba(241, 241, 245, 0.70);
   border-radius: 8px 8px 8px 8px;
 `


### PR DESCRIPTION
Fixes brave/brave-browser#6879

This tightens up the spacing around elements during captcha solve, this provides some leeway for the captcha image without creating a vertical overflow

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Defined in issue, please test a few times

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
