### PR TITLE
Update background option visibility whenever SR theme option changed

### DIFF
--- a/browser/resources/settings/brave_new_tab_page/brave_new_tab_browser_proxy.js
+++ b/browser/resources/settings/brave_new_tab_page/brave_new_tab_browser_proxy.js
@@ -4,12 +4,22 @@
 
  cr.define('settings', function() {
   /** @interface */
-  class BraveNewTabBrowserProxy {}
+  class BraveNewTabBrowserProxy {
+    /**
+     * @return {!Promise<Boolean>}
+     */
+    getIsSuperReferralActive() {}
+  }
 
   /**
    * @implements {settings.BraveNewTabBrowserProxy}
    */
-  class BraveNewTabBrowserProxyImpl {}
+  class BraveNewTabBrowserProxyImpl {
+    /** @override */
+    getIsSuperReferralActive() {
+      return cr.sendWithPromise('getIsSuperReferralActive');
+    }
+  }
 
   cr.addSingletonGetter(BraveNewTabBrowserProxyImpl);
 

--- a/browser/resources/settings/brave_new_tab_page/brave_new_tab_page.html
+++ b/browser/resources/settings/brave_new_tab_page/brave_new_tab_page.html
@@ -29,7 +29,7 @@
       <div class="flex">
         <div class="label primary-title">$i18n{braveNewTabCustomizeDashboard}</div>
         <div class="normalize-margin">
-          <template is="dom-if" if="[[shouldShowBackgroundImageOptions_()]]">
+          <template is="dom-if" if="[[!isSuperReferralActive_]]">
             <settings-toggle-button id="showBackgroundImageControlType"
                 class="secondary borderless"
                 pref="{{prefs.brave.new_tab_page.show_background_image}}"

--- a/browser/resources/settings/brave_new_tab_page/brave_new_tab_page.js
+++ b/browser/resources/settings/brave_new_tab_page/brave_new_tab_page.js
@@ -15,15 +15,29 @@
     /** @private {?settings.BraveNewTabBrowserProxy} */
     browserProxy_: null,
 
+    behaviors: [
+      WebUIListenerBehavior,
+    ],
+
+    properties: {
+      isSuperReferralActive_: Boolean,
+    },
+
     /** @override */
     created: function() {
       this.browserProxy_ = settings.BraveNewTabBrowserProxyImpl.getInstance();
+      isSuperReferralActive_ = false;
     },
 
-    shouldShowBackgroundImageOptions_: function() {
-      // Only show background image options if user doesn't use SR theme.
-      // With SR theme, user can't off bg images.
-      return !loadTimeData.getBoolean('isSuperReferralActive');
+    /** @override */
+    ready: function() {
+      this.browserProxy_.getIsSuperReferralActive().then(isSuperReferralActive => {
+        this.isSuperReferralActive_ = isSuperReferralActive;
+      })
+
+      this.addWebUIListener('super-referral-active-state-changed', (isSuperReferralActive) => {
+        this.isSuperReferralActive_ = isSuperReferralActive;
+      })
     },
 
     toggleBrandedBackgroundOption_: function(isBackgroundEnabled, isBrandedBackgroundEnabled) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -195,6 +195,8 @@ source_set("ui") {
     "//brave/browser/resources/settings:resources",
     "//brave/browser/tor",
     "//brave/components/brave_wayback_machine:buildflags",
+    "//brave/components/ntp_background_images/browser",
+    "//brave/components/ntp_background_images/common",
     "//brave/components/webcompat_reporter/browser",
     "//brave/common",
     "//brave/common:pref_names",

--- a/browser/ui/webui/settings/brave_appearance_handler.cc
+++ b/browser/ui/webui/settings/brave_appearance_handler.cc
@@ -7,10 +7,35 @@
 
 #include "base/bind.h"
 #include "base/strings/string_number_conversions.h"
+#include "brave/browser/ntp_background_images/view_counter_service_factory.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/common/pref_names.h"
+#include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
+#include "brave/components/ntp_background_images/browser/view_counter_service.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/web_ui.h"
+
+using ntp_background_images::ViewCounterServiceFactory;
+using ntp_background_images::prefs::kNewTabPageSuperReferralThemesOption;
+
+namespace {
+
+bool IsSuperReferralActive(Profile* profile) {
+  bool isSuperReferralActive = false;
+  auto* service = ViewCounterServiceFactory::GetForProfile(profile);
+  if (service) {
+    auto* data = service->GetCurrentBrandedWallpaperData();
+    if (data && data->IsSuperReferral()) {
+      isSuperReferralActive = true;
+    }
+  }
+
+  return isSuperReferralActive;
+}
+
+}  // namespace
 
 BraveAppearanceHandler::BraveAppearanceHandler() {
   local_state_change_registrar_.Init(g_browser_process->local_state());
@@ -23,6 +48,13 @@ BraveAppearanceHandler::BraveAppearanceHandler() {
 BraveAppearanceHandler::~BraveAppearanceHandler() = default;
 
 void BraveAppearanceHandler::RegisterMessages() {
+  profile_ = Profile::FromWebUI(web_ui());
+  profile_state_change_registrar_.Init(profile_->GetPrefs());
+  profile_state_change_registrar_.Add(
+      kNewTabPageSuperReferralThemesOption,
+      base::BindRepeating(&BraveAppearanceHandler::OnPreferenceChanged,
+      base::Unretained(this)));
+
   web_ui()->RegisterMessageCallback(
       "setBraveThemeType",
       base::BindRepeating(&BraveAppearanceHandler::SetBraveThemeType,
@@ -30,6 +62,10 @@ void BraveAppearanceHandler::RegisterMessages() {
   web_ui()->RegisterMessageCallback(
       "getBraveThemeType",
       base::BindRepeating(&BraveAppearanceHandler::GetBraveThemeType,
+                          base::Unretained(this)));
+  web_ui()->RegisterMessageCallback(
+      "getIsSuperReferralActive",
+      base::BindRepeating(&BraveAppearanceHandler::GetIsSuperReferralActive,
                           base::Unretained(this)));
 }
 
@@ -54,6 +90,15 @@ void BraveAppearanceHandler::GetBraveThemeType(const base::ListValue* args) {
       base::Value(static_cast<int>(dark_mode::GetBraveDarkModeType())));
 }
 
+void BraveAppearanceHandler::GetIsSuperReferralActive(
+    const base::ListValue* args) {
+  CHECK_EQ(args->GetSize(), 1U);
+
+  AllowJavascript();
+  ResolveJavascriptCallback(args->GetList()[0],
+                            base::Value(IsSuperReferralActive(profile_)));
+}
+
 void BraveAppearanceHandler::OnBraveDarkModeChanged() {
   // GetBraveThemeType() should be used because settings option displays all
   // available options including default.
@@ -61,5 +106,13 @@ void BraveAppearanceHandler::OnBraveDarkModeChanged() {
     FireWebUIListener(
         "brave-theme-type-changed",
         base::Value(static_cast<int>(dark_mode::GetBraveDarkModeType())));
+  }
+}
+
+void BraveAppearanceHandler::OnPreferenceChanged(const std::string& pref_name) {
+  DCHECK_EQ(kNewTabPageSuperReferralThemesOption, pref_name);
+  if (IsJavascriptAllowed()) {
+    FireWebUIListener("super-referral-active-state-changed",
+                      base::Value(IsSuperReferralActive(profile_)));
   }
 }

--- a/browser/ui/webui/settings/brave_appearance_handler.h
+++ b/browser/ui/webui/settings/brave_appearance_handler.h
@@ -6,9 +6,12 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_APPEARANCE_HANDLER_H_
 #define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_APPEARANCE_HANDLER_H_
 
-#include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
+#include <string>
 
+#include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
 #include "components/prefs/pref_change_registrar.h"
+
+class Profile;
 
 class BraveAppearanceHandler : public settings::SettingsPageUIHandler {
  public:
@@ -25,10 +28,14 @@ class BraveAppearanceHandler : public settings::SettingsPageUIHandler {
   void OnJavascriptDisallowed() override {}
 
   void OnBraveDarkModeChanged();
+  void OnPreferenceChanged(const std::string& pref_name);
   void SetBraveThemeType(const base::ListValue* args);
   void GetBraveThemeType(const base::ListValue* args);
+  void GetIsSuperReferralActive(const base::ListValue* args);
 
+  Profile* profile_ = nullptr;
   PrefChangeRegistrar local_state_change_registrar_;
+  PrefChangeRegistrar profile_state_change_registrar_;
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_APPEARANCE_HANDLER_H_

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -173,11 +173,6 @@ bool ViewCounterService::ShouldShowBrandedWallpaper() const {
 void ViewCounterService::InitializeWebUIDataSource(
     content::WebUIDataSource* html_source) {
   html_source->AddString("superReferralThemeName", GetSuperReferralThemeName());
-  // Set true if SR is active theme for this profile.
-  bool isSuperReferralActive = false;
-  if (auto* data = GetCurrentBrandedWallpaperData())
-    isSuperReferralActive = data->IsSuperReferral();
-  html_source->AddBoolean("isSuperReferralActive", isSuperReferralActive);
 }
 
 bool ViewCounterService::IsBrandedWallpaperActive() const {


### PR DESCRIPTION
So far, background option in settings page was updated when it's
newly opened because loadTimeData was used for it.

Instead of loadTimeData, property is used to update whenever theme
option is changed.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9353

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Launch Browser with clean profile with promoCode
2. After SR is ready, load settings page
3. Change to Brave default images and check background images and sponsored images settings are hidden immediately w/o any reloading.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
