### PR TITLE
Fix login issue on bitbucket.org

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -32,6 +32,9 @@ constexpr char kAexp[] = "https://[*.]aexp-static.com/*";
 constexpr char kSony[] = "https://[*.]sony.com/*";
 constexpr char kGoogle[] = "https://[*.]google.com/*";
 constexpr char kGoogleusercontent[] = "https://[*.]googleusercontent.com/*";
+constexpr char kBitbucket[] = "https://[*.]bitbucket.org/*";
+constexpr char kAtlassiannet[] = "https://[*.]atlassian.net/*";
+constexpr char kAtlassiancom[] = "https://[*.]atlassian.com/*";
 
 bool BraveIsAllowedThirdParty(
     const GURL& url,
@@ -96,6 +99,22 @@ bool BraveIsAllowedThirdParty(
           {
             ContentSettingsPattern::FromString(kTwitch),
             ContentSettingsPattern::FromString(kDiscord)
+          },
+          {
+            ContentSettingsPattern::FromString(kBitbucket),
+            ContentSettingsPattern::FromString(kAtlassiancom)
+          },
+          {
+            ContentSettingsPattern::FromString(kAtlassiancom),
+            ContentSettingsPattern::FromString(kBitbucket)
+          },
+          {
+            ContentSettingsPattern::FromString(kAtlassiancom),
+            ContentSettingsPattern::FromString(kAtlassiannet)
+          },
+          {
+            ContentSettingsPattern::FromString(kAtlassiannet),
+            ContentSettingsPattern::FromString(kAtlassiancom)
           }
       });
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->

Unable to login to bitbucket.org.  Fixes https://github.com/brave/brave-browser/issues/11532

1. Fixes cookie issues on during bitbucket.org/atlassian, 

**Bitbucket.org/atlassian.com:**
![bitbucketorg](https://user-images.githubusercontent.com/1659004/91770577-865ec100-ec35-11ea-9433-35b40c8f5b17.png)

2. Cookie issues on `atlassian.com` and `atlassian.net`. Redirects between these 2 domains during the login process.

Both are needed to allow the login process to be successful.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
