### PR TITLE
Fixes internal server error 500 can cause Confirmations to get stuck in the retry queue

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.cc
@@ -7,28 +7,16 @@
 
 namespace confirmations {
 
-ConfirmationInfo::ConfirmationInfo() :
-    id(""),
-    creative_instance_id(""),
-    type(ConfirmationType::UNKNOWN),
-    token_info(TokenInfo()),
-    payment_token(nullptr),
-    blinded_payment_token(nullptr),
-    credential(""),
-    timestamp_in_seconds(0),
-    created(false) {}
+ConfirmationInfo::ConfirmationInfo()
+    : type(ConfirmationType::UNKNOWN),
+      payment_token(nullptr),
+      blinded_payment_token(nullptr),
+      timestamp_in_seconds(0),
+      created(false) {}
 
-ConfirmationInfo::ConfirmationInfo(const ConfirmationInfo& info) :
-    id(info.id),
-    creative_instance_id(info.creative_instance_id),
-    type(info.type),
-    token_info(info.token_info),
-    payment_token(info.payment_token),
-    blinded_payment_token(info.blinded_payment_token),
-    credential(info.credential),
-    timestamp_in_seconds(info.timestamp_in_seconds),
-    created(info.created) {}
+ConfirmationInfo::ConfirmationInfo(
+    const ConfirmationInfo& info) = default;
 
-ConfirmationInfo::~ConfirmationInfo() {}
+ConfirmationInfo::~ConfirmationInfo() = default;
 
 }  // namespace confirmations

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
@@ -21,7 +21,8 @@ namespace confirmations {
 
 struct ConfirmationInfo {
   ConfirmationInfo();
-  explicit ConfirmationInfo(const ConfirmationInfo& info);
+  ConfirmationInfo(
+      const ConfirmationInfo& info);
   ~ConfirmationInfo();
 
   std::string id;


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7654

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Discuss with @amirsaber and @tmancey how we can test the following scenarios:

- Internal server error 500 where the POST /v1/confirmation/{confirmation_id}/{credential} end-point successfully creates a confirmation (will require assistance from @amirsaber)
- Internal server error 500 where the POST /v1/confirmation/{confirmation_id}/{credential} end-point fails to create a confirmation (can be recreated using Charles Proxy)

For both of the above scenarios, we need to make sure that failed confirmations retry and are successfully redeemed

@jsecretan experienced this issue and provided his broken user profile for testing

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
