### PR TITLE
Add notification list licensing info

### DIFF
--- a/components/third_party/adblock/lists/notifications/README.chromium
+++ b/components/third_party/adblock/lists/notifications/README.chromium
@@ -1,0 +1,4 @@
+Name: Notification List (Based on Fanboy's Annoyances)
+URL: https://github.com/easylist/easylist/tree/master/fanboy-addon
+License: CC-BY-3.0
+License File: /brave/common/licenses/CC-BY-3.0


### PR DESCRIPTION
With inclusion of the notification list;  https://github.com/brave/adblock-rust/pull/57

Based on fixes in Fanboy Annoyances in https://github.com/easylist/easylist/tree/master/fanboy-addon

