### PR TITLE
Fix missing favicons in auto-contribute table on Android

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -8,6 +8,22 @@ import("//build/config/features.gni")
 import("//components/gcm_driver/config.gni")
 import("//chrome/common/features.gni")
 
+source_set("favicon_source") {
+  sources = [
+    "//chrome/browser/ui/webui/favicon_source.cc",
+    "//chrome/browser/ui/webui/favicon_source.h",
+  ]
+
+  deps = [
+    "//components/favicon/core",
+    "//components/favicon_base",
+    "//components/history/core/browser",
+    "//net",
+    "//ui/native_theme",
+    "//url",
+  ]
+}
+
 source_set("ui") {
   sources = [
     "webui/basic_ui.cc",
@@ -201,6 +217,14 @@ source_set("ui") {
     "//ui/gfx",
     "//ui/resources",
   ]
+
+  # This is no longer compiled into Chromium on Android, but we still
+  # need it
+  if (is_android) {
+    deps += [
+      ":favicon_source",
+    ]
+  }
 
   if (enable_brave_sync) {
     deps += [

--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -297,12 +297,11 @@ RewardsDOMHandler::~RewardsDOMHandler() {
 
 void RewardsDOMHandler::RegisterMessages() {
 #if defined(OS_ANDROID)
-  // TODO(sergz) figure out why we have link error here
   // Create our favicon data source.
-  // Profile* profile = Profile::FromWebUI(web_ui());
-  // content::URLDataSource::Add(profile,
-  //                            std::make_unique<FaviconSource>(profile,
-  //                            chrome::FaviconUrlFormat::kFaviconLegacy));
+  Profile* profile = Profile::FromWebUI(web_ui());
+  content::URLDataSource::Add(
+      profile, std::make_unique<FaviconSource>(
+                   profile, chrome::FaviconUrlFormat::kFaviconLegacy));
 #endif
 
   web_ui()->RegisterMessageCallback("brave_rewards.createWalletRequested",

--- a/chromium_src/chrome/browser/ui/webui/favicon_source.cc
+++ b/chromium_src/chrome/browser/ui/webui/favicon_source.cc
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 The Brave Authors
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "build/build_config.h"
+
+#if defined(OS_ANDROID)
+#define IDR_DEFAULT_FAVICON_32 IDR_DEFAULT_FAVICON
+#define IDR_DEFAULT_FAVICON_64 IDR_DEFAULT_FAVICON
+#define IDR_DEFAULT_FAVICON_DARK_32 IDR_DEFAULT_FAVICON_DARK
+#define IDR_DEFAULT_FAVICON_DARK_64 IDR_DEFAULT_FAVICON_DARK
+#endif
+
+#include "../../../../../chrome/browser/ui/webui/favicon_source.cc"  // NOLINT


### PR DESCRIPTION
Fix github.com/brave/brave-browser/issues/7111

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Enable Rewards
1. Visit a website like google.com for > 8 seconds
1. Ensure that entry in Rewards auto-contribute table has the correct favicon associated with it

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
