### PR TITLE
Use the correct name for the setuid sandbox

### DIFF
--- a/patches/chrome-installer-linux-common-installer.include.patch
+++ b/patches/chrome-installer-linux-common-installer.include.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.include b/chrome/installer/linux/common/installer.include
-index 27393586fe37f441faa712c3b1388adab51891cf..0a6d8c54dfea80d56b29391041e374b76b30f2e3 100644
+index 27393586fe37f441faa712c3b1388adab51891cf..cdf66268f1a83ad9202235a62b1c2fe66d4a42a7 100644
 --- a/chrome/installer/linux/common/installer.include
 +++ b/chrome/installer/linux/common/installer.include
 @@ -75,6 +75,7 @@ process_template() (
@@ -36,6 +36,15 @@ index 27393586fe37f441faa712c3b1388adab51891cf..0a6d8c54dfea80d56b29391041e374b7
    # ICU data file; Necessary when the GN icu_use_data_file flag is true.
    install -m 644 "${BUILDDIR}/icudtl.dat" "${STAGEDIR}/${INSTALLDIR}/"
  
+@@ -185,7 +205,7 @@ stage_install_common() {
+   strippedfile="${buildfile}.stripped"
+   debugfile="${buildfile}.debug"
+   "${BUILDDIR}/installer/common/eu-strip" -o "${strippedfile}" -f "${debugfile}" "${buildfile}"
+-  install -m 4755 "${strippedfile}" "${STAGEDIR}/${INSTALLDIR}/${PROGNAME}-sandbox"
++  install -m 4755 "${strippedfile}" "${STAGEDIR}/${INSTALLDIR}/chrome-sandbox"
+ 
+   # l10n paks
+   install -m 755 -d "${STAGEDIR}/${INSTALLDIR}/locales/"
 @@ -286,11 +306,13 @@ stage_install_common() {
  
    # app icons
@@ -52,14 +61,7 @@ index 27393586fe37f441faa712c3b1388adab51891cf..0a6d8c54dfea80d56b29391041e374b7
      fi
    fi
    LOGO_RESOURCES_PNG=$(find "${BUILDDIR}/installer/theme/" \
-@@ -392,12 +414,14 @@ stage_install_common() {
-         exit 1
-       fi
-       local expected_perms=777
--    elif [ "${base_name}" = "chrome-sandbox" ]; then
-+    elif [ "${base_name}" = "brave-sandbox" ]; then
-       local expected_perms=4755
-     elif [[ "${base_name}" = "nacl_irt_"*".nexe" ]]; then
+@@ -398,6 +420,8 @@ stage_install_common() {
        local expected_perms=644
      elif [[ "${file_type}" = *"shell script"* ]]; then
        local expected_perms=755


### PR DESCRIPTION
Fixes brave/brave-browser#6247.

The browser actually [expects a hard-coded binary (`chrome-sandbox`)](https://cs.chromium.org/chromium/src/sandbox/linux/suid/client/setuid_sandbox_host.cc?l=124&rcl=9ca7a88f0a86bcc9c4b12915b03db45f6a94a385) in order for the deprecated SUID sandbox to be used. This change ensures that it doesn't get renamed to `brave-sandbox`.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Install the `.deb` package on an Ubuntu machine.
2. Disable user namespaces: `sudo sysctl -w kernel.unprivileged_userns_clone=0`
3. Launch `brave-browser-stable`.
4. Verify that the Layer 1 SUID sandbox is enabled in `brave://sandbox`:
![Screenshot from 2019-12-12 16-24-57](https://user-images.githubusercontent.com/167821/70760148-9af0d700-1cfd-11ea-8113-e49a31fee27b.png)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
