### PR TITLE
Revert "Merge pull request #5803 from brave/safebrowsing_endpoint"

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/net/brave_static_redirect_network_delegate_helper.h"
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "brave/browser/translate/buildflags/buildflags.h"
@@ -66,8 +65,7 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
     return net::OK;
   }
 
-  if (!std::string(SAFEBROWSING_ENDPOINT).empty() &&
-      safeBrowsing_pattern.MatchesHost(request_url)) {
+  if (safeBrowsing_pattern.MatchesHost(request_url)) {
     replacements.SetHostStr(SAFEBROWSING_ENDPOINT);
     *new_url = request_url.ReplaceComponents(replacements);
     return net::OK;

--- a/patches/components-safe_browsing-core-db-v4_protocol_manager_util.cc.patch
+++ b/patches/components-safe_browsing-core-db-v4_protocol_manager_util.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/safe_browsing/core/db/v4_protocol_manager_util.cc b/components/safe_browsing/core/db/v4_protocol_manager_util.cc
+index c7f7915a745f055a9af76d6dad48ff6339f02d02..d3da69ff70f2b8feac875ba2e3032570620afb60 100644
+--- a/components/safe_browsing/core/db/v4_protocol_manager_util.cc
++++ b/components/safe_browsing/core/db/v4_protocol_manager_util.cc
+@@ -29,7 +29,7 @@ namespace safe_browsing {
+ // Can be overriden by tests.
+ const char* g_sbv4_url_prefix_for_testing = nullptr;
+ 
+-const char kSbV4UrlPrefix[] = "https://safebrowsing.googleapis.com/v4";
++const char kSbV4UrlPrefix[] = "https://safebrowsing.brave.com/v4";
+ 
+ const base::FilePath::CharType kStoreSuffix[] = FILE_PATH_LITERAL(".store");
+ 


### PR DESCRIPTION
This reverts commit 40b0cf3c66313782211d88daee8a256911a4a0e2, reversing
changes made to 2c8b5660d24ac9ef0df95326a08bfb2852155945.

Reverts fix for https://github.com/brave/brave-browser/issues/10182

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
