### PR TITLE
Do not reverse rewrite the webtorrent URL when query string is not HT…

### DIFF
--- a/components/brave_webtorrent/browser/content_browser_client_helper.h
+++ b/components/brave_webtorrent/browser/content_browser_client_helper.h
@@ -52,7 +52,8 @@ static bool HandleTorrentURLReverseRewrite(GURL* url,
     content::BrowserContext* browser_context) {
   if (url->SchemeIs(extensions::kExtensionScheme) &&
       url->host() == brave_webtorrent_extension_id &&
-      url->ExtractFileName() == "brave_webtorrent.html") {
+      url->ExtractFileName() == "brave_webtorrent.html" &&
+      GURL(url->query()).SchemeIsHTTPOrHTTPS()) {
     *url =  TranslateTorrentUIURLReversed(*url);
     return true;
   }
@@ -72,7 +73,8 @@ static bool HandleTorrentURLRewrite(GURL* url,
   if (url->SchemeIsHTTPOrHTTPS() ||
       (url->SchemeIs(extensions::kExtensionScheme) &&
        url->host() == brave_webtorrent_extension_id &&
-       url->ExtractFileName() == "brave_webtorrent.html")) {
+       url->ExtractFileName() == "brave_webtorrent.html" &&
+       GURL(url->query()).SchemeIsHTTPOrHTTPS())) {
     return true;
   }
 


### PR DESCRIPTION
…TP/HTTPS URL.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9159

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Access https://webtorrent.io/torrents/sintel.torrent to make sure webtorrent is enabled and loaded.
2. Open a new tab and put `chrome-extension://lgjmpdmojkpocjcopdikifhejkkjglho/extension/brave_webtorrent.html?chrome://settings/` in the URL bar, then click enter.
3. A blank webtorrent extension page should be shown and URL stays the same as the URL in step 2.
4. Open a new tab and put `chrome-extension://lgjmpdmojkpocjcopdikifhejkkjglho/extension/brave_webtorrent.html?brave://rewards/` in the URL bar, then click enter.
5. A blank webtorrent extension page should be shown and URL stays the same as the URL in step 4.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
