### PR TITLE
Sync: miss records between S3=>SQS switch after chain creation (uplift to 1.3.x)

### DIFF
--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -46,6 +46,7 @@ FORWARD_DECLARE_TEST(BraveSyncServiceTest, SetSyncEnabled);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, SetSyncDisabled);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, IsSyncReadyOnNewProfile);
 FORWARD_DECLARE_TEST(BraveSyncServiceTest, SetThisDeviceCreatedTime);
+FORWARD_DECLARE_TEST(BraveSyncServiceTest, InitialFetchesStartWithZero);
 
 class BraveSyncServiceTest;
 
@@ -160,6 +161,7 @@ class BraveProfileSyncServiceImpl
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, SetSyncDisabled);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, IsSyncReadyOnNewProfile);
   FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, SetThisDeviceCreatedTime);
+  FRIEND_TEST_ALL_PREFIXES(::BraveSyncServiceTest, InitialFetchesStartWithZero);
 
   friend class ::BraveSyncServiceTest;
 
@@ -202,6 +204,8 @@ class BraveProfileSyncServiceImpl
   void ResendSyncRecords(const std::string& category_name);
 
   void RecordSyncStateP3A() const;
+
+  bool IsSQSReady() const;
 
   static base::TimeDelta GetRetryExponentialWaitAmount(int retry_number);
   static std::vector<unsigned> GetExponentialWaitsForTests();


### PR DESCRIPTION
Uplift of #4168

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.