### PR TITLE
 Fix 10351: safe-browsing URL replacement tests

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/strings/string_piece_forward.h"
 #include "brave/browser/translate/buildflags/buildflags.h"
 #include "brave/common/network_constants.h"
 #include "brave/common/translate_network_constants.h"
@@ -23,7 +24,7 @@ namespace {
 
 bool g_safebrowsing_api_endpoint_for_testing_ = false;
 
-std::string GetSafeBrowsingEndpoint() {
+base::StringPiece GetSafeBrowsingEndpoint() {
   if (g_safebrowsing_api_endpoint_for_testing_)
     return kSafeBrowsingTestingEndpoint;
   return SAFEBROWSING_ENDPOINT;
@@ -95,9 +96,10 @@ int OnBeforeURLRequest_StaticRedirectWorkForGURL(
     return net::OK;
   }
 
-  if (!GetSafeBrowsingEndpoint().empty() &&
+  auto safebrowsing_endpoint = GetSafeBrowsingEndpoint();
+  if (!safebrowsing_endpoint.empty() &&
       safeBrowsing_pattern.MatchesHost(request_url)) {
-    replacements.SetHostStr(GetSafeBrowsingEndpoint());
+    replacements.SetHostStr(safebrowsing_endpoint);
     *new_url = request_url.ReplaceComponents(replacements);
     return net::OK;
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10351

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

@Developers - Update your `npmconfig`

1. Setup fiddler/little snitch to intercept traffic
2. Open brave browser with a clean profile
3. Verify no connections are made to non-brave domains
4. Wait for ~5 mins and check if files in `<user-data-dir>/Safe Browsing` is populated
5. Navigate to https://testsafebrowsing.appspot.com and verify `website warnings` work.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
