### PR TITLE
Fixes reset Rewards crashes the browser in certain cases - 1.12.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -648,7 +648,7 @@ void AdsServiceImpl::ResetState() {
 
 void AdsServiceImpl::ResetAllState(
     const bool should_shutdown) {
-  if (!should_shutdown) {
+  if (!should_shutdown || !connected()) {
     ResetState();
     return;
   }

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1486,7 +1486,7 @@ void RewardsServiceImpl::StopLedger(StopLedgerCallback callback) {
   BLOG(1, "Shutting down ledger process");
   if (!Connected()) {
     BLOG(1, "Ledger process not running");
-    Reset();
+    OnStopLedger(std::move(callback), ledger::Result::LEDGER_OK);
     return;
   }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6368
Resolves https://github.com/brave/brave-browser/issues/11125

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
