### PR TITLE
Load regional catalog provided by brave-core-crx-packager

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,7 @@
 use_relative_paths = True
 
 deps = {
-  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@af293de6f3bf6119b05ca8e69530c32cc7743baa",
+  "vendor/adblock_rust_ffi": "https://github.com/brave/adblock-rust-ffi.git@f836fd3beacc38feba01eda8452d5e06f302a655",
   "vendor/extension-whitelist": "https://github.com/brave/extension-whitelist.git@b4d059c73042cacf3a5e9156d4b1698e7bc18678",
   "vendor/hashset-cpp": "https://github.com/brave/hashset-cpp.git@6eab0271d014ff09bd9f38abe1e0c117e13e9aa9",
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -17,6 +17,7 @@
 #include "base/synchronization/lock.h"
 #include "base/values.h"
 #include "brave/components/brave_component_updater/browser/brave_component.h"
+#include "brave/vendor/adblock_rust_ffi/src/wrapper.hpp"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 #include "url/gurl.h"
 
@@ -39,8 +40,10 @@ class AdBlockRegionalServiceManager {
   explicit AdBlockRegionalServiceManager(BraveComponent::Delegate* delegate);
   ~AdBlockRegionalServiceManager();
 
-  static bool IsSupportedLocale(const std::string& locale);
-  static std::unique_ptr<base::ListValue> GetRegionalLists();
+  bool IsSupportedLocale(const std::string& locale);
+  std::unique_ptr<base::ListValue> GetRegionalLists();
+
+  void SetRegionalCatalog(std::vector<adblock::FilterList> catalog);
 
   bool IsInitialized() const;
   bool Start();
@@ -72,6 +75,8 @@ class AdBlockRegionalServiceManager {
   base::Lock regional_services_lock_;
   std::map<std::string, std::unique_ptr<AdBlockRegionalService>>
       regional_services_;
+
+  std::vector<adblock::FilterList> regional_catalog_;
 
   DISALLOW_COPY_AND_ASSIGN(AdBlockRegionalServiceManager);
 };

--- a/components/brave_shields/browser/ad_block_regional_service_unittest.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_unittest.cc
@@ -3,14 +3,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_shields/browser/ad_block_regional_service_manager.h"
+#include "brave/components/brave_shields/browser/ad_block_service_helper.h"
+#include "brave/vendor/adblock_rust_ffi/src/wrapper.hpp"
 #include "testing/gtest/include/gtest/gtest.h"
 
 TEST(AdBlockRegionalServiceTest, UserModelLanguages) {
+  std::vector<adblock::FilterList> catalog = std::vector<adblock::FilterList>();
+  catalog.push_back(adblock::FilterList("uuid",
+                                        "https://brave.com",
+                                        "Testing Filter List",
+                                        {"fr"},
+                                        "https://support.brave.com",
+                                        "componentid",
+                                        "base64publickey",
+                                        "Filter list for testing purposes"));
+
   std::vector<std::string> languages({ "fr", "fR", "fr-FR", "fr-ca" });
   std::for_each(languages.begin(), languages.end(),
-      [](const std::string& language) {
-    EXPECT_TRUE(brave_shields::AdBlockRegionalServiceManager::IsSupportedLocale(
-        language));
+      [&](const std::string& language) {
+    EXPECT_TRUE(brave_shields::FindAdBlockFilterListByLocale(catalog, language)
+        != catalog.end());
   });
 }

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -49,6 +49,7 @@ class AdBlockService : public AdBlockBaseService {
                         const base::FilePath& install_dir,
                         const std::string& manifest) override;
   void OnResourcesFileDataReady(const std::string& resources);
+  void OnRegionalCatalogFileDataReady(const std::string& catalog_json);
 
  private:
   friend class ::AdBlockServiceTest;

--- a/components/brave_shields/browser/ad_block_service_helper.h
+++ b/components/brave_shields/browser/ad_block_service_helper.h
@@ -21,6 +21,9 @@ std::vector<adblock::FilterList>::const_iterator FindAdBlockFilterListByLocale(
     const std::vector<adblock::FilterList>& region_lists,
     const std::string& locale);
 
+std::vector<adblock::FilterList> RegionalCatalogFromJSON(
+    const std::string& catalog_json);
+
 void MergeResourcesInto(base::Value* into, base::Value* from, bool force_hide);
 
 }  // namespace brave_shields


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10830

- [x] Depends on https://github.com/brave/brave-core-crx-packager/pull/161

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Visit `brave://adblock` and verify that the most recent addition to our regional catalog (currently "AdGuard Français") appears in the list, and that toggling its checkbox persists across browsing sessions. Also verify that when toggled on, the associated entry in `brave://components` shows a version other than `0.0.0.0`.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
