### PR TITLE
Fix crash when brave action button is clicked with extension-toolbar-menu (uplift to 1.2.x)

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.h
+++ b/browser/ui/views/brave_actions/brave_actions_container.h
@@ -109,6 +109,9 @@ class BraveActionsContainer : public views::View,
  private:
   friend class ::BraveActionsContainerTest;
   friend class ::BraveRewardsBrowserTest;
+
+  class EmptyExtensionsContainer;
+
   // Special positions in the container designators
   enum ActionPosition : int {
     ACTION_ANY_POSITION = -1,
@@ -181,6 +184,8 @@ class BraveActionsContainer : public views::View,
   // Listen for Brave Rewards preferences changes.
   BooleanPrefMember brave_rewards_enabled_;
   BooleanPrefMember hide_brave_rewards_button_;
+
+  std::unique_ptr<EmptyExtensionsContainer> empty_extensions_container_;
 
   base::WeakPtrFactory<BraveActionsContainer> weak_ptr_factory_;
 


### PR DESCRIPTION
Uplift of #4065
Fixes https://github.com/brave/brave-browser/issues/5646

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.