### PR TITLE
Fix Single word keywords does not increase purchase intent when searching

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords.h
@@ -1760,6 +1760,111 @@ SegmentKeywordInfo({
     "automotive purchase intent by make-volvo",
     "automotive purchase intent by category-luxury suv"},
     "Volvo XC90"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-acura"},
+    "Acura"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-audi"},
+    "Audi"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-bmw"},
+    "BMW"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-buick"},
+    "Buick"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-cadillac"},
+    "Cadillac"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-chevrolet"},
+    "Chevrolet"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-chrysler"},
+    "Chrysler"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-dodge"},
+    "Dodge"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-fiat"},
+    "Fiat"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-ford"},
+    "Ford"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-gmc"},
+    "GMC"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-honda"},
+    "Honda"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-hyundai"},
+    "Hyundai"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-infiniti"},
+    "Infiniti"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-jaguar"},
+    "Jaguar"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-jeep"},
+    "Jeep"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-kia"},
+    "Kia"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-land rover"},
+    "Land Rover"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-lexus"},
+    "Lexus"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-lincoln"},
+    "Lincoln"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-mazda"},
+    "Mazda"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-mercedes-benz"},
+    "Mercedes-Benz"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-mini"},
+    "Mini"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-mitsubishi"},
+    "Mitsubishi"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-nissan"},
+    "Nissan"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-porsche"},
+    "Porsche"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-ram"},
+    "RAM"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-saab"},
+    "Saab"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-scion"},
+    "Scion"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-smart"},
+    "smart"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-subaru"},
+    "Subaru"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-suzuki"},
+    "Suzuki"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-toyota"},
+    "Toyota"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-volkswagen"},
+    "Volkswagen"),
+SegmentKeywordInfo({
+    "automotive purchase intent by make-volvo"},
+    "Volvo"),
 };
 
 static const std::vector<FunnelKeywordInfo>& _automotive_funnel_keywords = {

--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords_unittest.cc
@@ -20,6 +20,14 @@ using ::testing::_;
 
 namespace {
 
+const std::vector<std::string> kAudiSegments = {
+  "automotive purchase intent by make-audi"
+};
+
+const std::vector<std::string> kBmwSegments = {
+  "automotive purchase intent by make-bmw"
+};
+
 const std::vector<std::string> kAudiA4Segments = {
   "automotive purchase intent by make-audi",
   "automotive purchase intent by category-entry luxury car"
@@ -44,12 +52,14 @@ struct TestTriplet {
 };
 
 const std::vector<TestTriplet> kTestSearchqueries = {
+  {"BMW", kBmwSegments, 1},
   {"latest audi a6 review", kAudiA6Segments, 2},
   {"  \tlatest audi\na6 !?# @& review  \t  ", kAudiA6Segments, 2},
   {"latest audi a4 dealer reviews", kAudiA4Segments, 3},
   {"latest audi a6 ", kAudiA6Segments, 1},
   {"this is a test", kNoSegments, 1},
   {"audi a5 dealer opening times sell", kAudiA5Segments, 3},
+  {"audi", kAudiSegments, 1},
 };
 
 }  // namespace


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8942

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
- Clean profile
- Connect to US
- Run Brave with command line: `/usr/bin/brave-browser --enable-logging=stderr --vmodule=brave_ads=3 --brave-ads-staging --rewards=staging=true`
- Enable Rewards
- Search for "audi" in URL bar

### Expected result:
- purchase intent weight is increased
- automotive purchase intent by make-audi in Default/ads_service/client.json is not empty and contains one element

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
