### PR TITLE
Fixes ad notifications are not shown on Windows until a non ad notification has been authorized - 1.8.x

### DIFF
--- a/components/brave_ads/browser/notification_helper_win.cc
+++ b/components/brave_ads/browser/notification_helper_win.cc
@@ -183,23 +183,18 @@ bool NotificationHelperWin::IsFocusAssistEnabled() const {
 }
 
 bool NotificationHelperWin::IsNotificationsEnabled() {
-#if !defined(OFFICIAL_BUILD)
-  LOG(WARNING) << "Unable to detect the status of native notifications on non"
-      " official builds as the app is not code signed";
-  return true;
-#else
   HRESULT hr = InitializeToastNotifier();
   auto* notifier = notifier_.Get();
   if (!notifier || FAILED(hr)) {
     LOG(ERROR) << "Failed to initialize toast notifier";
-    return false;
+    return true;
   }
 
   ABI::Windows::UI::Notifications::NotificationSetting setting;
   hr = notifier->get_Setting(&setting);
   if (FAILED(hr)) {
     LOG(ERROR) << "Failed to get notification settings from toast notifier";
-    return false;
+    return true;
   }
 
   switch (setting) {
@@ -233,7 +228,6 @@ bool NotificationHelperWin::IsNotificationsEnabled() {
       return false;
     }
   }
-#endif
 }
 
 base::string16 NotificationHelperWin::GetAppId() const {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/5131
Resolves https://github.com/brave/brave-browser/issues/8932

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.