### PR TITLE
cr83 followup: fixes notarization on MacOS.

### DIFF
--- a/build/mac/notarize_dmg_pkg.py
+++ b/build/mac/notarize_dmg_pkg.py
@@ -67,7 +67,7 @@ def create_config(config_args, development, mac_provisioning_profile):
 
         config_class = DevelopmentCodeSignConfig
 
-    config_class = GetBraveSigningConfig(config_class, development, mac_provisioning_profile)
+    config_class = GetBraveSigningConfig(config_class, mac_provisioning_profile)
     return config_class(*config_args)
 
 

--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -120,7 +120,7 @@ def AddBravePartsForSigning(parts, config):
     return parts
 
 
-def GetBraveSigningConfig(config_class):
+def GetBraveSigningConfig(config_class, mac_provisioning_profile=None):
     class ConfigNonChromeBranded(config_class):
 
         @staticmethod
@@ -129,9 +129,13 @@ def GetBraveSigningConfig(config_class):
 
     config_class = ConfigNonChromeBranded
 
-    # Retrieve provisioning profile exported by build/mac/sign_app.sh
-    # If not set, then it's development config.
-    provisioning_profile = os.environ['MAC_PROVISIONING_PROFILE']
+    if mac_provisioning_profile is not None:
+        provisioning_profile = mac_provisioning_profile
+    else:
+        # Retrieve provisioning profile exported by build/mac/sign_app.sh
+        provisioning_profile = os.environ['MAC_PROVISIONING_PROFILE']
+
+    # If provisioning_profile is not set, then it's development config.
     if not len(provisioning_profile):
         return config_class
 


### PR DESCRIPTION
Fixes brave/brave-browser#9971

- Restored provisioning profile param in `GetBraveSigningConfig`.
- Updated notarization script to not pass `development` param to `GetBraveSigningConfig`.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
