### PR TITLE
Re-order brave menus at app menu

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -141,10 +141,11 @@ void BraveBrowserCommandController::UpdateCommandForWebcompatReporter() {
 
 #if BUILDFLAG(ENABLE_TOR)
 void BraveBrowserCommandController::UpdateCommandForTor() {
-  const bool is_tor_enabled =
-      !brave::IsTorDisabledForProfile(browser_->profile());
-  UpdateCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE, is_tor_enabled);
-  UpdateCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR, is_tor_enabled);
+  // Enable new tor connection only for tor profile.
+  UpdateCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE,
+                       brave::IsTorProfile(browser_->profile()));
+  UpdateCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR,
+                       !brave::IsTorDisabledForProfile(browser_->profile()));
 }
 #endif
 
@@ -153,7 +154,9 @@ void BraveBrowserCommandController::UpdateCommandForBraveSync() {
 }
 
 void BraveBrowserCommandController::UpdateCommandForBraveWallet() {
-  UpdateCommandEnabled(IDC_SHOW_BRAVE_WALLET, true);
+  UpdateCommandEnabled(
+      IDC_SHOW_BRAVE_WALLET,
+      browser_->profile()->GetPrefs()->GetBoolean(kBraveWalletEnabled));
 }
 
 bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -1,0 +1,195 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "brave/browser/profiles/profile_util.h"
+#include "brave/browser/tor/buildflags.h"
+#include "brave/browser/ui/brave_browser_command_controller.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
+#include "brave/components/brave_sync/buildflags/buildflags.h"
+#include "brave/components/brave_wallet/browser/buildflags/buildflags.h"
+#include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/chrome_notification_types.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_window.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/test/test_utils.h"
+
+#if BUILDFLAG(ENABLE_TOR)
+#include "brave/browser/tor/tor_profile_service.h"
+#endif
+
+using BraveBrowserCommandControllerTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
+                       BraveCommandsEnableTest) {
+  // Test normal browser's brave commands status.
+  auto* command_controller = browser()->command_controller();
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+#else
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
+
+#if BUILDFLAG(ENABLE_TOR)
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
+  EXPECT_TRUE(
+      command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
+#else
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_SYNC)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+#else
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+#endif
+
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_WALLET));
+#else
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_WALLET));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_ADD_NEW_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_OPEN_GUEST_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(
+                  IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER));
+
+  // Create private browser and test its brave commands status.
+  auto* private_browser = CreateIncognitoBrowser();
+  command_controller = private_browser->command_controller();
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
+
+#if BUILDFLAG(ENABLE_TOR)
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
+  EXPECT_TRUE(
+      command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_SYNC)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+#endif
+
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_WALLET));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_ADD_NEW_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_OPEN_GUEST_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(
+                  IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER));
+
+  // Create guest browser and test its brave commands status.
+  content::WindowedNotificationObserver browser_creation_observer(
+      chrome::NOTIFICATION_BROWSER_OPENED,
+      content::NotificationService::AllSources());
+  profiles::SwitchToGuestProfile(ProfileManager::CreateCallback());
+
+  browser_creation_observer.Wait();
+
+  auto* browser_list = BrowserList::GetInstance();
+  Browser* guest_browser = nullptr;
+  for (Browser* browser : *browser_list) {
+    if (browser->profile()->IsGuestSession()) {
+      guest_browser = browser;
+      break;
+    }
+  }
+  DCHECK(guest_browser);
+  command_controller = guest_browser->command_controller();
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
+
+#if BUILDFLAG(ENABLE_TOR)
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_SYNC)
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+#endif
+
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_WALLET));
+#endif
+
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_ADD_NEW_PROFILE));
+  EXPECT_FALSE(command_controller->IsCommandEnabled(IDC_OPEN_GUEST_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(
+                  IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER));
+
+  // Launch tor window and check its command status.
+  content::WindowedNotificationObserver tor_browser_creation_observer(
+      chrome::NOTIFICATION_BROWSER_OPENED,
+      content::NotificationService::AllSources());
+  brave::NewOffTheRecordWindowTor(browser());
+  tor_browser_creation_observer.Wait();
+  Browser* tor_browser = nullptr;
+  for (Browser* browser : *browser_list) {
+    if (brave::IsTorProfile(browser->profile())) {
+      tor_browser = browser;
+      break;
+    }
+  }
+  DCHECK(tor_browser);
+  command_controller = tor_browser->command_controller();
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_REWARDS));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_ADBLOCK));
+
+#if BUILDFLAG(ENABLE_TOR)
+  EXPECT_TRUE(
+      command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
+  EXPECT_TRUE(
+      command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_SYNC)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_SYNC));
+#endif
+
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_SHOW_BRAVE_WALLET));
+#endif
+
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_ADD_NEW_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(IDC_OPEN_GUEST_PROFILE));
+  EXPECT_TRUE(command_controller->IsCommandEnabled(
+                  IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER));
+
+  // Check tor commands when tor is disabled.
+#if BUILDFLAG(ENABLE_TOR)
+  tor::TorProfileService::SetTorDisabled(true);
+  command_controller = browser()->command_controller();
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
+  EXPECT_FALSE(
+      command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
+#endif
+}

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -5,24 +5,10 @@
 
 #include "brave/browser/ui/toolbar/brave_app_menu_model.h"
 
