### PR TITLE
Fixed crash when user tries to install ipfs extension from setting

### DIFF
--- a/browser/ui/webui/settings/brave_default_extensions_handler.cc
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.cc
@@ -22,6 +22,9 @@
 #include "chrome/browser/media/router/media_router_feature.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/lifetime/application_lifetime.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_window.h"
 #include "chrome/common/chrome_switches.h"
 #include "chrome/common/pref_names.h"
 #include "components/flags_ui/flags_ui_constants.h"
@@ -274,9 +277,15 @@ void BraveDefaultExtensionsHandler::SetIPFSCompanionEnabled(
   extensions::ExtensionSystem::Get(profile_)->extension_service();
   if (enabled) {
     if (!IsExtensionInstalled(ipfs_companion_extension_id)) {
+      // Using FindLastActiveWithProfile() here will be fine. Of course, it can
+      // return NULL but only return NULL when there was no activated window
+      // with |profile_| so far. But, it's impossible at here because user can't
+      // request ipfs install request w/o activating browser.
       scoped_refptr<extensions::WebstoreInstallWithPrompt> installer =
           new extensions::WebstoreInstallWithPrompt(
               ipfs_companion_extension_id, profile_,
+              chrome::FindLastActiveWithProfile(profile_)->window()->
+                  GetNativeWindow(),
               base::BindOnce(&BraveDefaultExtensionsHandler::OnInstallResult,
                              weak_ptr_factory_.GetWeakPtr(),
                              kIPFSCompanionEnabled));


### PR DESCRIPTION
When extension install is requested, install dialog is launched.
So far, we requested un-parented install dialog.
On linux, custom frame is not allowed for un-parented dialog.
Only platform-native frame is used for it. The problem was
install dialog tries to set title to custom frame. So, seg fault
happened only on linux. And Windows with classic theme will have
same issue. On macOS and Windows with aero, crash doesn't happen.
But, un-parented dialog on macOS has title area that looks ugly.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9092
Resolves https://github.com/brave/brave-browser/issues/7325

Linux:
![Screenshot from 2020-04-09 17-36-33](https://user-images.githubusercontent.com/6786187/78875436-d8d1f200-7a88-11ea-8ae4-5ffa7f7085ce.png)

MacOS (parented dialog)
<img width="549" alt="Screen Shot 2020-04-09 at 5 40 33 PM" src="https://user-images.githubusercontent.com/6786187/78875852-7decca80-7a89-11ea-9162-597e80523fb5.png">

MacOS (previously used one - un parented dialog)
<img width="538" alt="Screen Shot 2020-04-09 at 5 35 03 PM" src="https://user-images.githubusercontent.com/6786187/78875886-85ac6f00-7a89-11ea-96c7-c6d1200e6055.png">

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Launch browser and open settings
2. Toggle ipfs extensions on

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
