### PR TITLE
Top site SiteRemovalNotification spacing not correct

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/notification.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/notification.tsx
@@ -38,10 +38,10 @@ export default class Notification extends React.Component<Props, {}> {
     return (
        <SiteRemovalNotification>
          <SiteRemovalText>{getLocale('thumbRemoved')}</SiteRemovalText>
-         <SiteRemovalAction onClick={this.onUndoIgnoredTopSite}>{getLocale('undoRemoved')}</SiteRemovalAction>
-         <SiteRemovalAction onClick={this.onUndoAllSiteIgnored}>{getLocale('restoreAll')}</SiteRemovalAction>
-         <SiteRemovalAction onClick={this.onHideSiteRemovalNotification} iconOnly={true} title={getLocale('close')}>
-          <CloseStrokeIcon />
+         &nbps;<SiteRemovalAction onClick={this.onUndoIgnoredTopSite}>{getLocale('undoRemoved')}</SiteRemovalAction>
+         &nbps;<SiteRemovalAction onClick={this.onUndoAllSiteIgnored}>{getLocale('restoreAll')}</SiteRemovalAction>
+         &nbps;<SiteRemovalAction onClick={this.onHideSiteRemovalNotification} iconOnly={true} title={getLocale('close')}>
+         &nbps;<CloseStrokeIcon />
         </SiteRemovalAction>
        </SiteRemovalNotification>
     )


### PR DESCRIPTION
<!-- Have you searched for similar issues? Before submitting this issue, please check the open issues and add a note before logging a new issue. 

PLEASE USE THE TEMPLATE BELOW TO PROVIDE INFORMATION ABOUT THE ISSUE. 
INSUFFICIENT INFO WILL GET THE ISSUE CLOSED. IT WILL ONLY BE REOPENED AFTER SUFFICIENT INFO IS PROVIDED-->

## Description 
The issue happens once you remove the pinned site badge (top sites) from the homepage after opening the browser or opening new tab.

## Steps to Reproduce
   1. Open Brave
   2. Have several sites saved in the top sites
   3. Open new window or open new tab
   4. Click on X to remove the site
   5. Message appears (see image)



## Actual result:
![Screenshot 2020-03-01 at 18 01 48](https://user-images.githubusercontent.com/23336275/75629936-cc838b00-5be6-11ea-9c4d-585d3c4d0eab.png)
![Screenshot 2020-03-01 at 18 00 55](https://user-images.githubusercontent.com/23336275/75629937-d0171200-5be6-11ea-980d-f3bf965c19c3.png)



## Expected result:
Spacing between elements.

## Reproduces how often: 
Easily reproduced.


## Brave version (brave://version info)
Brave is up to date
Version 1.4.95 Chromium: 80.0.3987.122 (Official Build) (64-bit)

## Other Additional Information:
- macOS Catalina 10.15.3 (19D76)
- Mac mini (Late 2012)

## Miscellaneous Information:
Nope.