### PR TITLE
test: Simulate Sentinel value caching

### DIFF
--- a/browser/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats_updater_browsertest.cc
@@ -54,6 +54,9 @@ class BraveStatsUpdaterBrowserTest : public InProcessBrowserTest {
         testing_local_state_.registry());
     InitEmbeddedTestServer();
     SetBaseUpdateURLForTest();
+    // Simulate sentinel file creation as if chrome_browser_main.h was called,
+    // which reads in the sentinel value and caches it.
+    brave::BraveStatsUpdaterParams::SetFirstRunForTest(true);
   }
 
   void InitEmbeddedTestServer() {

--- a/browser/brave_stats_updater_params.cc
+++ b/browser/brave_stats_updater_params.cc
@@ -77,10 +77,12 @@ void BraveStatsUpdaterParams::LoadPrefs() {
   week_of_installation_ = pref_service_->GetString(kWeekOfInstallation);
   if (week_of_installation_.empty())
     week_of_installation_ = GetLastMondayAsYMD();
-  date_of_installation_ = brave::GetFirstRunTime(pref_service_);
-  DCHECK(!date_of_installation_.is_null());
-  if (ShouldForceFirstRun())
+  if (ShouldForceFirstRun()) {
     date_of_installation_ = GetCurrentTimeNow();
+  } else {
+    date_of_installation_ = brave::GetFirstRunTime(pref_service_);
+    DCHECK(!date_of_installation_.is_null());
+  }
 #if BUILDFLAG(ENABLE_BRAVE_REFERRALS)
   referral_promo_code_ = pref_service_->GetString(kReferralPromoCode);
 #endif

--- a/browser/brave_stats_updater_params.h
+++ b/browser/brave_stats_updater_params.h
@@ -11,6 +11,7 @@
 #include "base/macros.h"
 #include "base/time/time.h"
 
+class BraveStatsUpdaterBrowserTest;
 class BraveStatsUpdaterTest;
 class PrefService;
 
@@ -36,6 +37,7 @@ class BraveStatsUpdaterParams {
   void SavePrefs();
 
  private:
+  friend class ::BraveStatsUpdaterBrowserTest;
   friend class ::BraveStatsUpdaterTest;
   PrefService* pref_service_;
   std::string ymd_;

--- a/browser/brave_stats_updater_unittest.cc
+++ b/browser/brave_stats_updater_unittest.cc
@@ -36,16 +36,13 @@ class BraveStatsUpdaterTest: public testing::Test {
     brave::RegisterPrefsForBraveStatsUpdater(testing_local_state_.registry());
     brave::RegisterPrefsForBraveReferralsService(
         testing_local_state_.registry());
+    brave::BraveStatsUpdaterParams::SetFirstRunForTest(true);
   }
 
   PrefService* GetLocalState() { return &testing_local_state_; }
 
   void SetCurrentTimeForTest(const base::Time& current_time) {
     brave::BraveStatsUpdaterParams::SetCurrentTimeForTest(current_time);
-  }
-
-  void SetFirstRunForTest(bool first_run) {
-    brave::BraveStatsUpdaterParams::SetFirstRunForTest(first_run);
   }
 
  private:
@@ -168,7 +165,6 @@ TEST_F(BraveStatsUpdaterTest, HasDateOfInstallationFirstRun) {
 
   ASSERT_TRUE(base::Time::FromLocalExploded(exploded, &current_time));
   SetCurrentTimeForTest(current_time);
-  SetFirstRunForTest(true);
 
   brave::BraveStatsUpdaterParams brave_stats_updater_params(
       GetLocalState(), kToday, kThisWeek, kThisMonth);


### PR DESCRIPTION
CreateSentinelIfNeeded() is called in
chrome/browser/chrome_browser_main.cc, and that calls
GetFirstRunSentinelCreationTime() and caches the result of that
operation. This means when we call the function again in
BraveStatsUpdaterParams, the call will never block. Change the tests to
have this behavior, because right now tests are timing out.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10130

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [b] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
No browser regressions. Just a test fix

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
