### PR TITLE
[Android] Fix rewards balance is not up-to-date in rewards settings page.

### DIFF
--- a/components/brave_rewards/resources/android_page/components/settingsPage.tsx
+++ b/components/brave_rewards/resources/android_page/components/settingsPage.tsx
@@ -81,6 +81,12 @@ class SettingsPage extends React.Component<Props, State> {
       this.actions.onSettingSave('firstLoad', false)
     }
 
+    this.actions.getWalletProperties()
+    this.actions.getBalance()
+    this.balanceTimerId = setInterval(() => {
+      this.actions.getBalance()
+    }, 60000)
+
     if (this.props.rewardsData.firstLoad === false) {
       this.refreshActions()
     } else {
@@ -103,7 +109,6 @@ class SettingsPage extends React.Component<Props, State> {
       this.props.rewardsData.enabledMain
     ) {
       this.refreshActions()
-      this.actions.getBalance()
     }
 
     if (


### PR DESCRIPTION
Trigger getBalance when component is mounted and repeat it every min like we do currently on desktop.

Fix https://github.com/brave/brave-browser/issues/7107

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
   1. Clean profile
   2. Enable rewards
   3. Fund the wallet through uphold.com
   4. Click on BR panel and observe balance is reflected in BR panel
   5. Wallet balance should be reflected in the rewards settings page 
   6. Restart the browser and observe balance is reflected in the rewards settings page

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
