### PR TITLE
Resend DeviceInfo with send_tab_to_self_receiving_enabled flag

### DIFF
--- a/chromium_src/chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc
+++ b/chromium_src/chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This patch allows bubble controller to re-read all devices list each time
+// when the menu is shown.
+#define BRAVE_GET_VALID_DEVICES \
+  (const_cast<SendTabToSelfBubbleController*>(this))->FetchDeviceInfo()
+
+#include "../../../../../../../chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc"

--- a/chromium_src/components/send_tab_to_self/send_tab_to_self_bridge.cc
+++ b/chromium_src/components/send_tab_to_self/send_tab_to_self_bridge.cc
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This patch is to force update the device list, need this to to be aware of
+// the situation when one of devices in chain has changed it's
+// property, which manages whether the device should be displayed in the list
+// where to send the link to
+#define BRAVE_SHOULD_UPDATE_TARGET_DEVICE_INFO_LIST return true
+
+#include "../../../../components/send_tab_to_self/send_tab_to_self_bridge.cc"

--- a/chromium_src/components/sync_device_info/device_info_prefs.cc
+++ b/chromium_src/components/sync_device_info/device_info_prefs.cc
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "../../../../components/sync_device_info/device_info_prefs.cc"
+
+namespace syncer {
+
+PrefService* DeviceInfoPrefs::GetPrefService() {
+  return pref_service_;
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync_device_info/device_info_prefs.h
+++ b/chromium_src/components/sync_device_info/device_info_prefs.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_PREFS_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_PREFS_H_
+
+class PrefService;
+
+#define GarbageCollectExpiredCacheGuids \
+  GarbageCollectExpiredCacheGuids();    \
+  PrefService* GetPrefService
+
+#include "../../../../components/sync_device_info/device_info_prefs.h"
+
+#undef GarbageCollectExpiredCacheGuids
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_PREFS_H_

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.h
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_SYNC_BRIDGE_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_SYNC_BRIDGE_H_
 
+#include "components/prefs/pref_change_registrar.h"
 #include "components/sync_device_info/device_info_tracker.h"
 
 #define ForcePulseForTest                                                    \
@@ -14,9 +15,12 @@
   void ForcePulseForTest
 
 // private:
-#define StoreSpecifics                              \
-  OnDeviceInfoDeleted(const std::string& client_id, \
-                      base::OnceClosure callback);  \
+#define StoreSpecifics                                  \
+  OnDeviceInfoDeleted(const std::string& client_id,     \
+                      base::OnceClosure callback);      \
+  void InitSyncTabsPrefChangeRegistrar();               \
+  void OnSyncTabsPrefsChanged(const std::string& pref); \
+  PrefChangeRegistrar brave_pref_change_registrar_;     \
   void StoreSpecifics
 
 #include "../../../../components/sync_device_info/device_info_sync_bridge.h"

--- a/patches/chrome-browser-ui-send_tab_to_self-send_tab_to_self_bubble_controller.cc.patch
+++ b/patches/chrome-browser-ui-send_tab_to_self-send_tab_to_self_bubble_controller.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc b/chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc
+index c1432ff1e72561ee3e16f4c52085770cc2147e16..980d0b7e21aef4ed7ab2375f578cee1aebd65705 100644
+--- a/chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc
++++ b/chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble_controller.cc
+@@ -63,6 +63,7 @@ base::string16 SendTabToSelfBubbleController::GetWindowTitle() const {
+ 
+ const std::vector<TargetDeviceInfo>&
+ SendTabToSelfBubbleController::GetValidDevices() const {
++  BRAVE_GET_VALID_DEVICES;
+   return valid_devices_;
+ }
+ 

--- a/patches/components-send_tab_to_self-send_tab_to_self_bridge.cc.patch
+++ b/patches/components-send_tab_to_self-send_tab_to_self_bridge.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/send_tab_to_self/send_tab_to_self_bridge.cc b/components/send_tab_to_self/send_tab_to_self_bridge.cc
+index 28906d7d81abe28c59d8442a7a85d11c6f3942ed..9c4fa7e44b63cd4b2b632f4cc580fead8fd554bd 100644
+--- a/components/send_tab_to_self/send_tab_to_self_bridge.cc
++++ b/components/send_tab_to_self/send_tab_to_self_bridge.cc
+@@ -613,6 +613,7 @@ void SendTabToSelfBridge::DoGarbageCollection() {
+ }
+ 
+ bool SendTabToSelfBridge::ShouldUpdateTargetDeviceInfoList() const {
++  BRAVE_SHOULD_UPDATE_TARGET_DEVICE_INFO_LIST;
+   // The vector should be updated if any of these is true:
+   //   * The vector is empty.
+   //   * The number of total devices changed.

--- a/patches/components-sync_device_info-device_info_sync_bridge.cc.patch
+++ b/patches/components-sync_device_info-device_info_sync_bridge.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync_device_info/device_info_sync_bridge.cc b/components/sync_device_info/device_info_sync_bridge.cc
+index ea25c1eaf23e44d377066dfadd4c2ec70635822a..39e758ce988c53a72e70ba360b94b6009a8edbd8 100644
+--- a/components/sync_device_info/device_info_sync_bridge.cc
++++ b/components/sync_device_info/device_info_sync_bridge.cc
+@@ -206,6 +206,7 @@ DeviceInfoSyncBridge::DeviceInfoSyncBridge(
+   std::move(store_factory)
+       .Run(DEVICE_INFO, base::BindOnce(&DeviceInfoSyncBridge::OnStoreCreated,
+                                        weak_ptr_factory_.GetWeakPtr()));
++  BRAVE_DEVICE_INFO_SYNC_BRIDGE;
+ }
+ 
+ DeviceInfoSyncBridge::~DeviceInfoSyncBridge() {}


### PR DESCRIPTION
 when 'Open Tabs' category is changed

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves  https://github.com/brave/brave-browser/issues/11475

The root cause of problems related to `Open tabs` category and send link - is the field `send_tab_to_self_receiving_enabled`  not being updated when the corresponding flag on other device is switched. Also the current device does not send updated device_info immediately when it's `Open tabs` category is changed. Prior to this PR is was required to relaunch all the devices in the chain when even one of them got `Open tabs` category changed. This PR does mainly:
1. Forces to send to cloud updated device info with proper `send_tab_to_self_receiving_enabled` field as soon as the `Open tabs` sync category has changed
2. Forces to re-read all device info records from the sync DB to be aware if some other device in chain has `send_tab_to_self_receiving_enabled`.
3. Minor UI-related thing - forces re-read all devices into bubble class  just before showing the menu with device list - otherwise it would be required to open a new tab to re-fetch the devices for the case when we have new or removed some old.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
I. Desktop <=> Desktop

1. Create Sync chain on desktop A
2. Connect to Sync chain desktop B
3. Ensure only Bookmarks category is enabled on both A and B (default settings)
4. Open youtube.com on device A
5. Try to send link from A to B through click on URL bar and the send link button - expected not to have such button 
6. On both devices A and B enable `Open tabs` category
7. Wait ~1 min. repeat pt 5, expected to be able to send a link A=>B or B=>A
8. Turn off `Open tabs` category on device A, wait 1 minite, refresh youtube page - expected not to have the posibility to send the link


II. Desktop <=> Android
// The same steps, but device B is Android and to send link from Android use share buton in kebab menu
1. Create Sync chain on desktop A
2. Connect mobile device B to desktop A
3. Ensure `Open tabs` category is not enabled neither on A or B.
4. Ensure it is impossible to send link A => B or B => A
5. Enable `Open tabs` on both A and B 
6. Wait ~1 min.
7. Ensure it possible to send link A => B or B => A


III. Desktop <=> Android
// The same steps, but both devices A and B are Android and to send link from Android use share buton in kebab menu
1. Create Sync chain on mobile A
2. Connect mobile device B to mobilr A
3. Ensure `Open tabs` category is not enabled neither on A or B.
4. Ensure it is impossible to send link A => B or B => A
5. Enable `Open tabs` on both A and B 
6. Wait ~1 min.
7. Ensure it possible to send link A => B or B => A

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
