### PR TITLE
Fixes browser doesn't retry to get signed tokens in all cases

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/refill_tokens.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/refill_tokens.h
@@ -34,8 +34,6 @@ class RefillTokens {
 
   void Refill(const WalletInfo& wallet_info, const std::string& public_key);
 
-  void OnRefill(const Result result);
-
   void RetryGettingSignedTokens();
 
  private:
@@ -61,6 +59,10 @@ class RefillTokens {
       const int response_status_code,
       const std::string& response,
       const std::map<std::string, std::string>& headers);
+
+  void OnRefill(
+      const Result result,
+      const bool should_retry = true);
 
   bool ShouldRefillTokens() const;
   int CalculateAmountOfTokensToRefill() const;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/6647

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

See https://github.com/brave/brave-browser/issues/6647

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
