### PR TITLE
Friendly class names for styled-components Elements in non-official builds

### DIFF
--- a/components/webpack/webpack-ts-transformers.js
+++ b/components/webpack/webpack-ts-transformers.js
@@ -1,0 +1,8 @@
+const TypescriptPluginStyledComponents = require('typescript-plugin-styled-components')
+const createStyledComponentsTransformer = TypescriptPluginStyledComponents.default
+const styledComponentsTransformer = createStyledComponentsTransformer()
+module.exports = () => ({
+  before: [
+    styledComponentsTransformer
+  ]
+})

--- a/components/webpack/webpack.config.js
+++ b/components/webpack/webpack.config.js
@@ -1,5 +1,13 @@
+// Copyright (c) 2019 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
 const path = require('path')
 const GenerateDepfilePlugin = require('./webpack-plugin-depfile')
+const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default
+
+const styledComponentsTransformer = createStyledComponentsTransformer()
 
 module.exports = (env, argv) => ({
   devtool: argv.mode === 'development' ? '#inline-source-map' : false,
@@ -27,7 +35,10 @@ module.exports = (env, argv) => ({
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'awesome-typescript-loader'
+        loader: 'awesome-typescript-loader',
+        options: {
+          getCustomTransformers: path.join(__dirname, './webpack-ts-transformers.js')
+        }
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
Aids devtools usage. Instead of just the classname "iHRorp", an element will get an additional className to identify the component name, e.g. "Header-sc-ofpjq6 iHRorp"

![image](https://user-images.githubusercontent.com/741836/70076951-b1d45280-15b4-11ea-911e-6aa8bed8b1d5.png)

Fix https://github.com/brave/brave-browser/issues/7193

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
- Open NTP
- Inspect element
- Expected: all elements should have human-understandable class name


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
