### PR TITLE
Patch headless/BUILD.gn with missing deps.

### DIFF
--- a/patches/headless-BUILD.gn.patch
+++ b/patches/headless-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/headless/BUILD.gn b/headless/BUILD.gn
+index 4b58b5081b3a87b2a05f4baaeac6bfc8a396d074..e82091b907d06bd04e964f160e323cd8f0bd8341 100644
+--- a/headless/BUILD.gn
++++ b/headless/BUILD.gn
+@@ -550,6 +550,7 @@ if (!is_component_build) {
+     ]
+     if (enable_basic_printing) {
+       deps += [ "//components/printing/renderer" ]
++      deps += [ "//components/services/pdf_compositor", "//components/services/pdf_compositor/public/mojom" ]
+     }
+   }
+ } else {


### PR DESCRIPTION
Fixes brave/brave-browser#8756

This appears to be an upstream bug. The Chromium change below added
headless_content_utility_client.cc/h to the headless_renderer target but
didn't add deps to pdf_compositor (like headless_non_renderer target
does).

Something else must have been building those targets earlier on iOS and
MacOS (since the below change has been present since cr78), but not any
longer.

Chromium change:

https://chromium.googlesource.com/chromium/src/+/4d4bd27f36db6c5d994c55cea90ae363a5593a01

commit 4d4bd27f36db6c5d994c55cea90ae363a5593a01
Author: Chris Davis <chrdavis@microsoft.com>
Date:   Tue Aug 13 04:58:45 2019 +0000

    Link headless_renderer for chrome.dll when is_multi_dll_chrome=false

    A recent change made to enable is_multi_dll_chrome = false caused a
    regression for component builds where the crash export thunks were
    getting linked into chrome.dll instead of chrome_elf. Chrome.dll pulls
    in headless_shell_lib which on Windows depends on crash_export_thunks.
    This has the side-effect of statically linking these thunks into
    chrome.dll instead of having them be imported from chrome_elf.dll. The
    result of which is that the crash report database in chrome_elf.dll is
    never initialized. The bug only impacts component builds where
    is_multi_dll_chrome is set to false.

    Regression caused by: http://crrev.com/c/1697368

    Bug: 991886

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
