### PR TITLE
Fixing widget menus going offscreen at certain viewports

### DIFF
--- a/components/brave_new_tab_ui/components/default/widget/styles.ts
+++ b/components/brave_new_tab_ui/components/default/widget/styles.ts
@@ -95,7 +95,7 @@ export const StyledWidgetMenu = styled<WidgetMenuProps, 'div'>('div')`
 
   @media screen and (min-width: 950px) and (max-width: 1150px) {
     ${p => p.textDirection === 'ltr'
-    ? 'left: 8px'
+    ? `left: ${p.menuPosition === 'left' ? -130 : 8}px`
     : 'right: 8px'}
   }
 


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/9390
Fixes: https://github.com/brave/brave-browser/issues/9078
Fixes: https://github.com/brave/brave-browser/issues/9389

This was an issue between 950px and 1150px

<img width="713" alt="Screen Shot 2020-04-22 at 12 56 23 PM" src="https://user-images.githubusercontent.com/8732757/80027953-40c90500-8499-11ea-926b-6adc4f4ef8dd.png">
<img width="1603" alt="Screen Shot 2020-04-22 at 12 56 02 PM" src="https://user-images.githubusercontent.com/8732757/80027970-458db900-8499-11ea-8b67-e1109ea8a1f8.png">
<img width="1614" alt="Screen Shot 2020-04-22 at 12 55 55 PM" src="https://user-images.githubusercontent.com/8732757/80027975-46264f80-8499-11ea-95cd-a54fd34a4bf4.png">
<img width="1205" alt="Screen Shot 2020-04-22 at 12 55 15 PM" src="https://user-images.githubusercontent.com/8732757/80027977-46bee600-8499-11ea-99ea-d70a521d2598.png">
<img width="1203" alt="Screen Shot 2020-04-22 at 12 55 08 PM" src="https://user-images.githubusercontent.com/8732757/80027979-47577c80-8499-11ea-84fb-9e2c94d6fc26.png">
<img width="1206" alt="Screen Shot 2020-04-22 at 12 54 58 PM" src="https://user-images.githubusercontent.com/8732757/80027980-47f01300-8499-11ea-9978-7fd0a3f1e6f0.png">


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Defined in issues

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
