### PR TITLE
Use a new pref name for storing the publisher prefix list download time

### DIFF
--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -25,7 +25,7 @@ const char kRewardsNotificationStartupDelay[] =
     "brave.rewards.notification_startup_delay";
 const char kRewardsExternalWallets[] = "brave.rewards.external_wallets";
 const char kStateServerPublisherListStamp[] =
-    "brave.rewards.server_publisher_list_stamp";
+    "brave.rewards.publisher_prefix_list_stamp";
 const char kStateUpholdAnonAddress[] =
     "brave.rewards.uphold_anon_address";
 const char kRewardsBadgeText[] = "brave.rewards.badge_text";

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/state/state_keys.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/state/state_keys.h
@@ -10,7 +10,7 @@
 
 namespace ledger {
   const char kStateEnabled[] = "enabled";
-  const char kStateServerPublisherListStamp[] = "server_publisher_list_stamp";
+  const char kStateServerPublisherListStamp[] = "publisher_prefix_list_stamp";
   const char kStateUpholdAnonAddress[] = "uphold_anon_address";  // DEPRECATED
   const char kStatePromotionLastFetchStamp[] = "promotion_last_fetch_stamp";
   const char kStatePromotionCorruptedMigrated[] =


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10841

The ability to modify prefs from a database migration was removed in #6115, which broke migration 28 (supporting publisher list v4). This PR modifies the pref name used to store the last publisher prefix list download time, so that the pref does not need to be cleared from migration 28. Users upgrading to this commit will end up re-downloading the prefix list after upgrade.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

### Clean profile scenario

This test will verify that the pref is being written and read correctly.

- Start browser with clean profile and `--rewards=staging=true`.
- Enable rewards.
- Navigate to `brave://rewards-internals`, activate the "Log" tab, and press the "Refresh" button.
- Search for "Scheduling publisher prefix" in the logs.
  - Verify that the logs contain "Scheduling publisher prefix list update in 0 seconds".
  - Note: there may be additional log entries matching this string.
- Press the "Clear" button to clear the logs.
- Close browser.
- Reopen browser.
- Navigate to `brave://rewards-internals`, activate the "Log" tab, and press the "Refresh" button.
- Search for "Scheduling publisher prefix" in the logs.
  - Verify that the logs contain "Scheduling publisher prefix list update in X seconds", where X is some large number.

### Upgrade Scenario

This test will verify that the publisher prefix list is scheduled for download on upgrade from 1.11.x.

- Create a profile in 1.11.x pointed to staging.
- Enable rewards.
- Close 1.11.x browser.
- Start browser pointed to staging.
- Navigate to `brave://rewards-internals`, activate the "Log" tab, and press the "Refresh" button.
- Search for "Scheduling publisher prefix" in the logs.
  - Verify that the logs contain "Scheduling publisher prefix list update in 0 seconds".
  - Note: there may be additional log entries matching this string.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
