### PR TITLE
Fixed Saved Passwords section in settings is empty

### DIFF
--- a/chromium_src/components/password_manager/core/browser/login_database.cc
+++ b/chromium_src/components/password_manager/core/browser/login_database.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define BRAVE_STATEMENT_TO_FORMS \
+    if (result == ENCRYPTION_RESULT_SERVICE_FAILURE) \
+      result = ENCRYPTION_RESULT_ITEM_FAILURE;
+
+#include "../../../../../../components/password_manager/core/browser/login_database.cc"
+
+#undef BRAVE_STATEMENT_TO_FORMS

--- a/patches/components-password_manager-core-browser-login_database.cc.patch
+++ b/patches/components-password_manager-core-browser-login_database.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/password_manager/core/browser/login_database.cc b/components/password_manager/core/browser/login_database.cc
+index c0672306d732423749f44f7fae19e36dac826cca..cdf2626680670e1f5f26a3420aae9b26939d6027 100644
+--- a/components/password_manager/core/browser/login_database.cc
++++ b/components/password_manager/core/browser/login_database.cc
+@@ -1839,6 +1839,7 @@ FormRetrievalResult LoginDatabase::StatementToForms(
+     EncryptionResult result = InitPasswordFormFromStatement(
+         *statement, /*decrypt_and_fill_password_value=*/true, &primary_key,
+         new_form.get());
++    BRAVE_STATEMENT_TO_FORMS
+     if (result == ENCRYPTION_RESULT_SERVICE_FAILURE)
+       return FormRetrievalResult::kEncrytionServiceFailure;
+     if (result == ENCRYPTION_RESULT_ITEM_FAILURE) {


### PR DESCRIPTION
Some users reported that Saved Passwords sections is empty but passwords are autofilled
to website's password form on linux and macOS.

I think this can happen if user insert/update new password entries after login db encryption
is corrupted.
However, currently user can't anything even if current login db has decryptable entries.

The reason is LoginDatabase::StatementToForms() gives empty password entry when any entry in
login db has decryption failure on linux and macOS.

To fix this, ENCRYPTION_RESULT_ITEM_FAILURE is used for individual decryption failure
instead of ENCRYPTION_RESULT_SERVICE_FAILURE.

If ENCRYPTION_RESULT_SERVICE_FAILURE is returned, LoginDatabase::StatementToForms() assumes
all other entries will have decrypt failure. However, db could have decryptable entries
even if current entry is failed to decrypt.
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/3196

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Save some passwords by using Chrome and copy chrome's `Login Data` in user's profile folder to Brave's folder
2. Launch Brave and checks Saved Passwords section(brave://settings/passwords) is empty
3. Update some passwords by revisiting some websites
4. Check Saved Passwords section displays newly added passwords

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
