### PR TITLE
Greaselion local repo path and hot-reloading

### DIFF
--- a/components/greaselion/browser/BUILD.gn
+++ b/components/greaselion/browser/BUILD.gn
@@ -7,6 +7,8 @@ source_set("browser") {
     "greaselion_service.h",
     "greaselion_service_impl.cc",
     "greaselion_service_impl.h",
+    "switches.cc",
+    "switches.h",
   ]
 
   deps = [

--- a/components/greaselion/browser/greaselion_download_service.h
+++ b/components/greaselion/browser/greaselion_download_service.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/files/file_path_watcher.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/sequence_checker.h"
@@ -99,6 +100,7 @@ class GreaselionDownloadService : public LocalDataFilesObserver {
   friend class ::GreaselionServiceTest;
 
   void OnDATFileDataReady(std::string contents);
+  void OnDevModeLocalFileChanged(const base::FilePath& path, bool error);
   void LoadOnTaskRunner();
   void LoadDirectlyFromResourcePath();
 
@@ -106,6 +108,7 @@ class GreaselionDownloadService : public LocalDataFilesObserver {
   std::vector<std::unique_ptr<GreaselionRule>> rules_;
   base::FilePath resource_dir_;
   bool is_dev_mode_ = false;
+  std::unique_ptr<base::FilePathWatcher> dev_mode_path_watcher_;
 
   SEQUENCE_CHECKER(sequence_checker_);
   base::WeakPtrFactory<GreaselionDownloadService> weak_factory_;

--- a/components/greaselion/browser/greaselion_download_service.h
+++ b/components/greaselion/browser/greaselion_download_service.h
@@ -45,7 +45,7 @@ class GreaselionRule {
   void Parse(base::DictionaryValue* preconditions_value,
              base::ListValue* urls_value,
              base::ListValue* scripts_value,
-             const base::FilePath& root_dir);
+             const base::FilePath& resource_dir);
   ~GreaselionRule();
 
   bool Matches(GreaselionFeatures state) const;
@@ -100,10 +100,12 @@ class GreaselionDownloadService : public LocalDataFilesObserver {
 
   void OnDATFileDataReady(std::string contents);
   void LoadOnTaskRunner();
+  void LoadDirectlyFromResourcePath();
 
   base::ObserverList<Observer> observers_;
   std::vector<std::unique_ptr<GreaselionRule>> rules_;
-  base::FilePath install_dir_;
+  base::FilePath resource_dir_;
+  bool is_dev_mode_ = false;
 
   SEQUENCE_CHECKER(sequence_checker_);
   base::WeakPtrFactory<GreaselionDownloadService> weak_factory_;

--- a/components/greaselion/browser/greaselion_service_impl.cc
+++ b/components/greaselion/browser/greaselion_service_impl.cc
@@ -141,7 +141,8 @@ scoped_refptr<Extension> ConvertGreaselionRuleToExtensionOnTaskRunner(
   // Copy the script files to our extension directory.
   for (auto script : rule->scripts()) {
     if (!base::CopyFile(script, temp_dir.GetPath().Append(script.BaseName()))) {
-      LOG(ERROR) << "Could not copy Greaselion script";
+      LOG(ERROR) << "Could not copy Greaselion script at path: "
+          << script.LossyDisplayName();
       return nullptr;
     }
   }

--- a/components/greaselion/browser/switches.cc
+++ b/components/greaselion/browser/switches.cc
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/greaselion/browser/switches.h"
+
+#include "base/command_line.h"
+
+namespace greaselion {
+namespace switches {
+
+// Allows disabling Brave Sync.
+const char kGreaselionDataPath[] = "greaselion-data-path";
+
+}  // namespace switches
+}  // namespace greaselion

--- a/components/greaselion/browser/switches.h
+++ b/components/greaselion/browser/switches.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_GREASELION_BROWSER_SWITCHES_H_
+#define BRAVE_COMPONENTS_GREASELION_BROWSER_SWITCHES_H_
+
+namespace greaselion {
+namespace switches {
+
+// Allows forcing greaselion to use a local directory to find
+// the greaselion.json rule file and associated scripts.
+extern const char kGreaselionDataPath[];
+
+}  // namespace switches
+}  // namespace greaselion
+
+#endif  // BRAVE_COMPONENTS_GREASELION_BROWSER_SWITCHES_H_


### PR DESCRIPTION
Two commits that fall under the same "greaselion dev experience" umbrella.

## 1. Add cli switch to force local script path (--greaselion-data-path)
Fix https://github.com/brave/brave-browser/issues/7621

Enables a better development scenario where the developer can use the local source repository for greaselion scripts. Previously, the only supported scenario was modifying the browser profile data directory directly and copying / pasting the scripts back and forth (or attempting a FS symbolic link).

#### Test plan:
1. Clone brave/brave-site-specific-scripts to a local path
2. Add a rule to the cloned repo graselion.json and a corresponding script
```
# greaselion.json
[
  {
    "urls": [
      "https://brave.com/*"
    ],
    "scripts": [
      "brave.js"
    ]
  }
]

# brave.js
console.log('hello from your local repo')
```
3. Start the browser specifying the flag
```
npm start -- --greaselion-data-path=/Path/To/Your/Greaselion/Scripts/Repo`
```
4. Load `https://brave.com`
5. Open the DevTools and observe the expected message in the console

## 2. Hot-Reload when scripts change in dev mode
Fix https://github.com/brave/brave-browser/issues/7622

Recreates generated extensions when any files in the cli-flag-specified resource directory changes. Allows for more rapid development.

#### Test plan:
1. Follow previous test plan
3. Make a change to the script (`console.log('2')`
4. Refresh the tab and observe the new message is logged instead of the original 🍾 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
