### PR TITLE
Fixing widget context menu for top site tiles (uplift to 1.9.x)

### DIFF
--- a/components/brave_new_tab_ui/components/default/widget/styles.ts
+++ b/components/brave_new_tab_ui/components/default/widget/styles.ts
@@ -85,7 +85,7 @@ export const StyledWidgetMenu = styled<WidgetMenuProps, 'div'>('div')`
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.3);
   border-radius: 4px;
   top: 48px;
-  z-index: 1;
+  z-index: 4;
 
   @media screen and (min-width: 1150px) {
     ${p => (p.menuPosition === 'right' && p.textDirection === 'ltr') || (p.menuPosition === 'left' && p.textDirection === 'rtl')


### PR DESCRIPTION
Uplift of #5297
Fixes https://github.com/brave/brave-browser/issues/9267

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.