### PR TITLE
Force to refresh sync cycle(poll/nudge) when transiting from CONFIGURATION to NORMAL mode. (uplift to 1.13.x)

### DIFF
--- a/build/config/brave_build.gni
+++ b/build/config/brave_build.gni
@@ -4,6 +4,7 @@
 import("//brave/brave_repack_locales.gni")
 import("//brave/build/config/compiler.gni")
 import("//brave/build/features.gni")
+import("//brave/components/sync/sources.gni")
 import("//brave/components/sync/driver/sources.gni")
 import("//brave/net/sources.gni")
 import("//brave/third_party/blink/renderer/includes.gni")

--- a/chromium_src/components/sync/engine/sync_manager_factory.cc
+++ b/chromium_src/components/sync/engine/sync_manager_factory.cc
@@ -1,0 +1,10 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine_impl/brave_sync_manager_impl.h"
+
+#define SyncManagerImpl BraveSyncManagerImpl
+#include "../../../../../components/sync/engine/sync_manager_factory.cc"
+#undef SyncManagerImpl

--- a/components/sync/engine_impl/brave_sync_manager_impl.cc
+++ b/components/sync/engine_impl/brave_sync_manager_impl.cc
@@ -1,0 +1,24 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine_impl/brave_sync_manager_impl.h"
+
+namespace syncer {
+
+BraveSyncManagerImpl::BraveSyncManagerImpl(
+    const std::string& name,
+    network::NetworkConnectionTracker* network_connection_tracker)
+  : SyncManagerImpl(name, network_connection_tracker) {}
+
+BraveSyncManagerImpl::~BraveSyncManagerImpl() {}
+
+void BraveSyncManagerImpl::StartSyncingNormally(base::Time last_poll_time) {
+  SyncManagerImpl::StartSyncingNormally(last_poll_time);
+  // Remove this hack when we have FCM invalidation integrated.
+  // We only enable BOOKMARKS by default so only force refresh it
+  RefreshTypes(ModelTypeSet(BOOKMARKS));
+}
+
+}  // namespace syncer

--- a/components/sync/engine_impl/brave_sync_manager_impl.h
+++ b/components/sync/engine_impl/brave_sync_manager_impl.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SYNC_ENGINE_IMPL_BRAVE_SYNC_MANAGER_IMPL_H_
+#define BRAVE_COMPONENTS_SYNC_ENGINE_IMPL_BRAVE_SYNC_MANAGER_IMPL_H_
+
+#include <string>
+
+#include "components/sync/engine_impl/sync_manager_impl.h"
+
+namespace syncer {
+
+class BraveSyncManagerImpl : public SyncManagerImpl {
+ public:
+  BraveSyncManagerImpl(
+      const std::string& name,
+      network::NetworkConnectionTracker* network_connection_tracker);
+  ~BraveSyncManagerImpl() override;
+
+  void StartSyncingNormally(base::Time last_poll_time) override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(BraveSyncManagerImpl);
+};
+
+}  // namespace syncer
+
+#endif  // BRAVE_COMPONENTS_SYNC_ENGINE_IMPL_BRAVE_SYNC_MANAGER_IMPL_H_

--- a/components/sync/sources.gni
+++ b/components/sync/sources.gni
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+brave_components_sync_sources = [
+  "//brave/components/sync/engine_impl/brave_sync_manager_impl.cc",
+  "//brave/components/sync/engine_impl/brave_sync_manager_impl.h",
+]

--- a/patches/components-sync-BUILD.gn.patch
+++ b/patches/components-sync-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/BUILD.gn b/components/sync/BUILD.gn
+index db5a9d0154d0c1e1390e4af6272d7d6cebe24b57..3cde948c91c4aa13297de70dafa86ee33db32906 100644
+--- a/components/sync/BUILD.gn
++++ b/components/sync/BUILD.gn
+@@ -413,6 +413,7 @@ jumbo_static_library("rest_of_sync") {
+     "syncable/write_transaction_info.cc",
+     "syncable/write_transaction_info.h",
+   ]
++  sources += brave_components_sync_sources
+ 
+   configs += [ "//build/config:precompiled_headers" ]
+ 


### PR DESCRIPTION
Uplift of #6363
Resolves https://github.com/brave/brave-browser/issues/11116

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.