### PR TITLE
Fixes mac notarization that C79 update broke.

### DIFF
--- a/build/mac/notarize_dmg_pkg.py
+++ b/build/mac/notarize_dmg_pkg.py
@@ -24,7 +24,7 @@ packaging_signing_path = os.path.realpath(os.path.dirname(os.path.realpath(__fil
 sys.path.append(packaging_signing_path)
 
 # Import the entire module to avoid circular dependencies in the functions
-from signing import config, commands, model, notarize, pipeline, signing  # noqa: E402
+from signing import chromium_config, config, commands, model, notarize, pipeline, signing  # noqa: E402
 from signing_helper import GetBraveSigningConfig
 
 def run_command(args, **kwargs):
@@ -47,7 +47,7 @@ def create_config(config_args, development, mac_provisioning_profile):
     Returns:
         An instance of |model.CodeSignConfig|.
     """
-    config_class = config.CodeSignConfig
+    config_class = ChromiumCodeSignConfig
 
     if development:
 


### PR DESCRIPTION
Fixes brave/brave-browser#7191

When creating config use ChromiumCodeSigningConfig instead of the now
bare bones model.CodeSignConfig.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
