### PR TITLE
Add Sparkle hardened runtime support

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ deps = {
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
   "vendor/omaha":  "https://github.com/brave/omaha.git@de118d8511e4754a673d44a9f1e92d80442069e7",
-  "vendor/sparkle": "https://github.com/brave/Sparkle.git@c0759cce415d7c0feae45005c8a013b1898711f0",
+  "vendor/sparkle": "https://github.com/brave/Sparkle.git@577eee9cbf955b4dd39746b4f03a1944fcd323fd",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@13bb40a215248cfbdd87d0a6b425c8397402e9e6",
   "vendor/bat-native-anonize": "https://github.com/brave-intl/bat-native-anonize.git@e3742ba3e8942eea9e4755d91532491871bd3116",

--- a/patches/chrome-installer-mac-signing-signing.py.patch
+++ b/patches/chrome-installer-mac-signing-signing.py.patch
@@ -1,8 +1,12 @@
 diff --git a/chrome/installer/mac/signing/signing.py b/chrome/installer/mac/signing/signing.py
-index 18a73509f528e67c29c7ef896eee338e0970b4fa..117f2b88a4322448a4c0bdda797dd7f5d110a35d 100644
+index cd93959385debe65d04c0a4664f638173da54b75..70a1d7741908ee9481bd2026ec1d493c086f7e7d 100644
 --- a/chrome/installer/mac/signing/signing.py
 +++ b/chrome/installer/mac/signing/signing.py
-@@ -11,6 +11,7 @@ import os.path
+@@ -8,9 +8,11 @@ bundle that need to be signed, as well as providing utilities to sign them.
+ 
+ import copy
+ import os.path
++import collections
  
  from . import commands
  from .model import CodeSignOptions, CodeSignedProduct, VerifyOptions
@@ -10,15 +14,18 @@ index 18a73509f528e67c29c7ef896eee338e0970b4fa..117f2b88a4322448a4c0bdda797dd7f5
  
  _PROVISIONPROFILE_EXT = '.provisionprofile'
  _PROVISIONPROFILE_DEST = 'embedded.provisionprofile'
-@@ -136,6 +137,7 @@ def get_parts(config):
+@@ -136,7 +138,9 @@ def get_parts(config):
              library_basename.replace('.dylib', ''),
              verify_options=VerifyOptions.DEEP)
  
-+    AddBravePartsForSigning(parts, config)
-     return parts
+-    return parts
++    ordered_parts = collections.OrderedDict(parts)
++    AddBravePartsForSigning(ordered_parts, config)
++    return ordered_parts
  
  
-@@ -180,7 +182,7 @@ def sign_part(paths, config, part):
+ def get_installer_tools(config):
+@@ -180,7 +184,7 @@ def sign_part(paths, config, part):
          part: The |model.CodeSignedProduct| to sign. The product's |path| must
              be in |paths.work|.
      """
@@ -27,7 +34,7 @@ index 18a73509f528e67c29c7ef896eee338e0970b4fa..117f2b88a4322448a4c0bdda797dd7f5
      if config.notary_user:
          # Assume if the config has notary authentication information that the
          # products will be notarized, which requires a secure timestamp.
-@@ -270,6 +272,7 @@ def sign_chrome(paths, config, sign_framework=False):
+@@ -272,6 +276,7 @@ def sign_chrome(paths, config, sign_framework=False):
                  continue
              sign_part(paths, config, part)
  

--- a/patches/chrome-installer-mac-signing-signing.py.patch
+++ b/patches/chrome-installer-mac-signing-signing.py.patch
@@ -1,12 +1,8 @@
 diff --git a/chrome/installer/mac/signing/signing.py b/chrome/installer/mac/signing/signing.py
-index cd93959385debe65d04c0a4664f638173da54b75..70a1d7741908ee9481bd2026ec1d493c086f7e7d 100644
+index cd93959385debe65d04c0a4664f638173da54b75..0324d4f534f4cec4a3b70c0577284151110d1b14 100644
 --- a/chrome/installer/mac/signing/signing.py
 +++ b/chrome/installer/mac/signing/signing.py
-@@ -8,9 +8,11 @@ bundle that need to be signed, as well as providing utilities to sign them.
- 
- import copy
- import os.path
-+import collections
+@@ -11,6 +11,7 @@ import os.path
  
  from . import commands
  from .model import CodeSignOptions, CodeSignedProduct, VerifyOptions
@@ -14,18 +10,15 @@ index cd93959385debe65d04c0a4664f638173da54b75..70a1d7741908ee9481bd2026ec1d493c
  
  _PROVISIONPROFILE_EXT = '.provisionprofile'
  _PROVISIONPROFILE_DEST = 'embedded.provisionprofile'
-@@ -136,7 +138,9 @@ def get_parts(config):
+@@ -136,6 +137,7 @@ def get_parts(config):
              library_basename.replace('.dylib', ''),
              verify_options=VerifyOptions.DEEP)
  
--    return parts
-+    ordered_parts = collections.OrderedDict(parts)
-+    AddBravePartsForSigning(ordered_parts, config)
-+    return ordered_parts
++    parts = AddBravePartsForSigning(parts, config)
+     return parts
  
  
- def get_installer_tools(config):
-@@ -180,7 +184,7 @@ def sign_part(paths, config, part):
+@@ -180,7 +182,7 @@ def sign_part(paths, config, part):
          part: The |model.CodeSignedProduct| to sign. The product's |path| must
              be in |paths.work|.
      """
@@ -34,7 +27,7 @@ index cd93959385debe65d04c0a4664f638173da54b75..70a1d7741908ee9481bd2026ec1d493c
      if config.notary_user:
          # Assume if the config has notary authentication information that the
          # products will be notarized, which requires a secure timestamp.
-@@ -272,6 +276,7 @@ def sign_chrome(paths, config, sign_framework=False):
+@@ -272,6 +274,7 @@ def sign_chrome(paths, config, sign_framework=False):
                  continue
              sign_part(paths, config, part)
  

--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import collections
 import os
 import subprocess
 import sys
@@ -63,6 +64,7 @@ def GenerateBraveWidevineSigFile(paths, config, part):
 
 
 def AddBravePartsForSigning(parts, config):
+    parts = collections.OrderedDict(parts)
     from signing.model import CodeSignedProduct, VerifyOptions, CodeSignOptions
 
     development = True if config.provisioning_profile_basename is None else False
@@ -110,6 +112,8 @@ def AddBravePartsForSigning(parts, config):
     # Overwrite to avoid TeamID mismatch with widevine dylib.
     parts['helper-app'].entitlements = 'helper-entitlements.plist'
     parts['helper-app'].options = CodeSignOptions.RESTRICT + CodeSignOptions.KILL + CodeSignOptions.HARDENED_RUNTIME
+
+    return parts
 
 
 def GetBraveSigningConfig(config_class, development, mac_provisioning_profile=None):


### PR DESCRIPTION
This includes the updates:

* Point to Sparkle commit for branch merged_with_sparkle_1.22.0_v2
* Import Python collections library to sign fileop and Autoupdate
  in the correct order

Fixes: https://github.com/brave/brave-browser/issues/6572

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
