### PR TITLE
Fixes when rewards is reset ads service should shut down - 1.13.x

### DIFF
--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -133,7 +133,8 @@ class AdsService : public KeyedService {
       const bool flagged,
       OnToggleFlagAdCallback callback) = 0;
 
-  virtual void ResetAllState() = 0;
+  virtual void ResetAllState(
+      const bool should_shutdown) = 0;
 
   virtual void OnUserModelUpdated(
       const std::string& id) = 0;

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -141,6 +141,9 @@ class AdsServiceImpl : public AdsService,
       const bool flagged,
       OnToggleFlagAdCallback callback) override;
 
+  void ResetAllState(
+      const bool should_shutdown) override;
+
   // AdsClient implementation
   bool IsEnabled() const override;
 
@@ -189,7 +192,9 @@ class AdsServiceImpl : public AdsService,
   void Start();
   void Stop();
 
-  void ResetAllState() override;
+  void ResetState();
+  void OnShutdownAndResetBatAds(
+      const int32_t result);
   void OnResetAllState(
       const bool success);
 

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -374,9 +374,6 @@ RewardsServiceImpl::RewardsServiceImpl(Profile* profile)
       rewards_base_path_(profile_->GetPath().Append(kRewardsStatePath)),
       notification_service_(new RewardsNotificationServiceImpl(profile)),
       next_timer_id_(0) {
-  file_task_runner_->PostTask(
-      FROM_HERE, base::BindOnce(&EnsureRewardsBaseDirectoryExists,
-                                rewards_base_path_));
   // Set up the rewards data source
   content::URLDataSource::Add(profile_,
                               std::make_unique<BraveRewardsSource>(profile_));
@@ -428,6 +425,10 @@ void RewardsServiceImpl::StartLedger() {
     BLOG(1, "Ledger process is already running");
     return;
   }
+
+  file_task_runner_->PostTask(
+      FROM_HERE, base::BindOnce(&EnsureRewardsBaseDirectoryExists,
+                                rewards_base_path_));
 
   rewards_database_ =
       std::make_unique<RewardsDatabase>(publisher_info_db_path_);
@@ -3919,7 +3920,7 @@ void RewardsServiceImpl::OnCompleteReset(
 
   auto* ads_service = brave_ads::AdsServiceFactory::GetForProfile(profile_);
   if (ads_service) {
-    ads_service->ResetAllState();
+    ads_service->ResetAllState(/* should_shutdown */ true);
   }
 
   for (auto& observer : observers_) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6284
Resolves https://github.com/brave/brave-browser/issues/11035

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
