### PR TITLE
Uplift fixing the build to 1.5.x (#4499 and #4505)

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -131,6 +131,7 @@ source_set("browser_process") {
     "//brave/components/brave_referrals/browser",
     "//brave/components/brave_rewards/browser",
     "//brave/components/brave_shields/browser",
+    "//brave/components/brave_shields/common",
     "//brave/components/brave_wayback_machine:buildflags",
     "//brave/components/brave_webtorrent/browser/buildflags",
     "//brave/components/content_settings/core/browser",

--- a/components/brave_shields/browser/BUILD.gn
+++ b/components/brave_shields/browser/BUILD.gn
@@ -57,6 +57,7 @@ source_set("browser") {
   deps = [
     "//base",
     "//brave/components/brave_component_updater/browser",
+    "//brave/components/brave_shields/common",
     "//brave/components/content_settings/core/browser",
     "//brave/content:common",
     "//brave/vendor/adblock_rust_ffi:adblock_ffi",

--- a/components/brave_shields/common/BUILD.gn
+++ b/components/brave_shields/common/BUILD.gn
@@ -4,4 +4,8 @@ source_set("common") {
     "features.cc",
     "features.h",
   ]
+
+  deps = [
+    "//base",
+  ]
 }

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -6,8 +6,6 @@
 #include "brave/components/brave_shields/common/features.h"
 
 #include "base/feature_list.h"
-#include "build/build_config.h"
-#include "ui/base/ui_base_features.h"
 
 namespace brave_shields {
 namespace features {


### PR DESCRIPTION
Missing deps for and in brave_shields/common

Uplifting because the error is caused by https://github.com/brave/brave-core/pull/4269 which is on 1.5.x

https://github.com/brave/brave-browser/issues/8056
https://github.com/brave/brave-browser/issues/8062