### PR TITLE
BAT Confirmations should not be started if Rewards is disabled

### DIFF
--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -950,9 +950,8 @@ void ConfirmationsImpl::UpdateAdsRewards(const bool should_refresh) {
   if (!state_has_loaded_) {
     BLOG(ERROR) <<
         "Unable to update ads rewards as Confirmations state is not ready";
+    return;
   }
-
-  DCHECK(wallet_info_.IsValid());
 
   ads_rewards_->Update(wallet_info_, should_refresh);
 }

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -733,6 +733,10 @@ class LedgerImpl : public ledger::Ledger {
       ledger::GetUnblindedTokenListCallback callback);
 
  private:
+  void MaybeInitializeConfirmations(
+      const bool execute_create_script,
+      ledger::ResultCallback callback);
+
   void InitializeConfirmations(
       const bool execute_create_script,
       ledger::ResultCallback callback);
@@ -741,6 +745,19 @@ class LedgerImpl : public ledger::Ledger {
       const bool success,
       const bool execute_create_script,
       ledger::ResultCallback callback);
+
+  void InitializeDatabase(
+      const bool execute_create_script,
+      ledger::ResultCallback callback);
+
+  void StartConfirmations();
+
+  void OnConfirmationsStarted(
+      const bool success);
+
+  void ShutdownConfirmations();
+
+  bool IsConfirmationsRunning();
 
   void OnLoad(ledger::VisitDataPtr visit_data,
               const uint64_t& current_time) override;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/state_keys.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/state_keys.h
@@ -9,6 +9,8 @@
 #include <string>
 
 namespace ledger {
+  const char kStateEnabled[] = "enabled";
+  const char kStateEnabledMigrated[] = "enabled_migrated";
   const char kStateServerPublisherListStamp[] = "server_publisher_list_stamp";
   const char kStateUpholdAnonAddress[] = "uphold_anon_address";
   const char kStatePromotionLastFetchStamp[] = "promotion_last_fetch_stamp";

--- a/vendor/brave-ios/Ledger/BATBraveLedger.mm
+++ b/vendor/brave-ios/Ledger/BATBraveLedger.mm
@@ -1293,6 +1293,10 @@ BATLedgerBridge(BOOL,
 - (bool)getBooleanState:(const std::string&)name
 {
   const auto key = [NSString stringWithUTF8String:name.c_str()];
+  if (![self.prefs objectForKey:key]) {
+    return NO;
+  }
+
   return [self.prefs[key] boolValue];
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9544

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Test upgrade from nightly (before the fix)
- Test fresh install enabling rewards from the URL bar, then closing and restarting the browser
- Test fresh install enabling rewards from on-boarding, then closing and restarting the browser
- Test upgrade path from 0.61 (as the prefs to test if Rewards is enabled were introduced in commit-hash `13deb15e2bd2291398c81e83812b3d76278cad57` in 0.62) to the latest nightly build
- Toggle rewards off and back on
- Toggle rewards off, then restart the browser and switch rewards on
- The change should be tested on iOS

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
