### PR TITLE
Disabled key checker to avoid crashes on debug builds (uplift to 1.7.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java
+++ b/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 
 import org.chromium.chrome.browser.BraveHelper;
 import org.chromium.chrome.browser.flags.FeatureUtilities;
+import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
 
 /**
  * Base class for ChromeLauncherActivity
@@ -18,6 +19,8 @@ public class BraveLauncherActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        SharedPreferencesManager.getInstance().disableKeyCheckerForTesting();
 
         FeatureUtilities.isBottomToolbarEnabled();
         BraveHelper.DisableFREDRP();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/5006