### PR TITLE
Fixes Brave Ads Purchase Intent segments should fall back to parent segments - 1.14.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
@@ -245,8 +245,12 @@ class AdsImpl
       const Result result,
       const classification::CategoryList& categories,
       const CreativeAdNotificationList& ads);
-  bool ServeAdNotificationFromParentCategories(
+  void ServeAdNotificationFromParentCategories(
       const classification::CategoryList& categories);
+  void OnServeAdNotificationFromParentCategories(
+      const Result result,
+      const classification::CategoryList& categories,
+      const CreativeAdNotificationList& ads);
   void ServeUntargetedAdNotification();
   void OnServeUntargetedAdNotification(
       const Result result,

--- a/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util.cc
@@ -10,10 +10,39 @@
 namespace ads {
 namespace classification {
 
+namespace {
+const char kCategorySeparator[] = "-";
+}  // namespace
+
 std::vector<std::string> SplitCategory(
     const std::string& category) {
   return base::SplitString(category, kCategorySeparator, base::KEEP_WHITESPACE,
       base::SPLIT_WANT_ALL);
+}
+
+CategoryList GetParentCategories(
+    const CategoryList& categories) {
+  CategoryList parent_categories;
+
+  for (const auto& category : categories) {
+    std::string parent_category;
+
+    const size_t pos = category.find_last_of(kCategorySeparator);
+    if (pos != std::string::npos) {
+      parent_category = category.substr(0, pos);
+    } else {
+      parent_category = category;
+    }
+
+    if (std::find(parent_categories.begin(), parent_categories.end(),
+        parent_category) != parent_categories.end()) {
+      continue;
+    }
+
+    parent_categories.push_back(parent_category);
+  }
+
+  return parent_categories;
 }
 
 }  // namespace classification

--- a/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util.h
@@ -9,13 +9,16 @@
 #include <string>
 #include <vector>
 
+#include "bat/ads/internal/classification/page_classifier/page_classifier.h"
+
 namespace ads {
 namespace classification {
 
-const char kCategorySeparator[] = "-";
-
 std::vector<std::string> SplitCategory(
     const std::string& category);
+
+CategoryList GetParentCategories(
+    const CategoryList& categories);
 
 }  // namespace classification
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/classification/classification_util_unittest.cc
@@ -62,5 +62,41 @@ TEST(BatAdsClassificationUtilTest,
   EXPECT_EQ(expected_categories, categories);
 }
 
+TEST(BatAdsClassificationUtilTest,
+    GetParentCategories) {
+  // Arrange
+  const std::vector<std::string> categories = {
+    "technology & computing-software",
+    "personal-finance-banking",
+    "automobiles"
+  };
+
+  // Act
+  const CategoryList parent_categories = GetParentCategories(categories);
+
+  // Assert
+  const std::vector<std::string> expected_parent_categories = {
+    "technology & computing",
+    "personal-finance",
+    "automobiles"
+  };
+
+  EXPECT_EQ(expected_parent_categories, parent_categories);
+}
+
+TEST(BatAdsClassificationUtilTest,
+    GetParentCategoriesForEmptyList) {
+  // Arrange
+  const std::vector<std::string> categories = {};
+
+  // Act
+  const CategoryList parent_categories = GetParentCategories(categories);
+
+  // Assert
+  const std::vector<std::string> expected_parent_categories = {};
+
+  EXPECT_EQ(expected_parent_categories, parent_categories);
+}
+
 }  // namespace classification
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/classification/purchase_intent_classifier/purchase_intent_classifier_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/classification/purchase_intent_classifier/purchase_intent_classifier_unittest.cc
@@ -66,13 +66,13 @@ class BatAdsPurchaseIntentClassifierTest : public ::testing::Test {
           "funnel_sites": [
             {
               "sites": [
-                "http://brave.com", "http://crave.com"
+                "https://brave.com", "https://crave.com"
               ],
               "segments": [1, 2]
             },
             {
               "sites": [
-                "http://frexample.org", "http://example.org"
+                "https://frexample.org", "https://example.org"
               ],
               "segments": [0]
             }

--- a/vendor/bat-native-ads/src/bat/ads/internal/search_engine/search_providers.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/search_engine/search_providers.cc
@@ -51,7 +51,11 @@ bool SearchProviders::IsSearchEngine(
 
 std::string SearchProviders::ExtractSearchQueryKeywords(
     const std::string& url) {
-  std::string search_query_keywords = "";
+  std::string search_query_keywords;
+
+  if (!IsSearchEngine(url)) {
+    return search_query_keywords;
+  }
 
   const GURL visited_url = GURL(url);
   if (!visited_url.is_valid()) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6483
Resolves https://github.com/brave/brave-browser/issues/11410

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
