### PR TITLE
Remove uses of html imports from WebUI

### DIFF
--- a/components/brave_adblock_ui/brave_adblock.html
+++ b/components/brave_adblock_ui/brave_adblock.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width">
 <title>Ad Block</title>
 <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
-<link rel="import" href="chrome://resources/html/cr.html">
 <script src="chrome://resources/js/cr.js"></script>
 <script src="chrome://resources/js/load_time_data.js"></script>
 <script src="chrome://resources/js/util.js"></script>

--- a/components/brave_rewards/resources/android_page/brave_rewards_page.html
+++ b/components/brave_rewards/resources/android_page/brave_rewards_page.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, user-scalable=0">
 <title>Brave Rewards™</title>
 <link rel="shortcut icon" href="chrome://rewards/favicon.ico" type="image/x-icon">
-<link rel="import" href="chrome://resources/html/cr.html">
 <script src="chrome://resources/js/cr.js"></script>
 <script src="chrome://resources/js/load_time_data.js"></script>
 <script src="chrome://resources/js/util.js"></script>

--- a/components/brave_rewards/resources/internals/brave_rewards_internals.html
+++ b/components/brave_rewards/resources/internals/brave_rewards_internals.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width">
   <title>Rewards Internals</title>
   <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
-  <link rel="import" href="chrome://resources/html/cr.html">
   <script src="chrome://resources/js/cr.js"></script>
   <script src="chrome://resources/js/load_time_data.js"></script>
   <script src="chrome://resources/js/util.js"></script>

--- a/components/brave_rewards/resources/page/brave_rewards_page.html
+++ b/components/brave_rewards/resources/page/brave_rewards_page.html
@@ -5,14 +5,13 @@
 <meta name="viewport" content="width=device-width">
 <title>Rewards</title>
 <link rel="shortcut icon" href="chrome://rewards/favicon.ico" type="image/x-icon">
-<link rel="import" href="chrome://resources/html/cr.html">
 <link rel="stylesheet" href="chrome://resources/css/md_colors.css">
-<link rel="import" href="chrome://brave-resources/br_elements/br_toolbar/br_toolbar.html">
 <script src="chrome://resources/js/cr.js"></script>
 <script src="chrome://resources/js/load_time_data.js"></script>
 <script src="chrome://resources/js/util.js"></script>
 <script src="chrome://resources/js/i18n_template_no_process.js"></script>
 <script src="/brave_rewards_page.bundle.js"></script>
+<script type="module" src="chrome://brave-resources/br_elements/br_toolbar/br_toolbar.m.js"></script>
 <script src="/strings.js"></script>
 <style>
   #root {

--- a/components/brave_rewards/resources/tip/brave_rewards_tip.html
+++ b/components/brave_rewards/resources/tip/brave_rewards_tip.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>Rewards Tip</title>
-  <link rel="import" href="chrome://resources/html/cr.html">
   <script src="chrome://resources/js/cr.js"></script>
   <script src="chrome://resources/js/load_time_data.js"></script>
   <script src="chrome://resources/js/util.js"></script>

--- a/components/brave_wallet_ui/brave_wallet.html
+++ b/components/brave_wallet_ui/brave_wallet.html
@@ -4,15 +4,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>Crypto Wallets</title>
-  <link rel="import" href="chrome://resources/html/cr.html">
+
   <link rel="stylesheet" href="chrome://resources/css/md_colors.css">
-  <link rel="import" href="chrome://brave-resources/br_elements/br_toolbar/br_toolbar.html">
   <script src="chrome://resources/js/cr.js"></script>
   <script src="chrome://resources/js/load_time_data.js"></script>
   <script src="chrome://resources/js/util.js"></script>
   <script src="chrome://resources/js/i18n_template_no_process.js"></script>
   <script src="/strings.js"></script>
   <script src="/brave_wallet.bundle.js"></script>
+  <script type="module" src="chrome://brave-resources/br_elements/br_toolbar/br_toolbar.m.js"></script>
   <style>
     #root {
       display: flex;

--- a/components/ipfs_ui/ipfs.html
+++ b/components/ipfs_ui/ipfs.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width">
 <title>IPFS</title>
 <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
-<link rel="import" href="chrome://resources/html/cr.html">
 <script src="chrome://resources/js/cr.js"></script>
 <script src="chrome://resources/js/load_time_data.js"></script>
 <script src="chrome://resources/js/util.js"></script>

--- a/components/webcompat_reporter/ui/webcompat_reporter.html
+++ b/components/webcompat_reporter/ui/webcompat_reporter.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width">
 <title>Webcompat Reporter</title>
 <link rel="stylesheet" href="chrome://resources/css/text_defaults.css">
-<link rel="import" href="chrome://resources/html/cr.html">
 <script src="chrome://resources/js/cr.js"></script>
 <script src="chrome://resources/js/load_time_data.js"></script>
 <script src="/webcompat_reporter.bundle.js"></script>


### PR DESCRIPTION
Chromium 86 no longer supports html imports, even for WebUI. We were only using it to:
1. Import a polymer component, br-toolbar. This has already been converted to an es module, so we simply include that.
2. Import cr.html which was never neccessary because we also include cr.js already. cr.html only additionally adds the import for PromiseResolver, which no brave code uses.
  TODO: remove calls to cr.js and just `import * as cr from cr.m.js` directly wherever cr.* is used.

Fix https://github.com/brave/brave-browser/issues/11937

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Ensure https://github.com/brave/brave-browser/issues/11937 is resolved. Additionally ensure the following WebUI pages still work correctly:
- Rewards Tip
- Rewards Internal
- Ad Block
- IPFS
- Webcompat Reporter

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
