### PR TITLE
Fixed Disabled ads tracking option is reverted after reloading

### DIFF
--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_browser_proxy.js
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_browser_proxy.js
@@ -10,16 +10,16 @@ cr.define('settings', function() {
   /** @interface */
   /* #export */ class DefaultBraveShieldsBrowserProxy {
     /**
-     * @return {!Promise<string>}
+     * @return {!Promise<boolean>}
      */
-    getAdControlType() {}
+    isAdControlEnabled() {}
     /**
      * @param {string} value name.
      */
     setAdControlType(value) {}
 
     /**
-     * @return {!Promise<string>}
+     * @return {!Promise<boolean>}
      */
     isFirstPartyCosmeticFilteringEnabled() {}
     /**
@@ -61,8 +61,8 @@ cr.define('settings', function() {
    */
   /* #export */ class DefaultBraveShieldsBrowserProxyImpl {
     /** @override */
-    getAdControlType() {
-      return cr.sendWithPromise('getAdControlType');
+    isAdControlEnabled() {
+      return cr.sendWithPromise('isAdControlEnabled');
     }
 
     /** @override */

--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.js
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.js
@@ -70,9 +70,13 @@ Polymer({
     this.onHTTPSEverywhereControlChange_ = this.onHTTPSEverywhereControlChange_.bind(this)
     this.onNoScriptControlChange_ = this.onNoScriptControlChange_.bind(this)
 
-    Promise.all([this.browserProxy_.getAdControlType(), this.browserProxy_.isFirstPartyCosmeticFilteringEnabled()])
-        .then(([adControlType, hide1pContent]) => {
-      this.adControlType_ = (adControlType ? 'allow' : (hide1pContent ? 'block' : 'block_third_party'))
+    Promise.all([this.browserProxy_.isAdControlEnabled(), this.browserProxy_.isFirstPartyCosmeticFilteringEnabled()])
+        .then(([adControlEnabled, hide1pContent]) => {
+      if (adControlEnabled) {
+        this.adControlType_ = hide1pContent ? 'block' : 'block_third_party'
+      } else {
+        this.adControlType_ = 'allow'
+      }
     });
     this.browserProxy_.getCookieControlType().then(value => {
       this.cookieControlType_ = value;

--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.js
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.js
@@ -72,7 +72,7 @@ Polymer({
 
     Promise.all([this.browserProxy_.getAdControlType(), this.browserProxy_.isFirstPartyCosmeticFilteringEnabled()])
         .then(([adControlType, hide1pContent]) => {
-      this.adControlType_ = (adControlType === 'allow' ? 'allow' : (hide1pContent ? 'block' : 'block_third_party'))
+      this.adControlType_ = (adControlType ? 'allow' : (hide1pContent ? 'block' : 'block_third_party'))
     });
     this.browserProxy_.getCookieControlType().then(value => {
       this.cookieControlType_ = value;

--- a/browser/ui/webui/settings/default_brave_shields_handler.cc
+++ b/browser/ui/webui/settings/default_brave_shields_handler.cc
@@ -22,8 +22,8 @@ using brave_shields::ControlTypeToString;
 void DefaultBraveShieldsHandler::RegisterMessages() {
   profile_ = Profile::FromWebUI(web_ui());
   web_ui()->RegisterMessageCallback(
-      "getAdControlType",
-      base::BindRepeating(&DefaultBraveShieldsHandler::GetAdControlType,
+      "isAdControlEnabled",
+      base::BindRepeating(&DefaultBraveShieldsHandler::IsAdControlEnabled,
                           base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
       "setAdControlType",
@@ -68,7 +68,8 @@ void DefaultBraveShieldsHandler::RegisterMessages() {
                           base::Unretained(this)));
 }
 
-void DefaultBraveShieldsHandler::GetAdControlType(const base::ListValue* args) {
+void DefaultBraveShieldsHandler::IsAdControlEnabled(
+    const base::ListValue* args) {
   CHECK_EQ(args->GetSize(), 1U);
   CHECK(profile_);
 
@@ -78,7 +79,7 @@ void DefaultBraveShieldsHandler::GetAdControlType(const base::ListValue* args) {
   AllowJavascript();
   ResolveJavascriptCallback(
       args->GetList()[0].Clone(),
-      base::Value(setting == ControlType::ALLOW));
+      base::Value(setting == ControlType::BLOCK));
 }
 
 void DefaultBraveShieldsHandler::SetAdControlType(const base::ListValue* args) {

--- a/browser/ui/webui/settings/default_brave_shields_handler.h
+++ b/browser/ui/webui/settings/default_brave_shields_handler.h
@@ -22,7 +22,7 @@ class DefaultBraveShieldsHandler : public settings::SettingsPageUIHandler {
   void OnJavascriptDisallowed() override {}
 
   void SetAdControlType(const base::ListValue* args);
-  void GetAdControlType(const base::ListValue* args);
+  void IsAdControlEnabled(const base::ListValue* args);
   void SetCosmeticFilteringControlType(const base::ListValue* args);
   void IsFirstPartyCosmeticFilteringEnabled(const base::ListValue* args);
   void SetCookieControlType(const base::ListValue* args);


### PR DESCRIPTION
C++ gives ad control type as bool but webui compared it with string.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11585

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
