### PR TITLE
Default OOP rasterization to off (original value) (uplift to 1.3.x)

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -144,10 +144,6 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
       switches::kExtensionContentVerificationEnforceStrict);
   command_line.AppendSwitchASCII(switches::kExtensionsInstallVerification,
       "enforce");
-  // Otherwise BaseMark Web 3.0 suffers and it seems to be highly enabled
-  // by field trials in Chrome.
-  command_line.AppendSwitchASCII(switches::kEnableOopRasterization,
-      "Enabled");
 
   // Brave's sync protocol does not use the sync service url
   command_line.AppendSwitchASCII(switches::kSyncServiceURL,


### PR DESCRIPTION
Uplift of #4318
Fixes https://github.com/brave/brave-browser/issues/7581
Fixes https://github.com/brave/brave-browser/issues/6979

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.