### PR TITLE
Adjust wallet summary styles to display BAT and fiat on same line

### DIFF
--- a/components/brave_rewards/resources/ui/components/listToken/style.ts
+++ b/components/brave_rewards/resources/ui/components/listToken/style.ts
@@ -21,19 +21,11 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   font-size: 14px;
   line-height: 1.3;
   color: #4b4c5c;
-  flex-grow: 1;
-  flex-shrink: 1;
-  flex-basis: 60%;
-  padding: 10px 0px;
+  flex: 1 1;
+  padding: 10px 5px 10px 0;
 `
 
 export const StyledContentWrapper = styled<{}, 'div'>('div')`
-  flex-grow: 1;
-  flex-shrink: 1;
-  flex-basis: 40%;
+  flex: 1 1;
   text-align: right;
-
-  @media (max-width: 385px) {
-    flex-basis: 55%;
-  }
 `


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10446

The UI difference between the rewards popup and rewards page was caused by a media query that created a larger "flex-basis" in the popup case. This PR removes the media query and simplifies the CSS flex properties.
 
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Launch w/ staging flags.
- Claim UGP grant.
- Tip a publisher.
- Navigate to brave://rewards page.
  - Verify that wallet summary amounts are displayed on a single line.
- Open brave rewards popup.
  - Verify that wallet summary amounts are displayed on a single line.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
