### PR TITLE
[Android] Replace home button with a new tab button when homepage is disabled

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -92,6 +92,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/signin/BraveSigninManager.java",
   "../../brave/android/java/org/chromium/chrome/browser/sync/BraveSyncService.java",
   "../../brave/android/java/org/chromium/chrome/browser/sync/BraveSyncServiceObserver.java",
+  "../../brave/android/java/org/chromium/chrome/browser/toolbar/BraveHomeButton.java",
   "../../brave/android/java/org/chromium/chrome/browser/toolbar/bottom/BookmarksButton.java",
   "../../brave/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveBottomToolbarCoordinator.java",
   "../../brave/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveBottomToolbarVariationManager.java",

--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -100,6 +100,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/upgrade/BraveUpgradeJobIntentService.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/BraveReferrer.java",
   "../../brave/android/java/org/chromium/chrome/browser/util/PackageUtils.java",
+  "../../brave/android/java/org/chromium/chrome/browser/util/TabUtils.java",
 ]
 
 if (brave_rewards_enabled) {

--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -66,6 +66,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/qrreader/CameraSourcePreview.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BackgroundVideoPlaybackPreference.java",
+  "../../brave/android/java/org/chromium/chrome/browser/settings/BraveHomepagePreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveLicensePreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BravePreferenceFragment.java",

--- a/android/java/org/chromium/chrome/browser/settings/BraveHomepagePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveHomepagePreferences.java
@@ -1,0 +1,33 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.settings;
+
+import android.os.Bundle;
+
+import org.chromium.chrome.browser.partnercustomizations.HomepageManager;
+
+public class BraveHomepagePreferences extends HomepagePreferences {
+    private HomepageManager mHomepageManager;
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        super.onCreatePreferences(savedInstanceState, rootKey);
+
+        mHomepageManager = HomepageManager.getInstance();
+        ChromeSwitchPreference homepageSwitch =
+                (ChromeSwitchPreference) findPreference(PREF_HOMEPAGE_SWITCH);
+
+        if (homepageSwitch.isVisible()) return;
+        // Show homepage switch if it is hidden.
+        homepageSwitch.setVisible(true);
+        boolean isHomepageEnabled = mHomepageManager.getPrefHomepageEnabled();
+        homepageSwitch.setChecked(isHomepageEnabled);
+        homepageSwitch.setOnPreferenceChangeListener((preference, newValue) -> {
+            mHomepageManager.setPrefHomepageEnabled((boolean) newValue);
+            return true;
+        });
+    }
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -23,6 +23,7 @@ import org.chromium.chrome.browser.ChromeFeatureList;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
 import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
 import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
+import org.chromium.chrome.browser.settings.BraveHomepagePreferences;
 import org.chromium.chrome.browser.settings.download.BraveDownloadPreferences;
 import org.chromium.chrome.browser.settings.privacy.BravePrivacyPreferences;
 import org.chromium.components.search_engines.TemplateUrl;
@@ -46,6 +47,7 @@ public class BraveMainPreferencesBase extends PreferenceFragmentCompat {
     private static final String PREF_WELCOME_TOUR = "welcome_tour";
     private static final String PREF_BRAVE_REWARDS = "brave_rewards";
     private static final String PREF_DOWNLOADS = "downloads";
+    private static final String PREF_HOMEPAGE = "homepage";
 
     private final HashMap<String, Preference> mRemovedPreferences = new HashMap<>();
 
@@ -167,6 +169,7 @@ public class BraveMainPreferencesBase extends PreferenceFragmentCompat {
         // Replace fragment.
         findPreference(PREF_PRIVACY).setFragment(BravePrivacyPreferences.class.getName());
         findPreference(PREF_DOWNLOADS).setFragment(BraveDownloadPreferences.class.getName());
+        findPreference(PREF_HOMEPAGE).setFragment(BraveHomepagePreferences.class.getName());
     }
 
     private void initWelcomeTourPreference() {

--- a/android/java/org/chromium/chrome/browser/toolbar/BraveHomeButton.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/BraveHomeButton.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.chromium.chrome.browser.toolbar;
+
+import android.content.Context;
+import android.support.v4.content.ContextCompat;
+import android.util.AttributeSet;
+
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.partnercustomizations.HomepageManager;
+import org.chromium.chrome.browser.tab.Tab;
+
+/**
+ * Brave's extension of HomeButton.
+ */
+public class BraveHomeButton extends HomeButton {
+    private Context mContext;
+
+    public BraveHomeButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mContext = context;
+    }
+
+    /**
+     * Override to swap icon to new_tab_icon and enable the button when
+     * homepage is disabled.
+     */
+    @Override
+    public void updateButtonEnabledState(Tab tab) {
+        super.updateButtonEnabledState(tab);
+
+        final boolean isHomepageEnabled = HomepageManager.isHomepageEnabled();
+        if (!isHomepageEnabled) {
+            setImageDrawable(ContextCompat.getDrawable(mContext, R.drawable.new_tab_icon));
+            setEnabled(true);
+        } else { // swap back to home button icon
+            setImageDrawable(ContextCompat.getDrawable(mContext, R.drawable.btn_toolbar_home));
+        }
+    }
+}

--- a/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveBottomToolbarCoordinator.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveBottomToolbarCoordinator.java
@@ -21,13 +21,15 @@ import org.chromium.chrome.browser.ActivityTabProvider;
 import org.chromium.chrome.browser.ThemeColorProvider;
 import org.chromium.chrome.browser.compositor.layouts.EmptyOverviewModeObserver;
 import org.chromium.chrome.browser.compositor.layouts.OverviewModeBehavior;
-import org.chromium.chrome.browser.toolbar.bottom.BottomToolbarNewTabButton;
-import org.chromium.chrome.browser.toolbar.bottom.SearchAccelerator;
-import org.chromium.chrome.browser.toolbar.bottom.ShareButton;
+import org.chromium.chrome.browser.partnercustomizations.HomepageManager;
 import org.chromium.chrome.browser.toolbar.HomeButton;
 import org.chromium.chrome.browser.toolbar.IncognitoStateProvider;
 import org.chromium.chrome.browser.toolbar.TabCountProvider;
+import org.chromium.chrome.browser.toolbar.bottom.BottomToolbarNewTabButton;
+import org.chromium.chrome.browser.toolbar.bottom.SearchAccelerator;
+import org.chromium.chrome.browser.toolbar.bottom.ShareButton;
 import org.chromium.chrome.browser.ui.appmenu.AppMenuButtonHelper;
+import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.ui.widget.Toast;
 
 public class BraveBottomToolbarCoordinator
@@ -56,6 +58,12 @@ public class BraveBottomToolbarCoordinator
         Resources resources = mContext.getResources();
 
         if (v == mHomeButton) {
+            // It is currently a new tab button when homepage is disabled.
+            if (!HomepageManager.isHomepageEnabled()) {
+                TabUtils.showTabPopupMenu(mContext, v);
+                return true;
+            }
+
             description = resources.getString(R.string.accessibility_toolbar_btn_home);
         } else if (v == mBookmarksButton) {
             description = resources.getString(R.string.accessibility_toolbar_btn_bookmark);
@@ -63,7 +71,8 @@ public class BraveBottomToolbarCoordinator
             description =
                     resources.getString(R.string.accessibility_toolbar_btn_search_accelerator);
         } else if (v == mNewTabButton) {
-            description = resources.getString(R.string.accessibility_new_tab_page);
+            TabUtils.showTabPopupMenu(mContext, v);
+            return true;
         }
 
         return Toast.showAnchoredToast(mContext, v, description);
@@ -86,6 +95,17 @@ public class BraveBottomToolbarCoordinator
         mHomeButton = bottom_toolbar_browsing.findViewById(R.id.bottom_home_button);
         if (mHomeButton != null) {
             mHomeButton.setOnLongClickListener(this);
+
+            final OnClickListener homeButtonListener = v -> {
+                final boolean isHomepageEnabled = HomepageManager.isHomepageEnabled();
+                if (isHomepageEnabled) {
+                    TabUtils.openHomepage();
+                } else {
+                    TabUtils.openNewTab();
+                }
+            };
+
+            mHomeButton.setOnClickListener(homeButtonListener);
         }
 
         mBookmarksButton = bottom_toolbar_browsing.findViewById(R.id.bottom_bookmark_button);

--- a/android/java/org/chromium/chrome/browser/util/TabUtils.java
+++ b/android/java/org/chromium/chrome/browser/util/TabUtils.java
@@ -40,19 +40,33 @@ public class TabUtils {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
                 int id = item.getItemId();
-                if (chromeActivity != null)
-                    if (id == R.id.new_tab_menu_id) {
-                        openNewTab(chromeActivity, false);
-                    } else if (id == R.id.new_incognito_tab_menu_id) {
-                        openNewTab(chromeActivity, true);
-                    }
+                if (id == R.id.new_tab_menu_id) {
+                    openNewTab(chromeActivity, false);
+                } else if (id == R.id.new_incognito_tab_menu_id) {
+                    openNewTab(chromeActivity, true);
+                }
                 return true;
             }
         });
         popup.show(); // showing popup menu
     }
 
