### PR TITLE
Shields: Close popup if current window is not focused

### DIFF
--- a/components/brave_extension/extension/brave_extension/containers/braveShields.tsx
+++ b/components/brave_extension/extension/brave_extension/containers/braveShields.tsx
@@ -33,6 +33,7 @@ import {
   SetAdvancedViewFirstAccess,
   ShieldsReady
 } from '../types/actions/shieldsPanelActions'
+import { shieldsHasFocus } from '../helpers/shieldsUtils'
 
 interface Props {
   actions: {
@@ -85,6 +86,15 @@ export default class Shields extends React.PureComponent<Props, State> {
 
   componentDidMount () {
     this.props.actions.shieldsReady()
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    // If current window is not focused, close Shields immediately.
+    // See https://github.com/brave/brave-browser/issues/6601.
+    const { url }: Tab = this.props.shieldsPanelTabData
+    if (shieldsHasFocus(url) === false) {
+      window.close()
+    }
   }
 
   render () {

--- a/components/brave_extension/extension/brave_extension/helpers/shieldsUtils.ts
+++ b/components/brave_extension/extension/brave_extension/helpers/shieldsUtils.ts
@@ -77,3 +77,14 @@ export const sumAdsAndTrackers = (ads: number, trackers: number) => {
 export const mergeAdsAndTrackersResources = (ads: Array<string>, trackers: Array<string>) => {
   return [ ...ads, ...trackers ]
 }
+
+export const shieldsHasFocus = (url: string) => {
+  const devtoolsURL: string =
+    'chrome-extension://mnojpmjdmbbfmejpflffifhffcmidifd'
+  // Consider Shields to be focused if there's real focus
+  // or the focused window is a devtools window.
+  return (
+    document.hasFocus() ||
+    url.startsWith(devtoolsURL)
+  )
+}


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/6601

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Open two windows with different websites as their active tab
2. Open Shields in one window
3. Open devtools (right click->inspect)
4. Shields should remain open
5. Close devtools
6. With Shields still open, go to the second window and open shields in the active tab
7. Previous Shields popup should close, current Shields popup should show current data as expected (favicon, url, etc).
8. Profit 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
