### PR TITLE
Disable cosmetic filtering on vetted search engines in standard adblocking mode

### DIFF
--- a/components/brave_extension/extension/brave_extension/content_cosmetic.ts
+++ b/components/brave_extension/extension/brave_extension/content_cosmetic.ts
@@ -540,6 +540,8 @@ const scheduleQueuePump = (hide1pContent: boolean, generichide: boolean) => {
   }, { timeout: maxTimeMSBeforeStart })
 }
 
+const vettedSearchEngines = ['duckduckgo', 'qwant', 'bing', 'startpage', 'yahoo', 'onesearch', 'google', 'yandex']
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const action = typeof msg === 'string' ? msg : msg.type
   switch (action) {
@@ -554,7 +556,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       const { selectors } = msg
       let nextIndex = cosmeticStyleSheet.rules.length
       for (const selector of selectors) {
-        if (selector === '.ads-ad' && _parsedCurrentDomain.type === ParseResultType.Listed && _parsedCurrentDomain.icann.domain === 'google') {
+        if (_parsedCurrentDomain.type === ParseResultType.Listed && vettedSearchEngines.includes(_parsedCurrentDomain.icann.domain)) {
           continue
         }
         if (allSelectorsToRules.has(selector)) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10575

Depends on https://github.com/brave/brave-core/pull/6010

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Visit sites from the list in https://github.com/brave/brave-browser/issues/10575 in standard adblocking mode and verify that the search ads are displayed on the page. It may take multiple different queries to produce one with ads.

Visit the same sites in aggressive mode and verify that the search ads are _not_ shown.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
