### PR TITLE
Support regional and custom cosmetic filters

### DIFF
--- a/common/extensions/api/brave_shields.json
+++ b/common/extensions/api/brave_shields.json
@@ -90,10 +90,11 @@
                 "name": "hostnameSpecificResources",
                 "type": "object",
                 "properties": {
-                  "hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific CSS selectors that should be hidden from the page"},
+                  "hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific CSS selectors that should be hidden from the page if they are determined to not include 1st party content"},
                   "style_selectors": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}, "description": "Hostname-specific CSS selectors that should be restyled, with their associated CSS style rules"},
                   "exceptions": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific overrides for generic cosmetic blocking selectors"},
-                  "injected_script": {"type": "string", "description": "A script to inject as the page is loading"}
+                  "injected_script": {"type": "string", "description": "A script to inject as the page is loading"},
+                  "force_hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific CSS selectors that should be hidden from the page"}
                 }
               }
             ]
@@ -125,7 +126,12 @@
             "name": "callback",
             "parameters": [
               {
-                "name": "selectorsJson",
+                "name": "selectors",
+                "type": "array",
+                "items": {"type": "string"}
+              },
+              {
+                "name": "forceHideSelectors",
                 "type": "array",
                 "items": {"type": "string"}
               }

--- a/common/extensions/api/brave_shields.json
+++ b/common/extensions/api/brave_shields.json
@@ -126,7 +126,8 @@
             "parameters": [
               {
                 "name": "selectorsJson",
-                "type": "string"
+                "type": "array",
+                "items": {"type": "string"}
               }
             ]
           }

