### PR TITLE
Add BraveSharedResourcesDataSource when receiving ON_PROFILE_CREATED notification (uplift to 1.5.x)

### DIFF
--- a/browser/profiles/brave_profile_manager.h
+++ b/browser/profiles/brave_profile_manager.h
@@ -28,9 +28,14 @@ class BraveProfileManager : public ProfileManager {
                         bool success,
                         bool is_new_profile) override;
 
+  void Observe(int type,
+               const content::NotificationSource& source,
+               const content::NotificationDetails& details) override;
+
  protected:
   void DoFinalInitForServices(Profile* profile,
                                bool go_off_the_record) override;
+
  private:
   void MigrateProfileNames();
   DISALLOW_COPY_AND_ASSIGN(BraveProfileManager);


### PR DESCRIPTION
Uplift of #4534

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. (tested locally)
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.