### PR TITLE
isChromeSyncEnabled depends on profileSyncService.isSyncRequested (uplift to 1.13.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/sync/BraveAndroidSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/BraveAndroidSyncSettings.java
@@ -5,6 +5,7 @@
 
 package org.chromium.chrome.browser.sync;
 
+import org.chromium.chrome.browser.sync.ProfileSyncService;
 import org.chromium.components.sync.SyncContentResolverDelegate;
 
 // see org.brave.bytecode.BraveAndroidSyncSettingsAdapter
@@ -27,4 +28,14 @@ public class BraveAndroidSyncSettings extends AndroidSyncSettings {
 
     @Override
     public void disableChromeSync() { }
+
+    // We need to override this to make able
+    // DevicePickerBottomSheetContent.createContentView send the link
+    // For Brave we don't have an account in Android system account,
+    // so pretend sync for Brave "account" is always on when sync is requsted
+    @Override
+    public boolean isChromeSyncEnabled() {
+        ProfileSyncService profileSyncService = ProfileSyncService.get();
+        return profileSyncService != null && profileSyncService.isSyncRequested();
+    }
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6417

Resolves https://github.com/brave/brave-browser/issues/11210, https://github.com/brave/brave-browser/issues/11077

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.