### PR TITLE
Fixes Brave Ads intermittently crashes when opening a new tab - 1.13.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -545,6 +545,10 @@ void AdsServiceImpl::OnInitialize(
 }
 
 void AdsServiceImpl::ShutdownBatAds() {
+  if (!connected()) {
+    return;
+  }
+
   VLOG(1) << "Shutting down ads";
 
   bat_ads_->Shutdown(base::BindOnce(&AdsServiceImpl::OnShutdownBatAds,
@@ -626,10 +630,6 @@ void AdsServiceImpl::Start() {
 }
 
 void AdsServiceImpl::Stop() {
-  if (!connected()) {
-    return;
-  }
-
   ShutdownBatAds();
 }
 
@@ -824,10 +824,14 @@ void AdsServiceImpl::OnViewAdNotification(
   ads::AdNotificationInfo notification;
   notification.FromJson(json);
 
+  OpenNewTabWithUrl(notification.target_url);
+
+  if (!connected()) {
+    return;
+  }
+
   bat_ads_->OnAdNotificationEvent(notification.uuid,
       ads::AdNotificationEventType::kClicked);
-
-  OpenNewTabWithUrl(notification.target_url);
 }
 
 void AdsServiceImpl::RetryViewingAdNotification(
@@ -852,6 +856,10 @@ void AdsServiceImpl::ClearAdsServiceForNotificationHandler() {
 
 void AdsServiceImpl::OpenNewTabWithUrl(
     const std::string& url) {
+  if (g_brave_browser_process->IsShuttingDown()) {
+    return;
+  }
+
   GURL gurl(url);
   if (!gurl.is_valid()) {
     VLOG(0) << "Failed to open new tab due to invalid URL: " << url;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6304
Resolves https://github.com/brave/brave-browser/issues/9393

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
