### PR TITLE
Get proper CanvasRenderingContextHost to determine WebGL blocking

### DIFF
--- a/chromium_src/chrome/renderer/worker_content_settings_client.cc
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.cc
@@ -38,4 +38,12 @@ BraveFarblingLevel WorkerContentSettingsClient::GetBraveFarblingLevel() {
   }
 }
 
+bool WorkerContentSettingsClient::AllowFingerprinting(
+    bool enabled_per_settings) {
+  if (!enabled_per_settings)
+    return false;
+
+  return GetBraveFarblingLevel() != BraveFarblingLevel::MAXIMUM;
+}
+
 #include "../../../../chrome/renderer/worker_content_settings_client.cc"

--- a/chromium_src/chrome/renderer/worker_content_settings_client.h
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.h
@@ -6,8 +6,9 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_RENDERER_WORKER_CONTENT_SETTINGS_CLIENT_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_RENDERER_WORKER_CONTENT_SETTINGS_CLIENT_H_
 
-#define BRAVE_WORKER_CONTENT_SETTINGS_CLIENT_H \
-  BraveFarblingLevel GetBraveFarblingLevel() override;
+#define BRAVE_WORKER_CONTENT_SETTINGS_CLIENT_H         \
+  BraveFarblingLevel GetBraveFarblingLevel() override; \
+  bool AllowFingerprinting(bool enabled_per_settings) override;
 
 #include "../../../../chrome/renderer/worker_content_settings_client.h"
 

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -31,59 +31,64 @@ bool AllowFingerprintingFromExecutionContext(ExecutionContext* context) {
 
 }  // namespace
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_RETURN           \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_RETURN         \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return;
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_NULLPTR          \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_NULLPTR        \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return nullptr;
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_NULLOPT          \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_NULLOPT        \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return base::nullopt;
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_ZERO             \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_ZERO           \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return 0;
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_MINUS_ONE        \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_MINUS_ONE      \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return -1;
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_SCRIPT_VALUE     \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_SCRIPT_VALUE   \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return ScriptValue::CreateNull(script_state->GetIsolate());
 
-#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_STRING           \
-  if (canvas() && !AllowFingerprintingFromExecutionContext( \
-                      canvas()->GetTopExecutionContext()))  \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_STRING         \
+  if (Host() && !AllowFingerprintingFromExecutionContext( \
+                    Host()->GetTopExecutionContext()))    \
     return String();
 
