### PR TITLE
Convert some CHECKs to DCHECK for synced_bookmark_tracker and bookmar…

### DIFF
--- a/patches/components-sync_bookmarks-bookmark_remote_updates_handler.cc.patch
+++ b/patches/components-sync_bookmarks-bookmark_remote_updates_handler.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/sync_bookmarks/bookmark_remote_updates_handler.cc b/components/sync_bookmarks/bookmark_remote_updates_handler.cc
-index c31275713056a2a1dd07872bc3569d54a8cfce0e..700877cd135845fe686626e821870ff0bbc3f453 100644
+index c31275713056a2a1dd07872bc3569d54a8cfce0e..8128b7ceb92166d149056c15d9a9f7dc23fb5514 100644
 --- a/components/sync_bookmarks/bookmark_remote_updates_handler.cc
 +++ b/components/sync_bookmarks/bookmark_remote_updates_handler.cc
 @@ -144,6 +144,7 @@ void ApplyRemoteUpdate(
@@ -10,6 +10,17 @@ index c31275713056a2a1dd07872bc3569d54a8cfce0e..700877cd135845fe686626e821870ff0
        ComputeChildNodeIndex(new_parent, update_entity.unique_position, tracker);
    tracker->Update(update_entity.id, update.response_version,
                    update_entity.modification_time,
+@@ -241,8 +242,8 @@ void BookmarkRemoteUpdatesHandler::Process(
+         const bookmarks::BookmarkNode* old_node = old_entity->bookmark_node();
+         const bookmarks::BookmarkNode* new_node =
+             tracked_entity->bookmark_node();
+-        CHECK(old_node->type() == bookmarks::BookmarkNode::URL);
+-        CHECK(new_node->type() == bookmarks::BookmarkNode::URL);
++        // CHECK(old_node->type() == bookmarks::BookmarkNode::URL);
++        // CHECK(new_node->type() == bookmarks::BookmarkNode::URL);
+         CHECK(old_node->url() == new_node->url());
+         bookmark_tracker_->Remove(update_entity.originator_client_item_id);
+         bookmark_model_->Remove(old_node);
 @@ -449,9 +450,11 @@ bool BookmarkRemoteUpdatesHandler::ProcessCreate(
      LogProblematicBookmark(RemoteBookmarkUpdateError::kMissingParentNode);
      return false;

--- a/patches/components-sync_bookmarks-synced_bookmark_tracker.cc.patch
+++ b/patches/components-sync_bookmarks-synced_bookmark_tracker.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/sync_bookmarks/synced_bookmark_tracker.cc b/components/sync_bookmarks/synced_bookmark_tracker.cc
+index 5acee2729ad296a9c4a7cbafc2b4bbede0141bc5..324cc5ea8d4470feefa44288d1984dfc9722f1ba 100644
+--- a/components/sync_bookmarks/synced_bookmark_tracker.cc
++++ b/components/sync_bookmarks/synced_bookmark_tracker.cc
+@@ -497,7 +497,7 @@ void SyncedBookmarkTracker::UpdateSyncForLocalCreationIfNeeded(
+   // TODO(crbug.com/516866): The below CHECK is added to debug some crashes.
+   // Should be removed after figuring out the reason for the crash.
+   CHECK_EQ(1U, sync_id_to_entities_map_.count(old_id));
+-  CHECK_EQ(0U, sync_id_to_entities_map_.count(new_id));
++  // CHECK_EQ(0U, sync_id_to_entities_map_.count(new_id));
+ 
+   std::unique_ptr<Entity> entity =
+       std::move(sync_id_to_entities_map_.at(old_id));


### PR DESCRIPTION
…k_remote_updates_handler

May fix two of mentioned at https://github.com/brave/brave-browser/issues/8128 crashes

## Submitter Checklist:

- [?] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [?] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
