### PR TITLE
Do not generate dummy `originator_cache_guid` and random `originator_client_item_id` in GetUpdatesResponse (uplift to 1.4.x)

### DIFF
--- a/chromium_src/components/sync/engine_impl/get_updates_processor.cc
+++ b/chromium_src/components/sync/engine_impl/get_updates_processor.cc
@@ -109,12 +109,6 @@ void ExtractBookmarkMeta(sync_pb::SyncEntity* entity,
 }
 
 void MigrateFromLegacySync(sync_pb::SyncEntity* entity) {
-  if (!entity->has_originator_cache_guid()) {
-    entity->set_originator_cache_guid("legacy_originator_cache_guid");
-  }
-  if (!entity->has_originator_client_item_id()) {
-    entity->set_originator_client_item_id(base::GenerateGUID());
-  }
   if (!entity->has_position_in_parent()) {
     entity->set_position_in_parent(0);
   }


### PR DESCRIPTION
Uplift of #4623

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.