### PR TITLE
Fixes duplicate Brave Ads ad history entries are missing

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1054,6 +1054,7 @@ void AdsServiceImpl::OnGetAdsHistory(
 
     base::DictionaryValue ad_history_dictionary;
     ad_history_dictionary.SetKey("id", base::Value(entry.uuid));
+    ad_history_dictionary.SetKey("parent_uuid", base::Value(entry.parent_uuid));
     ad_history_dictionary.SetPath("adContent",
         std::move(ad_content_dictionary));
     ad_history_dictionary.SetPath("categoryContent",

--- a/vendor/bat-native-ads/include/bat/ads/ad_history.h
+++ b/vendor/bat-native-ads/include/bat/ads/ad_history.h
@@ -35,6 +35,7 @@ struct ADS_EXPORT AdHistory {
 
   uint64_t timestamp_in_seconds;
   std::string uuid;
+  std::string parent_uuid;
   AdContent ad_content;
   CategoryContent category_content;
 };

--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -13,6 +13,8 @@ namespace ads {
 class ConfirmationType {
  public:
   enum Value : int {
+    // When adding new confirmation types they must be added with highest
+    // priority at the top so that ads history can be filtered
     UNKNOWN,
     CLICK,
     DISMISS,
@@ -36,7 +38,7 @@ class ConfirmationType {
 
   bool IsSupported() const;
 
-  int value() const;
+  Value value() const;
   operator std::string() const;
 
   bool operator==(

--- a/vendor/bat-native-ads/include/bat/ads/notification_info.h
+++ b/vendor/bat-native-ads/include/bat/ads/notification_info.h
@@ -25,6 +25,7 @@ struct ADS_EXPORT NotificationInfo {
       std::string* error_description = nullptr);
 
   std::string id;
+  std::string parent_id;
   std::string creative_set_id;
   std::string category;
   std::string advertiser;

--- a/vendor/bat-native-ads/src/bat/ads/ad_history.cc
+++ b/vendor/bat-native-ads/src/bat/ads/ad_history.cc
@@ -22,6 +22,7 @@ AdHistory::AdHistory(
     const AdHistory& properties)
     : timestamp_in_seconds(properties.timestamp_in_seconds),
       uuid(properties.uuid),
+      parent_uuid(properties.parent_uuid),
       ad_content(properties.ad_content),
       category_content(properties.category_content) {}
 
@@ -31,6 +32,7 @@ bool AdHistory::operator==(
     const AdHistory& rhs) const {
   return timestamp_in_seconds == rhs.timestamp_in_seconds &&
       uuid == rhs.uuid &&
+      parent_uuid == rhs.parent_uuid &&
       ad_content == rhs.ad_content &&
       category_content == rhs.category_content;
 }
@@ -70,6 +72,13 @@ Result AdHistory::FromJson(
     uuid = document["uuid"].GetString();
   }
 
+  if (document.HasMember("parent_uuid")) {
+    parent_uuid = document["parent_uuid"].GetString();
+  } else {
+    // Migration for legacy ad history
+    parent_uuid = "";
+  }
+
   if (document.HasMember("ad_content")) {
     rapidjson::StringBuffer buffer;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -101,6 +110,9 @@ void SaveToJson(JsonWriter* writer, const AdHistory& history) {
 
   writer->String("uuid");
   writer->String(history.uuid.c_str());
+
+  writer->String("parent_uuid");
+  writer->String(history.parent_uuid.c_str());
 
   writer->String("ad_content");
   SaveToJson(writer, history.ad_content);

--- a/vendor/bat-native-ads/src/bat/ads/confirmation_type.cc
+++ b/vendor/bat-native-ads/src/bat/ads/confirmation_type.cc
@@ -44,7 +44,7 @@ bool ConfirmationType::IsSupported() const {
   return value_ != UNKNOWN;
 }
 
-int ConfirmationType::value() const {
+ConfirmationType::Value ConfirmationType::value() const {
   return value_;
 }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -1384,6 +1384,7 @@ bool AdsImpl::ShowAd(
 
   auto notification_info = std::make_unique<NotificationInfo>();
   notification_info->id = base::GenerateGUID();
+  notification_info->parent_id = base::GenerateGUID();
   notification_info->advertiser = ad.advertiser;
   notification_info->category = ad.category;
   notification_info->text = ad.notification_text;
@@ -2188,6 +2189,7 @@ void AdsImpl::GenerateAdsHistoryEntry(
   auto ad_history = std::make_unique<AdHistory>();
   ad_history->timestamp_in_seconds = Time::NowInSeconds();
   ad_history->uuid = base::GenerateGUID();
+  ad_history->parent_uuid = notification_info.parent_id;
   ad_history->ad_content.uuid = notification_info.uuid;
   ad_history->ad_content.creative_set_id = notification_info.creative_set_id;
   ad_history->ad_content.brand = notification_info.advertiser;

--- a/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter.cc
@@ -3,121 +3,74 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <algorithm>
 #include <map>
 #include <string>
 
 #include "bat/ads/internal/filters/ads_history_confirmation_filter.h"
-#include "bat/ads/confirmation_type.h"
 #include "bat/ads/ads_history.h"
 
 namespace ads {
 
-bool IsConfirmationTypeOfInterest(
-    const ConfirmationType& confirmation_type) {
-  bool is_of_interest = false;
-
-  switch (confirmation_type.value()) {
-    case ConfirmationType::Value::CLICK:
-    case ConfirmationType::Value::VIEW:
-    case ConfirmationType::Value::DISMISS: {
-      is_of_interest = true;
-      break;
-    }
-    case ConfirmationType::Value::UNKNOWN:
-    case ConfirmationType::Value::LANDED:
-    case ConfirmationType::Value::FLAG:
-    case ConfirmationType::Value::UPVOTE:
-    case ConfirmationType::Value::DOWNVOTE: {
-      is_of_interest = false;
-      break;
-    }
-  }
-  return is_of_interest;
-}
-
-bool DoesConfirmationTypeATrumpB(
-    const ConfirmationType& confirmation_type_a,
-    const ConfirmationType& confirmation_type_b) {
-  bool does_type_a_trump_type_b = false;
-
-  switch (confirmation_type_a.value()) {
-    case ConfirmationType::Value::CLICK: {
-      switch (confirmation_type_b.value()) {
-        case ConfirmationType::Value::CLICK:
-        case ConfirmationType::Value::VIEW:
-        case ConfirmationType::Value::DISMISS: {
-          does_type_a_trump_type_b = true;
-          break;
-        }
-        default: {
-          break;
-        }
-      }
-      break;
-    }
-    case ConfirmationType::Value::VIEW: {
-      switch (confirmation_type_b.value()) {
-        case ConfirmationType::Value::VIEW:
-        case ConfirmationType::Value::DISMISS: {
-          does_type_a_trump_type_b = true;
-          break;
-        }
-        default: {
-          break;
-        }
-      }
-      break;
-    }
-    case ConfirmationType::Value::DISMISS: {
-      switch (confirmation_type_b.value()) {
-        case ConfirmationType::Value::DISMISS: {
-          does_type_a_trump_type_b = true;
-          break;
-        }
-        default: {
-          break;
-        }
-      }
-      break;
-    }
-  }
-
-  return does_type_a_trump_type_b;
-}
+AdsHistoryConfirmationFilter::AdsHistoryConfirmationFilter() = default;
 
 AdsHistoryConfirmationFilter::~AdsHistoryConfirmationFilter() = default;
 
 std::deque<AdHistory> AdsHistoryConfirmationFilter::Apply(
     const std::deque<AdHistory>& history) const {
+  std::map<std::string, AdHistory> filtered_ads_history_map;
 
-  std::map<std::string, AdHistory> filtered_ad_history;
-
-  for (const AdHistory& entry : history) {
-    if (!IsConfirmationTypeOfInterest(entry.ad_content.ad_action)) {
+  for (const auto& ad : history) {
+    const ConfirmationType ad_action = ad.ad_content.ad_action;
+    if (ShouldFilterAction(ad_action)) {
       continue;
     }
-    if (filtered_ad_history.count(entry.ad_content.uuid) != 0) {
-      const AdHistory& check_entry =
-          filtered_ad_history[entry.ad_content.uuid];
 
-      if (entry.timestamp_in_seconds >= check_entry.timestamp_in_seconds) {
-        if (DoesConfirmationTypeATrumpB(entry.ad_content.ad_action,
-            check_entry.ad_content.ad_action)) {
-          filtered_ad_history[entry.ad_content.uuid] = entry;
-        }
-      }
+    const std::string uuid = ad.parent_uuid;
+
+    const auto it = filtered_ads_history_map.find(uuid);
+    if (it == filtered_ads_history_map.end()) {
+      filtered_ads_history_map.insert({uuid, ad});
     } else {
-      filtered_ad_history[entry.ad_content.uuid] = entry;
+      AdHistory filtered_ad = it->second;
+      if (filtered_ad.ad_content.ad_action.value() > ad_action.value()) {
+        filtered_ads_history_map[uuid] = ad;
+      }
     }
   }
 
-  std::deque<AdHistory> filtered_history;
-
-  for (const auto& ad_history : filtered_ad_history) {
-    filtered_history.push_back(ad_history.second);
+  std::deque<AdHistory> filtered_ads_history;
+  for (const auto& filtered_ad : filtered_ads_history_map) {
+    const AdHistory ad = filtered_ad.second;
+    filtered_ads_history.push_back(ad);
   }
 
-  return filtered_history;
+  return filtered_ads_history;
+}
+
+bool AdsHistoryConfirmationFilter::ShouldFilterAction(
+    const ConfirmationType& confirmation_type) const {
+  bool should_filter;
+
+  switch (confirmation_type.value()) {
+    case ConfirmationType::CLICK:
+    case ConfirmationType::VIEW:
+    case ConfirmationType::DISMISS: {
+      should_filter = false;
+      break;
+    }
+    case ConfirmationType::UNKNOWN:
+    case ConfirmationType::LANDED:
+    case ConfirmationType::FLAG:
+    case ConfirmationType::UPVOTE:
+    case ConfirmationType::DOWNVOTE:
+    case ConfirmationType::CONVERSION: {
+      should_filter = true;
+      break;
+    }
+  }
+
+  return should_filter;
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter.h
@@ -13,14 +13,19 @@
 namespace ads {
 
 struct AdsHistory;
+class ConfirmationType;
 
 class AdsHistoryConfirmationFilter : public AdsHistoryFilter {
- public :
-  AdsHistoryConfirmationFilter() = default;
+ public:
+  AdsHistoryConfirmationFilter();
   ~AdsHistoryConfirmationFilter() override;
 
   std::deque<AdHistory> Apply(
       const std::deque<AdHistory>& history) const override;
+
+ private:
+  bool ShouldFilterAction(
+    const ConfirmationType& confirmation_type) const;
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter_unittest.cc
@@ -3,21 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <map>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "testing/gtest/include/gtest/gtest.h"
-
 #include "bat/ads/internal/filters/ads_history_confirmation_filter.h"
-
-#include "bat/ads/ads_history.h"
-#include "bat/ads/ad_history.h"
 #include "bat/ads/internal/client_mock.h"
 #include "bat/ads/internal/ads_client_mock.h"
 #include "bat/ads/internal/ads_impl.h"
-#include "bat/ads/internal/time.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 
@@ -25,25 +18,16 @@ using std::placeholders::_1;
 using ::testing::_;
 using ::testing::Invoke;
 
-namespace {
-
-const std::vector<std::string> kTestAdUuids = {
-  "ab9deba5-01bf-492b-9bb8-7bc4318fe272",
-  "a577e7fe-d86c-4997-bbaa-4041dfd4075c",
-  "a6326b14-e4f4-4597-a358-ae6134eb26c1",
-};
-
-}  // namespace
-
 namespace ads {
 
 class BatAdsHistoryConfirmationFilterTest : public ::testing::Test {
  protected:
   BatAdsHistoryConfirmationFilterTest()
-  : mock_ads_client_(std::make_unique<MockAdsClient>()),
-    ads_(std::make_unique<AdsImpl>(mock_ads_client_.get())) {
+      : mock_ads_client_(std::make_unique<MockAdsClient>()),
+        ads_(std::make_unique<AdsImpl>(mock_ads_client_.get())) {
     // You can do set-up work for each test here
   }
+
   ~BatAdsHistoryConfirmationFilterTest() override {
     // You can do clean-up work that doesn't throw exceptions here
   }
@@ -59,12 +43,7 @@ class BatAdsHistoryConfirmationFilterTest : public ::testing::Test {
         &BatAdsHistoryConfirmationFilterTest::OnAdsImplInitialize, this, _1);
     ads_->Initialize(callback);
 
-    client_mock_ = std::make_unique<ClientMock>(ads_.get(),
-        mock_ads_client_.get());
-
     ads_history_filter_ = std::make_unique<AdsHistoryConfirmationFilter>();
-
-    ads_history_.clear();
   }
 
   void OnAdsImplInitialize(const Result result) {
@@ -76,326 +55,144 @@ class BatAdsHistoryConfirmationFilterTest : public ::testing::Test {
     // destructor)
   }
 
-  void PopulateAdHistory(const std::string& ad_uuid,
-      const ConfirmationType::Value* values, const uint32_t items,
-      const uint64_t time_offset_per_item) {
-    AdHistory ad_history;
+  bool CompareUnsortedAdsHistory(
+      const std::deque<AdHistory> a,
+      const std::deque<AdHistory> b) const {
+    const size_t n = a.size();
 
-    auto now_in_seconds = Time::NowInSeconds();
-
-    for (unsigned int i = 0; i < items; i++) {
-      ad_history.ad_content.uuid = ad_uuid;
-      ad_history.timestamp_in_seconds = now_in_seconds;
-      ad_history.ad_content.ad_action = ConfirmationType(values[i]);
-
-      ads_history_.push_back(ad_history);
-
-      now_in_seconds += time_offset_per_item;
-    }
-  }
-
-  bool IsConfirmationTypeOfInterest(const ConfirmationType& confirmation_type) {
-    bool is_of_interest = false;
-
-    if ((confirmation_type == ConfirmationType::Value::CLICK)
-        || (confirmation_type == ConfirmationType::Value::VIEW)
-        || (confirmation_type == ConfirmationType::Value::DISMISS)) {
-      is_of_interest = true;
+    if (b.size() != n) {
+      return false;
     }
 
-    return is_of_interest;
-  }
+    std::vector<bool> visited(n, false);
 
-  void TestFiltering(const std::string& ad_uuid,
-      ConfirmationType::Value expected_confirmation_type_value) {
-    std::map<std::string, AdHistory> ad_history_map;
+    size_t j;
+    for (size_t i = 0; i < n; i++) {
+      for (j = 0; j < n; j++) {
+        if (a[i] == b[j] && !visited[j]) {
+            visited[j] = true;
+            break;
+        }
+      }
 
-    for (const AdHistory& ad_history : ads_history_filtered_) {
-      EXPECT_TRUE(IsConfirmationTypeOfInterest(
-          ad_history.ad_content.ad_action));
-
-      if (ad_history.ad_content.uuid == ad_uuid) {
-        ad_history_map[ad_history.ad_content.uuid] = ad_history;
+      if (j == n) {
+        return false;
       }
     }
 
-    const AdHistory& ad_history = ad_history_map[ad_uuid];
-    EXPECT_EQ(ad_history.ad_content.ad_action.value(),
-        expected_confirmation_type_value);
-  }
-
-  void TestFilteringWithTimestamps(const std::string& ad_uuid,
-      uint64_t expected_timestamp_in_seconds,
-      ConfirmationType::Value expected_confirmation_type_value) {
-    std::map<std::string, AdHistory> ad_history_map;
-
-    for (const AdHistory& ad_history : ads_history_filtered_) {
-      EXPECT_TRUE(IsConfirmationTypeOfInterest(
-          ad_history.ad_content.ad_action));
-
-      if (ad_history.ad_content.uuid == ad_uuid) {
-        ad_history_map[ad_history.ad_content.uuid] = ad_history;
-      }
-    }
-
-    const AdHistory& ad_history = ad_history_map[ad_uuid];
-    EXPECT_EQ(ad_history.timestamp_in_seconds,
-        expected_timestamp_in_seconds);
-    EXPECT_EQ(ad_history.ad_content.ad_action.value(),
-        expected_confirmation_type_value);
-  }
-
-  void PerformBasicUnitTest(const std::string& ad_uuid,
-      const ConfirmationType::Value* values, const uint32_t items,
-      const ConfirmationType::Value expected_confirmation_value) {
-    PopulateAdHistory(ad_uuid, values, items, 1);
-
-    const AdHistory& expected_ad_history = ads_history_[1];  // Trump
-    const uint64_t expected_timestamp_in_seconds =
-        expected_ad_history.timestamp_in_seconds;
-
-    // Act
-    ads_history_filtered_ = ads_history_filter_->Apply(ads_history_);
-
-    // Assert
-    TestFilteringWithTimestamps(ad_uuid, expected_timestamp_in_seconds,
-        expected_confirmation_value);
+    return true;
   }
 
   std::unique_ptr<MockAdsClient> mock_ads_client_;
   std::unique_ptr<AdsImpl> ads_;
 
-  std::unique_ptr<ClientMock> client_mock_;
-
-  std::deque<AdHistory> ads_history_;
-  std::deque<AdHistory> ads_history_filtered_;
   std::unique_ptr<AdsHistoryFilter> ads_history_filter_;
 };
 
 TEST_F(BatAdsHistoryConfirmationFilterTest,
-    NoFilteredResultsWhenNoAds) {
+    FilterActions) {
   // Arrange
-  ConfirmationType::Value confirmation_types[] = {
-  };
+  AdHistory ad1;
+  ad1.parent_uuid = "ab9deba5-01bf-492b-9bb8-7bc4318fe272";  // Ad 1 (View)
+  ad1.ad_content.ad_action = ConfirmationType::VIEW;
 
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, 1);
+  AdHistory ad2;
+  ad2.parent_uuid = "a577e7fe-d86c-4997-bbaa-4041dfd4075c";  // Ad 2
+  ad2.ad_content.ad_action = ConfirmationType::VIEW;
+
+  AdHistory ad3;
+  ad3.parent_uuid = "ab9deba5-01bf-492b-9bb8-7bc4318fe272";  // Ad 1 (Click)
+  ad3.ad_content.ad_action = ConfirmationType::CLICK;
+
+  AdHistory ad4;
+  ad4.parent_uuid = "4424ff92-fa91-4ca9-a651-96b59cf1f68b";  // Ad 3 (Dismiss)
+  ad4.ad_content.ad_action = ConfirmationType::DISMISS;
+
+  AdHistory ad5;
+  ad5.parent_uuid = "4424ff92-fa91-4ca9-a651-96b59cf1f68b";  // Ad 3 (View)
+  ad5.ad_content.ad_action = ConfirmationType::VIEW;
+
+  AdHistory ad6;
+  ad6.parent_uuid = "d9253022-b023-4414-a85d-96b78d36435d";  // Ad 4
+  ad6.ad_content.ad_action = ConfirmationType::VIEW;
+
+  const std::deque<AdHistory> ads_history = {
+    ad1,
+    ad2,
+    ad3,
+    ad4,
+    ad5,
+    ad6
+  };
 
   // Act
-  ads_history_filtered_ = ads_history_filter_->Apply(ads_history_);
+  const std::deque<AdHistory> ads_history_filtered =
+      ads_history_filter_->Apply(ads_history);
 
   // Assert
-  EXPECT_EQ(ads_history_filtered_.size(), (uint64_t)0);
+  const std::deque<AdHistory> expected_ads_history = {
+    ad2,  // Ad 2
+    ad3,  // Ad 1 (Click) which should supercede Ad 1 (View)
+    ad4,  // Ad 3 (Dismiss) which should supercede Ad 3 (View)
+    ad6   // Ad 4
+  };
+
+  EXPECT_TRUE(CompareUnsortedAdsHistory(expected_ads_history,
+      ads_history_filtered));
 }
 
 TEST_F(BatAdsHistoryConfirmationFilterTest,
-    NoFilteredResultsForUnrecognisedConfirmationTypes) {
+    FilterUnsupportedActions) {
   // Arrange
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::UNKNOWN,
-    ConfirmationType::Value::FLAG,
-    ConfirmationType::Value::UPVOTE,
-    ConfirmationType::Value::DOWNVOTE,
-    ConfirmationType::Value::LANDED,
-  };
+  AdHistory ad1;
+  ad1.parent_uuid = "36c24bef-eaee-4507-bad6-15612dec1273";
+  ad1.ad_content.ad_action = ConfirmationType::UNKNOWN;       // Unsupported
 
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, 1);
+  AdHistory ad2;
+  ad2.parent_uuid = "69b684d7-d893-4f4e-b156-859919a0fcc9";
+  ad2.ad_content.ad_action = ConfirmationType::LANDED;        // Unsupported
+
+  AdHistory ad3;
+  ad3.parent_uuid = "d3be2e79-ffa8-4b4e-b61e-88545055fbad";
+  ad3.ad_content.ad_action = ConfirmationType::FLAG;          // Unsupported
+
+  AdHistory ad4;
+  ad4.parent_uuid = "9390f66a-d4f2-4c8a-8315-1baed4aae612";
+  ad4.ad_content.ad_action = ConfirmationType::UPVOTE;        // Unsupported
+
+  AdHistory ad5;
+  ad5.parent_uuid = "47c73793-d1c1-4fdb-8530-4ae478c79783";
+  ad5.ad_content.ad_action = ConfirmationType::DOWNVOTE;      // Unsupported
+
+  AdHistory ad6;
+  ad6.parent_uuid = "b7e1314c-73b0-4291-9cdd-6c5d2374c28f";
+  ad6.ad_content.ad_action = ConfirmationType::CONVERSION;    // Unsupported
+
+  AdHistory ad7;
+  ad7.parent_uuid = "ab9deba5-01bf-492b-9bb8-7bc4318fe272";   // Ad 1 (View)
+  ad7.ad_content.ad_action = ConfirmationType::VIEW;
+
+  const std::deque<AdHistory> ads_history = {
+    ad1,
+    ad2,
+    ad3,
+    ad4,
+    ad5,
+    ad6,
+    ad7
+  };
 
   // Act
-  ads_history_filtered_ = ads_history_filter_->Apply(ads_history_);
+  const std::deque<AdHistory> ads_history_filtered =
+      ads_history_filter_->Apply(ads_history);
 
   // Assert
-  EXPECT_EQ(ads_history_.size(), (uint64_t)5);
-  EXPECT_EQ(ads_history_filtered_.size(), (uint64_t)0);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    FilteredDismissResultWithUnrecognisedConfirmationTypes) {
-  // Arrange
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::UNKNOWN,
-    ConfirmationType::Value::FLAG,
-    ConfirmationType::Value::DISMISS,  // Trump
-    ConfirmationType::Value::UPVOTE,
-    ConfirmationType::Value::DOWNVOTE,
-    ConfirmationType::Value::LANDED,
+  const std::deque<AdHistory> expected_ads_history = {
+    ad7  // Ad 1 (View)
   };
 
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, 1);
-
-  const AdHistory& expected_ad_history = ads_history_[2];  // ::DISMISS
-  const uint64_t expected_timestamp = expected_ad_history.timestamp_in_seconds;
-
-  // Act
-  ads_history_filtered_ = ads_history_filter_->Apply(ads_history_);
-
-  // Assert
-  EXPECT_EQ(ads_history_.size(), (uint64_t)6);
-  EXPECT_EQ(ads_history_filtered_.size(), (uint64_t)1);
-  const AdHistory& ad_history = ads_history_filtered_.front();
-  EXPECT_EQ(ad_history.timestamp_in_seconds, expected_timestamp);
-  EXPECT_EQ(ad_history.ad_content.ad_action, ConfirmationType::Value::DISMISS);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    ExpectLatestDismiss) {
-  // Arrange
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::DISMISS,
-    ConfirmationType::Value::DISMISS,  // Trump
-  };
-
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, 1);
-
-  const AdHistory& expected_ad_history = ads_history_.back();  // Trump
-  const uint64_t expected_timestamp = expected_ad_history.timestamp_in_seconds;
-
-  // Act
-  ads_history_filtered_ = ads_history_filter_->Apply(ads_history_);
-
-  // Assert
-  EXPECT_EQ(ads_history_.size(), (uint64_t)2);
-  EXPECT_EQ(ads_history_filtered_.size(), (uint64_t)1);
-  const AdHistory& ad_history = ads_history_filtered_.front();
-  EXPECT_EQ(ad_history.timestamp_in_seconds, expected_timestamp);
-  EXPECT_EQ(ad_history.ad_content.ad_action, ConfirmationType::Value::DISMISS);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    ViewTrumpsDismiss) {
-  // Arrange
-  const ConfirmationType::Value expected_confirmation_type =
-    ConfirmationType::Value::VIEW;
-
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::DISMISS,
-    expected_confirmation_type,
-    ConfirmationType::Value::DISMISS,
-  };
-
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-
-  PerformBasicUnitTest(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, expected_confirmation_type);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    ClickTrumpsDismiss) {
-  // Arrange
-  const ConfirmationType::Value expected_confirmation_type =
-    ConfirmationType::Value::CLICK;
-
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::DISMISS,
-    expected_confirmation_type,
-    ConfirmationType::Value::DISMISS,
-  };
-
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-
-  PerformBasicUnitTest(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, expected_confirmation_type);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    ClickTrumpsView) {
-  // Arrange
-  const ConfirmationType::Value expected_confirmation_type =
-    ConfirmationType::Value::CLICK;
-
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::VIEW,
-    expected_confirmation_type,
-    ConfirmationType::Value::VIEW,
-  };
-
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-
-  PerformBasicUnitTest(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, expected_confirmation_type);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    ClickTrumpsViewAndDismiss) {
-  // Arrange
-  const ConfirmationType::Value expected_confirmation_type =
-    ConfirmationType::Value::CLICK;
-
-  ConfirmationType::Value confirmation_types[] = {
-    ConfirmationType::Value::DISMISS,
-    expected_confirmation_type,
-    ConfirmationType::Value::VIEW,
-  };
-
-  size_t size_of_confirmation_types = sizeof(confirmation_types) /
-      sizeof(ConfirmationType::Value);
-
-  PerformBasicUnitTest(kTestAdUuids[0], confirmation_types,
-      size_of_confirmation_types, expected_confirmation_type);
-}
-
-TEST_F(BatAdsHistoryConfirmationFilterTest,
-    MultipleAdHistoriesFilterCorrectly) {
-  // Arrange
-  size_t size_of_confirmation_types = 0;
-
-  ConfirmationType::Value confirmationTypesForAd1[] = {
-    ConfirmationType::Value::DISMISS,
-    ConfirmationType::Value::DISMISS,
-    ConfirmationType::Value::VIEW,  // Trump
-    ConfirmationType::Value::DISMISS,
-  };
-
-  size_of_confirmation_types = sizeof(confirmationTypesForAd1) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[0], confirmationTypesForAd1,
-      size_of_confirmation_types, 1);
-
-  ConfirmationType::Value confirmationTypesForAd2[] = {
-    ConfirmationType::Value::DISMISS,
-    ConfirmationType::Value::CLICK,  // Trump
-    ConfirmationType::Value::VIEW,
-    ConfirmationType::Value::DISMISS,
-  };
-
-  size_of_confirmation_types = sizeof(confirmationTypesForAd2) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[1], confirmationTypesForAd2,
-      size_of_confirmation_types, 1);
-
-  ConfirmationType::Value confirmationTypesForAd3[] = {
-    ConfirmationType::Value::CLICK,  // Trump
-    ConfirmationType::Value::VIEW,
-    ConfirmationType::Value::DISMISS,
-  };
-
-  size_of_confirmation_types = sizeof(confirmationTypesForAd3) /
-      sizeof(ConfirmationType::Value);
-  PopulateAdHistory(kTestAdUuids[2], confirmationTypesForAd3,
-      size_of_confirmation_types, 1);
-
-  // Act
-  ads_history_filtered_ =
-      ads_history_filter_->Apply(ads_history_);
-
-  // Assert
-  TestFiltering(kTestAdUuids[0], ConfirmationType::Value::VIEW);
-  TestFiltering(kTestAdUuids[1], ConfirmationType::Value::CLICK);
-  TestFiltering(kTestAdUuids[2], ConfirmationType::Value::CLICK);
+  EXPECT_TRUE(CompareUnsortedAdsHistory(expected_ads_history,
+      ads_history_filtered));
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/notifications.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/notifications.cc
@@ -24,6 +24,7 @@ const char kNotificationsStateName[] = "notifications.json";
 const char kNotificationsListKey[] = "notifications";
 
 const char kNotificationIdKey[] = "id";
+const char kNotificationParentIdKey[] = "parent_id";
 const char kNotificationCreativeSetIdKey[] = "creative_set_id";
 const char kNotificationCategoryKey[] = "category";
 const char kNotificationAdvertiserKey[] = "advertiser";
@@ -162,6 +163,11 @@ bool Notifications::GetNotificationFromDictionary(
     return false;
   }
 
+  if (!GetParentIdFromDictionary(dictionary, &notification_info.parent_id)) {
+    // Migrate for legacy notifications
+    notification_info.parent_id = "";
+  }
+
   if (!GetCreativeSetIdFromDictionary(dictionary,
       &notification_info.creative_set_id)) {
     return false;
@@ -196,6 +202,12 @@ bool Notifications::GetIdFromDictionary(
     base::DictionaryValue* dictionary,
     std::string* value) const {
   return GetStringFromDictionary(kNotificationIdKey, dictionary, value);
+}
+
+bool Notifications::GetParentIdFromDictionary(
+    base::DictionaryValue* dictionary,
+    std::string* value) const {
+  return GetStringFromDictionary(kNotificationParentIdKey, dictionary, value);
 }
 
 bool Notifications::GetCreativeSetIdFromDictionary(
@@ -366,6 +378,8 @@ base::Value Notifications::GetAsList() {
 
     dictionary.SetKey(kNotificationIdKey,
         base::Value(notification.id));
+    dictionary.SetKey(kNotificationParentIdKey,
+        base::Value(notification.parent_id));
     dictionary.SetKey(kNotificationCreativeSetIdKey,
         base::Value(notification.creative_set_id));
     dictionary.SetKey(kNotificationCategoryKey,

--- a/vendor/bat-native-ads/src/bat/ads/internal/notifications.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/notifications.h
@@ -55,6 +55,9 @@ class Notifications {
   bool GetIdFromDictionary(
       base::DictionaryValue* dictionary,
       std::string* value) const;
+  bool GetParentIdFromDictionary(
+      base::DictionaryValue* dictionary,
+      std::string* value) const;
   bool GetCreativeSetIdFromDictionary(
       base::DictionaryValue* dictionary,
       std::string* value) const;

--- a/vendor/bat-native-ads/src/bat/ads/notification_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/notification_info.cc
@@ -14,6 +14,7 @@ namespace ads {
 
 NotificationInfo::NotificationInfo() :
     id(""),
+    parent_id(""),
     creative_set_id(""),
     category(""),
     advertiser(""),
@@ -24,6 +25,7 @@ NotificationInfo::NotificationInfo() :
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     id(info.id),
+    parent_id(info.parent_id),
     creative_set_id(info.creative_set_id),
     category(info.category),
     advertiser(info.advertiser),
@@ -56,6 +58,10 @@ Result NotificationInfo::FromJson(
 
   if (document.HasMember("id")) {
     id = document["id"].GetString();
+  }
+
+  if (document.HasMember("parent_id")) {
+    parent_id = document["parent_id"].GetString();
   }
 
   if (document.HasMember("creative_set_id")) {
@@ -95,6 +101,9 @@ void SaveToJson(JsonWriter* writer, const NotificationInfo& info) {
 
   writer->String("id");
   writer->String(info.id.c_str());
+
+  writer->String("parent_id");
+  writer->String(info.parent_id.c_str());
 
   writer->String("creative_set_id");
   writer->String(info.creative_set_id.c_str());

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -13,6 +13,8 @@ namespace confirmations {
 class ConfirmationType {
  public:
   enum Value : int {
+    // When adding new confirmation types they must be added with highest
+    // priority at the top so that ads history can be filtered
     UNKNOWN,
     CLICK,
     DISMISS,
@@ -36,7 +38,7 @@ class ConfirmationType {
 
   bool IsSupported() const;
 
-  int value() const;
+  Value value() const;
   operator std::string() const;
 
   bool operator==(

--- a/vendor/bat-native-confirmations/include/bat/confirmations/notification_info.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/notification_info.h
@@ -19,6 +19,7 @@ struct CONFIRMATIONS_EXPORT NotificationInfo {
   ~NotificationInfo();
 
   std::string id;
+  std::string parent_id;
   std::string creative_set_id;
   std::string category;
   std::string advertiser;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/confirmation_type.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/confirmation_type.cc
@@ -43,7 +43,7 @@ bool ConfirmationType::IsSupported() const {
   return value_ != UNKNOWN;
 }
 
-int ConfirmationType::value() const {
+ConfirmationType::Value ConfirmationType::value() const {
   return value_;
 }
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
@@ -8,6 +8,8 @@
 namespace confirmations {
 
 NotificationInfo::NotificationInfo() :
+    id(""),
+    parent_id(""),
     creative_set_id(""),
     category(""),
     advertiser(""),
@@ -17,6 +19,8 @@ NotificationInfo::NotificationInfo() :
     type(ConfirmationType::UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
+    id(info.id),
+    parent_id(info.parent_id),
     creative_set_id(info.creative_set_id),
     category(info.category),
     advertiser(info.advertiser),

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1206,6 +1206,7 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
 
   auto notification_info = std::make_unique<confirmations::NotificationInfo>();
   notification_info->id = notification_info_ads.id;
+  notification_info->parent_id = notification_info_ads.parent_id;
   notification_info->creative_set_id = notification_info_ads.creative_set_id;
   notification_info->category = notification_info_ads.category;
   notification_info->advertiser = notification_info_ads.advertiser;
@@ -1240,17 +1241,30 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
     }
 
     case ads::ConfirmationType::FLAG: {
-      notification_info->type = confirmations::ConfirmationType::FLAG;
+      // Should never be reached as FLAG is handled by ConfirmAction, refactor
+      // code to abstract different ConfirmationTypes
+      NOTREACHED();
       break;
     }
 
     case ads::ConfirmationType::UPVOTE: {
-      notification_info->type = confirmations::ConfirmationType::UPVOTE;
+      // Should never be reached as UPVOTE is handled by ConfirmAction, refactor
+      // code to abstract different ConfirmationTypes
+      NOTREACHED();
       break;
     }
 
     case ads::ConfirmationType::DOWNVOTE: {
-      notification_info->type = confirmations::ConfirmationType::DOWNVOTE;
+      // Should never be reached as DOWNVOTE is handled by ConfirmAction,
+      // refactor code to abstract different ConfirmationTypes
+      NOTREACHED();
+      break;
+    }
+
+    case ads::ConfirmationType::CONVERSION: {
+      // Should never be reached as CONVERSION is handled by ConfirmAction,
+      // refactor code to abstract different ConfirmationTypes
+      NOTREACHED();
       break;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/7869

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

NOTES: An ad will need to be displayed upon launch before the history is updated to reflect the fix. Legacy ads history will show duplicates, i.e. viewed and clicked actions

- View multiple ads (and on occasion click some ads)
- Confirm ads which were clicked only appeared as clicked and do not appear as Viewed in the ad's history
- Confirm duplicate ads are shown
- Confirm ads are shown across multiple days
- Confirm ads older than 7 days are not shown

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
