### PR TITLE
Inject cosmetic filtering scriptlets in all frames

### DIFF
--- a/components/brave_extension/extension/brave_extension/actions/shieldsPanelActions.ts
+++ b/components/brave_extension/extension/brave_extension/actions/shieldsPanelActions.ts
@@ -147,20 +147,22 @@ export const generateClassIdStylesheet = (tabId: number, classes: string[], ids:
   }
 }
 
-export const cosmeticFilterRuleExceptions = (tabId: number, exceptions: string[], scriptlet: string, generichide: boolean) => {
+export const cosmeticFilterRuleExceptions: actions.CosmeticFilterRuleExceptions = (tabId: number, frameId: number, exceptions: string[], scriptlet: string, generichide: boolean) => {
   return {
     type: types.COSMETIC_FILTER_RULE_EXCEPTIONS,
     tabId,
+    frameId,
     exceptions,
     scriptlet,
     generichide
   }
 }
 
-export const contentScriptsLoaded: actions.ContentScriptsLoaded = (tabId: number, url: string) => {
+export const contentScriptsLoaded: actions.ContentScriptsLoaded = (tabId: number, frameId: number, url: string) => {
   return {
     type: types.CONTENT_SCRIPTS_LOADED,
     tabId,
+    frameId,
     url
   }
 }

--- a/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
+++ b/components/brave_extension/extension/brave_extension/background/api/cosmeticFilterAPI.ts
@@ -39,33 +39,35 @@ export const injectClassIdStylesheet = (tabId: number, classes: string[], ids: s
 }
 
 // Fires on content-script loaded
-export const applyAdblockCosmeticFilters = (tabId: number, url: string, hide1pContent: boolean) => {
+export const applyAdblockCosmeticFilters = (tabId: number, frameId: number, url: string, hide1pContent: boolean) => {
   chrome.braveShields.urlCosmeticResources(url, async (resources) => {
     if (chrome.runtime.lastError) {
       console.warn('Unable to get cosmetic filter data for the current host', chrome.runtime.lastError)
       return
     }
 
-    if (hide1pContent) {
-      resources.force_hide_selectors.push(...resources.hide_selectors)
-    } else {
-      informTabOfCosmeticRulesToConsider(tabId, resources.hide_selectors)
+    if (frameId === 0) {
+      if (hide1pContent) {
+        resources.force_hide_selectors.push(...resources.hide_selectors)
+      } else {
+        informTabOfCosmeticRulesToConsider(tabId, resources.hide_selectors)
+      }
+
+      let styledStylesheet = ''
+      if (resources.force_hide_selectors.length > 0) {
+        styledStylesheet += resources.force_hide_selectors.join(',') + '{display:none!important;}\n'
+      }
+      for (const selector in resources.style_selectors) {
+        styledStylesheet += selector + '{' + resources.style_selectors[selector].join(';') + ';}\n'
+      }
+      chrome.tabs.insertCSS(tabId, {
+        code: styledStylesheet,
+        cssOrigin: 'user',
+        runAt: 'document_start'
+      })
     }
 
-    let styledStylesheet = ''
-    if (resources.force_hide_selectors.length > 0) {
-      styledStylesheet += resources.force_hide_selectors.join(',') + '{display:none!important;}\n'
-    }
-    for (const selector in resources.style_selectors) {
-      styledStylesheet += selector + '{' + resources.style_selectors[selector].join(';') + ';}\n'
-    }
-    chrome.tabs.insertCSS(tabId, {
-      code: styledStylesheet,
-      cssOrigin: 'user',
-      runAt: 'document_start'
-    })
-
-    shieldsPanelActions.cosmeticFilterRuleExceptions(tabId, resources.exceptions, resources.injected_script || '', resources.generichide)
+    shieldsPanelActions.cosmeticFilterRuleExceptions(tabId, frameId, resources.exceptions, resources.injected_script || '', resources.generichide)
   })
 }
 

--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -42,7 +42,7 @@ chrome.contextMenus.onClicked.addListener((info: chrome.contextMenus.OnClickData
   onContextMenuClicked(info, tab)
 })
 
-// content script listener for right click DOM selection event
+// content script listener for events from the cosmetic filtering content script
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const action = typeof msg === 'string' ? msg : msg.type
   switch (action) {
@@ -71,11 +71,15 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       if (tabId === undefined) {
         break
       }
-      const url = tab.url
+      const url = msg.location.href
       if (url === undefined) {
         break
       }
-      shieldsPanelActions.contentScriptsLoaded(tabId, url)
+      const frameId = sender.frameId
+      if (frameId === undefined) {
+        break
+      }
+      shieldsPanelActions.contentScriptsLoaded(tabId, frameId, url)
     }
   }
 })

--- a/components/brave_extension/extension/brave_extension/content_cosmetic.ts
+++ b/components/brave_extension/extension/brave_extension/content_cosmetic.ts
@@ -10,7 +10,8 @@
 // The RenderView should always be ready when the content script begins, so
 // this message is used to trigger CSS insertion instead.
 chrome.runtime.sendMessage({
-  type: 'contentScriptsLoaded'
+  type: 'contentScriptsLoaded',
+  location: window.location
 })
 
 const parseDomain = require('parse-domain')
@@ -536,8 +537,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const action = typeof msg === 'string' ? msg : msg.type
   switch (action) {
     case 'cosmeticFilteringBackgroundReady': {
+      if (msg.hideOptions !== undefined) {
+        scheduleQueuePump(msg.hideOptions.hide1pContent, msg.hideOptions.generichide)
+      }
       injectScriptlet(msg.scriptlet)
-      scheduleQueuePump(msg.hide1pContent, msg.generichide)
       break
     }
     case 'cosmeticFilterConsiderNewSelectors': {

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -31,7 +31,7 @@
         "out/content_cosmetic.bundle.js"
       ],
       "run_at": "document_start",
-      "all_frames": false
+      "all_frames": true
     },
     {
       "matches": [

--- a/components/brave_extension/extension/brave_extension/types/actions/shieldsPanelActions.ts
+++ b/components/brave_extension/extension/brave_extension/types/actions/shieldsPanelActions.ts
@@ -187,23 +187,25 @@ export interface GenerateClassIdStylesheet {
 interface CosmeticFilterRuleExceptionsReturn {
   type: types.COSMETIC_FILTER_RULE_EXCEPTIONS,
   tabId: number,
+  frameId: number,
   exceptions: string[],
   scriptlet: string,
   generichide: boolean
 }
 
 export interface CosmeticFilterRuleExceptions {
-  (tabId: number, exceptions: string[], scriptlet: string): CosmeticFilterRuleExceptionsReturn
+  (tabId: number, frameId: number, exceptions: string[], scriptlet: string, generichide: boolean): CosmeticFilterRuleExceptionsReturn
 }
 
 interface ContentScriptsLoadedReturn {
   type: types.CONTENT_SCRIPTS_LOADED,
   tabId: number,
+  frameId: number,
   url: string,
 }
 
 export interface ContentScriptsLoaded {
-  (tabId: number, url: string): ContentScriptsLoadedReturn
+  (tabId: number, frameId: number, url: string): ContentScriptsLoadedReturn
 }
 
 export type shieldPanelActions =

--- a/components/brave_shields/browser/ad_block_service_browsertest.cc
+++ b/components/brave_shields/browser/ad_block_service_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/base64.h"
 #include "base/path_service.h"
 #include "base/task/post_task.h"
 #include "base/test/thread_test_helper.h"
@@ -1112,6 +1113,37 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   ASSERT_TRUE(ExecuteScriptAndExtractBool(
               contents,
               "checkSelector('.ad', 'color', 'Impossible value')",
+              &as_expected));
+  EXPECT_TRUE(as_expected);
+}
+
+// Test scriptlet injection that modifies window attributes
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
+                       CosmeticFilteringIframeScriptlet) {
+  std::string scriptlet = "(function() {"
+      "  window.JSON.parse = function() { return {} }"
+      "})();";
+  std::string scriptlet_base64;
+  base::Base64Encode(scriptlet, &scriptlet_base64);
+  UpdateAdBlockInstanceWithRules("b.com##+js(hjt)", "[{"
+          "\"name\": \"hijacktest\","
+          "\"aliases\": [\"hjt\"],"
+          "\"kind\": {\"mime\": \"application/javascript\"},"
+          "\"content\": \"" + scriptlet_base64 + "\"}]");
+
+  WaitForBraveExtensionShieldsDataReady();
+
+  GURL tab_url = embedded_test_server()->GetURL("b.com",
+                                                "/iframe_messenger.html");
+  ui_test_utils::NavigateToURL(browser(), tab_url);
+
+  content::WebContents* contents =
+    browser()->tab_strip_model()->GetActiveWebContents();
+
+  bool as_expected = true;
+  ASSERT_TRUE(ExecuteScriptAndExtractBool(
+              contents,
+              "window.domAutomationController.send(show_ad)",
               &as_expected));
   EXPECT_TRUE(as_expected);
 }

--- a/test/data/iframe_messenger.html
+++ b/test/data/iframe_messenger.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+    <title>iframe test</title>
+    <script>
+        let show_ad = true
+        window.onmessage = function(m) {
+            if (m.data == 'AD') {
+                show_ad = true
+            } else if (m.data == 'no ads') {
+                show_ad = false
+            }
+        }
+    </script>
+</head>
+<body>
+<iframe src="/send_success_message.html" id="test"></iframe>
+</body></html>

--- a/test/data/send_success_message.html
+++ b/test/data/send_success_message.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <title>iframe inner messenger script page</title>
+    <script>
+        setTimeout(() => {
+            const message = JSON.parse('{ "adPlacements": ["AD", "ad"] }')
+            if (message.adPlacements) {
+                window.top.postMessage(message.adPlacements[0], '*')
+            } else {
+                window.top.postMessage('no ads', '*')
+            }
+        }, 1000);
+    </script>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10319 and should clean up youtube ads on third-party iframe embeds.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Haven't found any sites which reproduce this issue 100% of the time. However, it should definitely be possible to visit https://www.pcmag.com/news/the-best-vr-games-for-2019 and play all of the videos without encountering any unskippable video ads at the very beginning.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
