### PR TITLE
generate brave_helper so we run the correct brave exe on mac

### DIFF
--- a/build/commands/lib/start.js
+++ b/build/commands/lib/start.js
@@ -118,25 +118,12 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
 
   let outputPath = options.output_path
   if (!outputPath) {
-    if (process.platform === 'darwin') {
-      let outputDir = config.outputDir
-      if (config.shouldSign()) {
-        outputDir = path.join(outputDir, config.mac_signing_output_prefix)
-      }
-
-      let appName = 'Brave\\ Browser\\ Development'
-
-      if (buildConfig === 'Release') {
-        appName = 'Brave\\ Browser'
-      }
-
-      outputPath = path.join(outputDir,
-                             appName + '.app', 'Contents', 'MacOS',
-                             appName)
-    } else if (process.platform === 'win32') {
-      outputPath = path.join(config.outputDir, 'brave.exe')
-    } else {
-      outputPath = path.join(config.outputDir, 'brave')
+    outputPath = path.join(config.outputDir, 'brave')
+    if (process.platform === 'win32') {
+      outputPath = outputPath + '.exe'
+    } else if (process.platform === 'darwin') {
+      outputPath = outputPath + '_helper'
+      fs.chmodSync(outputPath, 0755)
     }
   }
   util.run(outputPath, braveArgs, cmdOptions)

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -20,7 +20,24 @@ declare_args() {
   notarize_argument = "False"
 }
 
-group("brave") {}
+if (!skip_signing) {
+  target_sign_app_path = "$root_out_dir/$mac_signing_output_prefix/" + string_replace("$chrome_product_full_name", " ", "") + "-$chrome_version_full/$brave_exe"
+  packaging_dir = "$root_out_dir/" + string_replace("$chrome_product_full_name Packaging", " ", "_")
+  unsigned_pkg_path = "$root_out_dir/unsigned/$brave_pkg"
+  keychain_db = getenv("HOME") + "/Library/Keychains/${mac_signing_keychain}.keychain-db"
+}
+
+group("brave") {
+  if (skip_signing) {
+    app_path = "$root_out_dir/$chrome_product_full_name.app"
+  } else {
+    app_path = target_sign_app_path
+  }
+
+  exe_path = "$app_path/Contents/MacOS/$chrome_product_full_name"
+
+  write_file("$root_out_dir/brave_helper", [ string_replace(rebase_path(exe_path), " ", "\\ ") + " \$@" ])
+}
 
 ds_store_file_name = "DS_Store"
 dmg_icon_file_name = "dmg"
@@ -111,11 +128,6 @@ if (skip_signing) {
     }
   }
 } else {
-  packaging_dir = "$root_out_dir/" + string_replace("$chrome_product_full_name Packaging", " ", "_")
-  target_sign_app_path = "$root_out_dir/$mac_signing_output_prefix/" + string_replace("$chrome_product_full_name", " ", "") + "-$chrome_version_full/$brave_exe"
-  unsigned_pkg_path = "$root_out_dir/unsigned/$brave_pkg"
-  keychain_db = getenv("HOME") + "/Library/Keychains/${mac_signing_keychain}.keychain-db"
-
   action("sign_app") {
     script = "//build/gn_run_binary.py"
     shell_script = "//brave/build/mac/sign_app.sh"


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/11086

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
