### PR TITLE
Fix crashes while wayback infobar is hiding (uplift to 1.12.x)

### DIFF
--- a/browser/ui/views/infobars/brave_wayback_machine_infobar_contents_view.cc
+++ b/browser/ui/views/infobars/brave_wayback_machine_infobar_contents_view.cc
@@ -12,6 +12,7 @@
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/themes/theme_properties.h"
 #include "brave/browser/ui/views/infobars/brave_wayback_machine_infobar_button_container.h"
+#include "brave/components/brave_wayback_machine/brave_wayback_machine_infobar_delegate.h"
 #include "brave/components/brave_wayback_machine/wayback_machine_url_fetcher.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "brave/grit/brave_theme_resources.h"
@@ -20,6 +21,7 @@
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "chrome/browser/ui/views/chrome_typography.h"
 #include "components/grit/components_scaled_resources.h"
+#include "components/infobars/core/infobar.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/storage_partition.h"
@@ -44,10 +46,8 @@ constexpr int kInfoBarLabelTextColor = ThemeProperties::COLOR_BOOKMARK_TEXT;
 }  // namespace
 
 BraveWaybackMachineInfoBarContentsView::BraveWaybackMachineInfoBarContentsView(
-    infobars::InfoBar* infobar,
     content::WebContents* contents)
-    : infobar_(infobar),
-      contents_(contents),
+    : contents_(contents),
       wayback_machine_url_fetcher_(
           this,
           content::BrowserContext::GetDefaultStoragePartition(
@@ -102,7 +102,22 @@ void BraveWaybackMachineInfoBarContentsView::OnWaybackURLFetched(
 
   LoadURL(latest_wayback_url);
   // After loading to archived url, don't need to show infobar anymore.
-  InfoBarService::FromWebContents(contents_)->RemoveInfoBar(infobar_);
+  HideInfobar();
+}
+
+void BraveWaybackMachineInfoBarContentsView::HideInfobar() {
+  InfoBarService* infobar_service = InfoBarService::FromWebContents(contents_);
+  if (!infobar_service)
+    return;
+
+  for (size_t i = 0; i < infobar_service->infobar_count(); ++i) {
+    infobars::InfoBar* infobar = infobar_service->infobar_at(i);
+    if (infobar->delegate()->GetIdentifier() ==
+        BraveWaybackMachineInfoBarDelegate::WAYBACK_MACHINE_INFOBAR_DELEGATE) {
+      infobar_service->RemoveInfoBar(infobar);
+      break;
+    }
+  }
 }
 
 void BraveWaybackMachineInfoBarContentsView::InitializeChildren() {

--- a/browser/ui/views/infobars/brave_wayback_machine_infobar_contents_view.h
+++ b/browser/ui/views/infobars/brave_wayback_machine_infobar_contents_view.h
@@ -15,10 +15,6 @@ namespace content {
 class WebContents;
 }  // namespace content
 
-namespace infobars {
-class InfoBar;
-}  // namespace infobars
-
 namespace views {
 class ImageView;
 class Label;
@@ -33,8 +29,7 @@ class BraveWaybackMachineInfoBarContentsView
       public views::ButtonListener,
       public WaybackMachineURLFetcher::Client {
  public:
-  BraveWaybackMachineInfoBarContentsView(
-      infobars::InfoBar* infobar,
+  explicit BraveWaybackMachineInfoBarContentsView(
       content::WebContents* contents);
   ~BraveWaybackMachineInfoBarContentsView() override;
 
@@ -60,12 +55,12 @@ class BraveWaybackMachineInfoBarContentsView
   void UpdateChildrenVisibility(bool show_before_checking_views);
   void FetchWaybackURL();
   void LoadURL(const GURL& url);
+  void HideInfobar();
 
   // Used for labels theme changing all together.
   Labels labels_;
   Views views_visible_before_checking_;
   Views views_visible_after_checking_;
-  infobars::InfoBar* infobar_;
   content::WebContents* contents_;
   WaybackMachineURLFetcher wayback_machine_url_fetcher_;
 

--- a/browser/ui/views/infobars/brave_wayback_machine_infobar_view.cc
+++ b/browser/ui/views/infobars/brave_wayback_machine_infobar_view.cc
@@ -25,7 +25,7 @@ BraveWaybackMachineInfoBarView::BraveWaybackMachineInfoBarView(
       std::unique_ptr<BraveWaybackMachineInfoBarDelegate> delegate,
       content::WebContents* contents)
     : InfoBarView(std::move(delegate)) {
-  sub_views_ = new BraveWaybackMachineInfoBarContentsView(this, contents);
+  sub_views_ = new BraveWaybackMachineInfoBarContentsView(contents);
   sub_views_->SizeToPreferredSize();
   AddChildView(sub_views_);
 }


### PR DESCRIPTION
Uplift of #6137
Resolves https://github.com/brave/brave-browser/issues/10764

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.