### PR TITLE
Use a new pref name for storing the publisher prefix list download time (uplift to 1.12.x)

### DIFF
--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -25,7 +25,7 @@ const char kRewardsNotificationStartupDelay[] =
     "brave.rewards.notification_startup_delay";
 const char kRewardsExternalWallets[] = "brave.rewards.external_wallets";
 const char kStateServerPublisherListStamp[] =
-    "brave.rewards.server_publisher_list_stamp";
+    "brave.rewards.publisher_prefix_list_stamp";
 const char kStateUpholdAnonAddress[] =
     "brave.rewards.uphold_anon_address";
 const char kRewardsBadgeText[] = "brave.rewards.badge_text";

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/state/state_keys.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/state/state_keys.h
@@ -10,7 +10,7 @@
 
 namespace ledger {
   const char kStateEnabled[] = "enabled";
-  const char kStateServerPublisherListStamp[] = "server_publisher_list_stamp";
+  const char kStateServerPublisherListStamp[] = "publisher_prefix_list_stamp";
   const char kStateUpholdAnonAddress[] = "uphold_anon_address";
   const char kStatePromotionLastFetchStamp[] = "promotion_last_fetch_stamp";
   const char kStatePromotionCorruptedMigrated[] =


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Uplift of #6158
Resolves https://github.com/brave/brave-browser/issues/10841

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.

## Background

In 1.13, we are using a different user pref name to store a timestamp of the most recent successful download of the publisher prefix list. Uplifting this change into 1.12 will ensure that users do not have to re-download the v4 publisher prefix list on upgrade to 1.13.