### PR TITLE
Fixes brave_components_string.grd .pak names on iOS.

### DIFF
--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -45,7 +45,13 @@
     <output filename="brave_components_strings_en-GB.pak" type="data_package" lang="en-GB" />
     <output filename="brave_components_strings_en-US.pak" type="data_package" lang="en" />
     <output filename="brave_components_strings_es.pak" type="data_package" lang="es" />
-    <output filename="brave_components_strings_es-419.pak" type="data_package" lang="es-419" />
+    <if expr="is_ios">
+      <!-- iOS uses es-MX for es-419 -->
+      <output filename="brave_components_strings_es-MX.pak" type="data_package" lang="es-419" />
+    </if>
+    <if expr="not is_ios">
+      <output filename="brave_components_strings_es-419.pak" type="data_package" lang="es-419" />
+    </if>
     <output filename="brave_components_strings_et.pak" type="data_package" lang="et" />
     <output filename="brave_components_strings_fa.pak" type="data_package" lang="fa" />
     <output filename="brave_components_strings_fake-bidi.pak" type="data_package" lang="fake-bidi" />
@@ -72,7 +78,13 @@
          be 'nb'. -->
     <output filename="brave_components_strings_nb.pak" type="data_package" lang="no" />
     <output filename="brave_components_strings_pl.pak" type="data_package" lang="pl" />
-    <output filename="brave_components_strings_pt-BR.pak" type="data_package" lang="pt-BR" />
+    <if expr="is_ios">
+      <!-- iOS uses pt for pt-BR -->
+      <output filename="brave_components_strings_pt.pak" type="data_package" lang="pt-BR" />
+    </if>
+    <if expr="not is_ios">
+      <output filename="brave_components_strings_pt-BR.pak" type="data_package" lang="pt-BR" />
+    </if>
     <output filename="brave_components_strings_pt-PT.pak" type="data_package" lang="pt-PT" />
     <output filename="brave_components_strings_ro.pak" type="data_package" lang="ro" />
     <output filename="brave_components_strings_ru.pak" type="data_package" lang="ru" />


### PR DESCRIPTION
Fixes brave/brave-browser#10275

On iOS, the .pak name for es-419 is expected to be es-MX and for pt-BR -
just pt.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
