### PR TITLE
Fixes movement inside the more cards NTP settings section when interacting

### DIFF
--- a/components/brave_new_tab_ui/components/default/settings/index.ts
+++ b/components/brave_new_tab_ui/components/default/settings/index.ts
@@ -335,4 +335,14 @@ export const StyledButtonIcon = styled<{}, 'div'>('div')`
   display: inline-block;
   vertical-align: sub;
   margin-right: 5px;
+  height: 20px;
+  width: 20px;
+`
+
+export const StyledButtonLabel = styled<{}, 'span'>('span')`
+  max-width: 100px;
+  text-overflow: ellipsis;
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
 `

--- a/components/brave_new_tab_ui/containers/newTab/settings/moreCards.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings/moreCards.tsx
@@ -14,7 +14,8 @@ import {
   StyledWidgetToggle,
   SettingsWidget,
   StyledButtonIcon,
-  StyledWidgetSettings
+  StyledWidgetSettings,
+  StyledButtonLabel
 } from '../../../components/default'
 import togetherBanner from './assets/bravetogether.png'
 import binanceBanner from './assets/binance.png'
@@ -55,11 +56,13 @@ class MoreCardsSettings extends React.PureComponent<Props, {}> {
             : <AddIcon />
           }
         </StyledButtonIcon>
-        {
-          on
-          ? getLocale('hideWidget')
-          : getLocale('addWidget')
-        }
+        <StyledButtonLabel>
+          {
+            on
+            ? getLocale('hideWidget')
+            : getLocale('addWidget')
+          }
+        </StyledButtonLabel>
       </StyledWidgetToggle>
     )
   }


### PR DESCRIPTION
Fixes brave/brave-browser#10757

The actual SVG's differed in outer bound width slightly, so just defining height/width constraints for container fixes that.

This will also prevent long translated strings from causing the same issue.
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Defined in issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
