### PR TITLE
Allows send/save cookies for access token route [Binance] (uplift to 1.10.x)

### DIFF
--- a/components/binance/browser/binance_service.cc
+++ b/components/binance/browser/binance_service.cc
@@ -155,7 +155,7 @@ bool BinanceService::GetAccessToken(GetAccessTokenCallback callback) {
   url = net::AppendQueryParameter(url, "redirect_uri", oauth_callback);
   auth_token_.clear();
   return OAuthRequest(
-      base_url, "POST", url.query(), std::move(internal_callback), true);
+      base_url, "POST", url.query(), std::move(internal_callback), true, true);
 }
 
 bool BinanceService::GetAccountBalances(GetAccountBalancesCallback callback) {
@@ -163,7 +163,8 @@ bool BinanceService::GetAccountBalances(GetAccountBalancesCallback callback) {
       base::Unretained(this), std::move(callback));
   GURL url = GetURLWithPath(oauth_host_, oauth_path_account_balances);
   url = net::AppendQueryParameter(url, "access_token", access_token_);
-  return OAuthRequest(url, "GET", "", std::move(internal_callback), true);
+  return OAuthRequest(
+      url, "GET", "", std::move(internal_callback), true, false);
 }
 
 void BinanceService::OnGetAccountBalances(GetAccountBalancesCallback callback,
@@ -196,13 +197,18 @@ bool BinanceService::OAuthRequest(const GURL &url,
                                   const std::string& method,
                                   const std::string& post_data,
                                   URLRequestCallback callback,
-                                  bool auto_retry_on_network_change) {
+                                  bool auto_retry_on_network_change,
+                                  bool send_save_cookies) {
   auto request = std::make_unique<network::ResourceRequest>();
   request->url = url;
-  request->load_flags = net::LOAD_DO_NOT_SEND_COOKIES |
-                        net::LOAD_DO_NOT_SAVE_COOKIES |
-                        net::LOAD_BYPASS_CACHE |
+  request->load_flags = net::LOAD_BYPASS_CACHE |
                         net::LOAD_DISABLE_CACHE;
+
+  if (!send_save_cookies) {
+    request->load_flags |= net::LOAD_DO_NOT_SEND_COOKIES;
+    request->load_flags |= net::LOAD_DO_NOT_SAVE_COOKIES;
+  }
+
   request->method = method;
 
   auto url_loader = network::SimpleURLLoader::Create(
@@ -352,7 +358,8 @@ bool BinanceService::GetConvertQuote(
   url = net::AppendQueryParameter(url, "baseAsset", from);
   url = net::AppendQueryParameter(url, "amount", amount);
   url = net::AppendQueryParameter(url, "access_token", access_token_);
-  return OAuthRequest(url, "POST", "", std::move(internal_callback), true);
+  return OAuthRequest(
+      url, "POST", "", std::move(internal_callback), true, false);
 }
 
 void BinanceService::OnGetConvertQuote(
@@ -374,7 +381,8 @@ bool BinanceService::GetCoinNetworks(GetCoinNetworksCallback callback) {
   auto internal_callback = base::BindOnce(&BinanceService::OnGetCoinNetworks,
       base::Unretained(this), std::move(callback));
   GURL url = GetURLWithPath(gateway_host_, gateway_path_networks);
-  return OAuthRequest(url, "GET", "", std::move(internal_callback), true);
+  return OAuthRequest(
+      url, "GET", "", std::move(internal_callback), true, false);
 }
 
 void BinanceService::OnGetCoinNetworks(
@@ -397,7 +405,8 @@ bool BinanceService::GetDepositInfo(const std::string& symbol,
   url = net::AppendQueryParameter(url, "coin", symbol);
   url = net::AppendQueryParameter(url, "network", ticker_network);
   url = net::AppendQueryParameter(url, "access_token", access_token_);
-  return OAuthRequest(url, "GET", "", std::move(internal_callback), true);
+  return OAuthRequest(
+      url, "GET", "", std::move(internal_callback), true, false);
 }
 
 void BinanceService::OnGetDepositInfo(
@@ -423,7 +432,8 @@ bool BinanceService::ConfirmConvert(const std::string& quote_id,
   GURL url = GetURLWithPath(oauth_host_, oauth_path_convert_confirm);
   url = net::AppendQueryParameter(url, "quoteId", quote_id);
   url = net::AppendQueryParameter(url, "access_token", access_token_);
-  return OAuthRequest(url, "POST", "", std::move(internal_callback), false);
+  return OAuthRequest(
+      url, "POST", "", std::move(internal_callback), false, false);
 }
 
 void BinanceService::OnConfirmConvert(
@@ -446,7 +456,8 @@ bool BinanceService::GetConvertAssets(GetConvertAssetsCallback callback) {
       base::Unretained(this), std::move(callback));
   GURL url = GetURLWithPath(oauth_host_, oauth_path_convert_assets);
   url = net::AppendQueryParameter(url, "access_token", access_token_);
-  return OAuthRequest(url, "GET", "", std::move(internal_callback), true);
+  return OAuthRequest(
+      url, "GET", "", std::move(internal_callback), true, false);
 }
 
 void BinanceService::OnGetConvertAssets(GetConvertAssetsCallback callback,
@@ -466,7 +477,8 @@ bool BinanceService::RevokeToken(RevokeTokenCallback callback) {
       base::Unretained(this), std::move(callback));
   GURL url = GetURLWithPath(oauth_host_, oauth_path_revoke_token);
   url = net::AppendQueryParameter(url, "access_token", access_token_);
-  return OAuthRequest(url, "POST", "", std::move(internal_callback), true);
+  return OAuthRequest(
+      url, "POST", "", std::move(internal_callback), true, false);
 }
 
 void BinanceService::OnRevokeToken(RevokeTokenCallback callback,

--- a/components/binance/browser/binance_service.h
+++ b/components/binance/browser/binance_service.h
@@ -134,7 +134,7 @@ class BinanceService : public KeyedService {
         const std::map<std::string, std::string>& headers);
   bool OAuthRequest(const GURL& url, const std::string& method,
       const std::string& post_data, URLRequestCallback callback,
-      bool auto_retry_on_network_change);
+      bool auto_retry_on_network_change, bool save_send_cookies);
   bool LoadTokensFromPrefs();
   void OnURLLoaderComplete(
       SimpleURLLoaderList::iterator iter,

--- a/components/binance/browser/binance_service.h
+++ b/components/binance/browser/binance_service.h
@@ -133,7 +133,8 @@ class BinanceService : public KeyedService {
         const int status, const std::string& body,
         const std::map<std::string, std::string>& headers);
   bool OAuthRequest(const GURL& url, const std::string& method,
-      const std::string& post_data, URLRequestCallback callback);
+      const std::string& post_data, URLRequestCallback callback,
+      bool auto_retry_on_network_change);
   bool LoadTokensFromPrefs();
   void OnURLLoaderComplete(
       SimpleURLLoaderList::iterator iter,


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/5607
To avoid merge conflicts, this also had to be pulled in: https://github.com/brave/brave-core/pull/5543
Fixes https://github.com/brave/brave-browser/issues/9863
Fixes https://github.com/brave/brave-browser/issues/9377

# Why is this being requested for uplift?

If a user does the oauth flow on the Binance widget, but creates a new account, they will not be logged in.  This looks like a bug to the user for new users. This regressed with the 1.9.x release because of the ref code change we pulled in.

# If approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

# After you merge: 

- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.