### PR TITLE
Use a stubbed NativeTheme on Android to allow favicons to work

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/favicon_source.cc
+++ b/chromium_src/chrome/browser/ui/webui/favicon_source.cc
@@ -6,6 +6,9 @@
 #include "build/build_config.h"
 
 #if defined(OS_ANDROID)
+#include "ui/native_theme/native_theme.h"
+
+#define GetInstanceForNativeUi BraveGetInstanceForNativeUi
 #define IDR_DEFAULT_FAVICON_32 IDR_DEFAULT_FAVICON
 #define IDR_DEFAULT_FAVICON_64 IDR_DEFAULT_FAVICON
 #define IDR_DEFAULT_FAVICON_DARK_32 IDR_DEFAULT_FAVICON_DARK

--- a/chromium_src/ui/native_theme/native_theme.h
+++ b/chromium_src/ui/native_theme/native_theme.h
@@ -6,9 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_UI_NATIVE_THEME_NATIVE_THEME_H_
 #define BRAVE_CHROMIUM_SRC_UI_NATIVE_THEME_NATIVE_THEME_H_
 
-#define BRAVE_UI_NATIVE_THEME_NATIVE_THEME_H_ \
-  friend void SetUseDarkColors(bool dark_mode); \
-  friend void ReCalcAndSetPreferredColorScheme();
+#define BRAVE_UI_NATIVE_THEME_NATIVE_THEME_H_     \
+  friend void SetUseDarkColors(bool dark_mode);   \
+  friend void ReCalcAndSetPreferredColorScheme(); \
+  static NativeTheme* BraveGetInstanceForNativeUi();
 
 #include "../../../../ui/native_theme/native_theme.h"
 #undef BRAVE_UI_NATIVE_THEME_NATIVE_THEME_H_

--- a/chromium_src/ui/native_theme/native_theme_android.cc
+++ b/chromium_src/ui/native_theme/native_theme_android.cc
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 The Brave Authors
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "../../../../../ui/native_theme/native_theme_android.cc"
+
+ui::NativeTheme* ui::NativeTheme::BraveGetInstanceForNativeUi() {
+  struct StubNativeThemeAndroid : public ui::NativeThemeAndroid {
+    bool ShouldUseDarkColors() const override { return false; }
+  };
+  static base::NoDestructor<StubNativeThemeAndroid> s_native_theme;
+  return s_native_theme.get();
+}


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7657

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
