### PR TITLE
Brave Rewards notification not reflecting processed 'Auto Contribute' amount correctly

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -367,8 +367,8 @@ export class Panel extends React.Component<Props, State> {
 
         if (result === '0') {
           const currency = onlyAnonWallet ? getMessage('bap') : getMessage('bat')
-          const fixed = utils.convertProbiToFixed(notification.args[3])
-          text = getMessage('contributeNotificationSuccess', [fixed, currency])
+          const contributionAmount = parseFloat(notification.args[3]).toFixed(1)
+          text = getMessage('contributeNotificationSuccess', [contributionAmount, currency])
         } else if (result === '15') {
           text = getMessage('contributeNotificationNotEnoughFunds')
           isAlert = 'warning'


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7185

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
As per https://github.com/brave/brave-browser/issues/7185

Or; 
* Clean install Brave
* Launch using command line '--rewards=reconcile-interval=3' to fast track AC's
* Enable Rewards
* Verify Uphold
* Visit Verified Publisher(s)
* Confirm sites in AC list
* Wait for and then view the contribution notification

<img width="529" alt="Screenshot 2019-12-04 at 15 31 24" src="https://user-images.githubusercontent.com/11368284/70157159-ffcc8180-16ac-11ea-9403-8f13fe98ab65.png">

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
