### PR TITLE
Add localization support to Greaselion

### DIFF
--- a/components/greaselion/browser/greaselion_download_service.h
+++ b/components/greaselion/browser/greaselion_download_service.h
@@ -50,6 +50,7 @@ class GreaselionRule {
              base::ListValue* urls_value,
              base::ListValue* scripts_value,
              const std::string& run_at_value,
+             const base::FilePath& messages_value,
              const base::FilePath& resource_dir);
   ~GreaselionRule();
 
@@ -59,6 +60,9 @@ class GreaselionRule {
   std::vector<base::FilePath> scripts() const { return scripts_; }
   std::string run_at() const {
     return run_at_;
+  }
+  base::FilePath messages() const {
+    return messages_;
   }
   bool has_unknown_preconditions() const { return has_unknown_preconditions_; }
 
@@ -72,6 +76,7 @@ class GreaselionRule {
   std::vector<std::string> url_patterns_;
   std::vector<base::FilePath> scripts_;
   std::string run_at_;
+  base::FilePath messages_;
   GreaselionPreconditions preconditions_;
   bool has_unknown_preconditions_ = false;
   base::WeakPtrFactory<GreaselionRule> weak_factory_;

--- a/test/data/greaselion-data/1/Greaselion.json
+++ b/test/data/greaselion-data/1/Greaselion.json
@@ -51,5 +51,14 @@
         "scripts": [
             "scripts/b-com.js"
         ]
+    },
+    {
+        "urls": [
+            "http://messages.example.com/*"
+        ],
+        "scripts": [
+            "scripts/messages-example-com.js"
+        ],
+        "messages": "messages"
     }
 ]

--- a/test/data/greaselion-data/1/messages/de/messages.json
+++ b/test/data/greaselion-data/1/messages/de/messages.json
@@ -1,0 +1,6 @@
+{
+  "helloWorld": {
+    "message": "Hallo, Welt!",
+    "description": "Hello world message"
+  }
+}

--- a/test/data/greaselion-data/1/messages/en_US/messages.json
+++ b/test/data/greaselion-data/1/messages/en_US/messages.json
@@ -1,0 +1,6 @@
+{
+  "helloWorld": {
+    "message": "Hello, world!",
+    "description": "Hello world message"
+  }
+}

--- a/test/data/greaselion-data/1/scripts/messages-example-com.js
+++ b/test/data/greaselion-data/1/scripts/messages-example-com.js
@@ -1,0 +1,1 @@
+document.title = chrome.i18n.getMessage('helloWorld');


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11810

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

```
 ./brave_browser_tests.exe --gtest_filter=GreaselionServiceLocaleTestEnglish.ScriptInjectionWithMessagesDefaultLocale
 ./brave_browser_tests.exe --gtest_filter=GreaselionServiceLocaleTestGerman.ScriptInjectionWithMessagesNonDefaultLocale
 ./brave_browser_tests.exe --gtest_filter=GreaselionServiceLocaleTestFrench.ScriptInjectionWithMessagesUnsupportedLocale
```

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
