### PR TITLE
Allows l10n_push script to push specific resource.

### DIFF
--- a/build/commands/lib/pullL10n.js
+++ b/build/commands/lib/pullL10n.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const config = require('../lib/config')
 const util = require('../lib/util')
 const {braveTopLevelPaths, ethereumRemoteClientPaths} = require('./l10nUtil')
@@ -17,7 +18,7 @@ const pullL10n = (options) => {
   }
 
   braveTopLevelPaths.forEach((sourceStringPath) => {
-    if (!options.grd_path || sourceStringPath.endsWith(`/${options.grd_path}`))
+    if (!options.grd_path || sourceStringPath.endsWith(path.sep + options.grd_path))
       util.run('python', ['script/pull-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
   })
 }

--- a/build/commands/lib/pushL10n.js
+++ b/build/commands/lib/pushL10n.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const config = require('../lib/config')
 const util = require('../lib/util')
 const {braveTopLevelPaths, ethereumRemoteClientPaths} = require('./l10nUtil')
@@ -22,7 +23,8 @@ const pushL10n = (options) => {
     args = ['checkout', '--', '*.grd*']
     util.run('git', args, runOptions)
     braveTopLevelPaths.forEach((sourceStringPath) => {
-      util.run('python', ['script/push-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
+      if (!options.grd_path || sourceStringPath.endsWith(path.sep + options.grd_path))
+        util.run('python', ['script/push-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
     })
   }
 }

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -143,12 +143,13 @@ program
 program
   .command('pull_l10n')
   .option('--extension <extension>', 'Scope this command to localize a Brave extension such as ethereum-remote-client')
-  .option('--grd_path <grd_path>', `Relative path to match end of full GRD path, e.g: '/generated_resources.grd'.`)
+  .option('--grd_path <grd_path>', `Relative path to match end of full GRD path, e.g: 'generated_resources.grd'.`)
   .action(pullL10n)
 
 program
   .command('push_l10n')
   .option('--extension <extension>', 'Scope this command to localize a Brave extension such as ethereum-remote-client')
+  .option('--grd_path <grd_path>', `Relative path to match end of full GRD path, e.g: 'generated_resources.grd'.`)
   .action(pushL10n)
 
 program


### PR DESCRIPTION
Fixes brave/brave-browser#9430
Replaces brave/brave-browser#9432

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
