### PR TITLE
Allow `npm run test` to be run against a folder

### DIFF
--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -185,6 +185,7 @@ program
 
 program
   .command('test <suite>')
+  .option('-C <build_dir>', 'build config (out/Debug, out/Release')
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
   .option('--vmodule [modules]', 'verbose log from specific modules')
   .option('--filter <filter>', 'set test filter')


### PR DESCRIPTION
E.g. $ npm run test -- -C x86_android_master

Closes https://github.com/brave/brave-browser/issues/12095
