### PR TITLE
Fixed rewards settings page behaviour after reset rewards (uplift to 1.7.x)

### DIFF
--- a/components/brave_rewards/resources/android_page/components/app.tsx
+++ b/components/brave_rewards/resources/android_page/components/app.tsx
@@ -76,7 +76,7 @@ export class App extends React.Component<Props, State> {
   }
 
   render () {
-    const { walletCreated, walletCreateFailed } = this.props.rewardsData
+    const { walletCreated, walletCreateFailed, ui } = this.props.rewardsData
 
     let props: {onReTry?: () => void} = {}
 
@@ -89,7 +89,7 @@ export class App extends React.Component<Props, State> {
     return (
       <div id='rewardsPage'>
         {
-          !walletCreated
+          !walletCreated || ui.walletCorrupted
           ? <WelcomePage
             optInAction={this.onCreateWalletClicked}
             creating={this.state.creating}
@@ -98,7 +98,7 @@ export class App extends React.Component<Props, State> {
           : null
         }
         {
-          walletCreated
+          walletCreated && !ui.walletCorrupted
           ? <SettingsPage />
           : null
         }


### PR DESCRIPTION
Uplift of #4963

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.