### PR TITLE
Fixes missing Skip button on YouTube

### DIFF
--- a/components/brave_extension/extension/brave_extension/assets/removeEmptyElements.css
+++ b/components/brave_extension/extension/brave_extension/assets/removeEmptyElements.css
@@ -1,7 +1,6 @@
 .ad-hideable,
   .ad-div,
   .masthead-ad-control,
-  .video-ads,
   .promoted-sparkles-text-search-root-container,
   .ytd-compact-promoted-video-renderer,
   #ytd-promoted-sparkles-web-renderer,


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/8209

Working with @LaurenWags  It was reported Youtube ad skip this was still causing issues, found an older filter `.video-ads` was the main cause of this.

I was partially right on my previous commit https://github.com/brave/brave-core/pull/4403 with `##.ytp-ad-module` but missed the previous `.video-ads` filler in the removeEmptyElements list.  The full element we're incorrectly blocking: `youtube.com##.ytp-ad-module.video-ads`

To be sure this was resolved, I manually loaded our stylesheet.

**Elements being loaded:**
![div-elements](https://user-images.githubusercontent.com/1659004/74314145-d2513200-4dd9-11ea-894b-155fc23cadcf.png)
**Element: .video-ads overlay:**
![yt2](https://user-images.githubusercontent.com/1659004/74314213-f44ab480-4dd9-11ea-994a-77d6f61d38ae.png)


Can we get this into 1.4? @bsclifton 