+    public static void openHomepage() {
+        ChromeActivity chromeActivity = getChromeActivity();
+        if (chromeActivity != null && chromeActivity.getToolbarManager() != null) {
+            chromeActivity.getToolbarManager().openHomepage();
+        }
+    }
+
+    public static void openNewTab() {
+        ChromeActivity chromeActivity = getChromeActivity();
+        boolean isIncognito =
+                chromeActivity != null ? chromeActivity.getCurrentTabModel().isIncognito() : false;
+        openNewTab(chromeActivity, isIncognito);
+    }
+
     private static void openNewTab(ChromeActivity chromeActivity, boolean isIncognito) {
+        if (chromeActivity == null) return;
         chromeActivity.getTabModelSelector().getModel(isIncognito).commitAllTabClosures();
         chromeActivity.getTabCreator(isIncognito).launchNTP();
     }

--- a/android/java/org/chromium/chrome/browser/util/TabUtils.java
+++ b/android/java/org/chromium/chrome/browser/util/TabUtils.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.chromium.chrome.browser.util;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.ContextThemeWrapper;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.PopupMenu;
+
+import org.chromium.base.ApplicationStatus;
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.ChromeActivity;
+import org.chromium.chrome.browser.night_mode.GlobalNightModeStateProviderHolder;
+
+public class TabUtils {
+    public static void showTabPopupMenu(Context context, View view) {
+        ChromeActivity chromeActivity = getChromeActivity();
+        Context wrapper = new ContextThemeWrapper(context,
+                GlobalNightModeStateProviderHolder.getInstance().isInNightMode()
+                        ? R.style.NewTabPopupMenuDark
+                        : R.style.NewTabPopupMenuLight);
+        // Creating the instance of PopupMenu
+        PopupMenu popup = new PopupMenu(wrapper, view);
+        // Inflating the Popup using xml file
+        popup.getMenuInflater().inflate(R.menu.new_tab_menu, popup.getMenu());
+
+        if (chromeActivity != null && chromeActivity.getCurrentTabModel().isIncognito()) {
+            popup.getMenu().findItem(R.id.new_tab_menu_id).setVisible(false);
+        }
+        // registering popup with OnMenuItemClickListener
+        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                int id = item.getItemId();
+                if (chromeActivity != null)
+                    if (id == R.id.new_tab_menu_id) {
+                        openNewTab(chromeActivity, false);
+                    } else if (id == R.id.new_incognito_tab_menu_id) {
+                        openNewTab(chromeActivity, true);
+                    }
+                return true;
+            }
+        });
+        popup.show(); // showing popup menu
+    }
+
+    private static void openNewTab(ChromeActivity chromeActivity, boolean isIncognito) {
+        chromeActivity.getTabModelSelector().getModel(isIncognito).commitAllTabClosures();
+        chromeActivity.getTabCreator(isIncognito).launchNTP();
+    }
+
+    private static ChromeActivity getChromeActivity() {
+        for (Activity ref : ApplicationStatus.getRunningActivities()) {
+            if (!(ref instanceof ChromeActivity)) continue;
+            return (ChromeActivity) ref;
+        }
+        return null;
+    }
+}

