### PR TITLE
Fixed missing creative set segments and unknown types in the Brave Ads catalog should not fail to parse the catalog

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog_state.cc
@@ -93,12 +93,7 @@ Result CatalogState::FromJson(
       // Segments
       auto segments = creative_set["segments"].GetArray();
       if (segments.Size() == 0) {
-        if (error_description != nullptr) {
-          *error_description = "Catalog invalid: No segments for creativeSet "
-              "with creativeSetId: " + creative_set_info.creative_set_id;
-        }
-
-        return FAILED;
+        continue;
       }
 
       for (const auto& segment : segments) {
@@ -165,12 +160,9 @@ Result CatalogState::FromJson(
 
           creative_set_info.creative_ad_notifications.push_back(creative_info);
         } else {
-          if (error_description != nullptr) {
-            *error_description = "Catalog invalid: Invalid " + code
-                +" creative for creativeInstanceId: " + creative_instance_id;
-          }
-
-          return FAILED;
+          // Unknown type
+          NOTREACHED();
+          continue;
         }
       }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8799

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Using Charles Proxy and the Map Local feature rewrite the catalog so that there are empty `segments` for a creative set
```
"segments": [
]
```
and an unknown `code` for the `type` in a creative
```
"type": {
  "code": "unknown",
  "name": "notification",
  "platform": "all",
  "version": 1
}
```
The catalog should be parsed and ads should be shown to the user for other creatives

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
