### PR TITLE
10931: Record P3A if crash reporting is enabled. (uplift to 1.13.x)

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -170,6 +170,7 @@ source_set("browser_process") {
     "//components/gcm_driver:gcm_driver",
     "//components/gcm_driver:gcm_buildflags",
     "//components/keyed_service/content",
+    "//components/metrics",
     "//components/password_manager/core/common",
     "//components/permissions",
     "//components/policy/core/browser",

--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -5,10 +5,13 @@
 
 #include "brave/browser/brave_browser_main_extra_parts.h"
 
+#include "base/metrics/histogram_macros.h"
 #include "brave/browser/brave_browser_process_impl.h"
 #include "brave/components/brave_shields/browser/brave_shields_p3a.h"
 #include "brave/components/p3a/buildflags.h"
 #include "brave/components/p3a/brave_p3a_service.h"
+#include "components/prefs/pref_service.h"
+#include "components/metrics/metrics_pref_names.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
@@ -36,6 +39,12 @@ void RecordInitialP3AValues() {
 
   brave_shields::MaybeRecordShieldsUsageP3A(brave_shields::kNeverClicked,
                                             g_browser_process->local_state());
+
+  // Record crash reporting status stats.
+  const bool crash_reports_enabled = g_browser_process->local_state()->
+      GetBoolean(metrics::prefs::kMetricsReportingEnabled);
+  UMA_HISTOGRAM_BOOLEAN("Brave.Core.CrashReportsEnabled",
+                        crash_reports_enabled);
 }
 
 }  // namespace

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -50,6 +50,7 @@ constexpr uint64_t kDefaultUploadIntervalSeconds = 60;  // 1 minute.
 // updating on the fly.
 constexpr const char* kCollectedHistograms[] = {
     "Brave.Core.BookmarksCountOnProfileLoad.2",
+    "Brave.Core.CrashReportsEnabled",
     "Brave.Core.IsDefault",
     "Brave.Core.LastTimeIncognitoUsed",
     "Brave.Core.NumberOfExtensions",


### PR DESCRIPTION
Uplift of #6216
Fix https://github.com/brave/brave-browser/issues/10931

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.