### PR TITLE
Allow cookie exceptions for ubisoft.com/americanexpress.com

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -59,9 +59,11 @@ bool BraveIsAllowedThirdParty(
             ContentSettingsPattern::FromString(kUbi),
             ContentSettingsPattern::FromString(kUbisoft)
           },
+          {
             ContentSettingsPattern::FromString(kAmericanexpress),
             ContentSettingsPattern::FromString(kAexp)
           },
+          {
             ContentSettingsPattern::FromString(kAexp),
             ContentSettingsPattern::FromString(kAmericanexpress)
           }

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -43,7 +43,7 @@ bool BraveIsAllowedThirdParty(
           },
           {
             ContentSettingsPattern::FromString(kPlaystation),
-            ContentSettingsPattern::FromString(kSonyentertainmentnetwork),
+            ContentSettingsPattern::FromString(kSonyentertainmentnetwork)
           },
           {
             ContentSettingsPattern::FromString(kSonyentertainmentnetwork),
@@ -51,7 +51,7 @@ bool BraveIsAllowedThirdParty(
           },
           {
             ContentSettingsPattern::FromString(kUbisoft),
-            ContentSettingsPattern::FromString(kUbi),
+            ContentSettingsPattern::FromString(kUbi)
           },
           {
             ContentSettingsPattern::FromString(kUbi),

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -22,6 +22,8 @@ constexpr char kWordpress[] = "https://[*.]wordpress.com/*";
 constexpr char kPlaystation[] = "https://[*.]playstation.com/*";
 constexpr char kSonyentertainmentnetwork[] =
     "https://[*.]sonyentertainmentnetwork.com/*";
+constexpr char kUbisoft[] = "https://[*.]ubisoft.com/*";
+constexpr char kUbi[] = "https://[*.]ubi.com/*";
 
 bool BraveIsAllowedThirdParty(
     const GURL& url,
@@ -41,11 +43,20 @@ bool BraveIsAllowedThirdParty(
           },
           {
             ContentSettingsPattern::FromString(kPlaystation),
-            ContentSettingsPattern::FromString(kSonyentertainmentnetwork)},
+            ContentSettingsPattern::FromString(kSonyentertainmentnetwork),
+          },
           {
             ContentSettingsPattern::FromString(kSonyentertainmentnetwork),
             ContentSettingsPattern::FromString(kPlaystation)
           },
+          {
+            ContentSettingsPattern::FromString(kUbisoft),
+            ContentSettingsPattern::FromString(kUbi),
+          },
+          {
+            ContentSettingsPattern::FromString(kUbi),
+            ContentSettingsPattern::FromString(kUbisoft)
+          }
       });
 
   GURL first_party_url = site_for_cookies;

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -24,6 +24,8 @@ constexpr char kSonyentertainmentnetwork[] =
     "https://[*.]sonyentertainmentnetwork.com/*";
 constexpr char kUbisoft[] = "https://[*.]ubisoft.com/*";
 constexpr char kUbi[] = "https://[*.]ubi.com/*";
+constexpr char kAmericanexpress[] = "https://[*.]americanexpress.com/*";
+constexpr char kAexp[] = "https://[*.]aexp-static.com/*";
 
 bool BraveIsAllowedThirdParty(
     const GURL& url,
@@ -56,6 +58,12 @@ bool BraveIsAllowedThirdParty(
           {
             ContentSettingsPattern::FromString(kUbi),
             ContentSettingsPattern::FromString(kUbisoft)
+          },
+            ContentSettingsPattern::FromString(kAmericanexpress),
+            ContentSettingsPattern::FromString(kAexp)
+          },
+            ContentSettingsPattern::FromString(kAexp),
+            ContentSettingsPattern::FromString(kAmericanexpress)
           }
       });
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9285

## Submitter Checklist:
**2 Fixes:** 

1. Allow cookie for ubi.com and ubisoft.com and resolving  https://github.com/brave/brave-browser/issues/9285

2. Also fixed formatting on the  ContentSettingsPattern. Seems the orginal commit wasn't correct. If someone can confirm?



## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
