### PR TITLE
Apply device id v2

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@13bb40a215248cfbdd87d0a6b425c8397402e9e6",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@800f9d40b7409239ff192e0be634764e747c7a75",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@14682d439b4bbcbf1bad3c6c2442287f1b4b7854",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@77af1794c25d79bbb64b70bfcea0a0effd611798",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@45e32155af9897dbe1d5534dd36697ec4728bb75",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@c396fb4eb9e9bf63b89ae5a0ec0b5f201d43c7c5",
 }

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@13bb40a215248cfbdd87d0a6b425c8397402e9e6",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@800f9d40b7409239ff192e0be634764e747c7a75",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@f6a25c1fb62ef5c16e7cf7e2ff41e909a2123f5a",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@aed5381bff3c89caa2002919bb93b88d09878748",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@45e32155af9897dbe1d5534dd36697ec4728bb75",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@c396fb4eb9e9bf63b89ae5a0ec0b5f201d43c7c5",
 }

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@13bb40a215248cfbdd87d0a6b425c8397402e9e6",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@800f9d40b7409239ff192e0be634764e747c7a75",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@77af1794c25d79bbb64b70bfcea0a0effd611798",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@f6a25c1fb62ef5c16e7cf7e2ff41e909a2123f5a",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@45e32155af9897dbe1d5534dd36697ec4728bb75",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@c396fb4eb9e9bf63b89ae5a0ec0b5f201d43c7c5",
 }

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ deps = {
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@13bb40a215248cfbdd87d0a6b425c8397402e9e6",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@800f9d40b7409239ff192e0be634764e747c7a75",
-  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@aed5381bff3c89caa2002919bb93b88d09878748",
+  "components/brave_sync/extension/brave-sync": "https://github.com/brave/sync.git@bde4bf8dcd56e41cc064d613219dc3382c178856",
   "vendor/bat-native-usermodel": "https://github.com/brave-intl/bat-native-usermodel.git@45e32155af9897dbe1d5534dd36697ec4728bb75",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@c396fb4eb9e9bf63b89ae5a0ec0b5f201d43c7c5",
 }

--- a/browser/extensions/api/brave_sync_api.cc
+++ b/browser/extensions/api/brave_sync_api.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <utility>
+#include <string>
 #include <vector>
 
 #include "brave/common/extensions/api/brave_sync.h"

--- a/browser/extensions/api/brave_sync_api.cc
+++ b/browser/extensions/api/brave_sync_api.cc
@@ -88,7 +88,8 @@ ExtensionFunction::ResponseAction BraveSyncSaveInitDataFunction::Run() {
   DCHECK(sync_service);
   sync_service->GetBraveSyncClient()->sync_message_handler()->OnSaveInitData(
       params->seed ? *params->seed : std::vector<uint8_t>(),
-      params->device_id ? *params->device_id : std::vector<uint8_t>());
+      params->device_id ? *params->device_id : std::vector<uint8_t>(),
+      params->device_id_v2 ? *params->device_id_v2 : std::string());
 
   return RespondNow(NoArguments());
 }

