### PR TITLE
Store components data with unique folder

### DIFF
--- a/components/ntp_sponsored_images/browser/ntp_sponsored_images_component_installer.cc
+++ b/components/ntp_sponsored_images/browser/ntp_sponsored_images_component_installer.cc
@@ -24,7 +24,6 @@ using brave_component_updater::BraveOnDemandUpdater;
 namespace {
 
 constexpr char kNTPSponsoredImagesDisplayName[] = "NTP sponsored images";
-constexpr char kNTPSponsoredImagesBaseDirectory[] = "NTPSponsoredImages";
 constexpr size_t kHashSize = 32;
 
 class NTPSponsoredImagesComponentInstallerPolicy
@@ -54,6 +53,7 @@ class NTPSponsoredImagesComponentInstallerPolicy
   std::vector<std::string> GetMimeTypes() const override;
 
  private:
+  const std::string component_id_;
   OnComponentReadyCallback ready_callback_;
   uint8_t component_hash_[kHashSize];
 
@@ -63,7 +63,8 @@ class NTPSponsoredImagesComponentInstallerPolicy
 NTPSponsoredImagesComponentInstallerPolicy::
 NTPSponsoredImagesComponentInstallerPolicy(
     const RegionalComponentData& data, OnComponentReadyCallback callback)
-    : ready_callback_(callback) {
+    : component_id_(data.component_id),
+      ready_callback_(callback) {
   // Generate hash from public key.
   std::string decoded_public_key;
   base::Base64Decode(data.component_base64_public_key, &decoded_public_key);
@@ -107,7 +108,7 @@ bool NTPSponsoredImagesComponentInstallerPolicy::VerifyInstallation(
 
 base::FilePath NTPSponsoredImagesComponentInstallerPolicy::
     GetRelativeInstallDir() const {
-  return base::FilePath::FromUTF8Unsafe(kNTPSponsoredImagesBaseDirectory);
+  return base::FilePath::FromUTF8Unsafe(component_id_);
 }
 
 void NTPSponsoredImagesComponentInstallerPolicy::GetHash(


### PR DESCRIPTION
If same folder name is used, other component can use it.

Fix https://github.com/brave/brave-browser/issues/7946

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
