### PR TITLE
Fix indirect deps error while building //brave/browser/tor

### DIFF
--- a/browser/tor/BUILD.gn
+++ b/browser/tor/BUILD.gn
@@ -39,13 +39,23 @@ source_set("tor") {
     ]
 
     deps += [
-      "//brave/components/brave_referrals/buildflags",
       "//brave/components/services/tor/public/interfaces",
       "//content/public/common",
       "//extensions/common:common_constants",
       "//net",
       "//services/service_manager",
       "//url",
+    ]
+
+    # Below dep list are not directly used tor target.
+    # Only added to fix intermittent build failure.
+    # Most of the case comes from including brave_browser_process_impl.h`
+    # headers. That header includes some buildflags but sometimes they are
+    # not generated before evaluating tor target.
+    deps += [
+      "//brave/components/brave_referrals/buildflags",
+      "//brave/components/greaselion/browser/buildflags",
+      "//brave/components/speedreader:buildflags",
     ]
   }
 }


### PR DESCRIPTION

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves  https://github.com/brave/brave-browser/issues/8853
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