-#include "brave/app/brave_command_ids.h"
-#include "brave/browser/profiles/profile_util.h"
-#include "brave/common/pref_names.h"
-#include "brave/components/brave_wallet/browser/buildflags/buildflags.h"
-#include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/chrome_command_ids.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/browser.h"
-#include "components/prefs/pref_service.h"
+#include "chrome/grit/generated_resources.h"
 
-BraveAppMenuModel::BraveAppMenuModel(
-    ui::AcceleratorProvider* provider,
-    Browser* browser,
-    AppMenuIconController* app_menu_icon_controller)
-    : AppMenuModel(provider, browser, app_menu_icon_controller),
-      browser_(browser) {}
-
-BraveAppMenuModel::~BraveAppMenuModel() {}
+BraveAppMenuModel::~BraveAppMenuModel() = default;
 
 void BraveAppMenuModel::Build() {
   // Insert brave items after build chromium items.
@@ -31,62 +17,144 @@ void BraveAppMenuModel::Build() {
 }
 
 void BraveAppMenuModel::InsertBraveMenuItems() {
-  // Sync & Rewards pages are redirected to normal window when it is loaded in
-  // private window. So, only hide them in guest(tor) window.
-  if (!browser_->profile()->IsGuestSession()) {
-    bool walletEnabled = browser_->profile()->GetPrefs()->
-        GetBoolean(kBraveWalletEnabled);
-    InsertItemWithStringIdAt(
-        GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
-        IDC_SHOW_BRAVE_REWARDS,
-        IDS_SHOW_BRAVE_REWARDS);
-    if (walletEnabled) {
-#if BUILDFLAG(BRAVE_WALLET_ENABLED)
-      InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS),
-                               IDC_SHOW_BRAVE_WALLET, IDS_SHOW_BRAVE_WALLET);
-#endif
-    }
-    InsertItemWithStringIdAt(
-#if BUILDFLAG(BRAVE_WALLET_ENABLED)
-        GetIndexOfCommandId(walletEnabled ? IDC_SHOW_BRAVE_WALLET :
-            IDC_SHOW_BRAVE_REWARDS),
-#else
-        GetIndexOfCommandId(IDC_SHOW_BRAVE_REWARDS),
-#endif
-        IDC_SHOW_BRAVE_SYNC, IDS_SHOW_BRAVE_SYNC);
-  }
+  // Insert & reorder brave menus based on corresponding commands enable status.
+  // If we you want to add/remove from app menu, adjust commands enable status
+  // at BraveBrowserCommandController.
 
