### PR TITLE
Migration of duplicated bookmarks for sync (2)

### DIFF
--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -43,8 +43,10 @@ const char kSyncMigrateBookmarksVersion[]
                                        = "brave_sync.migrate_bookmarks_version";
 const char kSyncRecordsToResend[] = "brave_sync_records_to_resend";
 const char kSyncRecordsToResendMeta[] = "brave_sync_records_to_resend_meta";
-const char kDuplicatedBookmarksRecovered[] =
-    "brave_sync_duplicated_bookmarks_recovered";
+// const char kDuplicatedBookmarksRecovered[] =
+//     "brave_sync_duplicated_bookmarks_recovered";  // deprecated
+const char kDuplicatedBookmarksMigrateVersion[] =
+    "brave_sync_duplicated_bookmarks_migrate_version";
 
 Prefs::Prefs(PrefService* pref_service) : pref_service_(pref_service) {}
 
@@ -74,7 +76,7 @@ void Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   registry->RegisterListPref(prefs::kSyncRecordsToResend);
   registry->RegisterDictionaryPref(prefs::kSyncRecordsToResendMeta);
-  registry->RegisterBooleanPref(kDuplicatedBookmarksRecovered, false);
+  registry->RegisterIntegerPref(prefs::kDuplicatedBookmarksMigrateVersion, 0);
 }
 
 std::string Prefs::GetSeed() const {

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -15,6 +15,7 @@
 
 void MigrateBraveSyncPrefs(PrefService* prefs) {
   prefs->ClearPref(brave_sync::prefs::kSyncPrevSeed);
+  prefs->ClearPref(brave_sync::prefs::kDuplicatedBookmarksRecovered);
 }
 
 namespace brave_sync {
@@ -43,8 +44,8 @@ const char kSyncMigrateBookmarksVersion[]
                                        = "brave_sync.migrate_bookmarks_version";
 const char kSyncRecordsToResend[] = "brave_sync_records_to_resend";
 const char kSyncRecordsToResendMeta[] = "brave_sync_records_to_resend_meta";
-// const char kDuplicatedBookmarksRecovered[] =
-//     "brave_sync_duplicated_bookmarks_recovered";  // deprecated
+const char kDuplicatedBookmarksRecovered[] =
+    "brave_sync_duplicated_bookmarks_recovered";
 const char kDuplicatedBookmarksMigrateVersion[] =
     "brave_sync_duplicated_bookmarks_migrate_version";
 
@@ -76,6 +77,7 @@ void Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   registry->RegisterListPref(prefs::kSyncRecordsToResend);
   registry->RegisterDictionaryPref(prefs::kSyncRecordsToResendMeta);
+  registry->RegisterBooleanPref(kDuplicatedBookmarksRecovered, false);
   registry->RegisterIntegerPref(prefs::kDuplicatedBookmarksMigrateVersion, 0);
 }
 

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -73,7 +73,7 @@ extern const char kSyncRecordsToResend[];
 // Meta info of kSyncRecordsToResend
 extern const char kSyncRecordsToResendMeta[];
 // Flag indicates we had recovered duplicated bookmarks object ids (deprecated)
-// extern const char kDuplicatedBookmarksRecovered[];  // deprecated
+extern const char kDuplicatedBookmarksRecovered[];
 
 // Version indicates had recovered duplicated bookmarks object ids:
 // 1 - we had migrated object ids

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -72,8 +72,13 @@ extern const char kSyncMigrateBookmarksVersion[];
 extern const char kSyncRecordsToResend[];
 // Meta info of kSyncRecordsToResend
 extern const char kSyncRecordsToResendMeta[];
-// Flag indicates we had recovered duplicated bookmarks object ids
-extern const char kDuplicatedBookmarksRecovered[];
+// Flag indicates we had recovered duplicated bookmarks object ids (deprecated)
+// extern const char kDuplicatedBookmarksRecovered[];  // deprecated
+
+// Version indicates had recovered duplicated bookmarks object ids:
+// 1 - we had migrated object ids
+// 2 - we have migrated broken bookmarks orders
+extern const char kDuplicatedBookmarksMigrateVersion[];
 
 class Prefs {
  public:

--- a/components/brave_sync/syncer_helper.cc
+++ b/components/brave_sync/syncer_helper.cc
@@ -103,8 +103,8 @@ void AddBraveMetaInfo(const bookmarks::BookmarkNode* node) {
   DCHECK(!sync_timestamp.empty());
   // Set other_node to have same sync_timestamp as least added child
   if (node->parent()->type() == bookmarks::BookmarkNode::OTHER_NODE) {
-    tools::AsMutable(node->parent())->SetMetaInfo("sync_timestamp",
-                                                  sync_timestamp);
+    tools::AsMutable(node->parent())
+        ->SetMetaInfo("sync_timestamp", sync_timestamp);
   }
 }
 


### PR DESCRIPTION
consider creation time can be equal; fixes brave-browser#8358

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8358

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

### I. Test of object id migration

1. Build browser without bookmarks metainfo fix and without object_id migration
2. Enable sync on devices A and B
3. Create sync chain between devices A and B
4. On device A create bookmarks A.com, AA.com, AAA.com; wait until they will not appear on device B
5. Disable sync through flags on device A
6. Restart browser on device A
7. On device A select 3 bookmarks, copy and paste them 3 times: before original, inside original and after original
10. Enable sync through flags on device A
11. Close browser device A
12. Build browser with bookmarks metainfo fix and with object_id migration
13. Open browser device B

14. Order of bookmarks between A and B must be the same. It takes 10 minutes for changes to appear on device B because of resend.

For step 14 need to wait 10 minutes, because 1st attempt of send updates fails because js lib is not yet initialized, so actual send happens during re-send procedure.

### II. Test to ensure orders are ok if bookmarks are moved when sync is off
1. Create sync chain between A and B
2. Create on device A these bookmarks on following order:
```
A1.com
A2.com
A3.com
A4.com
```
3. Wait till they would be be synced to device B
4. Disable sync on device A
5. Arrange bookmarks on device A as:
```
A4.com
A2.com
A1.com
A3.com
```
6. Enable sync on device A
7. Expected/Actual: device B to have bookmarks in the same order. 

For step 7 need to wait 10 minutes, because 1st attempt of send updates fails because js lib is not yet initialized, so actual send happens during re-send procedure.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
