### PR TITLE
Fixes ads rewards are not refreshed after claiming an ad grant - 1.10.x

### DIFF
--- a/components/brave_rewards/browser/CHANGELOG.md
+++ b/components/brave_rewards/browser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ---
 
+### Changed API (5th June 2020)
+##### Related PR
+[https://github.com/brave/brave-core/pull/5748](https://github.com/brave/brave-core/pull/5748)
+##### Description
+With this PR we now pass `should_refresh`
+
+##### Change
+
+| | Old version | New version |
+|---|---|---|
+|  Signature    |  `UpdateAdsRewards`  | |
+|  Return value | | |
+|  Parameters   | | `const bool should_refresh` |
+
+---
+
 ### Changed API (11th November 2019)
 ##### Related PR
 [https://github.com/brave/brave-core/pull/3918](https://github.com/brave/brave-core/pull/3918)

--- a/components/services/bat_ledger/bat_ledger_impl.cc
+++ b/components/services/bat_ledger/bat_ledger_impl.cc
@@ -333,7 +333,7 @@ void BatLedgerImpl::SetAutoContribute(bool enabled) {
 }
 
 void BatLedgerImpl::UpdateAdsRewards() {
-  ledger_->UpdateAdsRewards();
+  ledger_->UpdateAdsRewards(false);
 }
 
 void BatLedgerImpl::OnTimer(uint32_t timer_id) {

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -149,7 +149,7 @@ class LEDGER_EXPORT Ledger {
 
   virtual void SetAutoContribute(bool enabled) = 0;
 
-  virtual void UpdateAdsRewards() = 0;
+  virtual void UpdateAdsRewards(const bool should_refresh) = 0;
 
   virtual uint64_t GetReconcileStamp() const = 0;
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.cc
@@ -1027,12 +1027,12 @@ void LedgerImpl::LogResponse(
     << "[ END RESPONSE ]";
 }
 
-void LedgerImpl::UpdateAdsRewards() {
+void LedgerImpl::UpdateAdsRewards(const bool should_refresh) {
   if (!IsConfirmationsRunning()) {
     return;
   }
 
-  bat_confirmations_->UpdateAdsRewards(false);
+  bat_confirmations_->UpdateAdsRewards(should_refresh);
 }
 
 void LedgerImpl::ResetReconcileStamp() {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl.h
@@ -145,7 +145,7 @@ class LedgerImpl : public ledger::Ledger {
 
   void SetAutoContribute(bool enabled) override;
 
-  void UpdateAdsRewards() override;
+  void UpdateAdsRewards(const bool should_refresh) override;
 
   void SavePendingContribution(
       ledger::PendingContributionList list,

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl_mock.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_impl_mock.h
@@ -107,7 +107,7 @@ class MockLedgerImpl : public LedgerImpl {
 
   MOCK_METHOD1(SetAutoContribute, void(bool));
 
-  MOCK_METHOD0(UpdateAdsRewards, void());
+  MOCK_METHOD1(UpdateAdsRewards, void(const bool));
 
   MOCK_METHOD2(SavePendingContribution,
       void(ledger::PendingContributionList,

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.cc
@@ -422,6 +422,10 @@ void Promotion::OnComplete(
         braveledger_time_util::GetCurrentYear(),
         ConvertPromotionTypeToReportType(promotion->type),
         promotion->approximate_value);
+
+    if (promotion->type == ledger::PromotionType::ADS) {
+      ledger_->UpdateAdsRewards(true);
+    }
   }
 
   callback(result, std::move(promotion));

--- a/vendor/brave-ios/Ledger/BATBraveLedger.mm
+++ b/vendor/brave-ios/Ledger/BATBraveLedger.mm
@@ -1466,7 +1466,7 @@ BATLedgerBridge(BOOL,
 
 - (void)updateAdsRewards
 {
-  ledger->UpdateAdsRewards();
+  ledger->UpdateAdsRewards(false);
 }
 
 - (void)adsDetailsForCurrentCycle:(void (^)(NSInteger adsReceived, double estimatedEarnings, NSDate *nextPaymentDate))completion


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/5748
Resolves https://github.com/brave/brave-browser/issues/10094

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
