### PR TITLE
Disable removal of Google repo in Debian package

### DIFF
--- a/patches/chrome-installer-linux-common-repo.cron.patch
+++ b/patches/chrome-installer-linux-common-repo.cron.patch
@@ -1,20 +1,11 @@
 diff --git a/chrome/installer/linux/common/repo.cron b/chrome/installer/linux/common/repo.cron
-index 2750e4924da6d0a723c1d649781637e7d08b3562..2b9a3f3591a93a033a93e201b2b1a1d13ebbecd4 100755
+index 2750e4924da6d0a723c1d649781637e7d08b3562..fbe7797e37633de174f4a83d7b11bf04b8813c1a 100755
 --- a/chrome/installer/linux/common/repo.cron
 +++ b/chrome/installer/linux/common/repo.cron
-@@ -17,6 +17,18 @@
+@@ -17,6 +17,9 @@
  # "false" as desired. An empty $DEFAULTS_FILE is the same as setting both values
  # to "false".
  
-+# Remove Chrome repo if erroneously added (brave/brave-browser#2927)
-+if [ -e "/etc/apt/sources.list.d/@@PACKAGE@@.list" ] ; then
-+  if [ ! -e "/etc/apt/sources.list.d/google-chrome.list" -a ! -e "/etc/apt/sources.list.d/google-chrome-beta.list" -a ! -e "/etc/apt/sources.list.d/google-chrome-unstable.list" ] ; then
-+    apt-key del D38B4796
-+  fi
-+  rm -f "/etc/default/@@PACKAGE@@"
-+  rm "/etc/apt/sources.list.d/@@PACKAGE@@.list"
-+fi
-+
 +# Don't add the Chrome repo (brave/brave-browser#1084)
 +exit 0
 +

--- a/patches/chrome-installer-linux-common-rpmrepo.cron.patch
+++ b/patches/chrome-installer-linux-common-rpmrepo.cron.patch
@@ -1,20 +1,11 @@
 diff --git a/chrome/installer/linux/common/rpmrepo.cron b/chrome/installer/linux/common/rpmrepo.cron
-index f7fe2bcf7d7cbf95b23067f21f87422706c5e4d0..3dbad7d3a412efb023f3d57707fe6723d5a78e66 100755
+index f7fe2bcf7d7cbf95b23067f21f87422706c5e4d0..3541826a03009e2adb8dbd6c258d254d31247a77 100755
 --- a/chrome/installer/linux/common/rpmrepo.cron
 +++ b/chrome/installer/linux/common/rpmrepo.cron
-@@ -14,6 +14,18 @@
+@@ -14,6 +14,9 @@
  # setting "repo_add_once" to "true" or "false" as desired. An empty
  # $DEFAULTS_FILE is the same as setting the value to "false".
  
-+# Remove Chrome repo if erroneously added (brave/brave-browser#2927)
-+if [ -e "/etc/yum.repos.d/@@PACKAGE@@.repo" ] ; then
-+  if [ ! -e "/etc/yum.repos.d/google-chrome.repo" -a ! -e "/etc/yum.repos.d/google-chrome-beta.repo" -a ! -e "/etc/yum.repos.d/google-chrome-unstable.repo" ] ; then
-+    rpm -e gpg-pubkey-7fac5991-4615767f
-+    rpm -e gpg-pubkey-d38b4796-570c8cd3
-+  fi
-+  rm "/etc/yum.repos.d/@@PACKAGE@@.repo"
-+fi
-+
 +# Don't add the Chrome repo (brave/brave-browser#1967)
 +exit 0
 +

--- a/patches/chrome-installer-linux-debian-postrm.patch
+++ b/patches/chrome-installer-linux-debian-postrm.patch
@@ -1,0 +1,9 @@
+diff --git a/chrome/installer/linux/debian/postrm b/chrome/installer/linux/debian/postrm
+index 85b9961013ff276c13810d32ec8d927859abba37..542e1298f986d90579182ecdf2c870365190f349 100755
+--- a/chrome/installer/linux/debian/postrm
++++ b/chrome/installer/linux/debian/postrm
+@@ -30,4 +30,3 @@ if [ -s "$DEFAULTS_FILE" ]; then
+   rm "$DEFAULTS_FILE" || exit 1
+ fi
+ # Remove any Google repository added by the package.
+-clean_sources_lists


### PR DESCRIPTION
Fixes brave/brave-browser#6912 and removes cleanup added to fix brave/brave-browser#2927.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Build the new `.deb` and then in a clean 

1. Install the repo and the `brave-keyring` package:

       sudo apt install apt-transport-https curl
       curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key --keyring /etc/apt/trusted.gpg.d/brave-browser-release.gpg add -
       echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser.list
       sudo apt update
       sudo apt install brave-keyring

2. Confirm that the `/etc/apt/sources.list.d/brave-browser.list` exists and is not empty.

3. Install the `brave-browser` package:

       sudo dpkg -i brave-browser-*.deb

4. Confirm that `/etc/apt/sources.list.d/brave-browser.list` still exists after installation and is not empty.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
