### PR TITLE
Fix crash when viewing Brave license or dev options on Android

### DIFF
--- a/android/java/res/xml/brave_license_preferences.xml
+++ b/android/java/res/xml/brave_license_preferences.xml
@@ -8,6 +8,6 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <org.chromium.chrome.browser.preferences.TextMessagePreference
+    <org.chromium.chrome.browser.settings.TextMessagePreference
         android:key="brave_license_text" />
 </PreferenceScreen>

--- a/android/java/res/xml/developer_preferences.xml
+++ b/android/java/res/xml/developer_preferences.xml
@@ -12,7 +12,7 @@
         android:fragment="org.chromium.chrome.browser.preferences.developer.TracingPreferences"
         android:key="tracing"
         android:title="Tracing" />
-    <org.chromium.chrome.browser.preferences.TextMessagePreference
+    <org.chromium.chrome.browser.settings.TextMessagePreference
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:enabled="false"
@@ -21,7 +21,7 @@
         app:allowDividerAbove="false"
         app:allowDividerBelow="false" />
     <Preference
-	android:fragment="org.chromium.chrome.browser.preferences.developer.BraveQAPreferences"
+        android:fragment="org.chromium.chrome.browser.settings.developer.BraveQAPreferences"
         android:key="qa_preferences"
         android:title="QA Preferences"/>
 </PreferenceScreen>

--- a/android/java/res/xml/legal_information_preferences.xml
+++ b/android/java/res/xml/legal_information_preferences.xml
@@ -6,20 +6,20 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <org.chromium.chrome.browser.preferences.HyperlinkPreference
+    <org.chromium.chrome.browser.settings.HyperlinkPreference
         android:key="open_source_license"
         android:title="@string/open_source_license_title"
         app:url="@string/open_source_license_url" />
-    <org.chromium.chrome.browser.preferences.HyperlinkPreference
+    <org.chromium.chrome.browser.settings.HyperlinkPreference
         android:key="terms_of_service"
         android:title="@string/terms_of_service_title"
         app:url="@string/brave_terms_of_service_url" />
-    <org.chromium.chrome.browser.preferences.HyperlinkPreference
+    <org.chromium.chrome.browser.settings.HyperlinkPreference
         android:key="privacy_notice"
         android:title="@string/privacy_notice_title"
         app:url="@string/brave_privacy_notice_url" />
     <Preference
-        android:fragment="org.chromium.chrome.browser.preferences.BraveLicensePreferences"
+        android:fragment="org.chromium.chrome.browser.settings.BraveLicensePreferences"
         android:key="brave_license"
         android:title="@string/brave_license_text" />
 </PreferenceScreen>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/8078

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