-  // Insert Create New Profile item
-  auto profile_items_insert_index = GetIndexOfCommandId(IDC_ZOOM_MENU) - 1;
-  InsertItemWithStringIdAt(profile_items_insert_index,
-    IDC_OPEN_GUEST_PROFILE,
-    IDS_OPEN_GUEST_PROFILE);
-  InsertItemWithStringIdAt(
-    GetIndexOfCommandId(IDC_OPEN_GUEST_PROFILE),
-    IDC_ADD_NEW_PROFILE,
-    IDS_ADD_NEW_PROFILE);
-  InsertSeparatorAt(
-    GetIndexOfCommandId(IDC_ADD_NEW_PROFILE), ui::NORMAL_SEPARATOR);
-
-  InsertItemWithStringIdAt(
-      GetIndexOfCommandId(IDC_SHOW_DOWNLOADS),
-      IDC_SHOW_BRAVE_ADBLOCK,
-      IDS_SHOW_BRAVE_ADBLOCK);
-  if (brave::IsTorProfile(browser_->profile())) {
+  // Step 1. Configure tab & windows section.
+  if (IsCommandIdEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE)) {
     InsertItemWithStringIdAt(
         GetIndexOfCommandId(IDC_NEW_WINDOW),
         IDC_NEW_TOR_CONNECTION_FOR_SITE,
         IDS_NEW_TOR_CONNECTION_FOR_SITE);
   }
-
   if (IsCommandIdEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR)) {
     InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_NEW_INCOGNITO_WINDOW) + 1,
                              IDC_NEW_OFFTHERECORD_WINDOW_TOR,
                              IDS_NEW_OFFTHERECORD_WINDOW_TOR);
   }
 
