### PR TITLE
Fixes crash when suggesting in Private window.

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -27,6 +27,8 @@ source_set("browser_process") {
   sources = [
     "autocomplete/brave_autocomplete_provider_client.cc",
     "autocomplete/brave_autocomplete_provider_client.h",
+    "autocomplete/brave_autocomplete_provider_client_for_classifier.cc",
+    "autocomplete/brave_autocomplete_provider_client_for_classifier.h",
     "autocomplete/brave_autocomplete_scheme_classifier.cc",
     "autocomplete/brave_autocomplete_scheme_classifier.h",
     "brave_rewards/rewards_tab_helper.cc",

--- a/browser/autocomplete/brave_autocomplete_provider_client.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client.cc
@@ -39,3 +39,14 @@ std::vector<base::string16> BraveAutocompleteProviderClient::GetBuiltinURLs() {
   }
   return v;
 }
+
+bool BraveAutocompleteProviderClient::IsOffTheRecord() const {
+  return profile_->IsOffTheRecord();
+}
+
+void BraveAutocompleteProviderClient::StartServiceWorker(
+    const GURL& destination_url) {
+  if (profile_->IsOffTheRecord())
+    return;
+  ChromeAutocompleteProviderClient::StartServiceWorker(destination_url);
+}

--- a/browser/autocomplete/brave_autocomplete_provider_client.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client.cc
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -6,26 +7,13 @@
 
 #include "base/strings/utf_string_conversions.h"
 #include "brave/common/webui_url_constants.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "chrome/common/webui_url_constants.h"
 
 BraveAutocompleteProviderClient::BraveAutocompleteProviderClient(
-    Profile* profile)
-    : ChromeAutocompleteProviderClient(profile->GetOriginalProfile()),
-      profile_(profile) {
+    Profile* profile) : ChromeAutocompleteProviderClient(profile) {
 }
 
 BraveAutocompleteProviderClient::~BraveAutocompleteProviderClient() {
-}
-
-TemplateURLService* BraveAutocompleteProviderClient::GetTemplateURLService() {
-  return TemplateURLServiceFactory::GetForProfile(profile_);
-}
-
-const TemplateURLService*
-BraveAutocompleteProviderClient::GetTemplateURLService() const {
-  return TemplateURLServiceFactory::GetForProfile(profile_);
 }
 
 std::vector<base::string16> BraveAutocompleteProviderClient::GetBuiltinURLs() {
@@ -38,15 +26,4 @@ std::vector<base::string16> BraveAutocompleteProviderClient::GetBuiltinURLs() {
     *it = base::ASCIIToUTF16(kBraveUISyncHost);
   }
   return v;
-}
-
-bool BraveAutocompleteProviderClient::IsOffTheRecord() const {
-  return profile_->IsOffTheRecord();
-}
-
-void BraveAutocompleteProviderClient::StartServiceWorker(
-    const GURL& destination_url) {
-  if (profile_->IsOffTheRecord())
-    return;
-  ChromeAutocompleteProviderClient::StartServiceWorker(destination_url);
 }

--- a/browser/autocomplete/brave_autocomplete_provider_client.h
+++ b/browser/autocomplete/brave_autocomplete_provider_client.h
@@ -1,49 +1,25 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_H_
 #define BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_H_
 
+#include <string>
+#include <vector>
+
 #include "chrome/browser/autocomplete/chrome_autocomplete_provider_client.h"
 
-// In brave, different AutocompleteClassifiers are created for normal and
-// incognito profile by changing
-// AutocompleteClassifierFactory::GetBrowserContextToUse().
-// This changes are needed to use different search engine used by web search in
-// web page context menu.
-// When context menu handles web search it gets search engine url from
-// ChromeAutocompleteProviderClient via AutocompleteClassifiers.
-// Because of this, private window will use same search engine url of normal
-// window if same AutocompleteClassifiers are used on normal and incognito.
-// So, we made this change.
-// However, ChromeAutocompleteProviderClient exposes many other services based
-// on profiles.
-// We don't want to change other services. Only wanted to get proper
-// TemplateURLService. To achieve this, BraveAutocompleteProviderClient is
-// introduced. It initializes ChromeAutocompleteProviderClient with original
-// profile and only overrided TemplateURLService getter.
-// BraveAutocompleteSchemeClassifier also initialize
-// ChromeAutocompleteSchemeClassifier with original profile for same reason.
 class BraveAutocompleteProviderClient
     : public ChromeAutocompleteProviderClient {
  public:
   explicit BraveAutocompleteProviderClient(Profile* profile);
   ~BraveAutocompleteProviderClient() override;
 
-  TemplateURLService* GetTemplateURLService() override;
-  const TemplateURLService* GetTemplateURLService() const override;
   std::vector<base::string16> GetBuiltinURLs() override;
 
-  // We should not hide the true nature of the profile when these methods in
-  // ChromeAutocompleteProviderClient are called as they control what is
-  // suitable for suggestions in regular vs incognito profiles.
-  bool IsOffTheRecord() const override;
-  void StartServiceWorker(const GURL& destination_url) override;
-
  private:
-  Profile* profile_;
-
   DISALLOW_COPY_AND_ASSIGN(BraveAutocompleteProviderClient);
 };
 

--- a/browser/autocomplete/brave_autocomplete_provider_client.h
+++ b/browser/autocomplete/brave_autocomplete_provider_client.h
@@ -35,6 +35,12 @@ class BraveAutocompleteProviderClient
   const TemplateURLService* GetTemplateURLService() const override;
   std::vector<base::string16> GetBuiltinURLs() override;
 
+  // We should not hide the true nature of the profile when these methods in
+  // ChromeAutocompleteProviderClient are called as they control what is
+  // suitable for suggestions in regular vs incognito profiles.
+  bool IsOffTheRecord() const override;
+  void StartServiceWorker(const GURL& destination_url) override;
+
  private:
   Profile* profile_;
 

--- a/browser/autocomplete/brave_autocomplete_provider_client_browsertest.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client_browsertest.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.h"
 
 #include "chrome/browser/autocomplete/autocomplete_classifier_factory.h"
 #include "chrome/browser/profiles/profile.h"
@@ -18,15 +18,15 @@ using BraveAutocompleteProviderClientTest = InProcessBrowserTest;
 IN_PROC_BROWSER_TEST_F(BraveAutocompleteProviderClientTest,
                        DependentServiceCheckTest) {
   Profile* profile = browser()->profile();
-  Profile* incognito_profile = profile->GetOffTheRecordProfile();
+  Profile* otr_profile = profile->GetOffTheRecordProfile();
 
   // Brave initiates different AutocompleteClassifier service for
   // normal/incognito profile.
   EXPECT_NE(AutocompleteClassifierFactory::GetForProfile(profile),
-            AutocompleteClassifierFactory::GetForProfile(incognito_profile));
+            AutocompleteClassifierFactory::GetForProfile(otr_profile));
 
-  BraveAutocompleteProviderClient normal_client(profile);
-  BraveAutocompleteProviderClient incognito_client(incognito_profile);
+  BraveAutocompleteProviderClientForClassifier normal_client(profile);
+  BraveAutocompleteProviderClientForClassifier incognito_client(otr_profile);
 
   // Check different TemplateURLService is used.
   EXPECT_NE(normal_client.GetTemplateURLService(),

--- a/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.cc
+++ b/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.h"
+
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+
+BraveAutocompleteProviderClientForClassifier::
+BraveAutocompleteProviderClientForClassifier(
+    Profile* profile)
+    : BraveAutocompleteProviderClient(profile->GetOriginalProfile()),
+      profile_(profile) {
+}
+
+BraveAutocompleteProviderClientForClassifier::
+~BraveAutocompleteProviderClientForClassifier() {
+}
+
+TemplateURLService*
+    BraveAutocompleteProviderClientForClassifier::GetTemplateURLService() {
+  return TemplateURLServiceFactory::GetForProfile(profile_);
+}
+
+const TemplateURLService*
+BraveAutocompleteProviderClientForClassifier::GetTemplateURLService() const {
+  return TemplateURLServiceFactory::GetForProfile(profile_);
+}

--- a/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.h
+++ b/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_FOR_CLASSIFIER_H_
+#define BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_FOR_CLASSIFIER_H_
+
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+
+// In brave, different AutocompleteClassifiers are created for normal and
+// incognito profile by changing
+// AutocompleteClassifierFactory::GetBrowserContextToUse().
+// This changes are needed to use different search engine used by web search in
+// web page context menu.
+// When context menu handles web search it gets search engine url from
+// ChromeAutocompleteProviderClient via AutocompleteClassifiers.
+// Because of this, private window will use same search engine url of normal
+// window if same AutocompleteClassifiers are used on normal and incognito.
+// So, we made this change.
+// However, ChromeAutocompleteProviderClient exposes many other services based
+// on profiles.
+// We don't want to change other services. Only wanted to get proper
+// TemplateURLService. To achieve this, BraveAutocompleteProviderClient is
+// introduced. It initializes ChromeAutocompleteProviderClient with original
+// profile and only overrided TemplateURLService getter.
+// BraveAutocompleteSchemeClassifier also initialize
+// ChromeAutocompleteSchemeClassifier with original profile for same reason.
+class BraveAutocompleteProviderClientForClassifier
+    : public BraveAutocompleteProviderClient {
+ public:
+  explicit BraveAutocompleteProviderClientForClassifier(Profile* profile);
+  ~BraveAutocompleteProviderClientForClassifier() override;
+
+  TemplateURLService* GetTemplateURLService() override;
+  const TemplateURLService* GetTemplateURLService() const override;
+
+ private:
+  Profile* profile_;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveAutocompleteProviderClientForClassifier);
+};
+
+#endif  // BRAVE_BROWSER_AUTOCOMPLETE_BRAVE_AUTOCOMPLETE_PROVIDER_CLIENT_FOR_CLASSIFIER_H_

--- a/chromium_src/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
+++ b/chromium_src/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
@@ -1,15 +1,16 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/autocomplete/brave_autocomplete_provider_client.h"
+#include "brave/browser/autocomplete/brave_autocomplete_provider_client_for_classifier.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/components/omnibox/browser/brave_autocomplete_controller.h"
 #include "components/omnibox/browser/autocomplete_classifier.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
 
 #define AutocompleteController BraveAutocompleteController
-#define ChromeAutocompleteProviderClient BraveAutocompleteProviderClient
+#define ChromeAutocompleteProviderClient BraveAutocompleteProviderClientForClassifier  // NOLINT
 #define ChromeAutocompleteSchemeClassifier BraveAutocompleteSchemeClassifier
 #include "../../../../../chrome/browser/autocomplete/autocomplete_classifier_factory.cc"
 #undef ChromeAutocompleteSchemeClassifier


### PR DESCRIPTION
Fixes brave/brave-browser#9119

When search suggestions are turned on and a user types into the omnibox
in a Private window a crash would occur. This started happening with the
upgrade to Chromium 81 because the check for BitmapFetchService bein
null has been removed in ChromeOmniboxClient::OnResultChanged (and other
places). This is because the code there isn't expected to be triggered
for an OTR profile.

Updated BraveAutocompleteProviderClient to override 2 additional
methods:

1. IsOffTheRecord
2. StartServiceWorker

These methods regulate when it is suitable to make suggestions and
should use the real profile (OTR or regular) instead of using regular
profile that we send to the base class even when the profile is OTR.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
See STR in brave/brave-browser#9119

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
