### PR TITLE
NTP: Prevent top sites interface from handling duplicated site entries

### DIFF
--- a/components/brave_new_tab_ui/helpers/newTabUtils.ts
+++ b/components/brave_new_tab_ui/helpers/newTabUtils.ts
@@ -115,3 +115,29 @@ export function filterFromExcludedSites (
         .every((removedSite: NewTab.Site) => removedSite.url !== site.url)
     })
 }
+
+export function equalsSite (
+  site: NewTab.Site,
+  siteToCompare: NewTab.Site
+): boolean {
+  return (
+    // Ensure there are no duplicated URLs
+    site.url === siteToCompare.url ||
+    // Ensure there are no duplicated IDs
+    site.id === siteToCompare.id
+  )
+}
+
+export function filterDuplicatedSitesbyIndexOrUrl (
+  sitesData: NewTab.Site[]
+): NewTab.Site[] {
+  const newGridSites: NewTab.Site[] = []
+
+  for (const site of sitesData) {
+    const isDuplicate = newGridSites.some(item => equalsSite(item, site))
+    if (!isDuplicate) {
+      newGridSites.push(site)
+    }
+  }
+  return newGridSites
+}

--- a/components/brave_new_tab_ui/state/gridSitesState.ts
+++ b/components/brave_new_tab_ui/state/gridSitesState.ts
@@ -9,7 +9,8 @@ import {
   getGridSitesWhitelist,
   isGridSitePinned,
   isGridSiteBookmarked,
-  filterFromExcludedSites
+  filterFromExcludedSites,
+  filterDuplicatedSitesbyIndexOrUrl
 } from '../helpers/newTabUtils'
 
 export function gridSitesReducerSetFirstRenderDataFromLegacy (
@@ -224,7 +225,15 @@ export function gridSitesReducerAddSiteOrSites (
     ...sitesToAdd,
     ...state.gridSites
   ]
-  state = gridSitesReducerDataUpdated(state, currentGridSitesWithNewItems)
+
+  // We have reports of users having duplicated entries
+  // after updating to the new storage. This is a special
+  // case that breaks all top sites mechanism. Ensure all
+  // entries defined visually in the grid are not duplicated.
+  const updatedGridSites =
+    filterDuplicatedSitesbyIndexOrUrl(currentGridSitesWithNewItems)
+
+  state = gridSitesReducerDataUpdated(state, updatedGridSites)
   return state
 }
 

--- a/components/test/brave_new_tab_ui/helpers/newTabUtils_test.ts
+++ b/components/test/brave_new_tab_ui/helpers/newTabUtils_test.ts
@@ -276,4 +276,34 @@ describe('new tab util files tests', () => {
       expect(assertion).toHaveLength(1)
     })
   })
+  describe('filterDuplicatedSitesbyIndexOrUrl', () => {
+    const sitesData: NewTab.Site[] = [{
+      id: 'topsite-000',
+      url: 'https://brave.com',
+      title: 'brave',
+      favicon: '',
+      letter: '',
+      pinnedIndex: undefined,
+      bookmarkInfo: undefined
+    }]
+    it('filter sites already included in the sites list', () => {
+      const duplicatedSitesData = [ ...sitesData, ...sitesData ]
+      const assertion = newTabUtils.filterDuplicatedSitesbyIndexOrUrl(duplicatedSitesData)
+      expect(assertion).toHaveLength(1)
+    })
+    it('does not filter sites not included in the sites list', () => {
+      const otherSitesData: NewTab.Site[] = [{
+        id: 'topsite-111',
+        url: 'https://new_site.com',
+        title: 'new_site',
+        favicon: '',
+        letter: '',
+        pinnedIndex: undefined,
+        bookmarkInfo: undefined
+      }]
+      const newSitesData: NewTab.Site[] = [ ...sitesData, ...otherSitesData ]
+      const assertion = newTabUtils.filterDuplicatedSitesbyIndexOrUrl(newSitesData)
+      expect(assertion).toHaveLength(2)
+    })
+  })
 })

