### PR TITLE
Fix #10607: Show warnings for TLS 1.0 and TLS 1.1 (uplift to 1.15.x)

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -42,6 +42,7 @@
 #include "content/public/common/content_features.h"
 #include "content/public/common/content_switches.h"
 #include "google_apis/gaia/gaia_switches.h"
+#include "net/base/features.h"
 #include "services/device/public/cpp/device_features.h"
 #include "services/network/public/cpp/features.h"
 #include "third_party/blink/public/common/features.h"
@@ -202,6 +203,7 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
       // Upgrade all mixed content
       blink::features::kMixedContentAutoupgrade.name,
       password_manager::features::kPasswordImport.name,
+      net::features::kLegacyTLSEnforced.name,
       // Remove URL bar mixed control and allow site specific override instead
       features::kMixedContentSiteSetting.name,
       // Warn about Mixed Content optionally blockable content

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -22,6 +22,7 @@
 #include "content/public/common/web_preferences.h"
 #include "content/public/test/browser_test.h"
 #include "gpu/config/gpu_finch_features.h"
+#include "net/base/features.h"
 #include "services/device/public/cpp/device_features.h"
 #include "services/network/public/cpp/features.h"
 #include "third_party/blink/public/common/features.h"
@@ -86,6 +87,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, EnabledFeatures) {
     &features::kWinrtGeolocationImplementation,
 #endif
     &omnibox::kOmniboxContextMenuShowFullUrls,
+    &net::features::kLegacyTLSEnforced,
   };
 
   for (const auto* feature : enabled_features)

--- a/chromium_src/chrome/browser/component_updater/tls_deprecation_config_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/tls_deprecation_config_component_installer.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/component_updater/tls_deprecation_config_component_installer.h"
+
+#define ReconfigureAfterNetworkRestart \
+  ReconfigureAfterNetworkRestart_ChromiumImpl
+#include "../../../../../chrome/browser/component_updater/tls_deprecation_config_component_installer.cc"  // NOLINT
+#undef ReconfigureAfterNetworkRestart
+
+#include "base/bind.h"
+#include "chrome/browser/browser_process.h"
+#include "content/public/browser/browser_thread.h"
+#include "services/network/public/proto/tls_deprecation_config.pb.h"
+
+namespace component_updater {
+
+namespace {
+
+std::string LoadEmptyConfig() {
+  base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                base::BlockingType::WILL_BLOCK);
+  auto config =
+      std::make_unique<chrome_browser_ssl::LegacyTLSExperimentConfig>();
+  config->set_version_id(1);
+  return config->SerializeAsString();
+}
+
+}  // namespace
+
+// static
+void TLSDeprecationConfigComponentInstallerPolicy::
+    ReconfigureAfterNetworkRestart() {
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
+      base::BindOnce(&LoadEmptyConfig),
+      base::BindOnce(&UpdateLegacyTLSConfigOnUI));
+}
+
+}  // namespace component_updater

--- a/chromium_src/chrome/browser/component_updater/tls_deprecation_config_component_installer.h
+++ b/chromium_src/chrome/browser/component_updater/tls_deprecation_config_component_installer.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_COMPONENT_UPDATER_TLS_DEPRECATION_CONFIG_COMPONENT_INSTALLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_COMPONENT_UPDATER_TLS_DEPRECATION_CONFIG_COMPONENT_INSTALLER_H_
+
+#define ReconfigureAfterNetworkRestart            \
+  ReconfigureAfterNetworkRestart_ChromiumImpl();  \
+  static void ReconfigureAfterNetworkRestart
+#include "../../../../../chrome/browser/component_updater/tls_deprecation_config_component_installer.h"
+#undef ReconfigureAfterNetworkRestart
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_COMPONENT_UPDATER_TLS_DEPRECATION_CONFIG_COMPONENT_INSTALLER_H_


### PR DESCRIPTION
Uplift of #6574
Resolves https://github.com/brave/brave-browser/issues/10607

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.