### PR TITLE
Fix sites removed from history are shown in top site tiles in NTP

### DIFF
--- a/components/brave_new_tab_ui/helpers/newTabUtils.ts
+++ b/components/brave_new_tab_ui/helpers/newTabUtils.ts
@@ -76,16 +76,16 @@ export const generateGridSiteProperties = (
   }
 }
 
-export const getGridSitesWhitelist = (
+export const getTopSitesWhitelist = (
   topSites: chrome.topSites.MostVisitedURL[]
   ): chrome.topSites.MostVisitedURL[] => {
   const defaultChromeWebStoreUrl: string = 'https://chrome.google.com/webstore'
-  const filteredGridSites: chrome.topSites.MostVisitedURL[] = topSites
+  const filteredTopSites: chrome.topSites.MostVisitedURL[] = topSites
     .filter(site => {
       // See https://github.com/brave/brave-browser/issues/5376
       return !site.url.startsWith(defaultChromeWebStoreUrl)
     })
-  return filteredGridSites
+  return filteredTopSites
 }
 
 export const generateGridSitesFromLegacyEntries = (

--- a/components/brave_new_tab_ui/reducers/grid_sites_reducer.ts
+++ b/components/brave_new_tab_ui/reducers/grid_sites_reducer.ts
@@ -44,7 +44,7 @@ export const gridSitesReducer: Reducer<NewTab.GridSitesState | undefined> = (
 
       // New profiles just store what comes from Chromium
       state = gridSitesState
-        .gridSitesReducerSetFirstRenderData(state, payload.topSites)
+        .gridSitesReducerSetFirstRenderData(state, payload.topSites, payload.defaultSuperReferralTopSites)
 
       // Handle default top sites data only once.
       if (payload.defaultSuperReferralTopSites && !storage.isDefaultSuperReferralTopSitesAddedToPinnedSites()) {

--- a/components/brave_new_tab_ui/reducers/grid_sites_reducer.ts
+++ b/components/brave_new_tab_ui/reducers/grid_sites_reducer.ts
@@ -52,6 +52,9 @@ export const gridSitesReducer: Reducer<NewTab.GridSitesState | undefined> = (
           .gridSitesReducerSetDefaultSuperReferralTopSites(state, payload.defaultSuperReferralTopSites)
         storage.setDefaultSuperReferralTopSitesAddedToPinnedSites()
       }
+
+      // Cached gridSites can be updated when history has modified.
+      state = gridSitesState.gridSitesReducerDataUpdated(state, state.gridSites)
       break
     }
 

--- a/components/brave_new_tab_ui/state/gridSitesState.ts
+++ b/components/brave_new_tab_ui/state/gridSitesState.ts
@@ -7,7 +7,7 @@ import {
   generateGridSiteProperties,
   generateGridSitePropertiesFromDefaultSuperReferralTopSite,
   isExistingGridSite,
-  getGridSitesWhitelist,
+  getTopSitesWhitelist,
   isGridSitePinned,
   filterFromExcludedSites,
   filterDuplicatedSitesbyIndexOrUrl
@@ -50,11 +50,33 @@ export function gridSitesReducerSetDefaultSuperReferralTopSites (
 
 export function gridSitesReducerSetFirstRenderData (
   state: NewTab.GridSitesState,
-  topSites: chrome.topSites.MostVisitedURL[]
+  topSites: chrome.topSites.MostVisitedURL[],
+  defaultSuperReferralTopSites: NewTab.DefaultSuperReferralTopSite[]
 ): NewTab.GridSitesState {
-  const gridSitesWhitelist = getGridSitesWhitelist(topSites)
+  const topSitesWhitelisted = getTopSitesWhitelist(topSites)
+  // |state.gridSites| has lastly used sites data for NTP.
+  // Delete sites from |state.gridSites| that don't exist in topSites(history).
+  // Then, |updatedGridSites| will only store previously used sites that topSites have.
+  const updatedGridSites: NewTab.Site[] = state.gridSites.filter((gridSite: NewTab.Site) => {
+    // Pinned tab will be remained even if it's deleted from history.
+    // If unpinned, it will not be visible if it's not in topSites.
+    if (gridSite.pinnedIndex !== undefined) {
+      return true
+    }
+    // Don't delete top sites came from SR's default top sites even if they
+    // are not in history.
+    if (defaultSuperReferralTopSites &&
+        defaultSuperReferralTopSites.some(site => site.url === gridSite.url)) {
+      return true
+    }
+    return topSitesWhitelisted.some(site => site.url === gridSite.url)
+  })
+  state = {
+    ...state,
+    gridSites: updatedGridSites
+  }
   const newGridSites: NewTab.Site[] = []
-  for (const [index, topSite] of gridSitesWhitelist.entries()) {
+  for (const [index, topSite] of topSitesWhitelisted.entries()) {
     if (isExistingGridSite(state.gridSites, topSite)) {
       // If topSite from Chromium exists in our gridSites list,
       // skip and iterate over the next item.

--- a/components/brave_new_tab_ui/state/gridSitesState.ts
+++ b/components/brave_new_tab_ui/state/gridSitesState.ts
@@ -58,11 +58,6 @@ export function gridSitesReducerSetFirstRenderData (
   // Delete sites from |state.gridSites| that don't exist in topSites(history).
   // Then, |updatedGridSites| will only store previously used sites that topSites have.
   const updatedGridSites: NewTab.Site[] = state.gridSites.filter((gridSite: NewTab.Site) => {
-    // Pinned tab will be remained even if it's deleted from history.
-    // If unpinned, it will not be visible if it's not in topSites.
-    if (gridSite.pinnedIndex !== undefined) {
-      return true
-    }
     // Don't delete top sites came from SR's default top sites even if they
     // are not in history.
     if (defaultSuperReferralTopSites &&

--- a/components/test/brave_new_tab_ui/helpers/newTabUtils_test.ts
+++ b/components/test/brave_new_tab_ui/helpers/newTabUtils_test.ts
@@ -196,18 +196,18 @@ describe('new tab util files tests', () => {
       })
     })
   })
-  describe('getGridSitesWhitelist', () => {
+  describe('getTopSitesWhitelist', () => {
     it('excludes https://chrome.google.com/webstore from list', () => {
       const topSites: chrome.topSites.MostVisitedURL[] = [
         { url: 'https://chrome.google.com/webstore', title: 'store' }
       ]
-      expect(newTabUtils.getGridSitesWhitelist(topSites)).toHaveLength(0)
+      expect(newTabUtils.getTopSitesWhitelist(topSites)).toHaveLength(0)
     })
     it('does not exclude an arbritary site from list', () => {
       const topSites: chrome.topSites.MostVisitedURL[] = [
         { url: 'https://tmz.com', title: 'tmz' }
       ]
-      expect(newTabUtils.getGridSitesWhitelist(topSites)).toHaveLength(1)
+      expect(newTabUtils.getTopSitesWhitelist(topSites)).toHaveLength(1)
     })
   })
   describe('filterFromExcludedSites', () => {

--- a/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
+++ b/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
@@ -60,7 +60,7 @@ describe('gridSitesReducer', () => {
 
       expect(gridSitesReducerSetFirstRenderDataStub).toBeCalledTimes(1)
       expect(gridSitesReducerSetFirstRenderDataStub)
-        .toBeCalledWith(storage.initialGridSitesState, [])
+        .toBeCalledWith(storage.initialGridSitesState, [], undefined)
     })
     it('populate state.gridSites list with Chromium topSites data', () => {
       const assertion = gridSitesReducer(storage.initialGridSitesState, {
@@ -69,6 +69,59 @@ describe('gridSitesReducer', () => {
       })
 
       expect(assertion.gridSites).toHaveLength(2)
+    })
+    it('check gridSites does not have sites that are removed from topSites', () => {
+      let state: NewTab.GridSitesState = storage.initialGridSitesState
+      state = {
+        ...state,
+        gridSites: [
+         {
+            url: 'www.basicattentiontoken.org',
+            title: 'BAT',
+            id: 'topsite-0',
+            favicon: '',
+            letter: 'b',
+            pinnedIndex: 0
+          },
+          {
+            url: 'www.brave.com',
+            title: 'Brave Software',
+            id: 'topsite-1',
+            favicon: '',
+            letter: 'c',
+            pinnedIndex: undefined
+          },
+          {
+            url: 'www.google.com',
+            title: 'Google',
+            id: 'topsite-2',
+            favicon: '',
+            letter: 'c',
+            pinnedIndex: undefined
+          }
+        ]
+      }
+
+      const topSites = [
+        {
+          url: 'www.brave.com',
+          title: 'brave'
+        }, {
+          url: 'www.cnn.com',
+          title: 'cnn'
+        }
+      ]
+      const assertion = gridSitesReducer(state, {
+        type: types.GRID_SITES_SET_FIRST_RENDER_DATA,
+        payload: { topSites }
+      })
+
+      // Initial state has google site but it's deleted because topSites doesn't
+      // have it.
+      expect(assertion.gridSites).toHaveLength(3)
+      expect(assertion.gridSites[0].url).toBe('www.basicattentiontoken.org')
+      expect(assertion.gridSites[1].url).toBe('www.cnn.com')
+      expect(assertion.gridSites[2].url).toBe('www.brave.com')
     })
     it('populate state.gridSites list without duplicates', () => {
       const brandNewSite: NewTab.Site = {

--- a/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
+++ b/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
@@ -118,10 +118,9 @@ describe('gridSitesReducer', () => {
 
       // Initial state has google site but it's deleted because topSites doesn't
       // have it.
-      expect(assertion.gridSites).toHaveLength(3)
-      expect(assertion.gridSites[0].url).toBe('www.basicattentiontoken.org')
-      expect(assertion.gridSites[1].url).toBe('www.cnn.com')
-      expect(assertion.gridSites[2].url).toBe('www.brave.com')
+      expect(assertion.gridSites).toHaveLength(2)
+      expect(assertion.gridSites[0].url).toBe('www.cnn.com')
+      expect(assertion.gridSites[1].url).toBe('www.brave.com')
     })
     it('populate state.gridSites list without duplicates', () => {
       const brandNewSite: NewTab.Site = {
@@ -162,7 +161,7 @@ describe('gridSitesReducer', () => {
 
       const assertion = gridSitesReducer(veryRepetitiveInitialGridSitesState, {
         type: types.GRID_SITES_SET_FIRST_RENDER_DATA,
-        payload: { topSites: [ brandNewSite ] }
+        payload: { topSites: [ brandNewSite, veryRepetitiveSite ] }
       })
       // We should see just one repetitive site and the new
       // one added on the payload above

--- a/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
+++ b/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
@@ -122,6 +122,68 @@ describe('gridSitesReducer', () => {
       expect(assertion.gridSites[0].url).toBe('www.cnn.com')
       expect(assertion.gridSites[1].url).toBe('www.brave.com')
     })
+    it('check sites from SR are not deleted from gridSites', () => {
+      let state: NewTab.GridSitesState = storage.initialGridSitesState
+      state = {
+        ...state,
+        gridSites: [
+          {
+            url: 'www.basicattentiontoken.org',
+            title: 'BAT',
+            id: 'topsite-0',
+            favicon: '',
+            letter: 'b',
+            pinnedIndex: 0
+          },
+          {
+            url: 'www.brave.com',
+            title: 'Brave Software',
+            id: 'topsite-1',
+            favicon: '',
+            letter: 'c',
+            pinnedIndex: undefined
+          },
+          {
+            url: 'www.google.com',
+            title: 'Google',
+            id: 'topsite-2',
+            favicon: '',
+            letter: 'c',
+            pinnedIndex: undefined
+          }
+        ]
+      }
+
+      const topSites = [
+        {
+          url: 'www.brave.com',
+          title: 'brave'
+        }, {
+          url: 'www.cnn.com',
+          title: 'cnn'
+        }
+      ]
+
+      const defaultSuperReferralTopSites = [
+        {
+          pinnedIndex: 0,
+          url: 'www.basicattentiontoken.org',
+          title: 'BAT',
+          favicon: 'favicon.png'
+        }
+      ]
+      const assertion = gridSitesReducer(state, {
+        type: types.GRID_SITES_SET_FIRST_RENDER_DATA,
+        payload: { topSites, defaultSuperReferralTopSites }
+      })
+
+      // topSites doesn't have bat site but it's in SR's default top sites.
+      // So, it's not deleted from gritSites.
+      expect(assertion.gridSites).toHaveLength(3)
+      expect(assertion.gridSites[0].url).toBe('www.basicattentiontoken.org')
+      expect(assertion.gridSites[1].url).toBe('www.cnn.com')
+      expect(assertion.gridSites[2].url).toBe('www.brave.com')
+    })
     it('populate state.gridSites list without duplicates', () => {
       const brandNewSite: NewTab.Site = {
         id: 'topsite-000',

--- a/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
+++ b/components/test/brave_new_tab_ui/reducers/grid_sites_reducer_test.ts
@@ -75,7 +75,7 @@ describe('gridSitesReducer', () => {
       state = {
         ...state,
         gridSites: [
-         {
+          {
             url: 'www.basicattentiontoken.org',
             title: 'BAT',
             id: 'topsite-0',


### PR DESCRIPTION
Sites that topSites(history) doesn't include are removed from gridSites.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9929

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Scenario 1.
  1. Launch browser and load some sites.
  2. Check top site in NTP has some sites
  3. Delete one of site from brave://history
  4. Reload NTP and check removed site is not visible in NTP.
  5. Pin one among top sites in NTP
  6. Delete pinned site from history
  7. Reload NTP and check removed pinned site is not visible
  8. Clear whole history
  9. Reload NTP and check topsite is empty

Scenario 2.
  1. Setup Super referral code.
  2. Launch browser and check NTP shows SR and it's top sites
  3. Check history is empty but top sites from SR are not deleted
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
