### PR TITLE
Fixes Twitch clips on Reddit

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -22,6 +22,9 @@ constexpr char kWordpress[] = "https://[*.]wordpress.com/*";
 constexpr char kPlaystation[] = "https://[*.]playstation.com/*";
 constexpr char kSonyentertainmentnetwork[] =
     "https://[*.]sonyentertainmentnetwork.com/*";
+constexpr char kTwitch[] = "https://clips.twitch.tv/embed?*";
+constexpr char kReddit[] = "https://[www|old]*.reddit.com/*";
+constexpr char kDiscord[] = "https://[*.]discord.com/channels/*";
 constexpr char kUbisoft[] = "https://[*.]ubisoft.com/*";
 constexpr char kUbi[] = "https://[*.]ubi.com/*";
 constexpr char kAmericanexpress[] = "https://[*.]americanexpress.com/*";
@@ -85,6 +88,14 @@ bool BraveIsAllowedThirdParty(
           {
             ContentSettingsPattern::FromString(kAexp),
             ContentSettingsPattern::FromString(kAmericanexpress)
+          },
+          {
+            ContentSettingsPattern::FromString(kTwitch),
+            ContentSettingsPattern::FromString(kReddit)
+          },
+          {
+            ContentSettingsPattern::FromString(kTwitch),
+            ContentSettingsPattern::FromString(kDiscord)
           }
       });
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#10494

Fixes embedded twitch.tv clips on reddit and discord.  Without the twitch cookies, the browser will render an error message or grey empty box. May affect other sites, but these 2 websites are the main/big sites.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
