### PR TITLE
Greaselion accepts "minimium_brave_version" config property and "supports-minimum-browser-version" precondition

### DIFF
--- a/components/greaselion/browser/BUILD.gn
+++ b/components/greaselion/browser/BUILD.gn
@@ -15,6 +15,7 @@ source_set("browser") {
     "//base",
     "//brave/components/brave_component_updater/browser",
     "//chrome/browser/extensions:extensions",
+    "//components/version_info",
     "//content/public/browser",
     "//content/public/common",
     "//extensions/browser",

--- a/components/greaselion/browser/greaselion_download_service.cc
+++ b/components/greaselion/browser/greaselion_download_service.cc
@@ -20,6 +20,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/post_task.h"
 #include "base/task_runner_util.h"
+#include "base/version.h"
 #include "brave/components/brave_component_updater/browser/dat_file_util.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_service.h"
 #include "brave/components/greaselion/browser/switches.h"
@@ -38,12 +39,17 @@ const char kURLs[] = "urls";
 const char kScripts[] = "scripts";
 const char kRunAt[] = "run_at";
 const char kMessages[] = "messages";
+// Note(petemill): "brave" instead of "browser" version in order
+// to preserve some sense of cross-browser targetting of the scripts.
+const char kMinimumBraveVersion[] = "minimum_brave_version";
 // precondition keys
 const char kRewards[] = "rewards-enabled";
 const char kTwitterTips[] = "twitter-tips-enabled";
 const char kRedditTips[] = "reddit-tips-enabled";
 const char kGithubTips[] = "github-tips-enabled";
 const char kAutoContribution[] = "auto-contribution-enabled";
+const char kSupportsMinimumBraveVersion[] =
+    "supports-minimum-brave-version";
 
 GreaselionPreconditionValue GreaselionRule::ParsePrecondition(
     const base::Value& value) {
@@ -61,6 +67,7 @@ void GreaselionRule::Parse(base::DictionaryValue* preconditions_value,
                            base::ListValue* urls_value,
                            base::ListValue* scripts_value,
                            const std::string& run_at_value,
+                           const std::string& minimum_brave_version_value,
                            const base::FilePath& messages_value,
                            const base::FilePath& resource_dir) {
   if (preconditions_value) {
@@ -76,6 +83,8 @@ void GreaselionRule::Parse(base::DictionaryValue* preconditions_value,
         preconditions_.github_tips_enabled = condition;
       }  else if (kv.first == kAutoContribution) {
         preconditions_.auto_contribution_enabled = condition;
+      }  else if (kv.first == kSupportsMinimumBraveVersion) {
+        preconditions_.supports_minimum_brave_version = condition;
       } else {
         LOG(INFO) << "Greaselion encountered an unknown precondition: "
             << kv.first;
@@ -104,6 +113,7 @@ void GreaselionRule::Parse(base::DictionaryValue* preconditions_value,
     }
   }
   run_at_ = run_at_value;
+  minimum_brave_version_ = minimum_brave_version_value;
   if (!messages_value.empty()) {
     messages_ = resource_dir.Append(messages_value);
   }
@@ -124,7 +134,9 @@ bool GreaselionRule::PreconditionFulfilled(
   }
 }
 
-bool GreaselionRule::Matches(GreaselionFeatures state) const {
+bool GreaselionRule::Matches(
+    GreaselionFeatures state, const base::Version& browser_version) const {
+  // Validate against preconditions.
   if (!PreconditionFulfilled(preconditions_.rewards_enabled,
                              state[greaselion::REWARDS]))
     return false;
@@ -140,6 +152,18 @@ bool GreaselionRule::Matches(GreaselionFeatures state) const {
   if (!PreconditionFulfilled(preconditions_.auto_contribution_enabled,
                              state[greaselion::AUTO_CONTRIBUTION]))
     return false;
+  if (!PreconditionFulfilled(preconditions_.supports_minimum_brave_version,
+                          state[greaselion::SUPPORTS_MINIMUM_BRAVE_VERSION]))
+    return false;
+  // Validate against browser version.
+  if (base::Version::IsValidWildcardString(minimum_brave_version_)) {
+    bool rule_version_is_higher_than_browser =
+        (browser_version.CompareToWildcardString(minimum_brave_version_) < 0);
+    if (rule_version_is_higher_than_browser) {
+      return false;
+    }
+  }
+  // Rule matches current state.
   return true;
 }
 
@@ -217,6 +241,10 @@ void GreaselionDownloadService::OnDATFileDataReady(std::string contents) {
     rule_dict->GetList(kScripts, &scripts_value);
     const std::string* run_at_ptr = rule_it.FindStringPath(kRunAt);
     const std::string run_at_value = run_at_ptr ? *run_at_ptr : "";
+    const std::string* minimum_brave_version_ptr = rule_it.FindStringPath(
+        kMinimumBraveVersion);
+    const std::string minimum_brave_version_value =
+        minimum_brave_version_ptr ? *minimum_brave_version_ptr : "";
     const std::string* messages = rule_it.FindStringPath(kMessages);
     base::FilePath messages_path;
     if (messages) {
@@ -225,8 +253,8 @@ void GreaselionDownloadService::OnDATFileDataReady(std::string contents) {
 
     std::unique_ptr<GreaselionRule> rule = std::make_unique<GreaselionRule>(
         base::StringPrintf(kRuleNameFormat, rules_.size()));
-    rule->Parse(preconditions_value, urls_value, scripts_value,
-        run_at_value, messages_path, resource_dir_);
+    rule->Parse(preconditions_value, urls_value, scripts_value, run_at_value,
+        minimum_brave_version_value, messages_path, resource_dir_);
     rules_.push_back(std::move(rule));
   }
   for (Observer& observer : observers_)

--- a/components/greaselion/browser/greaselion_download_service.h
+++ b/components/greaselion/browser/greaselion_download_service.h
@@ -25,6 +25,10 @@
 
 class GreaselionServiceTest;
 
+namespace base {
+class Version;
+}
+
 using brave_component_updater::LocalDataFilesObserver;
 using brave_component_updater::LocalDataFilesService;
 
@@ -41,6 +45,7 @@ struct GreaselionPreconditions {
   GreaselionPreconditionValue reddit_tips_enabled = kAny;
   GreaselionPreconditionValue github_tips_enabled = kAny;
   GreaselionPreconditionValue auto_contribution_enabled = kAny;
+  GreaselionPreconditionValue supports_minimum_brave_version = kAny;
 };
 
 class GreaselionRule {
@@ -50,11 +55,13 @@ class GreaselionRule {
              base::ListValue* urls_value,
              base::ListValue* scripts_value,
              const std::string& run_at_value,
+             const std::string& minimum_brave_version_value,
              const base::FilePath& messages_value,
              const base::FilePath& resource_dir);
   ~GreaselionRule();
 
-  bool Matches(GreaselionFeatures state) const;
+  bool Matches(
+      GreaselionFeatures state, const base::Version& browser_version) const;
   std::string name() const { return name_; }
   std::vector<std::string> url_patterns() const { return url_patterns_; }
   std::vector<base::FilePath> scripts() const { return scripts_; }
@@ -76,6 +83,7 @@ class GreaselionRule {
   std::vector<std::string> url_patterns_;
   std::vector<base::FilePath> scripts_;
   std::string run_at_;
+  std::string minimum_brave_version_;
   base::FilePath messages_;
   GreaselionPreconditions preconditions_;
   bool has_unknown_preconditions_ = false;

--- a/components/greaselion/browser/greaselion_service.h
+++ b/components/greaselion/browser/greaselion_service.h
@@ -17,6 +17,12 @@
 #include "extensions/common/extension_id.h"
 #include "url/gurl.h"
 
+class GreaselionServiceTest;
+
+namespace base {
+class Version;
+}
+
 namespace greaselion {
 
 enum GreaselionFeature {
@@ -26,6 +32,7 @@ enum GreaselionFeature {
   REDDIT_TIPS,
   GITHUB_TIPS,
   AUTO_CONTRIBUTION,
+  SUPPORTS_MINIMUM_BRAVE_VERSION,
   LAST_FEATURE
 };
 
@@ -52,6 +59,8 @@ class GreaselionService : public KeyedService,
   virtual void RemoveObserver(Observer* observer) = 0;
 
  private:
+  friend class ::GreaselionServiceTest;
+  virtual void SetBrowserVersionForTesting(const base::Version& version);
   DISALLOW_COPY_AND_ASSIGN(GreaselionService);
 };
 

--- a/components/greaselion/browser/greaselion_service_impl.cc
+++ b/components/greaselion/browser/greaselion_service_impl.cc
@@ -335,11 +335,12 @@ void GreaselionServiceImpl::RemoveObserver(Observer* observer) {
 void GreaselionServiceImpl::MaybeNotifyObservers() {
   if (!pending_installs_) {
     update_in_progress_ = false;
-    for (Observer& observer : observers_)
-      observer.OnExtensionsReady(this, all_rules_installed_successfully_);
     if (update_pending_) {
       update_pending_ = false;
       UpdateInstalledExtensions();
+    } else {
+      for (Observer& observer : observers_)
+        observer.OnExtensionsReady(this, all_rules_installed_successfully_);
     }
   }
 }

--- a/components/greaselion/browser/greaselion_service_impl.cc
+++ b/components/greaselion/browser/greaselion_service_impl.cc
@@ -27,10 +27,12 @@
 #include "base/task/post_task.h"
 #include "base/task_runner_util.h"
 #include "base/values.h"
+#include "base/version.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_component_updater/browser/switches.h"
 #include "brave/components/greaselion/browser/greaselion_download_service.h"
 #include "chrome/browser/extensions/extension_service.h"
+#include "components/version_info/version_info.h"
 #include "crypto/sha2.h"
 #include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_system.h"
@@ -195,10 +197,13 @@ GreaselionServiceImpl::GreaselionServiceImpl(
       update_pending_(false),
       pending_installs_(0),
       task_runner_(std::move(task_runner)),
+      browser_version_(version_info::GetVersion()),
       weak_factory_(this) {
   extension_registry_->AddObserver(this);
   for (int i = FIRST_FEATURE; i != LAST_FEATURE; i++)
     state_[static_cast<GreaselionFeature>(i)] = false;
+  // Static-value features
+  state_[GreaselionFeature::SUPPORTS_MINIMUM_BRAVE_VERSION] = true;
 }
 
 GreaselionServiceImpl::~GreaselionServiceImpl() {
@@ -249,7 +254,8 @@ void GreaselionServiceImpl::CreateAndInstallExtensions() {
   std::vector<std::unique_ptr<GreaselionRule>>* rules =
       download_service_->rules();
   for (const std::unique_ptr<GreaselionRule>& rule : *rules) {
-    if (rule->Matches(state_) && rule->has_unknown_preconditions() == false) {
+    if (rule->Matches(state_, browser_version_) &&
+        rule->has_unknown_preconditions() == false) {
       pending_installs_ += 1;
     }
   }
@@ -259,7 +265,8 @@ void GreaselionServiceImpl::CreateAndInstallExtensions() {
     return;
   }
   for (const std::unique_ptr<GreaselionRule>& rule : *rules) {
-    if (rule->Matches(state_) && rule->has_unknown_preconditions() == false) {
+    if (rule->Matches(state_, browser_version_) &&
+        rule->has_unknown_preconditions() == false) {
       // Convert script file to component extension. This must run on extension
       // file task runner, which was passed in in the constructor.
       base::PostTaskAndReplyWithResult(
@@ -354,6 +361,13 @@ void GreaselionServiceImpl::SetFeatureEnabled(GreaselionFeature feature,
 
 bool GreaselionServiceImpl::ready() {
   return !update_in_progress_;
+}
+
+void GreaselionServiceImpl::SetBrowserVersionForTesting(
+    const base::Version& version) {
+  CHECK(version.IsValid());
+  browser_version_ = version;
+  UpdateInstalledExtensions();
 }
 
 }  // namespace greaselion

--- a/components/greaselion/browser/greaselion_service_impl.h
+++ b/components/greaselion/browser/greaselion_service_impl.h
@@ -13,6 +13,7 @@
 #include "base/files/file_path.h"
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
+#include "base/version.h"
 #include "brave/components/greaselion/browser/greaselion_service.h"
 #include "extensions/common/extension_id.h"
 #include "url/gurl.h"
@@ -59,6 +60,7 @@ class GreaselionServiceImpl : public GreaselionService {
                            extensions::UnloadedExtensionReason reason) override;
 
  private:
+  void SetBrowserVersionForTesting(const base::Version& version) override;
   void CreateAndInstallExtensions();
   void PostConvert(scoped_refptr<extensions::Extension> extension);
   void Install(scoped_refptr<extensions::Extension> extension);
@@ -77,6 +79,7 @@ class GreaselionServiceImpl : public GreaselionService {
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   base::ObserverList<Observer> observers_;
   std::vector<extensions::ExtensionId> greaselion_extensions_;
+  base::Version browser_version_;
   base::WeakPtrFactory<GreaselionServiceImpl> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(GreaselionServiceImpl);

--- a/test/data/greaselion-data/1/Greaselion.json
+++ b/test/data/greaselion-data/1/Greaselion.json
@@ -60,5 +60,77 @@
             "scripts/messages-example-com.js"
         ],
         "messages": "messages"
+    },
+    {
+      "urls": [
+            "http://version-low-wild.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "0.1.*"
+    },
+    {
+      "urls": [
+            "http://version-low-format.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "1.1.3"
+    },
+    {
+      "urls": [
+            "http://version-match-wild.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "1.*"
+    },
+    {
+      "urls": [
+            "http://version-match-exact.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "1.2.3.4"
+    },
+    {
+      "urls": [
+            "http://version-high-wild.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "2.*"
+    },
+    {
+      "urls": [
+            "http://version-high-exact.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "2.2.3.4"
+    },
+    {
+      "urls": [
+            "http://version-empty.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": ""
+    },
+    {
+      "urls": [
+            "http://version-bad-format.example.com/*"
+      ],
+      "scripts": [
+            "scripts/a-com.js"
+      ],
+      "minimum_brave_version": "abcdefghi"
     }
 ]


### PR DESCRIPTION
Allows scripts to specify which minimum version of brave they are compatible with (supports wildcards). Also contains another precondition so that browsers which do not support this new config property can ignore scripts targeted to specific minimum brave versions. That new precondition can be temporary and removed in a few months when everyone is upgraded.

Also fixes a timing issue which we may also run in to in production (but definitely do in browser tests) whereby we updated the conditions during rule parse and install. We were defering notifying about extensions being installed until after the entire batch of pending updates is done, but not deferring OnRulesReady.

Resolves https://github.com/brave/brave-browser/issues/11847

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [x] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
