### PR TITLE
Turn off haptics for Brave Ads notifications on Android

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -32,6 +32,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/flags/BraveFeatureUtilities.java",
   "../../brave/android/java/org/chromium/chrome/browser/help/BraveHelpAndFeedback.java",
+  "../../brave/android/java/org/chromium/chrome/browser/notifications/BraveNotificationManagerProxyImpl.java",
   "../../brave/android/java/org/chromium/chrome/browser/notifications/BraveNotificationPlatformBridge.java",
   "../../brave/android/java/org/chromium/chrome/browser/notifications/BraveNotificationSettingsBridge.java",
   "../../brave/android/java/org/chromium/chrome/browser/notifications/BraveOnboardingNotification.java",

--- a/android/java/org/chromium/chrome/browser/notifications/BraveNotificationManagerProxyImpl.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BraveNotificationManagerProxyImpl.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.chromium.chrome.browser.notifications;
+
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.content.Context;
+import android.os.Build;
+
+import org.chromium.chrome.browser.notifications.channels.BraveChannelDefinitions;
+
+public class BraveNotificationManagerProxyImpl extends NotificationManagerProxyImpl {
+    public BraveNotificationManagerProxyImpl(Context context) {
+        super(context);
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    @Override
+    public void createNotificationChannel(NotificationChannel channel) {
+        if (channel.getId().equals(BraveChannelDefinitions.ChannelId.BRAVE_ADS)) {
+            channel.setVibrationPattern(new long[] {0L});
+            channel.enableVibration(true);
+        }
+        super.createNotificationChannel(channel);
+    }
+}

--- a/android/java/org/chromium/chrome/browser/notifications/BraveNotificationPlatformBridge.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BraveNotificationPlatformBridge.java
@@ -17,6 +17,8 @@ import org.chromium.base.ContextUtils;
 import org.chromium.base.annotations.CalledByNative;
 
 public class BraveNotificationPlatformBridge extends NotificationPlatformBridge {
+    private static final int[] EMPTY_VIBRATION_PATTERN = new int[0];
+
     private @NotificationType int mNotificationType;
 
     @CalledByNative
@@ -70,6 +72,10 @@ public class BraveNotificationPlatformBridge extends NotificationPlatformBridge 
             Bitmap icon, Bitmap badge, int[] vibrationPattern, long timestamp, boolean renotify,
             boolean silent, ActionInfo[] actions, String webApkPackage) {
         mNotificationType = notificationType;
+
+        if (notificationType == NotificationType.BRAVE_ADS) {
+            vibrationPattern = EMPTY_VIBRATION_PATTERN;
+        }
 
         return super.prepareNotificationBuilder(notificationId, notificationType, origin, scopeUrl,
                 profileId, incognito, title, body, image, icon, badge, vibrationPattern, timestamp,

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-notifications-NotificationBuilderFactory.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-notifications-NotificationBuilderFactory.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/notifications/NotificationBuilderFactory.java b/chrome/android/java/src/org/chromium/chrome/browser/notifications/NotificationBuilderFactory.java
+index 779ca00150bcf9ac11e6143c969a4e57a9aa0aa3..bd21920181886eb0afda01031298cb17dba2ddef 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/notifications/NotificationBuilderFactory.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/notifications/NotificationBuilderFactory.java
+@@ -67,7 +67,7 @@ public class NotificationBuilderFactory {
+         }
+ 
+         NotificationManagerProxyImpl notificationManagerProxy =
+-                new NotificationManagerProxyImpl(context);
++                new BraveNotificationManagerProxyImpl(context);
+ 
+         ChannelsInitializer channelsInitializer =
+                 new ChannelsInitializer(notificationManagerProxy, context.getResources());

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-notifications-channels-ChannelsUpdater.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-notifications-channels-ChannelsUpdater.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/notifications/channels/ChannelsUpdater.java b/chrome/android/java/src/org/chromium/chrome/browser/notifications/channels/ChannelsUpdater.java
+index d49ba4549b2a4de6e3d3503d3bb664d9b686b8c5..7294e66716e3a7dbf1b94aa753d61730107067bc 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/notifications/channels/ChannelsUpdater.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/notifications/channels/ChannelsUpdater.java
+@@ -36,7 +36,7 @@ public class ChannelsUpdater {
+         public static final ChannelsUpdater INSTANCE = Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+                 ? new ChannelsUpdater(false /* isAtLeastO */, null, null, -1)
+                 : new ChannelsUpdater(true /* isAtLeastO */, ContextUtils.getAppSharedPreferences(),
+-                          new ChannelsInitializer(new NotificationManagerProxyImpl(
++                          new ChannelsInitializer(new org.chromium.chrome.browser.notifications.BraveNotificationManagerProxyImpl(
+                                                           ContextUtils.getApplicationContext()),
+                                   ContextUtils.getApplicationContext().getResources()),
+                           ChannelDefinitions.CHANNELS_VERSION);


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/6814

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
