### PR TITLE
Explicitly set the default view for shield settings

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -33,10 +33,6 @@
 #include "brave/components/brave_webtorrent/browser/webtorrent_util.h"
 #endif
 
-#if !defined(OS_ANDROID)
-#include "chrome/browser/first_run/first_run.h"
-#endif
-
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
 #include "components/gcm_driver/gcm_channel_status_syncer.h"
 #endif
@@ -103,15 +99,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(kHTTPSEVerywhereControlType, true);
   registry->RegisterBooleanPref(kNoScriptControlType, false);
   registry->RegisterBooleanPref(kAdControlType, true);
-
-  // advanced view is defaulted to true for EXISTING users; false for new.
-  // also see brave_profile_impl.cc for where default is locked in.
-  bool is_new_user = false;
-#if !defined(OS_ANDROID)
-  is_new_user = first_run::IsChromeFirstRun();
-#endif
-  registry->RegisterBooleanPref(kShieldsAdvancedViewEnabled,
-                                is_new_user == false);
+  registry->RegisterBooleanPref(kShieldsAdvancedViewEnabled, false);
 
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
   // PushMessaging

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -103,12 +103,15 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(kHTTPSEVerywhereControlType, true);
   registry->RegisterBooleanPref(kNoScriptControlType, false);
   registry->RegisterBooleanPref(kAdControlType, true);
-  // > advanced view is defaulted to true for EXISTING users; false for new
-  bool is_new_user = false;
 
+  // advanced view is defaulted to true for EXISTING users; false for new.
+  // also see brave_profile_impl.cc for where default is locked in.
+  bool is_new_user = false;
 #if !defined(OS_ANDROID)
   is_new_user = first_run::IsChromeFirstRun();
 #endif
+  registry->RegisterBooleanPref(kShieldsAdvancedViewEnabled,
+                                is_new_user == false);
 
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
   // PushMessaging
@@ -116,8 +119,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 base::Value(false));
 #endif
 
-  registry->RegisterBooleanPref(kShieldsAdvancedViewEnabled,
-                                is_new_user == false);
   registry->RegisterBooleanPref(kShieldsStatsBadgeVisible, true);
   registry->RegisterBooleanPref(kGoogleLoginControlType, true);
   registry->RegisterBooleanPref(kFBEmbedControlType, true);

--- a/browser/brave_profile_prefs_browsertest.cc
+++ b/browser/brave_profile_prefs_browsertest.cc
@@ -82,17 +82,28 @@ typedef FirstRunMasterPrefsBrowserTestT<kFirstRunEmptyPrefs>
     BraveProfilePrefsFirstRunBrowserTest;
 IN_PROC_BROWSER_TEST_F(BraveProfilePrefsFirstRunBrowserTest,
                        AdvancedShieldsNewUserValue) {
-  EXPECT_FALSE(
-        browser()->profile()->GetPrefs()->GetBoolean(
+  // verify value of pref (default to simple view)
+  EXPECT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(
           kShieldsAdvancedViewEnabled));
+  // verify that pref was set (and is not default)
+  const PrefService::Preference* pref =
+      browser()->profile()->GetPrefs()->FindPreference(
+          kShieldsAdvancedViewEnabled);
+  EXPECT_TRUE(pref->HasUserSetting());
 }
 
 // Existing Brave users should default shields to Advanced view
 IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest,
                        AdvancedShieldsExistingUserValue) {
+  // verify value of pref (default to advanced view)
   EXPECT_TRUE(
         browser()->profile()->GetPrefs()->GetBoolean(
           kShieldsAdvancedViewEnabled));
+  // verify that pref was set (and is not default)
+  const PrefService::Preference* pref =
+      browser()->profile()->GetPrefs()->FindPreference(
+          kShieldsAdvancedViewEnabled);
+  EXPECT_TRUE(pref->HasUserSetting());
 }
 #endif
 

--- a/browser/profiles/brave_profile_impl.cc
+++ b/browser/profiles/brave_profile_impl.cc
@@ -7,11 +7,15 @@
 
 #include "base/task/post_task.h"
 #include "brave/browser/profiles/profile_util.h"
+#include "brave/common/pref_names.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/chrome_notification_types.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "content/public/browser/notification_source.h"
-#include "brave/common/pref_names.h"
+
+#if !defined(OS_ANDROID)
+#include "chrome/browser/first_run/first_run.h"
+#endif
 
 BraveProfileImpl::BraveProfileImpl(
     const base::FilePath& path,
@@ -25,10 +29,9 @@ BraveProfileImpl::BraveProfileImpl(
   const PrefService::Preference* pref =
       GetPrefs()->FindPreference(kShieldsAdvancedViewEnabled);
   if (!pref->HasUserSetting()) {
-    bool default_value = GetPrefs()->GetBoolean(kShieldsAdvancedViewEnabled);
     // advanced view is defaulted to true for EXISTING users; false for new.
     // preference needs to be explicitly set to hold its value
-    // see brave_profile_prefs.cc for where this default is determined
+    const bool default_value = !first_run::IsChromeFirstRun();
     GetPrefs()->SetBoolean(kShieldsAdvancedViewEnabled, default_value);
   }
 #endif


### PR DESCRIPTION
Defaults to:
- advanced for existing users
- simple for new users

Changing the default was not "locking in" the setting. This change
locks in that default.

Fixes https://github.com/brave/brave-browser/issues/8533

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
See https://github.com/brave/brave-browser/issues/8533

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
