### PR TITLE
Fixes remove publisher channel id containing landing TLD+1 for ad notification confirmations - 1.7.x

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmation_info.h
@@ -28,7 +28,6 @@ struct ConfirmationInfo {
 
   std::string id;
   std::string creative_instance_id;
-  std::string channel_id;
   ConfirmationType type;
   TokenInfo token_info;
   Token payment_token;

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/create_confirmation_request.cc
@@ -79,10 +79,6 @@ std::string CreateConfirmationRequest::CreateConfirmationRequestDTO(
   auto type = std::string(info.type);
   payload.SetKey("type", base::Value(type));
 
-  if (!info.channel_id.empty()) {
-    payload.SetKey("channelId", base::Value(info.channel_id));
-  }
-
   std::string json;
   base::JSONWriter::Write(payload, &json);
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
@@ -17,8 +17,6 @@
 #include "bat/confirmations/internal/time.h"
 #include "bat/confirmations/internal/token_info.h"
 #include "bat/confirmations/internal/confirmation_info.h"
-#include "url/gurl.h"
-#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 
 #include "base/logging.h"
 #include "base/guid.h"
@@ -150,9 +148,6 @@ void RedeemToken::CreateConfirmation(
 
   confirmation_info.id = base::GenerateGUID();
   confirmation_info.creative_instance_id = ad_info.creative_instance_id;
-  const std::string tld_plus_1 = GetDomainAndRegistry(GURL(ad_info.target_url),
-      net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
-  confirmation_info.channel_id = tld_plus_1;
   confirmation_info.type = confirmation_type;
   confirmation_info.token_info = token_info;
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/5033
Resolves https://github.com/brave/brave-browser/issues/8833

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.