### PR TITLE
Fixes 32-bit Windows build with 10.0.19041 SDK.

### DIFF
--- a/patches/build-config-win-BUILD.gn.patch
+++ b/patches/build-config-win-BUILD.gn.patch
@@ -1,0 +1,15 @@
+diff --git a/build/config/win/BUILD.gn b/build/config/win/BUILD.gn
+index 7b44f0e4372f45cb4606e909c934e93d48ea0e61..bd5f8a8edea4208713630329ac5b116a36f86796 100644
+--- a/build/config/win/BUILD.gn
++++ b/build/config/win/BUILD.gn
+@@ -82,6 +82,10 @@ config("compiler") {
+     # Don't look for includes in %INCLUDE%.
+     cflags += [ "/X" ]
+ 
++    # Required to make the 19041 SDK compatible with clang-cl.
++    # See https://crbug.com/1089996 issue #2 for details.
++    cflags += [ "/D__WRL_ENABLE_FUNCTION_STATICS__" ]
++
+     # Tell clang which version of MSVC to emulate.
+     cflags += [ "-fmsc-version=1916" ]
+ 


### PR DESCRIPTION
Fixes brave/brave-browser#10977

This is an upstream fix that comes with Chromium 85, but we need to
apply it to the current Chromium 84 - based builds since we only have a
singular CI setup that needs to be upgraded to 10.0.19041 Windows SDK
and work for both Cr84 and Cr85.

Once Cr85 is merged this patch will go away.

Upstream Chromium fix:

https://chromium.googlesource.com/chromium/src.git/+/ab3b65fecd8ddfd1c857567b2f358addae6679bf

commit ab3b65fecd8ddfd1c857567b2f358addae6679bf
Author: Bruce Dawson <brucedawson@chromium.org>
Date:   Fri Jun 5 20:43:15 2020 +0000

    Make the Windows 10.0.19041 SDK compatible with clang-cl

    The Windows 10.0.19041 SDK modifies module.h so that it passes a lambda
    to InitOnceExecuteOnce. This works poorly because it is not possible to
    specify the calling convention of a lambda, and the callback requires a
    specific and non-default calling convention.

    This code works with VC++ because VC++ lambdas provide all possible
    calling conventions. It works with 64-bit builds with clang-cl because
    there is only one calling convention. But it fails on 32-bit builds with
    clang-cl.

    This define tells module.h to use the old singleton technique. The
    Microsoft developer who wrote the new technique has been made aware. See
    the bug for details.

    This change is a NOP for packaged toolchain users until we switch the
    packaged toolchain to the new SDK, but it avoids problems for developers
    who install the new SDK and build with it.

    Bug: 1089996

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
N/A

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
