### PR TITLE
Fixes next payment date appearing as 4th instead of 5th for a user in Australia on Android

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -947,14 +947,14 @@ uint64_t ConfirmationsImpl::GetAdNotificationsReceivedThisMonthForTransactions(
 
   auto now = base::Time::Now();
   base::Time::Exploded now_exploded;
-  now.LocalExplode(&now_exploded);
+  now.UTCExplode(&now_exploded);
 
   for (const auto& transaction : transactions) {
     auto transaction_timestamp =
         Time::FromDoubleT(transaction.timestamp_in_seconds);
 
     base::Time::Exploded transaction_timestamp_exploded;
-    transaction_timestamp.LocalExplode(&transaction_timestamp_exploded);
+    transaction_timestamp.UTCExplode(&transaction_timestamp_exploded);
 
     if (transaction_timestamp_exploded.year == now_exploded.year &&
         transaction_timestamp_exploded.month == now_exploded.month &&

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payments.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payments.cc
@@ -128,7 +128,7 @@ base::Time Payments::CalculateNextPaymentDate(
     const base::Time& time,
     const uint64_t next_token_redemption_date_in_seconds) const {
   base::Time::Exploded now_exploded;
-  time.LocalExplode(&now_exploded);
+  time.UTCExplode(&now_exploded);
 
   int month = now_exploded.month;
 
@@ -153,7 +153,7 @@ base::Time Payments::CalculateNextPaymentDate(
           Time::FromDoubleT(next_token_redemption_date_in_seconds);
 
       base::Time::Exploded next_token_redemption_date_exploded;
-      next_token_redemption_date.LocalExplode(
+      next_token_redemption_date.UTCExplode(
           &next_token_redemption_date_exploded);
 
       if (next_token_redemption_date_exploded.month == month) {
@@ -177,10 +177,18 @@ base::Time Payments::CalculateNextPaymentDate(
     year++;
   }
 
-  auto date = base::StringPrintf("%d-%d-%d", year, month, kNextPaymentDay);
+  base::Time::Exploded next_payment_date_exploded = now_exploded;
+  next_payment_date_exploded.year = year;
+  next_payment_date_exploded.month = month;
+  next_payment_date_exploded.day_of_month = kNextPaymentDay;
+  next_payment_date_exploded.hour = 23;
+  next_payment_date_exploded.minute = 59;
+  next_payment_date_exploded.second = 59;
+  next_payment_date_exploded.millisecond = 999;
 
   base::Time next_payment_date;
-  bool success = base::Time::FromString(date.c_str(), &next_payment_date);
+  bool success = base::Time::FromUTCExploded(next_payment_date_exploded,
+      &next_payment_date);
   DCHECK(success);
 
   return next_payment_date;
@@ -321,7 +329,7 @@ PaymentInfo Payments::GetPaymentForTransactionMonth(
 
 std::string Payments::GetTransactionMonth(const base::Time& time) const {
   base::Time::Exploded time_exploded;
-  time.LocalExplode(&time_exploded);
+  time.UTCExplode(&time_exploded);
 
   return GetFormattedTransactionMonth(time_exploded.year, time_exploded.month);
 }
@@ -329,7 +337,7 @@ std::string Payments::GetTransactionMonth(const base::Time& time) const {
 std::string Payments::GetPreviousTransactionMonth(
     const base::Time& time) const {
   base::Time::Exploded time_exploded;
-  time.LocalExplode(&time_exploded);
+  time.UTCExplode(&time_exploded);
 
   time_exploded.month--;
   if (time_exploded.month < 1) {

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payments_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payments_unittest.cc
@@ -52,12 +52,12 @@ class ConfirmationsPaymentsTest : public ::testing::Test {
   }
 
   // Objects declared here can be used by all tests in the test case
-  base::Time GetNextPaymentDate(
+  base::Time GetNextPaymentUTCDate(
       const std::string& date,
       const std::string& next_token_redemption_date) {
-    auto current_date = DateFromString(date);
+    auto current_date = UTCDateFromString(date);
 
-    auto token_redemption_date = DateFromString(next_token_redemption_date);
+    auto token_redemption_date = UTCDateFromString(next_token_redemption_date);
     uint64_t token_redemption_date_in_seconds =
         token_redemption_date.ToDoubleT();
 
@@ -65,9 +65,12 @@ class ConfirmationsPaymentsTest : public ::testing::Test {
         token_redemption_date_in_seconds);
   }
 
-  base::Time DateFromString(const std::string& date) {
+  base::Time UTCDateFromString(
+      const std::string& date) {
+    const std::string utc_date = date + " 00:00:00 +00:00";
+
     base::Time time;
-    if (!base::Time::FromString(date.c_str(), &time)) {
+    if (!base::Time::FromString(utc_date.c_str(), &time)) {
       return base::Time();
     }
 
@@ -126,7 +129,7 @@ TEST_F(ConfirmationsPaymentsTest, InvalidJson_DefaultTransactionCount) {
   std::string json = "[{\"balance\":\"0.5\",\"month\":\"2019-06\",\"transactionCount\":\"INVALID\"}]";  // NOLINT
   payments_->SetFromJson(json);
 
-  auto date = DateFromString("6 July 2019");
+  auto date = UTCDateFromString("6 July 2019");
 
   // Act
   auto transaction_count = payments_->GetTransactionCountForMonth(date);
@@ -140,7 +143,7 @@ TEST_F(ConfirmationsPaymentsTest, InvalidJsonWrongType_DefaultTransactionCount) 
   std::string json = "[{\"balance\":\"0.5\",\"month\":\"2019-06\",\"transactionCount\":5}]";  // NOLINT
   payments_->SetFromJson(json);
 
-  auto date = DateFromString("6 July 2019");
+  auto date = UTCDateFromString("6 July 2019");
 
   // Act
   auto transaction_count = payments_->GetTransactionCountForMonth(date);
@@ -190,7 +193,7 @@ TEST_F(ConfirmationsPaymentsTest, TransactionCount_ForThisMonth) {
   std::string json = "[{\"balance\":\"0.5\",\"month\":\"2019-06\",\"transactionCount\":\"10\"}]";  // NOLINT
   payments_->SetFromJson(json);
 
-  auto date = DateFromString("6 June 2019");
+  auto date = UTCDateFromString("6 June 2019");
 
   // Act
   auto transaction_count = payments_->GetTransactionCountForMonth(date);
@@ -204,7 +207,7 @@ TEST_F(ConfirmationsPaymentsTest, TransactionCount_ForThisMonthWithMultiplePayme
   std::string json = "[{\"balance\":\"0.5\",\"month\":\"2019-06\",\"transactionCount\":\"10\"},{\"balance\":\"0.25\",\"month\":\"2019-05\",\"transactionCount\":\"5\"}]";  // NOLINT
   payments_->SetFromJson(json);
 
-  auto date = DateFromString("6 June 2019");
+  auto date = UTCDateFromString("6 June 2019");
 
   // Act
   auto transaction_count = payments_->GetTransactionCountForMonth(date);
@@ -218,7 +221,7 @@ TEST_F(ConfirmationsPaymentsTest, TransactionCount_ForThisMonthWithMultiplePayme
   std::string json = "[{\"balance\":\"0.25\",\"month\":\"2019-05\",\"transactionCount\":\"5\"},{\"balance\":\"0.5\",\"month\":\"2019-06\",\"transactionCount\":\"10\"}]";  // NOLINT
   payments_->SetFromJson(json);
 
-  auto date = DateFromString("6 June 2019");
+  auto date = UTCDateFromString("6 June 2019");
 
   // Act
   auto transaction_count = payments_->GetTransactionCountForMonth(date);
@@ -236,10 +239,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_BeforeNextPaymentDate
   std::string next_token_redemption_date = "21 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 July 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 July 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -252,10 +256,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_BeforeNextPaymentDate
   std::string next_token_redemption_date = "21 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 July 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 July 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -268,10 +273,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_BeforeNextPaymentDate
   std::string next_token_redemption_date = "21 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -284,10 +290,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_BeforeNextPaymentDate
   std::string next_token_redemption_date = "21 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -300,10 +307,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_BeforeNextPaymentDate
   std::string next_token_redemption_date = "21 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -316,10 +324,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "28 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -332,10 +341,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "28 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -348,10 +358,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "15 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -364,10 +375,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "15 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -380,10 +392,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "15 July 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+     GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 August 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 August 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -396,10 +409,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "15 August 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 September 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 September 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 
@@ -412,10 +426,11 @@ TEST_F(ConfirmationsPaymentsTest, CalculateNextPaymentDate_AfterNextPaymentDate_
   std::string next_token_redemption_date = "15 August 2019";
 
   // Act
-  auto next_payment_date = GetNextPaymentDate(date, next_token_redemption_date);
+  auto next_payment_date =
+      GetNextPaymentUTCDate(date, next_token_redemption_date);
 
   // Assert
-  auto expected_next_payment_date = DateFromString("5 September 2019");
+  auto expected_next_payment_date = UTCDateFromString("5 September 2019");
   EXPECT_EQ(expected_next_payment_date, next_payment_date);
 }
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7218

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Confirm "Next payment date" is correct for different timezones around the world

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
