### PR TITLE
Disable Wayback Machine for ".onion" addresses

### DIFF
--- a/components/brave_wayback_machine/brave_wayback_machine_utils.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils.cc
@@ -18,5 +18,8 @@ bool IsWaybackMachineDisabledFor(const GURL& url) {
   if (base::EndsWith(url.host(), ".local", base::CompareCase::SENSITIVE))
     return true;
 
+  if (base::EndsWith(url.host(), ".onion", base::CompareCase::SENSITIVE))
+    return true;
+
   return false;
 }

--- a/components/brave_wayback_machine/brave_wayback_machine_utils_unittest.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils_unittest.cc
@@ -10,10 +10,12 @@
 TEST(BraveWaybackMachineUtilsTest, LocalHostDisabledTest) {
   EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://localhost/index.html")));
   EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://abcd.local")));
+  EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://abcd.onion")));
   EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://127.0.0.1")));
   EXPECT_TRUE(IsWaybackMachineDisabledFor(GURL("http://[::1]")));
   EXPECT_TRUE(IsWaybackMachineDisabledFor(
       GURL("http://127.0045.1.2:8080/index.html")));
   EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.local-news.com")));
+  EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.onion-news.com")));
   EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.brave.com")));
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9342

## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [X] Ran `git rebase master` (if needed).
- [X] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [X] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Open a new private window with Tor (Use the hamburger menu on the top right corner of the Brave window, or press option + command + N)
2. Go to the 404 page for the New York Times (http://www.nytimes3xbfgragh.onion/404)
3. Check that the "Sorry, that page is missing" banner does not appear
NYT onion URL source: https://open.nytimes.com/https-open-nytimes-com-the-new-york-times-as-a-tor-onion-service-e0d0b67b7482

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.