### PR TITLE
Sync fix bookmarks object id duplication (uplift to 1.6.x)

### DIFF
--- a/browser/profiles/brave_bookmark_model_loaded_observer.cc
+++ b/browser/profiles/brave_bookmark_model_loaded_observer.cc
@@ -31,8 +31,11 @@ void BraveBookmarkModelLoadedObserver::BookmarkModelLoaded(
   // it is handled in BraveProfileSyncServiceImpl::OnSyncReady
   if (brave_profile_service && !brave_profile_service->IsBraveSyncEnabled())
     BraveMigrateOtherNode(model);
+
+  BraveProfileSyncServiceImpl::AddNonClonedBookmarkKeys(model);
 #else
   BraveMigrateOtherNode(model);
 #endif
+
   BookmarkModelLoadedObserver::BookmarkModelLoaded(model, ids_reassigned);
 }

--- a/components/brave_sync/brave_profile_sync_service_impl.cc
+++ b/components/brave_sync/brave_profile_sync_service_impl.cc
@@ -516,6 +516,17 @@ void BraveProfileSyncServiceImpl::OnSyncReadyBookmarksModelLoaded() {
   BraveMigrateOtherNode(model_);
 }
 
+// static
+void BraveProfileSyncServiceImpl::AddNonClonedBookmarkKeys(
+    BookmarkModel* model) {
+  DCHECK(model);
+  DCHECK(model->loaded());
+  model->AddNonClonedKey("object_id");
+  model->AddNonClonedKey("order");
+  model->AddNonClonedKey("sync_timestamp");
+  model->AddNonClonedKey("version");
+}
+
 syncer::ModelTypeSet BraveProfileSyncServiceImpl::GetPreferredDataTypes()
     const {
   // Force DEVICE_INFO type to have nudge cycle each time to fetch

--- a/components/brave_sync/brave_profile_sync_service_impl.h
+++ b/components/brave_sync/brave_profile_sync_service_impl.h
@@ -170,6 +170,8 @@ class BraveProfileSyncServiceImpl
   BraveSyncClient* GetBraveSyncClient() override;
 #endif
 
+  static void AddNonClonedBookmarkKeys(BookmarkModel* model);
+
   bool IsBraveSyncEnabled() const override;
 
   syncer::ModelTypeSet GetPreferredDataTypes() const override;

--- a/components/brave_sync/syncer_helper.cc
+++ b/components/brave_sync/syncer_helper.cc
@@ -13,11 +13,6 @@
 namespace brave_sync {
 namespace {
 
-// Get mutable node to prevent BookmarkMetaInfoChanged from being triggered
-bookmarks::BookmarkNode* AsMutable(const bookmarks::BookmarkNode* node) {
-  return const_cast<bookmarks::BookmarkNode*>(node);
-}
-
 void SetOrder(const bookmarks::BookmarkNode* node,
               const std::string& parent_order) {
   DCHECK(!parent_order.empty());
@@ -41,7 +36,7 @@ void SetOrder(const bookmarks::BookmarkNode* node,
 
   std::string order =
       brave_sync::GetOrder(prev_order, next_order, parent_order);
-  AsMutable(node)->SetMetaInfo("order", order);
+  tools::AsMutable(node)->SetMetaInfo("order", order);
 }
 
 }  // namespace
@@ -92,17 +87,17 @@ void AddBraveMetaInfo(const bookmarks::BookmarkNode* node) {
   if (object_id.empty()) {
     object_id = tools::GenerateObjectId();
   }
-  AsMutable(node)->SetMetaInfo("object_id", object_id);
+  tools::AsMutable(node)->SetMetaInfo("object_id", object_id);
 
   std::string parent_object_id;
   node->parent()->GetMetaInfo("object_id", &parent_object_id);
-  AsMutable(node)->SetMetaInfo("parent_object_id", parent_object_id);
+  tools::AsMutable(node)->SetMetaInfo("parent_object_id", parent_object_id);
 
   std::string sync_timestamp;
   node->GetMetaInfo("sync_timestamp", &sync_timestamp);
   if (sync_timestamp.empty()) {
     sync_timestamp = std::to_string(base::Time::Now().ToJsTime());
-    AsMutable(node)->SetMetaInfo("sync_timestamp", sync_timestamp);
+    tools::AsMutable(node)->SetMetaInfo("sync_timestamp", sync_timestamp);
   }
   DCHECK(!sync_timestamp.empty());
 }

--- a/components/brave_sync/tools.cc
+++ b/components/brave_sync/tools.cc
@@ -1,6 +1,8 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #include "brave/components/brave_sync/tools.h"
 
 #include <string>
@@ -15,20 +17,27 @@ namespace brave_sync {
 
 namespace tools {
 
-std::string GenerateObjectId() {
-  //16 random 8-bit unsigned numbers
-  const size_t length = 16;
-  uint8_t bytes[length];
-  crypto::RandBytes(bytes, sizeof(bytes));
+const size_t kIdSize = 16;
+
+namespace {
+std::string PrintObjectId(uint8_t* bytes) {
   std::stringstream ss;
-  for (size_t i = 0; i < length; ++i) {
-    const uint8_t &byte = bytes[i];
-    ss << std::dec << (int)byte;
-    if (i != length - 1) {
+  for (size_t i = 0; i < kIdSize; ++i) {
+    const uint8_t& byte = bytes[i];
+    ss << std::dec << static_cast<int>(byte);
+    if (i != kIdSize - 1) {
       ss << ", ";
     }
   }
   return ss.str();
+}
+}  // namespace
+
+std::string GenerateObjectId() {
+  // 16 random 8-bit unsigned numbers
+  uint8_t bytes[kIdSize];
+  crypto::RandBytes(bytes, sizeof(bytes));
+  return PrintObjectId(bytes);
 }
 
 std::string GetPlatformName() {
@@ -50,6 +59,11 @@ bool IsTimeEmpty(const base::Time &time) {
   return time.is_null() || base::checked_cast<int64_t>(time.ToJsTime()) == 0;
 }
 
-} // namespace tools
+// Get mutable node to prevent BookmarkMetaInfoChanged from being triggered
+bookmarks::BookmarkNode* AsMutable(const bookmarks::BookmarkNode* node) {
+  return const_cast<bookmarks::BookmarkNode*>(node);
+}
 
-} // namespace brave_sync
+}  // namespace tools
+
+}  // namespace brave_sync

--- a/components/brave_sync/tools.h
+++ b/components/brave_sync/tools.h
@@ -1,14 +1,20 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
-#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_TOOLS_H_
-#define BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_TOOLS_H_
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SYNC_TOOLS_H_
+#define BRAVE_COMPONENTS_BRAVE_SYNC_TOOLS_H_
 
 #include <string>
 
 namespace base {
-  class Time;
-} // namespace base
+class Time;
+}  // namespace base
+
+namespace bookmarks {
+class BookmarkNode;
+}
 
 namespace brave_sync {
 
@@ -19,8 +25,10 @@ std::string GetPlatformName();
 
 bool IsTimeEmpty(const base::Time &time);
 
-} // namespace tools
+bookmarks::BookmarkNode* AsMutable(const bookmarks::BookmarkNode* node);
 
-} // namespace brave_sync
+}  // namespace tools
 
-#endif // BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_TOOLS_H_
+}  // namespace brave_sync
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SYNC_TOOLS_H_


### PR DESCRIPTION
Sync fix bookmarks object id duplication

Uplift of https://github.com/brave/brave-core/pull/4710, created manually because had conflicts.

Fixes https://github.com/brave/brave-browser/issues/8325

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.