### PR TITLE
Shields: Better accomodate long strings in non-English languages

### DIFF
--- a/components/brave_extension/extension/brave_extension/components/display.ts
+++ b/components/brave_extension/extension/brave_extension/components/display.ts
@@ -93,7 +93,7 @@ export const BlockedInfoRowText = styled<{}, 'span'>('span')`
   box-sizing: border-box;
   font-size: 12px;
   font-weight: 500;
-  line-height: 1;
+  line-height: 1.2;
   color: ${p => p.theme.color.text};
 `
 
@@ -162,7 +162,7 @@ export const LinkAction = styled<LinkActionProps, any>(Link)`
   font-size: ${p => p.size === 'small' && '12px' || 'inherit'};
   line-height: ${p => p.size === 'small' && '1'};
   font-weight: 500;
-  z-index: 2;
+  z-index: ${p => p.size === 'small' ? '1' : '2'};
 
   &:focus {
     outline-offset: initial;

--- a/components/brave_extension/extension/brave_extension/components/structure/index.ts
+++ b/components/brave_extension/extension/brave_extension/components/structure/index.ts
@@ -97,15 +97,10 @@ export const SiteInfo = styled<{}, 'div'>('div')`
  * Interface/privacy Rows
  */
 
-interface BlockedInfoRowProps {
-  extraColumn?: boolean
-}
-
-export const BlockedInfoRow = styled<BlockedInfoRowProps, 'div'>('div')`
+export const BlockedInfoRow = styled<{}, 'div'>('div')`
   box-sizing: border-box;
   display: grid;
-  grid-template-columns: ${p => p.extraColumn ? '1fr auto auto' : '1fr auto'};
-  grid-gap: ${p => p.extraColumn ? '4px' : '0'};
+  grid-template-columns: 1fr auto;
   align-items: center;
   color: ${p => p.theme.color.text};
   user-select: none;
@@ -126,7 +121,7 @@ export const BlockedInfoRow = styled<BlockedInfoRowProps, 'div'>('div')`
   }
 `
 
-export const BlockedInfoRowDetails = styled<BlockedInfoRowProps, 'details'>('details')`
+export const BlockedInfoRowDetails = styled<{}, 'details'>('details')`
   box-sizing: border-box;
 `
 

--- a/components/brave_extension/extension/brave_extension/containers/advancedView/controls/scriptsControl.tsx
+++ b/components/brave_extension/extension/brave_extension/containers/advancedView/controls/scriptsControl.tsx
@@ -124,7 +124,7 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
     const { scriptsBlockedOpen } = this.state
     return (
       <>
-        <BlockedInfoRow id='scriptsControl' extraColumn={true}>
+        <BlockedInfoRow id='scriptsControl'>
           <BlockedInfoRowData
             disabled={this.shouldDisableResourcesRow}
             tabIndex={this.tabIndex}
@@ -133,25 +133,22 @@ export default class ScriptsControls extends React.PureComponent<Props, State> {
           >
             <ArrowDownIcon />
             <BlockedInfoRowStats id='blockScriptsStat'>{this.javascriptBlockedDisplay}</BlockedInfoRowStats>
-            <BlockedInfoRowText>{getLocale('scriptsBlocked')}</BlockedInfoRowText>
+            <BlockedInfoRowText>
+              {getLocale('scriptsBlocked')}
+              &nbsp;
+              {
+                this.shouldDisableResourcesRow === false
+                  && (
+                    <LinkAction
+                      size='small'
+                      onClick={this.onClickAllowScriptsOnce}
+                    >
+                      {getLocale('allowScriptsOnce')}
+                    </LinkAction>
+                  )
+              }
+            </BlockedInfoRowText>
           </BlockedInfoRowData>
-          {
-            this.shouldDisableResourcesRow === false
-              && (
-                <LinkAction
-                  size='small'
-                  onClick={this.onClickAllowScriptsOnce}
-                  style={{
-                    // TODO: cezaraugusto re-visit shields components.
-                    // this should be defined in the component itself and not inlined,
-                    // and ideally in a logic that is not bounded to a reusable component such as this one.
-                    zIndex: 1
-                  }}
-                >
-                  {getLocale('allowScriptsOnce')}
-                </LinkAction>
-              )
-          }
           <Toggle
             id='blockScripts'
             size='small'


### PR DESCRIPTION
### Reviewer's note: PR https://github.com/brave/brave-core/pull/4946 is needed for this.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Close https://github.com/brave/brave-browser/issues/4575

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Run Brave
2. Switch language to Russian
3. Should match screenshot attached

Lazy way:

1. `npm run storybook`
2. Go to `localeAPI.ts` file and change message path from `en_US` to `ru`
3. Should match screenshot attached

<img width="367" alt="Screen Shot 2020-03-16 at 12 35 49 PM" src="https://user-images.githubusercontent.com/4672033/76775115-a5e75780-6783-11ea-9271-0dbeeeda6023.png">

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
