### PR TITLE
isChromeSyncEnabled depends on profileSyncService.isSyncRequested (uplift to 1.12.x)

### DIFF
--- a/components/sync/android/java/src/org/chromium/components/sync/BraveAndroidSyncSettings.java
+++ b/components/sync/android/java/src/org/chromium/components/sync/BraveAndroidSyncSettings.java
@@ -5,6 +5,13 @@
 
 package org.chromium.components.sync;
 
+import java.lang.reflect.Method;
+
+//import org.chromium.chrome.browser.sync.ProfileSyncService;
+//import org.chromium.components.sync.AndroidSyncSettings;
+import org.chromium.components.sync.SyncContentResolverDelegate;
+  import org.chromium.base.Log;
+
 // see org.brave.bytecode.BraveAndroidSyncSettingsAdapter
 public class BraveAndroidSyncSettings extends AndroidSyncSettings {
     private boolean mMasterSyncEnabled;
@@ -25,4 +32,33 @@ public class BraveAndroidSyncSettings extends AndroidSyncSettings {
 
     @Override
     public void disableChromeSync() { }
+
+    // We need to override this to make able
+    // DevicePickerBottomSheetContent.createContentView send the link
+    // For Brave we don't have an account in Android system account,
+    // so pretend sync for Brave "account" is always on when sync is requsted
+    @Override
+    public boolean isChromeSyncEnabled() {
+        // On Chrome 84 ProfileSyncService.java is in //chrome/android:chrome_java
+        // but AndroidSyncSettings.java is in //components/sync/android:sync_java
+        // //chrome/android:chrome_java depends on //components/sync/android:sync_java
+        // so I cannot add deps to //components/sync/android:sync_java
+        // Therefore doing with reflection
+        try {
+            Method methodGet = Class.forName("org.chromium.chrome.browser.sync.ProfileSyncService").getDeclaredMethod("get");
+            Object profileSyncService = methodGet.invoke(null);
+            if (profileSyncService == null) {
+                return false;
+            }
+
+            Method methodIsSyncRequested = Class.forName("org.chromium.chrome.browser.sync.ProfileSyncService").getDeclaredMethod("isSyncRequested");
+            Object isSyncRequested = methodIsSyncRequested.invoke(profileSyncService);
+            boolean bIsSyncRequested = (boolean)isSyncRequested;
+            return bIsSyncRequested;
+        } catch (Exception e) {
+            assert false;
+            // failsafe, but should never reach
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6417

Resolves https://github.com/brave/brave-browser/issues/11210, https://github.com/brave/brave-browser/issues/11077

Created manually and had to re-do the PR merged to master

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.