### PR TITLE
Fixes duplicate Brave Ads ad history entries are missing - 1.4.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1021,6 +1021,7 @@ void AdsServiceImpl::OnGetAdsHistory(
 
     base::DictionaryValue ad_history_dictionary;
     ad_history_dictionary.SetKey("id", base::Value(entry.uuid));
+    ad_history_dictionary.SetKey("parent_uuid", base::Value(entry.parent_uuid));
     ad_history_dictionary.SetPath("adContent",
         std::move(ad_content_dictionary));
     ad_history_dictionary.SetPath("categoryContent",

--- a/vendor/bat-native-ads/include/bat/ads/ad_history.h
+++ b/vendor/bat-native-ads/include/bat/ads/ad_history.h
@@ -35,6 +35,7 @@ struct ADS_EXPORT AdHistory {
 
   uint64_t timestamp_in_seconds;
   std::string uuid;
+  std::string parent_uuid;
   AdContent ad_content;
   CategoryContent category_content;
 };

--- a/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
+++ b/vendor/bat-native-ads/include/bat/ads/confirmation_type.h
@@ -13,6 +13,8 @@ namespace ads {
 class ConfirmationType {
  public:
   enum Value : int {
+    // When adding new confirmation types they must be added with highest
+    // priority at the top so that ads history can be filtered
     UNKNOWN,
     CLICK,
     DISMISS,
@@ -32,7 +34,7 @@ class ConfirmationType {
 
   bool IsSupported() const;
 
-  int value() const;
+  Value value() const;
   operator std::string() const;
 
   bool operator==(ConfirmationType type) const;

--- a/vendor/bat-native-ads/include/bat/ads/notification_info.h
+++ b/vendor/bat-native-ads/include/bat/ads/notification_info.h
@@ -25,6 +25,7 @@ struct ADS_EXPORT NotificationInfo {
       std::string* error_description = nullptr);
 
   std::string id;
+  std::string parent_id;
   std::string creative_set_id;
   std::string category;
   std::string advertiser;

--- a/vendor/bat-native-ads/src/bat/ads/ad_history.cc
+++ b/vendor/bat-native-ads/src/bat/ads/ad_history.cc
@@ -22,6 +22,7 @@ AdHistory::AdHistory(
     const AdHistory& properties)
     : timestamp_in_seconds(properties.timestamp_in_seconds),
       uuid(properties.uuid),
+      parent_uuid(properties.parent_uuid),
       ad_content(properties.ad_content),
       category_content(properties.category_content) {}
 
@@ -31,6 +32,7 @@ bool AdHistory::operator==(
     const AdHistory& rhs) const {
   return timestamp_in_seconds == rhs.timestamp_in_seconds &&
       uuid == rhs.uuid &&
+      parent_uuid == rhs.parent_uuid &&
       ad_content == rhs.ad_content &&
       category_content == rhs.category_content;
 }
@@ -70,6 +72,13 @@ Result AdHistory::FromJson(
     uuid = document["uuid"].GetString();
   }
 
+  if (document.HasMember("parent_uuid")) {
+    parent_uuid = document["parent_uuid"].GetString();
+  } else {
+    // Migration for legacy ad history
+    parent_uuid = "";
+  }
+
   if (document.HasMember("ad_content")) {
     rapidjson::StringBuffer buffer;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -101,6 +110,9 @@ void SaveToJson(JsonWriter* writer, const AdHistory& history) {
 
   writer->String("uuid");
   writer->String(history.uuid.c_str());
+
+  writer->String("parent_uuid");
+  writer->String(history.parent_uuid.c_str());
 
   writer->String("ad_content");
   SaveToJson(writer, history.ad_content);

--- a/vendor/bat-native-ads/src/bat/ads/confirmation_type.cc
+++ b/vendor/bat-native-ads/src/bat/ads/confirmation_type.cc
@@ -39,7 +39,7 @@ bool ConfirmationType::IsSupported() const {
   return value_ != UNKNOWN;
 }
 
-int ConfirmationType::value() const {
+ConfirmationType::Value ConfirmationType::value() const {
   return value_;
 }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -1291,6 +1291,7 @@ bool AdsImpl::ShowAd(
 
   auto notification_info = std::make_unique<NotificationInfo>();
   notification_info->id = base::GenerateGUID();
+  notification_info->parent_id = base::GenerateGUID();
   notification_info->advertiser = ad.advertiser;
   notification_info->category = ad.category;
   notification_info->text = ad.notification_text;
@@ -2093,6 +2094,7 @@ void AdsImpl::GenerateAdsHistoryEntry(
   auto ad_history = std::make_unique<AdHistory>();
   ad_history->timestamp_in_seconds = Time::NowInSeconds();
   ad_history->uuid = base::GenerateGUID();
+  ad_history->parent_uuid = notification_info.parent_id;
   ad_history->ad_content.uuid = notification_info.uuid;
   ad_history->ad_content.creative_set_id = notification_info.creative_set_id;
   ad_history->ad_content.brand = notification_info.advertiser;

--- a/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter.h
@@ -13,14 +13,19 @@
 namespace ads {
 
 struct AdsHistory;
+class ConfirmationType;
 
 class AdsHistoryConfirmationFilter : public AdsHistoryFilter {
- public :
-  AdsHistoryConfirmationFilter() = default;
+ public:
+  AdsHistoryConfirmationFilter();
   ~AdsHistoryConfirmationFilter() override;
 
   std::deque<AdHistory> Apply(
       const std::deque<AdHistory>& history) const override;
+
+ private:
+  bool ShouldFilterAction(
+    const ConfirmationType& confirmation_type) const;
 };
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/notifications.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/notifications.cc
@@ -24,6 +24,7 @@ const char kNotificationsStateName[] = "notifications.json";
 const char kNotificationsListKey[] = "notifications";
 
 const char kNotificationIdKey[] = "id";
+const char kNotificationParentIdKey[] = "parent_id";
 const char kNotificationCreativeSetIdKey[] = "creative_set_id";
 const char kNotificationCategoryKey[] = "category";
 const char kNotificationAdvertiserKey[] = "advertiser";
@@ -162,6 +163,11 @@ bool Notifications::GetNotificationFromDictionary(
     return false;
   }
 
+  if (!GetParentIdFromDictionary(dictionary, &notification_info.parent_id)) {
+    // Migrate for legacy notifications
+    notification_info.parent_id = "";
+  }
+
   if (!GetCreativeSetIdFromDictionary(dictionary,
       &notification_info.creative_set_id)) {
     return false;
@@ -196,6 +202,12 @@ bool Notifications::GetIdFromDictionary(
     base::DictionaryValue* dictionary,
     std::string* value) const {
   return GetStringFromDictionary(kNotificationIdKey, dictionary, value);
+}
+
+bool Notifications::GetParentIdFromDictionary(
+    base::DictionaryValue* dictionary,
+    std::string* value) const {
+  return GetStringFromDictionary(kNotificationParentIdKey, dictionary, value);
 }
 
 bool Notifications::GetCreativeSetIdFromDictionary(
@@ -366,6 +378,8 @@ base::Value Notifications::GetAsList() {
 
     dictionary.SetKey(kNotificationIdKey,
         base::Value(notification.id));
+    dictionary.SetKey(kNotificationParentIdKey,
+        base::Value(notification.parent_id));
     dictionary.SetKey(kNotificationCreativeSetIdKey,
         base::Value(notification.creative_set_id));
     dictionary.SetKey(kNotificationCategoryKey,

--- a/vendor/bat-native-ads/src/bat/ads/internal/notifications.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/notifications.h
@@ -55,6 +55,9 @@ class Notifications {
   bool GetIdFromDictionary(
       base::DictionaryValue* dictionary,
       std::string* value) const;
+  bool GetParentIdFromDictionary(
+      base::DictionaryValue* dictionary,
+      std::string* value) const;
   bool GetCreativeSetIdFromDictionary(
       base::DictionaryValue* dictionary,
       std::string* value) const;

--- a/vendor/bat-native-ads/src/bat/ads/notification_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/notification_info.cc
@@ -14,6 +14,7 @@ namespace ads {
 
 NotificationInfo::NotificationInfo() :
     id(""),
+    parent_id(""),
     creative_set_id(""),
     category(""),
     advertiser(""),
@@ -24,6 +25,7 @@ NotificationInfo::NotificationInfo() :
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
     id(info.id),
+    parent_id(info.parent_id),
     creative_set_id(info.creative_set_id),
     category(info.category),
     advertiser(info.advertiser),
@@ -56,6 +58,10 @@ Result NotificationInfo::FromJson(
 
   if (document.HasMember("id")) {
     id = document["id"].GetString();
+  }
+
+  if (document.HasMember("parent_id")) {
+    parent_id = document["parent_id"].GetString();
   }
 
   if (document.HasMember("creative_set_id")) {
@@ -95,6 +101,9 @@ void SaveToJson(JsonWriter* writer, const NotificationInfo& info) {
 
   writer->String("id");
   writer->String(info.id.c_str());
+
+  writer->String("parent_id");
+  writer->String(info.parent_id.c_str());
 
   writer->String("creative_set_id");
   writer->String(info.creative_set_id.c_str());

--- a/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/confirmation_type.h
@@ -13,6 +13,8 @@ namespace confirmations {
 class ConfirmationType {
  public:
   enum Value : int {
+    // When adding new confirmation types they must be added with highest
+    // priority at the top so that ads history can be filtered
     UNKNOWN,
     CLICK,
     DISMISS,
@@ -32,7 +34,7 @@ class ConfirmationType {
 
   bool IsSupported() const;
 
-  int value() const;
+  Value value() const;
   operator std::string() const;
 
   bool operator==(ConfirmationType type) const;

--- a/vendor/bat-native-confirmations/include/bat/confirmations/notification_info.h
+++ b/vendor/bat-native-confirmations/include/bat/confirmations/notification_info.h
@@ -19,6 +19,7 @@ struct CONFIRMATIONS_EXPORT NotificationInfo {
   ~NotificationInfo();
 
   std::string id;
+  std::string parent_id;
   std::string creative_set_id;
   std::string category;
   std::string advertiser;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/confirmation_type.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/confirmation_type.cc
@@ -39,7 +39,7 @@ bool ConfirmationType::IsSupported() const {
   return value_ != UNKNOWN;
 }
 
-int ConfirmationType::value() const {
+ConfirmationType::Value ConfirmationType::value() const {
   return value_;
 }
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/notification_info.cc
@@ -8,6 +8,8 @@
 namespace confirmations {
 
 NotificationInfo::NotificationInfo() :
+    id(""),
+    parent_id(""),
     creative_set_id(""),
     category(""),
     advertiser(""),
@@ -17,6 +19,8 @@ NotificationInfo::NotificationInfo() :
     type(ConfirmationType::UNKNOWN) {}
 
 NotificationInfo::NotificationInfo(const NotificationInfo& info) :
+    id(info.id),
+    parent_id(info.parent_id),
     creative_set_id(info.creative_set_id),
     category(info.category),
     advertiser(info.advertiser),

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1173,6 +1173,7 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
 
   auto notification_info = std::make_unique<confirmations::NotificationInfo>();
   notification_info->id = notification_info_ads.id;
+  notification_info->parent_id = notification_info_ads.parent_id;
   notification_info->creative_set_id = notification_info_ads.creative_set_id;
   notification_info->category = notification_info_ads.category;
   notification_info->advertiser = notification_info_ads.advertiser;
@@ -1207,17 +1208,23 @@ void LedgerImpl::ConfirmAd(const std::string& info) {
     }
 
     case ads::ConfirmationType::FLAG: {
-      notification_info->type = confirmations::ConfirmationType::FLAG;
+      // Should never be reached as FLAG is handled by ConfirmAction, refactor
+      // code to abstract different ConfirmationTypes
+      NOTREACHED();
       break;
     }
 
     case ads::ConfirmationType::UPVOTE: {
-      notification_info->type = confirmations::ConfirmationType::UPVOTE;
+      // Should never be reached as UPVOTE is handled by ConfirmAction, refactor
+      // code to abstract different ConfirmationTypes
+      NOTREACHED();
       break;
     }
 
     case ads::ConfirmationType::DOWNVOTE: {
-      notification_info->type = confirmations::ConfirmationType::DOWNVOTE;
+      // Should never be reached as DOWNVOTE is handled by ConfirmAction,
+      // refactor code to abstract different ConfirmationTypes
+      NOTREACHED();
       break;
     }
   }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/4421
Resolves https://github.com/brave/brave-browser/issues/7869

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.