### PR TITLE
Use isFirstSetupComplete instead isSyncRequested for isChromeSyncEnabled (uplift to 1.14.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/sync/BraveAndroidSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/BraveAndroidSyncSettings.java
@@ -32,10 +32,10 @@ public class BraveAndroidSyncSettings extends AndroidSyncSettings {
     // We need to override this to make able
     // DevicePickerBottomSheetContent.createContentView send the link
     // For Brave we don't have an account in Android system account,
-    // so pretend sync for Brave "account" is always on when sync is requsted
+    // so pretend sync for Brave "account" is always on when sync is configured
     @Override
     public boolean isChromeSyncEnabled() {
         ProfileSyncService profileSyncService = ProfileSyncService.get();
-        return profileSyncService != null && profileSyncService.isSyncRequested();
+        return profileSyncService != null && profileSyncService.isFirstSetupComplete();
     }
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6480

Resolves https://github.com/brave/brave-browser/issues/11210, https://github.com/brave/brave-browser/issues/11077, https://github.com/brave/brave-browser/issues/11363

Created manually

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.