### PR TITLE
P2A for Brave Ads POC

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -265,11 +265,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   BraveOmniboxClientImpl::RegisterPrefs(registry);
 #endif
 
-// TODO(Moritz Haller): Put behind Ads enabled buildflag?
 #if !defined(OS_ANDROID)
   brave_ads::RegisterP2APrefs(registry);
 #endif
-
 
   RegisterProfilePrefsForMigration(registry);
 }

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -11,6 +11,7 @@
 #include "brave/common/pref_names.h"
 #include "brave/components/binance/browser/buildflags/buildflags.h"
 #include "brave/components/gemini/browser/buildflags/buildflags.h"
+#include "brave/components/brave_ads/browser/ads_p2a.h"
 #include "brave/components/brave_perf_predictor/browser/buildflags.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
@@ -263,6 +264,12 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 #if !defined(OS_ANDROID)
   BraveOmniboxClientImpl::RegisterPrefs(registry);
 #endif
+
+// TODO(Moritz Haller): Put behind Ads enabled buildflag?
+#if !defined(OS_ANDROID)
+  brave_ads::RegisterP2APrefs(registry);
+#endif
+
 
   RegisterProfilePrefsForMigration(registry);
 }

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -42,6 +42,8 @@ source_set("browser") {
     sources += [
       "ad_notification.cc",
       "ad_notification.h",
+      "ads_p2a.cc",
+      "ads_p2a.h",
       "ads_notification_handler.cc",
       "ads_notification_handler.h",
       "ads_service_impl.cc",

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -42,10 +42,10 @@ source_set("browser") {
     sources += [
       "ad_notification.cc",
       "ad_notification.h",
-      "ads_p2a.cc",
-      "ads_p2a.h",
       "ads_notification_handler.cc",
       "ads_notification_handler.h",
+      "ads_p2a.cc",
+      "ads_p2a.h",
       "ads_service_impl.cc",
       "ads_service_impl.h",
       "background_helper.cc",

--- a/components/brave_ads/browser/ads_p2a.cc
+++ b/components/brave_ads/browser/ads_p2a.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/browser/ads_p2a.h"
 
+#include <iostream>
+
 #include "base/metrics/histogram_macros.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/values.h"
@@ -16,6 +18,8 @@
 namespace brave_ads {
 namespace {
 
+constexpr int32_t kSuspendedMetricValue = INT32_MIN;
+
 const char kAdViewConfirmationCountHistogramName[] =
     "Brave.P2A.ViewConfirmationCount";
 const char kAdViewConfirmationCountPrefName[] =
@@ -23,8 +27,7 @@ const char kAdViewConfirmationCountPrefName[] =
 const uint16_t kAdViewConfirmationCountIntervals[] =
     {0, 5, 10, 20, 50, 100, 250, 500};
 
-void EmitAdViewConfirmationHistogram(
-    uint64_t number_of_confirmations) {
+void EmitAdViewConfirmationHistogram(uint64_t number_of_confirmations) {
   const uint16_t* it = std::lower_bound(kAdViewConfirmationCountIntervals,
       std::end(kAdViewConfirmationCountIntervals), number_of_confirmations);
   const uint16_t answer = it - kAdViewConfirmationCountIntervals;
@@ -46,6 +49,10 @@ void RecordEventInWeeklyStorage(
     storage.AddDelta(1);
     EmitAdViewConfirmationHistogram(storage.GetWeeklySum());
   }
+}
+
+void EmitSuspendedMetricValue() {
+    UMA_HISTOGRAM_EXACT_LINEAR("Brave.P2A.Test", kSuspendedMetricValue, 1);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_p2a.cc
+++ b/components/brave_ads/browser/ads_p2a.cc
@@ -5,11 +5,9 @@
 
 #include "brave/components/brave_ads/browser/ads_p2a.h"
 
-#include <iostream>
+#include <stdint.h>
 
 #include "base/metrics/histogram_macros.h"
-#include "base/strings/string_number_conversions.h"
-#include "base/values.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/weekly_storage/weekly_storage.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -18,41 +16,37 @@
 namespace brave_ads {
 namespace {
 
-constexpr int32_t kSuspendedMetricValue = INT32_MIN;
-
 const char kAdViewConfirmationCountHistogramName[] =
     "Brave.P2A.ViewConfirmationCount";
-const char kAdViewConfirmationCountPrefName[] =
-    "brave.weekly_storage.ad_view_confirmation_count";
 const uint16_t kAdViewConfirmationCountIntervals[] =
-    {0, 5, 10, 20, 50, 100, 250, 500};
+    { 0, 5, 10, 20, 50, 100, 250, 500 };
 
 void EmitAdViewConfirmationHistogram(uint64_t number_of_confirmations) {
-  const uint16_t* it = std::lower_bound(kAdViewConfirmationCountIntervals,
-      std::end(kAdViewConfirmationCountIntervals), number_of_confirmations);
+    const uint16_t* it = std::lower_bound(kAdViewConfirmationCountIntervals,
+    std::end(kAdViewConfirmationCountIntervals), number_of_confirmations);
   const uint16_t answer = it - kAdViewConfirmationCountIntervals;
-  UMA_HISTOGRAM_EXACT_LINEAR(kAdViewConfirmationCountHistogramName, answer,
-      base::size(kAdViewConfirmationCountIntervals));
+  EmitConfirmationsCountMetric(answer);
 }
 
 }  // namespace
 
 void RegisterP2APrefs(PrefRegistrySimple* registry) {
-  registry->RegisterListPref(kAdViewConfirmationCountPrefName);
+  registry->RegisterListPref(prefs::kAdViewConfirmationCountPrefName);
 }
 
 void RecordEventInWeeklyStorage(
     PrefService* prefs,
     const std::string& pref_name) {
-  if (pref_name == kAdViewConfirmationCountPrefName) {
-    WeeklyStorage storage(prefs, kAdViewConfirmationCountPrefName);
+  if (pref_name == prefs::kAdViewConfirmationCountPrefName) {
+    WeeklyStorage storage(prefs, prefs::kAdViewConfirmationCountPrefName);
     storage.AddDelta(1);
     EmitAdViewConfirmationHistogram(storage.GetWeeklySum());
   }
 }
 
-void EmitSuspendedMetricValue() {
-    UMA_HISTOGRAM_EXACT_LINEAR("Brave.P2A.Test", kSuspendedMetricValue, 1);
+void EmitConfirmationsCountMetric(int answer) {
+  UMA_HISTOGRAM_EXACT_LINEAR(kAdViewConfirmationCountHistogramName,
+                             answer, 8);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_p2a.cc
+++ b/components/brave_ads/browser/ads_p2a.cc
@@ -1,0 +1,51 @@
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/ads_p2a.h"
+
+#include "base/metrics/histogram_macros.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/values.h"
+#include "brave/components/brave_ads/common/pref_names.h"
+#include "brave/components/weekly_storage/weekly_storage.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_ads {
+namespace {
+
+const char kAdViewConfirmationCountHistogramName[] =
+    "Brave.P2A.ViewConfirmationCount";
+const char kAdViewConfirmationCountPrefName[] =
+    "brave.weekly_storage.ad_view_confirmation_count";
+const uint16_t kAdViewConfirmationCountIntervals[] =
+    {0, 5, 10, 20, 50, 100, 250, 500};
+
+void EmitAdViewConfirmationHistogram(
+    uint64_t number_of_confirmations) {
+  const uint16_t* it = std::lower_bound(kAdViewConfirmationCountIntervals,
+      std::end(kAdViewConfirmationCountIntervals), number_of_confirmations);
+  const uint16_t answer = it - kAdViewConfirmationCountIntervals;
+  UMA_HISTOGRAM_EXACT_LINEAR(kAdViewConfirmationCountHistogramName, answer,
+      base::size(kAdViewConfirmationCountIntervals));
+}
+
+}  // namespace
+
+void RegisterP2APrefs(PrefRegistrySimple* registry) {
+  registry->RegisterListPref(kAdViewConfirmationCountPrefName);
+}
+
+void RecordEventInWeeklyStorage(
+    PrefService* prefs,
+    const std::string& pref_name) {
+  if (pref_name == kAdViewConfirmationCountPrefName) {
+    WeeklyStorage storage(prefs, kAdViewConfirmationCountPrefName);
+    storage.AddDelta(1);
+    EmitAdViewConfirmationHistogram(storage.GetWeeklySum());
+  }
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/browser/ads_p2a.h
+++ b/components/brave_ads/browser/ads_p2a.h
@@ -1,0 +1,26 @@
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_P2A_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_P2A_H_
+
+#include <stdint.h>
+
+#include <string>
+
+class PrefService;
+class PrefRegistrySimple;
+
+namespace brave_ads {
+
+void RegisterP2APrefs(PrefRegistrySimple* prefs);
+
+void RecordEventInWeeklyStorage(
+    PrefService* prefs,
+    const std::string& pref_name);
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_P2A_H_

--- a/components/brave_ads/browser/ads_p2a.h
+++ b/components/brave_ads/browser/ads_p2a.h
@@ -21,6 +21,8 @@ void RecordEventInWeeklyStorage(
     PrefService* prefs,
     const std::string& pref_name);
 
+void EmitSuspendedMetricValue();
+
 }  // namespace brave_ads
 
 #endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_P2A_H_

--- a/components/brave_ads/browser/ads_p2a.h
+++ b/components/brave_ads/browser/ads_p2a.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_P2A_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_ADS_P2A_H_
 
-#include <stdint.h>
-
 #include <string>
 
 class PrefService;
@@ -21,7 +19,7 @@ void RecordEventInWeeklyStorage(
     PrefService* prefs,
     const std::string& pref_name);
 
-void EmitSuspendedMetricValue();
+void EmitConfirmationsCountMetric(int answer);
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1787,8 +1787,9 @@ void AdsServiceImpl::OnPrefsChanged(
       MaybeStart(false);
     } else {
       // Record "special value" to prevent sending this week's data to P2A
-      // server
-      brave_ads::EmitSuspendedMetricValue();
+      // server. Matches INT_MAX - 1 for |kSuspendedMetricValue| in
+      // |brave_p3a_service.cc|
+      brave_ads::EmitConfirmationsCountMetric(INT_MAX);
       Stop();
     }
 
@@ -1922,8 +1923,9 @@ void AdsServiceImpl::ConfirmAd(
   rewards_service_->ConfirmAd(info.ToJson(), confirmation_type);
 
   if (confirmation_type.value() == ads::ConfirmationType::kViewed) {
-    brave_ads::RecordEventInWeeklyStorage(profile_->GetPrefs(),
-        "brave.weekly_storage.ad_view_confirmation_count");
+    brave_ads::RecordEventInWeeklyStorage(
+        profile_->GetPrefs(),
+        prefs::kAdViewConfirmationCountPrefName);
   }
 }
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1786,6 +1786,9 @@ void AdsServiceImpl::OnPrefsChanged(
 
       MaybeStart(false);
     } else {
+      // Record "special value" to prevent sending this week's data to P2A
+      // server
+      brave_ads::EmitSuspendedMetricValue();
       Stop();
     }
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -32,6 +32,7 @@
 #include "bat/ads/resources/grit/bat_ads_resources.h"
 #include "brave/components/brave_ads/browser/ad_notification.h"
 #include "brave/components/brave_ads/browser/ads_notification_handler.h"
+#include "brave/components/brave_ads/browser/ads_p2a.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_ads/common/switches.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service.h"
@@ -1916,6 +1917,11 @@ void AdsServiceImpl::ConfirmAd(
     const ads::AdInfo& info,
     const ads::ConfirmationType confirmation_type) {
   rewards_service_->ConfirmAd(info.ToJson(), confirmation_type);
+
+  if (confirmation_type.value() == ads::ConfirmationType::kViewed) {
+    brave_ads::RecordEventInWeeklyStorage(profile_->GetPrefs(),
+        "brave.weekly_storage.ad_view_confirmation_count");
+  }
 }
 
 void AdsServiceImpl::ConfirmAction(

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -69,6 +69,9 @@ const char kVersion[] = "brave.brave_ads.prefs.version";
 
 const int kCurrentVersionNumber = 7;
 
+const char kAdViewConfirmationCountPrefName[] =
+    "brave.weekly_storage.p2a_ad_view_confirmation_count";
+
 }  // namespace prefs
 
 }  // namespace brave_ads

--- a/components/brave_ads/common/pref_names.h
+++ b/components/brave_ads/common/pref_names.h
@@ -38,6 +38,8 @@ extern const int kSupportedCountryCodesSchemaVersionNumber;
 extern const char kVersion[];
 extern const int kCurrentVersionNumber;
 
+extern const char kAdViewConfirmationCountPrefName[];
+
 }  // namespace prefs
 
 }  // namespace brave_ads

--- a/components/p3a/BUILD.gn
+++ b/components/p3a/BUILD.gn
@@ -14,6 +14,8 @@ source_set("p3a") {
   sources = [
     "brave_histogram_rewrite.cc",
     "brave_histogram_rewrite.h",
+    "brave_p2a_protocols.cc",
+    "brave_p2a_protocols.h",
     "brave_p3a_log_store.cc",
     "brave_p3a_log_store.h",
     "brave_p3a_service.cc",

--- a/components/p3a/brave_p2a_protocols.cc
+++ b/components/p3a/brave_p2a_protocols.cc
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <vector>
 
+#include "base/logging.h"
 #include "base/rand_util.h"
 
 namespace {
@@ -24,6 +25,8 @@ DirectEncodingProtocol::~DirectEncodingProtocol() = default;
 
 uint64_t DirectEncodingProtocol::Perturb(
     uint16_t bucket_count, uint64_t value) {
+  DCHECK_GT(bucket_count, 1);
+
   uint64_t perturbed_value = value;
   double probability = exp(kEpsilon) / (exp(kEpsilon) + bucket_count - 1);
 

--- a/components/p3a/brave_p2a_protocols.cc
+++ b/components/p3a/brave_p2a_protocols.cc
@@ -1,0 +1,48 @@
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/p3a/brave_p2a_protocols.h"
+
+#include <math.h>
+
+#include <numeric>
+#include <vector>
+
+#include "base/rand_util.h"
+
+namespace {
+const double kEpsilon = 2.1;
+}  // namespace
+
+namespace brave {
+
+DirectEncodingProtocol::DirectEncodingProtocol() = default;
+
+DirectEncodingProtocol::~DirectEncodingProtocol() = default;
+
+uint64_t DirectEncodingProtocol::Perturb(
+    uint16_t bucket_count, uint64_t value) {
+  uint64_t perturbed_value = value;
+  double probability = exp(kEpsilon) / (exp(kEpsilon) + bucket_count - 1);
+
+  // Return true value with probability
+  if (base::RandDouble() < probability) {
+      return perturbed_value;
+  }
+
+  // Generate set of non-truthful options by removing the true bucket from the
+  // candidate vector
+  std::vector<uint16_t> buckets(bucket_count);
+  std::iota(buckets.begin(), buckets.end(), 0);
+  buckets.erase(buckets.begin() + value);
+
+  // Now pick non-truthful bucket at uniform random
+  const int rand = base::RandInt(0, bucket_count - 2);
+  perturbed_value = buckets.at(rand);
+
+  return perturbed_value;
+}
+
+}  // namespace brave

--- a/components/p3a/brave_p2a_protocols.h
+++ b/components/p3a/brave_p2a_protocols.h
@@ -1,0 +1,24 @@
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_P3A_BRAVE_P2A_PROTOCOLS_H_
+#define BRAVE_COMPONENTS_P3A_BRAVE_P2A_PROTOCOLS_H_
+
+#include <stdint.h>
+
+namespace brave {
+
+class DirectEncodingProtocol {
+ public:
+  DirectEncodingProtocol();
+  ~DirectEncodingProtocol();
+
+  static uint64_t Perturb(
+      uint16_t bucket_count, uint64_t value);
+};
+
+}  // namespace brave
+
+#endif  // BRAVE_COMPONENTS_P3A_BRAVE_P2A_PROTOCOLS_H_

--- a/components/p3a/brave_p2a_protocols.h
+++ b/components/p3a/brave_p2a_protocols.h
@@ -15,8 +15,7 @@ class DirectEncodingProtocol {
   DirectEncodingProtocol();
   ~DirectEncodingProtocol();
 
-  static uint64_t Perturb(
-      uint16_t bucket_count, uint64_t value);
+  static uint64_t Perturb(uint16_t bucket_count, uint64_t value);
 };
 
 }  // namespace brave

--- a/components/p3a/brave_p2a_protocols_unittest.cc
+++ b/components/p3a/brave_p2a_protocols_unittest.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/p3a/brave_p2a_protocols.h"
+
+#include <stdint.h>
+
+#include <vector>
+#include <iostream>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=P2A*
+
+namespace {
+const size_t kTrials = 1000;
+}  // namespace
+
+namespace brave {
+
+TEST(P2AProtocolsTest, PerturbationTest) {
+  // Arrange
+  const uint16_t kBucketCount = 7;
+  const uint64_t kTrueValue = 4;
+
+  // Act
+  size_t true_value_count = 0;
+
+  for (size_t i = 0; i < kTrials; i++) {
+    if (kTrueValue == DirectEncodingProtocol::Perturb(kBucketCount,
+        kTrueValue)) {
+      true_value_count++;
+    }
+  }
+
+  // Assert
+  // TODO(Moritz Haller): Maybe assert that |true_value_count| is within
+  // confidence interval (e.g. |53 < true_value_count < 61| for 99% confidence
+  // level)
+  EXPECT_TRUE(true_value_count < kTrials);
+}
+
+}  // namespace brave

--- a/components/p3a/brave_p2a_protocols_unittest.cc
+++ b/components/p3a/brave_p2a_protocols_unittest.cc
@@ -8,7 +8,6 @@
 #include <stdint.h>
 
 #include <vector>
-#include <iostream>
 
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -29,8 +28,8 @@ TEST(P2AProtocolsTest, PerturbationTest) {
   size_t true_value_count = 0;
 
   for (size_t i = 0; i < kTrials; i++) {
-    if (kTrueValue == DirectEncodingProtocol::Perturb(kBucketCount,
-        kTrueValue)) {
+    if (kTrueValue == DirectEncodingProtocol::Perturb(
+        kBucketCount, kTrueValue)) {
       true_value_count++;
     }
   }

--- a/components/p3a/brave_p3a_log_store.cc
+++ b/components/p3a/brave_p3a_log_store.cc
@@ -64,6 +64,21 @@ void BraveP3ALogStore::UpdateValue(const std::string& histogram_name,
   update->SetPath({histogram_name, kLogSentKey}, base::Value(entry.sent));
 }
 
+void BraveP3ALogStore::RemoveValueIfExists(const std::string& histogram_name) {
+  DCHECK(delegate_->IsActualMetric(histogram_name));
+  log_.erase(histogram_name);
+  unsent_entries_.erase(histogram_name);
+
+  // Update the persistent value.
+  DictionaryPrefUpdate update(local_state_, kPrefName);
+  update->RemovePath(histogram_name);
+
+  if (has_staged_log() && staged_entry_key_ == histogram_name) {
+    staged_entry_key_.clear();
+    staged_log_.clear();
+  }
+}
+
 void BraveP3ALogStore::ResetUploadStamps() {
   // Clear log entries flags.
   DictionaryPrefUpdate update(local_state_, kPrefName);

--- a/components/p3a/brave_p3a_log_store.cc
+++ b/components/p3a/brave_p3a_log_store.cc
@@ -8,6 +8,7 @@
 #include "base/metrics/histogram_macros.h"
 #include "base/rand_util.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
@@ -103,6 +104,18 @@ const std::string& BraveP3ALogStore::staged_log() const {
   DCHECK(iter != log_.end());
 
   return staged_log_;
+}
+
+std::string BraveP3ALogStore::staged_log_type() const {
+  DCHECK(!staged_entry_key_.empty());
+  auto iter = log_.find(staged_entry_key_);
+  DCHECK(iter != log_.end());
+
+  if (base::StartsWith(iter->first, "Brave.P2A",
+                       base::CompareCase::SENSITIVE)) {
+    return "p2a";
+  }
+  return "p3a";
 }
 
 const std::string& BraveP3ALogStore::staged_log_hash() const {

--- a/components/p3a/brave_p3a_log_store.h
+++ b/components/p3a/brave_p3a_log_store.h
@@ -51,6 +51,7 @@ class BraveP3ALogStore : public metrics::LogStore {
   bool has_unsent_logs() const override;
   bool has_staged_log() const override;
   const std::string& staged_log() const override;
+  std::string staged_log_type() const;
   const std::string& staged_log_hash() const override;
   const std::string& staged_log_signature() const override;
   void StageNextLog() override;

--- a/components/p3a/brave_p3a_log_store.h
+++ b/components/p3a/brave_p3a_log_store.h
@@ -44,6 +44,8 @@ class BraveP3ALogStore : public metrics::LogStore {
   static void RegisterPrefs(PrefRegistrySimple* registry);
 
   void UpdateValue(const std::string& histogram_name, uint64_t value);
+  // Removes and also unstages the metric value if it is known and/or staged.
+  void RemoveValueIfExists(const std::string& histogram_name);
   // Marks all saved values as unsent.
   void ResetUploadStamps();
 

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -332,7 +332,9 @@ void BraveP3AService::OnHistogramChanged(base::StringPiece histogram_name,
 
   // Shortcut for the special values, see |kSuspendedMetricValue|
   // description for details.
+  VLOG(2) << "DEBUG 3 " << histogram_name << " - " << sample;
   if (IsSuspendedMetric(histogram_name, sample)) {
+    VLOG(2) << "DEBUG 4";
     base::PostTask(FROM_HERE, {content::BrowserThread::UI},
                    base::BindOnce(&BraveP3AService::OnHistogramChangedOnUI,
                                   this,

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -25,6 +25,7 @@
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_prochlo/prochlo_message.pb.h"
 #include "brave/components/brave_referrals/common/pref_names.h"
+#include "brave/components/p3a/brave_p2a_protocols.h"
 #include "brave/components/p3a/brave_p3a_log_store.h"
 #include "brave/components/p3a/brave_p3a_scheduler.h"
 #include "brave/components/p3a/brave_p3a_switches.h"
@@ -84,6 +85,7 @@ constexpr const char* kCollectedHistograms[] = {
 
     // P2A
     "Brave.P2A.Test",
+    "Brave.P2A.ViewConfirmationCount",
 };
 
 bool IsSuspendedMetric(base::StringPiece metric_name,
@@ -360,7 +362,9 @@ void BraveP3AService::OnHistogramChanged(base::StringPiece histogram_name,
     const size_t bucket_count = vector->bucket_ranges()->bucket_count() - 1;
     VLOG(2) << "P2A metric " << histogram_name << " has bucket count "
             << bucket_count;
-    // TODO: Perturb the bucket.
+
+    // Perturb the bucket.
+    bucket = DirectEncodingProtocol::Perturb(bucket_count, bucket);
   }
 
   base::PostTask(FROM_HERE, {content::BrowserThread::UI},

--- a/components/p3a/brave_p3a_service.h
+++ b/components/p3a/brave_p3a_service.h
@@ -51,6 +51,7 @@ class BraveP3AService : public base::RefCountedThreadSafe<BraveP3AService>,
   std::string Serialize(base::StringPiece histogram_name,
                         uint64_t value) const override;
 
+  // May be accessed from multiple threads, so this is thread-safe.
   bool IsActualMetric(base::StringPiece histogram_name) const override;
 
  private:
@@ -71,6 +72,9 @@ class BraveP3AService : public base::RefCountedThreadSafe<BraveP3AService>,
   void OnHistogramChangedOnUI(base::StringPiece histogram_name,
                               base::HistogramBase::Sample sample,
                               size_t bucket);
+
+  // Updates or removes a metric from the log.
+  void HandleHistogramChange(base::StringPiece histogram_name, size_t bucket);
 
   void OnLogUploadComplete(int response_code, int error_code, bool was_https);
 

--- a/components/p3a/brave_p3a_uploader.cc
+++ b/components/p3a/brave_p3a_uploader.cc
@@ -82,7 +82,7 @@ void BraveP3AUploader::UploadLog(const std::string& compressed_log_data,
                                  const std::string& upload_type) {
   auto resource_request = std::make_unique<network::ResourceRequest>();
   if (upload_type == "p2a") {
-    resource_request->url = p3a_endpoint_;
+    resource_request->url = p2a_endpoint_;
     resource_request->headers.SetHeader("X-Brave-P2A", "?1");
   } else if (upload_type == "p3a") {
     resource_request->url = p3a_endpoint_;

--- a/components/p3a/brave_p3a_uploader.cc
+++ b/components/p3a/brave_p3a_uploader.cc
@@ -17,12 +17,37 @@ namespace brave {
 namespace {
 
 // TODO(iefremov): Provide more details for the traffic annotation.
-net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotation() {
+net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotation(
+    base::StringPiece upload_type) {
+  if (upload_type == "p3a") {
+    return net::DefineNetworkTrafficAnnotation("metrics_report_uma", R"(
+        semantics {
+          sender: "Brave Privacy-Preserving Product Analytics Uploader"
+          description:
+            "Report of anonymized usage statistics. For more info, see "
+            "https://brave.com/P3A"
+          trigger:
+            "Reports are automatically generated on startup and at intervals "
+            "while Brave is running."
+          data:
+            "A protocol buffer with anonymized and encrypted usage data."
+          destination: WEBSITE
+        }
+        policy {
+          cookies_allowed: NO
+          setting:
+            "Users can enable or disable it in brave://settings/privacy"
+           policy_exception_justification:
+             "Not implemented."
+        })");
+  }
+  DCHECK_EQ(upload_type, "p2a");
   return net::DefineNetworkTrafficAnnotation("metrics_report_uma", R"(
       semantics {
-        sender: "Brave Privacy-Preserving Product Analytics Uploader"
+        sender: "Brave Privacy-Preserving Ad Analytics Uploader"
         description:
-          "Report of anonymized usage statistics. For more info, see https://brave.com/P3A"
+          "Report of anonymized usage statistics. For more info, see "
+          "https://brave.com/P2A"
         trigger:
           "Reports are automatically generated on startup and at intervals "
           "while Brave is running."
@@ -43,26 +68,35 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotation() {
 
 BraveP3AUploader::BraveP3AUploader(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    const GURL server_url,
-    const MetricsLogUploader::UploadCallback& on_upload_complete)
+    const GURL& p3a_endpoint,
+    const GURL& p2a_endpoint,
+    const UploadCallback& on_upload_complete)
     : url_loader_factory_(url_loader_factory),
-      server_url_(server_url),
+      p3a_endpoint_(p3a_endpoint),
+      p2a_endpoint_(p2a_endpoint),
       on_upload_complete_(on_upload_complete) {}
 
 BraveP3AUploader::~BraveP3AUploader() = default;
 
 void BraveP3AUploader::UploadLog(const std::string& compressed_log_data,
-                                 const std::string& log_hash,
-                                 const std::string& log_signature,
-                                 const metrics::ReportingInfo& reporting_info) {
+                                 const std::string& upload_type) {
   auto resource_request = std::make_unique<network::ResourceRequest>();
-  resource_request->url = server_url_;
+  if (upload_type == "p2a") {
+    resource_request->url = p3a_endpoint_;
+    resource_request->headers.SetHeader("X-Brave-P2A", "?1");
+  } else if (upload_type == "p3a") {
+    resource_request->url = p3a_endpoint_;
+    resource_request->headers.SetHeader("X-Brave-P3A", "?1");
+  } else {
+    NOTREACHED();
+  }
+
   resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
   resource_request->method = "POST";
-  resource_request->headers.SetHeader("X-Brave-P3A", "?1");
 
-  url_loader_ = network::SimpleURLLoader::Create(std::move(resource_request),
-                                                 GetNetworkTrafficAnnotation());
+  url_loader_ = network::SimpleURLLoader::Create(
+      std::move(resource_request),
+      GetNetworkTrafficAnnotation(upload_type));
   std::string base64;
   base::Base64Encode(compressed_log_data, &base64);
   url_loader_->AttachStringForUpload(base64, "application/base64");

--- a/components/p3a/brave_p3a_uploader.cc
+++ b/components/p3a/brave_p3a_uploader.cc
@@ -58,7 +58,8 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotation(
       policy {
         cookies_allowed: NO
         setting:
-          "Users can enable or disable it in brave://settings/privacy"
+          "Users can enable or disable it by enabling or disabling Brave rewards
+         or ads in brave://rewards"
          policy_exception_justification:
            "Not implemented."
       })");

--- a/components/p3a/brave_p3a_uploader.h
+++ b/components/p3a/brave_p3a_uploader.h
@@ -9,7 +9,8 @@
 #include <memory>
 #include <string>
 
-#include "components/metrics/metrics_log_uploader.h"
+#include "base/callback.h"
+#include "base/memory/ref_counted.h"
 #include "url/gurl.h"
 
 namespace network {
@@ -19,27 +20,29 @@ class SimpleURLLoader;
 
 namespace brave {
 
-class BraveP3AUploader : public metrics::MetricsLogUploader {
+class BraveP3AUploader {
  public:
+  using UploadCallback = base::RepeatingCallback<void(int, int, bool)>;
+
   BraveP3AUploader(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-      const GURL server_url,
-      const MetricsLogUploader::UploadCallback& on_upload_complete);
+      const GURL& p3a_endpoint,
+      const GURL& p2a_endpoint,
+      const UploadCallback& on_upload_complete);
 
-  ~BraveP3AUploader() override;
+  ~BraveP3AUploader();
 
   // From metrics::MetricsLogUploader
   void UploadLog(const std::string& compressed_log_data,
-                 const std::string& log_hash,
-                 const std::string& log_signature,
-                 const metrics::ReportingInfo& reporting_info) override;
+                 const std::string& upload_type);
 
   void OnUploadComplete(std::unique_ptr<std::string> response_body);
 
  private:
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
-  const GURL server_url_;
-  const MetricsLogUploader::UploadCallback on_upload_complete_;
+  const GURL p3a_endpoint_;
+  const GURL p2a_endpoint_;
+  const UploadCallback on_upload_complete_;
   std::unique_ptr<network::SimpleURLLoader> url_loader_;
   DISALLOW_COPY_AND_ASSIGN(BraveP3AUploader);
 };

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -148,6 +148,7 @@ test("brave_unit_tests") {
     "//brave/components/ntp_background_images/browser/ntp_background_images_source_unittest.cc",
     "//brave/components/ntp_background_images/browser/view_counter_model_unittest.cc",
     "//brave/components/ntp_background_images/browser/view_counter_service_unittest.cc",
+    "//brave/components/p3a/brave_p2a_protocols_unittest.cc",
     "//brave/components/rappor/log_uploader_unittest.cc",
     "//brave/components/translate/core/browser/translate_language_list_unittest.cc",
     "//brave/components/weekly_storage/weekly_storage_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10081

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
use flags to decrease upload and rotation time `--p3a-upload-interval-seconds=5 --p3a-rotation-interval-seconds=160`

case 1: send p2a message

- fresh profile, open browser with vpn to get us catalog, enable ads
- navigate to brave.com to have a page classification for ads
- let browser enter idle state, move mouse and trigger ad > observe p2a log
- wait a couple of minutes for p3a/p2a uploader to trigger > observe p2a message in charles proxy

case 2: prevent sending p2a message when disabling ads

- fresh profile, open browser with vpn to get us catalog, enable ads
- navigate to brave.com to have a page classification for ads
- let browser enter idle state, move mouse and trigger ad > observe p2a log
- disable ads and/or rewards > observe another p2a log
- wait a couple of minutes for p3a/p2a uploader to trigger > observe lack of p2a message in charles proxy

case 3:

- re-enable ads and observe new p2a logs in local state and/or charles

case 4:

- instead of re-enabling, create a new profile and observe p2a logs/uploads

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
