### PR TITLE
Revert "Hide sync menu from app menu if it's disabled"

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -5,10 +5,8 @@
 
 #include "brave/browser/ui/toolbar/brave_app_menu_model.h"
 
-#include "brave/components/brave_sync/buildflags/buildflags.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/grit/generated_resources.h"
-#include "components/sync/driver/sync_driver_switches.h"
 
 BraveAppMenuModel::~BraveAppMenuModel() = default;
 
@@ -78,15 +76,12 @@ void BraveAppMenuModel::InsertBraveMenuItems() {
                              IDS_SHOW_BRAVE_WALLET);
   }
 
-#if BUILDFLAG(ENABLE_BRAVE_SYNC)
   // Insert sync menu
-  if (switches::IsSyncAllowedByFlag() &&
-      IsCommandIdEnabled(IDC_SHOW_BRAVE_SYNC)) {
+  if (IsCommandIdEnabled(IDC_SHOW_BRAVE_SYNC)) {
     InsertItemWithStringIdAt(GetIndexOfBraveSyncItem(),
                              IDC_SHOW_BRAVE_SYNC,
                              IDS_SHOW_BRAVE_SYNC);
   }
-#endif
 
   // Insert adblock menu at last. Assumed this is always enabled.
   DCHECK(IsCommandIdEnabled(IDC_SHOW_BRAVE_ADBLOCK));


### PR DESCRIPTION
Reverts brave/brave-core#4571

Reason: The `IDC_SHOW_BRAVE_SYNC` enabling status is already managed properly by
`BraveBrowserCommandController::InitBraveCommandState()`.
So, checking `switches::IsSyncAllowedByFlag()` in `BraveAppMenuModel` is redundant now.