### PR TITLE
Don't append two equal signs in win stub installer (uplift to 1.9.x)

### DIFF
--- a/chromium_src/chrome/installer/mini_installer/mini_installer.cc
+++ b/chromium_src/chrome/installer/mini_installer/mini_installer.cc
@@ -17,7 +17,7 @@
        installer_filename.length() != 0) {                                   \
     ReferralCodeString referral_code;                                        \
     if (ParseReferralCode(installer_filename.get(), &referral_code)) {       \
-      cmd_line.append(L" --brave-referral-code=");                           \
+      cmd_line.append(L" --brave-referral-code");                            \
       cmd_line.append(L"=\"");                                               \
       cmd_line.append(referral_code.get());                                  \
       cmd_line.append(L"\"");                                                \


### PR DESCRIPTION
Uplift of #5556
Fixes https://github.com/brave/brave-browser/issues/9783

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.