### PR TITLE
Fix crashes while wayback infobar is hiding (uplift to 1.11.x)

### DIFF
--- a/browser/ui/views/infobars/brave_wayback_machine_infobar_contents_view.h
+++ b/browser/ui/views/infobars/brave_wayback_machine_infobar_contents_view.h
@@ -15,10 +15,6 @@ namespace content {
 class WebContents;
 }  // namespace content
 
-namespace infobars {
-class InfoBar;
-}  // namespace infobars
-
 namespace views {
 class ImageView;
 class Label;
@@ -34,8 +30,7 @@ class BraveWaybackMachineInfoBarContentsView
       public views::ButtonListener,
       public WaybackMachineURLFetcher::Client {
  public:
-  BraveWaybackMachineInfoBarContentsView(
-      infobars::InfoBar* infobar,
+  explicit BraveWaybackMachineInfoBarContentsView(
       content::WebContents* contents);
   ~BraveWaybackMachineInfoBarContentsView() override;
 
@@ -61,12 +56,12 @@ class BraveWaybackMachineInfoBarContentsView
   void UpdateChildrenVisibility(bool show_before_checking_views);
   void FetchWaybackURL();
   void LoadURL(const GURL& url);
+  void HideInfobar();
 
   // Used for labels theme changing all together.
   Labels labels_;
   Views views_visible_before_checking_;
   Views views_visible_after_checking_;
-  infobars::InfoBar* infobar_;
   content::WebContents* contents_;
   WaybackMachineURLFetcher wayback_machine_url_fetcher_;
 

--- a/browser/ui/views/infobars/brave_wayback_machine_infobar_view.cc
+++ b/browser/ui/views/infobars/brave_wayback_machine_infobar_view.cc
@@ -25,7 +25,7 @@ BraveWaybackMachineInfoBarView::BraveWaybackMachineInfoBarView(
       std::unique_ptr<BraveWaybackMachineInfoBarDelegate> delegate,
       content::WebContents* contents)
     : InfoBarView(std::move(delegate)) {
-  sub_views_ = new BraveWaybackMachineInfoBarContentsView(this, contents);
+  sub_views_ = new BraveWaybackMachineInfoBarContentsView(contents);
   sub_views_->SizeToPreferredSize();
   AddChildView(sub_views_);
 }


### PR DESCRIPTION
Uplift of #6137
Resolves https://github.com/brave/brave-browser/issues/10764

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.