### PR TITLE
Fix translation icon is visible after installing g-translate extension (uplift to 1.7.x)

### DIFF
--- a/browser/ui/views/translate/brave_translate_icon_view.cc
+++ b/browser/ui/views/translate/brave_translate_icon_view.cc
@@ -62,6 +62,7 @@ void BraveTranslateIconView::UpdateImpl() {
   if (registry->GetInstalledExtension(google_translate_extension_id)) {
     SetVisible(false);
     TranslateBubbleView::CloseCurrentBubble();
+    return;
   }
 
   TranslateIconView::UpdateImpl();


### PR DESCRIPTION
Uplift of #4928

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.