### PR TITLE
Fix 10269: Do not proxy downloads for Widevine (uplift to 1.10.x)

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -36,6 +36,9 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
                                          kSafeBrowsingPrefix);
   static URLPattern safebrowsingfilecheck_pattern(URLPattern::SCHEME_HTTPS,
                                          kSafeBrowsingFileCheckPrefix);
+
+  // To-Do (@jumde) - Update the naming for the variables below
+  // https://github.com/brave/brave-browser/issues/10314
   static URLPattern crlSet_pattern1(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS, kCRLSetPrefix1);
   static URLPattern crlSet_pattern2(
@@ -53,6 +56,13 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
   static URLPattern googleDl_pattern(
       URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
       "*://dl.google.com/*");
+
+  static URLPattern widevine_gvt1_pattern(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+      kWidevineGvt1Prefix);
+  static URLPattern widevine_google_dl_pattern(
+      URLPattern::SCHEME_HTTP | URLPattern::SCHEME_HTTPS,
+      kWidevineGoogleDlPrefix);
 
 #if BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
   static URLPattern translate_pattern(URLPattern::SCHEME_HTTPS,
@@ -123,14 +133,16 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
     return net::OK;
   }
 
-  if (gvt1_pattern.MatchesURL(request_url)) {
+  if (gvt1_pattern.MatchesURL(request_url) &&
+      !widevine_gvt1_pattern.MatchesURL(request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr(kBraveRedirectorProxy);
     *new_url = request_url.ReplaceComponents(replacements);
     return net::OK;
   }
 
-  if (googleDl_pattern.MatchesURL(request_url)) {
+  if (googleDl_pattern.MatchesURL(request_url) &&
+      !widevine_google_dl_pattern.MatchesURL(request_url)) {
     replacements.SetSchemeStr("https");
     replacements.SetHostStr(kBraveRedirectorProxy);
     *new_url = request_url.ReplaceComponents(replacements);

--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/strings/string_util.h"
 #include "brave/browser/net/url_context.h"
 #include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/network_constants.h"
@@ -235,6 +236,33 @@ TEST(BraveStaticRedirectNetworkDelegateHelperTest, ModifyGoogleDl) {
   int rc =
       OnBeforeURLRequest_StaticRedirectWork(ResponseCallback(), request_info);
   EXPECT_EQ(request_info->new_url_spec, expected_url);
+  EXPECT_EQ(rc, net::OK);
+}
+
+TEST(BraveStaticRedirectNetworkDelegateHelperTest, DontModifyGvt1ForWidevine) {
+  const GURL url(
+      "http://r2---sn-n4v7sn7y.gvt1.com/edgedl/chromewebstore/"
+      "L2Nocm9tZV9leHRlbnNpb24vYmxvYnMvYjYxQUFXaFBmeUtPbVFUYUh"
+      "mRGV0MS1Wdw/4.10.1610.0_oimompecagnajdejgnnjijobebaeigek"
+      ".crx");
+  auto request_info = std::make_shared<brave::BraveRequestInfo>(url);
+  int rc =
+      OnBeforeURLRequest_StaticRedirectWork(ResponseCallback(), request_info);
+  EXPECT_EQ(request_info->new_url_spec, "");
+  EXPECT_EQ(rc, net::OK);
+}
+
+TEST(BraveStaticRedirectNetworkDelegateHelperTest,
+     DontModifyGoogleDlForWidevine) {
+  const GURL url(
+      "http://dl.google.com/edgedl/chromewebstore/"
+      "L2Nocm9tZV9leHRlbnNpb24vYmxvYnMvYjYxQUFXaFBmeUtPbVFUYUh"
+      "mRGV0MS1Wdw/4.10.1610.0_oimompecagnajdejgnnjijobebaeigek"
+      ".crx");
+  auto request_info = std::make_shared<brave::BraveRequestInfo>(url);
+  int rc =
+      OnBeforeURLRequest_StaticRedirectWork(ResponseCallback(), request_info);
+  EXPECT_EQ(request_info->new_url_spec, "");
   EXPECT_EQ(rc, net::OK);
 }
 

--- a/common/network_constants.cc
+++ b/common/network_constants.cc
@@ -49,6 +49,12 @@ const char kCRLSetPrefix4[] =
     "/*crxd";
 const char kChromeCastPrefix[] =
     "*://*.gvt1.com/edgedl/chromewebstore/*pkedcjkdefgpdelpbcmbmeomcjbeemfm*";
+
+const char kWidevineGvt1Prefix[] =
+    "*://*.gvt1.com/*oimompecagnajdejgnnjijobebaeigek*";
+const char kWidevineGoogleDlPrefix[] =
+    "*://dl.google.com/*oimompecagnajdejgnnjijobebaeigek*";
+
 const char kForbesPattern[] = "https://www.forbes.com/*";
 const char kForbesExtraCookies[] =
     "forbes_ab=true; welcomeAd=true; adblock_session=Off; "

--- a/common/network_constants.h
+++ b/common/network_constants.h
@@ -37,6 +37,8 @@ extern const char kCRLSetPrefix4[];
 extern const char kChromeCastPrefix[];
 extern const char kTwitterPattern[];
 extern const char kGoogleOAuthPattern[];
+extern const char kWidevineGvt1Prefix[];
+extern const char kWidevineGoogleDlPrefix[];
 
 extern const char kCookieHeader[];
 extern const char kRefererHeader[];


### PR DESCRIPTION
Uplift of #5846
Resolves https://github.com/brave/brave-browser/issues/10269

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.