### PR TITLE
Support generichide adblock rules

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@8e45290ced608da6c9b992a92b10355d9e140aae",
+  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@8e9d17f8b0381c6d6c4cd7c825ccde74ba622c21",
   "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@b4d059c73042cacf3a5e9156d4b1698e7bc18678",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@6eab0271d014ff09bd9f38abe1e0c117e13e9aa9",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",

--- a/browser/extensions/api/brave_shields_api.cc
+++ b/browser/extensions/api/brave_shields_api.cc
@@ -49,22 +49,22 @@ const char kInvalidControlTypeError[] = "Invalid ControlType.";
 
 
 ExtensionFunction::ResponseAction
-BraveShieldsHostnameCosmeticResourcesFunction::Run() {
-  std::unique_ptr<brave_shields::HostnameCosmeticResources::Params> params(
-      brave_shields::HostnameCosmeticResources::Params::Create(*args_));
+BraveShieldsUrlCosmeticResourcesFunction::Run() {
+  std::unique_ptr<brave_shields::UrlCosmeticResources::Params> params(
+      brave_shields::UrlCosmeticResources::Params::Create(*args_));
   EXTENSION_FUNCTION_VALIDATE(params.get());
 
   base::Optional<base::Value> resources = g_brave_browser_process->
-      ad_block_service()->HostnameCosmeticResources(params->hostname);
+      ad_block_service()->UrlCosmeticResources(params->url);
 
   if (!resources || !resources->is_dict()) {
     return RespondNow(Error(
-        "Hostname-specific cosmetic resources could not be returned"));
+        "Url-specific cosmetic resources could not be returned"));
   }
 
   base::Optional<base::Value> regional_resources = g_brave_browser_process->
       ad_block_regional_service_manager()->
