### PR TITLE
Fix Ads Purchase Intent funnel keyword with higher weight is ignored

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords.cc
@@ -37,15 +37,17 @@ uint16_t Keywords::GetFunnelWeight(
     const std::string& search_query) {
   auto search_query_keyword_set = TransformIntoSetOfWords(search_query);
 
+  uint16_t max_weight = _default_signal_weight;
   for (const auto& keyword : _automotive_funnel_keywords) {
     auto list_keyword_set = TransformIntoSetOfWords(keyword.keywords);
 
-    if (Keywords::IsSubset(search_query_keyword_set, list_keyword_set)) {
-      return keyword.weight;
+    if (Keywords::IsSubset(search_query_keyword_set, list_keyword_set) &&
+        keyword.weight > max_weight) {
+      max_weight = keyword.weight;
     }
   }
 
-  return _default_signal_weight;
+  return max_weight;
 }
 
 // TODO(Moritz Haller): Rename to make explicit that method checks set_a is

--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords_unittest.cc
@@ -25,6 +25,11 @@ const std::vector<std::string> kAudiA4Segments = {
   "automotive purchase intent by category-entry luxury car"
 };
 
+const std::vector<std::string> kAudiA5Segments = {
+  "automotive purchase intent by make-audi",
+  "automotive purchase intent by category-entry luxury car"
+};
+
 const std::vector<std::string> kAudiA6Segments = {
   "automotive purchase intent by make-audi",
   "automotive purchase intent by category-mid luxury car"
@@ -44,6 +49,7 @@ const std::vector<TestTriplet> kTestSearchqueries = {
   {"latest audi a4 dealer reviews", kAudiA4Segments, 3},
   {"latest audi a6 ", kAudiA6Segments, 1},
   {"this is a test", kNoSegments, 1},
+  {"audi a5 dealer opening times sell", kAudiA5Segments, 3},
 };
 
 }  // namespace


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8965

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