-#define BRAVE_WEBGL_GET_PARAMETER_UNMASKED_RENDERER                \
-  if (ExtensionEnabled(kWebGLDebugRendererInfoName) && canvas() && \
-      !AllowFingerprintingFromExecutionContext(                    \
-          canvas()->GetTopExecutionContext()))                     \
-    return WebGLAny(                                               \
-        script_state,                                              \
-        String(brave::BraveSessionCache::From(                     \
-                   *(canvas()->GetTopExecutionContext()))          \
+#define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_GETSHADERINFOLOG \
+  range[0] = 0;                                             \
+  range[1] = 0;                                             \
+  precision = 0;
+
+#define BRAVE_WEBGL_GET_PARAMETER_UNMASKED_RENDERER              \
+  if (ExtensionEnabled(kWebGLDebugRendererInfoName) && Host() && \
+      !AllowFingerprintingFromExecutionContext(                  \
+          Host()->GetTopExecutionContext()))                     \
+    return WebGLAny(                                             \
+        script_state,                                            \
+        String(brave::BraveSessionCache::From(                   \
+                   *(Host()->GetTopExecutionContext()))          \
                    .GenerateRandomString("UNMASKED_RENDERER_WEBGL", 8)));
 
-#define BRAVE_WEBGL_GET_PARAMETER_UNMASKED_VENDOR                  \
-  if (ExtensionEnabled(kWebGLDebugRendererInfoName) && canvas() && \
-      !AllowFingerprintingFromExecutionContext(                    \
-          canvas()->GetTopExecutionContext()))                     \
-    return WebGLAny(                                               \
-        script_state,                                              \
-        String(brave::BraveSessionCache::From(                     \
-                   *(canvas()->GetTopExecutionContext()))          \
+#define BRAVE_WEBGL_GET_PARAMETER_UNMASKED_VENDOR                \
+  if (ExtensionEnabled(kWebGLDebugRendererInfoName) && Host() && \
+      !AllowFingerprintingFromExecutionContext(                  \
+          Host()->GetTopExecutionContext()))                     \
+    return WebGLAny(                                             \
+        script_state,                                            \
+        String(brave::BraveSessionCache::From(                   \
+                   *(Host()->GetTopExecutionContext()))          \
                    .GenerateRandomString("UNMASKED_VENDOR_WEBGL", 8)));
 
 #include "../../../../../../../third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc"

--- a/patches/third_party-blink-renderer-modules-webgl-webgl_rendering_context_base.cc.patch
+++ b/patches/third_party-blink-renderer-modules-webgl-webgl_rendering_context_base.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
-index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae97660709 100644
+index ed7ae523c40203425f6b08cd6308e1debac24d18..461da464c787af81c822a6bbcffcdfadfe7731b3 100644
 --- a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
 +++ b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
 @@ -2919,6 +2919,7 @@ WebGLActiveInfo* WebGLRenderingContextBase::getActiveAttrib(
@@ -42,15 +42,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
  
    switch (pname) {
      case GL_BUFFER_USAGE: {
-@@ -3054,6 +3059,7 @@ WebGLContextAttributes* WebGLRenderingContextBase::getContextAttributes()
-     const {
-   if (isContextLost())
-     return nullptr;
-+  BRAVE_WEBGL_RENDERING_CONTEXT_BASE_NULLPTR
- 
-   WebGLContextAttributes* result =
-       ToWebGLContextAttributes(CreationAttributes());
-@@ -3165,6 +3171,7 @@ ScriptValue WebGLRenderingContextBase::getFramebufferAttachmentParameter(
+@@ -3165,6 +3170,7 @@ ScriptValue WebGLRenderingContextBase::getFramebufferAttachmentParameter(
                                           target, attachment))
      return ScriptValue::CreateNull(script_state->GetIsolate());
  
@@ -58,7 +50,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (!framebuffer_binding_ || !framebuffer_binding_->Object()) {
      SynthesizeGLError(GL_INVALID_OPERATION, "getFramebufferAttachmentParameter",
                        "no framebuffer bound");
-@@ -3457,6 +3464,7 @@ ScriptValue WebGLRenderingContextBase::getParameter(ScriptState* script_state,
+@@ -3457,6 +3463,7 @@ ScriptValue WebGLRenderingContextBase::getParameter(ScriptState* script_state,
            "invalid parameter name, OES_standard_derivatives not enabled");
        return ScriptValue::CreateNull(script_state->GetIsolate());
      case WebGLDebugRendererInfo::kUnmaskedRendererWebgl:
@@ -66,7 +58,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
        if (ExtensionEnabled(kWebGLDebugRendererInfoName))
          return WebGLAny(script_state,
                          String(ContextGL()->GetString(GL_RENDERER)));
-@@ -3465,6 +3473,7 @@ ScriptValue WebGLRenderingContextBase::getParameter(ScriptState* script_state,
+@@ -3465,6 +3472,7 @@ ScriptValue WebGLRenderingContextBase::getParameter(ScriptState* script_state,
            "invalid parameter name, WEBGL_debug_renderer_info not enabled");
        return ScriptValue::CreateNull(script_state->GetIsolate());
      case WebGLDebugRendererInfo::kUnmaskedVendorWebgl:
@@ -74,7 +66,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
        if (ExtensionEnabled(kWebGLDebugRendererInfoName))
          return WebGLAny(script_state,
                          String(ContextGL()->GetString(GL_VENDOR)));
-@@ -3546,6 +3555,7 @@ ScriptValue WebGLRenderingContextBase::getProgramParameter(
+@@ -3546,6 +3554,7 @@ ScriptValue WebGLRenderingContextBase::getProgramParameter(
      ScriptState* script_state,
      WebGLProgram* program,
      GLenum pname) {
@@ -82,7 +74,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (!ValidateWebGLProgramOrShader("getProgramParamter", program)) {
      return ScriptValue::CreateNull(script_state->GetIsolate());
    }
-@@ -3607,6 +3617,7 @@ ScriptValue WebGLRenderingContextBase::getProgramParameter(
+@@ -3607,6 +3616,7 @@ ScriptValue WebGLRenderingContextBase::getProgramParameter(
  String WebGLRenderingContextBase::getProgramInfoLog(WebGLProgram* program) {
    if (!ValidateWebGLProgramOrShader("getProgramInfoLog", program))
      return String();
@@ -90,7 +82,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    GLStringQuery query(ContextGL());
    return query.Run<GLStringQuery::ProgramInfoLog>(ObjectNonZero(program));
  }
-@@ -3617,6 +3628,7 @@ ScriptValue WebGLRenderingContextBase::getRenderbufferParameter(
+@@ -3617,6 +3627,7 @@ ScriptValue WebGLRenderingContextBase::getRenderbufferParameter(
      GLenum pname) {
    if (isContextLost())
      return ScriptValue::CreateNull(script_state->GetIsolate());
@@ -98,7 +90,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (target != GL_RENDERBUFFER) {
      SynthesizeGLError(GL_INVALID_ENUM, "getRenderbufferParameter",
                        "invalid target");
-@@ -3662,6 +3674,7 @@ ScriptValue WebGLRenderingContextBase::getShaderParameter(
+@@ -3662,6 +3673,7 @@ ScriptValue WebGLRenderingContextBase::getShaderParameter(
      ScriptState* script_state,
      WebGLShader* shader,
      GLenum pname) {
@@ -106,7 +98,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (!ValidateWebGLProgramOrShader("getShaderParameter", shader)) {
      return ScriptValue::CreateNull(script_state->GetIsolate());
    }
-@@ -3693,6 +3706,7 @@ ScriptValue WebGLRenderingContextBase::getShaderParameter(
+@@ -3693,6 +3705,7 @@ ScriptValue WebGLRenderingContextBase::getShaderParameter(
  String WebGLRenderingContextBase::getShaderInfoLog(WebGLShader* shader) {
    if (!ValidateWebGLProgramOrShader("getShaderInfoLog", shader))
      return String();
@@ -114,15 +106,15 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    GLStringQuery query(ContextGL());
    return query.Run<GLStringQuery::ShaderInfoLog>(ObjectNonZero(shader));
  }
-@@ -3705,6 +3719,7 @@ WebGLShaderPrecisionFormat* WebGLRenderingContextBase::getShaderPrecisionFormat(
-   if (!ValidateShaderType("getShaderPrecisionFormat", shader_type)) {
-     return nullptr;
-   }
-+  BRAVE_WEBGL_RENDERING_CONTEXT_BASE_NULLPTR
-   switch (precision_type) {
-     case GL_LOW_FLOAT:
-     case GL_MEDIUM_FLOAT:
-@@ -3730,6 +3745,7 @@ WebGLShaderPrecisionFormat* WebGLRenderingContextBase::getShaderPrecisionFormat(
+@@ -3723,6 +3736,7 @@ WebGLShaderPrecisionFormat* WebGLRenderingContextBase::getShaderPrecisionFormat(
+   GLint precision = 0;
+   ContextGL()->GetShaderPrecisionFormat(shader_type, precision_type, range,
+                                         &precision);
++  BRAVE_WEBGL_RENDERING_CONTEXT_BASE_GETSHADERINFOLOG
+   return MakeGarbageCollected<WebGLShaderPrecisionFormat>(range[0], range[1],
+                                                           precision);
+ }
+@@ -3730,6 +3744,7 @@ WebGLShaderPrecisionFormat* WebGLRenderingContextBase::getShaderPrecisionFormat(
  String WebGLRenderingContextBase::getShaderSource(WebGLShader* shader) {
    if (!ValidateWebGLProgramOrShader("getShaderSource", shader))
      return String();
@@ -130,7 +122,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    return EnsureNotNull(shader->Source());
  }
  
-@@ -3737,6 +3753,7 @@ base::Optional<Vector<String>>
+@@ -3737,6 +3752,7 @@ base::Optional<Vector<String>>
  WebGLRenderingContextBase::getSupportedExtensions() {
    if (isContextLost())
      return base::nullopt;
@@ -138,7 +130,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
  
    Vector<String> result;
  
-@@ -3759,6 +3776,7 @@ ScriptValue WebGLRenderingContextBase::getTexParameter(
+@@ -3759,6 +3775,7 @@ ScriptValue WebGLRenderingContextBase::getTexParameter(
      GLenum pname) {
    if (isContextLost())
      return ScriptValue::CreateNull(script_state->GetIsolate());
@@ -146,7 +138,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (!ValidateTextureBinding("getTexParameter", target))
      return ScriptValue::CreateNull(script_state->GetIsolate());
    switch (pname) {
-@@ -3793,6 +3811,7 @@ ScriptValue WebGLRenderingContextBase::getUniform(
+@@ -3793,6 +3810,7 @@ ScriptValue WebGLRenderingContextBase::getUniform(
      const WebGLUniformLocation* uniform_location) {
    if (!ValidateWebGLProgramOrShader("getUniform", program))
      return ScriptValue::CreateNull(script_state->GetIsolate());
@@ -154,7 +146,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    DCHECK(uniform_location);
    if (uniform_location->Program() != program) {
      SynthesizeGLError(GL_INVALID_OPERATION, "getUniform",
-@@ -4073,6 +4092,7 @@ WebGLUniformLocation* WebGLRenderingContextBase::getUniformLocation(
+@@ -4073,6 +4091,7 @@ WebGLUniformLocation* WebGLRenderingContextBase::getUniformLocation(
      const String& name) {
    if (!ValidateWebGLProgramOrShader("getUniformLocation", program))
      return nullptr;
@@ -162,7 +154,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (!ValidateLocationLength("getUniformLocation", name))
      return nullptr;
    if (!ValidateString("getUniformLocation", name))
-@@ -4097,6 +4117,7 @@ ScriptValue WebGLRenderingContextBase::getVertexAttrib(
+@@ -4097,6 +4116,7 @@ ScriptValue WebGLRenderingContextBase::getVertexAttrib(
      GLenum pname) {
    if (isContextLost())
      return ScriptValue::CreateNull(script_state->GetIsolate());
@@ -170,7 +162,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    if (index >= max_vertex_attribs_) {
      SynthesizeGLError(GL_INVALID_VALUE, "getVertexAttrib",
                        "index out of range");
-@@ -4174,6 +4195,7 @@ int64_t WebGLRenderingContextBase::getVertexAttribOffset(GLuint index,
+@@ -4174,6 +4194,7 @@ int64_t WebGLRenderingContextBase::getVertexAttribOffset(GLuint index,
                                                           GLenum pname) {
    if (isContextLost())
      return 0;
@@ -178,7 +170,7 @@ index ed7ae523c40203425f6b08cd6308e1debac24d18..944961b5043cdd4aa77618f5308d5cae
    GLvoid* result = nullptr;
    // NOTE: If pname is ever a value that returns more than 1 element
    // this will corrupt memory.
-@@ -4532,6 +4554,7 @@ void WebGLRenderingContextBase::ReadPixelsHelper(GLint x,
+@@ -4532,6 +4553,7 @@ void WebGLRenderingContextBase::ReadPixelsHelper(GLint x,
                                                   int64_t offset) {
    if (isContextLost())
      return;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11839

Several root problems:

1. Farbling code was using `canvas()` to get access to execution context to determine fingerprinting status, which returns `null` in workers. Fixed by using `Host()` instead in all WebGL conditionals.
2. `WorkerContentSettingsClient` only provided `GetBraveFarblingLevel`, not `AllowFingerprinting`, so legacy code that called the latter was not respecting fingerprinting status anyway. Fixed by implementing `WorkerContentSettingsClient::AllowFingerprinting` method.
3. We had previously been patching `getContextAttributes` to return null in strict mode, which is unnecessary and in fact was masking other issues in manual fingerprinting tests. Fixed by removing that patch.
4. We had previously been patching `getShaderInfoLog` to return null in strict mode, which was masking other issues. Fixed by having it return an object of the expected type, but with all values inside set to 0.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
