### PR TITLE
Reload active tab when widevine library is ready to use (uplift to 1.7.x)

### DIFF
--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -5,15 +5,57 @@
 
 #include "brave/browser/brave_drm_tab_helper.h"
 
+#include <algorithm>
+#include <vector>
+
 #include "brave/browser/widevine/widevine_utils.h"
 #include "brave/common/pref_names.h"
+#include "chrome/browser/browser_process_impl.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "components/prefs/pref_service.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_handle.h"
 
+using component_updater::ComponentUpdateService;
+
+namespace {
+
+// Copied from widevine_cdm_component_installer.cc.
+// There is no shared constant value.
+constexpr char kWidevineComponentId[] = "oimompecagnajdejgnnjijobebaeigek";
+
+bool IsAlreadyRegistered(ComponentUpdateService* cus) {
+  std::vector<std::string> component_ids;
+  component_ids = cus->GetComponentIDs();
+  return std::find(component_ids.begin(),
+                   component_ids.end(),
+                   kWidevineComponentId) != component_ids.end();
+}
+
+content::WebContents* GetActiveWebContents() {
+  if (Browser* browser = chrome::FindLastActive())
+    return browser->tab_strip_model()->GetActiveWebContents();
+  return nullptr;
+}
+
+void ReloadIfActive(content::WebContents* web_contents) {
+  if (GetActiveWebContents() == web_contents)
+    web_contents->GetController().Reload(content::ReloadType::NORMAL, false);
+}
+
+}  // namespace
+
 BraveDrmTabHelper::BraveDrmTabHelper(content::WebContents* contents)
-    : WebContentsObserver(contents), receivers_(contents, this) {}
+    : WebContentsObserver(contents),
+      receivers_(contents, this),
+      observer_(this) {
+  auto* updater = g_browser_process->component_updater();
+  // We don't need to observe if widevine is already registered.
+  if (!IsAlreadyRegistered(updater))
+    observer_.Add(updater);
+}
 
 BraveDrmTabHelper::~BraveDrmTabHelper() {}
 
@@ -44,6 +86,17 @@ void BraveDrmTabHelper::OnWidevineKeySystemAccessRequest() {
   if (ShouldShowWidevineOptIn() && !is_permission_requested_) {
     is_permission_requested_ = true;
     RequestWidevinePermission(web_contents());
+  }
+}
+
+void BraveDrmTabHelper::OnEvent(Events event, const std::string& id) {
+  if (event == ComponentUpdateService::Observer::Events::COMPONENT_UPDATED &&
+      id == kWidevineComponentId) {
+    // When widevine is ready to use, only active tab that requests widevine is
+    // reloaded automatically. Then, stop observing component update.
+    if (is_widevine_requested_)
+      ReloadIfActive(web_contents());
+    observer_.RemoveAll();
   }
 }
 

--- a/browser/brave_drm_tab_helper.h
+++ b/browser/brave_drm_tab_helper.h
@@ -6,7 +6,11 @@
 #ifndef BRAVE_BROWSER_BRAVE_DRM_TAB_HELPER_H_
 #define BRAVE_BROWSER_BRAVE_DRM_TAB_HELPER_H_
 
+#include <string>
+
+#include "base/scoped_observer.h"
 #include "brave/components/brave_drm/brave_drm.mojom.h"
+#include "components/component_updater/component_updater_service.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_receiver_set.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -15,7 +19,8 @@
 class BraveDrmTabHelper final
     : public content::WebContentsObserver,
       public content::WebContentsUserData<BraveDrmTabHelper>,
-      public brave_drm::mojom::BraveDRM {
+      public brave_drm::mojom::BraveDRM,
+      public component_updater::ComponentUpdateService::Observer {
  public:
   explicit BraveDrmTabHelper(content::WebContents* contents);
   ~BraveDrmTabHelper() override;
@@ -29,6 +34,9 @@ class BraveDrmTabHelper final
   // blink::mojom::BraveDRM
   void OnWidevineKeySystemAccessRequest() override;
 
+  // component_updater::ComponentUpdateService::Observer
+  void OnEvent(Events event, const std::string& id) override;
+
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 
  private:
@@ -41,6 +49,9 @@ class BraveDrmTabHelper final
 
   // True if we are notified that a page requested widevine availability.
   bool is_widevine_requested_ = false;
+
+  ScopedObserver<component_updater::ComponentUpdateService,
+                 component_updater::ComponentUpdateService::Observer> observer_;
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_DRM_TAB_HELPER_H_

--- a/browser/widevine/widevine_utils.cc
+++ b/browser/widevine/widevine_utils.cc
@@ -11,7 +11,6 @@
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/permissions/permission_request_manager.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/subresource_filter/chrome_subresource_filter_client.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/pref_registry/pref_registry_syncable.h"
@@ -87,8 +86,6 @@ void EnableWidevineCdmComponent(content::WebContents* web_contents) {
 
   SetWidevineOptedIn(true);
   RegisterWidevineCdmComponent(g_brave_browser_process->component_updater());
-  ChromeSubresourceFilterClient::FromWebContents(web_contents)
-      ->OnReloadRequested();
 }
 #endif
 


### PR DESCRIPTION
Uplift of #4978
Fixes https://github.com/brave/brave-browser/issues/4646

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.