### PR TITLE
Skip DeleteDeviceInfo if sync engine is not active (Android) (uplift to 1.12.x)

### DIFF
--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -212,12 +212,11 @@ bool BraveSyncWorker::ResetSync(
     const base::android::JavaParamRef<jobject>& jcaller) {
   syncer::SyncService* sync_service = GetSyncService();
 
-  if (!sync_service ||
-      !sync_service->GetUserSettings()->IsFirstSetupComplete()) {
-    VLOG(1) << __func__
-            << " sync service is not available or first setup isn't complete, "
-               "cannot reset sync now";
-    return false;
+  // Do not send self deleted commit if engine is not up and running
+  if (!sync_service || sync_service->GetTransportState() !=
+      syncer::SyncService::TransportState::ACTIVE) {
+    OnSelfDeleted();
+    return true;
   }
 
   syncer::DeviceInfoTracker* tracker = GetDeviceInfoTracker();


### PR DESCRIPTION
Uplift of #6241
Resolves https://github.com/brave/brave-browser/issues/10861

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.