### PR TITLE
Manual uplift of PR 5348 to 1.9.x

### DIFF
--- a/android/java/org/chromium/chrome/browser/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/BraveActivity.java
@@ -12,6 +12,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
@@ -34,6 +35,7 @@ import org.chromium.chrome.browser.onboarding.OnboardingActivity;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
 import org.chromium.chrome.browser.preferences.Pref;
 import org.chromium.chrome.browser.preferences.PrefServiceBridge;
+import org.chromium.chrome.browser.settings.BraveRewardsPreferences;
 import org.chromium.chrome.browser.settings.BraveSearchEngineUtils;
 import org.chromium.chrome.browser.share.ShareDelegate;
 import org.chromium.chrome.browser.tab.Tab;
@@ -180,6 +182,9 @@ public abstract class BraveActivity extends ChromeActivity {
 
         int appOpenCount = ContextUtils.getAppSharedPreferences().getInt(BackgroundImagesPreferences.PREF_APP_OPEN_COUNT, 0);
         BackgroundImagesPreferences.setOnPreferenceValue(BackgroundImagesPreferences.PREF_APP_OPEN_COUNT , appOpenCount + 1);
+
+        //set bg ads to off for existing and new installations
+        setBgBraveAdsDefaultOff();
 
         Context app = ContextUtils.getApplicationContext();
         if (null != app && (this instanceof ChromeTabbedActivity)) {
@@ -369,5 +374,24 @@ public abstract class BraveActivity extends ChromeActivity {
         }
 
         return null;
+    }    
+
+    /**
+     * Disable background ads on Android. Issue #8641.
+     */
+    private void setBgBraveAdsDefaultOff() {
+        SharedPreferences sharedPreferences =
+                ContextUtils.getAppSharedPreferences();
+        boolean exists = sharedPreferences.contains(
+                BraveRewardsPreferences.PREF_ADS_SWITCH_DEFAULT_HAS_BEEN_SET);
+        if (!exists) {
+            SharedPreferences.Editor sharedPreferencesEditor =
+                    sharedPreferences.edit();
+            sharedPreferencesEditor.putBoolean(
+                    BraveRewardsPreferences.PREF_ADS_SWITCH, false);
+            sharedPreferencesEditor.putBoolean(
+                    BraveRewardsPreferences.PREF_ADS_SWITCH_DEFAULT_HAS_BEEN_SET, true);
+            sharedPreferencesEditor.apply();
+        }
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/BraveRewardsPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveRewardsPreferences.java
@@ -23,7 +23,10 @@ import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
  */
 public class BraveRewardsPreferences extends BravePreferenceFragment
         implements OnPreferenceChangeListener, BraveRewardsObserver {
-    private static final String PREF_ADS_SWITCH = "ads_switch";
+    public static final String PREF_ADS_SWITCH = "ads_switch";
+
+    // flag, if exists: default state (off) for background Brave ads has been set
+    public static final String PREF_ADS_SWITCH_DEFAULT_HAS_BEEN_SET = "ads_switch_default_set";
 
     private ChromeSwitchPreference mAdsSwitch;
 


### PR DESCRIPTION
Uplift of #5348
Fixes brave/brave-browser#8641
`Disable background ads on Android`

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
