### PR TITLE
[Android] Fix crashes when dispatching shields blocked events (uplift to 1.5.x)

### DIFF
--- a/browser/android/brave_shields_content_settings.cc
+++ b/browser/android/brave_shields_content_settings.cc
@@ -31,9 +31,10 @@ static void JNI_BraveShieldsContentSettings_Init(JNIEnv* env,
       new BraveShieldsContentSettings(env, jcaller);
 }
 
-BraveShieldsContentSettings::BraveShieldsContentSettings(JNIEnv* env,
-    const base::android::JavaRef<jobject>& obj):
-    weak_java_native_worker_(env, obj) {
+BraveShieldsContentSettings::BraveShieldsContentSettings(
+    JNIEnv* env,
+    const base::android::JavaRef<jobject>& obj)
+    : jobj_(base::android::ScopedJavaGlobalRef<jobject>(obj)) {
   Java_BraveShieldsContentSettings_setNativePtr(env, obj,
       reinterpret_cast<intptr_t>(this));
 }
@@ -49,8 +50,8 @@ void BraveShieldsContentSettings::Destroy(JNIEnv* env) {
 void BraveShieldsContentSettings::DispatchBlockedEventToJava(int tab_id,
         const std::string& block_type, const std::string& subresource) {
   JNIEnv* env = base::android::AttachCurrentThread();
-  Java_BraveShieldsContentSettings_blockedEvent(env,
-      weak_java_native_worker_.get(env), tab_id,
+  Java_BraveShieldsContentSettings_blockedEvent(
+      env, jobj_, tab_id,
       base::android::ConvertUTF8ToJavaString(env, block_type),
       base::android::ConvertUTF8ToJavaString(env, subresource));
 }

--- a/browser/android/brave_shields_content_settings.h
+++ b/browser/android/brave_shields_content_settings.h
@@ -8,26 +8,28 @@
 
 #include <jni.h>
 #include <string>
-#include "base/android/jni_weak_ref.h"
+#include "base/android/scoped_java_ref.h"
 
 namespace chrome {
 namespace android {
 
 class BraveShieldsContentSettings {
  public:
-    BraveShieldsContentSettings(JNIEnv* env,
-      const base::android::JavaRef<jobject>& obj);
-    ~BraveShieldsContentSettings();
+  BraveShieldsContentSettings(JNIEnv* env,
+                              const base::android::JavaRef<jobject>& obj);
+  ~BraveShieldsContentSettings();
 
-    void Destroy(JNIEnv* env);
-    void DispatchBlockedEventToJava(int tab_id, const std::string& block_type,
-        const std::string& subresource);
+  void Destroy(JNIEnv* env);
+  void DispatchBlockedEventToJava(int tab_id,
+                                  const std::string& block_type,
+                                  const std::string& subresource);
 
-    static void DispatchBlockedEvent(int tab_id,
-        const std::string& block_type, const std::string& subresource);
+  static void DispatchBlockedEvent(int tab_id,
+                                   const std::string& block_type,
+                                   const std::string& subresource);
 
  private:
-    JavaObjectWeakGlobalRef weak_java_native_worker_;
+  base::android::ScopedJavaGlobalRef<jobject> jobj_;
 };
 
 }  // namespace android


### PR DESCRIPTION
Uplift of #4598

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. (Tested on a local build only since a new nightly is not available yet.)
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.