### PR TITLE
Ensure learn more menu item is first, hide is last, [NTP widgets]

### DIFF
--- a/components/brave_new_tab_ui/components/default/widget/widgetMenu.tsx
+++ b/components/brave_new_tab_ui/components/default/widget/widgetMenu.tsx
@@ -110,12 +110,6 @@ export default class WidgetMenu extends React.PureComponent<Props, State> {
           menuPosition={menuPosition}
           widgetMenuPersist={widgetMenuPersist}
         >
-          <StyledWidgetButton
-            onClick={this.unmountWidget}
-          >
-            <StyledWidgetIcon><HideIcon/></StyledWidgetIcon>
-            <StyledSpan>{hideString}</StyledSpan>
-          </StyledWidgetButton>
           {
             onLearnMore
             ? <StyledWidgetLink
@@ -150,6 +144,12 @@ export default class WidgetMenu extends React.PureComponent<Props, State> {
               </StyledWidgetButton>
             : null
           }
+          <StyledWidgetButton
+            onClick={this.unmountWidget}
+          >
+            <StyledWidgetIcon><HideIcon/></StyledWidgetIcon>
+            <StyledSpan>{hideString}</StyledSpan>
+          </StyledWidgetButton>
         </StyledWidgetMenu>}
       </StyledWidgetMenuContainer>
     )


### PR DESCRIPTION
Fixes brave/brave-browser#9391

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Defined in issue

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
