### PR TITLE
Brave Ads catalog issuer confirmation token rotation

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -856,11 +856,21 @@ void ConfirmationsImpl::SetCatalogIssuers(std::unique_ptr<IssuersInfo> info) {
     BLOG(INFO) << "    Public key: " << issuer.public_key;
   }
 
+  const bool public_key_was_rotated =
+      !public_key_.empty() && public_key_ != info->public_key;
+
   public_key_ = info->public_key;
 
   catalog_issuers_.clear();
   for (const auto& issuer : info->issuers) {
     catalog_issuers_.insert({issuer.public_key, issuer.name});
+  }
+
+  if (public_key_was_rotated) {
+    unblinded_tokens_->RemoveAllTokens();
+    if (is_initialized_) {
+      RefillTokensIfNecessary();
+    }
   }
 
   NotifyAdsIfConfirmationsIsReady();

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
@@ -225,6 +225,12 @@ void RedeemToken::OnFetchPaymentToken(
     return;
   }
 
+  if (response_status_code == net::HTTP_BAD_REQUEST) {
+    BLOG(WARNING) << "Credential is invalid";
+    OnRedeem(FAILED, confirmation, false);
+    return;
+  }
+
   if (response_status_code != net::HTTP_OK) {
     BLOG(ERROR) << "Failed to fetch payment token";
     OnRedeem(FAILED, confirmation);


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/7796

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm unblinded tokens are recreated after a catalog issuer confirmation token rotation has occurred
- Confirm previously failed confirmations are redeemed after a catalog issuer confirmation token rotation has occurred if the legacy confirmation key is still valid on the server
- Confirm previously failed confirmations are not redeemed after a catalog issuer confirmation token rotation has occurred if the legacy confirmation key is not valid on the server

will require help from the ads-serve team

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
