### PR TITLE
[Android] Removed image in touch to fill dialog (uplift to 1.15.x)

### DIFF
--- a/browser/touch_to_fill/android/internal/java/res/layout/touch_to_fill_header_item.xml
+++ b/browser/touch_to_fill/android/internal/java/res/layout/touch_to_fill_header_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 The Brave Authors. All rights reserved.
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file. -->
+
+<!-- Please update R.dimens.touch_to_fill_sheet_height_single_credential
+     when modifying the margins image or text sizes. -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:layout_marginBottom="16dp"
+    android:orientation="vertical">
+
+    <!-- <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:importantForAccessibility="no"
+        app:srcCompat="@drawable/touch_to_fill_header_image" /> -->
+
+    <org.chromium.ui.widget.TextViewWithLeading
+        android:id="@+id/touch_to_fill_sheet_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:textAppearance="@style/TextAppearance.Headline.Primary" />
+
+    <org.chromium.ui.widget.TextViewWithLeading
+        android:id="@+id/touch_to_fill_sheet_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:textAppearance="@style/TextAppearance.TextMedium.Secondary" />
+</LinearLayout>

--- a/browser/touch_to_fill/android/internal/java/res/values/dimens.xml
+++ b/browser/touch_to_fill/android/internal/java/res/values/dimens.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 The Brave Authors. All rights reserved.
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file. -->
+
+<resources>
+    <dimen name="touch_to_fill_favicon_size">24dp</dimen>
+    <dimen name="touch_to_fill_sheet_margin">16dp</dimen>
+
+    <!-- Below are the different Half-state peeking heights. The height is the
+         sum of all components. It varies depending on the suggestion count. The
+         base height is 298dp:
+         Bottom sheet shadows and padding (18dp)
+         + Handlebar (16dp)
+         + Title size and margin (48+16dp)
+         + First suggestion (72dp) -->
+    <dimen name="touch_to_fill_sheet_height_single_credential">170dp</dimen>
+
+    <!-- Top padding between RecyclerView elements (8 dp)
+         + Extra suggestion height (72 dp). -->
+    <dimen name="touch_to_fill_sheet_height_second_credential">80dp</dimen>
+
+    <!-- Top padding between RecyclerView elements (8 dp)
+         + Top margin (2 dp)
+         + button height (48 dp)
+         + Bottom margin (2 dp) -->
+    <dimen name="touch_to_fill_sheet_height_button">60dp</dimen>
+
+    <!-- Depending on the experiments that are active we might show a call to
+         action button or branding message to the users, at which point we need
+         different bottom paddings. They are exposed here, so that they can be
+         added dynamically, depending on the state of the experiments. -->
+    <dimen name="touch_to_fill_sheet_bottom_padding_credentials">16dp</dimen>
+    <dimen name="touch_to_fill_sheet_bottom_padding_button">8dp</dimen>
+</resources>

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -340,13 +340,16 @@ const util = {
       const androidResTemplateDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_template')
       const androidContentPublicResSource = path.join(config.braveCoreDir, 'content', 'public', 'android', 'java', 'res')
       const androidContentPublicResDest = path.join(config.srcDir, 'content', 'public', 'android', 'java', 'res')
+      const androidTouchtoFillResSource = path.join(config.braveCoreDir, 'browser', 'touch_to_fill', 'android', 'internal', 'java', 'res')
+      const androidTouchtoFillResDest = path.join(config.srcDir, 'chrome', 'browser', 'touch_to_fill', 'android', 'internal', 'java', 'res')
 
       // Mapping for copying Brave's Android resource into chromium folder.
       const copyAndroidResourceMapping = {
         [androidIconSource]: [androidIconDest],
         [androidResSource]: [androidResDest],
         [androidResTemplateSource]: [androidResTemplateDest],
-        [androidContentPublicResSource]: [androidContentPublicResDest]
+        [androidContentPublicResSource]: [androidContentPublicResDest],
+        [androidTouchtoFillResSource]: [androidTouchtoFillResDest]
       }
 
       console.log('copy Android app icons and app resources')


### PR DESCRIPTION
Uplift of #6795
Resolves https://github.com/brave/brave-browser/issues/12018

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.