--- a/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
@@ -19,8 +19,7 @@ const informTabOfCosmeticRulesToConsider = (tabId: number, selectors: string[]) 
 
 // Fires when content-script calls hiddenClassIdSelectors
 export const injectClassIdStylesheet = (tabId: number, classes: string[], ids: string[], exceptions: string[]) => {
-  chrome.braveShields.hiddenClassIdSelectors(classes, ids, exceptions, (jsonSelectors) => {
-    const selectors = JSON.parse(jsonSelectors)
+  chrome.braveShields.hiddenClassIdSelectors(classes, ids, exceptions, (selectors) => {
     informTabOfCosmeticRulesToConsider(tabId, selectors)
   })
 }

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -202,13 +202,14 @@ base::Optional<base::Value> AdBlockBaseService::HostnameCosmeticResources(
           this->ad_block_client_->hostnameCosmeticResources(hostname));
 }
 
-std::string AdBlockBaseService::HiddenClassIdSelectors(
+base::Optional<base::Value> AdBlockBaseService::HiddenClassIdSelectors(
         const std::vector<std::string>& classes,
         const std::vector<std::string>& ids,
         const std::vector<std::string>& exceptions) {
-  return this->ad_block_client_->hiddenClassIdSelectors(classes,
-                                                        ids,
-                                                        exceptions);
+  return base::JSONReader::Read(
+          this->ad_block_client_->hiddenClassIdSelectors(classes,
+                                                         ids,
+                                                         exceptions));
 }
 
 void AdBlockBaseService::GetDATFileData(const base::FilePath& dat_file_path) {

--- a/components/brave_shields/browser/ad_block_base_service.h
+++ b/components/brave_shields/browser/ad_block_base_service.h
@@ -49,7 +49,7 @@ class AdBlockBaseService : public BaseBraveShieldsService {
 
   base::Optional<base::Value> HostnameCosmeticResources(
           const std::string& hostname);
-  std::string HiddenClassIdSelectors(
+  base::Optional<base::Value> HiddenClassIdSelectors(
           const std::vector<std::string>& classes,
           const std::vector<std::string>& ids,
           const std::vector<std::string>& exceptions);

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -206,7 +206,7 @@ AdBlockRegionalServiceManager::HostnameCosmeticResources(
         it->second->HostnameCosmeticResources(hostname);
     if (first_value) {
       if (next_value) {
-        MergeResourcesInto(&*first_value, &*next_value);
+        MergeResourcesInto(&*first_value, &*next_value, false);
       }
     } else {
       first_value = std::move(next_value);

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -191,6 +191,31 @@ void AdBlockRegionalServiceManager::EnableFilterList(const std::string& uuid,
                      base::Unretained(this), uuid, enabled));
 }
 
+base::Optional<base::Value>
+AdBlockRegionalServiceManager::HostnameCosmeticResources(
+        const std::string& hostname) {
+  auto it = this->regional_services_.begin();
+  if (it == this->regional_services_.end()) {
+    return base::Optional<base::Value>();
+  }
+  base::Optional<base::Value> first_value =
+      it->second->HostnameCosmeticResources(hostname);
+
+  for ( ; it != this->regional_services_.end(); it++) {
+    base::Optional<base::Value> next_value =
+        it->second->HostnameCosmeticResources(hostname);
+    if (first_value) {
+      if (next_value) {
+        MergeResourcesInto(&*first_value, &*next_value);
+      }
+    } else {
+      first_value = std::move(next_value);
+    }
+  }
+
+  return first_value;
+}
+
 // static
 bool AdBlockRegionalServiceManager::IsSupportedLocale(
     const std::string& locale) {

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -216,6 +216,37 @@ AdBlockRegionalServiceManager::HostnameCosmeticResources(
   return first_value;
 }
 
+base::Optional<base::Value>
+AdBlockRegionalServiceManager::HiddenClassIdSelectors(
+        const std::vector<std::string>& classes,
+        const std::vector<std::string>& ids,
+        const std::vector<std::string>& exceptions) {
+  auto it = this->regional_services_.begin();
+  if (it == this->regional_services_.end()) {
+    return base::Optional<base::Value>();
+  }
+  base::Optional<base::Value> first_value =
+      it->second->HiddenClassIdSelectors(classes, ids, exceptions);
+
+  for ( ; it != this->regional_services_.end(); it++) {
+    base::Optional<base::Value> next_value =
+        it->second->HiddenClassIdSelectors(classes, ids, exceptions);
+    if (first_value && first_value->is_list()) {
+      if (next_value && next_value->is_list()) {
+        for (auto i = next_value->GetList().begin();
+                i < next_value->GetList().end();
+                i++) {
+          first_value->Append(std::move(*i));
+        }
+      }
+    } else {
+      first_value = std::move(next_value);
+    }
+  }
+
+  return first_value;
+}
+
 // static
 bool AdBlockRegionalServiceManager::IsSupportedLocale(
     const std::string& locale) {

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -12,7 +12,9 @@
 
 #include "base/macros.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/optional.h"
 #include "base/synchronization/lock.h"
+#include "base/values.h"
 #include "brave/components/brave_component_updater/browser/brave_component.h"
 #include "content/public/common/resource_type.h"
 #include "url/gurl.h"
@@ -51,6 +53,9 @@ class AdBlockRegionalServiceManager {
   void EnableTag(const std::string& tag, bool enabled);
   void AddResources(const std::string& resources);
   void EnableFilterList(const std::string& uuid, bool enabled);
+
+  base::Optional<base::Value> HostnameCosmeticResources(
+          const std::string& hostname);
 
  private:
   friend class ::AdBlockServiceTest;

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "base/macros.h"
 #include "base/memory/scoped_refptr.h"
@@ -56,6 +57,10 @@ class AdBlockRegionalServiceManager {
 
   base::Optional<base::Value> HostnameCosmeticResources(
           const std::string& hostname);
+  base::Optional<base::Value> HiddenClassIdSelectors(
+          const std::vector<std::string>& classes,
+          const std::vector<std::string>& ids,
+          const std::vector<std::string>& exceptions);
 
  private:
   friend class ::AdBlockServiceTest;

--- a/components/brave_shields/browser/ad_block_service_helper.cc
+++ b/components/brave_shields/browser/ad_block_service_helper.cc
@@ -48,8 +48,24 @@ std::vector<FilterList>::const_iterator FindAdBlockFilterListByLocale(
 
 // Merges the contents of the second HostnameCosmeticResources Value into the
 // first one provided.
-void MergeResourcesInto(base::Value* into, base::Value* from) {
-  base::Value* resources_hide_selectors = into->FindKey("hide_selectors");
+//
+// If `force_hide` is true, the contents of `from`'s `hide_selectors` field
+// will be moved into a possibly new field of `into` called
+// `force_hide_selectors`.
+void MergeResourcesInto(
+        base::Value* into,
+        base::Value* from,
+        bool force_hide) {
+  base::Value* resources_hide_selectors = nullptr;
+  if (force_hide) {
+    resources_hide_selectors = into->FindKey("force_hide_selectors");
+    if (!resources_hide_selectors || !resources_hide_selectors->is_list()) {
+        into->SetPath("force_hide_selectors", base::ListValue());
+        resources_hide_selectors = into->FindKey("force_hide_selectors");
+    }
+  } else {
+    resources_hide_selectors = into->FindKey("hide_selectors");
+  }
   base::Value* from_resources_hide_selectors =
       from->FindKey("hide_selectors");
   if (resources_hide_selectors && from_resources_hide_selectors) {

--- a/components/brave_shields/browser/ad_block_service_helper.h
+++ b/components/brave_shields/browser/ad_block_service_helper.h
@@ -21,7 +21,7 @@ std::vector<adblock::FilterList>::const_iterator FindAdBlockFilterListByLocale(
     const std::vector<adblock::FilterList>& region_lists,
     const std::string& locale);
 
-void MergeResourcesInto(base::Value* into, base::Value* from);
+void MergeResourcesInto(base::Value* into, base::Value* from, bool force_hide);
 
 }  // namespace brave_shields
 

--- a/components/brave_shields/browser/ad_block_service_helper.h
+++ b/components/brave_shields/browser/ad_block_service_helper.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/values.h"
 #include "brave/vendor/adblock_rust_ffi/src/wrapper.hpp"
 
 namespace brave_shields {
@@ -19,6 +20,8 @@ std::vector<adblock::FilterList>::const_iterator FindAdBlockFilterListByUUID(
 std::vector<adblock::FilterList>::const_iterator FindAdBlockFilterListByLocale(
     const std::vector<adblock::FilterList>& region_lists,
     const std::string& locale);
+
+void MergeResourcesInto(base::Value* into, base::Value* from);
 
 }  // namespace brave_shields
 

--- a/components/brave_shields/browser/cosmetic_merge_unittest.cc
+++ b/components/brave_shields/browser/cosmetic_merge_unittest.cc
@@ -1,0 +1,132 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/json/json_reader.h"
+#include "brave/components/brave_shields/browser/ad_block_service_helper.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_shields {
+
+using ::testing::_;
+
+class CosmeticResourceMergeTest : public testing::Test {
+ public:
+  CosmeticResourceMergeTest() {}
+  ~CosmeticResourceMergeTest() override {}
+
+  void CompareMergeFromStrings(
+          const std::string& a,
+          const std::string& b,
+          const std::string& expected) {
+    base::Optional<base::Value> a_val = base::JSONReader::Read(a);
+    ASSERT_TRUE(a_val);
+
+    base::Optional<base::Value> b_val = base::JSONReader::Read(b);
+    ASSERT_TRUE(b_val);
+
+    const base::Optional<base::Value> expected_val =
+        base::JSONReader::Read(expected);
+    ASSERT_TRUE(expected_val);
+
+    MergeResourcesInto(&*a_val, &*b_val);
+
+    ASSERT_EQ(*a_val, *expected_val);
+  }
+
+ protected:
+  void SetUp() override {}
+
+  void TearDown() override {}
+};
+
+const char EMPTY_RESOURCES[] = "{"
+    "\"hide_selectors\": [], "
+    "\"style_selectors\": {}, "
+    "\"exceptions\": [], "
+    "\"injected_script\": \"\""
+"}";
+
+const char NONEMPTY_RESOURCES[] = "{"
+    "\"hide_selectors\": [\"a\", \"b\"], "
+    "\"style_selectors\": {\"c\": \"color: #fff\", \"d\": \"color: #000\"}, "
+    "\"exceptions\": [\"e\", \"f\"], "
+    "\"injected_script\": \"console.log('g')\""
+"}";
+
+TEST_F(CosmeticResourceMergeTest, MergeTwoEmptyResources) {
+  const std::string a = EMPTY_RESOURCES;
+  const std::string b = EMPTY_RESOURCES;
+
+  // Same as EMPTY_RESOURCES, but with an additional newline in the
+  // injected_script
+  const std::string expected = "{"
+      "\"hide_selectors\": [], "
+      "\"style_selectors\": {}, "
+      "\"exceptions\": [], "
+      "\"injected_script\": \"\n\""
+  "}";
+
+  CompareMergeFromStrings(a, b, expected);
+}
+
+TEST_F(CosmeticResourceMergeTest, MergeEmptyIntoNonEmpty) {
+  const std::string a = NONEMPTY_RESOURCES;
+  const std::string b = EMPTY_RESOURCES;
+
+  // Same as a, but with an additional newline at the end of the
+  // injected_script
+  const std::string expected = "{"
+      "\"hide_selectors\": [\"a\", \"b\"], "
+      "\"style_selectors\": {\"c\": \"color: #fff\", \"d\": \"color: #000\"}, "
+      "\"exceptions\": [\"e\", \"f\"], "
+      "\"injected_script\": \"console.log('g')\n\""
+  "}";
+
+  CompareMergeFromStrings(a, b, expected);
+}
+
+TEST_F(CosmeticResourceMergeTest, MergeNonEmptyIntoEmpty) {
+  const std::string a = EMPTY_RESOURCES;
+  const std::string b = NONEMPTY_RESOURCES;
+
+  // Same as b, but with an additional newline at the beginning of the
+  // injected_script
+  const std::string expected = "{"
+      "\"hide_selectors\": [\"a\", \"b\"],"
+      "\"style_selectors\": {\"c\": \"color: #fff\", \"d\": \"color: #000\"}, "
+      "\"exceptions\": [\"e\", \"f\"], "
+      "\"injected_script\": \"\nconsole.log('g')\""
+  "}";
+
+  CompareMergeFromStrings(a, b, expected);
+}
+
+TEST_F(CosmeticResourceMergeTest, MergeNonEmptyIntoNonEmpty) {
+  const std::string a = NONEMPTY_RESOURCES;
+  const std::string b = "{"
+      "\"hide_selectors\": [\"h\", \"i\"], "
+      "\"style_selectors\": {\"j\": \"color: #eee\", \"k\": \"color: #111\"}, "
+      "\"exceptions\": [\"l\", \"m\"], "
+      "\"injected_script\": \"console.log('n')\""
+  "}";
+
+  const std::string expected = "{"
+      "\"hide_selectors\": [\"a\", \"b\", \"h\", \"i\"], "
+      "\"style_selectors\": {"
+          "\"c\": \"color: #fff\", "
+          "\"d\": \"color: #000\", "
+          "\"j\": \"color: #eee\", "
+          "\"k\": \"color: #111\""
+      "}, "
+      "\"exceptions\": [\"e\", \"f\", \"l\", \"m\"], "
+      "\"injected_script\": \"console.log('g')\nconsole.log('n')\""
+  "}";
+
+  CompareMergeFromStrings(a, b, expected);
+}
+
+
+}  // namespace brave_shields

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -220,7 +220,7 @@ declare namespace chrome.braveShields {
     injected_script: string
   }
   const hostnameCosmeticResources: (hostname: string, callback: (resources: HostnameSpecificResources) => void) => void
-  const hiddenClassIdSelectors: (classes: string[], ids: string[], exceptions: string[], callback: (selectorsJson: string) => void) => void
+  const hiddenClassIdSelectors: (classes: string[], ids: string[], exceptions: string[], callback: (selectors: string[]) => void) => void
 
   type BraveShieldsViewPreferences = {
     showAdvancedView: boolean

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -218,9 +218,10 @@ declare namespace chrome.braveShields {
     style_selectors: any
     exceptions: string[]
     injected_script: string
+    force_hide_selectors: string[]
   }
   const hostnameCosmeticResources: (hostname: string, callback: (resources: HostnameSpecificResources) => void) => void
-  const hiddenClassIdSelectors: (classes: string[], ids: string[], exceptions: string[], callback: (selectors: string[]) => void) => void
+  const hiddenClassIdSelectors: (classes: string[], ids: string[], exceptions: string[], callback: (selectors: string[], forceHideSelectors: string[]) => void) => void
 
   type BraveShieldsViewPreferences = {
     showAdvancedView: boolean

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -95,6 +95,7 @@ test("brave_unit_tests") {
     "//brave/components/assist_ranker/ranker_model_loader_impl_unittest.cc",
     "//brave/components/brave_shields/browser/ad_block_regional_service_unittest.cc",
     "//brave/components/brave_shields/browser/adblock_stub_response_unittest.cc",
+    "//brave/components/brave_shields/browser/cosmetic_merge_unittest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_recently_used_cache_unittest.cpp",
     "//brave/components/ntp_sponsored_images/browser/view_counter_model_unittest.cc",
     "//brave/components/ntp_sponsored_images/browser/view_counter_service_unittest.cc",


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/4348

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

I have added some new unit tests to verify that the logic for merging cosmetic filter information from the different sources works as expected.

Manual verification of custom filter application:

1. Open [this sample page](https://myspace.com/article/2019/9/16/game-of-thrones-has-already-won-10-emmys-for-its-final-season-ew)
1. Ensure there is no blank space under the word "Advertisement" on the right column (default adblock lists)
1. Open brave://adblock in a new tab
1. At the bottom, add the following custom rule to the "Custom Filters" input: `myspace.com###articleLeft`
1. Return to the sample page and refresh
1. Ensure that there is still no blank space under the "Advertisement" label in the right column
1. Ensure that the text of the article is also hidden


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
