### PR TITLE
[Android] Removed option that offers translation

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -98,6 +98,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/qrreader/BarcodeTrackerFactory.java",
   "../../brave/android/java/org/chromium/chrome/browser/qrreader/CameraSource.java",
   "../../brave/android/java/org/chromium/chrome/browser/qrreader/CameraSourcePreview.java",
+  "../../brave/android/java/org/chromium/chrome/browser/language/settings/BraveLanguageSettings.java",
   "../../brave/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveStatsPreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java",

--- a/android/java/org/chromium/chrome/browser/language/settings/BraveLanguageSettings.java
+++ b/android/java/org/chromium/chrome/browser/language/settings/BraveLanguageSettings.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.language.settings;
+
+import android.os.Bundle;
+
+import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
+
+public class BraveLanguageSettings extends LanguageSettings {
+    static final String TRANSLATE_SWITCH_KEY = "translate_switch";
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        super.onCreatePreferences(savedInstanceState, rootKey);
+        ChromeSwitchPreference translateSwitch =
+                (ChromeSwitchPreference) findPreference(TRANSLATE_SWITCH_KEY);
+        if (translateSwitch != null) {
+            getPreferenceScreen().removePreference(translateSwitch);
+        }
+    }
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -53,6 +53,7 @@ public class BraveMainPreferencesBase extends BravePreferenceFragment {
     private static final String PREF_HOMEPAGE = "homepage";
     private static final String PREF_USE_CUSTOM_TABS = "use_custom_tabs";
     private static final String PREF_LANGUAGES = "languages";
+    private static final String PREF_BRAVE_LANGUAGES = "brave_languages";
     private static final String PREF_RATE_BRAVE = "rate_brave";
     private static final String PREF_BRAVE_STATS = "brave_stats";
 
@@ -90,6 +91,7 @@ public class BraveMainPreferencesBase extends BravePreferenceFragment {
         removePreferenceIfPresent(MainSettings.PREF_SYNC_AND_SERVICES);
         removePreferenceIfPresent(MainSettings.PREF_SEARCH_ENGINE);
         removePreferenceIfPresent(MainSettings.PREF_UI_THEME);
+        removePreferenceIfPresent(PREF_LANGUAGES);
 
         updateSearchEnginePreference();
         updateControlSectionPreferences();
@@ -139,7 +141,7 @@ public class BraveMainPreferencesBase extends BravePreferenceFragment {
         findPreference(PREF_SYNC).setOrder(++order);
         findPreference(PREF_ACCESSIBILITY).setOrder(++order);
         findPreference(PREF_CONTENT_SETTINGS).setOrder(++order);
-        findPreference(PREF_LANGUAGES).setOrder(++order);
+        findPreference(PREF_BRAVE_LANGUAGES).setOrder(++order);
         findPreference(MainSettings.PREF_DATA_REDUCTION).setOrder(++order);
         findPreference(MainSettings.PREF_DOWNLOADS).setOrder(++order);
         // This preference doesn't exist by default in Release mode

--- a/android/java/res/xml/brave_main_preferences.xml
+++ b/android/java/res/xml/brave_main_preferences.xml
@@ -73,4 +73,9 @@
         android:key="brave_sync_layout"
         android:order="22"
         android:title="@string/sync_category_title"/>
+    <Preference
+        android:fragment="org.chromium.chrome.browser.language.settings.BraveLanguageSettings"
+        android:key="brave_languages"
+        android:order="23"
+        android:title="@string/language_settings"/>
 </PreferenceScreen>

--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -262,6 +262,7 @@ source_set("browser_process") {
       "//brave/build/android:jni_headers",
       "//chrome/android:jni_headers",
       "//components/ntp_tiles",
+      "//components/translate/core/browser",
     ]
   }
 

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -72,6 +72,7 @@
 #if defined(OS_ANDROID)
 #include "components/feed/core/shared_prefs/pref_names.h"
 #include "components/ntp_tiles/pref_names.h"
+#include "components/translate/core/browser/translate_pref_names.h"
 #endif
 
 using extensions::FeatureSwitch;
@@ -156,6 +157,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->SetDefaultPrefValue(feed::prefs::kEnableSnippets,
                                 base::Value(false));
   registry->SetDefaultPrefValue(feed::prefs::kArticlesListVisible,
+                                base::Value(false));
+  // Translate is not available on Android
+  registry->SetDefaultPrefValue(prefs::kOfferTranslateEnabled,
                                 base::Value(false));
 #endif
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11496

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
