### PR TITLE
bug: Ensure usage pings sent on browser upgrade (uplift to 1.10.x)

### DIFF
--- a/browser/brave_stats_updater.cc
+++ b/browser/brave_stats_updater.cc
@@ -79,7 +79,8 @@ void BraveStatsUpdater::Start() {
   DCHECK(!server_ping_startup_timer_);
   server_ping_startup_timer_ = std::make_unique<base::OneShotTimer>();
 #if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
-  if (pref_service_->GetBoolean(kReferralInitialization)) {
+  if (pref_service_->GetBoolean(kReferralInitialization) ||
+        pref_service_->GetBoolean(kReferralCheckedForPromoCodeFile)) {
     StartServerPingStartupTimer();
   } else {
     pref_change_registrar_.reset(new PrefChangeRegistrar());


### PR DESCRIPTION
Uplift of #5635
Fixes https://github.com/brave/brave-browser/issues/9921

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.