### PR TITLE
Add missing context check in ChromeTypographyProvider::GetColor()

### DIFF
--- a/chromium_src/chrome/browser/ui/views/chrome_typography_provider.cc
+++ b/chromium_src/chrome/browser/ui/views/chrome_typography_provider.cc
@@ -9,10 +9,6 @@
 // Comes after the above includes.
 #include "chrome/browser/ui/views/chrome_typography_provider.h"
 
-namespace {
-  const SkColor kBraveGrey800 = SkColorSetRGB(0x3b, 0x3e, 0x4f);
-}
-
 #define ChromeTypographyProvider ChromeTypographyProvider_ChromiumImpl
 #include "../../../../../../chrome/browser/ui/views/chrome_typography_provider.cc"
 #undef ChromeTypographyProvider
@@ -24,8 +20,9 @@ SkColor ChromeTypographyProvider::GetColor(const views::View& view,
   const ui::NativeTheme* native_theme = view.GetNativeTheme();
   DCHECK(native_theme);
   if (ShouldIgnoreHarmonySpec(*native_theme)) {
-    return GetHarmonyTextColorForNonStandardNativeTheme(context, style,
-                                                        *native_theme);
+    return ChromeTypographyProvider_ChromiumImpl::GetColor(view,
+                                                           context,
+                                                           style);
   }
   // Override button text colors
   if (context == views::style::CONTEXT_BUTTON_MD) {
@@ -37,7 +34,7 @@ SkColor ChromeTypographyProvider::GetColor(const views::View& view,
         break;
       default:
         return native_theme->ShouldUseDarkColors() ? SK_ColorWHITE
-                                                   : kBraveGrey800;
+                                                   : gfx::kBraveGrey800;
     }
   }
   return ChromeTypographyProvider_ChromiumImpl::GetColor(view, context, style);

--- a/chromium_src/ui/gfx/color_palette.h
+++ b/chromium_src/ui/gfx/color_palette.h
@@ -11,6 +11,7 @@
 namespace gfx {
 
 constexpr SkColor kBraveGrey700 = SkColorSetRGB(0x4A, 0x4A, 0x4A);
+constexpr SkColor kBraveGrey800 = SkColorSetRGB(0x3b, 0x3e, 0x4f);
 constexpr SkColor kBraveNeutral300 = SkColorSetRGB(0xDE, 0xE2, 0xE6);
 constexpr SkColor kBraveNeutral800 = SkColorSetRGB(0x34, 0x3A, 0x40);
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/7245

I think context checking code about context menu was missed during the rebase.
With that, enabled label text was wrong in context menu item view.
Missed part was
```
    if (context == views::style::CONTEXT_MENU ||
        context == views::style::CONTEXT_TOUCH_MENU) {
      return TypographyProvider::GetColor(view, context, style);
    }
```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
In linux 18.04 (not 19.04)
1. Launch browser and set use gtk theme
2. Check context menu or app menu is visible properly

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
