### PR TITLE
NTP: Do not auto opt-in sponsored images after re-enabling backgrounds

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -60,10 +60,6 @@ export default class Settings extends React.PureComponent<Props, {}> {
 
   toggleShowBackgroundImage = () => {
     this.props.toggleShowBackgroundImage()
-    // Re opt-in to branded wallpaper if re-enabling background image
-    if (!this.props.showBackgroundImage && !this.props.brandedWallpaperOptIn) {
-      this.props.toggleBrandedWallpaperOptIn()
-    }
   }
 
   render () {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/8552

<!-- Add brave-browser issue bellow that this PR will resolve -->

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Go to brave://newtab -> and select dashboard setting
2. Toggle OFF both "Show Background Image" and "Show Sponsored Images"
3. Toggle ON "Show Background Image".
4. "Show Sponsored Images" should stay off.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
