### PR TITLE
(macOS signing) Library was renamed not removed

### DIFF
--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -80,6 +80,7 @@ def AddBravePartsForSigning(parts, config):
     brave_dylibs = (
         'libchallenge_bypass_ristretto.dylib',
         'libadblock.dylib',
+        'libspeedreader_ffi.dylib',
     )
     for library in brave_dylibs:
         library_basename = os.path.basename(library)


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/9650
