### PR TITLE
(1.5.x) Uplift New Tab Page Sponsored Images feature ON by default

### DIFF
--- a/components/ntp_sponsored_images/browser/features.cc
+++ b/components/ntp_sponsored_images/browser/features.cc
@@ -14,7 +14,7 @@ namespace features {
 
 const base::Feature kBraveNTPBrandedWallpaper{
     "BraveNTPBrandedWallpaperName",
-    base::FEATURE_DISABLED_BY_DEFAULT};
+    base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveNTPBrandedWallpaperDemo{
     "BraveNTPBrandedWallpaperDemoName",
     base::FEATURE_DISABLED_BY_DEFAULT};


### PR DESCRIPTION
Defaults NTP SI to ON for Dev channel

Uplift https://github.com/brave/brave-core/pull/4487 to put brave/brave-browser#8040 on 1.5.x