### PR TITLE
Display brave client id in sync-internals

### DIFF
--- a/components/sync/driver/brave_sync_auth_manager.cc
+++ b/components/sync/driver/brave_sync_auth_manager.cc
@@ -71,7 +71,11 @@ SyncAccountInfo BraveSyncAuthManager::DetermineAccountToUse() const {
     AccountInfo account_info;
     account_info.account_id = CoreAccountId::FromString(client_id);
     account_info.gaia = client_id;
-    account_info.email = "sync@brave.com";
+    // about:sync-internals needs space separator in order to confine table
+    // data within specific width. (ex. client_version and encrypted_types)
+    account_info.email =
+        std::string(client_id).insert(client_id.length() / 2, 1, ' ') +
+        " @brave.com";
     VLOG(1) << "brave client id=" << client_id;
     return SyncAccountInfo(account_info, true);
   } else {

--- a/components/sync/driver/brave_sync_auth_manager_unittest.cc
+++ b/components/sync/driver/brave_sync_auth_manager_unittest.cc
@@ -36,6 +36,10 @@ const char kAccessToken[] =
 const char kAccountId[] =
     "502042270C8145247ED70A18F87022A39886900AB36F2FFF655635DBE516765E";
 
+const char kAccountEmail[] =
+  "502042270C8145247ED70A18F87022A3 "
+  "9886900AB36F2FFF655635DBE516765E @brave.com";
+
 class BraveSyncAuthManagerTest : public testing::Test {
  protected:
   using AccountStateChangedCallback =
@@ -105,7 +109,7 @@ TEST_F(BraveSyncAuthManagerTest, GetAccessToken) {
   EXPECT_EQ(auth_manager->GetActiveAccountInfo().account_info.account_id,
             CoreAccountId::FromString(kAccountId));
   EXPECT_EQ(auth_manager->GetActiveAccountInfo().account_info.email,
-            "sync@brave.com");
+            kAccountEmail);
 }
 
 TEST_F(BraveSyncAuthManagerTest, Reset) {


### PR DESCRIPTION
Reason we need space separator:
In `components/sync/driver/about_sync_util.cc`,
`client_version` and `username` both are `Stat<std::string>*` setting a string
directly. And then pass data to js through `onAboutInfoUpdated` event
which will be eventually passed to `jstProcess` and get value through
`chrome.sync.about_tab.highlightIfChanged(this, this.children[1].innerText, stat_value)'>`
The whole process is no different between these two but <td> of
`username` will have tremendously long width if we don't put any space
in the string.

### with space
<img width="408" alt="Screen Shot 2020-06-24 at 16 00 41" src="https://user-images.githubusercontent.com/11330831/85636003-272c7100-b634-11ea-9e6a-047019545faf.png">

### without space
<img width="639" alt="Screen Shot 2020-06-24 at 16 02 37" src="https://user-images.githubusercontent.com/11330831/85636007-2a276180-b634-11ea-995f-408a2346f317.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10362

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
