### PR TITLE
Check NTP SI component update check more frequently

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service.cc
@@ -18,6 +18,7 @@
 #include "brave/common/brave_switches.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_ads/browser/locale_helper.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
 #include "brave/components/brave_referrals/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/features.h"
@@ -32,10 +33,13 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 
+using brave_component_updater::BraveOnDemandUpdater;
+
 namespace ntp_background_images {
 
 namespace {
 
+constexpr int kSIComponentUpdateCheckIntervalHours = 1;
 constexpr char kNTPManifestFile[] = "photo.json";
 constexpr char kNTPSRMappingTableFile[] = "mapping-table.json";
 
@@ -169,6 +173,12 @@ void NTPBackgroundImagesService::Init() {
 #endif
 }
 
+void NTPBackgroundImagesService::CheckSIComponentUpdate(
+    const std::string& component_id) {
+  DVLOG(2) << __func__ << ": Check NTP SI component update";
+  BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(component_id);
+}
+
 void NTPBackgroundImagesService::RegisterSponsoredImagesComponent() {
   const std::string locale =
       brave_ads::LocaleHelper::GetInstance()->GetLocale();
@@ -188,6 +198,15 @@ void NTPBackgroundImagesService::RegisterSponsoredImagesComponent() {
       base::BindRepeating(&NTPBackgroundImagesService::OnComponentReady,
                           weak_factory_.GetWeakPtr(),
                           false));
+  // SI component checks update more frequently than other components.
+  // By default, browser check update status every 5 hours.
+  // However, this background interval is too long for SI. Use 1 hour interval.
+  si_update_check_timer_.Start(
+      FROM_HERE,
+      base::TimeDelta::FromHours(kSIComponentUpdateCheckIntervalHours),
+      base::BindRepeating(&NTPBackgroundImagesService::CheckSIComponentUpdate,
+                          base::Unretained(this),
+                          data->component_id));
 }
 
 void NTPBackgroundImagesService::CheckSuperReferralComponent() {

--- a/components/ntp_background_images/browser/ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/ntp_background_images_service.h
@@ -119,6 +119,7 @@ class NTPBackgroundImagesService {
 
   void CacheTopSitesFaviconList();
   void RestoreCachedTopSitesFaviconList();
+  void CheckSIComponentUpdate(const std::string& component_id);
 
   // virtual for test.
   virtual void CheckSuperReferralComponent();
@@ -129,6 +130,7 @@ class NTPBackgroundImagesService {
   virtual void UnRegisterSuperReferralComponent();
   virtual void MarkThisInstallIsNotSuperReferralForever();
 
+  base::RepeatingTimer si_update_check_timer_;
   std::vector<std::string> cached_top_site_favicon_list_;
   bool test_data_used_ = false;
   component_updater::ComponentUpdateService* component_update_service_;


### PR DESCRIPTION
Make NTP SI component update check in background every hour after launching.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9590

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Launch browser
2. Open brave://components
3. Check `NTP Sponsored Images` component is refreshed every hours.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
