### PR TITLE
Fixes brave/brave-browser#10478

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -27,6 +27,8 @@ constexpr char kUbi[] = "https://[*.]ubi.com/*";
 constexpr char kAmericanexpress[] = "https://[*.]americanexpress.com/*";
 constexpr char kAexp[] = "https://[*.]aexp-static.com/*";
 constexpr char kSony[] = "https://[*.]sony.com/*";
+constexpr char kGoogle[] = "https://[*.]google.com/*";
+constexpr char kGoogleusercontent[] = "https://[*.]googleusercontent.com/*";
 
 bool BraveIsAllowedThirdParty(
     const GURL& url,
@@ -43,6 +45,14 @@ bool BraveIsAllowedThirdParty(
           {
             ContentSettingsPattern::FromString(kWordpress),
             ContentSettingsPattern::FromString(kWp)
+          },
+          {
+            ContentSettingsPattern::FromString(kGoogle),
+            ContentSettingsPattern::FromString(kGoogleusercontent)
+          },
+          {
+            ContentSettingsPattern::FromString(kGoogleusercontent),
+            ContentSettingsPattern::FromString(kGoogle)
           },
           {
             ContentSettingsPattern::FromString(kPlaystation),


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10478

This will allow the google image signatures work correctly.. Can make this more specific to `mail.google.com` if needed, but its within the google.com. There may be other issues between `google.com` and `googleusercontent.com` we're not aware of. 


