### PR TITLE
Fix crash on iOS when downloading protobuf contents for pub list v4 (uplift to 1.12.x)

### DIFF
--- a/vendor/brave-ios/Shared/BATCommonOperations.mm
+++ b/vendor/brave-ios/Shared/BATCommonOperations.mm
@@ -121,10 +121,9 @@
     const auto strongSelf = weakSelf;
 
     const auto response = (NSHTTPURLResponse *)urlResponse;
-    std::string json;
-    if (data) {
-      // Might be no reason to convert to an NSString back to a UTF8 pointer...
-      json = std::string([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding].UTF8String);
+    std::string body;
+    if (data && data.length > 0) {
+      body = std::string(static_cast<const char*>(data.bytes), data.length);
     }
     // For some reason I couldn't just do `std::map<std::string, std::string> responseHeaders;` due to std::map's
     // non-const key insertion
@@ -140,7 +139,7 @@
     dispatch_async(dispatch_get_main_queue(), ^{
       if (!weakSelf2) { return; }
       [weakSelf2.runningTasks removeObject:task];
-      callback((int)response.statusCode, json, copiedHeaders);
+      callback((int)response.statusCode, body, copiedHeaders);
     });
     delete responseHeaders;
   }];


### PR DESCRIPTION
iOS specific crash fix for pub list v4 which is set to release with 1.12.x

Uplift of #6038
Resolves https://github.com/brave/brave-browser/issues/10626

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.