### PR TITLE
Fixes ads serve catalog version mismatch for v2 catalogs

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_serve.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_serve.cc
@@ -50,7 +50,7 @@ void AdsServe::BuildUrl() {
     }
   }
 
-  url_ += CATALOG_PATH;
+  url_ += "/v" + std::to_string(kCatalogVersion) + "/catalog";
 }
 
 void AdsServe::DownloadCatalog() {

--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog_state.cc
@@ -50,7 +50,7 @@ Result CatalogState::FromJson(
   new_catalog_id = catalog["catalogId"].GetString();
 
   new_version = catalog["version"].GetUint64();
-  if (new_version != 1) {
+  if (new_version != kCatalogVersion) {
     // TODO(Terry Mancey): Implement Log (#44)
     // 'patch invalid', { reason: 'unsupported version', version: version }
     return SUCCESS;

--- a/vendor/bat-native-ads/src/bat/ads/internal/static_values.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/static_values.h
@@ -18,7 +18,7 @@ namespace ads {
 #define STAGING_SERVER "https://ads-serve.bravesoftware.com"
 #define DEVELOPMENT_SERVER "https://ads-serve.brave.software"
 
-#define CATALOG_PATH "/v2/catalog"
+const int kCatalogVersion = 2;
 
 const int kIdleThresholdInSeconds = 15;
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7632

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

See https://github.com/brave/brave-browser/issues/7632

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
