### PR TITLE
working prototype of push-PG-data-on-triggered-page-navigation

### DIFF
--- a/patches/third_party-blink-public-devtools_protocol-browser_protocol.pdl.patch
+++ b/patches/third_party-blink-public-devtools_protocol-browser_protocol.pdl.patch
@@ -18,12 +18,18 @@ index a90396259fd23ea1bfb732d05021fd0fcf5d42bd..6d3edf4e8bd8b3eb4f42e7ec0458ad12
    # Returns iframe node that owns iframe with the given domain.
    experimental command getFrameOwner
      parameters
-@@ -5409,6 +5418,11 @@ domain Page
+@@ -5409,6 +5418,17 @@ domain Page
    # Enables page domain notifications.
    command enable
  
 +  command generatePageGraph
 +    returns
++      # Generated page graph GraphML.
++      string data
++
++  # Page graph is about to become stale/dropped because of top-frame navigation
++  event finalPageGraph
++    parameters
 +      # Generated page graph GraphML.
 +      string data
 +

--- a/patches/third_party-blink-renderer-core-inspector-inspector_page_agent.cc.patch
+++ b/patches/third_party-blink-renderer-core-inspector-inspector_page_agent.cc.patch
@@ -37,6 +37,49 @@ index 98229c0fc7ff5c86fe0da4d20936cbcfe90c9720..0130fc2cfacb22aa2633c83560c85823
          ScriptController::kExecuteScriptWhenScriptsDisabled);
    }
  }
+@@ -941,9 +945,27 @@ void InspectorPageAgent::FrameRequestedNavigation(
+     Frame* target_frame,
+     const KURL& url,
+     ClientNavigationReason reason) {
++#if BUILDFLAG(BRAVE_PAGE_GRAPH_ENABLED)
++  if (target_frame->IsMainFrame()) { // probably not right once remote frames have PG support
++    LocalFrame* main_frame = inspected_frames_->Root();
++    if (main_frame) {
++      Document* document = main_frame->GetDocument();
++      if (document) {
++        ::brave_page_graph::PageGraph* const page_graph = document->GetPageGraph();
++        if (page_graph) {
++              std::string graphml(page_graph->ToGraphML());
++              GetFrontend()->finalPageGraph(String::FromUTF8(graphml.c_str()));
++        }
++      }
++    }
++  }
++#endif
++  using ReasonEnum =
++      protocol::Page::FrameScheduledNavigationNotification::ReasonEnum;
+   GetFrontend()->frameRequestedNavigation(
+       IdentifiersFactory::FrameId(target_frame),
+-      ClientNavigationReasonToProtocol(reason), url.GetString());
++      (reason == ClientNavigationReason::kNone) ? ReasonEnum::Reload : ClientNavigationReasonToProtocol(reason), // work around missing code in our snapshot of upstream Chromium
++      url.GetString());
+ }
+ 
+ void InspectorPageAgent::FrameScheduledNavigation(
+@@ -951,9 +973,12 @@ void InspectorPageAgent::FrameScheduledNavigation(
+     const KURL& url,
+     base::TimeDelta delay,
+     ClientNavigationReason reason) {
++  using ReasonEnum =
++      protocol::Page::FrameScheduledNavigationNotification::ReasonEnum;
+   GetFrontend()->frameScheduledNavigation(
+       IdentifiersFactory::FrameId(frame), delay.InSecondsF(),
+-      ClientNavigationReasonToProtocol(reason), url.GetString());
++      (reason == ClientNavigationReason::kNone) ? ReasonEnum::Reload : ClientNavigationReasonToProtocol(reason), // work around missing code in our snapshot of upstream Chromium
++      url.GetString());
+ }
+ 
+ void InspectorPageAgent::FrameClearedScheduledNavigation(LocalFrame* frame) {
 @@ -1380,6 +1384,29 @@ Response InspectorPageAgent::setInterceptFileChooserDialog(bool enabled) {
    return Response::OK();
  }

--- a/patches/third_party-blink-renderer-core-loader-frame_loader.cc.patch
+++ b/patches/third_party-blink-renderer-core-loader-frame_loader.cc.patch
@@ -16,6 +16,16 @@ index 1c1bd65c5f7ac55bf9d1f33ae7d7bcd2a5bc9d24..a4d38630fd7c0f4c7b4cd2c34add2122
  namespace blink {
  
  bool IsBackForwardLoadType(WebFrameLoadType type) {
+@@ -765,7 +772,8 @@ void FrameLoader::StartNavigation(const FrameLoadRequest& passed_request,
+     }
+   }
+ 
+-  if (request.ClientRedirectReason() != ClientNavigationReason::kNone) {
++  // work around missing code in our snapshot of upstream Chromium
++  if (1/*request.ClientRedirectReason() != ClientNavigationReason::kNone*/) {
+     probe::FrameRequestedNavigation(frame_, frame_, url,
+                                     request.ClientRedirectReason());
+   }
 @@ -765,6 +772,23 @@ void FrameLoader::StartNavigation(const FrameLoadRequest& passed_request,
        origin_document ? origin_document->AddressSpace()
                        : network::mojom::IPAddressSpace::kUnknown;


### PR DESCRIPTION
Motivation: grab the PG data from a page before content-triggered navigation (click, script, etc.) tears down the page

Implementation: tap into the existing signalling/handling plumbing for the `Page.frameRequestedNavigation` DevTools event and trigger a DevTools event of our own, `Page.finalPageGraph` containing the PG data if the requested navigation is for the root/main frame

Quirk/caveat: the upstream version of Chromium PG is currently based on has an incomplete implementation of `frameRequestedNavigation`, such that the event actually never fires properly (current Chromium code appears to have finished the implementation); for now I've hacked in some patches to make the event always fire on detected navigations (albeit with incorrect "navigation type"); when we next rebase PG to a newer Chromium base these hacks should definitely go away...