### PR TITLE
static_cast base::Time ToDoubleT() in Brave Ads to uint64_t

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1486,7 +1486,7 @@ uint64_t AdsServiceImpl::MigrateTimestampToDoubleT(
   auto delta = timestamp_in_seconds - now_in_seconds;
 
   auto date = now + base::TimeDelta::FromSeconds(delta);
-  return date.ToDoubleT();
+  return static_cast<uint64_t>(date.ToDoubleT());
 }
 
 void AdsServiceImpl::MaybeShowOnboarding() {
@@ -1520,7 +1520,7 @@ void AdsServiceImpl::ShowOnboarding() {
 
   SetBooleanPref(prefs::kShouldShowOnboarding, false);
 
-  auto now = base::Time::Now().ToDoubleT();
+  auto now = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   SetUint64Pref(prefs::kOnboardingTimestamp, now);
 
   StartRemoveOnboardingTimer();
@@ -1557,7 +1557,7 @@ void AdsServiceImpl::StartRemoveOnboardingTimer() {
     return;
   }
 
-  auto now_in_seconds = base::Time::Now().ToDoubleT();
+  auto now_in_seconds = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   auto timestamp_in_seconds =
       MigrateTimestampToDoubleT(GetUint64Pref(prefs::kOnboardingTimestamp));

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_conversions.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_conversions.cc
@@ -190,7 +190,7 @@ void AdConversions::AddItemToQueue(
     return;
   }
 
-  const uint64_t now = base::Time::Now().ToDoubleT();
+  const uint64_t now = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   client_->AppendTimestampToAdConversionHistory(creative_set_id, now);
 
   AdConversionQueueItemInfo ad_conversion;
@@ -279,7 +279,7 @@ void AdConversions::StartTimer(
   DCHECK(is_initialized_);
   DCHECK(!timer_.IsRunning());
 
-  const uint64_t now = base::Time::Now().ToDoubleT();
+  const uint64_t now = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   uint64_t delay;
   if (now < info.timestamp_in_seconds) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -216,8 +216,9 @@ void AdsImpl::RemoveAllAdNotificationsAfterReboot() {
   if (!ads_shown_history.empty()) {
     uint64_t ad_shown_timestamp =
         ads_shown_history.front().timestamp_in_seconds;
-    uint64_t boot_timestamp = base::Time::Now().ToDoubleT() -
-        static_cast<uint64_t>(base::SysInfo::Uptime().InSeconds());
+    uint64_t boot_timestamp =
+        static_cast<uint64_t>(base::Time::Now().ToDoubleT() -
+            static_cast<uint64_t>(base::SysInfo::Uptime().InSeconds()));
     if (ad_shown_timestamp <= boot_timestamp) {
       ad_notifications_->RemoveAll(false);
     }
@@ -1280,7 +1281,7 @@ bool AdsImpl::ShowAdNotification(
     return false;
   }
 
-  auto now_in_seconds = base::Time::Now().ToDoubleT();
+  auto now_in_seconds = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   client_->AppendTimestampToCreativeSetHistory(
       info.creative_set_id, now_in_seconds);
@@ -1364,7 +1365,7 @@ bool AdsImpl::IsAllowedToServeAdNotifications() {
 }
 
 void AdsImpl::StartDeliveringAdNotifications() {
-  auto now_in_seconds = base::Time::Now().ToDoubleT();
+  auto now_in_seconds = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   auto next_check_serve_ad_timestamp_in_seconds =
       client_->GetNextCheckServeAdNotificationTimestampInSeconds();
 
@@ -1385,7 +1386,8 @@ void AdsImpl::StartDeliveringAdNotifications() {
 
 void AdsImpl::StartDeliveringAdNotificationsAfterSeconds(
     const uint64_t seconds) {
-  auto timestamp_in_seconds = base::Time::Now().ToDoubleT() + seconds;
+  auto timestamp_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT() + seconds);
   client_->SetNextCheckServeAdNotificationTimestampInSeconds(
       timestamp_in_seconds);
 
@@ -1400,7 +1402,7 @@ bool AdsImpl::IsCatalogOlderThanOneDay() {
   auto catalog_last_updated_timestamp_in_seconds =
     bundle_->GetCatalogLastUpdatedTimestampInSeconds();
 
-  auto now_in_seconds = base::Time::Now().ToDoubleT();
+  auto now_in_seconds = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   if (catalog_last_updated_timestamp_in_seconds != 0 &&
       now_in_seconds > catalog_last_updated_timestamp_in_seconds
@@ -1516,7 +1518,8 @@ void AdsImpl::AppendAdNotificationToHistory(
     const AdNotificationInfo& info,
     const ConfirmationType& confirmation_type) {
   AdHistory ad_history;
-  ad_history.timestamp_in_seconds = base::Time::Now().ToDoubleT();
+  ad_history.timestamp_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   ad_history.uuid = base::GenerateGUID();
   ad_history.parent_uuid = info.parent_uuid;
   ad_history.ad_content.creative_instance_id = info.creative_instance_id;

--- a/vendor/bat-native-ads/src/bat/ads/internal/bundle.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/bundle.cc
@@ -197,7 +197,7 @@ std::unique_ptr<BundleState> Bundle::GenerateFromCatalog(
   state->catalog_version = catalog.GetVersion();
   state->catalog_ping = catalog.GetPing();
   state->catalog_last_updated_timestamp_in_seconds =
-      base::Time::Now().ToDoubleT();
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   state->creative_ad_notifications = creative_ad_notifications;
   state->ad_conversions = ad_conversions;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/client_mock.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client_mock.cc
@@ -19,7 +19,8 @@ void ClientMock::GeneratePastAdHistoryFromNow(
     const std::string& creative_instance_id,
     const int64_t time_offset_per_ad_in_seconds,
     const uint8_t count) {
-  uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   AdHistory ad_history;
   ad_history.uuid = base::GenerateGUID();
@@ -38,7 +39,8 @@ void ClientMock::GeneratePastCreativeSetHistoryFromNow(
     const std::string& creative_set_id,
     const int64_t time_offset_per_ad_in_seconds,
     const uint8_t count) {
-  uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   for (uint8_t i = 0; i < count; i++) {
     now_in_seconds -= time_offset_per_ad_in_seconds;
@@ -51,7 +53,8 @@ void ClientMock::GeneratePastCampaignHistoryFromNow(
     const std::string& campaign_id,
     const int64_t time_offset_per_ad_in_seconds,
     const uint8_t count) {
-  uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   for (uint8_t i = 0; i < count; i++) {
     now_in_seconds -= time_offset_per_ad_in_seconds;
@@ -64,7 +67,8 @@ void ClientMock::GeneratePastPurchaseIntentSignalHistoryFromNow(
     const std::string& segment,
     const uint64_t time_offset_in_seconds,
     const uint16_t weight) {
-  uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   now_in_seconds -= time_offset_in_seconds;
   PurchaseIntentSignalHistory history;
   history.timestamp_in_seconds = 0;
@@ -76,7 +80,8 @@ void ClientMock::GeneratePastAdConversionHistoryFromNow(
     const std::string& creative_set_id,
     const int64_t time_offset_per_ad_in_seconds,
     const uint8_t count) {
-  uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   for (uint8_t i = 0; i < count; i++) {
     now_in_seconds -= time_offset_per_ad_in_seconds;

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/frequency_capping.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/frequency_capping.cc
@@ -23,7 +23,7 @@ bool FrequencyCapping::DoesHistoryRespectCapForRollingTimeConstraint(
     const uint64_t cap) const {
   uint64_t count = 0;
 
-  auto now_in_seconds = base::Time::Now().ToDoubleT();
+  auto now_in_seconds = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   for (const auto& timestamp_in_seconds : history) {
     if (now_in_seconds - timestamp_in_seconds < time_constraint_in_seconds) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/purchase_intent_classifier.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/purchase_intent_classifier.cc
@@ -41,7 +41,8 @@ PurchaseIntentSignalInfo PurchaseIntentClassifier::ExtractIntentSignal(
     if (!keyword_segments.empty()) {
       uint16_t keyword_weight = Keywords::GetFunnelWeight(search_query);
 
-      signal_info.timestamp_in_seconds = base::Time::Now().ToDoubleT();
+      signal_info.timestamp_in_seconds =
+          static_cast<uint64_t>(base::Time::Now().ToDoubleT());
       signal_info.segments = keyword_segments;
       signal_info.weight = keyword_weight;
       return signal_info;
@@ -50,7 +51,8 @@ PurchaseIntentSignalInfo PurchaseIntentClassifier::ExtractIntentSignal(
     FunnelSiteInfo info = FunnelSites::GetFunnelSite(url);
 
     if (!info.url_netloc.empty()) {
-      signal_info.timestamp_in_seconds = base::Time::Now().ToDoubleT();
+      signal_info.timestamp_in_seconds =
+          static_cast<uint64_t>(base::Time::Now().ToDoubleT());
       signal_info.segments = info.segments;
       signal_info.weight = info.weight;
       return signal_info;

--- a/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/purchase_intent_classifier_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/purchase_intent/purchase_intent_classifier_unittest.cc
@@ -101,7 +101,7 @@ class AdsPurchaseIntentClassifierTest : public ::testing::Test {
         kPurchaseIntentSignalLevel, kPurchaseIntentClassificationThreshold,
             kPurchaseIntentSignalDecayTimeWindow);
 
-    auto now = base::Time::Now().ToDoubleT();
+    auto now = static_cast<uint64_t>(base::Time::Now().ToDoubleT());
     auto days = base::Time::kSecondsPerHour * base::Time::kHoursPerDay;
 
     auto p1 = PurchaseIntentSignalHistory();

--- a/vendor/bat-native-ads/src/bat/ads/internal/time_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/time_util.cc
@@ -70,7 +70,7 @@ uint64_t MigrateTimestampToDoubleT(
   const uint64_t delta = timestamp_in_seconds - now_in_seconds;
 
   const base::Time time = now + base::TimeDelta::FromSeconds(delta);
-  return time.ToDoubleT();
+  return static_cast<uint64_t>(time.ToDoubleT());
 }
 
 }  // namespace ads

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/ads_rewards.cc
@@ -210,7 +210,8 @@ void AdsRewards::Update() {
   auto now = base::Time::Now();
   auto next_payment_date = payments_->CalculateNextPaymentDate(now,
       confirmations_->GetNextTokenRedemptionDateInSeconds());
-  uint64_t next_payment_date_in_seconds = next_payment_date.ToDoubleT();
+  uint64_t next_payment_date_in_seconds =
+      static_cast<uint64_t>(next_payment_date.ToDoubleT());
 
   confirmations_->UpdateAdsRewards(estimated_pending_rewards,
       next_payment_date_in_seconds);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/confirmations_impl.cc
@@ -655,7 +655,8 @@ bool ConfirmationsImpl::GetTransactionHistoryFromDictionary(
           MigrateTimestampToDoubleT(timestamp_in_seconds);
     } else {
       // timestamp missing, fallback to default
-      info.timestamp_in_seconds = base::Time::Now().ToDoubleT();
+      info.timestamp_in_seconds =
+          static_cast<uint64_t>(base::Time::Now().ToDoubleT());
     }
 
     // Estimated redemption value
@@ -986,7 +987,8 @@ void ConfirmationsImpl::GetTransactionHistory(
   transactions_info->ad_notifications_received_this_month =
       ad_notifications_received_this_month;
 
-  auto to_timestamp_in_seconds = base::Time::Now().ToDoubleT();
+  auto to_timestamp_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   auto transactions = GetTransactionHistory(0, to_timestamp_in_seconds);
   transactions_info->transactions = transactions;
 
@@ -1117,7 +1119,8 @@ void ConfirmationsImpl::AppendTransactionToHistory(
   DCHECK(state_has_loaded_);
 
   TransactionInfo info;
-  info.timestamp_in_seconds = base::Time::Now().ToDoubleT();
+  info.timestamp_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
   info.estimated_redemption_value = estimated_redemption_value;
   info.confirmation_type = std::string(confirmation_type);
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payments_unittest.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payments_unittest.cc
@@ -58,7 +58,7 @@ class ConfirmationsPaymentsTest : public ::testing::Test {
 
     auto token_redemption_date = UTCDateFromString(next_token_redemption_date);
     uint64_t token_redemption_date_in_seconds =
-        token_redemption_date.ToDoubleT();
+        static_cast<uint64_t>(token_redemption_date.ToDoubleT());
 
     return payments_->CalculateNextPaymentDate(current_date,
         token_redemption_date_in_seconds);

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/payout_tokens.cc
@@ -149,7 +149,8 @@ uint64_t PayoutTokens::CalculatePayoutDelay() {
     UpdateNextTokenRedemptionDate();
   }
 
-  const uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  const uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   uint64_t delay;
   if (now_in_seconds >= token_redemption_timestamp_in_seconds_) {
@@ -163,7 +164,8 @@ uint64_t PayoutTokens::CalculatePayoutDelay() {
 }
 
 void PayoutTokens::UpdateNextTokenRedemptionDate() {
-  const uint64_t now_in_seconds = base::Time::Now().ToDoubleT();
+  const uint64_t now_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   uint64_t delay;
 

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/redeem_token.cc
@@ -453,7 +453,8 @@ ConfirmationInfo RedeemToken::CreateConfirmationInfo(
       build_channel, platform);
 
   confirmation.credential = request.CreateCredential(token, payload);
-  confirmation.timestamp_in_seconds = base::Time::Now().ToDoubleT();
+  confirmation.timestamp_in_seconds =
+      static_cast<uint64_t>(base::Time::Now().ToDoubleT());
 
   return confirmation;
 }

--- a/vendor/bat-native-confirmations/src/bat/confirmations/internal/time_util.cc
+++ b/vendor/bat-native-confirmations/src/bat/confirmations/internal/time_util.cc
@@ -70,7 +70,7 @@ uint64_t MigrateTimestampToDoubleT(
   const uint64_t delta = timestamp_in_seconds - now_in_seconds;
 
   const base::Time time = now + base::TimeDelta::FromSeconds(delta);
-  return time.ToDoubleT();
+  return static_cast<uint64_t>(time.ToDoubleT());
 }
 
 }  // namespace confirmations


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9726

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
