### PR TITLE
Work around race condition with shields tab data

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/shieldsPanelReducer.ts
@@ -395,13 +395,14 @@ export default function shieldsPanelReducer (
         console.error('Active tab not found')
         break
       }
-      const cosmeticBlockingEnabled = tabData.cosmeticBlocking
-      chrome.braveShields.getBraveShieldsEnabledAsync(action.url)
-        .then((braveShieldsEnabled: boolean) => {
+      Promise.all([chrome.braveShields.getBraveShieldsEnabledAsync(action.url), chrome.braveShields.getCosmeticFilteringEnabledAsync()])
+        .then(([braveShieldsEnabled, cosmeticBlockingEnabled]: [boolean, boolean]) => {
           const doCosmeticBlocking = braveShieldsEnabled && cosmeticBlockingEnabled
           if (doCosmeticBlocking) {
             applyAdblockCosmeticFilters(action.tabId, action.frameId, getHostname(action.url))
           }
+        }).catch(() => {
+          console.error('error getting cosmetic filtering enabled setting')
         })
       break
     }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10108

For some reason the shields panel data doesn't always get saved quickly enough for cosmetic filtering to work properly. This is especially apparent when opening a new tab rather than navigating within an existing tab. This PR works around that limitation quite simply by querying the state of cosmetic filtering _outside_ of the not-yet-saved shields panel data.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Visit youtube.com while logged in to a google account. Right click on arbitrary videos and select `Open link in new tab`. There should not be ads before the videos on any of the links clicked.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
