### PR TITLE
Adds recovery path for may payout problem

### DIFF
--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -34,7 +34,7 @@ const char kUseRewardsStagingServer[] = "brave.rewards.use_staging_server";
 const char kStatePromotionLastFetchStamp[] =
     "brave.rewards.promotion_last_fetch_stamp";
 const char kStatePromotionCorruptedMigrated[] =
-    "brave.rewards.promotion_corrupted_migrated";
+    "brave.rewards.promotion_corrupted_migrated2";
 const char kStateAnonTransferChecked[] =  "brave.rewards.anon_transfer_checked";
 }  // namespace prefs
 }  // namespace brave_rewards

--- a/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger.mojom
+++ b/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger.mojom
@@ -368,7 +368,8 @@ enum PromotionStatus {
   ACTIVE = 0,
   ATTESTED = 1,
   FINISHED = 4,
-  OVER = 5
+  OVER = 5,
+  CORRUPTED = 6
 };
 
 struct Promotion {
@@ -452,7 +453,8 @@ enum CredsBatchStatus {
   BLINDED = 1,
   CLAIMED = 2,
   SIGNED = 3,
-  FINISHED = 4
+  FINISHED = 4,
+  CORRUPTED = 5
 };
 
 struct CredsBatch {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/credentials/credentials_promotion.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/credentials/credentials_promotion.cc
@@ -102,6 +102,10 @@ void CredentialsPromotion::OnStart(
       callback(ledger::Result::LEDGER_OK);
       break;
     }
+    case ledger::CredsBatchStatus::CORRUPTED: {
+      callback(ledger::Result::LEDGER_ERROR);
+      break;
+    }
   }
 }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/credentials/credentials_sku.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/credentials/credentials_sku.cc
@@ -135,6 +135,10 @@ void CredentialsSKU::OnStart(
       callback(ledger::Result::LEDGER_OK);
       break;
     }
+    case ledger::CredsBatchStatus::CORRUPTED: {
+      callback(ledger::Result::LEDGER_ERROR);
+      break;
+    }
   }
 }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database.cc
@@ -214,6 +214,18 @@ void Database::UpdateCredsBatchStatus(
   creds_batch_->UpdateStatus(trigger_id, trigger_type, status, callback);
 }
 
+void Database::UpdateCredsBatchesStatus(
+    const std::vector<std::string>& trigger_ids,
+    const ledger::CredsBatchType trigger_type,
+    const ledger::CredsBatchStatus status,
+    ledger::ResultCallback callback) {
+  creds_batch_->UpdateRecordsStatus(
+      trigger_ids,
+      trigger_type,
+      status,
+      callback);
+}
+
 /**
  * MEDIA PUBLISHER INFO
  */
@@ -309,6 +321,13 @@ void Database::UpdatePromotionStatus(
   promotion_->UpdateStatus(promotion_id, status, callback);
 }
 
