### PR TITLE
Fixes storage not persist after reset

### DIFF
--- a/components/brave_rewards/resources/page/reducers/index.ts
+++ b/components/brave_rewards/resources/page/reducers/index.ts
@@ -24,8 +24,9 @@ const mergeReducers = (state: Rewards.State | undefined, action: any) => {
 
   if (!state) {
     state = storage.defaultState
-    storage.save(state)
-  } else if (state !== startingState) {
+  }
+
+  if (state !== startingState) {
     storage.debouncedSave(state)
   }
 

--- a/components/brave_rewards/resources/page/reducers/promotion_reducer.ts
+++ b/components/brave_rewards/resources/page/reducers/promotion_reducer.ts
@@ -39,6 +39,10 @@ const updatePromotion = (newPromotion: Rewards.Promotion, promotions: Rewards.Pr
 }
 
 const promotionReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State, action) => {
+  if (!state) {
+    return
+  }
+
   const payload = action.payload
   switch (action.type) {
     case types.FETCH_PROMOTIONS: {

--- a/components/brave_rewards/resources/page/reducers/publishers_reducer.ts
+++ b/components/brave_rewards/resources/page/reducers/publishers_reducer.ts
@@ -8,6 +8,10 @@ import { Reducer } from 'redux'
 import { types } from '../constants/rewards_types'
 
 const publishersReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State, action) => {
+  if (!state) {
+    return
+  }
+
   switch (action.type) {
     case types.ON_CONTRIBUTE_LIST:
       state = { ...state }

--- a/components/brave_rewards/resources/page/reducers/rewards_reducer.ts
+++ b/components/brave_rewards/resources/page/reducers/rewards_reducer.ts
@@ -9,6 +9,10 @@ import { types } from '../constants/rewards_types'
 import { defaultState } from '../storage'
 
 const rewardsReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State, action) => {
+  if (!state) {
+    return
+  }
+
   switch (action.type) {
     case types.TOGGLE_ENABLE_MAIN: {
       if (state.initializing) {

--- a/components/brave_rewards/resources/page/reducers/wallet_reducer.ts
+++ b/components/brave_rewards/resources/page/reducers/wallet_reducer.ts
@@ -22,6 +22,10 @@ const createWallet = (state: Rewards.State) => {
 }
 
 const walletReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State, action) => {
+  if (!state) {
+    return
+  }
+
   switch (action.type) {
     case types.CREATE_WALLET:
       state = { ...state }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/11024

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
- enable rewards
- reset rewards
- make sure that you see welcome page
- refresh page
- make sure that you still see welcome page

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
