### PR TITLE
Escape key should always close the tip dialog

### DIFF
--- a/components/brave_rewards/resources/tip/brave_rewards_tip.tsx
+++ b/components/brave_rewards/resources/tip/brave_rewards_tip.tsx
@@ -40,6 +40,12 @@ window.cr.define('brave_rewards_tip', function () {
       console.error('Error parsing incoming dialog args', dialogArgsRaw, e)
     }
 
+    document.body.addEventListener('keyup', (evt) => {
+      if (evt.key.toLowerCase() === 'escape') {
+        getActions().onCloseDialog()
+      }
+    })
+
     render(
       <Provider store={store}>
         <ThemeProvider theme={Theme}>

--- a/components/brave_rewards/resources/ui/components/siteBanner/index.tsx
+++ b/components/brave_rewards/resources/ui/components/siteBanner/index.tsx
@@ -233,12 +233,6 @@ export default class SiteBanner extends React.PureComponent<Props, {}> {
     }
   }
 
-  onKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key.toLowerCase() === 'escape' && this.props.onClose) {
-      this.props.onClose()
-    }
-  }
-
   renderConfirmation = () => {
     const { type, onTweet, onlyAnonWallet, monthlyDate, amount } = this.props
 
@@ -286,11 +280,7 @@ export default class SiteBanner extends React.PureComponent<Props, {}> {
     const batFormatString = onlyAnonWallet ? 'bap' : 'bat'
 
     return (
-      <StyledWrapper
-        id={id}
-        onKeyUp={this.onKeyUp}
-        tabIndex={0}
-      >
+      <StyledWrapper id={id} tabIndex={0}>
         <StyledBanner>
           <StyledClose onClick={onClose}>
             <CloseCircleOIcon />


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/7609

After the user presses the "Send Tip" button in the tip dialog, keyboard focus goes to `document.body` which does not have a `keyup` handler for the escape key.

This change adds the `keyup` handler to `document.body` at page initialization and removes the `keyup` handler from the site banner component.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Launch Brave with a clean profile and `--rewards=staging=true`
- Open the BR panel, join rewards and claim the grant
- Navigate to https://duckduckgo.com/
- Open BR panel and click "Send a tip"
- Press the ESC key.
  - Verify that the tip dialog closes
- Open BR panel and click "Send a tip"
- Select 1 BAT and click "Send Tip"
- Press the ESC key.
  - Verify that the tip dialog closes

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
