### PR TITLE
Fix partially hidden grant captcha drag and drop target image

### DIFF
--- a/components/brave_rewards/resources/page/components/promotion.tsx
+++ b/components/brave_rewards/resources/page/components/promotion.tsx
@@ -73,6 +73,7 @@ class Promotion extends React.Component<Props, State> {
           onClose={this.onHide}
           title={getLocale('grantGeneralErrorTitle')}
           text={''}
+          overlay={true}
         >
           <GrantError
             buttonText={getLocale('grantGeneralErrorButton')}
@@ -92,6 +93,7 @@ class Promotion extends React.Component<Props, State> {
         onClose={this.onHide}
         title={promotion.captchaStatus === 'wrongPosition' ? getLocale('notQuite') : getLocale('almostThere')}
         text={getLocale('proveHuman')}
+        overlay={true}
       >
         <GrantCaptcha
           onSolution={this.onSolution}
@@ -125,6 +127,7 @@ class Promotion extends React.Component<Props, State> {
         onClose={this.onFinish}
         title={title}
         text={text}
+        overlay={true}
       >
         <GrantComplete
           onClose={this.onFinish}

--- a/components/brave_rewards/resources/ui/components/grantCaptcha/style.ts
+++ b/components/brave_rewards/resources/ui/components/grantCaptcha/style.ts
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 
 export const StyledWrapper = styled<{}, 'div'>('div')`
   text-align: center;
-  margin: 10px 0 0 -32px;
+  margin: 10px -32px 0;
   width: 333px;
 `
 

--- a/components/brave_rewards/resources/ui/components/grantError/style.ts
+++ b/components/brave_rewards/resources/ui/components/grantError/style.ts
@@ -7,8 +7,7 @@ import styled from 'styled-components'
 export const StyledWrapper = styled<{}, 'div'>('div')`
   text-align: center;
   width: 100%;
-  padding: 20px 10px;
-  min-height: 350px;
+  padding: 20px 10px 0;
 `
 
 export const StyledText = styled<{}, 'div'>('div')`

--- a/components/brave_rewards/resources/ui/components/grantWrapper/index.tsx
+++ b/components/brave_rewards/resources/ui/components/grantWrapper/index.tsx
@@ -17,6 +17,7 @@ export interface Props {
   onClose: () => void
   title: string
   fullScreen?: boolean
+  overlay?: boolean
   hint?: string
   text: React.ReactNode
   children: React.ReactNode
@@ -24,7 +25,18 @@ export interface Props {
 
 export default class GrantWrapper extends React.PureComponent<Props, {}> {
   render () {
-    const { id, testId, isPanel, fullScreen, hint, onClose, title, text, children } = this.props
+    const {
+      id,
+      testId,
+      isPanel,
+      fullScreen,
+      overlay,
+      hint,
+      onClose,
+      title,
+      text,
+      children
+    } = this.props
 
     return (
       <StyledWrapper
@@ -32,6 +44,7 @@ export default class GrantWrapper extends React.PureComponent<Props, {}> {
         data-test-id={testId}
         isPanel={isPanel}
         fullScreen={fullScreen}
+        overlay={overlay}
       >
         <StyledClose onClick={onClose}>
           <CloseCircleOIcon />

--- a/components/brave_rewards/resources/ui/components/grantWrapper/style.ts
+++ b/components/brave_rewards/resources/ui/components/grantWrapper/style.ts
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 interface StyleProps {
   isPanel?: boolean
   fullScreen?: boolean
+  overlay?: boolean
 }
 
 const getBackground = (props: StyleProps) => {
@@ -22,7 +23,9 @@ const getBackground = (props: StyleProps) => {
 }
 
 export const StyledWrapper = styled<StyleProps, 'div'>('div')`
-  position: ${p => p.fullScreen ? 'fixed' : 'absolute'};
+  position: ${p => p.fullScreen
+    ? 'fixed'
+    : p.overlay ? 'absolute' : 'relative'};
   top: 0;
   left: 0;
   z-index: 6;
@@ -32,9 +35,12 @@ export const StyledWrapper = styled<StyleProps, 'div'>('div')`
   flex-wrap: wrap;
   overflow: hidden;
   width: 100%;
-  padding: 0 52px 20px;
+  padding: 0 52px 36px;
   border-radius: 6px;
-  height: ${p => (p.fullScreen || p.isPanel) ? '100%' : 'auto'};
+  min-height: ${p => (p.fullScreen || p.isPanel)
+    ? '100%'
+    : p.overlay ? '710px' : 'auto'};
+  min-width: 373px;
   overflow-y: ${p => p.fullScreen ? 'scroll' : 'hidden'};
   background: ${p => getBackground(p)};
 `

--- a/components/brave_rewards/resources/ui/components/walletWrapper/index.tsx
+++ b/components/brave_rewards/resources/ui/components/walletWrapper/index.tsx
@@ -569,6 +569,33 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       if (grant.amount) {
         grantAmount = grant.amount.toFixed(1)
       }
+
+      if (grant.captchaImage && grant.captchaStatus !== 'finished') {
+        let rendered = this.grantCaptcha()
+        if (rendered) {
+          return rendered
+        }
+      }
+
+      if (grant.captchaStatus === 'finished') {
+        return (
+          <GrantWrapper
+            isPanel={true}
+            onClose={this.onFinish.bind(this, grant.promotionId)}
+            title={grant.finishTitle || ''}
+            text={grant.finishText}
+          >
+            <GrantComplete
+              isMobile={true}
+              onClose={this.onFinish.bind(this, grant.promotionId)}
+              amount={grantAmount}
+              date={date}
+              tokenTitle={grant.finishTokenTitle}
+              onlyAnonWallet={onlyAnonWallet}
+            />
+          </GrantWrapper>
+        )
+      }
     }
 
     const walletVerified = walletState === 'verified' || walletState === 'disconnected_verified'
@@ -583,23 +610,6 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
           isMobile={isMobile}
           notification={notification}
         >
-          {
-            grant && grant.captchaImage && grant.captchaStatus !== 'finished'
-              ? this.grantCaptcha()
-              : null
-          }
-          {
-            grant && grant.captchaStatus === 'finished'
-              ? <GrantWrapper
-                isPanel={true}
-                onClose={this.onFinish.bind(this, grant.promotionId)}
-                title={grant.finishTitle || ''}
-                text={grant.finishText}
-              >
-                <GrantComplete isMobile={true} onClose={this.onFinish.bind(this, grant.promotionId)} amount={grantAmount} date={date} tokenTitle={grant.finishTokenTitle} onlyAnonWallet={onlyAnonWallet} />
-              </GrantWrapper>
-              : null
-          }
           <StyledHeader>
             {
               !notification


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/7597
Resolves https://github.com/brave/brave-browser/issues/7147

Currently, when the grant captcha title text spans more than one line the drag-and-drop target image can extend below the bottom border of the rewards extension popup. This is because the `GrantWrapper` is an absolutely positioned overlay (rendered on top of the wallet UI), and absolutely positioned elements without explicit height to not grow the height of their parent.

This change modifies the rewards extension so that `GrantWrapper` is relatively positioned and the wallet UI is not rendered at the same time. `GrantWrapper` is also used in the promotions component of the settings page; in order to avoid layout changes there, a new style prop, `overlay (boolean)` has been added to the component which will cause it to be absolutely positioned.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

### BR Panel

- Launch Brave with a clean profile and `--rewards=staging=true`
- Open BR panel, join rewards, and click "Claim"
  - Verify: draggable BAT logo is centered and drop tagets are visible
- Right-click the "Prove that you are human" text and select "Inspect"
- In DevTools, double-click the "Prove that you are human text" to edit
- Add a long string of many words to the text
- Press the TAB button to display the change
  - Verify: the size of the panel has grown to accomodate the additional text
- Solve the catcha image
  - Verify: the confirmation UI is displayed correctly

### BR Settings Page

- Launch Brave with a clean profile and `--rewards=staging=true`
- Navigate to `brave://rewards` and join rewards
- Click the "Claim" button
  - Verify: the captcha UI is displayed correctly
- Solve the captcha
  - Verify: the confirmation UI is displayed correctly

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
