### PR TITLE
Not calling CloseSelectedTabs() in CW reset action

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_controller.cc
+++ b/components/brave_wallet/browser/brave_wallet_controller.cc
@@ -176,10 +176,6 @@ void BraveWalletController::OnCryptoWalletsReset(bool success) {
 }
 
 void BraveWalletController::CloseTabsAndRestart() {
-  // Close current tab
-  auto* current_browser =
-      BrowserList::GetInstance()->GetLastActive();
-  current_browser->tab_strip_model()->CloseSelectedTabs();
   // Close all CW tabs in each browser instance
   for (auto* browser : *BrowserList::GetInstance()) {
     auto* tab_strip = browser->tab_strip_model();


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/8286

To be used with: https://github.com/brave/ethereum-remote-client/pull/106

Description in issue

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
There isn't really a visible effect of this than can be tested without the UI. It can be seen here (https://github.com/brave/brave-core/blob/master/components/brave_wallet/browser/brave_wallet_controller.cc#L184) that code exists to close any remaining CW tabs.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
