### PR TITLE
Fix 3628 offline reset

### DIFF
--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -28,6 +28,7 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnDeleteDevice);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnDeleteDeviceWhenOneDevice);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnDeleteDeviceWhenSelfDeleted);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnResetSync);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnResetSyncWhenOffline);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, ClientOnGetInitData);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnGetInitData);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, OnSaveBookmarksBaseOrder);
@@ -140,6 +141,7 @@ class BraveProfileSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest,
                            OnDeleteDeviceWhenSelfDeleted);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnResetSync);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnResetSyncWhenOffline);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, ClientOnGetInitData);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnSaveBookmarksBaseOrder);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, OnGetInitData);
@@ -236,6 +238,8 @@ class BraveProfileSyncServiceImpl
   std::unique_ptr<RecordsList> pending_received_records_;
   // Time when current device sent CREATE device record
   base::Time this_device_created_time_;
+
+  bool pending_self_reset_ = false;
 
   // Used to ensure that certain operations are performed on the sequence that
   // this object was created on.


### PR DESCRIPTION
## Submitter Checklist:

Fixes https://github.com/brave/brave-browser/issues/3628

- [x] Submitted a [Time out sync reset if device is offline](https://github.com/brave/brave-browser/issues/3628) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Create sync chain between devices A and B
2. Turn off the internet connection on deviceA 
3. Press `Leave Sync Chain` button on deviceA
4. Refresh page brave://sync on deviceA
_This point is required until sync UI is not modified to meet requirement one or more devices in chain (https://github.com/brave/brave-browser/issues/6941)._ 
5. See deviceA is not in the chain.
6. See on deviceB deviceA still present as `zombie`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
