### PR TITLE
Support CNAME adblocking

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -15,8 +15,6 @@
 #include "brave/browser/brave_browser_process_impl.h"
 #include "brave/browser/net/url_context.h"
 #include "brave/common/network_constants.h"
-#include "brave/components/brave_shields/browser/ad_block_custom_filters_service.h"
-#include "brave/components/brave_shields/browser/ad_block_regional_service_manager.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
@@ -42,44 +40,16 @@ void ShouldBlockAdOnTaskRunner(std::shared_ptr<BraveRequestInfo> ctx,
           ctx->request_url, ctx->resource_type, tab_host, &did_match_exception,
           &ctx->cancel_request_explicitly, &ctx->mock_data_url)) {
     ctx->blocked_by = kAdBlocked;
-  } else if (!did_match_exception &&
-             !g_brave_browser_process->ad_block_regional_service_manager()
-                  ->ShouldStartRequest(ctx->request_url, ctx->resource_type,
-                                       tab_host, &did_match_exception,
-                                       &ctx->cancel_request_explicitly,
-                                       &ctx->mock_data_url)) {
-    ctx->blocked_by = kAdBlocked;
-  } else if (!did_match_exception &&
-             !g_brave_browser_process->ad_block_custom_filters_service()
-                  ->ShouldStartRequest(ctx->request_url, ctx->resource_type,
-                                       tab_host, &did_match_exception,
-                                       &ctx->cancel_request_explicitly,
-                                       &ctx->mock_data_url)) {
-    ctx->blocked_by = kAdBlocked;
-  } else if (canonical_name && ctx->request_url.host() != *canonical_name) {
+  } else if (!did_match_exception
+             && canonical_name && ctx->request_url.host() != *canonical_name) {
     GURL::Replacements replacements = GURL::Replacements();
     replacements.SetHost(canonical_name->c_str(),
         url::Component(0, static_cast<int>(canonical_name->length())));
     const GURL canonical_url = ctx->request_url.ReplaceComponents(replacements);
 
-    if (!did_match_exception &&
-        !g_brave_browser_process->ad_block_service()->ShouldStartRequest(
+    if (!g_brave_browser_process->ad_block_service()->ShouldStartRequest(
             canonical_url, ctx->resource_type, tab_host, &did_match_exception,
             &ctx->cancel_request_explicitly, &ctx->mock_data_url)) {
-      ctx->blocked_by = kAdBlocked;
-    } else if (!did_match_exception &&
-               !g_brave_browser_process->ad_block_regional_service_manager()
-                    ->ShouldStartRequest(canonical_url, ctx->resource_type,
-                                         tab_host, &did_match_exception,
-                                         &ctx->cancel_request_explicitly,
-                                         &ctx->mock_data_url)) {
-      ctx->blocked_by = kAdBlocked;
-    } else if (!did_match_exception &&
-               !g_brave_browser_process->ad_block_custom_filters_service()
-                    ->ShouldStartRequest(canonical_url, ctx->resource_type,
-                                         tab_host, &did_match_exception,
-                                         &ctx->cancel_request_explicitly,
-                                         &ctx->mock_data_url)) {
       ctx->blocked_by = kAdBlocked;
     }
   }

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -91,8 +91,9 @@ void BraveRequestInfo::FillCTX(const network::ResourceRequest& request,
     // cross-site top-level navigations. Fortunately for now it is not a problem
     // for shields functionality. We should reconsider this machinery, also
     // given that this is always empty for subresources.
-    ctx->tab_origin =
-        request.trusted_params->isolation_info.network_isolation_key()
+    ctx->network_isolation_key =
+        request.trusted_params->isolation_info.network_isolation_key();
+    ctx->tab_origin = ctx->network_isolation_key
             .GetTopFrameOrigin()
             .value_or(url::Origin())
             .GetURL();

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -10,6 +10,7 @@
 #include <set>
 #include <string>
 
+#include "net/base/network_isolation_key.h"
 #include "net/http/http_request_headers.h"
 #include "net/http/http_response_headers.h"
 #include "net/url_request/referrer_policy.h"
@@ -96,6 +97,8 @@ struct BraveRequestInfo {
   bool cancel_request_explicitly = false;
   std::string mock_data_url;
   bool ipfs_local = true;
+
+  net::NetworkIsolationKey network_isolation_key = net::NetworkIsolationKey();
 
   // Default to invalid type for resource_type, so delegate helpers
   // can properly detect that the info couldn't be obtained.

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -72,6 +72,44 @@ std::string AdBlockService::g_ad_block_component_id_(kAdBlockComponentId);
 std::string AdBlockService::g_ad_block_component_base64_public_key_(
     kAdBlockComponentBase64PublicKey);
 
+bool AdBlockService::ShouldStartRequest(
+    const GURL& url,
+    blink::mojom::ResourceType resource_type,
+    const std::string& tab_host,
+    bool* did_match_exception,
+    bool* cancel_request_explicitly,
+    std::string* mock_data_url) {
+
+  if (!AdBlockBaseService::ShouldStartRequest(
+          url, resource_type, tab_host, did_match_exception,
+          cancel_request_explicitly, mock_data_url)) {
+    return false;
+  }
+  if (did_match_exception && *did_match_exception) {
+    return true;
+  }
+
+  if (!regional_service_manager()->ShouldStartRequest(
+          url, resource_type, tab_host, did_match_exception,
+          cancel_request_explicitly, mock_data_url)) {
+    return false;
+  }
+  if (did_match_exception && *did_match_exception) {
+    return true;
+  }
+
+  if (!custom_filters_service()->ShouldStartRequest(
+        url, resource_type, tab_host, did_match_exception,
+        cancel_request_explicitly, mock_data_url)) {
+    return false;
+  }
+  if (did_match_exception && *did_match_exception) {
+    return true;
+  }
+
+  return true;
+}
+
 AdBlockRegionalServiceManager* AdBlockService::regional_service_manager() {
   if (!regional_service_manager_)
     regional_service_manager_ =

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -46,6 +46,13 @@ class AdBlockService : public AdBlockBaseService {
   explicit AdBlockService(BraveComponent::Delegate* delegate);
   ~AdBlockService() override;
 
+  bool ShouldStartRequest(const GURL& url,
+                          blink::mojom::ResourceType resource_type,
+                          const std::string& tab_host,
+                          bool* did_match_exception,
+                          bool* cancel_request_explicitly,
+                          std::string* mock_data_url) override;
+
   AdBlockRegionalServiceManager* regional_service_manager();
   AdBlockCustomFiltersService* custom_filters_service();
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11712

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [ ] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

#### The actual test plan

When visiting https://mathon.fr, there should be a request to a URL of a similar format[1] to `https://xxxx.mathon.fr/xxxxxxxxxxx.js` that is blocked and displayed under the Shields panel advanced view when expanding the "Ads and trackers blocked" dropdown counter. Further, there should _**not**_ be a request to `https://static.criteo.net/js/ld/ld.js` in the list (or listed anywhere in the Dev Tools network tab).

1. _here, `x`'s are used to symbolize arbitrary alphanumeric characters_

#### Some optional background reading :)

The website `https://mathon.fr` pulls a CNAME-cloaked script that triggers a few extra network requests. The subdomain and path may change arbitrarily, but during my testing, a script was requested from `https://16ao.mathon.fr/frWWWMA6548.js`. Using the `dig` commandline tool, we can find the full DNS records for `16ao.mathon.fr`:
```
> dig 16ao.mathon.fr

; <<>> DiG 9.16.6 <<>> 16ao.mathon.fr
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 20370
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;16ao.mathon.fr.			IN	A

;; ANSWER SECTION:
16ao.mathon.fr.		147	IN	CNAME	mathon.eulerian.net.
mathon.eulerian.net.	7047	IN	CNAME	et5.eulerian.net.
et5.eulerian.net.	7047	IN	A	109.232.193.177              <- Canonical name

;; Query time: 0 msec
;; SERVER: ::1#53(::1)
;; WHEN: Thu Sep 17 16:09:00 EDT 2020
;; MSG SIZE  rcvd: 122
```

The canonical name for `16ao.mathon.fr` is `et5.eulerian.net`, which is blocked by uBlock Origin's default lists. This prevents several other network requests from starting. As a result, the Shields panel actually shows fewer blocked requests (4 instead of 7 in my configuration).

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