+void Database::UpdatePromotionsStatus(
+    const std::vector<std::string>& promotion_ids,
+    const ledger::PromotionStatus status,
+    ledger::ResultCallback callback) {
+  promotion_->UpdateRecordsStatus(promotion_ids, status, callback);
+}
+
 void Database::PromotionCredentialCompleted(
     const std::string& promotion_id,
     ledger::ResultCallback callback) {
@@ -325,6 +344,12 @@ void Database::GetPromotionListByType(
     const std::vector<ledger::PromotionType>& types,
     ledger::GetPromotionListCallback callback) {
   promotion_->GetRecordsByType(types, callback);
+}
+
+void Database::UpdatePromotionsBlankPublicKey(
+    const std::vector<std::string>& ids,
+    ledger::ResultCallback callback) {
+  promotion_->UpdateRecordsBlankPublicKey(ids, callback);
 }
 
 /**

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database.h
@@ -146,6 +146,12 @@ class Database {
       const ledger::CredsBatchStatus status,
       ledger::ResultCallback callback);
 
+  void UpdateCredsBatchesStatus(
+      const std::vector<std::string>& trigger_ids,
+      const ledger::CredsBatchType trigger_type,
+      const ledger::CredsBatchStatus status,
+      ledger::ResultCallback callback);
+
   /**
    * MEDIA PUBLISHER INFO
    */
@@ -213,6 +219,11 @@ class Database {
       const ledger::PromotionStatus status,
       ledger::ResultCallback callback);
 
+  void UpdatePromotionsStatus(
+      const std::vector<std::string>& promotion_ids,
+      const ledger::PromotionStatus status,
+      ledger::ResultCallback callback);
+
   void PromotionCredentialCompleted(
       const std::string& promotion_id,
       ledger::ResultCallback callback);
@@ -224,6 +235,10 @@ class Database {
   void GetPromotionListByType(
       const std::vector<ledger::PromotionType>& types,
       ledger::GetPromotionListCallback callback);
+
+  void UpdatePromotionsBlankPublicKey(
+      const std::vector<std::string>& ids,
+      ledger::ResultCallback callback);
 
   /**
    * PUBLISHER INFO

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_creds_batch.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_creds_batch.h
@@ -41,6 +41,12 @@ class DatabaseCredsBatch: public DatabaseTable {
       const ledger::CredsBatchStatus status,
       ledger::ResultCallback callback);
 
+  void UpdateRecordsStatus(
+      const std::vector<std::string>& trigger_ids,
+      const ledger::CredsBatchType trigger_type,
+      const ledger::CredsBatchStatus status,
+      ledger::ResultCallback callback);
+
  private:
   bool CreateTableV18(ledger::DBTransaction* transaction);
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_promotion.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/database/database_promotion.h
@@ -51,6 +51,11 @@ class DatabasePromotion: public DatabaseTable {
       const ledger::PromotionStatus status,
       ledger::ResultCallback callback);
 
+  void UpdateRecordsStatus(
+      const std::vector<std::string>& ids,
+      const ledger::PromotionStatus status,
+      ledger::ResultCallback callback);
+
   void CredentialCompleted(
       const std::string& promotion_id,
       ledger::ResultCallback callback);
@@ -58,6 +63,10 @@ class DatabasePromotion: public DatabaseTable {
   void GetRecordsByType(
       const std::vector<ledger::PromotionType>& types,
       ledger::GetPromotionListCallback callback);
+
+  void UpdateRecordsBlankPublicKey(
+      const std::vector<std::string>& ids,
+      ledger::ResultCallback callback);
 
  private:
   bool CreateTableV10(ledger::DBTransaction* transaction);

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1710,6 +1710,13 @@ void LedgerImpl::UpdatePromotionStatus(
   bat_database_->UpdatePromotionStatus(promotion_id, status, callback);
 }
 
+void LedgerImpl::UpdatePromotionsStatus(
+    const std::vector<std::string>& promotion_ids,
+    const ledger::PromotionStatus status,
+    ledger::ResultCallback callback) {
+  bat_database_->UpdatePromotionsStatus(promotion_ids, status, callback);
+}
+
 void LedgerImpl::PromotionCredentialCompleted(
     const std::string& promotion_id,
     ledger::ResultCallback callback) {
@@ -1739,6 +1746,18 @@ void LedgerImpl::UpdateCredsBatchStatus(
     ledger::ResultCallback callback) {
   bat_database_->UpdateCredsBatchStatus(
       trigger_id,
+      trigger_type,
+      status,
+      callback);
+}
+
+void LedgerImpl::UpdateCredsBatchesStatus(
+    const std::vector<std::string>& trigger_ids,
+    const ledger::CredsBatchType trigger_type,
+    const ledger::CredsBatchStatus status,
+    ledger::ResultCallback callback) {
+  bat_database_->UpdateCredsBatchesStatus(
+      trigger_ids,
       trigger_type,
       status,
       callback);
@@ -1829,6 +1848,12 @@ void LedgerImpl::GetSpendableUnblindedTokensByBatchTypes(
   bat_database_->GetSpendableUnblindedTokensByBatchTypes(
       batch_types,
       callback);
+}
+
+void LedgerImpl::UpdatePromotionsBlankPublicKey(
+    const std::vector<std::string>& ids,
+    ledger::ResultCallback callback) {
+  bat_database_->UpdatePromotionsBlankPublicKey(ids, callback);
 }
 
 }  // namespace bat_ledger

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -660,6 +660,11 @@ class LedgerImpl : public ledger::Ledger {
       const ledger::PromotionStatus status,
       ledger::ResultCallback callback);
 
+  void UpdatePromotionsStatus(
+      const std::vector<std::string>& promotion_ids,
+      const ledger::PromotionStatus status,
+      ledger::ResultCallback callback);
+
   void PromotionCredentialCompleted(
       const std::string& promotion_id,
       ledger::ResultCallback callback);
@@ -676,6 +681,12 @@ class LedgerImpl : public ledger::Ledger {
 
   void UpdateCredsBatchStatus(
       const std::string& trigger_id,
+      const ledger::CredsBatchType trigger_type,
+      const ledger::CredsBatchStatus status,
+      ledger::ResultCallback callback);
+
+  void UpdateCredsBatchesStatus(
+      const std::vector<std::string>& trigger_ids,
       const ledger::CredsBatchType trigger_type,
       const ledger::CredsBatchStatus status,
       ledger::ResultCallback callback);
@@ -732,6 +743,10 @@ class LedgerImpl : public ledger::Ledger {
   virtual void GetSpendableUnblindedTokensByBatchTypes(
       const std::vector<ledger::CredsBatchType>& batch_types,
       ledger::GetUnblindedTokenListCallback callback);
+
+  void UpdatePromotionsBlankPublicKey(
+      const std::vector<std::string>& ids,
+      ledger::ResultCallback callback);
 
  private:
   void MaybeInitializeConfirmations(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.cc
@@ -96,7 +96,7 @@ void Promotion::Initialize() {
         this,
         _1);
 
-    ledger_->GetAllCredsBatches(check_callback);
+    ledger_->GetAllPromotions(check_callback);
   }
 
   auto retry_callback = std::bind(&Promotion::Retry,
@@ -516,6 +516,7 @@ void Promotion::Retry(ledger::PromotionMap promotions) {
       }
       case ledger::PromotionStatus::ACTIVE:
       case ledger::PromotionStatus::FINISHED:
+      case ledger::PromotionStatus::CORRUPTED:
       case ledger::PromotionStatus::OVER: {
         break;
       }
@@ -557,8 +558,55 @@ void Promotion::Refresh(const bool retry_after_error) {
   ledger_->SetTimer(start_timer_in, &last_check_timer_id_);
 }
 
-void Promotion::CheckForCorrupted(ledger::CredsBatchList list) {
+void Promotion::CheckForCorrupted(const ledger::PromotionMap& promotions) {
+  if (promotions.empty()) {
+    return;
+  }
+
+  std::vector<std::string> corrupted_promotions;
+
+  for (const auto& item : promotions) {
+    if (!item.second ||
+        item.second->status != ledger::PromotionStatus::ATTESTED) {
+      continue;
+    }
+
+    if (item.second->public_keys.empty() ||
+        item.second->public_keys == "[]") {
+      corrupted_promotions.push_back(item.second->id);
+    }
+  }
+
+  if (corrupted_promotions.empty()) {
+    BLOG(ledger_, ledger::LogLevel::LOG_INFO) << "No corrupted promotions";
+    CorruptedPromotionFixed(ledger::Result::LEDGER_OK);
+    return;
+  }
+
+  auto get_callback = std::bind(&Promotion::CorruptedPromotionFixed,
+      this,
+      _1);
+
+  ledger_->UpdatePromotionsBlankPublicKey(corrupted_promotions, get_callback);
+}
+
+void Promotion::CorruptedPromotionFixed(const ledger::Result result) {
+  if (result != ledger::Result::LEDGER_OK) {
+    BLOG(ledger_, ledger::LogLevel::LOG_ERROR) <<
+        "Could not update public keys";
+    return;
+  }
+
+  auto check_callback = std::bind(&Promotion::CheckForCorruptedCreds,
+        this,
+        _1);
+
+  ledger_->GetAllCredsBatches(check_callback);
+}
+
+void Promotion::CheckForCorruptedCreds(ledger::CredsBatchList list) {
   if (list.empty()) {
+    ledger_->SetBooleanState(ledger::kStatePromotionCorruptedMigrated, true);
     return;
   }
 
@@ -586,6 +634,7 @@ void Promotion::CheckForCorrupted(ledger::CredsBatchList list) {
   }
 
   if (corrupted_promotions.empty()) {
+    BLOG(ledger_, ledger::LogLevel::LOG_INFO) << "No corrupted creds";
     ledger_->SetBooleanState(ledger::kStatePromotionCorruptedMigrated, true);
     return;
   }
@@ -612,6 +661,8 @@ void Promotion::CorruptedPromotions(
   }
 
   if (corrupted_claims.GetList().empty()) {
+    BLOG(ledger_, ledger::LogLevel::LOG_INFO) << "No corrupted creds";
+    ledger_->SetBooleanState(ledger::kStatePromotionCorruptedMigrated, true);
     return;
   }
 
@@ -650,20 +701,50 @@ void Promotion::OnCheckForCorrupted(
     return;
   }
 
-  auto save_callback = std::bind(&Promotion::PromotionListDeleted,
+  ledger_->SetBooleanState(ledger::kStatePromotionCorruptedMigrated, true);
+
+  auto update_callback = std::bind(&Promotion::ErrorStatusSaved,
+      this,
+      _1,
+      promotion_id_list);
+
+  ledger_->UpdatePromotionsStatus(
+      promotion_id_list,
+      ledger::PromotionStatus::CORRUPTED,
+      update_callback);
+}
+
+void Promotion::ErrorStatusSaved(
+    const ledger::Result result,
+    const std::vector<std::string>& promotion_id_list) {
+  // even if promotions fail, let's try to update at least creds
+  if (result != ledger::Result::LEDGER_OK) {
+    BLOG(ledger_, ledger::LogLevel::LOG_ERROR) <<
+        "Promotion status save failed";
+  }
+
+  auto update_callback = std::bind(&Promotion::ErrorCredsStatusSaved,
       this,
       _1);
 
-  ledger_->DeletePromotionList(promotion_id_list, save_callback);
+  ledger_->UpdateCredsBatchesStatus(
+      promotion_id_list,
+      ledger::CredsBatchType::PROMOTION,
+      ledger::CredsBatchStatus::CORRUPTED,
+      update_callback);
 }
 
-void Promotion::PromotionListDeleted(const ledger::Result result) {
+void Promotion::ErrorCredsStatusSaved(const ledger::Result result) {
   if (result != ledger::Result::LEDGER_OK) {
-    BLOG(ledger_, ledger::LogLevel::LOG_ERROR) << "Error deleting promotions";
-    return;
+    BLOG(ledger_, ledger::LogLevel::LOG_ERROR) << "Creds status save failed";
   }
 
-  ledger_->SetBooleanState(ledger::kStatePromotionCorruptedMigrated, true);
+  // let's retry promotions that are valid now
+  auto retry_callback = std::bind(&Promotion::Retry,
+    this,
+    _1);
+
+  ledger_->GetAllPromotions(retry_callback);
 }
 
 void Promotion::TransferTokens(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.h
@@ -117,7 +117,11 @@ class Promotion {
 
   void Retry(ledger::PromotionMap promotions);
 
-  void CheckForCorrupted(ledger::CredsBatchList list);
+  void CheckForCorrupted(const ledger::PromotionMap& promotions);
+
+  void CorruptedPromotionFixed(const ledger::Result result);
+
+  void CheckForCorruptedCreds(ledger::CredsBatchList list);
 
   void CorruptedPromotions(
       ledger::PromotionList promotions,
@@ -129,7 +133,11 @@ class Promotion {
       const std::map<std::string, std::string>& headers,
       const std::vector<std::string>& promotion_id_list);
 
-  void PromotionListDeleted(const ledger::Result result);
+  void ErrorStatusSaved(
+      const ledger::Result result,
+      const std::vector<std::string>& promotion_id_list);
+
+  void ErrorCredsStatusSaved(const ledger::Result result);
 
   std::unique_ptr<braveledger_attestation::AttestationImpl> attestation_;
   std::unique_ptr<PromotionTransfer> transfer_;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/request/request_promotion.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/request/request_promotion.cc
@@ -59,7 +59,7 @@ std::string GetReedemTokensUrl(const ledger::ContributionProcessor processor) {
 std::string ReportClobberedClaimsUrl() {
   return BuildUrl(
       "/promotions/reportclobberedclaims",
-      PREFIX_V1,
+      PREFIX_V2,
       ServerTypes::kPromotion);
 }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/state_keys.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/state_keys.h
@@ -15,7 +15,7 @@ namespace ledger {
   const char kStateUpholdAnonAddress[] = "uphold_anon_address";
   const char kStatePromotionLastFetchStamp[] = "promotion_last_fetch_stamp";
   const char kStatePromotionCorruptedMigrated[] =
-      "promotion_corrupted_migrated";
+      "promotion_corrupted_migrated2";
   const char kStateAnonTransferChecked[] = "anon_transfer_checked";
 }  // namespace ledger
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/9684

You can find diagram of what we do here https://github.com/brave/rewards/blob/master/monodraw/may_ads_payout_recovery.svg

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
plan 1:
- start browser from the master
- enable rewards
- fetch promotions
- claim promotion
- make sure that promotion was claimed
- close the browser
- open db and clear `unblinded_tokens` table. Change change status of `promotion` to 1 and `creds_batch` status to 3. Set `[]` for `public_keys` in promotion table
- start browser from this PR
- make sure that balance is now displayed correctly

plan 2:
- start browser from the master
- enable rewards
- fetch promotions
- claim promotion
- make sure that promotion was claimed
- close the browser
- open db and change status of `promotion` to 1 and `creds_batch` status to 3. Override `signed_creds` value with `blinded_creds` value.
- start browser from this PR
- make sure that in the logs you see post out to `/promotions/reportclobberedclaims`
- open db and check that `promotion` has status 6 and `creds_batch` has status 5

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
