### PR TITLE
Fix 11716: Fingerprint webauthn should work on macOS (uplift to 1.16.x)

### DIFF
--- a/app/app-entitlements-brave.plist
+++ b/app/app-entitlements-brave.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>com.apple.application-identifier</key>
+        <string>${CHROMIUM_TEAM_ID}.${CHROMIUM_BUNDLE_ID}</string>
+        <key>keychain-access-groups</key>
+        <array>
+                <string>${CHROMIUM_TEAM_ID}.${CHROMIUM_BUNDLE_ID}.webauthn</string>
+        </array>
+</dict>
+</plist>

--- a/patches/chrome-BUILD.gn.patch
+++ b/patches/chrome-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10da67af1d2 100644
+index 5670687f18f166da366afba61f7bbc3ecdf48acb..dbe4292308a80e59ccb205d8c02f401668f79311 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -146,6 +146,10 @@ if (!is_android && !is_mac) {
@@ -52,7 +52,7 @@ index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10d
      }
    }
  
-@@ -595,6 +602,7 @@ if (is_win) {
+@@ -595,9 +602,11 @@ if (is_win) {
        "--scm=0",
      ]
    }
@@ -60,7 +60,11 @@ index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10d
  
    compile_entitlements("entitlements") {
      entitlements_templates = [ "app/app-entitlements.plist" ]
-@@ -618,7 +626,7 @@ if (is_win) {
++    if (is_official_build) { entitlements_templates += [ "//brave/app/app-entitlements-brave.plist" ] }
+     if (is_chrome_branded) {
+       # These entitlements are bound to the official Google Chrome signing
+       # certificate and will not necessarily work in any other build.
+@@ -618,7 +627,7 @@ if (is_win) {
  
        output_name = chrome_helper_name + invoker.helper_name_suffix
  
@@ -69,7 +73,7 @@ index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10d
        extra_substitutions = [
          "CHROMIUM_BUNDLE_ID=$chrome_mac_bundle_id",
          "CHROMIUM_SHORT_NAME=$chrome_product_short_name",
-@@ -1007,6 +1015,10 @@ if (is_win) {
+@@ -1007,6 +1016,10 @@ if (is_win) {
      if (is_chrome_branded) {
        deps += [ ":default_apps" ]
      }
@@ -80,7 +84,7 @@ index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10d
  
      ldflags = [ "-Wl,-install_name,@executable_path/../Frameworks/$chrome_framework_name.framework/Versions/$chrome_version_full/$chrome_framework_name" ]
  
-@@ -1164,6 +1176,7 @@ if (is_win) {
+@@ -1164,6 +1177,7 @@ if (is_win) {
  
  group("browser_dependencies") {
    public_deps = [
@@ -88,7 +92,7 @@ index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10d
      "//chrome/browser",
      "//chrome/common",
      "//components/gwp_asan/buildflags",
-@@ -1239,12 +1252,13 @@ group("child_dependencies") {
+@@ -1239,12 +1253,13 @@ group("child_dependencies") {
        # this is OK because all of content is linked into one library.
        "//content/browser",
      ]
@@ -103,7 +107,7 @@ index 5670687f18f166da366afba61f7bbc3ecdf48acb..373e32e1b3b8c8153920fa807719e10d
      output = "$target_gen_dir/chrome_exe_version.rc"
    }
  
-@@ -1298,6 +1312,7 @@ group("resources") {
+@@ -1298,6 +1313,7 @@ group("resources") {
      "//chrome/browser:resources",
      "//chrome/common:resources",
      "//chrome/renderer:resources",


### PR DESCRIPTION
Uplift of #6751
Resolves https://github.com/brave/brave-browser/issues/11716

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.