### PR TITLE
Downloaded files not opening on Android

### DIFF
--- a/android/java/res_template/xml/file_paths.xml
+++ b/android/java/res_template/xml/file_paths.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2020 The Brave Authors. All rights reserved.
+     This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this file,
+     You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!-- The attributes in this XML file provide configuration information -->
+<!-- for the ContentProvider. -->
+
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="images" path="images/"/>
+    <cache-path name="cache" path="net-export/"/>
+    <cache-path name="passwords" path="passwords/"/>
+    <cache-path name="traces" path="traces/"/>
+    <cache-path name="webapk" path="webapks/" />
+    <cache-path name="offline-cache" path="Offline Pages/archives/" />
+
+    <!-- Note(twellington): This path is included to facilitate creating
+         content:// URIs for downloads. This may no longer work if/when users
+         are allowed to save files elsewhere. -->
+    <external-path name="downloads" path="Download/" />
+
+    <!-- Needed for Android Q+, due to scoped storage. -->
+    <external-path name="downloads" path="Android/data/{{ manifest_package }}/files/Download/" />
+</paths>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7993

Problem is due to scoped storage on Android Q+ (i.e., Android 10 and above). The specific issue is referenced here, which is that on Android Q downloaded files will go to an app-private download location rather than the public download directory:

https://cs.chromium.org/chromium/src/base/android/java/src/org/chromium/base/PathUtils.java?type=cs&g=0&l=200

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
