### PR TITLE
Enable cosmetic filtering by default

### DIFF
--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -788,19 +788,18 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, RedirectRulesAreRespected) {
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
-class CosmeticFilteringEnabledTest : public AdBlockServiceTest {
+class CosmeticFilteringDisabledTest : public AdBlockServiceTest {
  public:
-  CosmeticFilteringEnabledTest() {
-    feature_list_.InitAndEnableFeature(kBraveAdblockCosmeticFiltering);
+  CosmeticFilteringDisabledTest() {
+    feature_list_.InitAndDisableFeature(kBraveAdblockCosmeticFiltering);
   }
 
  private:
   base::test::ScopedFeatureList feature_list_;
 };
 
-// Ensure no cosmetic filtering occurs when the feature flag has not been
-// enabled
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringSimple) {
+// Ensure no cosmetic filtering occurs when the feature flag is disabled
+IN_PROC_BROWSER_TEST_F(CosmeticFilteringDisabledTest, CosmeticFilteringSimple) {
   UpdateAdBlockInstanceWithRules(
       "b.com###ad-banner\n"
       "##.ad");
@@ -837,7 +836,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringSimple) {
 }
 
 // Test simple cosmetic filtering
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringSimple) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringSimple) {
   UpdateAdBlockInstanceWithRules(
       "b.com###ad-banner\n"
       "##.ad");
@@ -874,7 +873,7 @@ IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringSimple) {
 }
 
 // Test cosmetic filtering ignores content determined to be 1st party
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest,
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                        CosmeticFilteringProtect1p) {
   UpdateAdBlockInstanceWithRules("b.com##.fpsponsored\n");
 
@@ -896,7 +895,7 @@ IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest,
 }
 
 // Test cosmetic filtering on elements added dynamically
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringDynamic) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringDynamic) {
   UpdateAdBlockInstanceWithRules("##.blockme");
 
   WaitForBraveExtensionShieldsDataReady();
@@ -925,7 +924,7 @@ IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringDynamic) {
 }
 
 // Test custom style rules
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest,
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                        CosmeticFilteringCustomStyle) {
   UpdateAdBlockInstanceWithRules("b.com##.ad:style(padding-bottom: 10px)");
 
@@ -947,7 +946,7 @@ IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest,
 }
 
 // Test rules overridden by hostname-specific exception rules
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringUnhide) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringUnhide) {
   UpdateAdBlockInstanceWithRules(
       "##.ad\n"
       "b.com#@#.ad\n"

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -12,7 +12,7 @@ namespace features {
 
 const base::Feature kBraveAdblockCosmeticFiltering{
     "BraveAdblockCosmeticFiltering",
-    base::FEATURE_DISABLED_BY_DEFAULT};
+    base::FEATURE_ENABLED_BY_DEFAULT};
 
 }  // namespace features
 }  // namespace brave_shields


### PR DESCRIPTION
Changes flag introduced by #4269 to be enabled by default. Needs uplifting to 1.5.x.

Fixes brave/brave-browser#8068

Depends on https://github.com/brave/brave-core/pull/4585.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
