### PR TITLE
Don’t reenable a-c after wallet creation

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -789,7 +789,6 @@ void RewardsServiceImpl::OnWalletInitialized(ledger::Result result) {
 
   if (result == ledger::Result::WALLET_CREATED) {
     SetRewardsMainEnabled(true);
-    SetAutoContribute(true);
     StartNotificationTimers(true);
 
     // Record P3A:

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/create.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/create.cc
@@ -255,6 +255,7 @@ void Create::RegisterPersonaCallback(
 
   ledger_->SetWalletInfo(wallet_info);
   ledger_->SetContributionAmount(fee_amount);
+  ledger_->SetAutoContribute(true);
   ledger_->SetBootStamp(braveledger_time_util::GetCurrentTimeStamp());
   ledger_->ResetReconcileStamp();
   callback(ledger::Result::WALLET_CREATED);


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/9750

`RewardsServiceImpl::OnWalletInitialized` was called multiple times and for example if extension state is cleared (which can happen) we check wallet initialization when panel is called. When this happens `WALLET_CREATED` will be returned and AC will be turned ON. This PR moved this toggle flags into shared lib into a function that is called only once when wallet is successfully created.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
- enable rewrads
- make sure that AC is ON
- turn AC OFF
- clear extension state via dev tools
- reopen panel
- make sure that AC stays OFF

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