--- a/browser/extensions/api/brave_sync_event_router.cc
+++ b/browser/extensions/api/brave_sync_event_router.cc
@@ -25,13 +25,15 @@ BraveSyncEventRouter::~BraveSyncEventRouter() {}
 void BraveSyncEventRouter::GotInitData(
     const brave_sync::Uint8Array& seed,
     const brave_sync::Uint8Array& device_id,
-    const extensions::api::brave_sync::Config& config) {
+    const extensions::api::brave_sync::Config& config,
+    const std::string& device_id_v2) {
   const std::vector<int> arg_seed(seed.begin(), seed.end());
   const std::vector<int> arg_device_id(device_id.begin(), device_id.end());
 
   std::unique_ptr<base::ListValue> args(
       extensions::api::brave_sync::OnGotInitData::Create(arg_seed,
-                                                         arg_device_id, config)
+                                                         arg_device_id, config,
+                                                         device_id_v2)
           .release());
   std::unique_ptr<Event> event(
      new Event(extensions::events::FOR_TEST,

--- a/browser/extensions/api/brave_sync_event_router.h
+++ b/browser/extensions/api/brave_sync_event_router.h
@@ -37,7 +37,8 @@ class BraveSyncEventRouter {
 
   void GotInitData(const brave_sync::Uint8Array& seed,
                    const brave_sync::Uint8Array& device_id,
-                   const extensions::api::brave_sync::Config& config);
+                   const extensions::api::brave_sync::Config& config,
+                   const std::string& device_id_v2);
 
   void FetchSyncRecords(
     const std::vector<std::string>& category_names,

--- a/browser/ui/webui/sync/sync_ui.cc
+++ b/browser/ui/webui/sync/sync_ui.cc
@@ -203,13 +203,13 @@ void SyncUIDOMHandler::SyncSavedSiteSettings(const base::ListValue* args) {
 
 void SyncUIDOMHandler::DeleteDevice(const base::ListValue* args) {
   DCHECK(sync_service_);
-  int i_device_id = -1;
-  if (!args->GetInteger(0, &i_device_id) || i_device_id == -1) {
-    DCHECK(false) << "[Brave Sync] could not get device id";
+  std::string device_id_v2;
+  if (!args->GetString(0, &device_id_v2)) {
+    DCHECK(false) << "[Brave Sync] could not get device id v2";
     return;
   }
 
-  sync_service_->OnDeleteDevice(std::to_string(i_device_id));
+  sync_service_->OnDeleteDevice(device_id_v2);
 }
 
 void SyncUIDOMHandler::ResetSync(const base::ListValue* args) {

--- a/common/extensions/api/brave_sync.json
+++ b/common/extensions/api/brave_sync.json
@@ -94,7 +94,8 @@
         "type": "object",
         "description": "Represents sync device",
         "properties": {
-          "name" : {"type": "string"}
+          "name" : {"type": "string"},
+          "deviceIdV2" : {"type": "string"}
         }
       },
       {
@@ -200,6 +201,11 @@
           {
             "$ref": "Config",
             "name": "config"
+          },
+          {
+            "type": "string",
+            "name": "device_id_v2",
+            "optional": true
           }
         ]
       },
@@ -355,6 +361,11 @@
           {
             "type": "binary",
             "name": "device_id",
+            "optional": true
+          },
+          {
+            "type": "string",
+            "name": "device_id_v2",
             "optional": true
           }
         ]

--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -5,10 +5,6 @@ import("//tools/grit/repack.gni")
 import("buildflags/buildflags.gni")
 
 declare_args() {
-  brave_sync_endpoint = "https://sync-staging.brave.com"
-}
-
-if (is_official_build) {
   brave_sync_endpoint = "https://sync.brave.com"
 }
 

--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -4,6 +4,20 @@ import("//tools/grit/grit_rule.gni")
 import("//tools/grit/repack.gni")
 import("buildflags/buildflags.gni")
 
+declare_args() {
+  brave_sync_endpoint = "https://sync-staging.brave.com"
+}
+
+if (is_official_build) {
+  brave_sync_endpoint = "https://sync.brave.com"
+}
+
+config("brave_sync_config") {
+  defines = [
+    "BRAVE_SYNC_ENDPOINT=\"$brave_sync_endpoint\""
+  ]
+}
+
 if (enable_brave_sync) {
   source_set("js_sync_lib_impl") {
     sources = [
@@ -18,6 +32,7 @@ if (enable_brave_sync) {
       "client/client_ext_impl_data.h",
     ]
 
+    configs += [ ":brave_sync_config" ]
     deps = [
       ":core",
       ":crypto",

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -930,6 +930,8 @@ void BraveProfileSyncServiceImpl::OnResolvedPreferences(
     const RecordsList& records) {
   const std::string this_device_object_id =
       brave_sync_prefs_->GetThisDeviceObjectId();
+  const std::string this_device_id_v2 =
+      brave_sync_prefs_->GetThisDeviceIdV2();
   bool this_device_deleted = false;
 
   auto sync_devices = brave_sync_prefs_->GetSyncDevices();
@@ -942,9 +944,13 @@ void BraveProfileSyncServiceImpl::OnResolvedPreferences(
                                      record->deviceId, device.deviceIdV2,
                                      record->syncTimestamp.ToJsTime()),
                           record->action, &actually_merged);
+      // We check object id here specifically because device which doesn't have
+      // device id v2 also doesn't have this object id stored. So we use this
+      // trait for migration.
       this_device_deleted =
           this_device_deleted ||
           (record->objectId == this_device_object_id &&
+           device.deviceIdV2 == this_device_id_v2 &&
            record->action == SyncRecord::Action::A_DELETE && actually_merged);
     }
   }  // for each device

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -434,7 +434,8 @@ void BraveProfileSyncServiceImpl::OnGetInitData(
 }
 
 void BraveProfileSyncServiceImpl::OnSaveInitData(
-    const Uint8Array& seed, const Uint8Array& device_id,
+    const Uint8Array& seed,
+    const Uint8Array& device_id,
     const std::string& device_id_v2) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   DCHECK(!brave_sync_ready_);
@@ -895,7 +896,7 @@ void BraveProfileSyncServiceImpl::SendDeleteDevice() {
   if (object_id.empty()) {
     auto sync_devices = brave_sync_prefs_->GetSyncDevices();
     std::vector<const SyncDevice*> devices =
-      sync_devices->GetByDeviceId(device_id);
+        sync_devices->GetByDeviceId(device_id);
     for (auto* device : devices) {
       if (device) {
         object_id = device->object_id_;
@@ -919,17 +920,16 @@ void BraveProfileSyncServiceImpl::SendDeviceSyncRecord(
     const std::string& device_id_v2,
     const std::string& object_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  RecordsListPtr records =
-      CreateDeviceRecord(device_name, object_id,
-                         static_cast<SyncRecord::Action>(action), device_id,
-                         device_id_v2);
+  RecordsListPtr records = CreateDeviceRecord(
+      device_name, object_id, static_cast<SyncRecord::Action>(action),
+      device_id, device_id_v2);
   SendSyncRecords(SyncRecordType_PREFERENCES, std::move(records));
 }
 
 void BraveProfileSyncServiceImpl::OnResolvedPreferences(
     const RecordsList& records) {
   const std::string this_device_object_id =
-    brave_sync_prefs_->GetThisDeviceObjectId();
+      brave_sync_prefs_->GetThisDeviceObjectId();
   bool this_device_deleted = false;
 
   auto sync_devices = brave_sync_prefs_->GetSyncDevices();
@@ -938,11 +938,10 @@ void BraveProfileSyncServiceImpl::OnResolvedPreferences(
     if (record->has_device()) {
       bool actually_merged = false;
       auto& device = record->GetDevice();
-      sync_devices->Merge(
-          SyncDevice(record->GetDevice().name, record->objectId,
-                     record->deviceId, device.deviceIdV2,
-                     record->syncTimestamp.ToJsTime()),
-          record->action, &actually_merged);
+      sync_devices->Merge(SyncDevice(record->GetDevice().name, record->objectId,
+                                     record->deviceId, device.deviceIdV2,
+                                     record->syncTimestamp.ToJsTime()),
+                          record->action, &actually_merged);
       this_device_deleted =
           this_device_deleted ||
           (record->objectId == this_device_object_id &&

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -875,6 +875,7 @@ void BraveProfileSyncServiceImpl::SendCreateDevice() {
 
   std::string device_name = brave_sync_prefs_->GetThisDeviceName();
   std::string object_id = tools::GenerateObjectId();
+  brave_sync_prefs_->SetThisDeviceObjectId(object_id);
   std::string device_id = brave_sync_prefs_->GetThisDeviceId();
   std::string device_id_v2 = brave_sync_prefs_->GetThisDeviceIdV2();
   CHECK(!device_id.empty());

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -428,7 +428,7 @@ void BraveProfileSyncServiceImpl::OnGetInitData(
 
   client_data::Config config;
   config.api_version = brave_sync_prefs_->GetApiVersion();
-  config.server_url = "https://sync-staging.brave.com";
+  config.server_url = BRAVE_SYNC_ENDPOINT;
   config.debug = true;
   brave_sync_client_->SendGotInitData(seed, device_id, config, device_id_v2);
 }

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -81,7 +81,8 @@ std::string GetDeviceName() {
 RecordsListPtr CreateDeviceRecord(const std::string& device_name,
                                   const std::string& object_id,
                                   const SyncRecord::Action& action,
-                                  const std::string& device_id) {
+                                  const std::string& device_id,
+                                  const std::string& device_id_v2) {
   RecordsListPtr records = std::make_unique<RecordsList>();
 
   SyncRecordPtr record = std::make_unique<SyncRecord>();
@@ -93,6 +94,7 @@ RecordsListPtr CreateDeviceRecord(const std::string& device_name,
 
   std::unique_ptr<Device> device = std::make_unique<Device>();
   device->name = device_name;
+  device->deviceIdV2 = device_id_v2;
   record->SetDevice(std::move(device));
 
   records->emplace_back(std::move(record));
@@ -157,6 +159,7 @@ SyncRecordPtr PrepareResolvedDevice(SyncDevice* device,
   std::unique_ptr<jslib::Device> device_record =
       std::make_unique<jslib::Device>();
   device_record->name = device->name_;
+  device_record->deviceIdV2 = device->device_id_v2_;
   record->SetDevice(std::move(device_record));
   return record;
 }
@@ -287,9 +290,10 @@ void BraveProfileSyncServiceImpl::OnDeleteDevice(const std::string& device_id) {
   const SyncDevice* device = sync_devices->GetByDeviceId(device_id);
   if (device) {
     const std::string device_name = device->name_;
+    const std::string device_id_v2 = device->device_id_v2_;
     const std::string object_id = device->object_id_;
     SendDeviceSyncRecord(SyncRecord::Action::A_DELETE, device_name, device_id,
-                         object_id);
+                         device_id_v2, object_id);
     if (device_id == brave_sync_prefs_->GetThisDeviceId()) {
       // Mark state we have sent DELETE for own device and we are going to
       // call ResetSyncInternal() at OnRecordsSent after ensuring we had made
@@ -407,6 +411,14 @@ void BraveProfileSyncServiceImpl::OnGetInitData(
     VLOG(1) << "[Brave Sync] Init empty device id";
   }
 
+  std::string device_id_v2;
+  if (!brave_sync_prefs_->GetDeviceIdV2().empty()) {
+    device_id_v2 = brave_sync_prefs_->GetDeviceIdV2();
+    VLOG(1) << "[Brave Sync] Init device id_v2 from prefs: " << device_id_v2;
+  } else {
+    VLOG(1) << "[Brave Sync] Init empty device id_v2";
+  }
+
   DCHECK(!sync_version.empty());
   // TODO(bridiver) - this seems broken because using the version we get back
   // from the server (currently v1.4.2) causes things to break. What is the
@@ -415,20 +427,19 @@ void BraveProfileSyncServiceImpl::OnGetInitData(
 
   client_data::Config config;
   config.api_version = brave_sync_prefs_->GetApiVersion();
-  config.server_url = "https://sync.brave.com";
+  config.server_url = "https://sync-staging.brave.com";
   config.debug = true;
-  brave_sync_client_->SendGotInitData(seed, device_id, config);
+  brave_sync_client_->SendGotInitData(seed, device_id, config, device_id_v2);
 }
 
-void BraveProfileSyncServiceImpl::OnSaveInitData(const Uint8Array& seed,
-                                                 const Uint8Array& device_id) {
+void BraveProfileSyncServiceImpl::OnSaveInitData(
+    const Uint8Array& seed, const Uint8Array& device_id,
+    const std::string& device_id_v2) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   DCHECK(!brave_sync_ready_);
-  // If we are here and brave_sync_initializing_ is false, we have came
-  // not from OnSetupSyncNewToSync or OnSetupSyncHaveCode.
-  // One case is we put wrong code words and then restarted before cleared
-  // kSyncEnabled pref. This should not happen.
-  DCHECK(brave_sync_initializing_);
+  // OnSaveInitData will not only be triggered by OnSetupSyncNewToSync or
+  // OnSetupSyncHaveCode, we use it to migrate device which doesn't have
+  // deviceIdV2
 
   std::string seed_str = StrFromUint8Array(seed);
   std::string device_id_str = StrFromUint8Array(device_id);
@@ -438,6 +449,9 @@ void BraveProfileSyncServiceImpl::OnSaveInitData(const Uint8Array& seed,
 
   brave_sync_prefs_->SetSeed(seed_str);
   brave_sync_prefs_->SetThisDeviceId(device_id_str);
+  if (!brave_sync_initializing_ && brave_sync_prefs_->GetDeviceIdV2().empty())
+    send_device_id_v2_update_ = true;
+  brave_sync_prefs_->SetDeviceIdV2(device_id_v2);
 
   brave_sync_initializing_ = false;
 }
@@ -861,21 +875,41 @@ void BraveProfileSyncServiceImpl::SendCreateDevice() {
   std::string device_name = brave_sync_prefs_->GetThisDeviceName();
   std::string object_id = tools::GenerateObjectId();
   std::string device_id = brave_sync_prefs_->GetThisDeviceId();
+  std::string device_id_v2 = brave_sync_prefs_->GetDeviceIdV2();
   CHECK(!device_id.empty());
 
   SendDeviceSyncRecord(SyncRecord::Action::A_CREATE, device_name, device_id,
-                       object_id);
+                       device_id_v2, object_id);
+}
+
+void BraveProfileSyncServiceImpl::SendUpdateDevice() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  std::string device_id = brave_sync_prefs_->GetThisDeviceId();
+  std::string device_name = brave_sync_prefs_->GetThisDeviceName();
+  std::string device_id_v2 = brave_sync_prefs_->GetDeviceIdV2();
+  auto sync_devices = brave_sync_prefs_->GetSyncDevices();
+  // TODO(darkdh): need to get device by object id
+  const SyncDevice* device = sync_devices->GetByDeviceId(device_id);
+  if (device) {
+    std::string object_id = device->object_id_;
+
+    SendDeviceSyncRecord(SyncRecord::Action::A_UPDATE, device_name, device_id,
+                         device_id_v2, object_id);
+  }
 }
 
 void BraveProfileSyncServiceImpl::SendDeviceSyncRecord(
     const int action,
     const std::string& device_name,
     const std::string& device_id,
+    const std::string& device_id_v2,
     const std::string& object_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   RecordsListPtr records =
       CreateDeviceRecord(device_name, object_id,
-                         static_cast<SyncRecord::Action>(action), device_id);
+                         static_cast<SyncRecord::Action>(action), device_id,
+                         device_id_v2);
   SendSyncRecords(SyncRecordType_PREFERENCES, std::move(records));
 }
 
@@ -889,9 +923,11 @@ void BraveProfileSyncServiceImpl::OnResolvedPreferences(
     DCHECK(record->has_device() || record->has_sitesetting());
     if (record->has_device()) {
       bool actually_merged = false;
+      auto& device = record->GetDevice();
       sync_devices->Merge(
           SyncDevice(record->GetDevice().name, record->objectId,
-                     record->deviceId, record->syncTimestamp.ToJsTime()),
+                     record->deviceId, device.deviceIdV2,
+                     record->syncTimestamp.ToJsTime()),
           record->action, &actually_merged);
       this_device_deleted =
           this_device_deleted ||
@@ -949,6 +985,10 @@ void BraveProfileSyncServiceImpl::OnPollSyncCycle(GetRecordsCallback cb,
   if (IsTimeEmpty(brave_sync_prefs_->GetLastFetchTime())) {
     SendCreateDevice();
     this_device_created_time_ = base::Time::Now();
+  }
+  if (send_device_id_v2_update_) {
+    SendUpdateDevice();
+    send_device_id_v2_update_ = false;
   }
 
   FetchDevices();

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -70,7 +70,7 @@ class BraveProfileSyncServiceImpl
   void OnSetupSyncHaveCode(const std::string& sync_words,
                            const std::string& device_name) override;
   void OnSetupSyncNewToSync(const std::string& device_name) override;
-  void OnDeleteDevice(const std::string& device_id) override;
+  void OnDeleteDevice(const std::string& device_id_v2) override;
   void OnResetSync() override;
   void GetSettingsAndDevices(
       const GetSettingsAndDevicesCallback& callback) override;
@@ -173,7 +173,7 @@ class BraveProfileSyncServiceImpl
                         int max_records);
   void FetchDevices();
   void SendCreateDevice();
-  void SendUpdateDevice();
+  void SendDeleteDevice();
   void SendDeviceSyncRecord(const int action,
                             const std::string& device_name,
                             const std::string& device_id,

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -88,7 +88,8 @@ class BraveProfileSyncServiceImpl
   void OnSyncSetupError(const std::string& error) override;
   void OnGetInitData(const std::string& sync_version) override;
   void OnSaveInitData(const brave_sync::Uint8Array& seed,
-                      const brave_sync::Uint8Array& device_id) override;
+                      const brave_sync::Uint8Array& device_id,
+                      const std::string& device_id_v2) override;
   void OnSyncReady() override;
   void OnGetExistingObjects(const std::string& category_name,
                             std::unique_ptr<brave_sync::RecordsList> records,
@@ -172,9 +173,11 @@ class BraveProfileSyncServiceImpl
                         int max_records);
   void FetchDevices();
   void SendCreateDevice();
+  void SendUpdateDevice();
   void SendDeviceSyncRecord(const int action,
                             const std::string& device_name,
                             const std::string& device_id,
+                            const std::string& device_id_v2,
                             const std::string& object_id);
   void OnResolvedPreferences(const brave_sync::RecordsList& records);
   void OnBraveSyncPrefsChanged(const std::string& pref);
@@ -226,6 +229,8 @@ class BraveProfileSyncServiceImpl
   // Prevent two sequential calls OnSetupSyncHaveCode or OnSetupSyncNewToSync
   // while being initializing
   bool brave_sync_initializing_ = false;
+
+  bool send_device_id_v2_update_ = false;
 
   Uint8Array seed_;
 

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -47,6 +47,8 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, SetSyncDisabled);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, IsSyncReadyOnNewProfile);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, SetThisDeviceCreatedTime);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, InitialFetchesStartWithZero);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, DeviceIdV2Migration);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, DeviceIdV2MigrationDupDeviceId);
 
 class BraveSyncServiceTest;
 
@@ -163,6 +165,9 @@ class BraveProfileSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, IsSyncReadyOnNewProfile);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, SetThisDeviceCreatedTime);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, InitialFetchesStartWithZero);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, DeviceIdV2Migration);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest,
+                           DeviceIdV2MigrationDupDeviceId);
 
   friend class ::BraveSyncServiceTest;
 

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -90,11 +90,11 @@ void Prefs::SetThisDeviceId(const std::string& device_id) {
   pref_service_->SetString(kSyncDeviceId, device_id);
 }
 
-std::string Prefs::GetDeviceIdV2() const {
+std::string Prefs::GetThisDeviceIdV2() const {
   return pref_service_->GetString(kSyncDeviceIdV2);
 }
 
-void Prefs::SetDeviceIdV2(const std::string& device_id_v2) {
+void Prefs::SetThisDeviceIdV2(const std::string& device_id_v2) {
   DCHECK(!device_id_v2.empty());
   pref_service_->SetString(kSyncDeviceIdV2, device_id_v2);
 }
@@ -152,7 +152,7 @@ std::unique_ptr<brave_sync::Settings> Prefs::GetBraveSyncSettings() const {
 
   settings->this_device_name_ = GetThisDeviceName();
   settings->this_device_id_ = GetThisDeviceId();
-  settings->this_device_id_v2_ = GetDeviceIdV2();
+  settings->this_device_id_v2_ = GetThisDeviceIdV2();
   settings->sync_this_device_ = GetSyncEnabled();
   settings->sync_bookmarks_ = GetSyncBookmarksEnabled();
   settings->sync_settings_ = GetSyncSiteSettingsEnabled();

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -22,6 +22,7 @@ namespace prefs {
 
 const char kSyncDeviceId[] = "brave_sync.device_id";
 const char kSyncDeviceIdV2[] = "brave_sync.device_id_v2";
+const char kSyncDeviceObjectId[] = "brave_sync.device_object_id";
 const char kSyncSeed[] = "brave_sync.seed";
 const char kSyncPrevSeed[] = "brave_sync.previous_seed";
 const char kSyncDeviceName[] = "brave_sync.device_name";
@@ -48,6 +49,7 @@ Prefs::Prefs(PrefService* pref_service) : pref_service_(pref_service) {}
 void Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterStringPref(prefs::kSyncDeviceId, std::string());
   registry->RegisterStringPref(prefs::kSyncDeviceIdV2, std::string());
+  registry->RegisterStringPref(prefs::kSyncDeviceObjectId, std::string());
   registry->RegisterStringPref(prefs::kSyncSeed, std::string());
   registry->RegisterStringPref(prefs::kSyncPrevSeed, std::string());
   registry->RegisterStringPref(prefs::kSyncDeviceName, std::string());
@@ -97,6 +99,15 @@ std::string Prefs::GetThisDeviceIdV2() const {
 void Prefs::SetThisDeviceIdV2(const std::string& device_id_v2) {
   DCHECK(!device_id_v2.empty());
   pref_service_->SetString(kSyncDeviceIdV2, device_id_v2);
+}
+
+std::string Prefs::GetThisDeviceObjectId() const {
+  return pref_service_->GetString(kSyncDeviceObjectId);
+}
+
+void Prefs::SetThisDeviceObjectId(const std::string& device_object_id) {
+  DCHECK(!device_object_id.empty());
+  pref_service_->SetString(kSyncDeviceObjectId, device_object_id);
 }
 
 std::string Prefs::GetThisDeviceName() const {
@@ -266,6 +277,8 @@ void Prefs::SetRecordToResendMeta(const std::string& object_id,
 
 void Prefs::Clear() {
   pref_service_->ClearPref(kSyncDeviceId);
+  pref_service_->ClearPref(kSyncDeviceIdV2);
+  pref_service_->ClearPref(kSyncDeviceObjectId);
   pref_service_->ClearPref(kSyncSeed);
   pref_service_->ClearPref(kSyncDeviceName);
   pref_service_->ClearPref(kSyncEnabled);

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -97,8 +97,8 @@ std::string Prefs::GetThisDeviceIdV2() const {
 }
 
 void Prefs::SetThisDeviceIdV2(const std::string& device_id_v2) {
-  DCHECK(!device_id_v2.empty());
-  pref_service_->SetString(kSyncDeviceIdV2, device_id_v2);
+  if (!device_id_v2.empty())
+    pref_service_->SetString(kSyncDeviceIdV2, device_id_v2);
 }
 
 std::string Prefs::GetThisDeviceObjectId() const {

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -21,6 +21,7 @@ namespace brave_sync {
 namespace prefs {
 
 const char kSyncDeviceId[] = "brave_sync.device_id";
+const char kSyncDeviceIdV2[] = "brave_sync.device_id_v2";
 const char kSyncSeed[] = "brave_sync.seed";
 const char kSyncPrevSeed[] = "brave_sync.previous_seed";
 const char kSyncDeviceName[] = "brave_sync.device_name";
@@ -46,6 +47,7 @@ Prefs::Prefs(PrefService* pref_service) : pref_service_(pref_service) {}
 
 void Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterStringPref(prefs::kSyncDeviceId, std::string());
+  registry->RegisterStringPref(prefs::kSyncDeviceIdV2, std::string());
   registry->RegisterStringPref(prefs::kSyncSeed, std::string());
   registry->RegisterStringPref(prefs::kSyncPrevSeed, std::string());
   registry->RegisterStringPref(prefs::kSyncDeviceName, std::string());
@@ -86,6 +88,15 @@ std::string Prefs::GetThisDeviceId() const {
 void Prefs::SetThisDeviceId(const std::string& device_id) {
   DCHECK(!device_id.empty());
   pref_service_->SetString(kSyncDeviceId, device_id);
+}
+
+std::string Prefs::GetDeviceIdV2() const {
+  return pref_service_->GetString(kSyncDeviceIdV2);
+}
+
+void Prefs::SetDeviceIdV2(const std::string& device_id_v2) {
+  DCHECK(!device_id_v2.empty());
+  pref_service_->SetString(kSyncDeviceIdV2, device_id_v2);
 }
 
 std::string Prefs::GetThisDeviceName() const {
@@ -141,6 +152,7 @@ std::unique_ptr<brave_sync::Settings> Prefs::GetBraveSyncSettings() const {
 
   settings->this_device_name_ = GetThisDeviceName();
   settings->this_device_id_ = GetThisDeviceId();
+  settings->this_device_id_v2_ = GetDeviceIdV2();
   settings->sync_this_device_ = GetSyncEnabled();
   settings->sync_bookmarks_ = GetSyncBookmarksEnabled();
   settings->sync_settings_ = GetSyncSiteSettingsEnabled();

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -85,6 +85,8 @@ class Prefs {
   void SetThisDeviceId(const std::string& device_id);
   std::string GetThisDeviceIdV2() const;
   void SetThisDeviceIdV2(const std::string& device_id_v2);
+  std::string GetThisDeviceObjectId() const;
+  void SetThisDeviceObjectId(const std::string& device_object_id);
   std::string GetThisDeviceName() const;
   void SetThisDeviceName(const std::string& device_name);
   std::string GetBookmarksBaseOrder();

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -83,8 +83,8 @@ class Prefs {
   void SetSeed(const std::string& seed);
   std::string GetThisDeviceId() const;
   void SetThisDeviceId(const std::string& device_id);
-  std::string GetDeviceIdV2() const;
-  void SetDeviceIdV2(const std::string& device_id_v2);
+  std::string GetThisDeviceIdV2() const;
+  void SetThisDeviceIdV2(const std::string& device_id_v2);
   std::string GetThisDeviceName() const;
   void SetThisDeviceName(const std::string& device_name);
   std::string GetBookmarksBaseOrder();

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -34,6 +34,7 @@ namespace prefs {
 
 // String of device id. Supposed to be an integer
 extern const char kSyncDeviceId[];
+extern const char kSyncDeviceIdV2[];
 // String of 32 comma separated bytes
 // like "145,58,125,111,85,164,236,38,204,67,40,31,182,114,14,152,242,..."
 extern const char kSyncSeed[];
@@ -82,6 +83,8 @@ class Prefs {
   void SetSeed(const std::string& seed);
   std::string GetThisDeviceId() const;
   void SetThisDeviceId(const std::string& device_id);
+  std::string GetDeviceIdV2() const;
+  void SetDeviceIdV2(const std::string& device_id_v2);
   std::string GetThisDeviceName() const;
   void SetThisDeviceName(const std::string& device_name);
   std::string GetBookmarksBaseOrder();

--- a/components/brave_sync/brave_sync_service.h
+++ b/components/brave_sync/brave_sync_service.h
@@ -35,7 +35,7 @@ class BraveSyncService {
       const std::string& sync_words,
       const std::string& device_name) = 0;
   virtual void OnSetupSyncNewToSync(const std::string& device_name) = 0;
-  virtual void OnDeleteDevice(const std::string& device_id) = 0;
+  virtual void OnDeleteDevice(const std::string& device_id_v2) = 0;
   virtual void OnResetSync() = 0;
   virtual void GetSettingsAndDevices(
       const GetSettingsAndDevicesCallback& callback) = 0;

--- a/components/brave_sync/client/brave_sync_client.h
+++ b/components/brave_sync/client/brave_sync_client.h
@@ -35,7 +35,8 @@ class SyncMessageHandler {
   virtual void OnGetInitData(const std::string &sync_version) = 0;
   // SAVE_INIT_DATA
   virtual void OnSaveInitData(const Uint8Array& seed,
-                              const Uint8Array& device_id) = 0;
+                              const Uint8Array& device_id,
+                              const std::string& device_id_v2) = 0;
   // SYNC_READY
   virtual void OnSyncReady() = 0;
   // GET_EXISTING_OBJECTS
@@ -68,7 +69,8 @@ class BraveSyncClient {
 
   virtual void SendGotInitData(const Uint8Array& seed,
                                const Uint8Array& device_id,
-                               const client_data::Config& config) = 0;
+                               const client_data::Config& config,
+                               const std::string& device_id_v2) = 0;
   virtual void SendFetchSyncRecords(
       const std::vector<std::string> &category_names,
       const base::Time &startAt,

--- a/components/brave_sync/client/brave_sync_client_impl.cc
+++ b/components/brave_sync/client/brave_sync_client_impl.cc
@@ -64,11 +64,13 @@ SyncMessageHandler* BraveSyncClientImpl::sync_message_handler() {
 
 void BraveSyncClientImpl::SendGotInitData(const Uint8Array& seed,
                                           const Uint8Array& device_id,
-                                          const client_data::Config& config) {
+                                          const client_data::Config& config,
+                                          const std::string& device_id_v2) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   extensions::api::brave_sync::Config config_extension;
   ConvertConfig(config, &config_extension);
-  brave_sync_event_router_->GotInitData(seed, device_id, config_extension);
+  brave_sync_event_router_->GotInitData(seed, device_id, config_extension,
+                                        device_id_v2);
 }
 
 void BraveSyncClientImpl::SendFetchSyncRecords(

--- a/components/brave_sync/client/brave_sync_client_impl.h
+++ b/components/brave_sync/client/brave_sync_client_impl.h
@@ -47,7 +47,8 @@ class BraveSyncClientImpl : public BraveSyncClient,
   // Browser to BraveSync messages
   void SendGotInitData(const Uint8Array& seed,
                        const Uint8Array& device_id,
-                       const client_data::Config& config) override;
+                       const client_data::Config& config,
+                       const std::string& device_id_v2) override;
   void SendFetchSyncRecords(
     const std::vector<std::string> &category_names, const base::Time &startAt,
     const int max_records) override;

--- a/components/brave_sync/client/client_ext_impl_data.cc
+++ b/components/brave_sync/client/client_ext_impl_data.cc
@@ -41,6 +41,7 @@ std::unique_ptr<brave_sync::jslib::Device> FromExtDevice(
     const extensions::api::brave_sync::Device &ext_device) {
   auto device = std::make_unique<brave_sync::jslib::Device>();
   device->name = ext_device.name;
+  device->deviceIdV2 = ext_device.device_id_v2;
   return device;
 }
 
@@ -204,6 +205,7 @@ std::unique_ptr<extensions::api::brave_sync::Device> FromLibDevice(
     const jslib::Device &lib_device) {
   auto ext_device = std::make_unique<extensions::api::brave_sync::Device>();
   ext_device->name = lib_device.name;
+  ext_device->device_id_v2 = lib_device.deviceIdV2;
   return ext_device;
 }
 

--- a/components/brave_sync/extension/background.js
+++ b/components/brave_sync/extension/background.js
@@ -1,11 +1,11 @@
 'use strict';
 
-chrome.braveSync.onGotInitData.addListener(function(seed, device_id, config, sync_words) {
+chrome.braveSync.onGotInitData.addListener(function(seed, device_id, config, device_id_v2) {
   if ((seed instanceof Array && seed.length == 0) || (seed instanceof Uint8Array && seed.length == 0)) {
     seed = null;
   }
-  console.log(`"got-init-data" seed=${JSON.stringify(seed)} device_id=${JSON.stringify(device_id)} config=${JSON.stringify(config)}`);
-  callbackList["got-init-data"](null, seed, device_id, config);
+  console.log(`"got-init-data" seed=${JSON.stringify(seed)} device_id=${JSON.stringify(device_id)} config=${JSON.stringify(config)} device_id_v2=${device_id_v2}`);
+  callbackList["got-init-data"](null, seed, device_id, config, device_id_v2);
 });
 
 chrome.braveSync.onFetchSyncRecords.addListener(function(category_names, start_at, max_records) {
@@ -169,8 +169,8 @@ class InjectedObject {
         if (!arg1) {
           arg1 = null;
         }
-        console.log(`"save-init-data" seed=${JSON.stringify(arg1)} deviceId=${JSON.stringify(deviceId)}`);
-        chrome.braveSync.saveInitData(arg1/*seed*/, deviceId);
+        console.log(`"save-init-data" seed=${JSON.stringify(arg1)} deviceId=${JSON.stringify(deviceId)} deviceIdV2=${arg3}`);
+        chrome.braveSync.saveInitData(arg1/*seed*/, deviceId, arg3);
         break;
       case "sync-ready":
         console.log(`"sync-ready"`);

--- a/components/brave_sync/jslib_messages.cc
+++ b/components/brave_sync/jslib_messages.cc
@@ -100,6 +100,7 @@ Device::~Device() = default;
 std::unique_ptr<Device> Device::Clone(const Device& device) {
   auto ret_val = std::make_unique<Device>();
   ret_val->name = device.name;
+  ret_val->deviceIdV2 = device.deviceIdV2;
   return ret_val;
 }
 

--- a/components/brave_sync/jslib_messages.h
+++ b/components/brave_sync/jslib_messages.h
@@ -113,6 +113,7 @@ class Device {
   ~Device();
   static std::unique_ptr<Device> Clone(const Device& device);
   std::string name;
+  std::string deviceIdV2;
 };
 
 

--- a/components/brave_sync/settings.h
+++ b/components/brave_sync/settings.h
@@ -1,16 +1,17 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_SETTINGS_H_
-#define BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_SETTINGS_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_SETTINGS_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_SETTINGS_H_
 
 #include <string>
 
 namespace brave_sync {
 
 class Settings {
-public:
+ public:
   Settings();
   std::string this_device_name_;
   std::string this_device_id_;
@@ -25,6 +26,6 @@ public:
   bool sync_configured_;
 };
 
-} // namespace brave_sync
+}  // namespace brave_sync
 
-#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_SETTINGS_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_SETTINGS_H_

--- a/components/brave_sync/settings.h
+++ b/components/brave_sync/settings.h
@@ -14,6 +14,7 @@ public:
   Settings();
   std::string this_device_name_;
   std::string this_device_id_;
+  std::string this_device_id_v2_;
   bool sync_this_device_;
   bool sync_bookmarks_;
   bool sync_settings_;

--- a/components/brave_sync/sync_devices.cc
+++ b/components/brave_sync/sync_devices.cc
@@ -23,16 +23,15 @@ SyncDevice::SyncDevice() :
 SyncDevice::SyncDevice(const SyncDevice& other) = default;
 
 SyncDevice::SyncDevice(const std::string& name,
-  const std::string& object_id,
-  const std::string& device_id,
-  const std::string& device_id_v2,
-  const double last_active_ts) :
-  name_(name),
-  object_id_(object_id),
-  device_id_(device_id),
-  device_id_v2_(device_id_v2),
-  last_active_ts_(last_active_ts) {
-}
+                       const std::string& object_id,
+                       const std::string& device_id,
+                       const std::string& device_id_v2,
+                       const double last_active_ts)
+    : name_(name),
+      object_id_(object_id),
+      device_id_(device_id),
+      device_id_v2_(device_id_v2),
+      last_active_ts_(last_active_ts) {}
 
 SyncDevice& SyncDevice::operator=(const SyncDevice&) & = default;
 
@@ -125,12 +124,8 @@ void SyncDevices::FromJson(const std::string& str_json) {
       LOG(WARNING) << "SyncDevices::FromJson: last_active is not a double";
     }
 
-    devices_.push_back(SyncDevice(
-      name,
-      object_id,
-      device_id,
-      device_id_v2,
-      last_active) );
+    devices_.push_back(
+        SyncDevice(name, object_id, device_id, device_id_v2, last_active));
   }
 }
 
@@ -184,8 +179,8 @@ SyncDevice* SyncDevices::GetByObjectId(const std::string &object_id) {
   return nullptr;
 }
 
-std::vector<const SyncDevice*>
-SyncDevices::GetByDeviceId(const std::string &device_id) {
+std::vector<const SyncDevice*> SyncDevices::GetByDeviceId(
+    const std::string& device_id) {
   std::vector<const SyncDevice*> devices;
   for (const auto& device : devices_) {
     if (device.device_id_ == device_id) {
@@ -196,8 +191,8 @@ SyncDevices::GetByDeviceId(const std::string &device_id) {
   return devices;
 }
 
-const SyncDevice*
-SyncDevices::GetByDeviceIdV2(const std::string &device_id_v2) {
+const SyncDevice* SyncDevices::GetByDeviceIdV2(
+    const std::string& device_id_v2) {
   for (const auto& device : devices_) {
     if (device.device_id_v2_ == device_id_v2) {
       return &device;

--- a/components/brave_sync/sync_devices.cc
+++ b/components/brave_sync/sync_devices.cc
@@ -184,9 +184,22 @@ SyncDevice* SyncDevices::GetByObjectId(const std::string &object_id) {
   return nullptr;
 }
 
-const SyncDevice* SyncDevices::GetByDeviceId(const std::string &device_id) {
+std::vector<const SyncDevice*>
+SyncDevices::GetByDeviceId(const std::string &device_id) {
+  std::vector<const SyncDevice*> devices;
   for (const auto& device : devices_) {
     if (device.device_id_ == device_id) {
+      devices.push_back(&device);
+    }
+  }
+
+  return devices;
+}
+
+const SyncDevice*
+SyncDevices::GetByDeviceIdV2(const std::string &device_id_v2) {
+  for (const auto& device : devices_) {
+    if (device.device_id_v2_ == device_id_v2) {
       return &device;
     }
   }

--- a/components/brave_sync/sync_devices.cc
+++ b/components/brave_sync/sync_devices.cc
@@ -25,10 +25,12 @@ SyncDevice::SyncDevice(const SyncDevice& other) = default;
 SyncDevice::SyncDevice(const std::string& name,
   const std::string& object_id,
   const std::string& device_id,
+  const std::string& device_id_v2,
   const double last_active_ts) :
   name_(name),
   object_id_(object_id),
   device_id_(device_id),
+  device_id_v2_(device_id_v2),
   last_active_ts_(last_active_ts) {
 }
 
@@ -43,6 +45,7 @@ std::unique_ptr<base::Value> SyncDevice::ToValue() const {
   val_sync_device->SetKey("name", base::Value(name_));
   val_sync_device->SetKey("object_id", base::Value(object_id_));
   val_sync_device->SetKey("device_id", base::Value(device_id_));
+  val_sync_device->SetKey("device_id_v2", base::Value(device_id_v2_));
   val_sync_device->SetKey("last_active", base::Value(last_active_ts_));
 
   return val_sync_device;
@@ -110,6 +113,10 @@ void SyncDevices::FromJson(const std::string& str_json) {
     std::string name = val.FindKey("name")->GetString();
     std::string object_id = val.FindKey("object_id")->GetString();
     std::string device_id = val.FindKey("device_id")->GetString();
+    std::string device_id_v2;
+    const base::Value* device_id_value = val.FindKey("device_id_v2");
+    if (device_id_value)
+      device_id_v2 = device_id_value->GetString();
     double last_active = 0;
     const base::Value *v_last_active = val.FindKey("last_active");
     if (v_last_active->is_double()) {
@@ -122,6 +129,7 @@ void SyncDevices::FromJson(const std::string& str_json) {
       name,
       object_id,
       device_id,
+      device_id_v2,
       last_active) );
   }
 }

--- a/components/brave_sync/sync_devices.h
+++ b/components/brave_sync/sync_devices.h
@@ -22,6 +22,7 @@ public:
   SyncDevice(const std::string& name,
     const std::string& object_id,
     const std::string& device_id,
+    const std::string& device_id_v2,
     const double last_active_ts);
   SyncDevice& operator=(const SyncDevice&) &;
   ~SyncDevice();
@@ -31,6 +32,7 @@ public:
   std::string name_;
   std::string object_id_;
   std::string device_id_;
+  std::string device_id_v2_;
   double last_active_ts_;
 };
 

--- a/components/brave_sync/sync_devices.h
+++ b/components/brave_sync/sync_devices.h
@@ -1,29 +1,30 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_DEVICES_H_
-#define BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_DEVICES_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_SYNC_DEVICES_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_SYNC_DEVICES_H_
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace base {
-  class Value;
-} // namespace base
+class Value;
+}  // namespace base
 
 namespace brave_sync {
 
 class SyncDevice {
-public:
+ public:
   SyncDevice();
   SyncDevice(const SyncDevice& other);
   SyncDevice(const std::string& name,
-    const std::string& object_id,
-    const std::string& device_id,
-    const std::string& device_id_v2,
-    const double last_active_ts);
+             const std::string& object_id,
+             const std::string& device_id,
+             const std::string& device_id_v2,
+             const double last_active_ts);
   SyncDevice& operator=(const SyncDevice&) &;
   ~SyncDevice();
 
@@ -37,24 +38,24 @@ public:
 };
 
 class SyncDevices {
-public:
-   SyncDevices();
-   ~SyncDevices();
-   std::vector<SyncDevice> devices_;
-   std::unique_ptr<base::Value> ToValue() const;
-   std::unique_ptr<base::Value> ToValueArrOnly() const;
-   std::string ToJson() const;
-   size_t size() const { return devices_.size(); }
-   void FromJson(const std::string &str_json);
-   void Merge(const SyncDevice& device, int action, bool* actually_merged);
+ public:
+  SyncDevices();
+  ~SyncDevices();
+  std::vector<SyncDevice> devices_;
+  std::unique_ptr<base::Value> ToValue() const;
+  std::unique_ptr<base::Value> ToValueArrOnly() const;
+  std::string ToJson() const;
+  size_t size() const { return devices_.size(); }
+  void FromJson(const std::string& str_json);
+  void Merge(const SyncDevice& device, int action, bool* actually_merged);
 
-   // deprecated. only used for migration and backward compatibility
-   std::vector<const SyncDevice*> GetByDeviceId(const std::string& device_id);
-   const SyncDevice* GetByDeviceIdV2(const std::string& device_id_v2);
-   SyncDevice* GetByObjectId(const std::string& object_id);
-   void DeleteByObjectId(const std::string& object_id);
+  // deprecated. only used for migration and backward compatibility
+  std::vector<const SyncDevice*> GetByDeviceId(const std::string& device_id);
+  const SyncDevice* GetByDeviceIdV2(const std::string& device_id_v2);
+  SyncDevice* GetByObjectId(const std::string& object_id);
+  void DeleteByObjectId(const std::string& object_id);
 };
 
-} // namespace brave_sync
+}  // namespace brave_sync
 
-#endif //BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_DEVICES_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_SYNC_DEVICES_H_

--- a/components/brave_sync/sync_devices.h
+++ b/components/brave_sync/sync_devices.h
@@ -48,7 +48,9 @@ public:
    void FromJson(const std::string &str_json);
    void Merge(const SyncDevice& device, int action, bool* actually_merged);
 
-   const SyncDevice* GetByDeviceId(const std::string& device_id);
+   // deprecated. only used for migration and backward compatibility
+   std::vector<const SyncDevice*> GetByDeviceId(const std::string& device_id);
+   const SyncDevice* GetByDeviceIdV2(const std::string& device_id_v2);
    SyncDevice* GetByObjectId(const std::string& object_id);
    void DeleteByObjectId(const std::string& object_id);
 };

--- a/components/brave_sync/test_util.cc
+++ b/components/brave_sync/test_util.cc
@@ -123,7 +123,9 @@ SyncRecordPtr SimpleFolderSyncRecord(
 
 SyncRecordPtr SimpleDeviceRecord(
     const int action,
+    const std::string& object_id,
     const std::string& device_id,
+    const std::string& device_id_v2,
     const std::string& name) {
   auto record = std::make_unique<brave_sync::jslib::SyncRecord>();
   record->action = ConvertEnum<brave_sync::jslib::SyncRecord::Action>(action,
@@ -131,12 +133,13 @@ SyncRecordPtr SimpleDeviceRecord(
     brave_sync::jslib::SyncRecord::Action::A_MAX,
     brave_sync::jslib::SyncRecord::Action::A_INVALID);
   record->deviceId = device_id;
-  record->objectId = tools::GenerateObjectId();
+  record->objectId = object_id.empty() ? tools::GenerateObjectId() : object_id;
   record->objectData = "device";
   record->syncTimestamp = base::Time::Now();
 
   auto device = std::make_unique<brave_sync::jslib::Device>();
   device->name = name;
+  device->deviceIdV2 = device_id_v2;
   record->SetDevice(std::move(device));
 
   return record;

--- a/components/brave_sync/test_util.h
+++ b/components/brave_sync/test_util.h
@@ -35,10 +35,11 @@ class MockBraveSyncClient : public BraveSyncClient {
   ~MockBraveSyncClient() override;
 
   MOCK_METHOD0(sync_message_handler, SyncMessageHandler*());
-  MOCK_METHOD3(SendGotInitData,
+  MOCK_METHOD4(SendGotInitData,
                void(const Uint8Array& seed,
                     const Uint8Array& device_id,
-                    const client_data::Config& config));
+                    const client_data::Config& config,
+                    const std::string& device_id_v2));
   MOCK_METHOD3(SendFetchSyncRecords, void(
     const std::vector<std::string>& category_names, const base::Time& startAt,
     const int max_records));
@@ -79,7 +80,9 @@ SyncRecordPtr SimpleFolderSyncRecord(
 
 SyncRecordPtr SimpleDeviceRecord(
     const int action,
+    const std::string& object_id,
     const std::string& device_id,
+    const std::string& device_id_v2,
     const std::string& name);
 
 }  // namespace brave_sync

--- a/components/brave_sync/ui/actions/sync_actions.ts
+++ b/components/brave_sync/ui/actions/sync_actions.ts
@@ -56,11 +56,11 @@ export const onGenerateQRCodeImageSource = (imageSource: string) => {
 
 /**
  * Dispatches a message telling the back-end that the user removed a given device
- * @param {number} id - The device ID
+ * @param {number} id - The device ID V2
  * @param {string} deviceName - The device name
  */
-export const onRemoveDevice = (id: number, deviceName: string) => {
-  return action(types.SYNC_ON_REMOVE_DEVICE, { id, deviceName })
+export const onRemoveDevice = (idv2: number, deviceName: string) => {
+  return action(types.SYNC_ON_REMOVE_DEVICE, { idv2, deviceName })
 }
 
 /**

--- a/components/brave_sync/ui/containers/enabledContent.tsx
+++ b/components/brave_sync/ui/containers/enabledContent.tsx
@@ -80,7 +80,9 @@ export default class SyncEnabledContent extends React.PureComponent<Props, State
         content: [
           { content: (
             <TableRowDevice>
-              {device.name} {device.id === this.props.syncData.thisDeviceId ? getLocale('thisDevice') : null}
+              {device.name} {
+                  device.id_v2 === this.props.syncData.thisDeviceIdV2 ? getLocale('thisDevice') : null
+              }
             </TableRowDevice>
           )},
           { content: device.lastActive },

--- a/components/brave_sync/ui/containers/enabledContent.tsx
+++ b/components/brave_sync/ui/containers/enabledContent.tsx
@@ -90,6 +90,7 @@ export default class SyncEnabledContent extends React.PureComponent<Props, State
             content: (
               <TableRowRemoveButton
                 data-id={device.id}
+                data-idv2={device.id_v2}
                 data-name={device.name}
                 onClick={this.onClickRemoveDeviceButton}
               >
@@ -145,7 +146,7 @@ export default class SyncEnabledContent extends React.PureComponent<Props, State
     const target = event.currentTarget as HTMLButtonElement
     this.setState({
       deviceToRemoveName: target.dataset.name,
-      deviceToRemoveId: target.dataset.id,
+      deviceToRemoveId: target.dataset.idv2,
       removeDevice: true
     })
   }
@@ -223,7 +224,7 @@ export default class SyncEnabledContent extends React.PureComponent<Props, State
                 <RemoveDeviceModal
                   syncData={syncData}
                   deviceName={deviceToRemoveName}
-                  deviceId={deviceToRemoveId}
+                  deviceIdV2={deviceToRemoveId}
                   actions={actions}
                   onClose={this.onClickCancelRemoveDeviceButton}
                 />

--- a/components/brave_sync/ui/containers/modals/removeDevice.tsx
+++ b/components/brave_sync/ui/containers/modals/removeDevice.tsx
@@ -28,7 +28,7 @@ interface Props {
   onClose: (event?: React.MouseEvent<HTMLButtonElement>) => void
   actions: any
   deviceName: string | undefined
-  deviceId: string | undefined
+  deviceIdV2: string | undefined
 }
 
 interface State {
@@ -59,13 +59,13 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, St
   }
 
   onClickConfirmRemoveDeviceButton = () => {
-    const { deviceName, deviceId } = this.props
-    this.props.actions.onRemoveDevice(Number(deviceId), deviceName)
+    const { deviceName, deviceIdV2 } = this.props
+    this.props.actions.onRemoveDevice(deviceIdV2, deviceName)
     this.setState({ willRemoveDevice: true })
   }
 
   render () {
-    const { syncData, deviceName, deviceId } = this.props
+    const { syncData, deviceName, deviceIdV2 } = this.props
     const { willRemoveDevice } = this.state
 
     return (
@@ -75,7 +75,7 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, St
         </ModalHeader>
         <ModalContent>
           {
-            deviceId === syncData.thisDeviceId
+            deviceIdV2 === syncData.thisDeviceIdV2
             ? <div>
                 <Paragraph>{getLocale('thisDeviceRemovalDescription')}</Paragraph>
                 <Paragraph>{getLocale('joinSyncChain')}</Paragraph>

--- a/components/brave_sync/ui/reducers/sync_reducer.ts
+++ b/components/brave_sync/ui/reducers/sync_reducer.ts
@@ -92,10 +92,10 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
       break
 
     case types.SYNC_ON_REMOVE_DEVICE:
-      if (typeof payload.id === 'undefined' || typeof payload.deviceName === 'undefined') {
+      if (typeof payload.idv2 === 'undefined' || typeof payload.deviceName === 'undefined') {
         break
       }
-      chrome.send('deleteDevice', [payload.id])
+      chrome.send('deleteDevice', [payload.idv2])
       break
 
     case types.SYNC_BOOKMARKS:

--- a/components/brave_sync/ui/reducers/sync_reducer.ts
+++ b/components/brave_sync/ui/reducers/sync_reducer.ts
@@ -34,6 +34,7 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
         return {
           name: device.name,
           id: device.device_id,
+          id_v2: device.device_id_v2,
           lastActive: (new Date(device.last_active)).toDateString()
         }
       })
@@ -44,6 +45,7 @@ const syncReducer: Reducer<Sync.State | undefined> = (state: Sync.State | undefi
         isSyncConfigured: payload.settings.sync_configured,
         thisDeviceName: payload.settings.this_device_name,
         thisDeviceId: payload.settings.this_device_id,
+        thisDeviceIdV2: payload.settings.this_device_id_v2,
         syncBookmarks: payload.settings.sync_bookmarks,
         syncSavedSiteSettings: payload.settings.sync_settings,
         syncBrowsingHistory: payload.settings.sync_history

--- a/components/brave_sync/ui/storage.ts
+++ b/components/brave_sync/ui/storage.ts
@@ -10,6 +10,7 @@ const keyName = 'sync-data_t'
 export const defaultState = {
   thisDeviceName: '',
   thisDeviceId: '',
+  thisDeviceIdV2: '',
   devices: [],
   isSyncConfigured: false,
   seedQRImageSource: '',

--- a/components/brave_sync/values_conv.cc
+++ b/components/brave_sync/values_conv.cc
@@ -24,6 +24,7 @@ std::unique_ptr<Value> BraveSyncSettingsToValue(brave_sync::Settings *brave_sync
 
   result->SetKey("this_device_name", Value(brave_sync_settings->this_device_name_));
   result->SetKey("this_device_id", Value(brave_sync_settings->this_device_id_));
+  result->SetKey("this_device_id_v2", Value(brave_sync_settings->this_device_id_v2_));
   result->SetKey("sync_this_device", Value(brave_sync_settings->sync_this_device_));
   result->SetKey("sync_bookmarks", Value(brave_sync_settings->sync_bookmarks_));
   result->SetKey("sync_settings", Value(brave_sync_settings->sync_settings_));

--- a/components/brave_sync/values_conv.cc
+++ b/components/brave_sync/values_conv.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -8,37 +9,43 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/values.h"
-#include "brave/components/brave_sync/settings.h"
-#include "brave/components/brave_sync/sync_devices.h"
 #include "brave/components/brave_sync/jslib_const.h"
 #include "brave/components/brave_sync/jslib_messages.h"
+#include "brave/components/brave_sync/settings.h"
+#include "brave/components/brave_sync/sync_devices.h"
 #include "components/bookmarks/browser/bookmark_node.h"
 
 namespace brave_sync {
 
 using base::Value;
 
-std::unique_ptr<Value> BraveSyncSettingsToValue(brave_sync::Settings *brave_sync_settings) {
+std::unique_ptr<Value> BraveSyncSettingsToValue(
+    brave_sync::Settings* brave_sync_settings) {
   CHECK(brave_sync_settings);
   auto result = std::make_unique<Value>(Value::Type::DICTIONARY);
 
-  result->SetKey("this_device_name", Value(brave_sync_settings->this_device_name_));
+  result->SetKey("this_device_name",
+                 Value(brave_sync_settings->this_device_name_));
   result->SetKey("this_device_id", Value(brave_sync_settings->this_device_id_));
-  result->SetKey("this_device_id_v2", Value(brave_sync_settings->this_device_id_v2_));
-  result->SetKey("sync_this_device", Value(brave_sync_settings->sync_this_device_));
+  result->SetKey("this_device_id_v2",
+                 Value(brave_sync_settings->this_device_id_v2_));
+  result->SetKey("sync_this_device",
+                 Value(brave_sync_settings->sync_this_device_));
   result->SetKey("sync_bookmarks", Value(brave_sync_settings->sync_bookmarks_));
   result->SetKey("sync_settings", Value(brave_sync_settings->sync_settings_));
   result->SetKey("sync_history", Value(brave_sync_settings->sync_history_));
 
-  result->SetKey("sync_configured", Value(brave_sync_settings->sync_configured_));
+  result->SetKey("sync_configured",
+                 Value(brave_sync_settings->sync_configured_));
 
   return result;
 }
 
 template <typename TEnum>
 TEnum ConvertEnum(const int ival, TEnum min, TEnum max, TEnum def) {
-  DCHECK(ival >= min && ival <= max) << " Unexpected enum value " << ival <<
-    " Should be between or include " << min << " and " << max;
+  DCHECK(ival >= min && ival <= max)
+      << " Unexpected enum value " << ival << " Should be between or include "
+      << min << " and " << max;
   if (ival < min && ival > max) {
     return def;
   }
@@ -46,28 +53,36 @@ TEnum ConvertEnum(const int ival, TEnum min, TEnum max, TEnum def) {
   return static_cast<TEnum>(ival);
 }
 
-template
-jslib::SiteSetting::AdControl ConvertEnum<jslib::SiteSetting::AdControl>(const int ival,
-  jslib::SiteSetting::AdControl, jslib::SiteSetting::AdControl, jslib::SiteSetting::AdControl);
+template jslib::SiteSetting::AdControl
+ConvertEnum<jslib::SiteSetting::AdControl>(const int ival,
+                                           jslib::SiteSetting::AdControl,
+                                           jslib::SiteSetting::AdControl,
+                                           jslib::SiteSetting::AdControl);
 
-template
-jslib::SiteSetting::CookieControl ConvertEnum<jslib::SiteSetting::CookieControl>(const int ival,
-  jslib::SiteSetting::CookieControl, jslib::SiteSetting::CookieControl, jslib::SiteSetting::CookieControl);
+template jslib::SiteSetting::CookieControl ConvertEnum<
+    jslib::SiteSetting::CookieControl>(const int ival,
+                                       jslib::SiteSetting::CookieControl,
+                                       jslib::SiteSetting::CookieControl,
+                                       jslib::SiteSetting::CookieControl);
 
-template
-jslib::SyncRecord::Action ConvertEnum<jslib::SyncRecord::Action>(const int ival,
-  jslib::SyncRecord::Action, jslib::SyncRecord::Action, jslib::SyncRecord::Action);
-
+template jslib::SyncRecord::Action ConvertEnum<jslib::SyncRecord::Action>(
+    const int ival,
+    jslib::SyncRecord::Action,
+    jslib::SyncRecord::Action,
+    jslib::SyncRecord::Action);
 
 template <typename TEnum>
-TEnum ExtractEnum(const base::Value *val, const std::string &fileld_name,
-  TEnum min, TEnum max, TEnum def
-  ) {
+TEnum ExtractEnum(const base::Value* val,
+                  const std::string& fileld_name,
+                  TEnum min,
+                  TEnum max,
+                  TEnum def) {
   DCHECK(val);
   DCHECK(!fileld_name.empty());
   DCHECK(val->is_dict());
 
-  const base::Value *int_value = val->FindKeyOfType(fileld_name, base::Value::Type::INTEGER);
+  const base::Value* int_value =
+      val->FindKeyOfType(fileld_name, base::Value::Type::INTEGER);
   DCHECK(int_value);
   if (!int_value) {
     return def;
@@ -77,22 +92,31 @@ TEnum ExtractEnum(const base::Value *val, const std::string &fileld_name,
   return ConvertEnum<TEnum>(ival, min, max, def);
 }
 
-template
-jslib::SiteSetting::AdControl ExtractEnum<jslib::SiteSetting::AdControl>(const base::Value *val, const std::string &fileld_name,
-  jslib::SiteSetting::AdControl, jslib::SiteSetting::AdControl, jslib::SiteSetting::AdControl);
+template jslib::SiteSetting::AdControl
+ExtractEnum<jslib::SiteSetting::AdControl>(const base::Value* val,
+                                           const std::string& fileld_name,
+                                           jslib::SiteSetting::AdControl,
+                                           jslib::SiteSetting::AdControl,
+                                           jslib::SiteSetting::AdControl);
 
-template
-jslib::SiteSetting::CookieControl ExtractEnum<jslib::SiteSetting::CookieControl>(const base::Value *val, const std::string &fileld_name,
-  jslib::SiteSetting::CookieControl, jslib::SiteSetting::CookieControl, jslib::SiteSetting::CookieControl);
+template jslib::SiteSetting::CookieControl ExtractEnum<
+    jslib::SiteSetting::CookieControl>(const base::Value* val,
+                                       const std::string& fileld_name,
+                                       jslib::SiteSetting::CookieControl,
+                                       jslib::SiteSetting::CookieControl,
+                                       jslib::SiteSetting::CookieControl);
 
-template
-jslib::SyncRecord::Action ExtractEnum<jslib::SyncRecord::Action>(const base::Value *val, const std::string &fileld_name,
-  jslib::SyncRecord::Action, jslib::SyncRecord::Action, jslib::SyncRecord::Action);
+template jslib::SyncRecord::Action ExtractEnum<jslib::SyncRecord::Action>(
+    const base::Value* val,
+    const std::string& fileld_name,
+    jslib::SyncRecord::Action,
+    jslib::SyncRecord::Action,
+    jslib::SyncRecord::Action);
 
-std::string StrFromUint8Array(const Uint8Array &arr) {
+std::string StrFromUint8Array(const Uint8Array& arr) {
   std::string result;
   for (size_t i = 0; i < arr.size(); ++i) {
-    result += base::NumberToString( static_cast<unsigned char>( arr.at(i)));
+    result += base::NumberToString(static_cast<unsigned char>(arr.at(i)));
     if (i != arr.size() - 1) {
       result += ", ";
     }
@@ -100,20 +124,18 @@ std::string StrFromUint8Array(const Uint8Array &arr) {
   return result;
 }
 
-std::string StrFromUnsignedCharArray(const std::vector<unsigned char> &vec) {
+std::string StrFromUnsignedCharArray(const std::vector<unsigned char>& vec) {
   return StrFromUint8Array(vec);
 }
 
-Uint8Array Uint8ArrayFromString(const std::string &data_string) {
+Uint8Array Uint8ArrayFromString(const std::string& data_string) {
   return UCharVecFromString(data_string);
 }
 
-std::vector<unsigned char> UCharVecFromString(const std::string &data_string) {
-  std::vector<std::string> splitted = SplitString(
-      data_string,
-      ", ",
-      base::WhitespaceHandling::TRIM_WHITESPACE,
-      base::SplitResult::SPLIT_WANT_NONEMPTY);
+std::vector<unsigned char> UCharVecFromString(const std::string& data_string) {
+  std::vector<std::string> splitted =
+      SplitString(data_string, ", ", base::WhitespaceHandling::TRIM_WHITESPACE,
+                  base::SplitResult::SPLIT_WANT_NONEMPTY);
 
   std::vector<unsigned char> result;
   result.reserve(splitted.size());
@@ -129,4 +151,4 @@ std::vector<unsigned char> UCharVecFromString(const std::string &data_string) {
   return result;
 }
 
-} // namespace brave_sync
+}  // namespace brave_sync

--- a/components/definitions/sync.d.ts
+++ b/components/definitions/sync.d.ts
@@ -14,6 +14,7 @@ declare namespace Sync {
   export interface DevicesFromBackEnd {
     name: string
     device_id: number
+    device_id_v2: string
     last_active: number
   }
 
@@ -33,6 +34,7 @@ export type SetupErrorType =
   export interface State {
     thisDeviceName: string
     thisDeviceId: string
+    thisDeviceIdV2: string
     devices: Devices[]
     isSyncConfigured: boolean
     seedQRImageSource: string

--- a/components/test/brave_sync_ui/actions/sync_actions_test.ts
+++ b/components/test/brave_sync_ui/actions/sync_actions_test.ts
@@ -67,10 +67,10 @@ describe('sync_actions', () => {
   })
 
   it('onRemoveDevice', () => {
-    expect(actions.onRemoveDevice(1337, 'clifton windows')).toEqual({
+    expect(actions.onRemoveDevice('beef00', 'clifton windows')).toEqual({
       type: types.SYNC_ON_REMOVE_DEVICE,
       meta: undefined,
-      payload: { id: 1337, deviceName: 'clifton windows' }
+      payload: { idv2: 'beef00', deviceName: 'clifton windows' }
     })
   })
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/7339

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
### Test SQS Queue migration
1. Establish sync chain between device A and device B without this fix
2. Wait for 2 minutes for SQS queues to be initiated
3. Add A1.com on device A and wait for it appeared on device B
4. Quit Brave on device A
5. Add  B1.com on device B and make sure the record is sent (check log in chrome://inspect/#extensions) and then quit Brave on device B
6. Upgrade Brave on both devices to have this fix
7. device A should be able to receive B1.com shortly
### Test device id v2 migration
1. Establish sync chain between device A and device B without this fix
2. Wait for device list showed on both devices
3. Quit Brave on both devices
4. Upgrade Brave on both devices to have this fix
5. Wait for 1-2 minutes for both devices to send and fetch records (check log in chrome://inspect/#extensions)
6. Delete device B on device A
7. device A should have itself alone and device B is reset
### Test duplicate device id migration
1. Create sync chain on device A and copy the sync code
2. Make device B and device C joined the sync chain at the same time
3. There should be two `(This Device)` on list on device B and C
4. Quit Brave on three devices
5. Upgrade Brave on three devices to have this fix
6. Wait for 1-2 minutes for both devices to send and fetch records (check log in chrome://inspect/#extensions)
7. device list should be normal on three devices
8. Add a bookmark on device A
9. The bookmark should show up on device B and C shortly.
10. Delete device C on device C
11. device A and B should have each other on list and device C is reset
### Old device in sync chain 
1. Establish sync chain between device A and device B without this fix
2. Quit Brave on device A
3. Upgrade device A
4. Add a bookmark on device A
5. device B should have same bookmark shortly
### Old device in sync chain with dup device id
1. Create sync chain on device A and copy the sync code
2. Make device B and device C joined the sync chain at the same time
3. There should be two `(This Device)` on list on device B and C
4. Quit Brave on device A and B
5. Upgrade Brave on device A and device B to have this fix
6. Wait for 1-2 minutes for both devices to send and fetch records (check log in chrome://inspect/#extensions)
7. device list should be normal on device A & B
8. device C should be reset

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
