### PR TITLE
Fixes ad notifications are not shown until a non ad notification has been authorized

### DIFF
--- a/components/brave_ads/browser/notification_helper_win.cc
+++ b/components/brave_ads/browser/notification_helper_win.cc
@@ -183,23 +183,18 @@ bool NotificationHelperWin::IsFocusAssistEnabled() const {
 }
 
 bool NotificationHelperWin::IsNotificationsEnabled() {
-#if !defined(OFFICIAL_BUILD)
-  LOG(WARNING) << "Unable to detect the status of native notifications on non"
-      " official builds as the app is not code signed";
-  return true;
-#else
   HRESULT hr = InitializeToastNotifier();
   auto* notifier = notifier_.Get();
   if (!notifier || FAILED(hr)) {
     LOG(ERROR) << "Failed to initialize toast notifier";
-    return false;
+    return true;
   }
 
   ABI::Windows::UI::Notifications::NotificationSetting setting;
   hr = notifier->get_Setting(&setting);
   if (FAILED(hr)) {
     LOG(ERROR) << "Failed to get notification settings from toast notifier";
-    return false;
+    return true;
   }
 
   switch (setting) {
@@ -233,7 +228,6 @@ bool NotificationHelperWin::IsNotificationsEnabled() {
       return false;
     }
   }
-#endif
 }
 
 base::string16 NotificationHelperWin::GetAppId() const {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8932

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- View an ad notification
- Install Chrome side-by-side with Brave and view an ad notification
- View an ad notification, disable notifications for Brave Browser in "Windows > Settings > Notifications & actions", confirm ad notifications are no longer shown and that users are no longer rewarded for ads
- View an ad notification, enable Focus Assist, confirm ad notifications are no longer shown and that users are no longer rewarded for ads

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
