### PR TITLE
Fixed Disabled ads tracking option is reverted after reloading (uplift to 1.15.x)

### DIFF
--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_browser_proxy.js
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_browser_proxy.js
@@ -10,16 +10,16 @@ cr.define('settings', function() {
   /** @interface */
   /* #export */ class DefaultBraveShieldsBrowserProxy {
     /**
-     * @return {!Promise<string>}
+     * @return {!Promise<boolean>}
      */
-    getAdControlType() {}
+    isAdControlEnabled() {}
     /**
      * @param {string} value name.
      */
     setAdControlType(value) {}
 
     /**
-     * @return {!Promise<string>}
+     * @return {!Promise<boolean>}
      */
     isFirstPartyCosmeticFilteringEnabled() {}
     /**
@@ -61,8 +61,8 @@ cr.define('settings', function() {
    */
   /* #export */ class DefaultBraveShieldsBrowserProxyImpl {
     /** @override */
-    getAdControlType() {
-      return cr.sendWithPromise('getAdControlType');
+    isAdControlEnabled() {
+      return cr.sendWithPromise('isAdControlEnabled');
     }
 
     /** @override */

--- a/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.js
+++ b/browser/resources/settings/default_brave_shields_page/default_brave_shields_page.js
@@ -70,9 +70,13 @@ Polymer({
     this.onHTTPSEverywhereControlChange_ = this.onHTTPSEverywhereControlChange_.bind(this)
     this.onNoScriptControlChange_ = this.onNoScriptControlChange_.bind(this)
 
-    Promise.all([this.browserProxy_.getAdControlType(), this.browserProxy_.isFirstPartyCosmeticFilteringEnabled()])
-        .then(([adControlType, hide1pContent]) => {
-      this.adControlType_ = (adControlType === 'allow' ? 'allow' : (hide1pContent ? 'block' : 'block_third_party'))
+    Promise.all([this.browserProxy_.isAdControlEnabled(), this.browserProxy_.isFirstPartyCosmeticFilteringEnabled()])
+        .then(([adControlEnabled, hide1pContent]) => {
+      if (adControlEnabled) {
+        this.adControlType_ = hide1pContent ? 'block' : 'block_third_party'
+      } else {
+        this.adControlType_ = 'allow'
+      }
     });
     this.browserProxy_.getCookieControlType().then(value => {
       this.cookieControlType_ = value;

--- a/browser/ui/webui/settings/default_brave_shields_handler.cc
+++ b/browser/ui/webui/settings/default_brave_shields_handler.cc
@@ -22,8 +22,8 @@ using brave_shields::ControlTypeToString;
 void DefaultBraveShieldsHandler::RegisterMessages() {
   profile_ = Profile::FromWebUI(web_ui());
   web_ui()->RegisterMessageCallback(
-      "getAdControlType",
-      base::BindRepeating(&DefaultBraveShieldsHandler::GetAdControlType,
+      "isAdControlEnabled",
+      base::BindRepeating(&DefaultBraveShieldsHandler::IsAdControlEnabled,
                           base::Unretained(this)));
   web_ui()->RegisterMessageCallback(
       "setAdControlType",
@@ -68,7 +68,8 @@ void DefaultBraveShieldsHandler::RegisterMessages() {
                           base::Unretained(this)));
 }
 
-void DefaultBraveShieldsHandler::GetAdControlType(const base::ListValue* args) {
+void DefaultBraveShieldsHandler::IsAdControlEnabled(
+    const base::ListValue* args) {
   CHECK_EQ(args->GetSize(), 1U);
   CHECK(profile_);
 
@@ -78,7 +79,7 @@ void DefaultBraveShieldsHandler::GetAdControlType(const base::ListValue* args) {
   AllowJavascript();
   ResolveJavascriptCallback(
       args->GetList()[0].Clone(),
-      base::Value(setting == ControlType::ALLOW));
+      base::Value(setting == ControlType::BLOCK));
 }
 
 void DefaultBraveShieldsHandler::SetAdControlType(const base::ListValue* args) {

--- a/browser/ui/webui/settings/default_brave_shields_handler.h
+++ b/browser/ui/webui/settings/default_brave_shields_handler.h
@@ -22,7 +22,7 @@ class DefaultBraveShieldsHandler : public settings::SettingsPageUIHandler {
   void OnJavascriptDisallowed() override {}
 
   void SetAdControlType(const base::ListValue* args);
-  void GetAdControlType(const base::ListValue* args);
+  void IsAdControlEnabled(const base::ListValue* args);
   void SetCosmeticFilteringControlType(const base::ListValue* args);
   void IsFirstPartyCosmeticFilteringEnabled(const base::ListValue* args);
   void SetCookieControlType(const base::ListValue* args);


### PR DESCRIPTION
Uplift of #6693 
Resolves https://github.com/brave/brave-browser/issues/11585

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.