### PR TITLE
C79 linux widevine

### DIFF
--- a/browser/widevine/brave_widevine_bundle_manager.h
+++ b/browser/widevine/brave_widevine_bundle_manager.h
@@ -93,6 +93,11 @@ class BraveWidevineBundleManager {
   void ScheduleBackgroundUpdate();
   void OnBackgroundUpdateFinished(const std::string& error);
 
+  // Delete user-dir/WidevineCdm/libwidevinecdm.so if exists.
+  // After c79, libwidevinecdm.so is located under
+  // user-dir/WidevineCdm/_platform_specific/linux_x64/ and old one is not used.
+  void DeleteDeprecatedWidevineCdmLib();
+
   scoped_refptr<base::SequencedTaskRunner> file_task_runner();
 
   bool is_test_ = false;

--- a/browser/widevine/widevine_permission_request.cc
+++ b/browser/widevine/widevine_permission_request.cc
@@ -12,6 +12,12 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
+#if BUILDFLAG(BUNDLE_WIDEVINE_CDM)
+#include "base/bind.h"
+#include "base/task/post_task.h"
+#include "base/task/task_traits.h"
+#endif
+
 WidevinePermissionRequest::WidevinePermissionRequest(
     content::WebContents* web_contents)
     : web_contents_(web_contents) {
@@ -39,7 +45,11 @@ void WidevinePermissionRequest::PermissionGranted() {
 #endif
 
 #if BUILDFLAG(BUNDLE_WIDEVINE_CDM)
-  InstallBundleOrRestartBrowser();
+  // Run next commands at the next loop turn to prevent this is destroyed
+  // by restarting process. This should be destroyed by RequestFinished().
+  PostTask(FROM_HERE,
+           { base::CurrentThread(), base::TaskPriority::BEST_EFFORT },
+           base::BindOnce(&InstallBundleOrRestartBrowser));
 #endif
 }
 

--- a/common/brave_paths.cc
+++ b/common/brave_paths.cc
@@ -14,7 +14,6 @@
 #include "third_party/widevine/cdm/buildflags.h"
 
 #if BUILDFLAG(BUNDLE_WIDEVINE_CDM)
-#include "base/native_library.h"
 #include "chrome/common/chrome_paths.h"
 #include "third_party/widevine/cdm/widevine_cdm_common.h"
 #endif
@@ -54,7 +53,7 @@ void OverridePath() {
   base::FilePath widevine_cdm_path;
   if (base::PathService::Get(chrome::DIR_USER_DATA, &widevine_cdm_path)) {
     widevine_cdm_path =
-      widevine_cdm_path.AppendASCII(kWidevineCdmBaseDirectory);
+        widevine_cdm_path.AppendASCII(kWidevineCdmBaseDirectory);
     base::PathService::OverrideAndCreateIfNeeded(
         chrome::DIR_BUNDLED_WIDEVINE_CDM, widevine_cdm_path, true, false);
   }

--- a/patches/third_party-widevine-cdm-widevine.gni.patch
+++ b/patches/third_party-widevine-cdm-widevine.gni.patch
@@ -1,14 +1,13 @@
 diff --git a/third_party/widevine/cdm/widevine.gni b/third_party/widevine/cdm/widevine.gni
-index 580e5bbcfcb4e90810d9aac53a2bd03776070b92..ba6bfd659cedd4dc9b06259850e493210e332762 100644
+index 580e5bbcfcb4e90810d9aac53a2bd03776070b92..ba09d096bfbe598251eeca01e9ef155f9408953c 100644
 --- a/third_party/widevine/cdm/widevine.gni
 +++ b/third_party/widevine/cdm/widevine.gni
-@@ -37,6 +37,9 @@ enable_widevine_cdm_component =
+@@ -37,6 +37,8 @@ enable_widevine_cdm_component =
  
  # Widevine CDM is bundled as part of Google Chrome builds.
  bundle_widevine_cdm = enable_library_widevine_cdm && is_chrome_branded
-+if (brave_chromium_build) {
-+  bundle_widevine_cdm = enable_library_widevine_cdm && is_desktop_linux
-+}
++bundle_widevine_cdm = enable_library_widevine_cdm && is_desktop_linux
++enable_widevine_cdm_component = enable_library_widevine_cdm && (is_win || is_mac)
  
  enable_widevine_cdm_host_verification =
      enable_library_widevine_cdm && enable_cdm_host_verification


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
