### PR TITLE
Revert "Fix deps in //brave/components/p3a/* #6259"

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -36,6 +36,8 @@ source_set("browser_process") {
     "//brave/test:*",
   ]
 
+  defines = [ "BRAVE_STATS_API_KEY=\"$brave_stats_api_key\"" ]
+
   sources = [
     "autocomplete/brave_autocomplete_scheme_classifier.cc",
     "autocomplete/brave_autocomplete_scheme_classifier.h",
@@ -55,6 +57,12 @@ source_set("browser_process") {
     "brave_local_state_prefs.h",
     "brave_profile_prefs.cc",
     "brave_profile_prefs.h",
+    "brave_stats_updater.cc",
+    "brave_stats_updater.h",
+    "brave_stats_updater_params.cc",
+    "brave_stats_updater_params.h",
+    "brave_stats_updater_util.cc",
+    "brave_stats_updater_util.h",
     "brave_tab_helpers.cc",
     "brave_tab_helpers.h",
     "browser_context_keyed_service_factories.cc",
@@ -104,7 +112,6 @@ source_set("browser_process") {
 
   deps = [
     ":sparkle_buildflags",
-    ":stats_updater",
     ":version_info",
     "autoplay",
     "content_settings",
@@ -145,6 +152,7 @@ source_set("browser_process") {
     "//brave/components/speedreader:buildflags",
     "//brave/components/weekly_storage",
     "//brave/services/network/public/cpp",
+    "//chrome/common",
     "//components/autofill/core/common",
     "//components/browsing_data/core",
     "//components/component_updater",
@@ -450,23 +458,6 @@ source_set("version_info") {
   sources = [
     "version_info.cc",
     "version_info.h",
-  ]
-}
-
-source_set("stats_updater") {
-  defines = [ "BRAVE_STATS_API_KEY=\"$brave_stats_api_key\"" ]
-
-  sources = [
-    "brave_stats_updater.cc",
-    "brave_stats_updater.h",
-    "brave_stats_updater_params.cc",
-    "brave_stats_updater_params.h",
-    "brave_stats_updater_util.cc",
-    "brave_stats_updater_util.h",
-  ]
-
-  deps = [
-    "//chrome/common",
   ]
 }
 

--- a/components/p3a/BUILD.gn
+++ b/components/p3a/BUILD.gn
@@ -9,6 +9,8 @@ buildflag_header("buildflags") {
 }
 
 source_set("p3a") {
+  # Remove when https://github.com/brave/brave-browser/issues/10640 is resolved
+  check_includes = false
   sources = [
     "brave_histogram_rewrite.cc",
     "brave_histogram_rewrite.h",
@@ -26,10 +28,7 @@ source_set("p3a") {
   ]
 
   deps = [
-    "//brave/browser:stats_updater",
-    "//brave/browser:version_info",
     "//brave/common",
-    "//brave/common:pref_names",
     "//brave/components/p3a:buildflags",
     "//brave/components/brave_prochlo",
     "//brave/components/brave_prochlo:prochlo_proto",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Reverts https://github.com/brave/brave-core/pull/6259 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
