### PR TITLE
Issue 7306: Fix the P3A answer count default value. (uplift to 1.3.x)

### DIFF
--- a/components/p3a/brave_p3a_log_store.cc
+++ b/components/p3a/brave_p3a_log_store.cc
@@ -26,7 +26,7 @@ void RecordP3A(uint64_t answers_count) {
     answer = 1;
   } else if (5 <= answers_count && answers_count < 10) {
     answer = 2;
-  } else {
+  } else if (10 <= answers_count) {
     answer = 3;
   }
   UMA_HISTOGRAM_COUNTS_100("Brave.P3A.SentAnswersCount", answer);


### PR DESCRIPTION
Uplift of #4241
Fixes https://github.com/brave/brave-browser/issues/7306

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.