### PR TITLE
Fix os_crypt_win patch

### DIFF
--- a/patches/components-os_crypt-os_crypt_win.cc.patch
+++ b/patches/components-os_crypt-os_crypt_win.cc.patch
@@ -1,20 +1,20 @@
 diff --git a/components/os_crypt/os_crypt_win.cc b/components/os_crypt/os_crypt_win.cc
-index 792233d4405f115f4fc72423dad10c415f4df66b..1fb45bb390dba292b3a075dad620a3b7e73ccd84 100644
+index 8a7f33e76963..ca64e70f4a76 100644
 --- a/components/os_crypt/os_crypt_win.cc
 +++ b/components/os_crypt/os_crypt_win.cc
-@@ -26,6 +26,7 @@ bool OSCrypt::DecryptString16(const std::string& ciphertext,
- 
+@@ -134,6 +134,7 @@ bool OSCrypt::DecryptString16(const std::string& ciphertext,
+ // static
  bool OSCrypt::EncryptString(const std::string& plaintext,
                              std::string* ciphertext) {
 +  if (IsEncryptionDisabled(plaintext, ciphertext)) { return true; }
-   DATA_BLOB input;
-   input.pbData = const_cast<BYTE*>(
-       reinterpret_cast<const BYTE*>(plaintext.data()));
-@@ -49,6 +50,7 @@ bool OSCrypt::EncryptString(const std::string& plaintext,
- 
+   if (g_use_legacy)
+     return EncryptStringWithDPAPI(plaintext, ciphertext);
+
+@@ -160,6 +161,7 @@ bool OSCrypt::EncryptString(const std::string& plaintext,
+ // static
  bool OSCrypt::DecryptString(const std::string& ciphertext,
                              std::string* plaintext) {
-+  if (IsEncryptionDisabled(ciphertext, plaintext)) { return true; }
-   DATA_BLOB input;
-   input.pbData = const_cast<BYTE*>(
-       reinterpret_cast<const BYTE*>(ciphertext.data()));
++  if (IsEncryptionDisabled(plaintext, ciphertext)) { return true; }
+   if (!base::StartsWith(ciphertext, kEncryptionVersionPrefix,
+                         base::CompareCase::SENSITIVE))
+     return DecryptStringWithDPAPI(ciphertext, plaintext);


### PR DESCRIPTION
Fix regression introduced by #3385. [components-os_crypt-os_crypt_win.cc.patch](https://github.com/brave/brave-core/blob/master/patches/components-os_crypt-os_crypt_win.cc.patch) has to be updated following [this commit](https://github.com/chromium/chromium/commit/265b39473af0faac989b44afb6d4eb5cb2fd2e24#diff-efaab3ed7e2e146a09d7930295d44768R6) on chromium. See also portapps/brave-portable#33.