### PR TITLE
disables data reduction promo on Android

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -13,6 +13,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/BraveAppHooks.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveBadge.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveFeatureList.java",
+  "../../brave/android/java/org/chromium/chrome/browser/BraveHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRelaunchUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveSyncWorker.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRewardsNativeWorker.java",

--- a/android/java/org/chromium/chrome/browser/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/BraveActivity.java
@@ -29,10 +29,8 @@ import org.chromium.base.Log;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveSyncWorker;
-import org.chromium.chrome.browser.ChromeSwitches;
 import org.chromium.chrome.browser.bookmarks.BookmarkBridge;
 import org.chromium.chrome.browser.bookmarks.BookmarkModel;
-import org.chromium.chrome.browser.firstrun.FirstRunStatus;
 import org.chromium.chrome.browser.notifications.BraveSetDefaultBrowserNotificationService;
 import org.chromium.chrome.browser.onboarding.OnboardingActivity;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
@@ -163,8 +161,7 @@ public abstract class BraveActivity extends ChromeActivity {
 
         // Disable FRE for arm64 builds where ChromeActivity is the one that
         // triggers FRE instead of ChromeLauncherActivity on arm32 build.
-        CommandLine.getInstance().appendSwitch(ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE);
-        FirstRunStatus.setFirstRunFlowComplete(true);
+        BraveHelper.DisableFREDRP();
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/BraveHelper.java
+++ b/android/java/org/chromium/chrome/browser/BraveHelper.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import org.chromium.base.CommandLine;
+import org.chromium.base.ContextUtils;
+import org.chromium.chrome.browser.ChromeSwitches;
+import org.chromium.chrome.browser.firstrun.FirstRunStatus;
+
+public class BraveHelper {
+  public static final String SHARED_PREF_DISPLAYED_INFOBAR_PROMO =
+            "displayed_data_reduction_infobar_promo";
+
+  public BraveHelper() {}
+
+  public static void DisableFREDRP() {
+      CommandLine.getInstance().appendSwitch(ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE);
+      FirstRunStatus.setFirstRunFlowComplete(true);
+      
+      // Disables data reduction promo dialog
+      ContextUtils.getAppSharedPreferences()
+              .edit()
+              .putBoolean(SHARED_PREF_DISPLAYED_INFOBAR_PROMO, true);
+  }
+}

--- a/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java
+++ b/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java
@@ -8,10 +8,7 @@ package org.chromium.chrome.browser.document;
 import android.app.Activity;
 import android.os.Bundle;
 
-import org.chromium.base.CommandLine;
-import org.chromium.base.Log;
-import org.chromium.chrome.browser.ChromeSwitches;
-import org.chromium.chrome.browser.firstrun.FirstRunStatus;
+import org.chromium.chrome.browser.BraveHelper;
 import org.chromium.chrome.browser.util.FeatureUtilities;
 
 /**
@@ -22,10 +19,7 @@ public class BraveLauncherActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Disable FTR experience
-        CommandLine.getInstance().appendSwitch(ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE);
-        FirstRunStatus.setFirstRunFlowComplete(true);
-
         FeatureUtilities.isBottomToolbarEnabled();
+        BraveHelper.DisableFREDRP();
     }
 }


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/7925
fixes https://github.com/brave/brave-browser/issues/7926
fixes https://github.com/brave/brave-browser/issues/7927

The crash was caused on update only. There was a check on whether to show a data reduction promo dialog on some websites or not. And a function to get a current app version was called that wants a chromium's version format `xx.xx.xx.xx`. It throws an exception. The fix disables the dialog completely.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
