### PR TITLE
Fixes Twitch clips on Reddit and Discord

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -22,6 +22,9 @@ constexpr char kWordpress[] = "https://[*.]wordpress.com/*";
 constexpr char kPlaystation[] = "https://[*.]playstation.com/*";
 constexpr char kSonyentertainmentnetwork[] =
     "https://[*.]sonyentertainmentnetwork.com/*";
+constexpr char kTwitch[] = "https://[*.]twitch.tv/*";
+constexpr char kReddit[] = "https://[*.]reddit.com/*";
+constexpr char kDiscord[] = "https://[*.]discord.com/*";
 constexpr char kUbisoft[] = "https://[*.]ubisoft.com/*";
 constexpr char kUbi[] = "https://[*.]ubi.com/*";
 constexpr char kAmericanexpress[] = "https://[*.]americanexpress.com/*";
@@ -75,6 +78,18 @@ bool BraveIsAllowedThirdParty(
           {
             ContentSettingsPattern::FromString(kAexp),
             ContentSettingsPattern::FromString(kAmericanexpress)
+          },
+            ContentSettingsPattern::FromString(kTwitch),
+            ContentSettingsPattern::FromString(kReddit)
+          },
+            ContentSettingsPattern::FromString(kReddit),
+            ContentSettingsPattern::FromString(kTwitch)
+          },
+            ContentSettingsPattern::FromString(kTwitch),
+            ContentSettingsPattern::FromString(kDiscord)
+          },
+            ContentSettingsPattern::FromString(kDiscord),
+            ContentSettingsPattern::FromString(kTwitch)
           }
       });
 

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -82,14 +82,8 @@ bool BraveIsAllowedThirdParty(
             ContentSettingsPattern::FromString(kTwitch),
             ContentSettingsPattern::FromString(kReddit)
           },
-            ContentSettingsPattern::FromString(kReddit),
-            ContentSettingsPattern::FromString(kTwitch)
-          },
             ContentSettingsPattern::FromString(kTwitch),
             ContentSettingsPattern::FromString(kDiscord)
-          },
-            ContentSettingsPattern::FromString(kDiscord),
-            ContentSettingsPattern::FromString(kTwitch)
           }
       });
 


### PR DESCRIPTION

Fix embedded Twitch clips on Reddit and Discord (fixes brave/brave-browser#10494)

Without the Twitch cookies, the browser will render an error message or grey empty box.