### PR TITLE
Comment out failing browser tests

### DIFF
--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -837,41 +837,41 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringSimple) {
 }
 
 // Test simple cosmetic filtering
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringSimple) {
-  UpdateAdBlockInstanceWithRules(
-      "b.com###ad-banner\n"
-      "##.ad");
+// IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringSimple) {
+//   UpdateAdBlockInstanceWithRules(
+//       "b.com###ad-banner\n"
+//       "##.ad");
 
-  WaitForBraveExtensionShieldsDataReady();
+//   WaitForBraveExtensionShieldsDataReady();
 
-  GURL tab_url = embedded_test_server()->GetURL("b.com",
-                                                "/cosmetic_filtering.html");
-  ui_test_utils::NavigateToURL(browser(), tab_url);
+//   GURL tab_url = embedded_test_server()->GetURL("b.com",
+//                                                 "/cosmetic_filtering.html");
+//   ui_test_utils::NavigateToURL(browser(), tab_url);
 
-  content::WebContents* contents =
-    browser()->tab_strip_model()->GetActiveWebContents();
+//   content::WebContents* contents =
+//     browser()->tab_strip_model()->GetActiveWebContents();
 
-  bool as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(
-              contents,
-              "checkSelector('#ad-banner', 'display', 'none')",
-              &as_expected));
-  EXPECT_TRUE(as_expected);
+//   bool as_expected = false;
+//   ASSERT_TRUE(ExecuteScriptAndExtractBool(
+//               contents,
+//               "checkSelector('#ad-banner', 'display', 'none')",
+//               &as_expected));
+//   EXPECT_TRUE(as_expected);
 
-  as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(
-              contents,
-              "checkSelector('.ad-banner', 'display', 'block')",
-              &as_expected));
-  EXPECT_TRUE(as_expected);
+//   as_expected = false;
+//   ASSERT_TRUE(ExecuteScriptAndExtractBool(
+//               contents,
+//               "checkSelector('.ad-banner', 'display', 'block')",
+//               &as_expected));
+//   EXPECT_TRUE(as_expected);
 
-  as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(
-              contents,
-              "checkSelector('.ad', 'display', 'none')",
-              &as_expected));
-  EXPECT_TRUE(as_expected);
-}
+//   as_expected = false;
+//   ASSERT_TRUE(ExecuteScriptAndExtractBool(
+//               contents,
+//               "checkSelector('.ad', 'display', 'none')",
+//               &as_expected));
+//   EXPECT_TRUE(as_expected);
+// }
 
 // Test cosmetic filtering ignores content determined to be 1st party
 IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest,
@@ -947,33 +947,33 @@ IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest,
 }
 
 // Test rules overridden by hostname-specific exception rules
-IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringUnhide) {
-  UpdateAdBlockInstanceWithRules(
-      "##.ad\n"
-      "b.com#@#.ad\n"
-      "###ad-banner\n"
-      "a.com#@##ad-banner");
+// IN_PROC_BROWSER_TEST_F(CosmeticFilteringEnabledTest, CosmeticFilteringUnhide) {
+//   UpdateAdBlockInstanceWithRules(
+//       "##.ad\n"
+//       "b.com#@#.ad\n"
+//       "###ad-banner\n"
+//       "a.com#@##ad-banner");
 
-  WaitForBraveExtensionShieldsDataReady();
+//   WaitForBraveExtensionShieldsDataReady();
 
-  GURL tab_url = embedded_test_server()->GetURL("b.com",
-                                                "/cosmetic_filtering.html");
-  ui_test_utils::NavigateToURL(browser(), tab_url);
+//   GURL tab_url = embedded_test_server()->GetURL("b.com",
+//                                                 "/cosmetic_filtering.html");
+//   ui_test_utils::NavigateToURL(browser(), tab_url);
 
-  content::WebContents* contents =
-    browser()->tab_strip_model()->GetActiveWebContents();
+//   content::WebContents* contents =
+//     browser()->tab_strip_model()->GetActiveWebContents();
 
-  bool as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(
-              contents,
-              "checkSelector('.ad', 'display', 'block')",
-              &as_expected));
-  EXPECT_TRUE(as_expected);
+//   bool as_expected = false;
+//   ASSERT_TRUE(ExecuteScriptAndExtractBool(
+//               contents,
+//               "checkSelector('.ad', 'display', 'block')",
+//               &as_expected));
+//   EXPECT_TRUE(as_expected);
 
-  as_expected = false;
-  ASSERT_TRUE(ExecuteScriptAndExtractBool(
-              contents,
-              "checkSelector('#ad-banner', 'display', 'none')",
-              &as_expected));
-  EXPECT_TRUE(as_expected);
-}
+//   as_expected = false;
+//   ASSERT_TRUE(ExecuteScriptAndExtractBool(
+//               contents,
+//               "checkSelector('#ad-banner', 'display', 'none')",
+//               &as_expected));
+//   EXPECT_TRUE(as_expected);
+// }


### PR DESCRIPTION
Follow up to https://github.com/brave/brave-core/pull/4999

Functionality (and tests) work as expected in 1.7 and later. Not enabled / needed for 1.5

For example where it failed, see:
- https://ci.brave.com/view/release/job/brave-browser-build-macos/1576/execution/node/92/log/
- https://ci.brave.com/view/release/job/brave-browser-build-linux/1349/execution/node/97/log/