### PR TITLE
Show wallet backup notification only once for non-verified profiles

### DIFF
--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -46,8 +46,6 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterStringPref(prefs::kRewardsNotifications, "");
   registry->RegisterTimeDeltaPref(prefs::kRewardsNotificationTimerInterval,
                                   base::TimeDelta::FromDays(1));
-  registry->RegisterTimeDeltaPref(prefs::kRewardsBackupNotificationFrequency,
-                                  base::TimeDelta::FromDays(30));
   registry->RegisterTimeDeltaPref(prefs::kRewardsBackupNotificationInterval,
                                   base::TimeDelta::FromDays(30));
   registry->RegisterTimeDeltaPref(prefs::kRewardsNotificationStartupDelay,

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -13,8 +13,6 @@ const char kBraveRewardsEnabled[] = "brave.rewards.enabled";
 const char kRewardsNotifications[] = "brave.rewards.notifications";
 const char kRewardsNotificationTimerInterval[]=
     "brave.rewards.notification_timer_interval";
-const char kRewardsBackupNotificationFrequency[] =
-    "brave.rewards.backup_notification_frequency";
 const char kRewardsBackupNotificationInterval[] =
     "brave.rewards.backup_notification_interval";
 const char kRewardsBackupSucceeded[] = "brave.rewards.backup_succeeded";

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -13,7 +13,6 @@ extern const char kHideBraveRewardsButton[];
 extern const char kBraveRewardsEnabled[];
 extern const char kRewardsNotifications[];
 extern const char kRewardsNotificationTimerInterval[];
-extern const char kRewardsBackupNotificationFrequency[];
 extern const char kRewardsBackupNotificationInterval[];
 extern const char kRewardsBackupSucceeded[];
 extern const char kRewardsUserHasFunded[];


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/6259

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

### Case 1: Backup notification is shown only once for non-verified profiles

- Start the browser with a clean profile pointed to staging.
- Enable rewards.
- Claim the grant.
- Quit the browser.
- Edit the "Preferences" file with the following changes:
  - (Note: the following step will ensure that the backup notification timer is triggered every 5 seconds.)
  - Under the keys "brave" > "rewards", add the following entries:
    - `"backup_notification_interval": "4000000",`
    - `"notification_startup_delay": "4000000",`
    - `"notification_timer_interval": "5000000",`
- Start the browser.
- Wait 5 seconds.
  - Verify that backup notification is shown.
- Dismiss the backup notification.
- Wait 5 seconds.
  - Verify that the backup notification is not shown again.

### Case 2: Backup notification is not shown for verified users

- Start the browser with a clean profile pointed to staging.
- Enable rewards.
- Connect KYC'd staging wallet that has a non-zero balance.
- Quit the browser.
- Edit the "Preferences" file with the following changes:
  - (Note: the following step will ensure that the backup notification timer is triggered every 5 seconds.)
  - Under the keys "brave" > "rewards", add the following entries:
    - `"backup_notification_interval": "4000000",`
    - `"notification_startup_delay": "4000000",`
    - `"notification_timer_interval": "5000000",`
- Start the browser.
- Wait 5 seconds.
  - Verify that the backup notification is not shown.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
