### PR TITLE
[Android] Fix for rewards icon reappearing after restarting

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayout.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayout.java
@@ -237,6 +237,7 @@ public abstract class BraveToolbarLayout extends ToolbarLayout implements OnClic
 
     SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
     if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_REWARDS)
+        && !BravePrefServiceBridge.getInstance().getSafetynetCheckFailed()
         && !sharedPreferences.getBoolean(
           AppearancePreferences.PREF_HIDE_BRAVE_REWARDS_ICON, false)
         && mRewardsLayout != null) {

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayout.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayout.java
@@ -237,11 +237,11 @@ public abstract class BraveToolbarLayout extends ToolbarLayout implements OnClic
 
     SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
     if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_REWARDS)
-        && !BravePrefServiceBridge.getInstance().getSafetynetCheckFailed()
-        && !sharedPreferences.getBoolean(
-          AppearancePreferences.PREF_HIDE_BRAVE_REWARDS_ICON, false)
-        && mRewardsLayout != null) {
-      mRewardsLayout.setVisibility(View.VISIBLE);
+            && !BravePrefServiceBridge.getInstance().getSafetynetCheckFailed()
+            && !sharedPreferences.getBoolean(
+                    AppearancePreferences.PREF_HIDE_BRAVE_REWARDS_ICON, false)
+            && mRewardsLayout != null) {
+        mRewardsLayout.setVisibility(View.VISIBLE);
     }
     if (mShieldsLayout != null) {
       updateShieldsLayoutBackground(!(mRewardsLayout != null && mRewardsLayout.getVisibility() == View.VISIBLE));


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9871
Fix was reverted, I got it back

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
