### PR TITLE
[Android] Fix for crash on menu footer initialization (uplift to 1.11.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
+++ b/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
@@ -24,6 +24,7 @@ import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.multiwindow.MultiWindowModeStateDispatcher;
 import org.chromium.chrome.browser.notifications.BraveSetDefaultBrowserNotificationService;
 import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
+import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.chrome.browser.tabbed_mode.TabbedAppMenuPropertiesDelegate;
 import org.chromium.chrome.browser.tabmodel.TabModelSelector;
 import org.chromium.chrome.browser.toolbar.ToolbarManager;
@@ -80,6 +81,13 @@ public class BraveTabbedAppMenuPropertiesDelegate extends TabbedAppMenuPropertie
             shareItem.setTitle(mContext.getString(R.string.share));
             shareItem.setIcon(AppCompatResources.getDrawable(mContext, R.drawable.share_icon));
         }
+
+        // By this we forcibly initialize mBookmarkBridge
+        MenuItem bookmarkItem = menu.findItem(R.id.bookmark_this_page_id);
+        Tab currentTab = mActivityTabProvider.get();
+        if (bookmarkItem != null && currentTab != null) {
+            updateBookmarkMenuItem(bookmarkItem, currentTab);
+        }
     }
 
     @Override
@@ -93,6 +101,15 @@ public class BraveTabbedAppMenuPropertiesDelegate extends TabbedAppMenuPropertie
 
     @Override
     public void onFooterViewInflated(AppMenuHandler appMenuHandler, View view) {
+        // If it's still null, just hide the whole view
+        if (mBookmarkBridge == null) {
+            if (view != null) {
+                view.setVisibility(View.GONE);
+            }
+            // Normally it should not happen
+            assert false;
+            return;
+        }
         super.onFooterViewInflated(appMenuHandler, view);
 
         // Hide bookmark button if bottom toolbar is enabled

--- a/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java
+++ b/android/java/org/chromium/chrome/browser/document/BraveLauncherActivity.java
@@ -9,6 +9,7 @@ import android.app.Activity;
 import android.os.Bundle;
 
 import org.chromium.chrome.browser.BraveHelper;
+import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
 import org.chromium.chrome.browser.toolbar.bottom.BottomToolbarConfiguration;
 
 /**
@@ -18,6 +19,9 @@ public class BraveLauncherActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Disable key checker to avoid asserts on Brave keys in debug
+        SharedPreferencesManager.getInstance().disableKeyCheckerForTesting();
 
         BottomToolbarConfiguration.isBottomToolbarEnabled();
         BraveHelper.DisableFREDRP();


### PR DESCRIPTION
Uplift of #6023
Resolves https://github.com/brave/brave-browser/issues/10593

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.