### PR TITLE
Fixes duplicate/bad confirmations retry logic

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
@@ -52,7 +52,7 @@ RedeemToken::RedeemToken(
 RedeemToken::~RedeemToken() = default;
 
 void RedeemToken::Redeem(
-    const AdInfo& info,
+    const AdInfo& ad,
     const ConfirmationType confirmation_type) {
   BLOG(INFO) << "Redeem";
 
@@ -61,10 +61,12 @@ void RedeemToken::Redeem(
     return;
   }
 
-  auto token_info = unblinded_tokens_->GetToken();
-  unblinded_tokens_->RemoveToken(token_info);
+  const TokenInfo token = unblinded_tokens_->GetToken();
+  unblinded_tokens_->RemoveToken(token);
 
-  CreateConfirmation(info, confirmation_type, token_info);
+  const ConfirmationInfo confirmation =
+      CreateConfirmationInfo(ad, confirmation_type, token);
+  CreateConfirmation(confirmation);
 
   confirmations_->RefillTokensIfNecessary();
 }
@@ -79,10 +81,10 @@ void RedeemToken::Redeem(
   DCHECK(!creative_instance_id.empty());
   DCHECK(!creative_set_id.empty());
 
-  AdInfo info;
-  info.creative_instance_id = creative_instance_id;
-  info.creative_set_id = creative_set_id;
-  Redeem(info, confirmation_type);
+  AdInfo ad;
+  ad.creative_instance_id = creative_instance_id;
+  ad.creative_set_id = creative_set_id;
+  Redeem(ad, confirmation_type);
 }
 
 void RedeemToken::Redeem(
@@ -91,8 +93,6 @@ void RedeemToken::Redeem(
 
   if (!confirmation.created) {
     CreateConfirmation(confirmation);
-
-    confirmations_->RefillTokensIfNecessary();
 
     return;
   }
@@ -138,34 +138,6 @@ void RedeemToken::CreateConfirmation(
       method, callback);
 }
 
-void RedeemToken::CreateConfirmation(
-    const AdInfo& ad_info,
-    const ConfirmationType confirmation_type,
-    const TokenInfo& token_info) {
-  DCHECK(!ad_info.creative_instance_id.empty());
-
-  ConfirmationInfo confirmation_info;
-
-  confirmation_info.id = base::GenerateGUID();
-  confirmation_info.creative_instance_id = ad_info.creative_instance_id;
-  confirmation_info.type = confirmation_type;
-  confirmation_info.token_info = token_info;
-
-  auto payment_tokens = helper::Security::GenerateTokens(1);
-  confirmation_info.payment_token = payment_tokens.front();
-
-  auto blinded_payment_tokens = helper::Security::BlindTokens(payment_tokens);
-  auto blinded_payment_token = blinded_payment_tokens.front();
-  confirmation_info.blinded_payment_token = blinded_payment_token;
-
-  CreateConfirmationRequest request;
-  auto payload = request.CreateConfirmationRequestDTO(confirmation_info);
-  confirmation_info.credential = request.CreateCredential(token_info, payload);
-  confirmation_info.timestamp_in_seconds = Time::NowInSeconds();
-
-  CreateConfirmation(confirmation_info);
-}
-
 void RedeemToken::OnCreateConfirmation(
     const std::string& url,
     const int response_status_code,
@@ -185,15 +157,11 @@ void RedeemToken::OnCreateConfirmation(
     BLOG(INFO) << "    " << header.first << ": " << header.second;
   }
 
-  // FetchPaymentToken and OnFetchPaymentToken will handle all other HTTP
-  // response status codes
   if (response_status_code == net::HTTP_BAD_REQUEST) {
-    BLOG(WARNING) << "Duplicate confirmation";
-    OnRedeem(FAILED, confirmation, false);
-
-    // Duplicate confirmation so redeem a new token
-    Redeem(confirmation);
-    return;
+    // OnFetchPaymentToken handles HTTP response status codes for duplicate/bad
+    // confirmations as we cannot guarantee if the confirmation was created or
+    // not, i.e. after an internal server error 500
+    BLOG(WARNING) << "Duplicate/bad confirmation";
   }
 
   ConfirmationInfo new_confirmation = confirmation;
@@ -304,7 +272,7 @@ void RedeemToken::OnFetchPaymentToken(
     OnRedeem(FAILED, confirmation, false);
 
     // Token is in a bad state so redeem a new token
-    Redeem(confirmation);
+    OnRedeem(FAILED, confirmation);
     return;
   }
 
@@ -434,13 +402,71 @@ void RedeemToken::OnRedeem(
         << " creative instance id for " << std::string(confirmation.type);
 
     if (should_retry) {
-      confirmations_->AppendConfirmationToQueue(confirmation);
+      if (!confirmation.created) {
+        CreateAndAppendNewConfirmationToRetryQueue(confirmation);
+      } else {
+        AppendConfirmationToRetryQueue(confirmation);
+      }
     }
   } else {
     BLOG(INFO) << "Successfully redeemed " << confirmation.id
         << " confirmation id with " << confirmation.creative_instance_id
         << " creative instance id for " << std::string(confirmation.type);
   }
+}
+
+void RedeemToken::CreateAndAppendNewConfirmationToRetryQueue(
+    const ConfirmationInfo& confirmation) {
+  if (unblinded_tokens_->IsEmpty()) {
+    AppendConfirmationToRetryQueue(confirmation);
+    return;
+  }
+
+  AdInfo ad;
+  ad.creative_instance_id = confirmation.creative_instance_id;
+
+  const TokenInfo token = unblinded_tokens_->GetToken();
+  unblinded_tokens_->RemoveToken(token);
+
+  const ConfirmationInfo new_confirmation =
+      CreateConfirmationInfo(ad, confirmation.type, token);
+
+  AppendConfirmationToRetryQueue(new_confirmation);
+
+  confirmations_->RefillTokensIfNecessary();
+}
+
+void RedeemToken::AppendConfirmationToRetryQueue(
+    const ConfirmationInfo& confirmation) {
+  confirmations_->AppendConfirmationToQueue(confirmation);
+}
+
+ConfirmationInfo RedeemToken::CreateConfirmationInfo(
+    const AdInfo& ad,
+    const ConfirmationType confirmation_type,
+    const TokenInfo& token) {
+  DCHECK(!ad.creative_instance_id.empty());
+
+  ConfirmationInfo confirmation;
+
+  confirmation.id = base::GenerateGUID();
+  confirmation.creative_instance_id = ad.creative_instance_id;
+  confirmation.type = confirmation_type;
+  confirmation.token_info = token;
+
+  auto payment_tokens = helper::Security::GenerateTokens(1);
+  confirmation.payment_token = payment_tokens.front();
+
+  auto blinded_payment_tokens = helper::Security::BlindTokens(payment_tokens);
+  auto blinded_payment_token = blinded_payment_tokens.front();
+  confirmation.blinded_payment_token = blinded_payment_token;
+
+  CreateConfirmationRequest request;
+  auto payload = request.CreateConfirmationRequestDTO(confirmation);
+  confirmation.credential = request.CreateCredential(token, payload);
+  confirmation.timestamp_in_seconds = Time::NowInSeconds();
+
+  return confirmation;
 }
 
 bool RedeemToken::Verify(

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.h
@@ -37,7 +37,7 @@ class RedeemToken {
   ~RedeemToken();
 
   void Redeem(
-      const AdInfo& info,
+      const AdInfo& ad,
       const ConfirmationType confirmation_type);
   void Redeem(
       const std::string& creative_instance_id,
@@ -49,10 +49,6 @@ class RedeemToken {
  private:
   void CreateConfirmation(
       const ConfirmationInfo& confirmation);
-  void CreateConfirmation(
-      const AdInfo& ad_info,
-      const ConfirmationType confirmation_type,
-      const TokenInfo& token_info);
   void OnCreateConfirmation(
       const std::string& url,
       const int response_status_code,
@@ -73,6 +69,16 @@ class RedeemToken {
       const Result result,
       const ConfirmationInfo& confirmation,
       const bool should_retry = true);
+
+  void CreateAndAppendNewConfirmationToRetryQueue(
+      const ConfirmationInfo& confirmation);
+  void AppendConfirmationToRetryQueue(
+      const ConfirmationInfo& confirmation);
+
+  ConfirmationInfo CreateConfirmationInfo(
+      const AdInfo& ad,
+      const ConfirmationType confirmation_type,
+      const TokenInfo& token);
 
   bool Verify(
      const ConfirmationInfo& confirmation) const;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9242

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

@laurenwags @btlechowski @kjozwiak If you could please check the below test plan, thanks

Pre-requisites:
- Import "Issues 9242" Charles Proxy rewrite settings

**Test Case 1** (Create confirmation fails with 400 BAD REQUEST):
- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Launch Brave Browser (Fresh install)
- Enable Rewards
- Wait for "Added 50 unblinded tokens, you now have 50 unblinded tokens" to appear in the console log
- Enable "/v1/confirmation/*/*" location in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other locations)
- Enable "Status 201 -> 400" action in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other actions)
- View an ad

_EXPECTED RESULT:_ "Duplicate/bad confirmation" and "GET /v1/confirmation/{confirmation_id}/paymentToken" should appear in the console log

**Test Case 2** (Create confirmation fails with 500 INTERNAL SERVER ERROR):
- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Launch Brave Browser (Fresh install)
- Enable Rewards
- Wait for "Added 50 unblinded tokens, you now have 50 unblinded tokens" to appear in the console log
- Enable "/v1/confirmation/*/*" location in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other locations)
- Enable "Status 201 -> 500" action in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other actions)
- View an ad

_EXPECTED RESULT:_ "GET /v1/confirmation/{confirmation_id}/paymentToken" should appear in the console log

**Test Case 3** (Create confirmation succeeds with 201 CREATED):
- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Launch Brave Browser (Fresh install)
- Enable Rewards
- Wait for "Added 50 unblinded tokens, you now have 50 unblinded tokens" to appear in the console log
- View an ad

_EXPECTED RESULT:_ "GET /v1/confirmation/{confirmation_id}/paymentToken" should appear in the console log

**Test Case 4** (Fetch payment token fails with 404 NOT FOUND):
- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Launch Brave Browser (Fresh install)
- Enable Rewards
- Wait for "Added 50 unblinded tokens, you now have 50 unblinded tokens" to appear in the console log
- Enable "/v1/confirmation/*/paymentToken" location in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other locations)
- Enable "Status 200 -> 404" action in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other actions)
- View an ad
- Make a copy of "Default/rewards_service/confirmations.json"
- Search for "Retry failed confirmations at" in the console log and wait for the event to be triggered

__EXPECTED RESULT:__ Compare confirmations > failed_confirmations in `Default/rewards_service/confirmations.json` against the copy you made of this file to confirm a new confirmation is created and added to the retry queue

- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Search for "Retry failed confirmations at" in the console log and wait for the event to be triggered

_EXPECTED RESULT:_ Failed confirmation should retry and "Successfully redeemed" should appear in the console log

**Test Case 5** (Fetch payment token fails with 500 INTERNAL SERVER ERROR):
- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Launch Brave Browser (Fresh install)
- Enable Rewards
- Wait for "Added 50 unblinded tokens, you now have 50 unblinded tokens" to appear in the console log
- Enable "/v1/confirmation/*/paymentToken" location in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other locations)
- Enable "Status 200 -> 500" action in Charles Proxy under Tools > Rewrite > "Issues 9242" (disable all other actions)
- View an ad
- Make a copy of "Default/rewards_service/confirmations.json"
- Search for "Retry failed confirmations at" in the console log and wait for the event to be t-triggered
- Confirm that tokens are refilled when running low (19 tokens or less)

**Test Case 6** (Fetch payment token succeeds with 200 OK):
- Disable "Issues 9242" rewrite rule in Charles Proxy under Tools > Rewrite
- Launch Brave Browser (Fresh install)
- Enable Rewards
- Wait for "Added 50 unblinded tokens, you now have 50 unblinded tokens" to appear in the console log
- View an ad

_EXPECTED RESULT:_ "Successfully redeemed" should appear in the console log

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
