### PR TITLE
Removes the "No Thank You" opt-out action from the Gemini widget

### DIFF
--- a/components/brave_new_tab_ui/components/default/gemini/index.tsx
+++ b/components/brave_new_tab_ui/components/default/gemini/index.tsx
@@ -420,8 +420,6 @@ class Gemini extends React.PureComponent<Props, State> {
   }
 
   renderAuthView () {
-    const { onDisableWidget } = this.props
-
     return (
       <>
         <IntroTitle>
@@ -430,17 +428,10 @@ class Gemini extends React.PureComponent<Props, State> {
         <Copy>
           {getLocale('geminiWidgetConnectCopy')}
         </Copy>
-        <ActionsWrapper>
-          {
-            <>
-              <ConnectButton onClick={this.connectGemini}>
-                {getLocale('geminiWidgetConnectButton')}
-              </ConnectButton>
-              <DismissAction onClick={onDisableWidget}>
-                {getLocale('geminiWidgetDismissText')}
-              </DismissAction>
-            </>
-          }
+        <ActionsWrapper isAuth={true}>
+          <ConnectButton onClick={this.connectGemini}>
+            {getLocale('geminiWidgetConnectButton')}
+          </ConnectButton>
         </ActionsWrapper>
       </>
     )

--- a/components/brave_new_tab_ui/components/default/gemini/style.ts
+++ b/components/brave_new_tab_ui/components/default/gemini/style.ts
@@ -20,6 +20,7 @@ interface StyleProps {
   itemsShowing?: boolean
   disabled?: boolean
   isSmall?: boolean
+  isAuth?: boolean
 }
 
 export const WidgetWrapper = styled<StyleProps, 'div'>('div')`
@@ -84,8 +85,8 @@ export const Copy = styled<{}, 'p'>('p')`
   color: #A6A6A6;
 `
 
-export const ActionsWrapper = styled<{}, 'div'>('div')`
-  margin-bottom: 5px;
+export const ActionsWrapper = styled<StyleProps, 'div'>('div')`
+  margin-bottom: ${p => p.isAuth ? 20 : 5}px;
   text-align: center;
 `
 


### PR DESCRIPTION
Fixes brave/brave-browser#10823

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Confirm that "No Thank You" does not appear in the disconnected state.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
