### PR TITLE
Fix bat-ads unit tests on Linux due to different behavior on handling regular expressions

### DIFF
--- a/components/brave_ads/test/BUILD.gn
+++ b/components/brave_ads/test/BUILD.gn
@@ -22,6 +22,8 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/classification/page_classifier/page_classifier_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/classification/page_classifier/page_classifier_util_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/classification/purchase_intent_classifier/purchase_intent_classifier_unittest.cc",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/database/tables/ad_conversions_database_table_unittest.cc",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_confirmation_filter_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_conversion_filter_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/filters/ads_history_date_range_filter_unittest.cc",
@@ -66,14 +68,6 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/url_util_unittest.cc",
     ]
 
-    if (!is_asan) {
-       # Move sources out of the !is_asan block when
-       # https://github.com/brave/brave-browser/issues/11938 is fixed
-       sources += [
-         "//brave/vendor/bat-native-ads/src/bat/ads/internal/database/tables/ad_conversions_database_table_unittest.cc",
-         "//brave/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_unittest.cc",
-       ]
-    }
     if (!is_android) {
       sources += [
         # TODO(https://github.com/brave-intl/bat-native-usermodel/issues/26):

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
@@ -113,18 +113,30 @@ bool ParseTimeTag(
   return true;
 }
 
-void ParseAndReplaceTags(
+std::vector<std::string> ParseTagsForText(
     std::string* text) {
   DCHECK(text);
 
   re2::StringPiece text_string_piece(*text);
   RE2 r("<(.*)>");
 
-  std::string tag;
+  std::vector<std::string> tags;
 
+  std::string tag;
   while (RE2::FindAndConsume(&text_string_piece, r, &tag)) {
     tag = base::ToLowerASCII(tag);
+    tags.push_back(tag);
+  }
 
+  return tags;
+}
+
+void ReplaceTagsForText(
+    std::string* text,
+    const std::vector<std::string>& tags) {
+  DCHECK(text);
+
+  for (const auto& tag : tags) {
     const std::vector<std::string> components = base::SplitString(tag, ":",
         base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
 
@@ -151,6 +163,12 @@ void ParseAndReplaceTags(
 
     RE2::Replace(text, escaped_enclosed_tag, value);
   }
+}
+
+void ParseAndReplaceTagsForText(
+    std::string* text) {
+  const std::vector<std::string> tags = ParseTagsForText(text);
+  ReplaceTagsForText(text, tags);
 }
 
 std::string GetUuid(
@@ -577,7 +595,7 @@ void MockUrlRequest(
               ASSERT_TRUE(base::ReadFileToString(path, &body));
             }
 
-            ParseAndReplaceTags(&body);
+            ParseAndReplaceTagsForText(&body);
           }
         }
 


### PR DESCRIPTION
Closes https://github.com/brave/brave-browser/issues/11938

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_unit_tests -- --target_os linux --target_arch "x64" --filter="BatAdsAd*"` for `--is_asan` builds

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
