### PR TITLE
Fix ViewCounterModel is not updated when SR is ended

### DIFF
--- a/browser/ntp_background_images/android/ntp_background_images_bridge.cc
+++ b/browser/ntp_background_images/android/ntp_background_images_bridge.cc
@@ -200,3 +200,7 @@ void NTPBackgroundImagesBridge::OnUpdated(NTPBackgroundImagesData* data) {
   JNIEnv* env = AttachCurrentThread();
   Java_NTPBackgroundImagesBridge_onUpdated(env, java_object_);
 }
+
+void NTPBackgroundImagesBridge::OnSuperReferralEnded() {
+  // Android doesn't need to get this update.
+}

--- a/browser/ntp_background_images/android/ntp_background_images_bridge.h
+++ b/browser/ntp_background_images/android/ntp_background_images_bridge.h
@@ -53,6 +53,8 @@ class NTPBackgroundImagesBridge : public NTPBackgroundImagesService::Observer,
 
  private:
   void OnUpdated(NTPBackgroundImagesData* data) override;
+  void OnSuperReferralEnded() override;
+
   base::android::ScopedJavaLocalRef<jobject> CreateWallpaper();
 
   Profile* profile_;

--- a/components/ntp_background_images/browser/ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service.cc
@@ -508,15 +508,19 @@ void NTPBackgroundImagesService::OnGetComponentJsonData(
                                                       si_installed_dir_));
   }
 
+  bool sr_ended = false;
+  if (is_super_referral && !sr_images_data_->IsValid()) {
+    DVLOG(2) << __func__ << ": NTP SR campaign ends.";
+    sr_ended = true;
+    UnRegisterSuperReferralComponent();
+    MarkThisInstallIsNotSuperReferralForever();
+  }
+
   for (auto& observer : observer_list_) {
     observer.OnUpdated(is_super_referral ? sr_images_data_.get()
                                          : si_images_data_.get());
-  }
-
-  if (is_super_referral && !sr_images_data_->IsValid()) {
-    DVLOG(2) << __func__ << ": NTP SR campaign ends.";
-    UnRegisterSuperReferralComponent();
-    MarkThisInstallIsNotSuperReferralForever();
+    if (sr_ended)
+      observer.OnSuperReferralEnded();
   }
 }
 

--- a/components/ntp_background_images/browser/ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/ntp_background_images_service.h
@@ -35,6 +35,8 @@ class NTPBackgroundImagesService {
    public:
     // Called whenever ntp background images component is updated.
     virtual void OnUpdated(NTPBackgroundImagesData* data) = 0;
+    // Called when SR campaign ended.
+    virtual void OnSuperReferralEnded() = 0;
    protected:
     virtual ~Observer() {}
   };
@@ -101,6 +103,7 @@ class NTPBackgroundImagesService {
                            IsActiveOptedIn);
   FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesViewCounterTest,
                            ActiveInitiallyOptedIn);
+  FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesViewCounterTest, ModelTest);
   FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesSourceTest, BasicTest);
   FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesSourceTest,
                            BasicSuperReferralDataTest);

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -49,8 +49,10 @@ void ViewCounterModel::RegisterPageView() {
   }
 }
 
-void ViewCounterModel::Reset() {
-  count_to_branded_wallpaper_ = kInitialCountToBrandedWallpaper;
+void ViewCounterModel::Reset(bool use_initial_count) {
+  count_to_branded_wallpaper_ =
+      use_initial_count ? kInitialCountToBrandedWallpaper
+                        : kRegularCountToBrandedWallpaper;
   current_wallpaper_image_index_ = 0;
   total_image_count_ = -1;
   ignore_count_to_branded_wallpaper_ = false;

--- a/components/ntp_background_images/browser/view_counter_model.h
+++ b/components/ntp_background_images/browser/view_counter_model.h
@@ -31,13 +31,16 @@ class ViewCounterModel {
   void RegisterPageView();
   void ResetCurrentWallpaperImageIndex();
 
-  void Reset();
+  // If |true|, kInitialCountToBrandedWallpaper is set to
+  // |count_to_branded_wallpaper_|.
+  void Reset(bool use_initial_count = true);
 
  private:
   static const int kInitialCountToBrandedWallpaper = 1;
   static const int kRegularCountToBrandedWallpaper = 3;
 
   FRIEND_TEST_ALL_PREFIXES(ViewCounterModelTest, NTPSponsoredImagesTest);
+  FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesViewCounterTest, ModelTest);
 
   int current_wallpaper_image_index_ = 0;
   int count_to_branded_wallpaper_ = 0;

--- a/components/ntp_background_images/browser/view_counter_service.h
+++ b/components/ntp_background_images/browser/view_counter_service.h
@@ -85,6 +85,7 @@ class ViewCounterService : public KeyedService,
                            ActiveInitiallyOptedIn);
   FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesViewCounterTest,
                            ActiveOptedInWithNTPBackgoundOption);
+  FRIEND_TEST_ALL_PREFIXES(NTPBackgroundImagesViewCounterTest, ModelTest);
 
   void OnPreferenceChanged(const std::string& pref_name);
 
@@ -93,6 +94,7 @@ class ViewCounterService : public KeyedService,
 
   // NTPBackgroundImagesService::Observer
   void OnUpdated(NTPBackgroundImagesData* data) override;
+  void OnSuperReferralEnded() override;
 
   void ResetNotificationState();
   bool IsSponsoredImagesWallpaperOptedIn() const;


### PR DESCRIPTION
When SR campaign is ended, ViewCounterModel should be reset because
NTP shows SR images for every tab loading but SI images are only
visible for 4th NTP. If model isn't reset, SI image is visible for
every NTP after SR campaign ends.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9716

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_unit_tests`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
