### PR TITLE
[Android] Fix for crash on Sync settings when rewards are not available (uplift to 1.12.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BravePreferenceFragment.java
+++ b/android/java/org/chromium/chrome/browser/settings/BravePreferenceFragment.java
@@ -59,6 +59,7 @@ public class BravePreferenceFragment extends PreferenceFragmentCompat {
         super.onResume();
         if (!ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_REWARDS)
                 || BravePrefServiceBridge.getInstance().getSafetynetCheckFailed()) {
+            if (getPreferenceScreen() == null) return;
             Preference braveRewardsDebugPreference =
                     getPreferenceScreen().findPreference(BraveRewardsDebugPreferences.KEY);
             if (braveRewardsDebugPreference != null) {


### PR DESCRIPTION
Uplift of #6205
Resolves https://github.com/brave/brave-browser/issues/10915

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.