-  InsertItemWithStringIdAt(
-      GetIndexOfCommandId(IDC_ABOUT),
-      IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER,
-      IDS_SHOW_BRAVE_WEBCOMPAT_REPORTER);
+  // Step 2. Configure second section that includes history, downloads and
+  // bookmark. Then, insert brave items.
+
+  // First, reorder original menus We want to move them in order of bookmark,
+  // download and extensions.
+  const int bookmark_item_index = GetIndexOfCommandId(IDC_BOOKMARKS_MENU);
+  // If bookmark is not used, we don't need to adjust download item.
+  if (bookmark_item_index != -1) {
+    // Place download menu under bookmark.
+    DCHECK(IsCommandIdEnabled(IDC_SHOW_DOWNLOADS));
+    RemoveItemAt(GetIndexOfCommandId(IDC_SHOW_DOWNLOADS));
+    InsertItemWithStringIdAt(bookmark_item_index,
+                             IDC_SHOW_DOWNLOADS,
+                             IDS_SHOW_DOWNLOADS);
+  }
+  // Move extensions menu under download.
+  ui::SimpleMenuModel* model = static_cast<ui::SimpleMenuModel*>(
+      GetSubmenuModelAt(GetIndexOfCommandId(IDC_MORE_TOOLS_MENU)));
+  DCHECK(model);
+  model->RemoveItemAt(model->GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS));
+
+  if (IsCommandIdEnabled(IDC_MANAGE_EXTENSIONS)) {
+    InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_SHOW_DOWNLOADS) + 1,
+                             IDC_MANAGE_EXTENSIONS,
+                             IDS_SHOW_EXTENSIONS);
+  }
+
+  if (IsCommandIdEnabled(IDC_SHOW_BRAVE_REWARDS)) {
+    InsertItemWithStringIdAt(GetIndexOfBraveRewardsItem(),
+                             IDC_SHOW_BRAVE_REWARDS,
+                             IDS_SHOW_BRAVE_REWARDS);
+  }
+
+  // Insert wallet menu after download menu.
+  if (IsCommandIdEnabled(IDC_SHOW_BRAVE_WALLET)) {
+    InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_SHOW_DOWNLOADS) + 1,
+                             IDC_SHOW_BRAVE_WALLET,
+                             IDS_SHOW_BRAVE_WALLET);
+  }
+
+  // Insert sync menu
+  if (IsCommandIdEnabled(IDC_SHOW_BRAVE_SYNC)) {
+    InsertItemWithStringIdAt(GetIndexOfBraveSyncItem(),
+                             IDC_SHOW_BRAVE_SYNC,
+                             IDS_SHOW_BRAVE_SYNC);
+  }
+
+  // Insert adblock menu at last. Assumed this is always enabled.
+  DCHECK(IsCommandIdEnabled(IDC_SHOW_BRAVE_ADBLOCK));
+  InsertItemWithStringIdAt(GetIndexOfBraveAdBlockItem(),
+                           IDC_SHOW_BRAVE_ADBLOCK,
+                           IDS_SHOW_BRAVE_ADBLOCK);
+
+  // Insert Create New Profile item
+  if (IsCommandIdEnabled(IDC_OPEN_GUEST_PROFILE)) {
+    InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_ZOOM_MENU) - 1,
+                             IDC_OPEN_GUEST_PROFILE,
+                             IDS_OPEN_GUEST_PROFILE);
+    InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_OPEN_GUEST_PROFILE),
+                             IDC_ADD_NEW_PROFILE,
+                             IDS_ADD_NEW_PROFILE);
+    InsertSeparatorAt(GetIndexOfCommandId(IDC_ADD_NEW_PROFILE),
+                      ui::NORMAL_SEPARATOR);
+  }
+
+  // Insert webcompat reporter item.
+  InsertItemWithStringIdAt(GetIndexOfCommandId(IDC_ABOUT),
+                           IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER,
+                           IDS_SHOW_BRAVE_WEBCOMPAT_REPORTER);
+}
+
+int BraveAppMenuModel::GetIndexOfBraveAdBlockItem() const {
+  // Insert as a last item in second section.
+  int adblock_item_index = -1;
+  adblock_item_index = GetIndexOfCommandId(IDC_SHOW_BRAVE_SYNC);
+  if (adblock_item_index != -1)
+    return adblock_item_index + 1;
+
+  adblock_item_index = GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS);
+  if (adblock_item_index != -1)
+    return adblock_item_index + 1;
+
+  adblock_item_index = GetIndexOfCommandId(IDC_SHOW_BRAVE_WALLET);
+  if (adblock_item_index != -1)
+    return adblock_item_index + 1;
+
+  adblock_item_index = GetIndexOfCommandId(IDC_SHOW_DOWNLOADS);
+  DCHECK_NE(-1, adblock_item_index) << "No download item";
+  return adblock_item_index + 1;
+}
+
+int BraveAppMenuModel::GetIndexOfBraveRewardsItem() const {
+  // Insert rewards menu at first of this section. If history menu is not
+  // available, check below items.
+  int rewards_index = -1;
+  rewards_index = GetIndexOfCommandId(IDC_RECENT_TABS_MENU);
+  if (rewards_index != -1)
+    return rewards_index;
+
+  rewards_index = GetIndexOfCommandId(IDC_BOOKMARKS_MENU);
+  if (rewards_index != -1)
+    return rewards_index;
+
+  rewards_index = GetIndexOfCommandId(IDC_SHOW_DOWNLOADS);
+  DCHECK_NE(-1, rewards_index) << "No download item";
+  return rewards_index;
+}
+
+int BraveAppMenuModel::GetIndexOfBraveSyncItem() const {
+  // Insert sync menu under extensions menu. If extensions menu is not
+  // available, check above items.
+  int sync_index = -1;
+  sync_index = GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS);
+  if (sync_index != -1)
+    return sync_index + 1;
+
+  sync_index = GetIndexOfCommandId(IDC_SHOW_BRAVE_WALLET);
+  if (sync_index != -1)
+    return sync_index + 1;
+
+  sync_index = GetIndexOfCommandId(IDC_SHOW_DOWNLOADS);
+  DCHECK_NE(-1, sync_index) << "No download item";
+  return sync_index + 1;
 }

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -10,20 +10,20 @@
 
 class BraveAppMenuModel : public AppMenuModel {
  public:
-  BraveAppMenuModel(ui::AcceleratorProvider* provider,
-      Browser* browser,
-      AppMenuIconController* app_menu_icon_controller = nullptr);
+  using AppMenuModel::AppMenuModel;
   ~BraveAppMenuModel() override;
+
+  BraveAppMenuModel(const BraveAppMenuModel&) = delete;
+  BraveAppMenuModel& operator=(const BraveAppMenuModel&) = delete;
 
  private:
   // AppMenuModel overrides:
   void Build() override;
 
   void InsertBraveMenuItems();
-
-  Browser* const browser_;  // weak
-
-  DISALLOW_COPY_AND_ASSIGN(BraveAppMenuModel);
+  int GetIndexOfBraveRewardsItem() const;
+  int GetIndexOfBraveAdBlockItem() const;
+  int GetIndexOfBraveSyncItem() const;
 };
 
 #endif  // BRAVE_BROWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -52,8 +52,8 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, BasicTest) {
 #if BUILDFLAG(ENABLE_TOR)
   EXPECT_NE(
       -1, normal_model.GetIndexOfCommandId(IDC_NEW_OFFTHERECORD_WINDOW_TOR));
