### PR TITLE
Fix buffer overflow in AudioBuffer::copyFromChannel (uplift to 1.9.x)

### DIFF
--- a/chromium_src/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
@@ -24,15 +24,15 @@
     }                                                               \
   }
 
-#define BRAVE_AUDIOBUFFER_COPYFROMCHANNEL                             \
-  LocalDOMWindow* window = LocalDOMWindow::From(script_state);        \
-  if (window) {                                                       \
-    double fudge_factor =                                             \
-        brave::BraveSessionCache::From(*(window->document()))         \
-            .GetFudgeFactor();                                        \
-    for (unsigned i = 0; i < count; ++i) {                            \
-      dst[i + buffer_offset] = dst[i + buffer_offset] * fudge_factor; \
-    }                                                                 \
+#define BRAVE_AUDIOBUFFER_COPYFROMCHANNEL                      \
+  LocalDOMWindow* window = LocalDOMWindow::From(script_state); \
+  if (window) {                                                \
+    double fudge_factor =                                      \
+        brave::BraveSessionCache::From(*(window->document()))  \
+            .GetFudgeFactor();                                 \
+    for (unsigned i = 0; i < count; i++) {                     \
+      dst[i] = dst[i] * fudge_factor;                          \
+    }                                                          \
   }
 
 #include "../../../../../../third_party/blink/renderer/modules/webaudio/audio_buffer.cc"


### PR DESCRIPTION
Uplift of #5427
Fixes https://github.com/brave/brave-browser/issues/9552

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.