### PR TITLE
Revert "Exclude chrome-VERSION.patch from CODEOWNERS."

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 patches/ @bridiver
-!patches/chrome-VERSION.patch @bridiver
 chromium_src/ @bridiver
 script/build-bisect.py @bsclifton
 script/uplift.py @bsclifton


### PR DESCRIPTION
Reverts #6464

Doesn't look like the ! syntax is supported after all, even though https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax claims to support gitignore syntax.