-  // Check tor browser commands are disabled.
-  EXPECT_TRUE(
+  // Check new tor browser command is only enabled for normal window.
+  EXPECT_FALSE(
       command_controller->IsCommandEnabled(IDC_NEW_TOR_CONNECTION_FOR_SITE));
   EXPECT_TRUE(
       command_controller->IsCommandEnabled(IDC_NEW_OFFTHERECORD_WINDOW_TOR));

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -525,6 +525,7 @@ test("brave_browser_tests") {
     "//brave/browser/search_engines/search_engine_provider_service_browsertest.cc",
     "//brave/browser/themes/brave_theme_service_browsertest.cc",
     "//brave/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc",
+    "//brave/browser/ui/brave_browser_command_controller_browsertest.cc",
     "//brave/browser/ui/content_settings/brave_autoplay_blocked_image_model_browsertest.cc",
     "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc",
     "//brave/browser/ui/views/omnibox/omnibox_autocomplete_browsertest.cc",


### PR DESCRIPTION
Insert & reorder brave menus based on corresponding commands enable status.
If we want to add/remove from app menu, adjust enable commands status
instead of adjusting it in app menu model directly.
App menu model will add/delete based on commands status.

Fix https://github.com/brave/brave-browser/issues/5552
Normal window app menu
<img width="537" alt="Screen Shot 2019-12-15 at 11 43 49 AM" src="https://user-images.githubusercontent.com/6786187/70857755-e393d480-1f37-11ea-984c-f9ef3ce54a2a.png">
Private window app menu
<img width="537" alt="Screen Shot 2019-12-15 at 11 44 18 AM" src="https://user-images.githubusercontent.com/6786187/70857756-e393d480-1f37-11ea-8435-165ec65775d9.png">
Tor window app menu
<img width="541" alt="Screen Shot 2019-12-15 at 11 44 34 AM" src="https://user-images.githubusercontent.com/6786187/70857757-e42c6b00-1f37-11ea-8081-7a9a980afa9d.png">
Guest window app menu
<img width="543" alt="Screen Shot 2019-12-15 at 11 44 50 AM" src="https://user-images.githubusercontent.com/6786187/70857758-e42c6b00-1f37-11ea-8406-f14d3162c5ea.png">


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
