### PR TITLE
Fix Sometimes purchase intent weight in not increased on google

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/keywords.cc
@@ -24,6 +24,10 @@ PurchaseIntentSegmentList Keywords::GetSegments(
   for (const auto& keyword : _automotive_segment_keywords) {
     auto list_keyword_set = TransformIntoSetOfWords(keyword.keywords);
 
+    // Intended behaviour relies on early return from list traversal and
+    // implicitely on the ordering of |_automotive_segment_keywords| to ensure
+    // specific segments are matched over general segments, e.g. "audi a6"
+    // segments should be returned over "audi" segments if possible.
     if (Keywords::IsSubset(search_query_keyword_set, list_keyword_set)) {
       segment_list = keyword.segments;
       return segment_list;

--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/purchase_intent_classifier_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/purchase_intent_classifier_unittest.cc
@@ -25,6 +25,11 @@ using ::testing::_;
 
 namespace ads {
 
+const std::vector<std::string> audi_a4_segments = {
+  "automotive purchase intent by make-audi",
+  "automotive purchase intent by category-entry luxury car"
+};
+
 const std::vector<std::string> audi_a6_segments = {
   "automotive purchase intent by make-audi",
   "automotive purchase intent by category-mid luxury car"
@@ -65,6 +70,10 @@ std::vector<TestTriplets> kTestSearchQueries = {
       no_segments, 0},
   {"https://creators.brave.com/",
       no_segments, 0},
+  {"https://www.google.com/search?ei=bY2CXvHBMK2tytMPqYq--A4&q=audi+a4",
+      audi_a4_segments, 1},
+  {"https://www.google.com/search?source=hp&ei=y2eDXsWuI6fIrgThwZuQDw&q=audi+a4",  // NOLINT
+      audi_a4_segments, 1},
 };
 
 class AdsPurchaseIntentClassifierTest : public ::testing::Test {

--- a/vendor/bat-native-ads/src/bat/ads/internal/search_providers.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/search_providers.cc
@@ -68,23 +68,17 @@ std::string SearchProviders::ExtractSearchQueryKeywords(
       continue;
     }
 
-    size_t index = search_provider.search_template.find('{');
-    std::string substring = search_provider.search_template.substr(0, index);
-    size_t href_index = url.find(substring);
-
-    if (index != std::string::npos && href_index != std::string::npos) {
-      // Checking if search template in as defined in |search_providers.h|
-      // is defined, e.g. |https://searx.me/?q={searchTerms}&categories=general|
-      // matches |?q={|
-      std::string key;
-      if (!RE2::PartialMatch(
-          search_provider.search_template, "\\?(.*?)\\={", &key)) {
-        return search_query_keywords;
-      }
-
-      search_query_keywords = helper::Uri::GetValueForKeyInQuery(url, key);
-      break;
+    // Checking if search template in as defined in |search_providers.h|
+    // is defined, e.g. |https://searx.me/?q={searchTerms}&categories=general|
+    // matches |?q={|
+    std::string key;
+    if (!RE2::PartialMatch(
+        search_provider.search_template, "\\?(.*?)\\={", &key)) {
+      return search_query_keywords;
     }
+
+    search_query_keywords = helper::Uri::GetValueForKeyInQuery(url, key);
+    break;
   }
 
   return search_query_keywords;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8939

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Clean profile
- Connect to US
- Run Brave with command line: `/usr/bin/brave-browser --enable-logging=stderr --vmodule=brave_ads=3 --brave-ads-staging --rewards=staging=true`
- Enable Rewards
- Open google.com
- Search for "audi a4"

### Expected result:

- purchase intent weight is increased
- automotive purchase intent by make-audi in Default/ads_service/client.json is not empty and contains one element

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
