### PR TITLE
Skip DeleteDeviceInfo if sync engine is not active

### DIFF
--- a/browser/resources/settings/brave_sync_page/brave_sync_configure.js
+++ b/browser/resources/settings/brave_sync_page/brave_sync_configure.js
@@ -100,11 +100,7 @@ Polymer({
     if (!shouldReset) {
       return
     }
-    const resetResult = await this.browserProxy_.resetSyncChain();
-    if (!resetResult) {
-      // When this happens, setup process will be terminated.
-      return;
-    }
+    await this.browserProxy_.resetSyncChain();
     const router = Router.getInstance();
     router.navigateTo(router.getRoutes().BRAVE_SYNC);
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10856

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
### Offline reset
STR in https://github.com/brave/brave-browser/issues/10856

### Transient error when sync chain setup
1. Launch Brave with `--enable-logging=stderr --vmodule=traffic_logger=3`
2. Start a new sync chain
3. Reset sync chain
4. Repeat step 2-3 until seeing `TRANSIENT_ERROR` for `NEW_CLIENT` when creating a new sync chain like
```
[45764:58627:0722/120403.494257:VERBOSE1:traffic_logger.cc(30)]
******Client To Server Message******
{
   "client_status": {

   },
   "debug_info": {
      "cryptographer_has_pending_keys": false,
      "cryptographer_ready": false,
      "events": [ {
         "singleton_event": "INITIALIZATION_COMPLETE"
      } ],
      "events_dropped": false
   },
   "get_updates": {
      "caller_info": {
         "notifications_enabled": false
      },
      "create_mobile_bookmarks_folder": true,
      "fetch_folders": true,
      "from_progress_marker": [ {
         "data_type_id": "47745"
      } ],
      "get_updates_origin": "NEW_CLIENT",
      "need_encryption_key": true
   },
   "protocol_version": "52",
   "share": "3C070DB758271D6343715A20972D8A36 716958BC2659802E83E2F46B657C6C9F @brave.com"
}


[45764:58627:0722/120403.568049:VERBOSE1:traffic_logger.cc(30)]
******Server Response******
{
   "client_command": {
      "max_commit_batch_size": "90",
      "sessions_commit_delay_seconds": "30",
      "set_sync_poll_interval": "60"
   },
   "error_code": "TRANSIENT_ERROR",
   "error_message": "nigori root folder entity is not ready yet",
   "get_updates": {
      "changes_remaining": "0",
      "new_progress_marker": [ {
         "data_type_id": "47745",
         "token": "AAAAAAAAAAAAAA=="
      } ]
   },
   "store_birthday": "1"
}
```
5. Reset sync chain
6. It should be able to reset not aborting reset process

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
