### PR TITLE
Only show not installed in brave://ipfs before IPFS component is inst…

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -793,6 +793,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "launched", IDS_IPFS_LAUNCHED },
         { "launch", IDS_IPFS_LAUNCH },
         { "shutdown", IDS_IPFS_SHUTDOWN },
+        { "not_installed", IDS_IPFS_NOT_INSTALLED },
       }
     }, {
 #endif

--- a/components/definitions/ipfs.d.ts
+++ b/components/definitions/ipfs.d.ts
@@ -18,6 +18,7 @@ declare namespace IPFS {
   }
 
   export interface DaemonStatus {
+    installed: bool
     launched: bool
   }
 }

--- a/components/ipfs_ui/components/addressesConfig.tsx
+++ b/components/ipfs_ui/components/addressesConfig.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 
+import { getLocale } from '../../common/locale'
+
 import { Section, Title } from '../style'
 
 interface Props {
@@ -20,16 +22,16 @@ export class AddressesConfig extends React.Component<Props, {}> {
     return (
       <Section>
         <Title>
-          <span i18n-content='addressesConfigTitle'/>
+          {getLocale('addressesConfigTitle')}
         </Title>
         <div>
-          <span i18n-content='api'/>: {this.props.addressesConfig.api}
+          {getLocale('api')}: {this.props.addressesConfig.api}
         </div>
         <div>
-          <span i18n-content='gateway'/>: {this.props.addressesConfig.gateway}
+          {getLocale('gateway')}: {this.props.addressesConfig.gateway}
         </div>
         <div>
-          <span i18n-content='swarm'/>: {this.props.addressesConfig.swarm.toString()}
+          {getLocale('swarm')}: {this.props.addressesConfig.swarm.toString()}
         </div>
       </Section>
     )

--- a/components/ipfs_ui/components/app.tsx
+++ b/components/ipfs_ui/components/app.tsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux'
 import { AddressesConfig } from './addressesConfig'
 import { ConnectedPeers } from './connectedPeers'
 import { DaemonStatus } from './daemonStatus'
+import { UninstalledView } from './uninstalledView'
 
 // Utils
 import * as ipfsActions from '../actions/ipfs_actions'
@@ -49,6 +50,14 @@ export class IPFSPage extends React.Component<Props, {}> {
   }
 
   render () {
+    if (!this.props.ipfsData.daemonStatus.installed) {
+      return (
+        <div id='ipfsPage'>
+          <UninstalledView />
+        </div>
+      )
+    }
+
     return (
       <div id='ipfsPage'>
         <DaemonStatus daemonStatus={this.props.ipfsData.daemonStatus} onLaunch={this.launchDaemon} onShutdown={this.shutdownDaemon}/>

--- a/components/ipfs_ui/components/connectedPeers.tsx
+++ b/components/ipfs_ui/components/connectedPeers.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 
+import { getLocale } from '../../common/locale'
+
 import { Section } from '../style'
 
 interface Props {
@@ -20,8 +22,7 @@ export class ConnectedPeers extends React.Component<Props, {}> {
     return (
       <Section>
         <div>
-          <span i18n-content='connectedPeersTitle'/>
-          {this.props.peerCount}
+          {getLocale('connectedPeersTitle')} {this.props.peerCount}
         </div>
       </Section>
     )

--- a/components/ipfs_ui/components/daemonStatus.tsx
+++ b/components/ipfs_ui/components/daemonStatus.tsx
@@ -24,10 +24,10 @@ export class DaemonStatus extends React.Component<Props, {}> {
     return (
       <Section>
         <Title>
-          <span i18n-content='daemonStatusTitle'/>
+          {getLocale('daemonStatusTitle')}
         </Title>
         <div>
-          <span i18n-content='launched'/>: {this.props.daemonStatus.launched.toString()}
+          {getLocale('launched')}: {this.props.daemonStatus.launched.toString()}
         </div>
         <SideBySideButtons>
           <PaddedButton

--- a/components/ipfs_ui/components/uninstalledView.tsx
+++ b/components/ipfs_ui/components/uninstalledView.tsx
@@ -1,0 +1,23 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+import { Section, Title } from '../style'
+
+export class UninstalledView extends React.Component {
+  render () {
+    return (
+      <Section>
+        <Title>
+          <span i18n-content='daemonStatusTitle'/>
+        </Title>
+        <div>
+          <span i18n-content='not_installed'/>
+        </div>
+      </Section>
+    )
+  }
+}

--- a/components/ipfs_ui/components/uninstalledView.tsx
+++ b/components/ipfs_ui/components/uninstalledView.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 
+import { getLocale } from '../../common/locale'
+
 import { Section, Title } from '../style'
 
 export class UninstalledView extends React.Component {
@@ -12,10 +14,10 @@ export class UninstalledView extends React.Component {
     return (
       <Section>
         <Title>
-          <span i18n-content='daemonStatusTitle'/>
+          {getLocale('daemonStatusTitle')}
         </Title>
         <div>
-          <span i18n-content='not_installed'/>
+          {getLocale('not_installed')}
         </div>
       </Section>
     )

--- a/components/ipfs_ui/storage.ts
+++ b/components/ipfs_ui/storage.ts
@@ -17,6 +17,7 @@ export const defaultState: IPFS.State = {
     swarm: []
   },
   daemonStatus: {
+    installed: false,
     launched: false
   }
 }

--- a/components/resources/ipfs_strings.grdp
+++ b/components/resources/ipfs_strings.grdp
@@ -10,5 +10,6 @@
      <message name="IDS_IPFS_LAUNCHED" desc="Title of the launched status">Launched</message>
      <message name="IDS_IPFS_LAUNCH" desc="Text of launch action">Launch</message>
      <message name="IDS_IPFS_SHUTDOWN" desc="Text of shutdown action">Shutdown</message>
+     <message name="IDS_IPFS_NOT_INSTALLED" desc="Text of not installed state">Not Installed</message>
   </if>
 </grit-part>


### PR DESCRIPTION
…alled

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11559

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Start Brave with a fresh profile using `npm start -- --user_data_dir_name=test_ipfs_not_installed`.
2. Go to brave://flags and search ipfs flag to enable ipfs native support, quit and start the browser again using the same command as step 1.
3. Open brave://ipfs, should see
<img width="614" alt="Screen Shot 2020-09-08 at 4 52 16 PM" src="https://user-images.githubusercontent.com/4730197/92538709-3b741900-f1f4-11ea-97f2-518b0128b10f.png">

4. Visit ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR and accept when ipfs infobar prompted
5. After daemon is installed and run, refresh brave://ipfs page, should now see daemon status and launch/shutdown buttons.
<img width="842" alt="Screen Shot 2020-09-08 at 5 31 26 PM" src="https://user-images.githubusercontent.com/4730197/92540351-2948a980-f1f9-11ea-8eea-275ef5734330.png">

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
