### PR TITLE
[Uplift to 1.3] Don't use cached images for NTP Sponsored images

### DIFF
--- a/components/ntp_sponsored_images/browser/ntp_sponsored_image_source.cc
+++ b/components/ntp_sponsored_images/browser/ntp_sponsored_image_source.cc
@@ -99,6 +99,10 @@ std::string NTPSponsoredImageSource::GetMimeType(const std::string& path) {
   return "image/jpg";
 }
 
+bool NTPSponsoredImageSource::AllowCaching() {
+  return false;
+}
+
 bool NTPSponsoredImageSource::IsValidPath(const std::string& path) const {
   if (IsLogoPath(path))
     return true;

--- a/components/ntp_sponsored_images/browser/ntp_sponsored_image_source.h
+++ b/components/ntp_sponsored_images/browser/ntp_sponsored_image_source.h
@@ -34,6 +34,7 @@ class NTPSponsoredImageSource : public content::URLDataSource {
                         const content::WebContents::Getter& wc_getter,
                         GotDataCallback callback) override;
   std::string GetMimeType(const std::string& path) override;
+  bool AllowCaching() override;
 
   void OnGotImageFile(GotDataCallback callback,
                       base::Optional<std::string> input);


### PR DESCRIPTION
When assets are updated, we should display new images always.

Fix https://github.com/brave/brave-browser/issues/8112