### PR TITLE
don't fire notifications on initialization (uplift to 1.11.x)

### DIFF
--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.h
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.h
@@ -75,6 +75,8 @@ class BravePrefProvider : public PrefProvider,
   std::map<bool /* is_incognito */, std::vector<Rule>> cookie_rules_;
   std::map<bool /* is_incognito */, std::vector<Rule>> brave_cookie_rules_;
 
+  bool initialized_;
+
   base::WeakPtrFactory<BravePrefProvider> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(BravePrefProvider);


### PR DESCRIPTION
Uplift of #6126
fix https://github.com/brave/brave-browser/issues/9481

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.