### PR TITLE
instrumentation of Document.referrer and Window.location Web APIs

### DIFF
--- a/patches/third_party-blink-renderer-core-dom-document.cc.patch
+++ b/patches/third_party-blink-renderer-core-dom-document.cc.patch
@@ -226,3 +226,23 @@ index 02e6831f00c14a9aab6ba6d4218a94ec133c6076..091eb1776f2ae37992024de1e641ed64
    cookie_jar_->SetCookie(value);
  }
  
+@@ -5996,6 +6184,19 @@ bool Document::CookiesEnabled() const {
+ }
+ 
+ const AtomicString& Document::referrer() const {
++#if BUILDFLAG(BRAVE_PAGE_GRAPH_ENABLED)
++  {
++    brave_page_graph::PageGraph* page_graph =
++        const_cast<Document*>(this)->GetPageGraph();
++    if (page_graph != nullptr) {
++      page_graph->RegisterWebAPICall(brave_page_graph::kWebAPIDocumentReferrer,
++                                     std::vector<const String>());
++      page_graph->RegisterWebAPIResult(
++          brave_page_graph::kWebAPIDocumentReferrer,
++          Loader() ? Loader()->GetReferrer().referrer : g_null_atom);
++    }
++  }
++#endif
+   if (Loader())
+     return Loader()->GetReferrer().referrer;
+   return g_null_atom;

--- a/patches/third_party-blink-renderer-core-frame-location.cc.patch
+++ b/patches/third_party-blink-renderer-core-frame-location.cc.patch
@@ -1,0 +1,218 @@
+diff --git a/third_party/blink/renderer/core/frame/location.cc b/third_party/blink/renderer/core/frame/location.cc
+index 1d21eaac8747..bd6b607fbf87 100644
+--- a/third_party/blink/renderer/core/frame/location.cc
++++ b/third_party/blink/renderer/core/frame/location.cc
+@@ -66,36 +66,69 @@ inline const KURL& Location::Url() const {
+   return url;
+ }
+ 
++void Location::PageGraphLogWebAPI(const brave_page_graph::WebAPI web_api,
++                                  const String& value,
++                                  bool is_set) const {
++#if BUILDFLAG(BRAVE_PAGE_GRAPH_ENABLED)
++  {
++    brave_page_graph::PageGraph* page_graph =
++        const_cast<Location*>(this)->GetDocument()->GetPageGraph();
++    if (page_graph != nullptr) {
++      page_graph->RegisterWebAPICall(web_api,
++                                     is_set ? std::vector<const String>({value})
++                                            : std::vector<const String>());
++      page_graph->RegisterWebAPIResult(web_api, is_set ? g_null_atom : value);
++    }
++  }
++#endif
++}
++
+ String Location::href() const {
+-  return Url().StrippedForUseAsHref();
++  const String& result = Url().StrippedForUseAsHref();
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHref, result, false);
++  return result;
+ }
+ 
+ String Location::protocol() const {
+-  return DOMURLUtilsReadOnly::protocol(Url());
++  const String& result = DOMURLUtilsReadOnly::protocol(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationProtocol, result, false);
++  return result;
+ }
+ 
+ String Location::host() const {
+-  return DOMURLUtilsReadOnly::host(Url());
++  const String& result = DOMURLUtilsReadOnly::host(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHost, result, false);
++  return result;
+ }
+ 
+ String Location::hostname() const {
+-  return DOMURLUtilsReadOnly::hostname(Url());
++  const String& result = DOMURLUtilsReadOnly::hostname(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHostname, result, false);
++  return result;
+ }
+ 
+ String Location::port() const {
+-  return DOMURLUtilsReadOnly::port(Url());
++  const String& result = DOMURLUtilsReadOnly::port(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationPort, result, false);
++  return result;
+ }
+ 
+ String Location::pathname() const {
+-  return DOMURLUtilsReadOnly::pathname(Url());
++  const String& result = DOMURLUtilsReadOnly::pathname(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationPathname, result, false);
++  return result;
+ }
+ 
+ String Location::search() const {
+-  return DOMURLUtilsReadOnly::search(Url());
++  const String& result = DOMURLUtilsReadOnly::search(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationSearch, result, false);
++  return result;
+ }
+ 
+ String Location::origin() const {
+-  return DOMURLUtilsReadOnly::origin(Url());
++  const String& result = DOMURLUtilsReadOnly::origin(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationOrigin, result, false);
++  return result;
+ }
+ 
+ FragmentDirective* Location::fragmentDirective() const {
+@@ -104,13 +137,29 @@ FragmentDirective* Location::fragmentDirective() const {
+ 
+ DOMStringList* Location::ancestorOrigins() const {
+   auto* origins = MakeGarbageCollected<DOMStringList>();
+-  if (!IsAttached())
+-    return origins;
+-  for (Frame* frame = dom_window_->GetFrame()->Tree().Parent(); frame;
+-       frame = frame->Tree().Parent()) {
+-    origins->Append(
+-        frame->GetSecurityContext()->GetSecurityOrigin()->ToString());
++  if (IsAttached()) {
++    for (Frame* frame = dom_window_->GetFrame()->Tree().Parent(); frame;
++         frame = frame->Tree().Parent()) {
++      origins->Append(
++          frame->GetSecurityContext()->GetSecurityOrigin()->ToString());
++    }
+   }
++
++#if BUILDFLAG(BRAVE_PAGE_GRAPH_ENABLED)
++  {
++    base::ListValue things;
++    for (uint32_t i = 0; i < origins->length(); ++i) {
++      things.AppendString(origins->item(i).Utf8());
++    }
++
++    std::string output;
++    JSONStringValueSerializer serializer{&output};
++    DCHECK(serializer.Serialize(things));
++    PageGraphLogWebAPI(brave_page_graph::kWebAPILocationAncestorOrigins,
++                       String::FromUTF8(output), false);
++  }
++#endif
++
+   return origins;
+ }
+ 
+@@ -119,12 +168,15 @@ String Location::toString() const {
+ }
+ 
+ String Location::hash() const {
+-  return DOMURLUtilsReadOnly::hash(Url());
++  const String& result = DOMURLUtilsReadOnly::hash(Url());
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHash, result, false);
++  return result;
+ }
+ 
+ void Location::setHref(v8::Isolate* isolate,
+                        const String& url_string,
+                        ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHref, url_string, true);
+   LocalDOMWindow* incumbent_window = IncumbentDOMWindow(isolate);
+   LocalDOMWindow* entered_window = EnteredDOMWindow(isolate);
+   SetLocation(url_string, incumbent_window, entered_window, &exception_state);
+@@ -141,6 +193,7 @@ void Location::setProtocol(v8::Isolate* isolate,
+     return;
+   }
+ 
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationProtocol, protocol, true);
+   SetLocation(url.GetString(), IncumbentDOMWindow(isolate),
+               EnteredDOMWindow(isolate), &exception_state);
+ }
+@@ -148,6 +201,7 @@ void Location::setProtocol(v8::Isolate* isolate,
+ void Location::setHost(v8::Isolate* isolate,
+                        const String& host,
+                        ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHost, host, true);
+   KURL url = GetDocument()->Url();
+   url.SetHostAndPort(host);
+   SetLocation(url.GetString(), IncumbentDOMWindow(isolate),
+@@ -157,6 +211,7 @@ void Location::setHost(v8::Isolate* isolate,
+ void Location::setHostname(v8::Isolate* isolate,
+                            const String& hostname,
+                            ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHostname, hostname, true);
+   KURL url = GetDocument()->Url();
+   url.SetHost(hostname);
+   SetLocation(url.GetString(), IncumbentDOMWindow(isolate),
+@@ -166,6 +221,7 @@ void Location::setHostname(v8::Isolate* isolate,
+ void Location::setPort(v8::Isolate* isolate,
+                        const String& port,
+                        ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationPort, port, true);
+   KURL url = GetDocument()->Url();
+   url.SetPort(port);
+   SetLocation(url.GetString(), IncumbentDOMWindow(isolate),
+@@ -175,6 +231,7 @@ void Location::setPort(v8::Isolate* isolate,
+ void Location::setPathname(v8::Isolate* isolate,
+                            const String& pathname,
+                            ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationPathname, pathname, true);
+   KURL url = GetDocument()->Url();
+   url.SetPath(pathname);
+   SetLocation(url.GetString(), IncumbentDOMWindow(isolate),
+@@ -184,6 +241,7 @@ void Location::setPathname(v8::Isolate* isolate,
+ void Location::setSearch(v8::Isolate* isolate,
+                          const String& search,
+                          ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationSearch, search, true);
+   KURL url = GetDocument()->Url();
+   url.SetQuery(search);
+   SetLocation(url.GetString(), IncumbentDOMWindow(isolate),
+@@ -198,6 +256,8 @@ void Location::setHash(v8::Isolate* isolate,
+   String new_fragment_identifier = hash;
+   if (hash[0] == '#')
+     new_fragment_identifier = hash.Substring(1);
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationHash,
++                     new_fragment_identifier, true);
+   url.SetFragmentIdentifier(new_fragment_identifier);
+   // Note that by parsing the URL and *then* comparing fragments, we are
+   // comparing fragments post-canonicalization, and so this handles the
+@@ -211,6 +271,7 @@ void Location::setHash(v8::Isolate* isolate,
+ void Location::assign(v8::Isolate* isolate,
+                       const String& url_string,
+                       ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationAssign, url_string, true);
+   LocalDOMWindow* incumbent_window = IncumbentDOMWindow(isolate);
+   LocalDOMWindow* entered_window = EnteredDOMWindow(isolate);
+   SetLocation(url_string, incumbent_window, entered_window, &exception_state);
+@@ -219,6 +280,8 @@ void Location::assign(v8::Isolate* isolate,
+ void Location::replace(v8::Isolate* isolate,
+                        const String& url_string,
+                        ExceptionState& exception_state) {
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationReplace, url_string,
++                     true);
+   LocalDOMWindow* incumbent_window = IncumbentDOMWindow(isolate);
+   LocalDOMWindow* entered_window = EnteredDOMWindow(isolate);
+   SetLocation(url_string, incumbent_window, entered_window, &exception_state,
+@@ -232,6 +295,8 @@ void Location::reload() {
+     return;
+   // reload() is not cross-origin accessible, so |dom_window_| will always be
+   // local.
++  PageGraphLogWebAPI(brave_page_graph::kWebAPILocationReload, g_null_atom,
++                     false);
+   To<LocalDOMWindow>(dom_window_.Get())
+       ->GetFrame()
+       ->Reload(WebFrameLoadType::kReload);

--- a/patches/third_party-blink-renderer-core-frame-location.h.patch
+++ b/patches/third_party-blink-renderer-core-frame-location.h.patch
@@ -1,0 +1,29 @@
+diff --git a/third_party/blink/renderer/core/frame/location.h b/third_party/blink/renderer/core/frame/location.h
+index 5708dec7dd70..7a2afb3f71a8 100644
+--- a/third_party/blink/renderer/core/frame/location.h
++++ b/third_party/blink/renderer/core/frame/location.h
+@@ -37,6 +37,12 @@
+ #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+ #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+ 
++#include "brave/third_party/blink/brave_page_graph/buildflags/buildflags.h"
++#if BUILDFLAG(BRAVE_PAGE_GRAPH_ENABLED)
++#include "brave/third_party/blink/brave_page_graph/types.h"
++#include "base/json/json_string_value_serializer.h"
++#endif
++
+ namespace blink {
+ 
+ class Document;
+@@ -116,6 +122,11 @@ class CORE_EXPORT Location final : public ScriptWrappable {
+   const Member<DOMWindow> dom_window_;
+ 
+   Member<FragmentDirective> fragment_directive_;
++
++  // Internal helper method for PageGraph WebAPI recording
++  void PageGraphLogWebAPI(const brave_page_graph::WebAPI web_api,
++                          const String& value,
++                          bool is_set) const;
+ };
+ 
+ }  // namespace blink

--- a/third_party/blink/brave_page_graph/page_graph.cc
+++ b/third_party/blink/brave_page_graph/page_graph.cc
@@ -1097,6 +1097,11 @@ void PageGraph::GenerateReportForNode(const blink::DOMNodeId node_id,
   }
 }
 
+void PageGraph::RegisterWebAPICall(const WebAPI web_api,
+    const vector<const String>& arguments) {
+  RegisterWebAPICall(WebAPIToString(web_api), arguments);
+}
+
 void PageGraph::RegisterWebAPICall(const MethodName& method,
     const vector<const String>& arguments) {
   vector<const string> local_args;
@@ -1127,6 +1132,11 @@ void PageGraph::RegisterWebAPICall(const MethodName& method,
 
   AddEdge(new EdgeJSCall(this, static_cast<NodeScript*>(acting_node),
     webapi_node, local_args));
+}
+
+void PageGraph::RegisterWebAPIResult(const WebAPI web_api,
+    const String& result) {
+  RegisterWebAPIResult(WebAPIToString(web_api), result);
 }
 
 void PageGraph::RegisterWebAPIResult(const MethodName& method,

--- a/third_party/blink/brave_page_graph/page_graph.h
+++ b/third_party/blink/brave_page_graph/page_graph.h
@@ -154,8 +154,12 @@ friend NodeHTMLElement;
     const StorageLocation location);
   void RegisterStorageClear(const StorageLocation location);
 
+  void RegisterWebAPICall(const WebAPI web_api,
+    const std::vector<const WTF::String>& arguments);
   void RegisterWebAPICall(const MethodName& method,
     const std::vector<const WTF::String>& arguments);
+  void RegisterWebAPIResult(const WebAPI web_api,
+    const WTF::String& result);
   void RegisterWebAPIResult(const MethodName& method,
     const WTF::String& result);
   void RegisterJSBuiltInCall(const JSBuiltIn built_in,

--- a/third_party/blink/brave_page_graph/types.cc
+++ b/third_party/blink/brave_page_graph/types.cc
@@ -244,6 +244,52 @@ const string& JSBuiltInToSting(const JSBuiltIn built_in) noexcept {
   return js_built_in_enum_to_str_map.at(built_in);
 }
 
+namespace {
+  const map<WebAPI, string> web_api_enum_to_str_map = {
+    {kWebAPIDocumentReferrer, "Document.referrer"},
+    {kWebAPILocationAncestorOrigins, "Location.ancestorOrigins"},
+    {kWebAPILocationAssign, "Location.assign"},
+    {kWebAPILocationHash, "Location.hash"},
+    {kWebAPILocationHost, "Location.host"},
+    {kWebAPILocationHostname, "Location.hostname"},
+    {kWebAPILocationHref, "Location.href"},
+    {kWebAPILocationOrigin, "Location.origin"},
+    {kWebAPILocationPathname, "Location.pathname"},
+    {kWebAPILocationPort, "Location.port"},
+    {kWebAPILocationProtocol, "Location.protocol"},
+    {kWebAPILocationReload, "Location.reload"},
+    {kWebAPILocationReplace, "Location.replace"},
+    {kWebAPILocationSearch, "Location.search"},
+  };
+
+  const map<string, WebAPI> web_api_str_to_enum_map = {
+    {"Document.referrer", kWebAPIDocumentReferrer},
+    {"Location.ancestorOrigins", kWebAPILocationAncestorOrigins},
+    {"Location.assign", kWebAPILocationAssign},
+    {"Location.hash", kWebAPILocationHash},
+    {"Location.host", kWebAPILocationHost},
+    {"Location.hostname", kWebAPILocationHostname},
+    {"Location.href", kWebAPILocationHref},
+    {"Location.origin", kWebAPILocationOrigin},
+    {"Location.pathname", kWebAPILocationPathname},
+    {"Location.port", kWebAPILocationPort},
+    {"Location.protocol", kWebAPILocationProtocol},
+    {"Location.reload", kWebAPILocationReload},
+    {"Location.replace", kWebAPILocationReplace},
+    {"Location.search", kWebAPILocationSearch},
+  };
+}
+
+WebAPI WebAPIFromString(const string& web_api_name) noexcept {
+  LOG_ASSERT(web_api_str_to_enum_map.count(web_api_name) != 0);
+  return web_api_str_to_enum_map.at(web_api_name);
+}
+
+const string& WebAPIToString(const WebAPI web_api) noexcept {
+  LOG_ASSERT(web_api_enum_to_str_map.count(web_api) != 0);
+  return web_api_enum_to_str_map.at(web_api);
+}
+
 FingerprintingRule::FingerprintingRule(const std::string& primary_pattern,
                                        const std::string& secondary_pattern,
                                        const std::string& source,

--- a/third_party/blink/brave_page_graph/types.h
+++ b/third_party/blink/brave_page_graph/types.h
@@ -190,6 +190,25 @@ typedef enum {
 JSBuiltIn JSBuiltInFromString(const std::string& built_in_name) noexcept;
 const std::string& JSBuiltInToSting(const JSBuiltIn built_in_name) noexcept;
 
+typedef enum {
+  kWebAPIDocumentReferrer = 0,
+  kWebAPILocationAncestorOrigins,
+  kWebAPILocationAssign,
+  kWebAPILocationHash,
+  kWebAPILocationHost,
+  kWebAPILocationHostname,
+  kWebAPILocationHref,
+  kWebAPILocationOrigin,
+  kWebAPILocationPathname,
+  kWebAPILocationPort,
+  kWebAPILocationProtocol,
+  kWebAPILocationReload,
+  kWebAPILocationReplace,
+  kWebAPILocationSearch,
+} WebAPI;
+WebAPI WebAPIFromString(const std::string& built_in_name) noexcept;
+const std::string& WebAPIToString(const WebAPI built_in_name) noexcept;
+
 typedef unsigned SourceCodeHash;
 typedef unsigned UrlHash;
 typedef int ScriptId;


### PR DESCRIPTION
Added WebAPI instrumentation points to record read access to `document.referrer` and read/write access to `location.href` and friends (all properties of `window.location` with custom getter/setter bindings and the standard `Location` mutation methods).

Used a new enumeration-based interface for registering Web API activity (like the one already in place for JS built-in APIs); existing Web API instrumentation can/should be migrated to this new interface in the future as time permits.