### PR TITLE
added more tests to github upload

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -35,17 +35,13 @@ def dist_dir(target_os, target_arch):
 
 
 def output_dir(target_os, target_arch):
+    target_os_prefix = ''
     if target_os in ['android', 'ios']:
         target_os_prefix = target_os + '_'
-    else:
-        target_os_prefix = ''
 
-    if target_os_prefix:
+    target_arch_suffix = ''
+    if target_arch != 'x64':
         target_arch_suffix = '_' + target_arch
-    elif target_arch != 'x64':
-        target_arch_suffix = '_' + target_arch
-    else:
-        target_arch_suffix = ''
 
     return os.path.join(CHROMIUM_ROOT, 'out', target_os_prefix + 'Release' + target_arch_suffix)
 

--- a/script/test/test_config.py
+++ b/script/test/test_config.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+from lib import config
+
+
+class TestConfig(unittest.TestCase):
+
+    def test_output_dir_android_arm(self):
+        self.assertEquals(config.output_dir('android', 'arm').endswith('android_Release_arm'), True)
+
+    def test_output_dir_android_arm64(self):
+        self.assertEquals(config.output_dir('android', 'arm64').endswith('android_Release_arm64'), True)
+
+    def test_output_dir_android_x86(self):
+        self.assertEquals(config.output_dir('android', 'x86').endswith('android_Release_x86'), True)
+
+    def test_output_dir_android_x64(self):
+        self.assertEquals(config.output_dir('android', 'x64').endswith('android_Release'), True)
+
+    def test_output_dir_darwin_x64(self):
+        self.assertEquals(config.output_dir('darwin', 'x64').endswith('Release'), True)
+
+    def test_output_dir_linux_x64(self):
+        self.assertEquals(config.output_dir('linux', 'x64').endswith('Release'), True)
+
+    def test_output_dir_win32_x86(self):
+        self.assertEquals(config.output_dir('win32', 'x86').endswith('Release_x86'), True)
+
+    def test_output_dir_win32_x64(self):
+        self.assertEquals(config.output_dir('win32', 'x64').endswith('Release'), True)

--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -71,6 +71,105 @@ class TestGetBravePackages(unittest.TestCase):
                         f.write(name32 + '\n')
         self.__class__._is_setup = True
 
+    def test_only_returns_android_packages(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', ''))
+        self.assertEquals(pkgs,
+                          sorted(['BraveModernarm.apk',
+                                  'BraveModernx86.apk',
+                                  'BraveMonoarm.apk',
+                                  'BraveMonoarm64.apk',
+                                  'BraveMonox64.apk',
+                                  'BraveMonox86.apk',
+                                  'Bravearm.apk',
+                                  'Bravex86.apk']))
+
+    def test_only_returns_android_packages_arm(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'arm'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveModernarm.apk',
+                                  'BraveMonoarm.apk',
+                                  'Bravearm.apk']))
+
+    def test_only_returns_android_packages_arm_classic(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'arm', 'classic'))
+        self.assertEquals(pkgs,
+                          sorted(['Bravearm.apk']))
+
+    def test_only_returns_android_packages_arm_modern(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'arm', 'modern'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveModernarm.apk']))
+
+    def test_only_returns_android_packages_arm_mono(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'arm', 'mono'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveMonoarm.apk']))
+
+    def test_only_returns_android_packages_arm64(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'arm64'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveMonoarm64.apk']))
+
+    def test_only_returns_android_packages_x86(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'x86'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveModernx86.apk',
+                                  'BraveMonox86.apk',
+                                  'Bravex86.apk']))
+
+    def test_only_returns_android_packages_x86_classic(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'x86', 'classic'))
+        self.assertEquals(pkgs,
+                          sorted(['Bravex86.apk']))
+
+    def test_only_returns_android_packages_x86_modern(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'x86', 'modern'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveModernx86.apk']))
+
+    def test_only_returns_android_packages_x86_mono(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'x86', 'mono'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveMonox86.apk']))
+
+    def test_only_returns_android_packages_x64(self):
+        upload.PLATFORM = 'linux'
+        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
+                                                           'android'),
+                                              'nightly', '1.5.8', 'android', 'x64'))
+        self.assertEquals(pkgs,
+                          sorted(['BraveMonox64.apk']))
+
     def test_only_returns_nightly_darwin_packages(self):
         upload.PLATFORM = 'darwin'
         pkgs = list(upload.get_brave_packages(os.path.join(
@@ -294,105 +393,6 @@ class TestGetBravePackages(unittest.TestCase):
                                         'BraveBrowserStandaloneSilentSetup32.exe',
                                         'BraveBrowserStandaloneUntaggedSetup32.exe',
                                         'BraveBrowserUntaggedSetup32.exe']))
-
-    def test_only_returns_android_packages(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', ''))
-        self.assertEquals(pkgs,
-                          sorted(['BraveModernarm.apk',
-                                  'BraveModernx86.apk',
-                                  'BraveMonoarm.apk',
-                                  'BraveMonoarm64.apk',
-                                  'BraveMonox64.apk',
-                                  'BraveMonox86.apk',
-                                  'Bravearm.apk',
-                                  'Bravex86.apk']))
-
-    def test_only_returns_android_packages_arm(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'arm'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveModernarm.apk',
-                                  'BraveMonoarm.apk',
-                                  'Bravearm.apk']))
-
-    def test_only_returns_android_packages_arm_classic(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'arm', 'classic'))
-        self.assertEquals(pkgs,
-                          sorted(['Bravearm.apk']))
-
-    def test_only_returns_android_packages_arm_modern(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'arm', 'modern'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveModernarm.apk']))
-
-    def test_only_returns_android_packages_arm_mono(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'arm', 'mono'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveMonoarm.apk']))
-
-    def test_only_returns_android_packages_arm64(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'arm64'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveMonoarm64.apk']))
-
-    def test_only_returns_android_packages_x86(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'x86'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveModernx86.apk',
-                                  'BraveMonox86.apk',
-                                  'Bravex86.apk']))
-
-    def test_only_returns_android_packages_x86_classic(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'x86', 'classic'))
-        self.assertEquals(pkgs,
-                          sorted(['Bravex86.apk']))
-
-    def test_only_returns_android_packages_x86_modern(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'x86', 'modern'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveModernx86.apk']))
-
-    def test_only_returns_android_packages_x86_mono(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'x86', 'mono'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveMonox86.apk']))
-
-    def test_only_returns_android_packages_x64(self):
-        upload.PLATFORM = 'linux'
-        pkgs = list(upload.get_brave_packages(os.path.join(self.get_pkgs_dir,
-                                                           'android'),
-                                              'nightly', '1.5.8', 'android', 'x64'))
-        self.assertEquals(pkgs,
-                          sorted(['BraveMonox64.apk']))
 
 # get an existing release (in draft status) from GitHub given a tag name
 


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
