### PR TITLE
Add Brave Sync flag to control whether to append `--disable-sync`

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -151,11 +151,6 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
 
   command_line.AppendSwitch(switches::kDisableDatabases);
 
-#if !defined(OS_ANDROID)
-  // Disable sync temporarily
-  command_line.AppendSwitch(switches::kDisableSync);
-#endif
-
   // Enabled features.
   const std::unordered_set<const char*> enabled_features = {
       password_manager::features::kPasswordImport.name,

--- a/browser/brave_browser_main_parts.h
+++ b/browser/brave_browser_main_parts.h
@@ -16,6 +16,7 @@ class BraveBrowserMainParts : public ChromeBrowserMainParts {
 
   void PostBrowserStart() override;
   void PreShutdown() override;
+  void PreProfileInit() override;
   void PostProfileInit() override;
 
  private:

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -3,13 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/ntp_sponsored_images/browser/features.h"
 #include "brave/components/brave_shields/common/features.h"
+#include "brave/components/brave_sync/features.h"
+#include "brave/components/ntp_sponsored_images/browser/features.h"
 #include "chrome/browser/about_flags.h"
 
+using brave_shields::features::kBraveAdblockCosmeticFiltering;
+using brave_sync::features::kBraveSync;
 using ntp_sponsored_images::features::kBraveNTPBrandedWallpaper;
 using ntp_sponsored_images::features::kBraveNTPBrandedWallpaperDemo;
-using brave_shields::features::kBraveAdblockCosmeticFiltering;
 
 #define BRAVE_FEATURE_ENTRIES \
     {"brave-ntp-branded-wallpaper",                                        \
@@ -23,7 +25,11 @@ using brave_shields::features::kBraveAdblockCosmeticFiltering;
     {"brave-adblock-cosmetic-filtering",                                   \
      flag_descriptions::kBraveAdblockCosmeticFilteringName,                \
      flag_descriptions::kBraveAdblockCosmeticFilteringDescription, kOsAll, \
-     FEATURE_VALUE_TYPE(kBraveAdblockCosmeticFiltering)},
+     FEATURE_VALUE_TYPE(kBraveAdblockCosmeticFiltering)},                  \
+    {"brave-sync",                                                         \
+     flag_descriptions::kBraveSyncName,                                    \
+     flag_descriptions::kBraveSyncDescription, kOsDesktop,                 \
+     FEATURE_VALUE_TYPE(kBraveSync)},
 
 #define SetFeatureEntryEnabled SetFeatureEntryEnabled_ChromiumImpl
 #include "../../../../chrome/browser/about_flags.cc"  // NOLINT

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -19,4 +19,6 @@ const char kBraveNTPBrandedWallpaperDemoDescription[] =
 const char kBraveAdblockCosmeticFilteringName[] = "Enable cosmetic filtering";
 const char kBraveAdblockCosmeticFilteringDescription[] =
     "Enable support for cosmetic filtering";
+const char kBraveSyncName[] = "Enable Brave Sync";
+const char kBraveSyncDescription[] = "Brave Sync is disabled by default";
 }  // namespace flag_descriptions

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -15,6 +15,8 @@ extern const char kBraveNTPBrandedWallpaperDemoName[];
 extern const char kBraveNTPBrandedWallpaperDemoDescription[];
 extern const char kBraveAdblockCosmeticFilteringName[];
 extern const char kBraveAdblockCosmeticFilteringDescription[];
+extern const char kBraveSyncName[];
+extern const char kBraveSyncDescription[];
 }
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_FLAG_DESCRIPTIONS_H_

--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -103,6 +103,17 @@ source_set("crypto") {
   }
 }
 
+source_set("features") {
+  sources = [
+    "features.cc",
+    "features.h",
+  ]
+
+  deps = [
+    "//base",
+  ]
+}
+
 source_set("public") {
   sources = [
     "public/brave_profile_sync_service.h",
@@ -130,6 +141,7 @@ source_set("core") {
 
   deps = [
     ":crypto",
+    ":features",
     ":jslib_messages",
     ":prefs",
     "//base",

--- a/components/brave_sync/features.cc
+++ b/components/brave_sync/features.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_sync/features.h"
+
+#include "base/feature_list.h"
+
+namespace brave_sync {
+namespace features {
+
+const base::Feature kBraveSync{"BraveSync", base::FEATURE_DISABLED_BY_DEFAULT};
+
+}  // namespace features
+}  // namespace brave_sync

--- a/components/brave_sync/features.h
+++ b/components/brave_sync/features.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_FEATURES_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_FEATURES_H_
+
+namespace base {
+struct Feature;
+}  // namespace base
+
+namespace brave_sync {
+namespace features {
+
+extern const base::Feature kBraveSync;
+
+}  // namespace features
+}  // namespace brave_sync
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_FEATURES_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8187

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Launch Brave with the fix
2. Go to `about:version`
3. There should be `--disable-sync` switch appended
4. Go to `chrome://flags/#brave-sync` and select `Enabled` (Default/Disabled => Enabled)
5. After relaunch, go to `about:version`
6. There shouldn't be `--disable-sync` switch appended
7. Go to `chrome://flags/#brave-sync` and select `Default or Disabled` (Enabled => Default/Disabled)
8. After relaunch, go to `about:version`
9. There should be `--disable-sync` switch appended


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
