### PR TITLE
Ads pacing with pass-through-rate parameter in the catalog

### DIFF
--- a/components/brave_ads/test/BUILD.gn
+++ b/components/brave_ads/test/BUILD.gn
@@ -18,6 +18,7 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/ad_conversions/ad_conversions_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/ads_client_mock.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/ads_client_mock.h",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/ads_pacing_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/ads_tabs_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/classification/page_classifier/page_classifier_unittest.cc",

--- a/vendor/bat-native-ads/BUILD.gn
+++ b/vendor/bat-native-ads/BUILD.gn
@@ -224,6 +224,8 @@ source_set("ads") {
     "src/bat/ads/internal/eligible_ads/eligible_ads_filter_factory.cc",
     "src/bat/ads/internal/eligible_ads/eligible_ads_filter_factory.h",
     "src/bat/ads/internal/eligible_ads/eligible_ads_filter.h",
+    "src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.cc",
+    "src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.h",
     "src/bat/ads/internal/eligible_ads/eligible_ads_priority_filter.cc",
     "src/bat/ads/internal/eligible_ads/eligible_ads_priority_filter.h",
     "src/bat/ads/internal/filters/ads_history_confirmation_filter.cc",

--- a/vendor/bat-native-ads/data/resources/catalog-schema.json
+++ b/vendor/bat-native-ads/data/resources/catalog-schema.json
@@ -61,6 +61,9 @@
           "priority": {
             "type": "number"
           },
+          "ptr": {
+            "type": "number"
+          },
           "advertiserId": {
             "type": "string"
           },

--- a/vendor/bat-native-ads/data/test/catalog.json
+++ b/vendor/bat-native-ads/data/test/catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "issuers": [
     {
       "name": "confirmation",

--- a/vendor/bat-native-ads/data/test/catalog.json
+++ b/vendor/bat-native-ads/data/test/catalog.json
@@ -136,7 +136,8 @@
       "endAt": "<time:distant_future>",
       "dailyCap": 10,
       "advertiserId": "db3f5832-ce6a-401d-b8ba-8be4a67137a0",
-      "priority": 1
+      "priority": 1,
+      "ptr": 0.5
     }
   ],
   "catalogId": "29e5c8bc0ba319069980bb390d8e8f9b58c05a20"

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -860,11 +860,16 @@ void AdsImpl::OnServeUntargetedAdNotification(
 
 void AdsImpl::ServeAdNotificationWithPacing(
     const CreativeAdNotificationList& ads) {
-  const auto filter = EligibleAdsFilterFactory::Build(
-      EligibleAdsFilter::Type::kPriority);
-  DCHECK(filter);
+  const auto pacing_filter =
+      EligibleAdsFilterFactory::Build(EligibleAdsFilter::Type::kPacing);
+  DCHECK(pacing_filter);
 
-  const CreativeAdNotificationList eligible_ads = filter->Apply(ads);
+  const auto priority_filter =
+      EligibleAdsFilterFactory::Build(EligibleAdsFilter::Type::kPriority);
+  DCHECK(priority_filter);
+
+  const CreativeAdNotificationList eligible_ads =
+      priority_filter->Apply(pacing_filter->Apply(ads));
   if (eligible_ads.empty()) {
     FailedToServeAdNotification("No eligible ads found");
     return;
@@ -874,20 +879,6 @@ void AdsImpl::ServeAdNotificationWithPacing(
 
   const int rand = base::RandInt(0, eligible_ads.size() - 1);
   const CreativeAdNotificationInfo ad = eligible_ads.at(rand);
-
-  if (ad.priority == 0) {
-    FailedToServeAdNotification("Pacing ad delivery [0]");
-    return;
-  }
-
-  const int rand_priority = base::RandInt(1, ad.priority);
-  if (rand_priority != 1) {
-    const std::string message = base::StringPrintf("Pacing ad delivery "
-        "[Roll(%d):%d]", ad.priority, rand_priority);
-
-    FailedToServeAdNotification(message);
-    return;
-  }
 
   ShowAdNotification(ad);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_pacing_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_pacing_unittest.cc
@@ -1,0 +1,236 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/test/task_environment.h"
+#include "bat/ads/internal/ads_client_mock.h"
+#include "bat/ads/internal/ads_impl.h"
+#include "bat/ads/internal/unittest_utils.h"
+#include "brave/components/l10n/browser/locale_helper_mock.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Between;
+using ::testing::Field;
+using ::testing::InvokeArgument;
+using ::testing::Matcher;
+using ::testing::NiceMock;
+using ::testing::Pointee;
+using ::testing::Return;
+
+// npm run test -- brave_unit_tests --filter=BatAds*
+
+namespace ads {
+
+namespace {
+
+Matcher<AdNotificationInfo> IsNotification(
+    const std::string& creative_instance_id) {
+  return AllOf(Field("creative_instance_id",
+                     &AdNotificationInfo::creative_instance_id,
+                     creative_instance_id));
+}
+
+}  // namespace
+
+class BatAdsPacingTest : public ::testing::Test {
+ protected:
+  BatAdsPacingTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME),
+        ads_client_mock_(std::make_unique<NiceMock<AdsClientMock>>()),
+        ads_(std::make_unique<AdsImpl>(ads_client_mock_.get())),
+        locale_helper_mock_(
+            std::make_unique<NiceMock<brave_l10n::LocaleHelperMock>>()) {
+    // You can do set-up work for each test here
+
+    brave_l10n::LocaleHelper::GetInstance()->set_for_testing(
+        locale_helper_mock_.get());
+  }
+
+  ~BatAdsPacingTest() override {
+    // You can do clean-up work that doesn't throw exceptions here
+  }
+
+  // If the constructor and destructor are not enough for setting up and
+  // cleaning up each test, you can use the following methods
+
+  void SetUp() override {
+    // Code here will be called immediately after the constructor (right before
+    // each test)
+
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    const base::FilePath path = temp_dir_.GetPath();
+
+    ON_CALL(*ads_client_mock_, IsEnabled()).WillByDefault(Return(true));
+
+    ON_CALL(*locale_helper_mock_, GetLocale()).WillByDefault(Return("en-US"));
+
+    MockLoad(ads_client_mock_);
+    MockLoadUserModelForId(ads_client_mock_);
+    MockLoadResourceForId(ads_client_mock_);
+    MockSave(ads_client_mock_);
+
+    database_ = std::make_unique<Database>(path.AppendASCII("database.sqlite"));
+    MockRunDBTransaction(ads_client_mock_, database_);
+
+    Initialize(ads_);
+
+    info_1_.creative_instance_id = "3519f52c-46a4-4c48-9c2b-c264c0067f04";
+    info_1_.creative_set_id = "c2ba3e7d-f688-4bc4-a053-cbe7ac1e6123";
+    info_1_.campaign_id = "84197fc8-830a-4a8e-8339-7a70c2bfa104";
+    info_1_.start_at_timestamp = DistantPast();
+    info_1_.end_at_timestamp = DistantFuture();
+    info_1_.daily_cap = 1;
+    info_1_.advertiser_id = "5484a63f-eb99-4ba5-a3b0-8c25d3c0e4b2";
+    info_1_.priority = 1;
+    info_1_.per_day = 3;
+    info_1_.total_max = 4;
+    info_1_.category = "Technology & Computing-Software";
+    info_1_.geo_targets = {"US"};
+    info_1_.target_url = "https://brave.com";
+    info_1_.title = "Test Ad 1 Title";
+    info_1_.body = "Test Ad 1 Body";
+    info_1_.ptr = 1.0;
+
+    info_2_.creative_instance_id = "a1ac44c2-675f-43e6-ab6d-500614cafe63";
+    info_2_.creative_set_id = "5800049f-cee5-4bcb-90c7-85246d5f5e7c";
+    info_2_.campaign_id = "3d62eca2-324a-4161-a0c5-7d9f29d10ab0";
+    info_2_.start_at_timestamp = DistantPast();
+    info_2_.end_at_timestamp = DistantFuture();
+    info_2_.daily_cap = 1;
+    info_2_.advertiser_id = "9a11b60f-e29d-4446-8d1f-318311e36e0a";
+    info_2_.priority = 2;
+    info_2_.per_day = 3;
+    info_2_.total_max = 4;
+    info_2_.category = "Food & Drink";
+    info_2_.geo_targets = {"US"};
+    info_2_.target_url = "https://brave.com";
+    info_2_.title = "Test Ad 2 Title";
+    info_2_.body = "Test Ad 2 Body";
+    info_2_.ptr = 1.0;
+  }
+
+  void TearDown() override {
+    // Code here will be called immediately after each test (right before the
+    // destructor)
+  }
+
+  // Objects declared here can be used by all tests in the test case
+
+  base::test::TaskEnvironment task_environment_;
+
+  base::ScopedTempDir temp_dir_;
+
+  std::unique_ptr<AdsClientMock> ads_client_mock_;
+  std::unique_ptr<AdsImpl> ads_;
+  std::unique_ptr<brave_l10n::LocaleHelperMock> locale_helper_mock_;
+  std::unique_ptr<Database> database_;
+
+  CreativeAdNotificationInfo info_1_, info_2_;
+};
+
+TEST_F(BatAdsPacingTest, PacingDisableDelivery) {
+  CreativeAdNotificationList creative_ad_notifications;
+  info_1_.ptr = 0;
+  creative_ad_notifications.push_back(info_1_);
+
+  int iterations = 1000;
+  EXPECT_CALL(*ads_client_mock_, ShowNotification(_)).Times(0);
+
+  for (int i = 0; i < iterations; i++) {
+    ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
+  }
+}
+
+TEST_F(BatAdsPacingTest, NoPacing) {
+  CreativeAdNotificationList creative_ad_notifications;
+  info_1_.ptr = 1.0;
+  creative_ad_notifications.push_back(info_1_);
+
+  int iterations = 1000;
+  EXPECT_CALL(*ads_client_mock_, ShowNotification(_)).Times(iterations);
+
+  for (int i = 0; i < iterations; i++) {
+    ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
+  }
+}
+
+TEST_F(BatAdsPacingTest, SimplePacing) {
+  CreativeAdNotificationList creative_ad_notifications;
+  info_1_.ptr = 0.2;
+  creative_ad_notifications.push_back(info_1_);
+
+  int iterations = 1000;
+  EXPECT_CALL(*ads_client_mock_, ShowNotification(_))
+      .Times(Between(iterations * info_1_.ptr * 0.8,
+                     iterations * info_1_.ptr * 1.2));
+
+  for (int i = 0; i < iterations; i++) {
+    ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
+  }
+}
+
+TEST_F(BatAdsPacingTest, NoPacingPrioritized) {
+  CreativeAdNotificationList creative_ad_notifications;
+  creative_ad_notifications.push_back(info_1_);
+  creative_ad_notifications.push_back(info_2_);
+
+  EXPECT_CALL(
+      *ads_client_mock_,
+      ShowNotification(Pointee(IsNotification(info_1_.creative_instance_id))))
+      .Times(1);
+
+  ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
+}
+
+TEST_F(BatAdsPacingTest, PacingDisableDeliveryPrioritized) {
+  CreativeAdNotificationList creative_ad_notifications;
+  info_1_.ptr = 0;
+  creative_ad_notifications.push_back(info_1_);
+  creative_ad_notifications.push_back(info_2_);
+
+  EXPECT_CALL(
+      *ads_client_mock_,
+      ShowNotification(Pointee(IsNotification(info_2_.creative_instance_id))))
+      .Times(1);
+
+  ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
+}
+
+TEST_F(BatAdsPacingTest, PacingAndPrioritization) {
+  CreativeAdNotificationList creative_ad_notifications;
+  info_1_.ptr = 0.5;
+  creative_ad_notifications.push_back(info_1_);
+  info_2_.ptr = 0.5;
+  creative_ad_notifications.push_back(info_2_);
+
+  int iterations = 1000;
+
+  EXPECT_CALL(
+      *ads_client_mock_,
+      ShowNotification(Pointee(IsNotification(info_1_.creative_instance_id))))
+      .Times(Between(iterations * info_1_.ptr * 0.8,
+                     iterations * info_1_.ptr * 1.2));
+
+  // info_2_ ad would be shown probabilistically when info_1_ gets dropped due
+  // to pacing.
+  EXPECT_CALL(
+      *ads_client_mock_,
+      ShowNotification(Pointee(IsNotification(info_2_.creative_instance_id))))
+      .Times(Between(iterations * info_1_.ptr * 0.8 * info_2_.ptr,
+                     iterations * info_1_.ptr * 1.2 * info_2_.ptr));
+
+  for (int i = 0; i < iterations; i++) {
+    ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
+  }
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_pacing_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_pacing_unittest.cc
@@ -11,7 +11,7 @@
 #include "base/test/task_environment.h"
 #include "bat/ads/internal/ads_client_mock.h"
 #include "bat/ads/internal/ads_impl.h"
-#include "bat/ads/internal/unittest_utils.h"
+#include "bat/ads/internal/unittest_util.h"
 #include "brave/components/l10n/browser/locale_helper_mock.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -48,11 +48,15 @@ class BatAdsPacingTest : public ::testing::Test {
         ads_client_mock_(std::make_unique<NiceMock<AdsClientMock>>()),
         ads_(std::make_unique<AdsImpl>(ads_client_mock_.get())),
         locale_helper_mock_(
-            std::make_unique<NiceMock<brave_l10n::LocaleHelperMock>>()) {
+            std::make_unique<NiceMock<brave_l10n::LocaleHelperMock>>()),
+        platform_helper_mock_(
+            std::make_unique<NiceMock<PlatformHelperMock>>()) {
     // You can do set-up work for each test here
 
     brave_l10n::LocaleHelper::GetInstance()->set_for_testing(
         locale_helper_mock_.get());
+
+    PlatformHelper::GetInstance()->set_for_testing(platform_helper_mock_.get());
   }
 
   ~BatAdsPacingTest() override {
@@ -71,7 +75,17 @@ class BatAdsPacingTest : public ::testing::Test {
 
     ON_CALL(*ads_client_mock_, IsEnabled()).WillByDefault(Return(true));
 
+    ON_CALL(*ads_client_mock_, ShouldAllowAdConversionTracking())
+        .WillByDefault(Return(true));
+
+    SetBuildChannel(false, "test");
+
     ON_CALL(*locale_helper_mock_, GetLocale()).WillByDefault(Return("en-US"));
+
+    MockPlatformHelper(platform_helper_mock_, PlatformType::kMacOS);
+
+    ads_->OnWalletUpdated("c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+                          "5BEKM1Y7xcRSg/1q8in/+Lki2weFZQB+UMYZlRw8ql8=");
 
     MockLoad(ads_client_mock_);
     MockLoadUserModelForId(ads_client_mock_);
@@ -82,40 +96,49 @@ class BatAdsPacingTest : public ::testing::Test {
     MockRunDBTransaction(ads_client_mock_, database_);
 
     Initialize(ads_);
+    SetupTestAds();
+  }
 
-    info_1_.creative_instance_id = "3519f52c-46a4-4c48-9c2b-c264c0067f04";
-    info_1_.creative_set_id = "c2ba3e7d-f688-4bc4-a053-cbe7ac1e6123";
-    info_1_.campaign_id = "84197fc8-830a-4a8e-8339-7a70c2bfa104";
-    info_1_.start_at_timestamp = DistantPast();
-    info_1_.end_at_timestamp = DistantFuture();
-    info_1_.daily_cap = 1;
-    info_1_.advertiser_id = "5484a63f-eb99-4ba5-a3b0-8c25d3c0e4b2";
-    info_1_.priority = 1;
-    info_1_.per_day = 3;
-    info_1_.total_max = 4;
-    info_1_.category = "Technology & Computing-Software";
-    info_1_.geo_targets = {"US"};
-    info_1_.target_url = "https://brave.com";
-    info_1_.title = "Test Ad 1 Title";
-    info_1_.body = "Test Ad 1 Body";
-    info_1_.ptr = 1.0;
+  void SetupTestAds() {
+    CreativeAdNotificationInfo ad_creative;
 
-    info_2_.creative_instance_id = "a1ac44c2-675f-43e6-ab6d-500614cafe63";
-    info_2_.creative_set_id = "5800049f-cee5-4bcb-90c7-85246d5f5e7c";
-    info_2_.campaign_id = "3d62eca2-324a-4161-a0c5-7d9f29d10ab0";
-    info_2_.start_at_timestamp = DistantPast();
-    info_2_.end_at_timestamp = DistantFuture();
-    info_2_.daily_cap = 1;
-    info_2_.advertiser_id = "9a11b60f-e29d-4446-8d1f-318311e36e0a";
-    info_2_.priority = 2;
-    info_2_.per_day = 3;
-    info_2_.total_max = 4;
-    info_2_.category = "Food & Drink";
-    info_2_.geo_targets = {"US"};
-    info_2_.target_url = "https://brave.com";
-    info_2_.title = "Test Ad 2 Title";
-    info_2_.body = "Test Ad 2 Body";
-    info_2_.ptr = 1.0;
+    ad_creative.creative_instance_id = "3519f52c-46a4-4c48-9c2b-c264c0067f04";
+    ad_creative.creative_set_id = "c2ba3e7d-f688-4bc4-a053-cbe7ac1e6123";
+    ad_creative.campaign_id = "84197fc8-830a-4a8e-8339-7a70c2bfa104";
+    ad_creative.start_at_timestamp = DistantPast();
+    ad_creative.end_at_timestamp = DistantFuture();
+    ad_creative.daily_cap = 1;
+    ad_creative.advertiser_id = "5484a63f-eb99-4ba5-a3b0-8c25d3c0e4b2";
+    ad_creative.priority = 1;
+    ad_creative.per_day = 3;
+    ad_creative.total_max = 4;
+    ad_creative.category = "Technology & Computing-Software";
+    ad_creative.geo_targets = {"US"};
+    ad_creative.target_url = "https://brave.com";
+    ad_creative.title = "Test Ad 1 Title";
+    ad_creative.body = "Test Ad 1 Body";
+    ad_creative.ptr = 1.0;
+
+    test_creative_notifications_.push_back(ad_creative);
+
+    ad_creative.creative_instance_id = "a1ac44c2-675f-43e6-ab6d-500614cafe63";
+    ad_creative.creative_set_id = "5800049f-cee5-4bcb-90c7-85246d5f5e7c";
+    ad_creative.campaign_id = "3d62eca2-324a-4161-a0c5-7d9f29d10ab0";
+    ad_creative.start_at_timestamp = DistantPast();
+    ad_creative.end_at_timestamp = DistantFuture();
+    ad_creative.daily_cap = 1;
+    ad_creative.advertiser_id = "9a11b60f-e29d-4446-8d1f-318311e36e0a";
+    ad_creative.priority = 2;
+    ad_creative.per_day = 3;
+    ad_creative.total_max = 4;
+    ad_creative.category = "Food & Drink";
+    ad_creative.geo_targets = {"US"};
+    ad_creative.target_url = "https://brave.com";
+    ad_creative.title = "Test Ad 2 Title";
+    ad_creative.body = "Test Ad 2 Body";
+    ad_creative.ptr = 1.0;
+
+    test_creative_notifications_.push_back(ad_creative);
   }
 
   void TearDown() override {
@@ -132,15 +155,16 @@ class BatAdsPacingTest : public ::testing::Test {
   std::unique_ptr<AdsClientMock> ads_client_mock_;
   std::unique_ptr<AdsImpl> ads_;
   std::unique_ptr<brave_l10n::LocaleHelperMock> locale_helper_mock_;
+  std::unique_ptr<PlatformHelperMock> platform_helper_mock_;
   std::unique_ptr<Database> database_;
 
-  CreativeAdNotificationInfo info_1_, info_2_;
+  std::vector<CreativeAdNotificationInfo> test_creative_notifications_;
 };
 
 TEST_F(BatAdsPacingTest, PacingDisableDelivery) {
   CreativeAdNotificationList creative_ad_notifications;
-  info_1_.ptr = 0;
-  creative_ad_notifications.push_back(info_1_);
+  test_creative_notifications_[0].ptr = 0;
+  creative_ad_notifications.push_back(test_creative_notifications_[0]);
 
   int iterations = 1000;
   EXPECT_CALL(*ads_client_mock_, ShowNotification(_)).Times(0);
@@ -152,8 +176,8 @@ TEST_F(BatAdsPacingTest, PacingDisableDelivery) {
 
 TEST_F(BatAdsPacingTest, NoPacing) {
   CreativeAdNotificationList creative_ad_notifications;
-  info_1_.ptr = 1.0;
-  creative_ad_notifications.push_back(info_1_);
+  test_creative_notifications_[0].ptr = 1.0;
+  creative_ad_notifications.push_back(test_creative_notifications_[0]);
 
   int iterations = 1000;
   EXPECT_CALL(*ads_client_mock_, ShowNotification(_)).Times(iterations);
@@ -165,13 +189,13 @@ TEST_F(BatAdsPacingTest, NoPacing) {
 
 TEST_F(BatAdsPacingTest, SimplePacing) {
   CreativeAdNotificationList creative_ad_notifications;
-  info_1_.ptr = 0.2;
-  creative_ad_notifications.push_back(info_1_);
+  test_creative_notifications_[0].ptr = 0.2;
+  creative_ad_notifications.push_back(test_creative_notifications_[0]);
 
   int iterations = 1000;
   EXPECT_CALL(*ads_client_mock_, ShowNotification(_))
-      .Times(Between(iterations * info_1_.ptr * 0.8,
-                     iterations * info_1_.ptr * 1.2));
+      .Times(Between(iterations * test_creative_notifications_[0].ptr * 0.8,
+                     iterations * test_creative_notifications_[0].ptr * 1.2));
 
   for (int i = 0; i < iterations; i++) {
     ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
@@ -180,12 +204,12 @@ TEST_F(BatAdsPacingTest, SimplePacing) {
 
 TEST_F(BatAdsPacingTest, NoPacingPrioritized) {
   CreativeAdNotificationList creative_ad_notifications;
-  creative_ad_notifications.push_back(info_1_);
-  creative_ad_notifications.push_back(info_2_);
+  creative_ad_notifications.push_back(test_creative_notifications_[0]);
+  creative_ad_notifications.push_back(test_creative_notifications_[1]);
 
-  EXPECT_CALL(
-      *ads_client_mock_,
-      ShowNotification(Pointee(IsNotification(info_1_.creative_instance_id))))
+  EXPECT_CALL(*ads_client_mock_,
+              ShowNotification(Pointee(IsNotification(
+                  test_creative_notifications_[0].creative_instance_id))))
       .Times(1);
 
   ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
@@ -193,13 +217,13 @@ TEST_F(BatAdsPacingTest, NoPacingPrioritized) {
 
 TEST_F(BatAdsPacingTest, PacingDisableDeliveryPrioritized) {
   CreativeAdNotificationList creative_ad_notifications;
-  info_1_.ptr = 0;
-  creative_ad_notifications.push_back(info_1_);
-  creative_ad_notifications.push_back(info_2_);
+  test_creative_notifications_[0].ptr = 0;
+  creative_ad_notifications.push_back(test_creative_notifications_[0]);
+  creative_ad_notifications.push_back(test_creative_notifications_[1]);
 
-  EXPECT_CALL(
-      *ads_client_mock_,
-      ShowNotification(Pointee(IsNotification(info_2_.creative_instance_id))))
+  EXPECT_CALL(*ads_client_mock_,
+              ShowNotification(Pointee(IsNotification(
+                  test_creative_notifications_[1].creative_instance_id))))
       .Times(1);
 
   ads_->ServeAdNotificationWithPacing(creative_ad_notifications);
@@ -207,26 +231,28 @@ TEST_F(BatAdsPacingTest, PacingDisableDeliveryPrioritized) {
 
 TEST_F(BatAdsPacingTest, PacingAndPrioritization) {
   CreativeAdNotificationList creative_ad_notifications;
-  info_1_.ptr = 0.5;
-  creative_ad_notifications.push_back(info_1_);
-  info_2_.ptr = 0.5;
-  creative_ad_notifications.push_back(info_2_);
+  test_creative_notifications_[0].ptr = 0.5;
+  creative_ad_notifications.push_back(test_creative_notifications_[0]);
+  test_creative_notifications_[1].ptr = 0.5;
+  creative_ad_notifications.push_back(test_creative_notifications_[1]);
 
   int iterations = 1000;
 
-  EXPECT_CALL(
-      *ads_client_mock_,
-      ShowNotification(Pointee(IsNotification(info_1_.creative_instance_id))))
-      .Times(Between(iterations * info_1_.ptr * 0.8,
-                     iterations * info_1_.ptr * 1.2));
+  EXPECT_CALL(*ads_client_mock_,
+              ShowNotification(Pointee(IsNotification(
+                  test_creative_notifications_[0].creative_instance_id))))
+      .Times(Between(iterations * test_creative_notifications_[0].ptr * 0.8,
+                     iterations * test_creative_notifications_[0].ptr * 1.2));
 
-  // info_2_ ad would be shown probabilistically when info_1_ gets dropped due
-  // to pacing.
-  EXPECT_CALL(
-      *ads_client_mock_,
-      ShowNotification(Pointee(IsNotification(info_2_.creative_instance_id))))
-      .Times(Between(iterations * info_1_.ptr * 0.8 * info_2_.ptr,
-                     iterations * info_1_.ptr * 1.2 * info_2_.ptr));
+  // test_creative_notifications_[1] ad would be shown probabilistically when
+  // test_creative_notifications_[0] gets dropped due to pacing.
+  EXPECT_CALL(*ads_client_mock_,
+              ShowNotification(Pointee(IsNotification(
+                  test_creative_notifications_[1].creative_instance_id))))
+      .Times(Between(iterations * test_creative_notifications_[0].ptr * 0.8 *
+                         test_creative_notifications_[1].ptr,
+                     iterations * test_creative_notifications_[0].ptr * 1.2 *
+                         test_creative_notifications_[1].ptr));
 
   for (int i = 0; i < iterations; i++) {
     ads_->ServeAdNotificationWithPacing(creative_ad_notifications);

--- a/vendor/bat-native-ads/src/bat/ads/internal/bundle/creative_ad_info.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/bundle/creative_ad_info.h
@@ -27,6 +27,7 @@ struct CreativeAdInfo {
   unsigned int daily_cap = 0;
   std::string advertiser_id;
   unsigned int priority = 0;
+  double ptr = 1.0;
   bool conversion = false;
   unsigned int per_day = 0;
   unsigned int total_max = 0;

--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_state.cc
@@ -43,7 +43,7 @@ Result CatalogState::FromJson(
   new_catalog_id = document["catalogId"].GetString();
 
   new_version = document["version"].GetUint64();
-  if (new_version != 3) {
+  if (new_version != 4) {
     return SUCCESS;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/ad_conversions_database_table_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/ad_conversions_database_table_unittest.cc
@@ -325,7 +325,7 @@ TEST_F(BatAdsAdConversionsDatabaseTableTest,
 
   const URLEndpoints endpoints = {
     {
-      "/v3/catalog", {
+      "/v4/catalog", {
         {
           net::HTTP_OK, "/catalog.json"
         }

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.cc
@@ -96,7 +96,8 @@ void CreativeAdNotifications::GetCreativeAdNotifications(
           "gt.geo_target, "
           "can.target_url, "
           "can.title, "
-          "can.body "
+          "can.body, "
+          "can.ptr "
       "FROM %s AS can "
           "INNER JOIN categories AS c "
               "ON c.creative_instance_id = can.creative_instance_id "
@@ -134,7 +135,8 @@ void CreativeAdNotifications::GetCreativeAdNotifications(
     DBCommand::RecordBindingType::STRING_TYPE,  // geo_target
     DBCommand::RecordBindingType::STRING_TYPE,  // target_url
     DBCommand::RecordBindingType::STRING_TYPE,  // title
-    DBCommand::RecordBindingType::STRING_TYPE   // body
+    DBCommand::RecordBindingType::STRING_TYPE,  // body
+    DBCommand::RecordBindingType::DOUBLE_TYPE   // ptr
   };
 
   DBTransactionPtr transaction = DBTransaction::New();
@@ -164,7 +166,8 @@ void CreativeAdNotifications::GetAllCreativeAdNotifications(
           "gt.geo_target, "
           "can.target_url, "
           "can.title, "
-          "can.body "
+          "can.body, "
+          "can.ptr "
       "FROM %s AS can "
           "INNER JOIN categories AS c "
               "ON c.creative_instance_id = can.creative_instance_id "
@@ -194,7 +197,8 @@ void CreativeAdNotifications::GetAllCreativeAdNotifications(
     DBCommand::RecordBindingType::STRING_TYPE,  // geo_target
     DBCommand::RecordBindingType::STRING_TYPE,  // target_url
     DBCommand::RecordBindingType::STRING_TYPE,  // title
-    DBCommand::RecordBindingType::STRING_TYPE   // body
+    DBCommand::RecordBindingType::STRING_TYPE,  // body
+    DBCommand::RecordBindingType::DOUBLE_TYPE   // ptr
   };
 
   DBTransactionPtr transaction = DBTransaction::New();
@@ -275,6 +279,7 @@ int CreativeAdNotifications::BindParameters(
     BindString(command, index++, creative_ad_notification.target_url);
     BindString(command, index++, creative_ad_notification.title);
     BindString(command, index++, creative_ad_notification.body);
+    BindDouble(command, index++, creative_ad_notification.ptr);
 
     count++;
   }
@@ -302,9 +307,10 @@ std::string CreativeAdNotifications::BuildInsertOrUpdateQuery(
           "total_max, "
           "target_url, "
           "title, "
-          "body) VALUES %s",
+          "body, "
+          "ptr) VALUES %s",
       get_table_name().c_str(),
-      BuildBindingParameterPlaceholders(14, count).c_str());
+      BuildBindingParameterPlaceholders(15, count).c_str());
 }
 
 void CreativeAdNotifications::OnGetCreativeAdNotifications(
@@ -380,6 +386,7 @@ CreativeAdNotifications::GetCreativeAdNotificationFromRecord(
   info.target_url = ColumnString(record, 13);
   info.title = ColumnString(record, 14);
   info.body = ColumnString(record, 15);
+  info.ptr = ColumnDouble(record, 16);
 
   return info;
 }
@@ -411,6 +418,7 @@ void CreativeAdNotifications::CreateTableV1(
           "target_url TEXT NOT NULL, "
           "title TEXT NOT NULL, "
           "body TEXT NOT NULL, "
+          "ptr DOUBLE NOT NULL DEFAULT 1, "
           "PRIMARY KEY(creative_instance_id))",
       get_table_name().c_str());
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_unittest.cc
@@ -824,7 +824,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
 
   const URLEndpoints endpoints = {
     {
-      "/v3/catalog", {
+      "/v4/catalog", {
         {
           net::HTTP_OK, "/catalog.json"
         }

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_unittest.cc
@@ -142,6 +142,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -160,6 +161,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 0.8;
   creative_ad_notifications.push_back(info_2);
 
   // Act
@@ -207,6 +209,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications_1.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -225,6 +228,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 1.0;
   creative_ad_notifications_1.push_back(info_2);
 
   SaveDatabase(creative_ad_notifications_1);
@@ -248,6 +252,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_3.target_url = "https://brave.com";
   info_3.title = "Test Ad 3 Title";
   info_3.body = "Test Ad 3 Body";
+  info_3.ptr = 1.0;
   creative_ad_notifications_2.push_back(info_3);
 
   SaveDatabase(creative_ad_notifications_2);
@@ -292,6 +297,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -310,6 +316,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 1.0;
   creative_ad_notifications.push_back(info_2);
 
   CreativeAdNotificationInfo info_3;
@@ -328,6 +335,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_3.target_url = "https://brave.com";
   info_3.title = "Test Ad 3 Title";
   info_3.body = "Test Ad 3 Body";
+  info_3.ptr = 1.0;
   creative_ad_notifications.push_back(info_3);
 
   // Act
@@ -375,6 +383,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info.target_url = "https://brave.com";
   info.title = "Test Ad 1 Title";
   info.body = "Test Ad 1 Body";
+  info.ptr = 1.0;
   creative_ad_notifications.push_back(info);
 
   SaveDatabase(creative_ad_notifications);
@@ -424,6 +433,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -442,6 +452,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 1.0;
   creative_ad_notifications.push_back(info_2);
 
   SaveDatabase(creative_ad_notifications);
@@ -490,6 +501,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info.target_url = "https://brave.com";
   info.title = "Test Ad 1 Title";
   info.body = "Test Ad 1 Body";
+  info.ptr = 1.0;
   creative_ad_notifications.push_back(info);
 
   SaveDatabase(creative_ad_notifications);
@@ -535,6 +547,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info.target_url = "https://brave.com";
   info.title = "Test Ad 1 Title";
   info.body = "Test Ad 1 Body";
+  info.ptr = 1.0;
   creative_ad_notifications.push_back(info);
 
   SaveDatabase(creative_ad_notifications);
@@ -582,6 +595,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -600,6 +614,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 1.0;
   creative_ad_notifications.push_back(info_2);
 
   CreativeAdNotificationInfo info_3;
@@ -618,6 +633,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_3.target_url = "https://brave.com";
   info_3.title = "Test Ad 3 Title";
   info_3.body = "Test Ad 3 Body";
+  info_3.ptr = 1.0;
   creative_ad_notifications.push_back(info_3);
 
   SaveDatabase(creative_ad_notifications);
@@ -668,6 +684,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -686,6 +703,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 1.0;
   creative_ad_notifications.push_back(info_2);
 
   SaveDatabase(creative_ad_notifications);
@@ -735,6 +753,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_1.target_url = "https://brave.com";
   info_1.title = "Test Ad 1 Title";
   info_1.body = "Test Ad 1 Body";
+  info_1.ptr = 1.0;
   creative_ad_notifications.push_back(info_1);
 
   CreativeAdNotificationInfo info_2;
@@ -753,6 +772,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableTest,
   info_2.target_url = "https://brave.com";
   info_2.title = "Test Ad 2 Title";
   info_2.body = "Test Ad 2 Body";
+  info_2.ptr = 1.0;
   creative_ad_notifications.push_back(info_2);
 
   SaveDatabase(creative_ad_notifications);

--- a/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_filter.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_filter.h
@@ -13,7 +13,8 @@ namespace ads {
 class EligibleAdsFilter {
  public:
   enum class Type {
-    kPriority
+    kPriority,
+    kPacing
   };
 
   virtual ~EligibleAdsFilter() = default;

--- a/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_filter_factory.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_filter_factory.cc
@@ -5,8 +5,8 @@
 
 #include "bat/ads/internal/eligible_ads/eligible_ads_filter_factory.h"
 
-#include "bat/ads/internal/eligible_ads/eligible_ads_priority_filter.h"
 #include "bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.h"
+#include "bat/ads/internal/eligible_ads/eligible_ads_priority_filter.h"
 
 namespace ads {
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_filter_factory.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_filter_factory.cc
@@ -6,6 +6,7 @@
 #include "bat/ads/internal/eligible_ads/eligible_ads_filter_factory.h"
 
 #include "bat/ads/internal/eligible_ads/eligible_ads_priority_filter.h"
+#include "bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.h"
 
 namespace ads {
 
@@ -14,6 +15,9 @@ std::unique_ptr<EligibleAdsFilter> EligibleAdsFilterFactory::Build(
   switch (type) {
     case EligibleAdsFilter::Type::kPriority: {
       return std::make_unique<EligibleAdsPriorityFilter>();
+    }
+    case EligibleAdsFilter::Type::kPacing: {
+      return std::make_unique<EligibleAdsPacingFilter>();
     }
   }
 }

--- a/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.h"
+
+#include <algorithm>
+#include <map>
+#include <utility>
+
+#include "base/rand_util.h"
+#include "bat/ads/internal/logging.h"
+
+namespace ads {
+
+EligibleAdsPacingFilter::EligibleAdsPacingFilter() = default;
+
+EligibleAdsPacingFilter::~EligibleAdsPacingFilter() = default;
+
+CreativeAdNotificationList EligibleAdsPacingFilter::Apply(
+    const CreativeAdNotificationList& ads) const {
+  CreativeAdNotificationList paced_ads;
+
+  for (const auto& ad : ads) {
+    const int rand = base::RandDouble();
+    if (rand <= ad.ptr)
+      paced_ads.emplace_back(ad);
+  }
+
+  BLOG(2, paced_ads.size() << " eligible ads after pacing");
+
+  return paced_ads;
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.cc
@@ -23,7 +23,7 @@ CreativeAdNotificationList EligibleAdsPacingFilter::Apply(
   CreativeAdNotificationList paced_ads;
 
   for (const auto& ad : ads) {
-    const int rand = base::RandDouble();
+    const double rand = base::RandDouble();
     if (rand <= ad.ptr)
       paced_ads.emplace_back(ad);
   }

--- a/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/eligible_ads/eligible_ads_pacing_filter.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BAT_ADS_INTERNAL_ELIGIBLE_ADS_ELIGIBLE_ADS_PACING_FILTER_H_
+#define BAT_ADS_INTERNAL_ELIGIBLE_ADS_ELIGIBLE_ADS_PACING_FILTER_H_
+
+#include "bat/ads/internal/eligible_ads/eligible_ads_filter.h"
+
+namespace ads {
+
+class EligibleAdsPacingFilter : public EligibleAdsFilter {
+ public:
+  EligibleAdsPacingFilter();
+  ~EligibleAdsPacingFilter() override;
+
+  CreativeAdNotificationList Apply(
+      const CreativeAdNotificationList& ads) const override;
+};
+
+}  // namespace ads
+
+#endif  // BAT_ADS_INTERNAL_ELIGIBLE_ADS_ELIGIBLE_ADS_PACING_FILTER_H_

--- a/vendor/bat-native-ads/src/bat/ads/internal/server/get_catalog/get_catalog_url_request_builder.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/server/get_catalog/get_catalog_url_request_builder.cc
@@ -14,7 +14,7 @@ GetCatalogUrlRequestBuilder::GetCatalogUrlRequestBuilder() = default;
 
 GetCatalogUrlRequestBuilder::~GetCatalogUrlRequestBuilder() = default;
 
-// GET /v2/catalog
+// GET /v4/catalog
 
 UrlRequestPtr GetCatalogUrlRequestBuilder::Build() {
   UrlRequestPtr url_request = UrlRequest::New();
@@ -27,7 +27,7 @@ UrlRequestPtr GetCatalogUrlRequestBuilder::Build() {
 ///////////////////////////////////////////////////////////////////////////////
 
 std::string GetCatalogUrlRequestBuilder::BuildUrl() const {
-  return base::StringPrintf("%s/v3/catalog", server::GetDomain().c_str());
+  return base::StringPrintf("%s/v4/catalog", server::GetDomain().c_str());
 }
 
 }  // namespace ads


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11057

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

Unit tests cover probabilistic handling of pass-through rates.

For end-to-end testing:
- note the number of ads logged in brave://rewards-internals as `X eligible ads after pacing`
- adjust `Pass Through Rate` on the ads management system for one or more `house` type ads to `0`, once the ads catalog is refreshed by the client, make sure that the count logged has decreased by the number of ads edited
- adjust `Pass Through Rate` on the ads management system for one or more `house` type ads to `0.5`, once the ads catalog is refreshed by the client, wait for an ad to be shown 3-4 times, make sure that the count logged has changed on subsequent intervals without any other catalog changes

To test effects of pacing on delivery rate:
1. Note the number of ads delivered over the course of a day, hourly, for the release channel being tested
2. Adjust a group of campaigns with similar targeting criteria to have `Pass Through Rate` of 0.5
3. Collect the data over the course of another day
4. Compare the hourly delivery rates for each campaign to verify that it has decreased
5. time permitting, repeat steps 2-3 with `Pass Through Rate` of 0.75, verify the delivery rates are in between the previous days' values

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
