### PR TITLE
Update generateCosmeticBlockingStylesheet implementation w/ tests

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
@@ -4,7 +4,7 @@
 
 import shieldsPanelActions from '../actions/shieldsPanelActions'
 
-const generateCosmeticBlockingStylesheet = (hideSelectors: string[], styleSelectors: any) => {
+export const generateCosmeticBlockingStylesheet = (hideSelectors: string[], styleSelectors: any) => {
   let stylesheet = ''
   if (hideSelectors.length > 0) {
     stylesheet += hideSelectors[0]
@@ -14,7 +14,7 @@ const generateCosmeticBlockingStylesheet = (hideSelectors: string[], styleSelect
     stylesheet += '{display:none !important;}\n'
   }
   for (const selector in styleSelectors) {
-    stylesheet += selector + '{' + styleSelectors[selector] + '\n'
+    stylesheet += selector + '{' + styleSelectors[selector] + '}\n'
   }
 
   return stylesheet

--- a/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
@@ -368,7 +368,7 @@ export default function shieldsPanelReducer (
       }
       state = shieldsPanelState.saveCosmeticFilterRuleExceptions(state, action.tabId, action.exceptions)
       chrome.tabs.sendMessage(action.tabId, {
-        type: 'cosmeticFilterGenericExceptions'
+        type: 'cosmeticFilteringEnabled'
       })
       break
     }

--- a/components/brave_extension/extension/brave_extension/content_cosmetic.ts
+++ b/components/brave_extension/extension/brave_extension/content_cosmetic.ts
@@ -68,7 +68,7 @@ function applyCosmeticFilterMutationObserver () {
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const action = typeof msg === 'string' ? msg : msg.type
   switch (action) {
-    case 'cosmeticFilterGenericExceptions': {
+    case 'cosmeticFilteringEnabled': {
       let allNodes = Array.from(document.querySelectorAll('[id],[class]'))
       handleNewNodes(allNodes)
       applyCosmeticFilterMutationObserver()

--- a/components/test/brave_extension/background/api/cosmeticFilterAPI_test.ts
+++ b/components/test/brave_extension/background/api/cosmeticFilterAPI_test.ts
@@ -7,6 +7,50 @@ import * as sinon from 'sinon'
 import * as cosmeticFilterAPI from '../../../../brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI'
 
 describe('cosmeticFilter API', () => {
+  describe('generateCosmeticBlockingStylesheet', () => {
+    it('produces an empty string when no selectors are provided', () => {
+      const hideSelectors = []
+      const styleSelectors = {}
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('')
+    })
+    it('hides a single selector in hideSelectors', () => {
+      const hideSelectors = ['.hideme']
+      const styleSelectors = {}
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('.hideme{display:none !important;}\n')
+    })
+    it('hides multiple selectors in hideSelectors', () => {
+      const hideSelectors = ['.hideme', '#content-panel > .ad', 'div#ad-header']
+      const styleSelectors = {}
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('.hideme,#content-panel > .ad,div#ad-header{display:none !important;}\n')
+    })
+    it('restyles a styled selector with a single rule', () => {
+      const hideSelectors = []
+      const styleSelectors = { '#page-backdrop': ['background: #fff'] }
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('#page-backdrop{background: #fff}\n')
+    })
+    it('restyles a styled selector with multiple rules', () => {
+      const hideSelectors = []
+      const styleSelectors = { '#darkmode div.between-paragraphs': ['background: black', 'border-bottom: 10px'] }
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('#darkmode div.between-paragraphs{background: black,border-bottom: 10px}\n')
+    })
+    it('restyles multiple styled selectors', () => {
+      const hideSelectors = []
+      const styleSelectors = { '#page-backdrop': ['background: #fff'], '#darkmode div.between-paragraphs': ['background: black', 'border-bottom: 10px'] }
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('#page-backdrop{background: #fff}\n#darkmode div.between-paragraphs{background: black,border-bottom: 10px}\n')
+    })
+    it('hides and restyles selectors together', () => {
+      const hideSelectors = ['.hideme', '#content-panel > .ad', 'div#ad-header']
+      const styleSelectors = { '#page-backdrop': ['background: #fff'], '#darkmode div.between-paragraphs': ['background: black', 'border-bottom: 10px'] }
+      const stylesheet = cosmeticFilterAPI.generateCosmeticBlockingStylesheet(hideSelectors, styleSelectors)
+      expect(stylesheet).toBe('.hideme,#content-panel > .ad,div#ad-header{display:none !important;}\n#page-backdrop{background: #fff}\n#darkmode div.between-paragraphs{background: black,border-bottom: 10px}\n')
+    })
+  })
   describe('addSiteCosmeticFilter', () => {
     const url = 'https://www.brave.com'
     const filter = '#cssFilter'


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7442.

I also took the chance to rename the `cosmeticFilterGenericExceptions` event to `cosmeticFilteringEnabled`, since generic exceptions are no longer sent to the content script as per @bridiver's feedback on #3303.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

New unit tests are added for `generateCosmeticBlockingStylesheet` to ensure the generated stylesheets are correctly formatted.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