--- a/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
+++ b/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
@@ -10,7 +10,7 @@ import * as gridSitesState from '../../../brave_new_tab_ui/state/gridSitesState'
 
 const bookmarkInfo: chrome.bookmarks.BookmarkTreeNode = {
   dateAdded: 123123,
-  id: '',
+  id: 'topsite-0',
   index: 1337,
   parentId: '',
   title: 'brave',
@@ -78,6 +78,53 @@ describe('gridSitesReducer', () => {
         payload: { topSites }
       })
 
+      expect(assertion.gridSites).toHaveLength(2)
+    })
+    it('populate state.gridSites list without duplicates', () => {
+      const brandNewSite: NewTab.Site = {
+        id: 'topsite-000',
+        url: 'https://.com',
+        title: 'g. clooney free propaganda',
+        pinnedIndex: 0,
+        favicon: '',
+        letter: '',
+        bookmarkInfo: undefined
+      }
+      const veryRepetitiveSite: NewTab.Site = {
+        id: 'topsite-111',
+        url: 'https://serg-loves-pokemon-4ever.com',
+        title: 'pokemon fan page',
+        pinnedIndex: 0,
+        favicon: '',
+        letter: '',
+        bookmarkInfo: undefined
+      }
+
+      const veryRepetitiveSiteList: NewTab.Site[] = [
+        veryRepetitiveSite,
+        veryRepetitiveSite,
+        veryRepetitiveSite,
+        veryRepetitiveSite,
+        veryRepetitiveSite
+      ]
+
+      // Add repetitiveSiteList everywhere. Dupe party.
+      const veryRepetitiveInitialGridSitesState: NewTab.GridSitesState = {
+        gridSites: veryRepetitiveSiteList,
+        removedSites: veryRepetitiveSiteList,
+        shouldShowSiteRemovedNotification: false,
+        legacy: {
+          pinnedTopSites: veryRepetitiveSiteList,
+          ignoredTopSites: veryRepetitiveSiteList
+        }
+      }
+
+      const assertion = gridSitesReducer(veryRepetitiveInitialGridSitesState, {
+        type: types.GRID_SITES_SET_FIRST_RENDER_DATA,
+        payload: { topSites: [ brandNewSite ] }
+      })
+      // We should see just one repetitive site and the new
+      // one added on the payload above
       expect(assertion.gridSites).toHaveLength(2)
     })
   })
