### PR TITLE
Fixes ad notification timeout timers are not cancelled if a Brave Ad is clicked

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -215,7 +215,6 @@ class AdsServiceImpl : public AdsService,
       const std::string& url);
 
   void NotificationTimedOut(
-      const uint32_t timer_id,
       const std::string& uuid);
 
   void OnURLLoaderComplete(
@@ -351,10 +350,6 @@ class AdsServiceImpl : public AdsService,
   void OnPrefsChanged(
       const std::string& pref);
 
-  uint32_t next_timer_id();
-  void KillTimer(
-      const uint32_t timer_id);
-
   std::string LoadDataResourceAndDecompressIfNeeded(
       const int id) const;
 
@@ -381,6 +376,10 @@ class AdsServiceImpl : public AdsService,
   void ShowNotification(
       std::unique_ptr<ads::AdNotificationInfo> info) override;
   bool ShouldShowNotifications() override;
+  void StartNotificationTimeoutTimer(
+      const std::string& uuid);
+  bool StopNotificationTimeoutTimer(
+      const std::string& uuid);
   void CloseNotification(
       const std::string& uuid) override;
 
@@ -460,8 +459,8 @@ class AdsServiceImpl : public AdsService,
 
   const base::FilePath base_path_;
 
-  std::map<uint32_t, std::unique_ptr<base::OneShotTimer>> timers_;
-  uint32_t next_timer_id_;
+  std::map<std::string, std::unique_ptr<base::OneShotTimer>>
+      notification_timers_;
 
   std::string retry_viewing_ad_notification_with_uuid_;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -407,6 +407,9 @@ void AdsImpl::OnAdNotificationEvent(
 
   AdNotificationInfo info;
   if (!ad_notifications_->Get(uuid, &info)) {
+    BLOG(ERROR) << "Failed to trigger ad event as ad notification was not "
+        "found for uuid " << uuid;
+
     return;
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9154

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm `Timeout ad notification with uuid` appears in the console log when an ad notification appears
- Confirm `Cancelled timeout for ad notification with uuid` appears in the console log when clicking an ad notification
- Confirm `Cancelled timeout for ad notification with uuid` appears in the console log when dismissing an ad notification
- Confirm `Timed out ad notification with uuid` appears in the console log when an ad notification times out
- Confirm `Timed out ad notification with uuid` does not appear in the console log if the user clicks and ad notification
- Confirm `Timed out ad notification with uuid` does not appear in the console log if the user dismisses an ad notification

NOTE: Ad notifications timeout after 2 minutes on desktop (for official builds)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
