### PR TITLE
Fixed link color of bookmark instruction view is not used with light theme (uplift to 1.12.x)

### DIFF
--- a/browser/ui/views/bookmarks/bookmark_bar_instructions_view.cc
+++ b/browser/ui/views/bookmarks/bookmark_bar_instructions_view.cc
@@ -136,14 +136,7 @@ void BookmarkBarInstructionsView::UpdateColors() {
   if (!import_link_)
     return;
 
-  // Use the default link color if it provides enough contrast. If
-  // contrast is too low, fall back to the bookmark text color and use an
-  // underline to make it obvious it's a link. The default color readability
-  // code (which only adjusts luminance) doesn't work well in this case.
-  SkColor bg = theme_provider->GetColor(ThemeProperties::COLOR_TOOLBAR);
   SkColor link_color =
       GetNativeTheme()->GetSystemColor(ui::NativeTheme::kColorId_LinkEnabled);
-  bool link_has_contrast = color_utils::GetContrastRatio(link_color, bg) >=
-                           color_utils::kMinimumReadableContrastRatio;
-  import_link_->SetEnabledColor(link_has_contrast ? link_color : text_color);
+  import_link_->SetEnabledColor(link_color);
 }


### PR DESCRIPTION
Uplift of #6134
Resolves https://github.com/brave/brave-browser/issues/10798

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.