### PR TITLE
Fixes ads enabled by default on upgrade of 1.2 to 1.3 for new ad regions

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -605,7 +605,9 @@ ExtensionFunction::ResponseAction BraveRewardsSaveAdsSettingFunction::Run() {
   AdsService* ads_service_ = AdsServiceFactory::GetForProfile(profile);
   if (ads_service_) {
     if (params->key == "adsEnabled") {
-      ads_service_->SetEnabled(params->value == "true");
+      const auto is_enabled =
+          params->value == "true" && ads_service_->IsSupportedLocale();
+      ads_service_->SetEnabled(is_enabled);
     } else if (params->key == "shouldAllowAdConversionTracking") {
       ads_service_->SetAllowAdConversionTracking(params->value == "true");
     }

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1237,7 +1237,8 @@ bool AdsServiceImpl::MigratePrefs(
     {{2, 3}, &AdsServiceImpl::MigratePrefsVersion2To3},
     {{3, 4}, &AdsServiceImpl::MigratePrefsVersion3To4},
     {{4, 5}, &AdsServiceImpl::MigratePrefsVersion4To5},
-    {{5, 6}, &AdsServiceImpl::MigratePrefsVersion5To6}
+    {{5, 6}, &AdsServiceImpl::MigratePrefsVersion5To6},
+    {{6, 7}, &AdsServiceImpl::MigratePrefsVersion6To7}
   };
 
   // Cycle through migration paths, i.e. if upgrading from version 2 to 5 we
@@ -1420,6 +1421,72 @@ void AdsServiceImpl::MigratePrefsVersion5To6() {
   // migrate to the new value
 
   SetUint64Pref(prefs::kAdsPerDay, 20);
+}
+
+void AdsServiceImpl::MigratePrefsVersion6To7() {
+  // Disable ads for newly supported regions due to a bug where ads were enabled
+  // even if the users region was not supported
+
+  const auto locale = GetLocale();
+  const auto region = ads::Ads::GetRegion(locale);
+
+  const std::vector<std::string> legacy_regions = {
+    "US",  // United States of America
+    "CA",  // Canada
+    "GB",  // United Kingdom (Great Britain and Northern Ireland)
+    "DE",  // Germany
+    "FR",  // France
+    "AU",  // Australia
+    "NZ",  // New Zealand
+    "IE",  // Ireland
+    "AR",  // Argentina
+    "AT",  // Austria
+    "BR",  // Brazil
+    "CH",  // Switzerland
+    "CL",  // Chile
+    "CO",  // Colombia
+    "DK",  // Denmark
+    "EC",  // Ecuador
+    "IL",  // Israel
+    "IN",  // India
+    "IT",  // Italy
+    "JP",  // Japan
+    "KR",  // Korea
+    "MX",  // Mexico
+    "NL",  // Netherlands
+    "PE",  // Peru
+    "PH",  // Philippines
+    "PL",  // Poland
+    "SE",  // Sweden
+    "SG",  // Singapore
+    "VE",  // Venezuela
+    "ZA",  // South Africa
+    "KY"   // Cayman Islands
+  };
+
+  const bool is_a_legacy_region = std::find(legacy_regions.begin(),
+      legacy_regions.end(), region) != legacy_regions.end();
+
+  if (is_a_legacy_region) {
+    // Do not disable Brave Ads for legacy regions introduced before version
+    // 1.3.x
+    return;
+  }
+
+  const int last_schema_version =
+      GetIntegerPref(prefs::kSupportedRegionsLastSchemaVersion);
+
+  if (last_schema_version >= 4) {
+    // Do not disable Brave Ads if |prefs::kSupportedRegionsLastSchemaVersion|
+    // is newer than or equal to schema version 4. This can occur if a user is
+    // upgrading from an older version of 1.3.x or above
+    return;
+  }
+
+  SetEnabled(false);
+
+  SetBooleanPref(prefs::kShouldShowOnboarding, true);
+  SetUint64Pref(prefs::kOnboardingTimestamp, 0);
 }
 
 int AdsServiceImpl::GetPrefsVersion() const {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -286,6 +286,7 @@ class AdsServiceImpl : public AdsService,
   void MigratePrefsVersion3To4();
   void MigratePrefsVersion4To5();
   void MigratePrefsVersion5To6();
+  void MigratePrefsVersion6To7();
   int GetPrefsVersion() const;
 
   bool IsUpgradingFromPreBraveAdsBuild();

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -55,7 +55,7 @@ const int kSupportedRegionsSchemaVersionNumber = 5;
 // Stores the preferences version number
 const char kVersion[] = "brave.brave_ads.prefs.version";
 
-const int kCurrentVersionNumber = 6;
+const int kCurrentVersionNumber = 7;
 
 }  // namespace prefs
 

--- a/components/brave_rewards/browser/rewards_service_browsertest.cc
+++ b/components/brave_rewards/browser/rewards_service_browsertest.cc
@@ -607,7 +607,7 @@ class BraveRewardsBrowserTest
       {"BraveAdsLocaleIsSupported", "en_US"},
       {"BraveAdsLocaleIsNotSupported", "en_XX"},
       {"BraveAdsLocaleIsNewlySupported", "ja_JP"},
-      {"BraveAdsLocaleIsNewlySupportedForLatestSchemaVersion", "en_VN"},
+      {"BraveAdsLocaleIsNewlySupportedForLatestSchemaVersion", newly_supported_locale_},  // NOLINT
       {"BraveAdsLocaleIsNotNewlySupported", "en_XX"},
       {"PRE_AutoEnableAdsForSupportedLocales", "en_US"},
       {"AutoEnableAdsForSupportedLocales", "en_US"},
@@ -638,14 +638,32 @@ class BraveRewardsBrowserTest
       return;
     }
 
-    const std::string supported_locale_parameter = parameters.at(1);
-    ASSERT_TRUE(!supported_locale_parameter.empty());
+    const ::testing::TestInfo* const test_info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    ASSERT_NE(nullptr, test_info);
+    const std::string test_name = test_info->name();
+
+    const std::string newly_supported_locale_parameter = parameters.at(2);
+    ASSERT_TRUE(!newly_supported_locale_parameter.empty());
 
     std::string locale;
-    if (supported_locale_parameter == "ForSupportedLocale") {
-      locale = "en_US";
+    if (test_name.find("PRE_UpgradePath") == 0) {
+      if (newly_supported_locale_parameter == "ForNewlySupportedLocale") {
+        locale = newly_supported_locale_;
+      } else {
+        locale = "en_US";
+      }
     } else {
-      locale = "en_XX";
+      const std::string supported_locale_parameter = parameters.at(1);
+      ASSERT_TRUE(!supported_locale_parameter.empty());
+
+      if (newly_supported_locale_parameter == "ForNewlySupportedLocale") {
+        locale = newly_supported_locale_;
+      } else if (supported_locale_parameter == "ForSupportedLocale") {
+        locale = "en_US";
+      } else {
+        locale = "en_XX";
+      }
     }
 
     MockLocaleHelper(locale);
@@ -712,20 +730,21 @@ class BraveRewardsBrowserTest
     //   1 = Parameters
 
     const std::string name = test_name_components.at(0);
-    if (name != "UpgradePath") {
+    if (name != "UpgradePath" && name != "PRE_UpgradePath") {
       return false;
     }
 
     // parameters:
     //   0 = Preferences
     //   1 = Supported locale
-    //   2 = Rewards enabled
-    //   3 = Ads enabled
-    //   4 = Should show notification
+    //   2 = Newly supported locale
+    //   3 = Rewards enabled
+    //   4 = Ads enabled
+    //   5 = Should show notification
 
     *parameters = base::SplitString(test_name_components.at(1), "_",
         base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
-    EXPECT_EQ(5UL, parameters->size());
+    EXPECT_EQ(6UL, parameters->size());
 
     return true;
   }
@@ -1695,6 +1714,8 @@ class BraveRewardsBrowserTest
   brave_ads::AdsServiceImpl* ads_service_;
 
   std::unique_ptr<brave_ads::LocaleHelperMock> locale_helper_mock_;
+  const std::string newly_supported_locale_ = "cs_CZ";
+
   std::unique_ptr<brave_ads::NotificationHelperMock> notification_helper_mock_;
 
   brave_rewards::Promotion promotion_;
@@ -3319,10 +3340,9 @@ IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(BraveRewardsBrowserTest,
     BraveAdsLocaleIsNewlySupportedForLatestSchemaVersion) {
-  // "BraveAdsLocaleIsNewlySupportedForLatestSchemaVersion" key in "const
-  // std::map<std::string, std::string> locale_for_tests" will need the value
-  // updating with a locale from the latest supported regions schema version
-  // defined in "vendor/bat-native-ads/src/bat/ads/internal/static_values.h"
+  // IMPORTANT: When adding new schema versions |newly_supported_locale_| must
+  // be updated in |BraveRewardsBrowserTest| to reflect a locale from the latest
+  // schema version in "bat-native-ads/src/bat/ads/internal/static_values.h"
 
   GetPrefs()->SetInteger(brave_ads::prefs::kSupportedRegionsLastSchemaVersion,
       brave_ads::prefs::kSupportedRegionsSchemaVersionNumber);
@@ -3445,6 +3465,10 @@ struct BraveAdsUpgradePathParamInfo {
   // supported locale; otherwise, should be set to |false|
   bool supported_locale;
 
+  // |newly_supported_locale| should be set to |true| if the locale should be
+  // set to a newly supported locale; otherwise, should be set to |false|
+  bool newly_supported_locale;
+
   // |rewards_enabled| should be set to |true| if Brave rewards should be
   // enabled after upgrade; otherwise, should be set to |false|
   bool rewards_enabled;
@@ -3470,13 +3494,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion062WithRewardsDisabled",
     false, /* supported_locale */
-    false, /* rewards_enabled */
-    false, /* ads_enabled */
-    false  /* should_show_onboarding */
-  },
-  {
-    "PreferencesForVersion062WithRewardsDisabled",
-    true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3484,13 +3502,39 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion062WithRewardsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion062WithRewardsDisabled",
+    true,  /* supported_locale */
+    false, /* newly_supported_locale */
+    false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
   },
   {
     "PreferencesForVersion062WithRewardsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion062WithRewardsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion062WithRewardsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3500,6 +3544,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion063WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3507,6 +3552,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion063WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3514,6 +3560,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion063WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3521,6 +3568,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion063WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3528,6 +3576,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion063WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3537,15 +3586,41 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   // {
   //   "PreferencesForVersion063WithRewardsAndAdsEnabled",
   //   true,  /* supported_locale */
+  //   false, /* newly_supported_locale */
   //   true,  /* rewards_enabled */
   //   true,  /* ads_enabled */
   //   false  /* should_show_onboarding */
   // },
+  {
+    "PreferencesForVersion063WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion063WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion063WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
 
   // Upgrade from 0.67 to current version
   {
     "PreferencesForVersion067WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3553,6 +3628,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion067WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3560,6 +3636,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion067WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3567,6 +3644,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion067WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3574,6 +3652,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion067WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3581,15 +3660,41 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion067WithRewardsAndAdsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     true,  /* ads_enabled */
     false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion067WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion067WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion067WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
   },
 
   // Upgrade from 0.68 to current version
   {
     "PreferencesForVersion068WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3597,6 +3702,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion068WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3604,6 +3710,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion068WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3611,6 +3718,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion068WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3618,6 +3726,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion068WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3625,15 +3734,41 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion068WithRewardsAndAdsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     true,  /* ads_enabled */
     false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion068WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion068WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion068WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
   },
 
   // Upgrade from 0.69 to current version
   {
     "PreferencesForVersion069WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3641,6 +3776,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion069WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3648,6 +3784,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion069WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3655,6 +3792,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion069WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3662,6 +3800,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion069WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3669,15 +3808,41 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion069WithRewardsAndAdsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     true,  /* ads_enabled */
     false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion069WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion069WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion069WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
   },
 
   // Upgrade from 0.70 to current version
   {
     "PreferencesForVersion070WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3685,6 +3850,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion070WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3692,6 +3858,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion070WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3699,6 +3866,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion070WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3706,6 +3874,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion070WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3713,15 +3882,41 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion070WithRewardsAndAdsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     true,  /* ads_enabled */
     false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion070WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion070WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion070WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
   },
 
   // Upgrade from 0.71 to current version
   {
     "PreferencesForVersion071WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3729,6 +3924,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion071WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3736,6 +3932,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion071WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3743,6 +3940,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion071WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3750,6 +3948,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion071WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3757,15 +3956,41 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion071WithRewardsAndAdsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     true,  /* ads_enabled */
     false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion071WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion071WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion071WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
   },
 
   // Upgrade from 0.72 to current version
   {
     "PreferencesForVersion072WithRewardsAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3773,6 +3998,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion072WithRewardsEnabledAndAdsDisabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3780,13 +4006,15 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion072WithRewardsAndAdsEnabled",
     false, /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
-    true, /* ads_enabled */
+    false, /* ads_enabled */
     false  /* should_show_onboarding */
   },
   {
     "PreferencesForVersion072WithRewardsAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     false, /* rewards_enabled */
     false, /* ads_enabled */
     false  /* should_show_onboarding */
@@ -3794,6 +4022,7 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion072WithRewardsEnabledAndAdsDisabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     false, /* ads_enabled */
     true   /* should_show_onboarding */
@@ -3801,20 +4030,124 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
   {
     "PreferencesForVersion072WithRewardsAndAdsEnabled",
     true,  /* supported_locale */
+    false, /* newly_supported_locale */
     true,  /* rewards_enabled */
     true,  /* ads_enabled */
     false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion072WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion072WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion072WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+
+  // Upgrade from 1.2 to current version
+  {
+    "PreferencesForVersion12WithRewardsAndAdsDisabled",
+    false, /* supported_locale */
+    false, /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsEnabledAndAdsDisabled",
+    false, /* supported_locale */
+    false, /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsAndAdsEnabled",
+    false, /* supported_locale */
+    false, /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    false, /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    false, /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    false, /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    true,  /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    false, /* rewards_enabled */
+    false, /* ads_enabled */
+    false  /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsEnabledAndAdsDisabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
+  },
+  {
+    "PreferencesForVersion12WithRewardsAndAdsEnabled",
+    true,  /* supported_locale */
+    true,  /* newly_supported_locale */
+    true,  /* rewards_enabled */
+    false, /* ads_enabled */
+    true   /* should_show_onboarding */
   }
 };
+
+IN_PROC_BROWSER_TEST_P(BraveAdsBrowserTest, PRE_UpgradePath) {
+  // Handled in |MaybeMockLocaleHelperForBraveAdsUpgradePath|
+}
 
 IN_PROC_BROWSER_TEST_P(BraveAdsBrowserTest, UpgradePath) {
   BraveAdsUpgradePathParamInfo param(GetParam());
 
+  EXPECT_EQ(IsRewardsEnabled(), param.rewards_enabled);
+
+  EXPECT_EQ(IsAdsEnabled(), param.ads_enabled);
+
   bool is_showing_notification = IsShowingNotificationForType(
       RewardsNotificationType::REWARDS_NOTIFICATION_ADS_ONBOARDING);
-
-  EXPECT_EQ(IsRewardsEnabled(), param.rewards_enabled);
-  EXPECT_EQ(IsAdsEnabled(), param.ads_enabled);
   EXPECT_EQ(is_showing_notification, param.should_show_onboarding);
 }
 
@@ -3827,6 +4160,9 @@ static std::string GetTestCaseName(
   const char* supported_locale = param_info.param.supported_locale ?
       "ForSupportedLocale" : "ForUnsupportedLocale";
 
+  const char* newly_supported_locale = param_info.param.newly_supported_locale ?
+      "ForNewlySupportedLocale" : "ForUnsupportedLocale";
+
   const char* rewards_enabled = param_info.param.rewards_enabled ?
       "RewardsShouldBeEnabled" : "RewardsShouldBeDisabled";
 
@@ -3838,8 +4174,9 @@ static std::string GetTestCaseName(
 
   // NOTE: You should not remove, change the format or reorder the following
   // parameters as they are parsed in |GetUpgradePathParams|
-  return base::StringPrintf("%s_%s_%s_%s_%s", preferences, supported_locale,
-      rewards_enabled, ads_enabled, should_show_onboarding);
+  return base::StringPrintf("%s_%s_%s_%s_%s_%s", preferences, supported_locale,
+      newly_supported_locale, rewards_enabled, ads_enabled,
+          should_show_onboarding);
 }
 
 INSTANTIATE_TEST_SUITE_P(BraveRewardsBrowserTest,

--- a/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsAndAdsDisabled
+++ b/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsAndAdsDisabled
@@ -1,0 +1,319 @@
+{
+  "account_id_migration_state": 2,
+  "account_tracker_service_last_update": "13223730695621666",
+  "apps": {
+    "shortcuts_version": 6
+  },
+  "autocomplete": {
+    "retention_policy_last_version": 79
+  },
+  "autofill": {
+    "orphan_rows_removed": true
+  },
+  "brave": {
+    "brave_ads": {
+      "ads_per_hour": "2",
+      "enabled": true,
+      "prefs": {
+        "version": 6
+      },
+      "supported_regions_last_schema_version_number": 0,
+      "supported_regions_schema_version_number": 4,
+      "should_show_first_launch_notification": true,
+      "were_disabled": false
+    },
+    "rewards": {
+      "badge_text": "",
+      "enabled": false,
+      "enabled_migrated": true,
+      "external_wallets": {
+        "uphold": {
+          "address": "",
+          "one_time_string": "E632B87C51F7CF75A5A45C0D6C914DE42BE52C15C90F27E84E65F6EC9193EEC4",
+          "status": 0,
+          "token": "",
+          "transferred": false,
+          "user_name": ""
+        }
+      },
+      "notifications": "{\"displayed\":[],\"notifications\":[]}",
+      "server_publisher_list_stamp": "1579257114"
+    }
+  },
+  "browser": {
+    "has_seen_welcome_page": true,
+    "window_placement": {
+      "bottom": 1252,
+      "left": 2876,
+      "maximized": false,
+      "right": 4024,
+      "top": 219,
+      "work_area_bottom": 1440,
+      "work_area_left": 2560,
+      "work_area_right": 5120,
+      "work_area_top": 23
+    }
+  },
+  "countryid_at_install": 16965,
+  "data_reduction": {
+    "daily_original_length": [
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "6743267"
+    ],
+    "daily_received_length": [
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "6743267"
+    ],
+    "last_update_date": "13223692800000000",
+    "network_properties": {},
+    "this_week_number": 2611,
+    "this_week_services_downstream_foreground_kb": {
+      "6019475": 153,
+      "11793316": 1,
+      "47942479": 1,
+      "51242536": 7,
+      "54845618": 6424,
+      "115765598": 1,
+      "119416099": 1
+    }
+  },
+  "default_apps_install_state": 3,
+  "extensions": {
+    "alerts": {
+      "initialized": true
+    },
+    "chrome_url_overrides": {},
+    "last_chrome_version": "79.1.2.42"
+  },
+  "gcm": {
+    "product_category_for_subtypes": "com.brave.macosx"
+  },
+  "google": {
+    "services": {
+      "signin_scoped_device_id": "a9b60c17-2147-4a24-9d9b-2990fa51a00e"
+    }
+  },
+  "http_original_content_length": "6743267",
+  "http_received_content_length": "6743267",
+  "invalidation": {
+    "per_sender_topics_to_handler": {
+      "8181035976": {}
+    }
+  },
+  "invalidator": {
+    "client_id": "WXdMSkOUiITLZaw8tWxkIw=="
+  },
+  "language_model_counters": {
+    "en": 1
+  },
+  "media": {
+    "device_id_salt": "9485B18C0C60A579F2CFA282023B50B7",
+    "engagement": {
+      "schema_version": 4
+    }
+  },
+  "media_router": {
+    "enable_media_router": false
+  },
+  "ntp": {
+    "num_personal_suggestions": 1
+  },
+  "plugins": {
+    "plugins_list": []
+  },
+  "previews": {
+    "litepage": {
+      "user-needs-notification": false
+    },
+    "offline_helper": {
+      "available_pages": {}
+    }
+  },
+  "profile": {
+    "avatar_bubble_tutorial_shown": 2,
+    "avatar_index": 26,
+    "block_third_party_cookies": true,
+    "content_settings": {
+      "exceptions": {
+        "accessibility_events": {},
+        "app_banner": {},
+        "auto_select_certificate": {},
+        "automatic_downloads": {},
+        "autoplay": {},
+        "background_sync": {},
+        "bluetooth_guard": {},
+        "bluetooth_scanning": {},
+        "client_hints": {},
+        "clipboard": {},
+        "cookies": {},
+        "durable_storage": {},
+        "flash_data": {},
+        "geolocation": {},
+        "hid_chooser_data": {},
+        "hid_guard": {},
+        "images": {},
+        "important_site_info": {},
+        "intent_picker_auto_display": {},
+        "javascript": {},
+        "legacy_cookie_access": {},
+        "media_engagement": {},
+        "media_stream_camera": {},
+        "media_stream_mic": {},
+        "midi_sysex": {},
+        "mixed_script": {},
+        "native_file_system_write_guard": {},
+        "notifications": {},
+        "password_protection": {},
+        "payment_handler": {},
+        "permission_autoblocking_data": {},
+        "plugins": {},
+        "popups": {},
+        "ppapi_broker": {},
+        "protocol_handler": {},
+        "sensors": {},
+        "serial_chooser_data": {},
+        "serial_guard": {},
+        "site_engagement": {},
+        "sound": {},
+        "ssl_cert_decisions": {},
+        "subresource_filter": {},
+        "subresource_filter_data": {},
+        "usb_chooser_data": {},
+        "usb_guard": {}
+      },
+      "pref_version": 1
+    },
+    "created_by_version": "79.1.2.42",
+    "default_content_setting_values": {
+      "cookies": 1
+    },
+    "exit_type": "Normal",
+    "exited_cleanly": true,
+    "managed_user_id": "",
+    "name": "Profile 1",
+    "password_manager_onboarding_state": 1
+  },
+  "signin": {
+    "allowed": false
+  },
+  "translate_site_blacklist_with_time": {},
+  "web_apps": {
+    "system_web_app_last_update": "79.1.2.42"
+  }
+}

--- a/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsAndAdsEnabled
+++ b/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsAndAdsEnabled
@@ -1,0 +1,319 @@
+{
+  "account_id_migration_state": 2,
+  "account_tracker_service_last_update": "13223730695621666",
+  "apps": {
+    "shortcuts_version": 6
+  },
+  "autocomplete": {
+    "retention_policy_last_version": 79
+  },
+  "autofill": {
+    "orphan_rows_removed": true
+  },
+  "brave": {
+    "brave_ads": {
+      "ads_per_hour": "2",
+      "enabled": true,
+      "prefs": {
+        "version": 6
+      },
+      "supported_regions_last_schema_version_number": 0,
+      "supported_regions_schema_version_number": 4,
+      "should_show_first_launch_notification": true,
+      "were_disabled": false
+    },
+    "rewards": {
+      "badge_text": "",
+      "enabled": true,
+      "enabled_migrated": true,
+      "external_wallets": {
+        "uphold": {
+          "address": "",
+          "one_time_string": "E632B87C51F7CF75A5A45C0D6C914DE42BE52C15C90F27E84E65F6EC9193EEC4",
+          "status": 0,
+          "token": "",
+          "transferred": false,
+          "user_name": ""
+        }
+      },
+      "notifications": "{\"displayed\":[],\"notifications\":[]}",
+      "server_publisher_list_stamp": "1579257114"
+    }
+  },
+  "browser": {
+    "has_seen_welcome_page": true,
+    "window_placement": {
+      "bottom": 1252,
+      "left": 2876,
+      "maximized": false,
+      "right": 4024,
+      "top": 219,
+      "work_area_bottom": 1440,
+      "work_area_left": 2560,
+      "work_area_right": 5120,
+      "work_area_top": 23
+    }
+  },
+  "countryid_at_install": 16965,
+  "data_reduction": {
+    "daily_original_length": [
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "6743267"
+    ],
+    "daily_received_length": [
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "6743267"
+    ],
+    "last_update_date": "13223692800000000",
+    "network_properties": {},
+    "this_week_number": 2611,
+    "this_week_services_downstream_foreground_kb": {
+      "6019475": 153,
+      "11793316": 1,
+      "47942479": 1,
+      "51242536": 7,
+      "54845618": 6424,
+      "115765598": 1,
+      "119416099": 1
+    }
+  },
+  "default_apps_install_state": 3,
+  "extensions": {
+    "alerts": {
+      "initialized": true
+    },
+    "chrome_url_overrides": {},
+    "last_chrome_version": "79.1.2.42"
+  },
+  "gcm": {
+    "product_category_for_subtypes": "com.brave.macosx"
+  },
+  "google": {
+    "services": {
+      "signin_scoped_device_id": "a9b60c17-2147-4a24-9d9b-2990fa51a00e"
+    }
+  },
+  "http_original_content_length": "6743267",
+  "http_received_content_length": "6743267",
+  "invalidation": {
+    "per_sender_topics_to_handler": {
+      "8181035976": {}
+    }
+  },
+  "invalidator": {
+    "client_id": "WXdMSkOUiITLZaw8tWxkIw=="
+  },
+  "language_model_counters": {
+    "en": 1
+  },
+  "media": {
+    "device_id_salt": "9485B18C0C60A579F2CFA282023B50B7",
+    "engagement": {
+      "schema_version": 4
+    }
+  },
+  "media_router": {
+    "enable_media_router": false
+  },
+  "ntp": {
+    "num_personal_suggestions": 1
+  },
+  "plugins": {
+    "plugins_list": []
+  },
+  "previews": {
+    "litepage": {
+      "user-needs-notification": false
+    },
+    "offline_helper": {
+      "available_pages": {}
+    }
+  },
+  "profile": {
+    "avatar_bubble_tutorial_shown": 2,
+    "avatar_index": 26,
+    "block_third_party_cookies": true,
+    "content_settings": {
+      "exceptions": {
+        "accessibility_events": {},
+        "app_banner": {},
+        "auto_select_certificate": {},
+        "automatic_downloads": {},
+        "autoplay": {},
+        "background_sync": {},
+        "bluetooth_guard": {},
+        "bluetooth_scanning": {},
+        "client_hints": {},
+        "clipboard": {},
+        "cookies": {},
+        "durable_storage": {},
+        "flash_data": {},
+        "geolocation": {},
+        "hid_chooser_data": {},
+        "hid_guard": {},
+        "images": {},
+        "important_site_info": {},
+        "intent_picker_auto_display": {},
+        "javascript": {},
+        "legacy_cookie_access": {},
+        "media_engagement": {},
+        "media_stream_camera": {},
+        "media_stream_mic": {},
+        "midi_sysex": {},
+        "mixed_script": {},
+        "native_file_system_write_guard": {},
+        "notifications": {},
+        "password_protection": {},
+        "payment_handler": {},
+        "permission_autoblocking_data": {},
+        "plugins": {},
+        "popups": {},
+        "ppapi_broker": {},
+        "protocol_handler": {},
+        "sensors": {},
+        "serial_chooser_data": {},
+        "serial_guard": {},
+        "site_engagement": {},
+        "sound": {},
+        "ssl_cert_decisions": {},
+        "subresource_filter": {},
+        "subresource_filter_data": {},
+        "usb_chooser_data": {},
+        "usb_guard": {}
+      },
+      "pref_version": 1
+    },
+    "created_by_version": "79.1.2.42",
+    "default_content_setting_values": {
+      "cookies": 1
+    },
+    "exit_type": "Normal",
+    "exited_cleanly": true,
+    "managed_user_id": "",
+    "name": "Profile 1",
+    "password_manager_onboarding_state": 1
+  },
+  "signin": {
+    "allowed": false
+  },
+  "translate_site_blacklist_with_time": {},
+  "web_apps": {
+    "system_web_app_last_update": "79.1.2.42"
+  }
+}

--- a/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsEnabledAndAdsDisabled
+++ b/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsEnabledAndAdsDisabled
@@ -1,0 +1,319 @@
+{
+  "account_id_migration_state": 2,
+  "account_tracker_service_last_update": "13223730695621666",
+  "apps": {
+    "shortcuts_version": 6
+  },
+  "autocomplete": {
+    "retention_policy_last_version": 79
+  },
+  "autofill": {
+    "orphan_rows_removed": true
+  },
+  "brave": {
+    "brave_ads": {
+      "ads_per_hour": "2",
+      "enabled": false,
+      "prefs": {
+        "version": 6
+      },
+      "supported_regions_last_schema_version_number": 0,
+      "supported_regions_schema_version_number": 4,
+      "should_show_first_launch_notification": true,
+      "were_disabled": false
+    },
+    "rewards": {
+      "badge_text": "",
+      "enabled": true,
+      "enabled_migrated": true,
+      "external_wallets": {
+        "uphold": {
+          "address": "",
+          "one_time_string": "E632B87C51F7CF75A5A45C0D6C914DE42BE52C15C90F27E84E65F6EC9193EEC4",
+          "status": 0,
+          "token": "",
+          "transferred": false,
+          "user_name": ""
+        }
+      },
+      "notifications": "{\"displayed\":[],\"notifications\":[]}",
+      "server_publisher_list_stamp": "1579257114"
+    }
+  },
+  "browser": {
+    "has_seen_welcome_page": true,
+    "window_placement": {
+      "bottom": 1252,
+      "left": 2876,
+      "maximized": false,
+      "right": 4024,
+      "top": 219,
+      "work_area_bottom": 1440,
+      "work_area_left": 2560,
+      "work_area_right": 5120,
+      "work_area_top": 23
+    }
+  },
+  "countryid_at_install": 16965,
+  "data_reduction": {
+    "daily_original_length": [
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "6743267"
+    ],
+    "daily_received_length": [
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "6743267"
+    ],
+    "last_update_date": "13223692800000000",
+    "network_properties": {},
+    "this_week_number": 2611,
+    "this_week_services_downstream_foreground_kb": {
+      "6019475": 153,
+      "11793316": 1,
+      "47942479": 1,
+      "51242536": 7,
+      "54845618": 6424,
+      "115765598": 1,
+      "119416099": 1
+    }
+  },
+  "default_apps_install_state": 3,
+  "extensions": {
+    "alerts": {
+      "initialized": true
+    },
+    "chrome_url_overrides": {},
+    "last_chrome_version": "79.1.2.42"
+  },
+  "gcm": {
+    "product_category_for_subtypes": "com.brave.macosx"
+  },
+  "google": {
+    "services": {
+      "signin_scoped_device_id": "a9b60c17-2147-4a24-9d9b-2990fa51a00e"
+    }
+  },
+  "http_original_content_length": "6743267",
+  "http_received_content_length": "6743267",
+  "invalidation": {
+    "per_sender_topics_to_handler": {
+      "8181035976": {}
+    }
+  },
+  "invalidator": {
+    "client_id": "WXdMSkOUiITLZaw8tWxkIw=="
+  },
+  "language_model_counters": {
+    "en": 1
+  },
+  "media": {
+    "device_id_salt": "9485B18C0C60A579F2CFA282023B50B7",
+    "engagement": {
+      "schema_version": 4
+    }
+  },
+  "media_router": {
+    "enable_media_router": false
+  },
+  "ntp": {
+    "num_personal_suggestions": 1
+  },
+  "plugins": {
+    "plugins_list": []
+  },
+  "previews": {
+    "litepage": {
+      "user-needs-notification": false
+    },
+    "offline_helper": {
+      "available_pages": {}
+    }
+  },
+  "profile": {
+    "avatar_bubble_tutorial_shown": 2,
+    "avatar_index": 26,
+    "block_third_party_cookies": true,
+    "content_settings": {
+      "exceptions": {
+        "accessibility_events": {},
+        "app_banner": {},
+        "auto_select_certificate": {},
+        "automatic_downloads": {},
+        "autoplay": {},
+        "background_sync": {},
+        "bluetooth_guard": {},
+        "bluetooth_scanning": {},
+        "client_hints": {},
+        "clipboard": {},
+        "cookies": {},
+        "durable_storage": {},
+        "flash_data": {},
+        "geolocation": {},
+        "hid_chooser_data": {},
+        "hid_guard": {},
+        "images": {},
+        "important_site_info": {},
+        "intent_picker_auto_display": {},
+        "javascript": {},
+        "legacy_cookie_access": {},
+        "media_engagement": {},
+        "media_stream_camera": {},
+        "media_stream_mic": {},
+        "midi_sysex": {},
+        "mixed_script": {},
+        "native_file_system_write_guard": {},
+        "notifications": {},
+        "password_protection": {},
+        "payment_handler": {},
+        "permission_autoblocking_data": {},
+        "plugins": {},
+        "popups": {},
+        "ppapi_broker": {},
+        "protocol_handler": {},
+        "sensors": {},
+        "serial_chooser_data": {},
+        "serial_guard": {},
+        "site_engagement": {},
+        "sound": {},
+        "ssl_cert_decisions": {},
+        "subresource_filter": {},
+        "subresource_filter_data": {},
+        "usb_chooser_data": {},
+        "usb_guard": {}
+      },
+      "pref_version": 1
+    },
+    "created_by_version": "79.1.2.42",
+    "default_content_setting_values": {
+      "cookies": 1
+    },
+    "exit_type": "Normal",
+    "exited_cleanly": true,
+    "managed_user_id": "",
+    "name": "Profile 1",
+    "password_manager_onboarding_state": 1
+  },
+  "signin": {
+    "allowed": false
+  },
+  "translate_site_blacklist_with_time": {},
+  "web_apps": {
+    "system_web_app_last_update": "79.1.2.42"
+  }
+}

--- a/vendor/bat-native-ads/src/bat/ads/internal/static_values.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/static_values.h
@@ -149,6 +149,10 @@ const std::map<int, std::map<std::string, bool>> kSupportedRegionsSchemas = {
       { "VN", false }   // Vietnam
     }
   }
+
+  // IMPORTANT: When adding new schema versions |newly_supported_locale_| must
+  // be updated in |BraveRewardsBrowserTest| to reflect a locale from the latest
+  // schema version in "bat-native-ads/src/bat/ads/internal/static_values.h"
 };
 
 const char kUntargetedPageClassification[] = "untargeted";


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7741

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Recommend tests:

Following upgrade paths from 0.63, 0.67, 0.68, 0.69, 0.70, 0.71, 0.72, 1.0, 1.1 and 1.2

- Test upgrade path for unsupported locale (on above versions) to supported locale on 1.3.x
- Test upgrade path for unsupported locale (on above versions) to unsupported locale on 1.3.x
- Test upgrade path for supported locale (on above versions, with Brave Ads enabled) to supported locale on 1.3.x

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
