### PR TITLE
Fix Tor profile hitting DCHECK in ProfileDestroyer

### DIFF
--- a/chromium_src/chrome/browser/profiles/profile_window.cc
+++ b/chromium_src/chrome/browser/profiles/profile_window.cc
@@ -10,14 +10,12 @@
 #undef CreateAndSwitchToNewProfile
 
 #include "base/bind.h"
-#include "base/task/post_task.h"
+#include "base/threading/sequenced_task_runner_handle.h"
 #include "brave/browser/profiles/brave_profile_manager.h"
 #include "chrome/browser/profiles/profile_attributes_storage.h"
 #include "chrome/browser/profiles/profile_avatar_icon_util.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/browser/profiles/profile_metrics.h"
-#include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
 
 namespace profiles {
 
@@ -66,8 +64,9 @@ void OnTorRegularProfileCreated(ProfileManager::CreateCallback callback,
   // hosts in time before the off-the-record Tor profile is destroyed and hit
   // DCHECK in ProfileDestroyer because a render process host wasn't destroyed
   // before the off-the-record profile is destroyed.
-  base::PostTask(FROM_HERE, {content::BrowserThread::UI},
-                 base::BindOnce(&profiles::OpenBrowserWindowForTorProfile,
+  DCHECK(base::SequencedTaskRunnerHandle::IsSet());
+  base::SequencedTaskRunnerHandle::Get()->PostTask(
+      FROM_HERE, base::BindOnce(&profiles::OpenBrowserWindowForTorProfile,
                                 callback, always_create, is_new_profile,
                                 unblock_extensions, profile, status));
 }


### PR DESCRIPTION
Don't create off-the-record Tor profile before the regular Tor profile finishes ProfileManager::DoFinalInit.

This PR fixes that current Tor profile related tests would crash with DCHECKs on.

Resolves https://github.com/brave/brave-browser/issues/8318
Resolves https://github.com/brave/brave-browser/issues/8262

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm test brave_browser_tests`

1. Open a debug build or a build with DCHECK on
2. Open a Tor window
3. Quit Brave and make sure no crashes (DCHECK).

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
