### PR TITLE
Changed android version code generation

### DIFF
--- a/patches/build-util-android_chrome_version.py.patch
+++ b/patches/build-util-android_chrome_version.py.patch
@@ -1,0 +1,13 @@
+diff --git a/build/util/android_chrome_version.py b/build/util/android_chrome_version.py
+index eb58b2f97e9129a52e2b9f67b7534cf7e8cc199a..37969e5812bb105011edb60ba83c8de88c4e2020 100644
+--- a/build/util/android_chrome_version.py
++++ b/build/util/android_chrome_version.py
+@@ -142,7 +142,7 @@ def GenerateVersionCodes(version_values, arch, is_next_build):
+   Thus, this method is responsible for the final two digits of versionCode.
+   """
+ 
+-  base_version_code = '%s%03d00' % (version_values['BUILD'],
++  base_version_code = '%02d%02d%03d00' % (int(version_values['MINOR']) + 40, int(version_values['BUILD']),
+                                     int(version_values['PATCH']))
+   new_version_code = int(base_version_code)
+ 


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
