### PR TITLE
Use a delegate for BraveComponentLoader usage in Crypto Wallets (uplift to 1.10.x)

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -4,8 +4,10 @@ assert(brave_wallet_enabled)
 
 source_set("brave_wallet") {
   sources = [
-    "brave_wallet_service_factory.h",
+    "brave_wallet_delegate_impl.cc",
+    "brave_wallet_delegate_impl.h",
     "brave_wallet_service_factory.cc",
+    "brave_wallet_service_factory.h",
     "brave_wallet_utils.cc",
     "brave_wallet_utils.h",
   ]

--- a/browser/brave_wallet/brave_wallet_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_delegate_impl.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
++ * This Source Code Form is subject to the terms of the Mozilla Public
++ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
++ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_wallet/brave_wallet_delegate_impl.h"
+
+#include "brave/browser/extensions/brave_component_loader.h"
+#include "chrome/browser/extensions/extension_service.h"
+#include "content/public/browser/browser_context.h"
+#include "extensions/browser/extension_system.h"
+
+BraveWalletDelegateImpl::~BraveWalletDelegateImpl() {
+}
+
+void BraveWalletDelegateImpl::LoadCryptoWalletsExtension(
+    content::BrowserContext* context) {
+  extensions::ExtensionService* service =
+      extensions::ExtensionSystem::Get(context)->extension_service();
+  if (service) {
+    extensions::ComponentLoader* loader = service->component_loader();
+    static_cast<extensions::BraveComponentLoader*>(loader)->
+        AddEthereumRemoteClientExtension();
+  }
+}

--- a/browser/brave_wallet/brave_wallet_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_delegate_impl.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_DELEGATE_IMPL_H_
+#define BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_DELEGATE_IMPL_H_
+
+#include "brave/components/brave_wallet/browser/brave_wallet_delegate.h"
+
+class BraveWalletDelegateImpl : public BraveWalletDelegate {
+ public:
+  ~BraveWalletDelegateImpl() override;
+  void LoadCryptoWalletsExtension(content::BrowserContext* context) override;
+};
+
+#endif  // BRAVE_BROWSER_BRAVE_WALLET_BRAVE_WALLET_DELEGATE_IMPL_H_

--- a/browser/brave_wallet/brave_wallet_service_factory.cc
+++ b/browser/brave_wallet/brave_wallet_service_factory.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "brave/browser/brave_wallet/brave_wallet_delegate_impl.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
@@ -34,7 +35,8 @@ BraveWalletServiceFactory::~BraveWalletServiceFactory() {
 
 KeyedService* BraveWalletServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  return new BraveWalletService(Profile::FromBrowserContext(context));
+  return new BraveWalletService(Profile::FromBrowserContext(context),
+      std::make_unique<BraveWalletDelegateImpl>());
 }
 
 content::BrowserContext* BraveWalletServiceFactory::GetBrowserContextToUse(

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -9,6 +9,7 @@ source_set("browser") {
     ]
 
     sources = [
+        "brave_wallet_delegate.h",
         "brave_wallet_service.h",
         "brave_wallet_service.cc",
     ]

--- a/components/brave_wallet/browser/brave_wallet_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_delegate.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
++ * This Source Code Form is subject to the terms of the Mozilla Public
++ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
++ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_DELEGATE_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_DELEGATE_H_
+
+namespace content {
+class BrowserContext;
+}  // namespace content
+
+class BraveWalletDelegate {
+ public:
+  virtual ~BraveWalletDelegate() = default;
+  virtual void LoadCryptoWalletsExtension(content::BrowserContext* context) = 0;
+};
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_DELEGATE_H_

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -26,6 +26,7 @@
 #include "extensions/browser/extension_registry_observer.h"
 #include "url/gurl.h"
 
+class BraveWalletDelegate;
 class PrefChangeRegistrar;
 class PrefService;
 
@@ -41,7 +42,8 @@ class BrowserContext;
 class BraveWalletService : public KeyedService,
     public extensions::ExtensionRegistryObserver {
  public:
-  explicit BraveWalletService(content::BrowserContext* context);
+  explicit BraveWalletService(content::BrowserContext* context,
+      std::unique_ptr<BraveWalletDelegate> brave_wallet_delegate);
   ~BraveWalletService() override;
   using LoadUICallback = base::OnceCallback<void()>;
 
@@ -81,6 +83,7 @@ class BraveWalletService : public KeyedService,
 
   content::BrowserContext* context_;
   std::unique_ptr<PrefChangeRegistrar> pref_change_registrar_;
+  std::unique_ptr<BraveWalletDelegate> brave_wallet_delegate_;
   ScopedObserver<extensions::ExtensionRegistry,
       extensions::ExtensionRegistryObserver> extension_registry_observer_{this};
   scoped_refptr<base::SequencedTaskRunner> file_task_runner_;


### PR DESCRIPTION
Uplift of #5675
Resolves https://github.com/brave/brave-browser/issues/9973

# Why is this needed?

It's not needed, but if it's not included builds can intermittently fail. That might cause a build failure when we're waiting for builds and cause delays down the line. 

# Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

# After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.