### PR TITLE
Cleanup BraveAppMenuModel and its test

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -53,6 +53,8 @@ void BraveAppMenuModel::InsertBraveMenuItems() {
   ui::SimpleMenuModel* model = static_cast<ui::SimpleMenuModel*>(
       GetSubmenuModelAt(GetIndexOfCommandId(IDC_MORE_TOOLS_MENU)));
   DCHECK(model);
+  // More tools menu adds extensions item always.
+  DCHECK_NE(-1, model->GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS));
   model->RemoveItemAt(model->GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS));
 
   if (IsCommandIdEnabled(IDC_MANAGE_EXTENSIONS)) {

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -28,6 +28,16 @@
 
 using BraveAppMenuBrowserTest = InProcessBrowserTest;
 
+void CheckCommandsAreDisabledInMenuModel(
+    Browser* browser,
+    const std::vector<int>& disabled_commands) {
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
+  BraveAppMenuModel model(browser_view->toolbar(), browser);
+  model.Init();
+  for (int id : disabled_commands)
+    EXPECT_EQ(-1, model.GetIndexOfCommandId(id));
+}
+
 void CheckCommandsAreInOrderInMenuModel(
     Browser* browser,
     const std::vector<int>& commands_in_order) {
@@ -80,6 +90,8 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
   };
   CheckCommandsAreInOrderInMenuModel(browser(),
                                      commands_in_order_for_normal_profile);
+  CheckCommandsAreDisabledInMenuModel(browser(),
+                                      commands_disabled_for_normal_profile);
 
   auto* private_browser = CreateIncognitoBrowser();
   std::vector<int> commands_in_order_for_private_profile = {
@@ -112,6 +124,8 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
   };
   CheckCommandsAreInOrderInMenuModel(private_browser,
                                      commands_in_order_for_private_profile);
+  CheckCommandsAreDisabledInMenuModel(private_browser,
+                                      commands_disabled_for_private_profile);
 
   content::WindowedNotificationObserver browser_creation_observer(
       chrome::NOTIFICATION_BROWSER_OPENED,
@@ -138,6 +152,28 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
   };
   CheckCommandsAreInOrderInMenuModel(guest_browser,
                                      commands_in_order_for_guest_profile);
+  std::vector<int> commands_disabled_for_guest_profile = {
+    IDC_NEW_INCOGNITO_WINDOW,
+#if BUILDFLAG(ENABLE_TOR)
+    IDC_NEW_OFFTHERECORD_WINDOW_TOR,
+#endif
+#if BUILDFLAG(BRAVE_REWARDS_ENABLED)
+    IDC_SHOW_BRAVE_REWARDS,
+#endif
+    IDC_RECENT_TABS_MENU,
+    IDC_BOOKMARKS_MENU,
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+    IDC_SHOW_BRAVE_WALLET,
+#endif
+    IDC_MANAGE_EXTENSIONS,
+#if BUILDFLAG(ENABLE_BRAVE_SYNC)
+    IDC_SHOW_BRAVE_SYNC,
+#endif
+    IDC_ADD_NEW_PROFILE,
+    IDC_OPEN_GUEST_PROFILE,
+  };
+  CheckCommandsAreDisabledInMenuModel(guest_browser,
+                                      commands_disabled_for_guest_profile);
 
   content::WindowedNotificationObserver tor_browser_creation_observer(
       chrome::NOTIFICATION_BROWSER_OPENED,
@@ -177,9 +213,10 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, MenuOrderTest) {
     IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER
   };
   std::vector<int> commands_disabled_for_tor_profile = {
-    IDC_NEW_TOR_CONNECTION_FOR_SITE,
     IDC_RECENT_TABS_MENU,
   };
   CheckCommandsAreInOrderInMenuModel(tor_browser,
                                      commands_in_order_for_tor_profile);
+  CheckCommandsAreDisabledInMenuModel(tor_browser,
+                                      commands_disabled_for_tor_profile);
 }


### PR DESCRIPTION
Added DCHECK for checking extensions item is always added to more tools
menu and added more disabled menu items check in its browser tests.

fix https://github.com/brave/brave-browser/issues/7565

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_browser_tests -- --filter=*BraveAppMenu*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
