### PR TITLE
Fix 7956: Disable reporting observers to expose violation reports to JS

### DIFF
--- a/chromium_src/third_party/blink/renderer/core/frame/reporting_observer_browsertest.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/reporting_observer_browsertest.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test_utils.h"
+
+namespace {
+
+const char kReportingObserver[] = "/reporting_observer.html";
+
+}  // namespace
+
+class ReportingObserverTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    content::SetupCrossSiteRedirector(embedded_test_server());
+
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+    ASSERT_TRUE(embedded_test_server()->Start());
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(ReportingObserverTest, IsDisabled) {
+  GURL url = embedded_test_server()->GetURL(kReportingObserver);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  EXPECT_EQ(true, EvalJs(contents, "isReportingObserverDisabled();"));
+}

--- a/patches/third_party-blink-renderer-core-frame-reporting_observer.idl.patch
+++ b/patches/third_party-blink-renderer-core-frame-reporting_observer.idl.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/renderer/core/frame/reporting_observer.idl b/third_party/blink/renderer/core/frame/reporting_observer.idl
+index a248a08fcd1e3566c838f26393fd64c877bab11b..a1ae499dab51d79756e339cfd2ac508675f97b90 100644
+--- a/third_party/blink/renderer/core/frame/reporting_observer.idl
++++ b/third_party/blink/renderer/core/frame/reporting_observer.idl
+@@ -7,6 +7,7 @@
+ callback ReportingObserverCallback = void (sequence<Report> reports, ReportingObserver observer);
+ 
+ [
++    ContextEnabled=ReportingObservers,
+     Constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options),
+     ConstructorCallWith=ExecutionContext,
+     ActiveScriptWrappable

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -569,6 +569,7 @@ test("brave_browser_tests") {
     "//brave/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view_browsertest.cc",
     "//brave/chromium_src/components/content_settings/core/browser/brave_content_settings_registry_browsertest.cc",
     "//brave/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc",
+    "//brave/chromium_src/third_party/blink/renderer/core/frame/reporting_observer_browsertest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/battery/navigator_batterytest.cc",
     "//brave/chromium_src/third_party/blink/renderer/modules/bluetooth/navigator_bluetoothtest.cc",
     "//brave/common/brave_channel_info_browsertest.cc",

--- a/test/data/reporting_observer.html
+++ b/test/data/reporting_observer.html
@@ -1,0 +1,11 @@
+<script>
+  function isReportingObserverDisabled() {
+    try {
+      new ReportingObserver(function(reports, observer) {
+      	return false;
+	  }, {});
+    } catch (err) {
+      return true;
+    }
+  }
+</script>


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7956

Reporting API is disabled on master because we disable `background sync` by default. But, the `ReportingViolations` can still be accessed via Reporting Observers. Disabling queuing of reports via reporting observers with this change.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Navigate to https://jumde.github.io/test/reporting_observer.html
2. Verify `Reporting Observers not available` is echoed to the document.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