-          HostnameCosmeticResources(params->hostname);
+          UrlCosmeticResources(params->url);
 
   if (regional_resources && regional_resources->is_dict()) {
     ::brave_shields::MergeResourcesInto(
@@ -75,7 +75,7 @@ BraveShieldsHostnameCosmeticResourcesFunction::Run() {
 
   base::Optional<base::Value> custom_resources = g_brave_browser_process->
       ad_block_custom_filters_service()->
-          HostnameCosmeticResources(params->hostname);
+          UrlCosmeticResources(params->url);
 
   if (custom_resources && custom_resources->is_dict()) {
     ::brave_shields::MergeResourcesInto(

--- a/browser/extensions/api/brave_shields_api.h
+++ b/browser/extensions/api/brave_shields_api.h
@@ -11,12 +11,12 @@
 namespace extensions {
 namespace api {
 
-class BraveShieldsHostnameCosmeticResourcesFunction : public ExtensionFunction {
+class BraveShieldsUrlCosmeticResourcesFunction : public ExtensionFunction {
  public:
-  DECLARE_EXTENSION_FUNCTION("braveShields.hostnameCosmeticResources", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("braveShields.urlCosmeticResources", UNKNOWN)
 
  protected:
-  ~BraveShieldsHostnameCosmeticResourcesFunction() override {}
+  ~BraveShieldsUrlCosmeticResourcesFunction() override {}
 
   ResponseAction Run() override;
 };

--- a/common/extensions/api/brave_shields.json
+++ b/common/extensions/api/brave_shields.json
@@ -74,12 +74,12 @@
         "parameters": []
       },
       {
-        "name": "hostnameCosmeticResources",
+        "name": "urlCosmeticResources",
         "type": "function",
-        "description": "Get a cosmetic adblocking stylesheet, generic style exceptions, and script injections specific for the given hostname and domain",
+        "description": "Get a cosmetic adblocking stylesheet, generic style exceptions, script injections, and whether or not a generichide rule was present, all specific for the given URL",
         "parameters": [
           {
-            "name": "hostname",
+            "name": "url",
             "type": "string"
           },
           {
@@ -87,14 +87,15 @@
             "name": "callback",
             "parameters": [
               {
-                "name": "hostnameSpecificResources",
+                "name": "urlSpecificResources",
                 "type": "object",
                 "properties": {
-                  "hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific CSS selectors that should be hidden from the page if they are determined to not include 1st party content"},
-                  "style_selectors": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}, "description": "Hostname-specific CSS selectors that should be restyled, with their associated CSS style rules"},
-                  "exceptions": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific overrides for generic cosmetic blocking selectors"},
+                  "hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "URL-specific CSS selectors that should be hidden from the page if they are determined to not include 1st party content"},
+                  "style_selectors": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}, "description": "URL-specific CSS selectors that should be restyled, with their associated CSS style rules"},
+                  "exceptions": {"type": "array", "items": {"type": "string"}, "description": "URL-specific overrides for generic cosmetic blocking selectors"},
                   "injected_script": {"type": "string", "description": "A script to inject as the page is loading"},
-                  "force_hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "Hostname-specific CSS selectors that should be hidden from the page"}
+                  "force_hide_selectors": {"type": "array", "items": {"type": "string"}, "description": "URL-specific CSS selectors that should be hidden from the page"},
+                  "generichide": {"type": "boolean", "description": "Indicates whether or not the URL matched a generichide exception rule"}
                 }
               }
             ]

--- a/components/brave_extension/extension/brave_extension/actions/shieldsPanelActions.ts
+++ b/components/brave_extension/extension/brave_extension/actions/shieldsPanelActions.ts
@@ -147,12 +147,13 @@ export const generateClassIdStylesheet = (tabId: number, classes: string[], ids:
   }
 }
 
-export const cosmeticFilterRuleExceptions = (tabId: number, exceptions: string[], scriptlet: string) => {
+export const cosmeticFilterRuleExceptions = (tabId: number, exceptions: string[], scriptlet: string, generichide: boolean) => {
   return {
     type: types.COSMETIC_FILTER_RULE_EXCEPTIONS,
     tabId,
     exceptions,
-    scriptlet
+    scriptlet,
+    generichide
   }
 }
 

--- a/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
@@ -39,8 +39,8 @@ export const injectClassIdStylesheet = (tabId: number, classes: string[], ids: s
 }
 
 // Fires on content-script loaded
-export const applyAdblockCosmeticFilters = (tabId: number, hostname: string, hide1pContent: boolean) => {
-  chrome.braveShields.hostnameCosmeticResources(hostname, async (resources) => {
+export const applyAdblockCosmeticFilters = (tabId: number, url: string, hide1pContent: boolean) => {
+  chrome.braveShields.urlCosmeticResources(url, async (resources) => {
     if (chrome.runtime.lastError) {
       console.warn('Unable to get cosmetic filter data for the current host', chrome.runtime.lastError)
       return
@@ -65,7 +65,7 @@ export const applyAdblockCosmeticFilters = (tabId: number, hostname: string, hid
       runAt: 'document_start'
     })
 
-    shieldsPanelActions.cosmeticFilterRuleExceptions(tabId, resources.exceptions, resources.injected_script || '')
+    shieldsPanelActions.cosmeticFilterRuleExceptions(tabId, resources.exceptions, resources.injected_script || '', resources.generichide)
   })
 }
 

--- a/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
@@ -386,7 +386,8 @@ export default function shieldsPanelReducer (
       chrome.tabs.sendMessage(action.tabId, {
         type: 'cosmeticFilteringBackgroundReady',
         scriptlet: action.scriptlet,
-        hide1pContent: tabData.firstPartyCosmeticFiltering
+        hide1pContent: tabData.firstPartyCosmeticFiltering,
+        generichide: action.generichide
       })
       break
     }
@@ -399,7 +400,7 @@ export default function shieldsPanelReducer (
       Promise.all([chrome.braveShields.shouldDoCosmeticFilteringAsync(action.url), chrome.braveShields.isFirstPartyCosmeticFilteringEnabledAsync(action.url)])
         .then(([doCosmeticBlocking, hide1pContent]: [boolean, boolean]) => {
           if (doCosmeticBlocking) {
-            applyAdblockCosmeticFilters(action.tabId, getHostname(action.url), hide1pContent)
+            applyAdblockCosmeticFilters(action.tabId, action.url, hide1pContent)
           }
         })
         .catch(() => {

--- a/components/brave_extension/extension/brave_extension/content_cosmetic.ts
+++ b/components/brave_extension/extension/brave_extension/content_cosmetic.ts
@@ -507,7 +507,7 @@ const startObserving = () => {
 
 let _hasDelayOcurred: boolean = false
 let _startCheckingId: number | undefined = undefined
-const scheduleQueuePump = (hide1pContent: boolean) => {
+const scheduleQueuePump = (hide1pContent: boolean, generichide: boolean) => {
   // Three states possible here.  First, the delay has already occurred.  If so,
   // pass through to pumpCosmeticFilterQueues immediately.
   if (_hasDelayOcurred === true) {
@@ -523,7 +523,9 @@ const scheduleQueuePump = (hide1pContent: boolean) => {
   // called, in which case set up a timmer and quit
   _startCheckingId = window.requestIdleCallback(function ({ didTimeout }) {
     _hasDelayOcurred = true
-    startObserving()
+    if (!generichide) {
+      startObserving()
+    }
     if (!hide1pContent) {
       pumpCosmeticFilterQueuesOnIdle()
     }
@@ -535,7 +537,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (action) {
     case 'cosmeticFilteringBackgroundReady': {
       injectScriptlet(msg.scriptlet)
-      scheduleQueuePump(msg.hide1pContent)
+      scheduleQueuePump(msg.hide1pContent, msg.generichide)
       break
     }
     case 'cosmeticFilterConsiderNewSelectors': {
@@ -560,7 +562,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         // @ts-ignore
         document.adoptedStyleSheets = [cosmeticStyleSheet]
       }
-      scheduleQueuePump(false)
+      scheduleQueuePump(false, false)
       break
     }
   }

--- a/components/brave_extension/extension/brave_extension/types/actions/shieldsPanelActions.ts
+++ b/components/brave_extension/extension/brave_extension/types/actions/shieldsPanelActions.ts
@@ -188,7 +188,8 @@ interface CosmeticFilterRuleExceptionsReturn {
   type: types.COSMETIC_FILTER_RULE_EXCEPTIONS,
   tabId: number,
   exceptions: string[],
-  scriptlet: string
+  scriptlet: string,
+  generichide: boolean
 }
 
 export interface CosmeticFilterRuleExceptions {

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -197,10 +197,10 @@ bool AdBlockBaseService::TagExists(const std::string& tag) {
   return std::find(tags_.begin(), tags_.end(), tag) != tags_.end();
 }
 
-base::Optional<base::Value> AdBlockBaseService::HostnameCosmeticResources(
-        const std::string& hostname) {
+base::Optional<base::Value> AdBlockBaseService::UrlCosmeticResources(
+        const std::string& url) {
   return base::JSONReader::Read(
-          this->ad_block_client_->hostnameCosmeticResources(hostname));
+          this->ad_block_client_->urlCosmeticResources(url));
 }
 
 base::Optional<base::Value> AdBlockBaseService::HiddenClassIdSelectors(

--- a/components/brave_shields/browser/ad_block_base_service.h
+++ b/components/brave_shields/browser/ad_block_base_service.h
@@ -50,8 +50,8 @@ class AdBlockBaseService : public BaseBraveShieldsService {
   void EnableTag(const std::string& tag, bool enabled);
   bool TagExists(const std::string& tag);
 
-  base::Optional<base::Value> HostnameCosmeticResources(
-          const std::string& hostname);
+  base::Optional<base::Value> UrlCosmeticResources(
+          const std::string& url);
   base::Optional<base::Value> HiddenClassIdSelectors(
           const std::vector<std::string>& classes,
           const std::vector<std::string>& ids,

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -192,18 +192,18 @@ void AdBlockRegionalServiceManager::EnableFilterList(const std::string& uuid,
 }
 
 base::Optional<base::Value>
-AdBlockRegionalServiceManager::HostnameCosmeticResources(
-        const std::string& hostname) {
+AdBlockRegionalServiceManager::UrlCosmeticResources(
+        const std::string& url) {
   auto it = this->regional_services_.begin();
   if (it == this->regional_services_.end()) {
     return base::Optional<base::Value>();
   }
   base::Optional<base::Value> first_value =
-      it->second->HostnameCosmeticResources(hostname);
+      it->second->UrlCosmeticResources(url);
 
   for ( ; it != this->regional_services_.end(); it++) {
     base::Optional<base::Value> next_value =
-        it->second->HostnameCosmeticResources(hostname);
+        it->second->UrlCosmeticResources(url);
     if (first_value) {
       if (next_value) {
         MergeResourcesInto(&*first_value, &*next_value, false);

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -55,8 +55,8 @@ class AdBlockRegionalServiceManager {
   void AddResources(const std::string& resources);
   void EnableFilterList(const std::string& uuid, bool enabled);
 
-  base::Optional<base::Value> HostnameCosmeticResources(
-          const std::string& hostname);
+  base::Optional<base::Value> UrlCosmeticResources(
+          const std::string& url);
   base::Optional<base::Value> HiddenClassIdSelectors(
           const std::vector<std::string>& classes,
           const std::vector<std::string>& ids,

--- a/components/brave_shields/browser/ad_block_service_helper.cc
+++ b/components/brave_shields/browser/ad_block_service_helper.cc
@@ -46,8 +46,8 @@ std::vector<FilterList>::const_iterator FindAdBlockFilterListByLocale(
       });
 }
 
-// Merges the contents of the second HostnameCosmeticResources Value into the
-// first one provided.
+// Merges the contents of the second UrlCosmeticResources Value into the first
+// one provided.
 //
 // If `force_hide` is true, the contents of `from`'s `hide_selectors` field
 // will be moved into a possibly new field of `into` called
@@ -113,6 +113,15 @@ void MergeResourcesInto(
             resources_injected_script->GetString()
             + '\n'
             + from_resources_injected_script->GetString());
+  }
+
+  base::Value* resources_generichide = into->FindKey("generichide");
+  base::Value* from_resources_generichide =
+      from->FindKey("generichide");
+  if (from_resources_generichide) {
+    if (from_resources_generichide->GetBool()) {
+      *resources_generichide = base::Value(true);
+    }
   }
 }
 

--- a/components/brave_shields/browser/cosmetic_merge_unittest.cc
+++ b/components/brave_shields/browser/cosmetic_merge_unittest.cc
@@ -47,14 +47,16 @@ const char EMPTY_RESOURCES[] = "{"
     "\"hide_selectors\": [], "
     "\"style_selectors\": {}, "
     "\"exceptions\": [], "
-    "\"injected_script\": \"\""
+    "\"injected_script\": \"\", "
+    "\"generichide\": false"
 "}";
 
 const char NONEMPTY_RESOURCES[] = "{"
     "\"hide_selectors\": [\"a\", \"b\"], "
     "\"style_selectors\": {\"c\": \"color: #fff\", \"d\": \"color: #000\"}, "
     "\"exceptions\": [\"e\", \"f\"], "
-    "\"injected_script\": \"console.log('g')\""
+    "\"injected_script\": \"console.log('g')\", "
+    "\"generichide\": false"
 "}";
 
 TEST_F(CosmeticResourceMergeTest, MergeTwoEmptyResources) {
@@ -67,7 +69,8 @@ TEST_F(CosmeticResourceMergeTest, MergeTwoEmptyResources) {
       "\"hide_selectors\": [], "
       "\"style_selectors\": {}, "
       "\"exceptions\": [], "
-      "\"injected_script\": \"\n\""
+      "\"injected_script\": \"\n\", "
+      "\"generichide\": false"
   "}";
 
   CompareMergeFromStrings(a, b, false, expected);
@@ -83,7 +86,8 @@ TEST_F(CosmeticResourceMergeTest, MergeEmptyIntoNonEmpty) {
       "\"hide_selectors\": [\"a\", \"b\"], "
       "\"style_selectors\": {\"c\": \"color: #fff\", \"d\": \"color: #000\"}, "
       "\"exceptions\": [\"e\", \"f\"], "
-      "\"injected_script\": \"console.log('g')\n\""
+      "\"injected_script\": \"console.log('g')\n\", "
+      "\"generichide\": false"
   "}";
 
   CompareMergeFromStrings(a, b, false, expected);
@@ -99,7 +103,8 @@ TEST_F(CosmeticResourceMergeTest, MergeNonEmptyIntoEmpty) {
       "\"hide_selectors\": [\"a\", \"b\"],"
       "\"style_selectors\": {\"c\": \"color: #fff\", \"d\": \"color: #000\"}, "
       "\"exceptions\": [\"e\", \"f\"], "
-      "\"injected_script\": \"\nconsole.log('g')\""
+      "\"injected_script\": \"\nconsole.log('g')\", "
+      "\"generichide\": false"
   "}";
 
   CompareMergeFromStrings(a, b, false, expected);
@@ -111,7 +116,8 @@ TEST_F(CosmeticResourceMergeTest, MergeNonEmptyIntoNonEmpty) {
       "\"hide_selectors\": [\"h\", \"i\"], "
       "\"style_selectors\": {\"j\": \"color: #eee\", \"k\": \"color: #111\"}, "
       "\"exceptions\": [\"l\", \"m\"], "
-      "\"injected_script\": \"console.log('n')\""
+      "\"injected_script\": \"console.log('n')\", "
+      "\"generichide\": false"
   "}";
 
   const std::string expected = "{"
@@ -123,7 +129,8 @@ TEST_F(CosmeticResourceMergeTest, MergeNonEmptyIntoNonEmpty) {
           "\"k\": \"color: #111\""
       "}, "
       "\"exceptions\": [\"e\", \"f\", \"l\", \"m\"], "
-      "\"injected_script\": \"console.log('g')\nconsole.log('n')\""
+      "\"injected_script\": \"console.log('g')\nconsole.log('n')\", "
+      "\"generichide\": false"
   "}";
 
   CompareMergeFromStrings(a, b, false, expected);
@@ -140,6 +147,7 @@ TEST_F(CosmeticResourceMergeTest, MergeEmptyForceHide) {
       "\"style_selectors\": {}, "
       "\"exceptions\": [], "
       "\"injected_script\": \"\n\","
+      "\"generichide\": false, "
       "\"force_hide_selectors\": []"
   "}";
 
@@ -152,7 +160,8 @@ TEST_F(CosmeticResourceMergeTest, MergeNonEmptyForceHide) {
       "\"hide_selectors\": [\"h\", \"i\"], "
       "\"style_selectors\": {\"j\": \"color: #eee\", \"k\": \"color: #111\"}, "
       "\"exceptions\": [\"l\", \"m\"], "
-      "\"injected_script\": \"console.log('n')\""
+      "\"injected_script\": \"console.log('n')\", "
+      "\"generichide\": false"
   "}";
 
   const std::string expected = "{"
@@ -165,10 +174,78 @@ TEST_F(CosmeticResourceMergeTest, MergeNonEmptyForceHide) {
       "}, "
       "\"exceptions\": [\"e\", \"f\", \"l\", \"m\"], "
       "\"injected_script\": \"console.log('g')\nconsole.log('n')\","
+      "\"generichide\": false, "
       "\"force_hide_selectors\": [\"h\", \"i\"]"
   "}";
 
   CompareMergeFromStrings(a, b, true, expected);
+}
+
+TEST_F(CosmeticResourceMergeTest, MergeNonGenerichideIntoGenerichide) {
+  const std::string a = "{"
+      "\"hide_selectors\": [], "
+      "\"style_selectors\": {}, "
+      "\"exceptions\": [], "
+      "\"injected_script\": \"\n\", "
+      "\"generichide\": true"
+  "}";
+  const std::string b = EMPTY_RESOURCES;
+
+  const std::string expected = "{"
+      "\"hide_selectors\": [], "
+      "\"style_selectors\": {}, "
+      "\"exceptions\": [], "
+      "\"injected_script\": \"\n\n\", "
+      "\"generichide\": true"
+  "}";
+
+  CompareMergeFromStrings(a, b, false, expected);
+}
+
+TEST_F(CosmeticResourceMergeTest, MergeGenerichideIntoNonGenerichide) {
+  const std::string a = NONEMPTY_RESOURCES;
+  const std::string b = "{"
+      "\"hide_selectors\": [\"h\", \"i\"], "
+      "\"style_selectors\": {\"j\": \"color: #eee\", \"k\": \"color: #111\"}, "
+      "\"exceptions\": [\"l\", \"m\"], "
+      "\"injected_script\": \"console.log('n')\", "
+      "\"generichide\": true"
+  "}";
+
+  const std::string expected = "{"
+      "\"hide_selectors\": [\"a\", \"b\", \"h\", \"i\"], "
+      "\"style_selectors\": {"
+          "\"c\": \"color: #fff\", "
+          "\"d\": \"color: #000\", "
+          "\"j\": \"color: #eee\", "
+          "\"k\": \"color: #111\""
+      "}, "
+      "\"exceptions\": [\"e\", \"f\", \"l\", \"m\"], "
+      "\"injected_script\": \"console.log('g')\nconsole.log('n')\", "
+      "\"generichide\": true"
+  "}";
+
+  CompareMergeFromStrings(a, b, false, expected);
+}
+
+TEST_F(CosmeticResourceMergeTest, MergeGenerichideIntoGenerichide) {
+  const std::string a = "{"
+      "\"hide_selectors\": [], "
+      "\"style_selectors\": {}, "
+      "\"exceptions\": [], "
+      "\"injected_script\": \"\", "
+      "\"generichide\": true"
+  "}";
+
+  const std::string expected = "{"
+      "\"hide_selectors\": [], "
+      "\"style_selectors\": {}, "
+      "\"exceptions\": [], "
+      "\"injected_script\": \"\n\", "
+      "\"generichide\": true"
+  "}";
+
+  CompareMergeFromStrings(a, a, false, expected);
 }
 
 

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -234,14 +234,15 @@ declare namespace chrome.braveShields {
   const onShieldsPanelShown: any
   const reportBrokenSite: any
 
-  interface HostnameSpecificResources {
+  interface UrlSpecificResources {
     hide_selectors: string[]
     style_selectors: any
     exceptions: string[]
     injected_script: string
     force_hide_selectors: string[]
+    generichide: boolean
   }
-  const hostnameCosmeticResources: (hostname: string, callback: (resources: HostnameSpecificResources) => void) => void
+  const urlCosmeticResources: (url: string, callback: (resources: UrlSpecificResources) => void) => void
   const hiddenClassIdSelectors: (classes: string[], ids: string[], exceptions: string[], callback: (selectors: string[], forceHideSelectors: string[]) => void) => void
 
   type BraveShieldsViewPreferences = {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/8803

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Visit http://raymondhill.net/ublock/tiles1.html in a new tab
- Set the first dropdown to "Trackers & ads blocked (aggressive)"
- Refresh the page. Observe that the tile on the right is **green**.
- In a new tab, open brave://adblock and add the following to the "Custom Filters" box:
```
@@||raymondhill.net^$generichide
```
- Return to http://raymondhill.net/ublock/tiles1.html. Refresh the page. The tile on the right should be **red**.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
