### PR TITLE
Improve warning text contrast on Shields dark mode

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/structure/index.ts
+++ b/components/brave_extension/extension/brave_extension/components/structure/index.ts
@@ -476,6 +476,7 @@ export const Overlay = styled<{}, 'div'>('div')`
 export const WarningText = styled<{}, 'p'>('p')`
   margin: 0 0 24px;
   line-height: 18px;
+  color: ${p => p.theme.color.text};
 `
 
 export const WarningModal = styled<{}, 'div'>('div')`


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7628

When opening Shields advanced panel in dark mode for the first time, users see a warning text with low contrast, making reading difficult.

## Test Plan:

1. Fresh profile
2. Set Brave theme to dark mode
3. Open Shields
4. Toggle to the advanced panel view
5. Text should be visible (#FFF)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
