### PR TITLE
Fixes category name is missing from ad history - 1.7.x

### DIFF
--- a/components/brave_ads/browser/bundle_state_database.cc
+++ b/components/brave_ads/browser/bundle_state_database.cc
@@ -482,7 +482,7 @@ bool BundleStateDatabase::GetCreativeAdNotifications(
     info.advertiser_id = statement.ColumnString(10);
     info.per_day = statement.ColumnInt(11);
     info.total_max = statement.ColumnInt(12);
-    info.category = statement.ColumnInt(13);
+    info.category = statement.ColumnString(13);
     ads->emplace_back(info);
   }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/4914
Resolves https://github.com/brave/brave-browser/issues/8646

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.