### PR TITLE
Fix 10528: Parse resource.json for regional adblock lists

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@da31bb0a986a42419f449833b7ae111864275d17",
+  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@af293de6f3bf6119b05ca8e69530c32cc7743baa",
   "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@b4d059c73042cacf3a5e9156d4b1698e7bc18678",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@6eab0271d014ff09bd9f38abe1e0c117e13e9aa9",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",

--- a/components/brave_shields/browser/ad_block_regional_service.h
+++ b/components/brave_shields/browser/ad_block_regional_service.h
@@ -36,6 +36,7 @@ class AdBlockRegionalService : public AdBlockBaseService {
   void OnComponentReady(const std::string& component_id,
                         const base::FilePath& install_dir,
                         const std::string& manifest) override;
+  void OnResourcesFileDataReady(const std::string& resources);
 
  private:
   friend class ::AdBlockServiceTest;
@@ -49,6 +50,7 @@ class AdBlockRegionalService : public AdBlockBaseService {
   std::string uuid_;
   std::string title_;
 
+  base::WeakPtrFactory<AdBlockRegionalService> weak_factory_{this};
   DISALLOW_COPY_AND_ASSIGN(AdBlockRegionalService);
 };
 

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -85,8 +85,6 @@ void AdBlockService::OnComponentReady(const std::string& component_id,
 
 void AdBlockService::OnResourcesFileDataReady(const std::string& resources) {
   g_brave_browser_process->ad_block_service()->AddResources(resources);
-  g_brave_browser_process->ad_block_regional_service_manager()->AddResources(
-      resources);
   g_brave_browser_process->ad_block_custom_filters_service()->AddResources(
       resources);
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10528

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

1. Navigate to brave://adblock
2. Select a new adblock list
3. Confirm that no error - `Failed to parse JSON adblock resources: EOF while parsing a value at line 1 column 0` is displayed.

`resource.json` should be added to all regional adblock lists by https://github.com/brave/brave-core-crx-packager/pull/138

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
