### PR TITLE
Allow using `npm run start` inside brave-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "sync": "npm --prefix ../../ run sync --",
     "build": "npm --prefix ../../ run build --",
+    "start": "npm --prefix ../../ run start --",
     "test": "npm --prefix ../../ run test --",
     "lint": "tslint --project tsconfig-lint.json \"components/**/*.{ts,tsx}\"",
     "pep8": "pycodestyle --max-line-length 120 -r script",


### PR DESCRIPTION
https://github.com/brave/brave-core/pull/5719 allowed `npm run build` and `npm run sync` from the `brave-core` root, it would be super convenient to be able to use `npm run start` from there as well.