### PR TITLE
[1.11.x] Do not immediately expire sync v1 infobar about v2

### DIFF
--- a/browser/infobars/sync_v1_deprecation_infobar_delegate.cc
+++ b/browser/infobars/sync_v1_deprecation_infobar_delegate.cc
@@ -63,6 +63,11 @@ SyncV1DeprecationInfoBarDelegate::GetIdentifier() const {
   return SYNC_V1_DEPRECATION_INFOBAR_DELEGATE;
 }
 
+bool SyncV1DeprecationInfoBarDelegate::ShouldExpire(
+    const NavigationDetails& details) const {
+  return false;
+}
+
 const gfx::VectorIcon& SyncV1DeprecationInfoBarDelegate::GetVectorIcon() const {
   return vector_icons::kSyncIcon;
 }

--- a/browser/infobars/sync_v1_deprecation_infobar_delegate.h
+++ b/browser/infobars/sync_v1_deprecation_infobar_delegate.h
@@ -27,6 +27,7 @@ class SyncV1DeprecationInfoBarDelegate : public ConfirmInfoBarDelegate {
   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
   const gfx::VectorIcon& GetVectorIcon() const override;
   int GetButtons() const override;
+  bool ShouldExpire(const NavigationDetails& details) const override;
   base::string16 GetMessageText() const override;
   base::string16 GetLinkText() const override;
   GURL GetLinkURL() const override;


### PR DESCRIPTION
We were relying on the base implementation. Possibly i don't understand how that works because I had assumed that it would only expire the infobar after a change of site, not a New Tab or resurrecting a tab on browser restart. But in release (and frustratingly not on local builds) that's not the case - the infobar was immediately dismissing. So, change the logic to an info bar which does not automatically expire for the active tab.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10621

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
