### PR TITLE
Persist native Brave Ads storage on a new profile

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_conversion_tracking.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_conversion_tracking.cc
@@ -280,6 +280,7 @@ void AdConversionTracking::OnStateLoaded(
         "values";
 
     queue_.clear();
+    SaveState();
   } else {
     if (!FromJson(json)) {
       BLOG(ERROR) << "Failed to parse ad conversions state: " << json;

--- a/vendor/bat-native-ads/src/bat/ads/internal/client.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client.cc
@@ -637,6 +637,7 @@ void Client::OnStateLoaded(const Result result, const std::string& json) {
     BLOG(ERROR) << "Failed to load client state, resetting to default values";
 
     client_state_.reset(new ClientState());
+    SaveState();
   } else {
     if (!FromJson(json)) {
       BLOG(ERROR) << "Failed to parse client state: " << json;

--- a/vendor/bat-native-ads/src/bat/ads/internal/notifications.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/notifications.cc
@@ -302,6 +302,7 @@ void Notifications::OnStateLoaded(
         << "Failed to load notifications state, resetting to default values";
 
     notifications_.clear();
+    SaveState();
   } else {
     if (!FromJson(json)) {
       BLOG(ERROR) << "Failed to parse notifications state: " << json;


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/8138

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm "Failed to load client state, resetting to default values" is only shown in the console log once after a fresh install, and not after subsequent launches of the application
- Confirm "Failed to load notifications state, resetting to default values" is only shown in the console log once after a fresh install, and not after subsequent launches of the application
- Confirm "Failed to load ad conversions state, resetting to default values" is only shown in the console log once after a fresh install, and not after subsequent launches of the application
- Confirm "Failed to load confirmations state, resetting to default values" is only shown in the console log once after a fresh install, and not after subsequent launches of the application

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
