### PR TITLE
Fix hover/focus circle is too small in tab close button

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -102,6 +102,8 @@ source_set("ui") {
       "views/rounded_separator.h",
       "views/tabs/brave_browser_tab_strip_controller.cc",
       "views/tabs/brave_browser_tab_strip_controller.h",
+      "views/tabs/brave_tab_close_button.cc",
+      "views/tabs/brave_tab_close_button.h",
       "views/tabs/brave_tab_context_menu_contents.cc",
       "views/tabs/brave_tab_context_menu_contents.h",
       "views/toolbar/bookmark_button.cc",

--- a/browser/ui/views/tabs/brave_tab_close_button.cc
+++ b/browser/ui/views/tabs/brave_tab_close_button.cc
@@ -1,0 +1,53 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/tabs/brave_tab_close_button.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "ui/views/animation/ink_drop_mask.h"
+#include "ui/views/controls/highlight_path_generator.h"
+
+namespace {
+
+int GetRadius(const gfx::Size& size) {
+  return std::min(size.width(), size.height()) / 2;
+}
+
+class TabCloseButtonHighlightPathGenerator
+    : public views::HighlightPathGenerator {
+ public:
+  TabCloseButtonHighlightPathGenerator() = default;
+
+  TabCloseButtonHighlightPathGenerator(
+      const TabCloseButtonHighlightPathGenerator&) = delete;
+  TabCloseButtonHighlightPathGenerator& operator=(
+      const TabCloseButtonHighlightPathGenerator&) = delete;
+
+  // views::HighlightPathGenerator:
+  SkPath GetHighlightPath(const views::View* view) override {
+    const gfx::Rect bounds = view->GetContentsBounds();
+    const gfx::Point center = bounds.CenterPoint();
+    return SkPath().addCircle(center.x(), center.y(), GetRadius(bounds.size()));
+  }
+};
+
+}  //  namespace
+
+BraveTabCloseButton::BraveTabCloseButton(
+    views::ButtonListener* listener,
+    MouseEventCallback mouse_event_callback)
+    : TabCloseButton(listener, std::move(mouse_event_callback)) {
+  views::HighlightPathGenerator::Install(
+      this, std::make_unique<TabCloseButtonHighlightPathGenerator>());
+}
+
+std::unique_ptr<views::InkDropMask>
+BraveTabCloseButton::CreateInkDropMask() const {
+  const gfx::Rect bounds = GetContentsBounds();
+  return std::make_unique<views::CircleInkDropMask>(
+      size(), GetMirroredRect(bounds).CenterPoint(), GetRadius(bounds.size()));
+}

--- a/browser/ui/views/tabs/brave_tab_close_button.h
+++ b/browser/ui/views/tabs/brave_tab_close_button.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CLOSE_BUTTON_H_
+#define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CLOSE_BUTTON_H_
+
+#include <memory>
+
+#include "chrome/browser/ui/views/tabs/tab_close_button.h"
+
+class BraveTabCloseButton : public TabCloseButton {
+ public:
+  BraveTabCloseButton(views::ButtonListener* listener,
+                      MouseEventCallback mouse_event_callback);
+  ~BraveTabCloseButton() override = default;
+
+  BraveTabCloseButton(const BraveTabCloseButton&) = delete;
+  BraveTabCloseButton& operator=(const BraveTabCloseButton&) = delete;
+
+ private:
+  // TabCloseButton overrides:
+  std::unique_ptr<views::InkDropMask> CreateInkDropMask() const override;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CLOSE_BUTTON_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.cc
@@ -4,7 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/tabs/brave_alert_indicator.h"
+#include "brave/browser/ui/views/tabs/brave_tab_close_button.h"
 
 #define AlertIndicator BraveAlertIndicator
+#define TabCloseButton BraveTabCloseButton
 #include "../../../../../../../chrome/browser/ui/views/tabs/tab.cc"  // NOLINT
 #undef AlertIndicator
+#undef TabCloseButton


### PR DESCRIPTION
After c79 bump, close button uses ink drop for hover effect and
highlight generator for focus ring.
Both uses LayoutProvider::GetCornerRadiusMetric() with EMPHASIS_MAXIMUM
for calculating radius for their circle shape effect.
However, we modified to return 4 always. Because of this, small circle
was drawn. So, orignal maximum radius calculation logic is applied
by subclassing TabCloseButton.

Fix https://github.com/brave/brave-browser/issues/7276

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
See https://github.com/brave/brave-browser/issues/7276

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
