### PR TITLE
Disable sync (Uplift to 1.3.x)

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -148,6 +148,9 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
   command_line.AppendSwitchASCII(switches::kSyncServiceURL,
                                  "https://no-thanks.invalid");
 
+  // Disable sync temporarily
+  command_line.AppendSwitch(switches::kDisableSync);
+
   // Enabled features.
   const std::unordered_set<const char*> enabled_features = {
       password_manager::features::kPasswordImport.name,

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -27,6 +27,7 @@
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/prefs/pref_service.h"
+#include "components/sync/driver/sync_driver_switches.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_navigation_observer.h"
@@ -154,10 +155,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadCustomBravePages) {
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
         "rewards",
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_SYNC)
-        chrome::kChromeUISyncHost,
-#endif
   };
+#if BUILDFLAG(ENABLE_BRAVE_SYNC)
+  if (switches::IsSyncAllowedByFlag())
+    pages.push_back(chrome::kChromeUISyncHost);
+#endif
 
   std::vector<std::string> schemes {
     "brave://",
@@ -221,7 +223,10 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
         browser()->tab_strip_model()->GetActiveWebContents();
     ui_test_utils::NavigateToURL(
         browser(), GURL(scheme + chrome::kChromeUISyncInternalsHost));
-    ASSERT_TRUE(WaitForLoadStop(contents));
+    if (switches::IsSyncAllowedByFlag())
+      ASSERT_TRUE(WaitForLoadStop(contents));
+    else
+      ASSERT_FALSE(WaitForLoadStop(contents));
 
     EXPECT_STREQ(base::UTF16ToUTF8(browser()->location_bar_model()
                     ->GetFormattedFullURL()).c_str(),


### PR DESCRIPTION
DON'T MERGE THIS, IT'S CRASHING ON STARTUP

Uplift of #4565

Append --disable-sync swtich to disable sync temporarily

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
