### PR TITLE
Make speaker icon on pinned tab un-clickable

### DIFF
--- a/browser/ui/views/tabs/brave_alert_indicator.cc
+++ b/browser/ui/views/tabs/brave_alert_indicator.cc
@@ -35,6 +35,9 @@ class BraveAlertIndicator::BraveAlertBackground : public views::Background {
 
   // views::Background overrides:
   void Paint(gfx::Canvas* canvas, views::View* view) const override {
+    if (!host_view_->IsTabAudioToggleable())
+      return;
+
     gfx::Point center = host_view_->GetContentsBounds().CenterPoint();
     SkPath path;
     path.setFillType(SkPath::kEvenOdd_FillType);
@@ -58,7 +61,7 @@ BraveAlertIndicator::BraveAlertIndicator(Tab* parent_tab)
 
 SkColor BraveAlertIndicator::GetBackgroundColor() const {
   TabStyle::TabColors colors = parent_tab_->tab_style()->CalculateColors();
-  if (!IsAudioState(alert_state_) || !IsMouseHovered())
+  if (!IsTabAudioToggleable() || !IsMouseHovered())
     return colors.background_color;
 
   // Approximating the InkDrop behavior of the close button.
@@ -70,7 +73,7 @@ bool BraveAlertIndicator::OnMousePressed(const ui::MouseEvent& event) {
   mouse_pressed_ = true;
   SchedulePaint();
 
-  if (!IsAudioState(alert_state_))
+  if (!IsTabAudioToggleable())
     return AlertIndicator::OnMousePressed(event);
 
   return true;
@@ -80,7 +83,7 @@ void BraveAlertIndicator::OnMouseReleased(const ui::MouseEvent& event) {
   mouse_pressed_ = false;
   SchedulePaint();
 
-  if (!IsAudioState(alert_state_) || !IsMouseHovered())
+  if (!IsTabAudioToggleable() || !IsMouseHovered())
     return AlertIndicator::OnMouseReleased(event);
 
   auto* tab_strip = static_cast<TabStrip*>(parent_tab_->controller());
@@ -99,19 +102,26 @@ void BraveAlertIndicator::OnMouseReleased(const ui::MouseEvent& event) {
 }
 
 void BraveAlertIndicator::OnMouseEntered(const ui::MouseEvent& event) {
-  if (IsAudioState(alert_state_))
+  if (IsTabAudioToggleable())
     SchedulePaint();
   AlertIndicator::OnMouseExited(event);
 }
 
 void BraveAlertIndicator::OnMouseExited(const ui::MouseEvent& event) {
-  if (IsAudioState(alert_state_))
+  if (IsTabAudioToggleable())
     SchedulePaint();
   AlertIndicator::OnMouseExited(event);
 }
 
 bool BraveAlertIndicator::OnMouseDragged(const ui::MouseEvent& event) {
-  if (IsAudioState(alert_state_))
+  if (IsTabAudioToggleable())
     SchedulePaint();
   return AlertIndicator::OnMouseDragged(event);
+}
+
+bool BraveAlertIndicator::IsTabAudioToggleable() const {
+  if (parent_tab_->controller()->IsTabPinned(parent_tab_))
+    return false;
+
+  return IsAudioState(alert_state_);
 }

--- a/browser/ui/views/tabs/brave_alert_indicator.h
+++ b/browser/ui/views/tabs/brave_alert_indicator.h
@@ -24,6 +24,8 @@ class BraveAlertIndicator : public AlertIndicator {
 
   SkColor GetBackgroundColor() const;
 
+  bool IsTabAudioToggleable() const;
+
   bool mouse_pressed_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(BraveAlertIndicator);


### PR DESCRIPTION
Getting context menu of pinned tab is very difficult when tab has
sound. To fix this, speaker icon becomes un-clickable on pinned tab.

Fix https://github.com/brave/brave-browser/issues/6358

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Open tab that has sound such as youtube
2. Pin that tab
3. Check speaker icon is not clickable on pinned tab

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
