### PR TITLE
Revert "Fix deps in //brave/components/content_settings/renderer/"

### DIFF
--- a/components/content_settings/renderer/BUILD.gn
+++ b/components/content_settings/renderer/BUILD.gn
@@ -1,6 +1,8 @@
 import("//build/config/features.gni")
 
 source_set("renderer") {
+  # Remove when https://github.com/brave/brave-browser/issues/10637 is resolved
+  check_includes = false
   visibility = [
     "//chrome/renderer/*",
     "//components/content_settings/renderer/*",
@@ -18,7 +20,6 @@ source_set("renderer") {
     "//base",
     "//brave/common",
     "//brave/components/brave_shields/common",
-    "//brave/third_party/blink/renderer:renderer",
     "//chrome/common",
     "//components/content_settings/core/common",
     "//components/content_settings/renderer",
@@ -26,7 +27,6 @@ source_set("renderer") {
     "//mojo/public/cpp/bindings",
     "//services/service_manager/public/cpp",
     "//third_party/blink/public:blink",
-    "//third_party/blink/public/mojom:mojom_platform_blink",
     "//brave/content:common",
     "//url",
   ]

--- a/components/content_settings/renderer/brave_content_settings_agent_impl.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl.cc
@@ -18,7 +18,6 @@
 #include "brave/components/brave_shields/common/brave_shield_utils.h"
 #include "brave/components/brave_shields/common/features.h"
 #include "brave/content/common/frame_messages.h"
-#include "brave/third_party/blink/renderer/brave_farbling_constants.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/content_settings/core/common/content_settings_utils.h"
 #include "content/public/renderer/render_frame.h"

--- a/components/content_settings/renderer/brave_content_settings_agent_impl.h
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/strings/string16.h"
+#include "brave/third_party/blink/renderer/brave_farbling_constants.h"
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_types.h"
 #include "components/content_settings/renderer/content_settings_agent_impl.h"


### PR DESCRIPTION
Reverts brave/brave-core#6246

The PR being reverted because it appears to have broken unit tests Debug build on Windows:
<pre>
FAILED: brave_unit_tests.exe brave_unit_tests.exe.pdb
ninja -t msvc -e environment.x64 -- ..\..\third_party\llvm-build\Release+Asserts\bin\lld-link.exe /nologo "-libpath:..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\ATLMFC\lib\x64" "-libpath:..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\lib\x64" "-libpath:..\..\..\..\..\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64" "-libpath:..\..\..\..\..\Program Files (x86)\Windows Kits\10\lib\10.0.19041.0\ucrt\x64" "-libpath:..\..\..\..\..\Program Files (x86)\Windows Kits\10\lib\10.0.19041.0\um\x64" /OUT:./brave_unit_tests.exe /PDB:./brave_unit_tests.exe.pdb @./brave_unit_tests.exe.rsp
lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::BlobProxy::BlobProxy(class mojo::MessageReceiverWithResponder *)
>>> defined at .\gen\third_party\blink\public\mojom\blob\blob.mojom-blink.cc:302
>>>            obj/third_party/blink/public/mojom/android_mojo_bindings_blink/blob.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::BlobReaderClientProxy::BlobReaderClientProxy(class mojo::MessageReceiverWithResponder *)
>>> defined at .\gen\third_party\blink\public\mojom\blob\blob.mojom-blink.cc:47
>>>            obj/third_party/blink/public/mojom/android_mojo_bindings_blink/blob.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::InspectorIssueDetails::InspectorIssueDetails(void)
>>> defined at .\gen\third_party\blink\public\mojom\devtools\inspector_issue.mojom-blink.cc:168
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/inspector_issue.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::InspectorIssueInfo::InspectorIssueInfo(enum blink::mojom::InspectorIssueCode, class mojo::StructPtr<class blink::mojom::blink::InspectorIssueDetails>)
>>> defined at .\gen\third_party\blink\public\mojom\devtools\inspector_issue.mojom-blink.cc:191
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/inspector_issue.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::test::mojom::blink::PermissionAutomationProxy::PermissionAutomationProxy(class mojo::MessageReceiverWithResponder *)
>>> defined at .\gen\third_party\blink\public\mojom\permissions\permission_automation.mojom-blink.cc:61
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/permission_automation.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::SpeechSynthesisClientProxy::SpeechSynthesisClientProxy(class mojo::MessageReceiverWithResponder *)
>>> defined at .\gen\third_party\blink\public\mojom\speech\speech_synthesis.mojom-blink.cc:247
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/speech_synthesis.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::SpeechSynthesisVoice::SpeechSynthesisVoice(void)
>>> defined at .\gen\third_party\blink\public\mojom\speech\speech_synthesis.mojom-blink.cc:87
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/speech_synthesis.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::SpeechSynthesisVoiceListObserverProxy::SpeechSynthesisVoiceListObserverProxy(class mojo::MessageReceiverWithResponder *)
>>> defined at .\gen\third_party\blink\public\mojom\speech\speech_synthesis.mojom-blink.cc:119
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/speech_synthesis.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl network::mojom::blink::ContentSecurityPolicy::~ContentSecurityPolicy(void)
>>> defined at .\gen\services\network\public\mojom\content_security_policy.mojom-blink.cc:156
>>>            obj/services/network/public/mojom/mojom_blink/content_security_policy.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::DataElement::~DataElement(void)
>>> defined at .\gen\third_party\blink\public\mojom\blob\data_element.mojom-blink.cc:135
>>>            obj/third_party/blink/public/mojom/android_mojo_bindings_blink/data_element.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::FaviconURL::~FaviconURL(void)
>>> defined at .\gen\third_party\blink\public\mojom\favicon\favicon_url.mojom-blink.cc:57
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/favicon_url.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::FullscreenOptions::~FullscreenOptions(void)
>>> defined at .\gen\third_party\blink\public\mojom\frame\fullscreen.mojom-blink.cc:54
>>>            obj/third_party/blink/public/mojom/frame/frame_blink/fullscreen.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::InspectorIssueDetails::~InspectorIssueDetails(void)
>>> defined at .\gen\third_party\blink\public\mojom\devtools\inspector_issue.mojom-blink.cc:176
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/inspector_issue.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::InspectorIssueInfo::~InspectorIssueInfo(void)
>>> defined at .\gen\third_party\blink\public\mojom\devtools\inspector_issue.mojom-blink.cc:193
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/inspector_issue.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::MenuItem::~MenuItem(void)
>>> defined at .\gen\third_party\blink\public\mojom\choosers\popup_menu.mojom-blink.cc:72
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/popup_menu.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::PermissionDescriptor::~PermissionDescriptor(void)
>>> defined at .\gen\third_party\blink\public\mojom\permissions\permission.mojom-blink.cc:112
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/permission.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::ResourceTimingInfo::~ResourceTimingInfo(void)
>>> defined at .\gen\third_party\blink\public\mojom\timing\resource_timing.mojom-blink.cc:128
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/resource_timing.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::ScrollIntoViewParams::~ScrollIntoViewParams(void)
>>> defined at .\gen\third_party\blink\public\mojom\scroll\scroll_into_view_params.mojom-blink.cc:104
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/scroll_into_view_params.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::SpeechSynthesisUtterance::~SpeechSynthesisUtterance(void)
>>> defined at .\gen\third_party\blink\public\mojom\speech\speech_synthesis.mojom-blink.cc:66
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/speech_synthesis.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: duplicate symbol: public: __cdecl blink::mojom::blink::SpeechSynthesisVoice::~SpeechSynthesisVoice(void)
>>> defined at .\gen\third_party\blink\public\mojom\speech\speech_synthesis.mojom-blink.cc:101
>>>            obj/third_party/blink/public/mojom/mojom_platform_blink/speech_synthesis.mojom-blink.obj
>>> defined at blink_platform.dll

lld-link: error: too many errors emitted, stopping now (use /errorlimit:0 to see all errors)
</pre>