@@ -224,7 +271,8 @@ describe('gridSitesReducer', () => {
     it('push an item from state.removedSites list back to state.gridSites list', () => {
       const removedSite: NewTab.Site = {
         ...gridSites[1],
-        url: 'https://example.com'
+        url: 'https://example.com',
+        id: 'topsite-999999'
       }
       const newStateWithGridSites: NewTab.State = {
         ...storage.initialGridSitesState,
@@ -277,10 +325,12 @@ describe('gridSitesReducer', () => {
     it('push all items from state.removedSites list back to state.gridSites list', () => {
       const removedSites: NewTab.Site[] = [{
         ...gridSites[0],
-        url: 'https://example.com'
+        url: 'https://example.com',
+        id: 'topsite-999999'
       }, {
         ...gridSites[1],
-        url: 'https://another-example.com'
+        url: 'https://another-example.com',
+        id: 'topsite-999998'
       }]
       const newStateWithGridSites: NewTab.State = {
         ...storage.initialGridSitesState,
@@ -440,7 +490,8 @@ describe('gridSitesReducer', () => {
     it('add sites to state.gridSites list', () => {
       const newSite: NewTab.Site = {
         ...gridSites[0],
-        url: 'https://example.com'
+        url: 'https://example.com',
+        id: 'topsite-99999'
       }
       const newStateWithGridSites: NewTab.State = {
         ...storage.initialGridSitesState,

--- a/components/test/brave_new_tab_ui/state/gridSitesState_test.ts
+++ b/components/test/brave_new_tab_ui/state/gridSitesState_test.ts
@@ -200,7 +200,7 @@ describe('gridSitesState', () => {
   })
   describe('gridSitesReducerUndoRemoveSite', () => {
     it('push an item from the state.removedSites list back to state.gridSites list', () => {
-      const removedSite: NewTab.Site = { ...gridSites[1], url: 'https://example.com' }
+      const removedSite: NewTab.Site = { ...gridSites[1], id: 'topsite-000', url: 'https://example.com' }
       const newState: NewTab.State = {
         ...storage.initialGridSitesState,
         gridSites,
@@ -230,10 +230,12 @@ describe('gridSitesState', () => {
     it('push all items from state.removedSites list back to state.gridSites list', () => {
       const removedSites: NewTab.Site[] = [{
         ...gridSites[0],
-        url: 'https://example.com'
+        url: 'https://example.com',
+        id: 'topsite-000'
       }, {
         ...gridSites[1],
-        url: 'https://another-example.com'
+        url: 'https://another-example.com',
+        id: 'topsite-111'
       }]
 
       const newState: NewTab.State = {
@@ -300,13 +302,30 @@ describe('gridSitesState', () => {
   })
   describe('gridSitesReducerAddSiteOrSites', () => {
     it('add sites to state.gridSites list', () => {
-      const newSite: NewTab.Site = { ...gridSites[0], url: 'https://example.com' }
+      const newSite: NewTab.Site = { ...gridSites[0], id: 'topsite-111', url: 'https://example.com' }
       const newState: NewTab.State = { ...storage.initialGridSitesState, gridSites }
 
       const assertion = gridSitesState
         .gridSitesReducerAddSiteOrSites(newState, newSite)
 
       expect(assertion.gridSites).toHaveLength(3)
+    })
+    it('do not allow duplicated sites to be added in state.gridSites list', () => {
+      const duplicatedGridSites: NewTab.Site[] = [
+        ...gridSites,
+        ...gridSites
+      ]
+
+      expect(duplicatedGridSites).toHaveLength(4)
+
+      const assertion = gridSitesState
+      .gridSitesReducerAddSiteOrSites(
+        storage.initialGridSitesState,
+        duplicatedGridSites
+        )
+
+      // Array length should reduce since it should filter dupes
+      expect(assertion.gridSites).toHaveLength(2)
     })
   })
   describe('gridSitesReducerShowSiteRemovedNotification', () => {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/9008

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Covered by automated tests `npm run test-unit`

## (Manual) Test Plan

1. Check you have an existing profile with some top site. If you do not, navigate some websites until 
 typing `chrome.topSites.get(site => console.log(site))` in your NTP console outputs more than one result (this bug only happens in existing profiles w/ top sites).
2. Copy/paste the code below in devtools on your NTP console tab. The code is corrupted storage with two top sites repeated and pinned at indexes 1 and 2, respectively.
3. Refresh the page
4. You should see Google Translate and GitHub as top sites, pinned, at indexes 1 and 2, respectively. If you had any top site before this check, they should be there too, but pinned indexes should be respected.

<details>
<summary>👉👉👉👉👉👉👉Code you need to copy 👈👈👈👈👈👈👈</summary>

```javascript
localStorage.setItem('grid-sites-data-v1', JSON.stringify({
  gridSites: [
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    },
    {
      title: "Google Translate",
      url: "https://translate.google.com/",
      id: "topsite-3742-1585908285880",
      letter: "G",
      favicon: "chrome://favicon/size/64@1x/https://translate.google.com/",
      pinnedIndex: 1
    },
    {
      title: "GitHub",
      url: "https://github.com/congard",
      id: "topsite-3742-1585908285881",
      letter: "C",
      favicon: "chrome://favicon/size/64@1x/https://github.com/congard",
      bookmarkInfo: {},
      pinnedIndex: 2
    }
  ],
  removedSites: [],
  shouldShowSiteRemovedNotification: false,
  legacy: {
    pinnedTopSites: [],
    ignoredTopSites: []
  }
}
))
```
</details>

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
