### PR TITLE
initializes bottom menu toolbar variable on Android (uplift to 1.15.x)

### DIFF
--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-toolbar-ToolbarAppMenuManager.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-toolbar-ToolbarAppMenuManager.java.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarAppMenuManager.java b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarAppMenuManager.java
+index cabff32bdae3..a74dd961aebb 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarAppMenuManager.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarAppMenuManager.java
+@@ -162,6 +162,7 @@ class ToolbarAppMenuManager implements AppMenuObserver {
+         mAppMenuHandler = appMenuHandler;
+         mAppMenuHandler.addObserver(this);
+         mAppMenuButtonHelper = mAppMenuHandler.createAppMenuButtonHelper();
++        mAppMenuButtonHelper.setMenuShowsFromBottom(mBottomToolbarEnabled);
+         mAppMenuButtonHelper.setOnAppMenuShownListener(() -> {
+             RecordUserAction.record("MobileToolbarShowMenu");
+             mToolbar.onMenuShown();
+@@ -203,4 +204,5 @@ class ToolbarAppMenuManager implements AppMenuObserver {
+             mToolbar.removeAppMenuUpdateBadge(false);
+         }
+     }
++    private boolean mBottomToolbarEnabled = false; public void setBottomMenu(boolean enabled) {mBottomToolbarEnabled = enabled;if (mAppMenuButtonHelper != null) mAppMenuButtonHelper.setMenuShowsFromBottom(enabled); }
+ }

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-toolbar-ToolbarManager.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-toolbar-ToolbarManager.java.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
-index 4c2c4fd10ba6c6f9981aa581b5630a38b4ee91f0..dbdfad69468c09d0f0adc4ca9b71e59244125666 100644
+index 4c2c4fd10ba6..226caf69236b 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
 @@ -1253,6 +1253,7 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
@@ -10,3 +10,11 @@ index 4c2c4fd10ba6c6f9981aa581b5630a38b4ee91f0..dbdfad69468c09d0f0adc4ca9b71e592
      }
  
      private void updateReloadState(boolean tabCrashed) {
+@@ -1354,6 +1355,7 @@ public class ToolbarManager implements UrlFocusChangeListener, ThemeColorObserve
+         mToolbar.onBottomToolbarVisibilityChanged(visible);
+         mBottomToolbarVisibilitySupplier.set(visible);
+         mBottomControlsCoordinator.setBottomControlsVisible(visible);
++        mAppMenuManager.setBottomMenu(isMenuFromBottom());
+     }
+ 
+     /**


### PR DESCRIPTION
Uplift of #6592
Resolves https://github.com/brave/brave-browser/issues/11620

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.