--- a/android/java/res/menu/new_tab_menu.xml
+++ b/android/java/res/menu/new_tab_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 The Brave Authors. All rights reserved.
+     This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this file,
+     You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+	<item android:id="@id/new_tab_menu_id"
+          android:title="@string/menu_new_tab" />
+    <item android:id="@id/new_incognito_tab_menu_id"
+          android:title="@string/brave_new_private_tab" />
+</menu>

--- a/android/java/res/values/brave_colors.xml
+++ b/android/java/res/values/brave_colors.xml
@@ -55,4 +55,7 @@
     <color name="incognito_emphasis">@android:color/white</color>
 
     <color name="find_in_page_query_incognito_hint_color">@color/white_alpha_70</color>
+
+    <color name="new_tab_menu_text_dark_color">@android:color/white</color>
+    <color name="new_tab_menu_bg_dark_color">@color/modern_grey_800</color>
 </resources>

--- a/android/java/res/values/brave_styles.xml
+++ b/android/java/res/values/brave_styles.xml
@@ -63,4 +63,14 @@
         <item name="android:textAllCaps">false</item>
         <item name="android:textSize">14sp</item>
     </style>
+
+    <style name="NewTabPopupMenuLight" parent="Widget.AppCompat.PopupMenu">
+      <item name="android:textColor">@android:color/black</item>
+      <item name="android:itemBackground">@android:color/white</item>
+    </style>
+
+    <style name="NewTabPopupMenuDark" parent="Widget.AppCompat.PopupMenu">
+      <item name="android:textColor">@color/new_tab_menu_text_dark_color</item>
+      <item name="android:itemBackground">@color/new_tab_menu_bg_dark_color</item>
+    </style>
 </resources>

