### PR TITLE
Don't consider Android releases when doing Desktop bisect

### DIFF
--- a/script/build-bisect.py
+++ b/script/build-bisect.py
@@ -85,9 +85,10 @@ def get_releases(repo):
             if release['draft']:
                 draft_count = draft_count + 1
                 continue
-            if 'android' in release['tag_name'] or 'b' in release['tag_name']:
-                continue
             tag_name = str(release['tag_name'].strip().replace('v', ''))
+            # skip "android" releases and others not matching version format
+            if not tag_name.replace('.','').isdigit():
+                continue
             tag_names.append(tag_name)
             releases[tag_name] = release
         page = page + 1
@@ -295,6 +296,8 @@ def get_github_token():
         if result == 'undefined':
             raise Exception('`BRAVE_GITHUB_TOKEN` value not found!')
         return result
+    else:
+        return github_token
 
 
 def get_nearest_index(version, index_to_get, default):

--- a/script/build-bisect.py
+++ b/script/build-bisect.py
@@ -85,6 +85,8 @@ def get_releases(repo):
             if release['draft']:
                 draft_count = draft_count + 1
                 continue
+            if 'android' in release['tag_name'] or 'b' in release['tag_name']:
+                continue
             tag_name = str(release['tag_name'].strip().replace('v', ''))
             tag_names.append(tag_name)
             releases[tag_name] = release


### PR DESCRIPTION
No corresponding GitHub issue (doesn't affect browser)

Fixes bisect script problem:
```
clifton@Brians-MacBook-Pro-2 (master *=) $ ./src/brave/script/build-bisect.py --good=1.5.111 --bad=1.8.11 --channel=nightly --verbose
fetching releases from GitHub...
fetch complete; 1189 versions found (excluding 0 drafts)
Traceback (most recent call last):
  File "./src/brave/script/build-bisect.py", line 442, in <module>
    sys.exit(main())
  File "./src/brave/script/build-bisect.py", line 419, in main
    tag_names.sort(key=lambda s: map(int, s.split('.')))
  File "./src/brave/script/build-bisect.py", line 419, in <lambda>
    tag_names.sort(key=lambda s: map(int, s.split('.')))
ValueError: invalid literal for int() with base 10: '111-android'
```