### PR TITLE
Remove "sign-in" promo that shows after saving a credit card (uplift to 1.3.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/autofill/payments/brave_save_card_bubble_controller_impl_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/autofill/payments/brave_save_card_bubble_controller_impl_browsertest.cc
@@ -1,0 +1,45 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.h"
+
+#include <memory>
+
+#include "base/macros.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class BraveSaveCardBubbleControllerImplTest : public InProcessBrowserTest {
+ public:
+  BraveSaveCardBubbleControllerImplTest() {}
+
+  void ShowUi() {
+    content::WebContents* web_contents =
+        browser()->tab_strip_model()->GetActiveWebContents();
+
+    // Do lazy initialization of SaveCardBubbleControllerImpl.
+    autofill::SaveCardBubbleControllerImpl::CreateForWebContents(web_contents);
+    controller_ =
+        autofill::SaveCardBubbleControllerImpl::FromWebContents(web_contents);
+    DCHECK(controller_);
+    controller_->ShowBubbleForSignInPromo();
+  }
+
+  autofill::SaveCardBubbleControllerImpl* controller() { return controller_; }
+
+ private:
+  autofill::SaveCardBubbleControllerImpl* controller_ = nullptr;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveSaveCardBubbleControllerImplTest);
+};
+
+// Tests that requesting to open signin promo bubble doesn't result in the
+// bubble being shown.
+IN_PROC_BROWSER_TEST_F(BraveSaveCardBubbleControllerImplTest, NoSignInPromo) {
+  ShowUi();
+  EXPECT_EQ(nullptr, controller()->save_card_bubble_view());
+}

--- a/chromium_src/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
+++ b/chromium_src/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
@@ -1,0 +1,10 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define BRAVE_SHOULD_SHOW_SIGNIN_PROMO_SHORT_CIRCUIT_TO_FALSE \
+return false;
+
+#include "../../../../../../../chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc"  // NOLINT
+#undef BRAVE_SHOULD_SHOW_SIGNIN_PROMO_SHORT_CIRCUIT_TO_FALSE

--- a/patches/chrome-browser-ui-autofill-payments-save_card_bubble_controller_impl.cc.patch
+++ b/patches/chrome-browser-ui-autofill-payments-save_card_bubble_controller_impl.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc b/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
+index 4e932e3882fe07386deaa030031c15bcc1891dc3..15fdf5240ab7b2b0b9b21c6e27b3b664245a3a0b 100644
+--- a/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
++++ b/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
+@@ -476,6 +476,7 @@ bool SaveCardBubbleControllerImpl::ShouldRequestExpirationDateFromUser() const {
+ }
+ 
+ bool SaveCardBubbleControllerImpl::ShouldShowSignInPromo() const {
++  BRAVE_SHOULD_SHOW_SIGNIN_PROMO_SHORT_CIRCUIT_TO_FALSE;
+   if (is_upload_save_)
+     return false;
+ 


### PR DESCRIPTION
Uplift of #4151
Fixes https://github.com/brave/brave-browser/issues/7219

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.