### PR TITLE
Add BraveSharedResourcesDataSource when receiving ON_PROFILE_CREATED notification (uplift to 1.4.x)

### DIFF
--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -26,6 +26,7 @@
 #include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
 #include "brave/content/browser/webui/brave_shared_resources_data_source.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/chrome_notification_types.h"
 #include "chrome/browser/profiles/profile_attributes_entry.h"
 #include "chrome/browser/profiles/profile_attributes_storage.h"
 #include "chrome/browser/profiles/profiles_state.h"
@@ -39,6 +40,8 @@
 #include "components/signin/public/base/signin_pref_names.h"
 #include "components/translate/core/browser/translate_pref_names.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/browser/notification_source.h"
 #include "content/public/browser/url_data_source.h"
 #include "extensions/buildflags/buildflags.h"
 #include "third_party/blink/public/common/peerconnection/webrtc_ip_handling_policy.h"
@@ -58,6 +61,9 @@ using content::BrowserThread;
 BraveProfileManager::BraveProfileManager(const base::FilePath& user_data_dir)
     : ProfileManager(user_data_dir) {
   MigrateProfileNames();
+
+  registrar_.Add(this, chrome::NOTIFICATION_PROFILE_CREATED,
+                 content::NotificationService::AllSources());
 }
 
 BraveProfileManager::~BraveProfileManager() {
@@ -135,8 +141,6 @@ void BraveProfileManager::DoFinalInitForServices(Profile* profile,
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
   gcm::BraveGCMChannelStatus::GetForProfile(profile);
 #endif
-  content::URLDataSource::Add(profile,
-      std::make_unique<brave_content::BraveSharedResourcesDataSource>());
 }
 
 void BraveProfileManager::OnProfileCreated(Profile* profile,
@@ -205,4 +209,22 @@ void BraveProfileManager::MigrateProfileNames() {
     }
   }
 #endif
+}
+
+void BraveProfileManager::Observe(int type,
+                                  const content::NotificationSource& source,
+                                  const content::NotificationDetails& details) {
+  switch (type) {
+    case chrome::NOTIFICATION_PROFILE_CREATED: {
+      Profile* profile = content::Source<Profile>(source).ptr();
+      content::URLDataSource::Add(
+          profile,
+          std::make_unique<brave_content::BraveSharedResourcesDataSource>());
+      break;
+    }
+    default: {
+      ProfileManager::Observe(type, source, details);
+      break;
+    }
+  }
 }

--- a/browser/profiles/brave_profile_manager.h
+++ b/browser/profiles/brave_profile_manager.h
@@ -28,9 +28,14 @@ class BraveProfileManager : public ProfileManager {
                         bool success,
                         bool is_new_profile) override;
 
+  void Observe(int type,
+               const content::NotificationSource& source,
+               const content::NotificationDetails& details) override;
+
  protected:
   void DoFinalInitForServices(Profile* profile,
                                bool go_off_the_record) override;
+
  private:
   void MigrateProfileNames();
   DISALLOW_COPY_AND_ASSIGN(BraveProfileManager);


### PR DESCRIPTION
Uplift of #4534

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. (tested locally)
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.