### PR TITLE
Add myself to licensing-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,3 +30,8 @@ vendor/bat-native-ledger/src/bat/ledger/internal/static_values.h @gdregalo
 
 # Network
 browser/net/ @iefremov
+
+# Licensing of third-party components
+common_licenses/ @fmarier
+components/brave_new_tab_ui/data/backgrounds.ts @fmarier
+script/brave_license_helper.py @fmarier


### PR DESCRIPTION
To keep an eye on the licenses that get added and to make sure that any changes to the backgrounds we ship are reflected in the LICENSE file.