### PR TITLE
Brave extension: wait for content load 

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/api/shieldsAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/shieldsAPI.ts
@@ -13,6 +13,11 @@ import * as SettingsPrivate from '../../../../../common/settingsPrivate'
  * @return a promise with the corresponding shields panel data for the input tabData
  */
 export const getShieldSettingsForTabData = (tabData?: chrome.tabs.Tab) => {
+  // Supress data until page load completes
+  if (tabData && tabData.status === 'loading' && !tabData.url) {
+    return new Promise(r => r({}))
+  }
+
   if (tabData === undefined || !tabData.url) {
     return Promise.reject(new Error('No tab url specified'))
   }
@@ -20,6 +25,12 @@ export const getShieldSettingsForTabData = (tabData?: chrome.tabs.Tab) => {
   const url = new window.URL(tabData.url)
   const origin = url.origin
   const hostname = url.hostname
+  const protocol = url.protocol
+
+  // Check whether it is an internal page
+  if (protocol === 'chrome:') {
+    return new Promise(r => r({}))
+  }
 
   return Promise.all([
     chrome.braveShields.getBraveShieldsEnabledAsync(tabData.url),


### PR DESCRIPTION
Brave Extension used to flood error logs with message like:
> [Shields]: Can't request shields panel data. Error: No tab url
  specified

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10236

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
