### PR TITLE
Fixes when rewards is reset ads service should shut down

### DIFF
--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -133,7 +133,8 @@ class AdsService : public KeyedService {
       const bool flagged,
       OnToggleFlagAdCallback callback) = 0;
 
-  virtual void ResetAllState() = 0;
+  virtual void ResetAllState(
+      const bool should_shutdown) = 0;
 
   virtual void OnUserModelUpdated(
       const std::string& id) = 0;

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -205,7 +205,6 @@ AdsServiceImpl::AdsServiceImpl(Profile* profile) :
            base::TaskPriority::BEST_EFFORT,
             base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
     base_path_(profile_->GetPath().AppendASCII("ads_service")),
-    database_(new ads::Database(base_path_.AppendASCII("database.sqlite"))),
     last_idle_state_(ui::IdleState::IDLE_STATE_ACTIVE),
     display_service_(NotificationDisplayService::GetForProfile(profile_)),
     rewards_service_(brave_rewards::RewardsServiceFactory::GetForProfile(
@@ -576,6 +575,10 @@ void AdsServiceImpl::ShutdownBatAds() {
 
   VLOG(1) << "Shutting down ads";
 
+  const bool success = file_task_runner_->DeleteSoon(FROM_HERE,
+      database_.release());
+  VLOG_IF(1, !success) << "Failed to release database";
+
   bat_ads_->Shutdown(base::BindOnce(&AdsServiceImpl::OnShutdownBatAds,
       AsWeakPtr()));
 }
@@ -658,11 +661,48 @@ void AdsServiceImpl::Stop() {
   ShutdownBatAds();
 }
 
-void AdsServiceImpl::ResetAllState() {
+void AdsServiceImpl::ResetState() {
+  VLOG(1) << "Resetting ads state";
+
+  profile_->GetPrefs()->ClearPrefsWithPrefixSilently("brave.brave_ads");
+
   base::PostTaskAndReplyWithResult(
       file_task_runner_.get(), FROM_HERE,
       base::BindOnce(&ResetOnFileTaskRunner, base_path_),
       base::BindOnce(&AdsServiceImpl::OnResetAllState, AsWeakPtr()));
+}
+
+void AdsServiceImpl::ResetAllState(
+    const bool should_shutdown) {
+  if (!should_shutdown) {
+    ResetState();
+    return;
+  }
+
+  VLOG(1) << "Shutting down and resetting ads state";
+
+  const bool success = file_task_runner_->DeleteSoon(FROM_HERE,
+      database_.release());
+  VLOG_IF(1, !success) << "Failed to release database";
+
+  bat_ads_->Shutdown(base::BindOnce(&AdsServiceImpl::OnShutdownAndResetBatAds,
+      AsWeakPtr()));
+}
+
+void AdsServiceImpl::OnShutdownAndResetBatAds(
+    const int32_t result) {
+  DCHECK(is_initialized_);
+
+  if (result != ads::Result::SUCCESS) {
+    VLOG(0) << "Failed to shutdown and reset ads state";
+    return;
+  }
+
+  Shutdown();
+
+  VLOG(1) << "Successfully shutdown ads";
+
+  ResetState();
 }
 
 void AdsServiceImpl::OnResetAllState(
@@ -671,8 +711,6 @@ void AdsServiceImpl::OnResetAllState(
     VLOG(0) << "Failed to reset ads state";
     return;
   }
-
-  profile_->GetPrefs()->ClearPrefsWithPrefixSilently("brave.brave_ads");
 
   VLOG(1) << "Successfully reset ads state";
 }
@@ -698,6 +736,9 @@ void AdsServiceImpl::OnEnsureBaseDirectoryExists(
       bat_ads_client_receiver_.BindNewEndpointAndPassRemote(),
       bat_ads_.BindNewEndpointAndPassReceiver(),
       base::BindOnce(&AdsServiceImpl::OnCreate, AsWeakPtr()));
+
+  database_ = std::make_unique<ads::Database>(
+      base_path_.AppendASCII("database.sqlite"));
 
   const std::string locale = GetLocale();
   RegisterUserModelComponentsForLocale(locale);
@@ -2051,6 +2092,8 @@ std::string AdsServiceImpl::LoadResourceForId(
 ads::DBCommandResponsePtr RunDBTransactionOnFileTaskRunner(
     ads::DBTransactionPtr transaction,
     ads::Database* database) {
+  DCHECK(database);
+
   auto response = ads::DBCommandResponse::New();
 
   if (!database) {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -141,6 +141,9 @@ class AdsServiceImpl : public AdsService,
       const bool flagged,
       OnToggleFlagAdCallback callback) override;
 
+  void ResetAllState(
+      const bool should_shutdown) override;
+
   // AdsClient implementation
   bool IsEnabled() const override;
 
@@ -189,7 +192,9 @@ class AdsServiceImpl : public AdsService,
   void Start();
   void Stop();
 
-  void ResetAllState() override;
+  void ResetState();
+  void OnShutdownAndResetBatAds(
+      const int32_t result);
   void OnResetAllState(
       const bool success);
 

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -363,9 +363,6 @@ RewardsServiceImpl::RewardsServiceImpl(Profile* profile)
       rewards_base_path_(profile_->GetPath().Append(kRewardsStatePath)),
       notification_service_(new RewardsNotificationServiceImpl(profile)),
       next_timer_id_(0) {
-  file_task_runner_->PostTask(
-      FROM_HERE, base::BindOnce(&EnsureRewardsBaseDirectoryExists,
-                                rewards_base_path_));
   // Set up the rewards data source
   content::URLDataSource::Add(profile_,
                               std::make_unique<BraveRewardsSource>(profile_));
@@ -417,6 +414,10 @@ void RewardsServiceImpl::StartLedger() {
     BLOG(1, "Ledger process is already running");
     return;
   }
+
+  file_task_runner_->PostTask(
+      FROM_HERE, base::BindOnce(&EnsureRewardsBaseDirectoryExists,
+                                rewards_base_path_));
 
   rewards_database_ =
       std::make_unique<RewardsDatabase>(publisher_info_db_path_);
@@ -3887,7 +3888,7 @@ void RewardsServiceImpl::CompleteReset(SuccessCallback callback) {
 
   auto* ads_service = brave_ads::AdsServiceFactory::GetForProfile(profile_);
   if (ads_service) {
-    ads_service->ResetAllState();
+    ads_service->ResetAllState(/* should_shutdown */ true);
   }
 
   StopNotificationTimers();


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11035

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Confirm Ads state is deleted when reseting Brave Rewards
- Confirm Confirmations state is deleted when reseting Brave Rewards
- Confirm Ads state is not deleted when toggling Ads on/off switch
- Confirm Ads is started and ads can be shown when disabling and then re-enabling ads 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
