### PR TITLE
New Tab Page WebUI: Prompt to turn on Brave Ads instead of Brave Rewards when Brave Ads is off

### DIFF
--- a/.storybook/locale.ts
+++ b/.storybook/locale.ts
@@ -221,6 +221,7 @@ const locale: Record<string, string> = {
   rewardsWidgetAdsOptInDescription: 'Earn tokens by viewing privacy-respecting ads.',
   rewardsWidgetMonthlyTips: 'Tips and contributions this month',
   rewardsWidgetNotificationTitle: 'Way to Go!',
+  rewardsWidgetEnableBrandedWallpaperSubTitle: 'Turn on $3 to claim your share. You can also choose to $1hide sponsored images$2.',
   rewardsWidgetBrandedNotificationTitle: 'You\'re getting paid to view this background image.',
   rewardsWidgetBrandedNotificationDescription: '$1Learn more$2 about sponsored images in Brave Rewards.',
   rewardsWidgetAboutRewards: '$1Learn more$2 about Brave Rewards',

--- a/components/brave_new_tab_ui/components/default/rewards/brandedWallpaperNotification.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/brandedWallpaperNotification.tsx
@@ -52,6 +52,7 @@ export default class BrandedWallpaperRewardsNotification extends React.PureCompo
 
   renderPreAdsOptInContent () {
     const text = getLocale('rewardsWidgetEnableBrandedWallpaperSubTitle')
+      .replace('$3', 'Brave Ads')
     const { beforeTag, duringTag, afterTag } = splitStringForTag(text, '$1', '$2')
     return (
       <>

--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -116,6 +116,7 @@ class Rewards extends React.PureComponent<RewardsProps, {}> {
     if (isShowingBrandedWallpaper) {
       titleText = getLocale('rewardsWidgetEnableBrandedWallpaperTitle')
       const text = getLocale('rewardsWidgetEnableBrandedWallpaperSubTitle')
+        .replace('$3', 'Brave Rewards')
       const { beforeTag, duringTag, afterTag } = splitStringForTag(text, '$1', '$2')
       subTitleText = (
         <>

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -671,7 +671,7 @@
       <message name="IDS_REWARDS_WIDGET_ENABLE_BRANDED_WALLPAPER_SUBTITLE"
         desc="Description for prompt to enable Brave Rewards when a Branded Wallpaper is currently being displayed"
       >
-        Turn on Brave Rewards to claim your share. You can also choose to <ph name="LINK_BEGIN">$1</ph>hide sponsored images<ph name="LINK_END">$2</ph>.
+        Turn on <ph name="PRODUCT_NAME">$3<ex>Brave Rewards</ex></ph> to claim your share. You can also choose to <ph name="LINK_BEGIN">$1</ph>hide sponsored images<ph name="LINK_END">$2</ph>.
       </message>
       <message name="IDS_REWARDS_WIDGET_NOTIFICATION_TITLE" desc="">Way to Go!</message>
       <message name="IDS_REWARDS_WIDGET_NOTIFICATION_TEXT_ADS" desc="">Your rewards from Ads are here</message>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7939

## Test Plan:
On https://github.com/brave/brave-browser/issues/7939
**And in addition:**

0. Clean profile, keep Rewards OFF
1. Enable flag for SNTP. Restart.
2. Open new tab until you see a SNTP.

**Expected:** Rewards widget shows `"Turn on Brave Rewards to claim your share"`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
