### PR TITLE
New Tab Page WebUI: Rewards widget does not display Ads item if non-ads region

### DIFF
--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -220,7 +220,8 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
   renderRewardsInfo = () => {
     const {
       enabledMain,
-      walletCreated
+      walletCreated,
+      adsSupported
     } = this.props
 
     if (!enabledMain || !walletCreated) {
@@ -229,7 +230,7 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
 
     return (
       <div data-test-id2={'enableMain'}>
-        {this.renderAmountItem(AmountItemType.ADS)}
+        {adsSupported && this.renderAmountItem(AmountItemType.ADS)}
         {this.renderAmountItem(AmountItemType.TIPS)}
       </div>
     )

--- a/components/brave_new_tab_ui/components/default/rewards/style.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/style.tsx
@@ -194,7 +194,7 @@ export const NotificationButton = styled(CoinsButton)`
 `
 
 export const AmountItem = styled<StyleProps, 'div'>('div')`
-  margin-top: ${p => p.isLast ? 18 : 12}px;
+  margin-top: 18px;
   margin-bottom: ${p => p.isLast ? -10 : 0}px;
   ${p => p.isActionPrompt && css`
     text-align: center;

--- a/components/brave_new_tab_ui/stories/default.tsx
+++ b/components/brave_new_tab_ui/stories/default.tsx
@@ -18,6 +18,7 @@ storiesOf('New Tab/Default', module)
         showBrandedWallpaper={boolean('Show branded wallpaper?', false)}
         showTopSitesNotification={boolean('Show top sites notification?', false)}
         isAdsOn={boolean('Ads on?', true)}
+        isAdsSupported={boolean('Ads region supported?', true)}
       />
     )
   })

--- a/components/brave_new_tab_ui/stories/default/index.tsx
+++ b/components/brave_new_tab_ui/stories/default/index.tsx
@@ -48,6 +48,7 @@ interface Props {
   showBrandedWallpaper: boolean
   showTopSitesNotification: boolean
   isAdsOn: boolean
+  isAdsSupported: boolean
 }
 
 export default class NewTabPage extends React.PureComponent<Props, State> {
@@ -240,7 +241,7 @@ export default class NewTabPage extends React.PureComponent<Props, State> {
           {(showRewards || (showBrandedWallpaper && !this.state.isBrandedWallpaperNotificationDismissed)) &&
           <Page.GridItemRewards>
             <Rewards
-              adsSupported={true}
+              adsSupported={this.props.isAdsSupported}
               promotions={promotions}
               balance={balance}
               enabledAds={enabledAds}


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7944

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
