### PR TITLE
New Tab Page Sponsored Images feature ON by default

### DIFF
--- a/components/ntp_sponsored_images/browser/features.cc
+++ b/components/ntp_sponsored_images/browser/features.cc
@@ -14,7 +14,7 @@ namespace features {
 
 const base::Feature kBraveNTPBrandedWallpaper{
     "BraveNTPBrandedWallpaperName",
-    base::FEATURE_DISABLED_BY_DEFAULT};
+    base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveNTPBrandedWallpaperDemo{
     "BraveNTPBrandedWallpaperDemoName",
     base::FEATURE_DISABLED_BY_DEFAULT};


### PR DESCRIPTION
Flip feature flag for NTP Sponsored Images to on by default

Fix https://github.com/brave/brave-browser/issues/8040
