### PR TITLE
Fix 6633: Prevent click event from bubbling up to the toggle (uplift to 1.2.x)

### DIFF
--- a/browser/resources/settings/brave_privacy_page/brave_personalization_options.js
+++ b/browser/resources/settings/brave_privacy_page/brave_personalization_options.js
@@ -85,7 +85,8 @@ Polymer({
     return enabled != this.browserProxy_.wasPushMessagingEnabledAtStartup();
   },
 
-  restartBrowser_: function() {
+  restartBrowser_: function(e) {
+    e.stopPropagation();
     window.open("chrome://restart", "_self");
   },
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/4042
Fixes https://github.com/brave/brave-browser/issues/6633

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.