### PR TITLE
Replacing license files from Prebake with Easylist Cookie

### DIFF
--- a/components/third_party/adblock/lists/easylist-cookie/README.chromium
+++ b/components/third_party/adblock/lists/easylist-cookie/README.chromium
@@ -1,0 +1,4 @@
+Name: EasyList
+URL: https://easylist.to/
+License: GPL-3.0-or-later OR CC-BY-SA-3.0
+License File: /brave/common/licenses/EasyList

--- a/components/third_party/adblock/lists/easylist-cookie/README.chromium
+++ b/components/third_party/adblock/lists/easylist-cookie/README.chromium
@@ -1,4 +1,4 @@
 Name: EasyList Cookie
-URL: https://easylist.to/
+URL: https://github.com/easylist/easylist/tree/master/easylist_cookie
 License: GPL-3.0-or-later OR CC-BY-SA-3.0
 License File: /brave/common/licenses/EasyList

--- a/components/third_party/adblock/lists/easylist-cookie/README.chromium
+++ b/components/third_party/adblock/lists/easylist-cookie/README.chromium
@@ -1,4 +1,4 @@
-Name: EasyList
+Name: EasyList Cookie
 URL: https://easylist.to/
 License: GPL-3.0-or-later OR CC-BY-SA-3.0
 License File: /brave/common/licenses/EasyList

--- a/components/third_party/adblock/lists/prebake/LICENSE
+++ b/components/third_party/adblock/lists/prebake/LICENSE
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright (c) 2015 Liam Anderson, Prebake Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/components/third_party/adblock/lists/prebake/README.chromium
+++ b/components/third_party/adblock/lists/prebake/README.chromium
@@ -1,3 +1,0 @@
-Name: Prebake
-URL: https://github.com/liamja/Prebake
-License: MIT


### PR DESCRIPTION
prebake list hasn;t been updated since 2018. 

adblock-rust request: https://github.com/brave/adblock-rust/pull/67