### PR TITLE
don't fire notifications on initialization (uplift to 1.12.x)

### DIFF
--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -114,6 +114,7 @@ BravePrefProvider::BravePrefProvider(PrefService* prefs,
                                      bool store_last_modified,
                                      bool restore_session)
     : PrefProvider(prefs, off_the_record, store_last_modified, restore_session),
+      initialized_(false),
       weak_factory_(this) {
   brave_pref_change_registrar_.Init(prefs_);
   brave_pref_change_registrar_.Add(
@@ -138,8 +139,11 @@ BravePrefProvider::BravePrefProvider(PrefService* prefs,
 
   MigrateShieldsSettings(off_the_record);
 
-  AddObserver(this);
   OnCookieSettingsChanged(ContentSettingsType::PLUGINS);
+
+  // Enable change notifications after initial setup to avoid notification spam
+  initialized_ = true;
+  AddObserver(this);
 }
 
 BravePrefProvider::~BravePrefProvider() {}
@@ -442,7 +446,7 @@ void BravePrefProvider::UpdateCookieRules(ContentSettingsType content_type,
   }
 
   // Notify brave cookie changes as ContentSettingsType::COOKIES
-  if (content_type == ContentSettingsType::PLUGINS) {
+  if (initialized_ && content_type == ContentSettingsType::PLUGINS) {
     // PostTask here to avoid content settings autolock DCHECK
     base::PostTask(
         FROM_HERE,

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.h
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.h
@@ -75,6 +75,8 @@ class BravePrefProvider : public PrefProvider,
   std::map<bool /* is_incognito */, std::vector<Rule>> cookie_rules_;
   std::map<bool /* is_incognito */, std::vector<Rule>> brave_cookie_rules_;
 
+  bool initialized_;
+
   base::WeakPtrFactory<BravePrefProvider> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(BravePrefProvider);


### PR DESCRIPTION
Uplift of #6126
fix https://github.com/brave/brave-browser/issues/9481

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.