### PR TITLE
[Android] Changed access type for getSearchEngineSourceType (uplift to 1.13.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
@@ -68,7 +68,7 @@ public class BraveBaseSearchEngineAdapter extends BaseAdapter {
         }
     }
 
-    private static @SearchEngineAdapter.TemplateUrlSourceType int getSearchEngineSourceType(
+    public static @SearchEngineAdapter.TemplateUrlSourceType int getSearchEngineSourceType(
             TemplateUrl templateUrl, TemplateUrl defaultSearchEngine) {
         if (templateUrl.getIsPrepopulated()) {
             return SearchEngineAdapter.TemplateUrlSourceType.PREPOPULATED;


### PR DESCRIPTION
Uplift of #6272
Resolves https://github.com/brave/brave-browser/issues/11022

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.