### PR TITLE
Partially revert https://github.com/brave/brave-core/pull/4094

### DIFF
--- a/components/brave_extension/extension/brave_extension/assets/removeEmptyElements.css
+++ b/components/brave_extension/extension/brave_extension/assets/removeEmptyElements.css
@@ -2,8 +2,6 @@
   .ad-div,
   .masthead-ad-control,
   .video-ads,
-  .ytp-ad-module,
-  .ytp-ad-progress,
   .promoted-sparkles-text-search-root-container,
   .ytd-compact-promoted-video-renderer,
   #ytd-promoted-sparkles-web-renderer,


### PR DESCRIPTION
We have a few complaints of unskippable ads on `youtube.com` Not an issue with a standard adblocker, since its enabled or not. Unskippable ads only occurs when a user disable site-trackers on `youtube.com`.

This is partial revert of 2 cosmetic filters from https://github.com/brave/brave-core/pull/4094