### PR TITLE
Always show bookmark bar on NTP if its setting is on

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -44,12 +44,6 @@ source_set("ui") {
 
   if (!is_android) {
     sources += [
-      "bookmark/brave_bookmark_tab_helper.cc",
-      "bookmark/brave_bookmark_tab_helper.h",
-      "bookmark/bookmark_prefs_service.cc",
-      "bookmark/bookmark_prefs_service.h",
-      "bookmark/bookmark_prefs_service_factory.cc",
-      "bookmark/bookmark_prefs_service_factory.h",
       "brave_browser_command_controller.cc",
       "brave_browser_command_controller.h",
       "brave_browser_content_setting_bubble_model_delegate.cc",
@@ -246,8 +240,8 @@ source_set("ui") {
     deps += [
       "//brave/app:brave_generated_resources_grit",
       "//brave/browser:version_info",
+      "//brave/browser/ui/bookmark",
       "//brave/components/brave_sync",
-      "//components/bookmarks/common",
       "//components/sync_device_info",
       "//third_party/blink/public/common",
     ]

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -247,6 +247,7 @@ source_set("ui") {
       "//brave/app:brave_generated_resources_grit",
       "//brave/browser:version_info",
       "//brave/components/brave_sync",
+      "//components/bookmarks/common",
       "//components/sync_device_info",
       "//third_party/blink/public/common",
     ]

--- a/browser/ui/bookmark/BUILD.gn
+++ b/browser/ui/bookmark/BUILD.gn
@@ -1,0 +1,21 @@
+source_set("bookmark") {
+  sources = [
+    "brave_bookmark_tab_helper.cc",
+    "brave_bookmark_tab_helper.h",
+    "bookmark_prefs_service.cc",
+    "bookmark_prefs_service.h",
+    "bookmark_prefs_service_factory.cc",
+    "bookmark_prefs_service_factory.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/common",
+    "//components/bookmarks/common",
+    "//components/keyed_service/content",
+    "//components/keyed_service/core",
+    "//components/prefs",
+    "//components/pref_registry",
+    "//content/public/browser",
+  ]
+}

--- a/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc
+++ b/browser/ui/bookmark/bookmark_tab_helper_browsertest.cc
@@ -56,26 +56,27 @@ void AddBookmarkNode(Profile* profile) {
 
 IN_PROC_BROWSER_TEST_F(BookmarkTabHelperBrowserTest, BookmarkBarOnNTPTest) {
   auto* profile = browser()->profile();
+  auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
 
-  // Check Bookmark bar is hidden by default.
+  // Check Bookmark bar is hidden by default for non NTP.
+  EXPECT_FALSE(IsNTP(contents));
   EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
 
-  // Check default is on.
+  // Check show bookarks on NTP is on by default.
   EXPECT_TRUE(profile->GetPrefs()->GetBoolean(kAlwaysShowBookmarkBarOnNTP));
 
   // Loading NTP.
-  auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
   EXPECT_TRUE(content::NavigateToURL(contents,
                                      GURL(chrome::kChromeUINewTabURL)));
   EXPECT_TRUE(IsNTP(contents));
 
-  // Check bookmark bar on NTP is hidden if bookmark bar is empty and
-  // kBookmarkBar is off.
-  EXPECT_EQ(BookmarkBar::HIDDEN, browser()->bookmark_bar_state());
+  // Check bookmark bar on NTP is shown even if bookmark bar is empty.
+  EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
 
   AddBookmarkNode(profile);
 
-  // Check bookmark is visible on NTP after adding bookmark.
+  // Check bookmark is also visible on NTP after adding bookmark regardless of
+  // show bookmark bar option value.
   chrome::ToggleBookmarkBar(browser());
   EXPECT_EQ(BookmarkBar::SHOW, browser()->bookmark_bar_state());
   chrome::ToggleBookmarkBar(browser());

--- a/browser/ui/bookmark/brave_bookmark_tab_helper.cc
+++ b/browser/ui/bookmark/brave_bookmark_tab_helper.cc
@@ -7,7 +7,31 @@
 
 #include "brave/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search/search.h"
+#include "chrome/browser/ui/webui/new_tab_page/new_tab_page_ui.h"
+#include "chrome/browser/ui/webui/ntp/new_tab_ui.h"
+#include "components/bookmarks/common/bookmark_pref_names.h"
 #include "components/prefs/pref_service.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/web_contents.h"
+
+namespace {
+
+bool IsNTP(content::WebContents* web_contents) {
+  // Use the committed entry so the bookmarks bar disappears at the same time
+  // the page does.
+  content::NavigationEntry* entry =
+      web_contents->GetController().GetLastCommittedEntry();
+  if (!entry)
+    entry = web_contents->GetController().GetVisibleEntry();
+  if (!entry)
+    return false;
+  const GURL& url = entry->GetURL();
+  return NewTabUI::IsNewTab(url) || NewTabPageUI::IsNewTabPageOrigin(url) ||
+         search::NavEntryIsInstantNTP(web_contents, entry);
+}
+
+}  // namespace
 
 BraveBookmarkTabHelper::BraveBookmarkTabHelper(
     content::WebContents* web_contents)
@@ -32,17 +56,22 @@ bool BraveBookmarkTabHelper::ShouldShowBookmarkBar() {
   if (!helper)
     return false;
 
-  // Originally, bookmark is visible for NTP when bookmarks are non empty.
-  // In that case, we want to hide bookmark bar on NTP if user chooses to hide.
-  // When bookmark should be hidden, we do not change it.
-  bool should_show = helper->ShouldShowBookmarkBar();
-  if (should_show) {
+  if (IsNTP(web_contents_)) {
     Profile* profile =
         Profile::FromBrowserContext(web_contents_->GetBrowserContext());
-    should_show = profile->GetPrefs()->GetBoolean(kAlwaysShowBookmarkBarOnNTP);
+
+    if (profile->IsGuestSession())
+      return false;
+
+    PrefService* prefs = profile->GetPrefs();
+    if (prefs->IsManagedPreference(bookmarks::prefs::kShowBookmarkBar) &&
+        !prefs->GetBoolean(bookmarks::prefs::kShowBookmarkBar))
+      return false;
+
+    return prefs->GetBoolean(kAlwaysShowBookmarkBarOnNTP);
   }
 
-  return should_show;
+  return helper->ShouldShowBookmarkBar();
 }
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(BraveBookmarkTabHelper)


### PR DESCRIPTION
To do this, we can make user see bookmark instruction text always on NTP
if there is no bookmark items.
Previously, bookmark on NTP is hidden if there is no bookmark item.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10450

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_browser_tests -- --filter=BookmarkTabHelperBrowserTest*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