--- a/patches/chrome-android-java-res-layout-bottom_toolbar_browsing.xml.patch
+++ b/patches/chrome-android-java-res-layout-bottom_toolbar_browsing.xml.patch
@@ -1,16 +1,19 @@
 diff --git a/chrome/android/java/res/layout/bottom_toolbar_browsing.xml b/chrome/android/java/res/layout/bottom_toolbar_browsing.xml
-index 76d517641db816c12bd35ae6497cd172eea71fd0..8c3d3f5e8c1a35343bf30f4b1ff2a1b521e70b06 100644
+index 76d517641db816c12bd35ae6497cd172eea71fd0..34653dbf1849b43ada4dd34651ba9b3c6eab5596 100644
 --- a/chrome/android/java/res/layout/bottom_toolbar_browsing.xml
 +++ b/chrome/android/java/res/layout/bottom_toolbar_browsing.xml
-@@ -16,7 +16,7 @@
+@@ -16,9 +16,9 @@
      android:paddingStart="@dimen/bottom_toolbar_padding"
      android:paddingEnd="@dimen/bottom_toolbar_padding" >
  
 -    <include layout="@layout/toolbar_space" />
 +    <!-- <include layout="@layout/toolbar_space" /> -->
  
-     <org.chromium.chrome.browser.toolbar.HomeButton
+-    <org.chromium.chrome.browser.toolbar.HomeButton
++    <org.chromium.chrome.browser.toolbar.BraveHomeButton
          android:id="@+id/bottom_home_button"
+         app:tint="@color/standard_mode_tint"
+         android:background="?attr/selectableItemBackgroundBorderless"
 @@ -26,6 +26,7 @@
          android:visibility="gone"
          style="@style/SplitToolbarButton" />


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/7090

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Go to settings, and click `Home page` preference in `Basics` session.
2. Check the on/off switch is shown in the `Home page` preference page.
3. Turn the above switch to off and go back to normal browsing.
4. Home button in the bottom toolbar should now be replaced with a new tab button.
5. Long click on the new tab button should popup a menu to open a normal new tab or a private new tab.
6. Turn the homepage switch back to on, the button should be replaced with a home button.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
