### PR TITLE
Fixes when rewards is reset ads service should shut down - 1.12.x

### DIFF
--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -133,7 +133,8 @@ class AdsService : public KeyedService {
       const bool flagged,
       OnToggleFlagAdCallback callback) = 0;
 
-  virtual void ResetAllState() = 0;
+  virtual void ResetAllState(
+      const bool should_shutdown) = 0;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -217,7 +217,6 @@ AdsServiceImpl::AdsServiceImpl(Profile* profile) :
            base::TaskPriority::BEST_EFFORT,
             base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
     base_path_(profile_->GetPath().AppendASCII("ads_service")),
-    database_(new ads::Database(base_path_.AppendASCII("database.sqlite"))),
     last_idle_state_(ui::IdleState::IDLE_STATE_ACTIVE),
     display_service_(NotificationDisplayService::GetForProfile(profile_)),
     rewards_service_(brave_rewards::RewardsServiceFactory::GetForProfile(
@@ -545,6 +544,10 @@ void AdsServiceImpl::OnInitialize(
 void AdsServiceImpl::ShutdownBatAds() {
   VLOG(1) << "Shutting down ads";
 
+  const bool success = file_task_runner_->DeleteSoon(FROM_HERE,
+      database_.release());
+  VLOG_IF(1, !success) << "Failed to release database";
+
   bat_ads_->Shutdown(base::BindOnce(&AdsServiceImpl::OnShutdownBatAds,
       AsWeakPtr()));
 }
@@ -631,11 +634,48 @@ void AdsServiceImpl::Stop() {
   ShutdownBatAds();
 }
 
-void AdsServiceImpl::ResetAllState() {
+void AdsServiceImpl::ResetState() {
+  VLOG(1) << "Resetting ads state";
+
+  profile_->GetPrefs()->ClearPrefsWithPrefixSilently("brave.brave_ads");
+
   base::PostTaskAndReplyWithResult(
       file_task_runner_.get(), FROM_HERE,
       base::BindOnce(&ResetOnFileTaskRunner, base_path_),
       base::BindOnce(&AdsServiceImpl::OnResetAllState, AsWeakPtr()));
+}
+
+void AdsServiceImpl::ResetAllState(
+    const bool should_shutdown) {
+  if (!should_shutdown) {
+    ResetState();
+    return;
+  }
+
+  VLOG(1) << "Shutting down and resetting ads state";
+
+  const bool success = file_task_runner_->DeleteSoon(FROM_HERE,
+      database_.release());
+  VLOG_IF(1, !success) << "Failed to release database";
+
+  bat_ads_->Shutdown(base::BindOnce(&AdsServiceImpl::OnShutdownAndResetBatAds,
+      AsWeakPtr()));
+}
+
+void AdsServiceImpl::OnShutdownAndResetBatAds(
+    const int32_t result) {
+  DCHECK(is_initialized_);
+
+  if (result != ads::Result::SUCCESS) {
+    VLOG(0) << "Failed to shutdown and reset ads state";
+    return;
+  }
+
+  Shutdown();
+
+  VLOG(1) << "Successfully shutdown ads";
+
+  ResetState();
 }
 
 void AdsServiceImpl::OnResetAllState(
@@ -644,8 +684,6 @@ void AdsServiceImpl::OnResetAllState(
     VLOG(0) << "Failed to reset ads state";
     return;
   }
-
-  profile_->GetPrefs()->ClearPrefsWithPrefixSilently("brave.brave_ads");
 
   VLOG(1) << "Successfully reset ads state";
 }
@@ -671,6 +709,9 @@ void AdsServiceImpl::OnEnsureBaseDirectoryExists(
       bat_ads_client_receiver_.BindNewEndpointAndPassRemote(),
       bat_ads_.BindNewEndpointAndPassReceiver(),
       base::BindOnce(&AdsServiceImpl::OnCreate, AsWeakPtr()));
+
+  database_ = std::make_unique<ads::Database>(
+      base_path_.AppendASCII("database.sqlite"));
 
   MaybeShowMyFirstAdNotification();
 }
@@ -1997,6 +2038,8 @@ std::string AdsServiceImpl::LoadJsonSchema(
 ads::DBCommandResponsePtr RunDBTransactionOnFileTaskRunner(
     ads::DBTransactionPtr transaction,
     ads::Database* database) {
+  DCHECK(database);
+
   auto response = ads::DBCommandResponse::New();
 
   if (!database) {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -138,6 +138,9 @@ class AdsServiceImpl : public AdsService,
       const bool flagged,
       OnToggleFlagAdCallback callback) override;
 
+  void ResetAllState(
+      const bool should_shutdown) override;
+
   // AdsClient implementation
   bool IsEnabled() const override;
 
@@ -182,7 +185,9 @@ class AdsServiceImpl : public AdsService,
   void Start();
   void Stop();
 
-  void ResetAllState() override;
+  void ResetState();
+  void OnShutdownAndResetBatAds(
+      const int32_t result);
   void OnResetAllState(
       const bool success);
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6284
Resolves https://github.com/brave/brave-browser/issues/11035

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
