### PR TITLE
Fixes ad conversion detection fails if the target URL of the last shown ad matches the conversion URL pattern - 1.5.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -696,6 +696,8 @@ void AdsImpl::OnPageLoaded(
     return;
   }
 
+  CheckAdConversion(url);
+
   if (DomainsMatch(url, last_shown_notification_info_.url)) {
     BLOG(INFO) << "Site visited " << url
         << ", domain matches the last shown ad notification for "
@@ -734,8 +736,6 @@ void AdsImpl::OnPageLoaded(
   MaybeClassifyPage(url, html);
 
   CheckEasterEgg(url);
-
-  CheckAdConversion(url);
 
   BLOG(INFO) << "Site visited " << url << ", previous tab url was "
       << previous_tab_url_;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/4717
Resolves https://github.com/brave/brave-browser/issues/8362

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.