### PR TITLE
Fix bug that we might block on non-Mac when constructing IPFS interstitial controller client

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -474,7 +474,8 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
   std::unique_ptr<content::NavigationThrottle> ipfs_navigation_throttle =
     ipfs::IpfsNavigationThrottle::MaybeCreateThrottleFor(handle,
         ipfs::IpfsServiceFactory::GetForContext(context),
-        brave::IsRegularProfile(context));
+        brave::IsRegularProfile(context),
+        g_brave_browser_process->GetApplicationLocale());
   if (ipfs_navigation_throttle)
     throttles.push_back(std::move(ipfs_navigation_throttle));
 #endif

--- a/components/ipfs/BUILD.gn
+++ b/components/ipfs/BUILD.gn
@@ -35,7 +35,6 @@ source_set("ipfs") {
     "//brave/components/services/ipfs/public/mojom",
     "//components/infobars/core",
     "//components/keyed_service/core",
-    "//components/language/core/browser:browser",
     "//components/prefs",
     "//components/security_interstitials/content:security_interstitial_page",
     "//components/security_interstitials/core",

--- a/components/ipfs/ipfs_interstitial_controller_client.cc
+++ b/components/ipfs/ipfs_interstitial_controller_client.cc
@@ -7,7 +7,6 @@
 
 #include "brave/components/ipfs/ipfs_utils.h"
 #include "brave/components/ipfs/pref_names.h"
-#include "components/language/core/browser/locale_util.h"
 #include "components/prefs/pref_service.h"
 #include "components/security_interstitials/core/metrics_helper.h"
 #include "content/public/browser/page_navigator.h"
@@ -31,12 +30,13 @@ IPFSInterstitialControllerClient::GetMetricsHelper(const GURL& url) {
 IPFSInterstitialControllerClient::IPFSInterstitialControllerClient(
     content::WebContents* web_contents,
     const GURL& request_url,
-    PrefService* prefs)
+    PrefService* prefs,
+    const std::string& locale)
     : security_interstitials::SecurityInterstitialControllerClient(
           web_contents,
           GetMetricsHelper(request_url),
           prefs,
-          language::GetApplicationLocale(prefs),
+          locale,
           GURL("about:blank") /* default_safe_page */),
       request_url_(request_url) {}
 

--- a/components/ipfs/ipfs_interstitial_controller_client.h
+++ b/components/ipfs/ipfs_interstitial_controller_client.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_IPFS_IPFS_INTERSTITIAL_CONTROLLER_CLIENT_H_
 
 #include <memory>
+#include <string>
 
 #include "components/security_interstitials/content/security_interstitial_controller_client.h"
 #include "url/gurl.h"
@@ -29,7 +30,8 @@ class IPFSInterstitialControllerClient
 
   IPFSInterstitialControllerClient(content::WebContents* web_contents,
                                    const GURL& request_url,
-                                   PrefService* prefs);
+                                   PrefService* prefs,
+                                   const std::string& locale);
   ~IPFSInterstitialControllerClient() override = default;
 
   IPFSInterstitialControllerClient(const IPFSInterstitialControllerClient&) =

--- a/components/ipfs/ipfs_navigation_throttle.cc
+++ b/components/ipfs/ipfs_navigation_throttle.cc
@@ -62,20 +62,23 @@ std::unique_ptr<IpfsNavigationThrottle>
 IpfsNavigationThrottle::MaybeCreateThrottleFor(
     content::NavigationHandle* navigation_handle,
     IpfsService* ipfs_service,
-    bool regular_profile) {
+    bool regular_profile,
+    const std::string& locale) {
   auto* context = navigation_handle->GetWebContents()->GetBrowserContext();
   if (!IpfsService::IsIpfsEnabled(context, regular_profile))
     return nullptr;
 
   return std::make_unique<IpfsNavigationThrottle>(navigation_handle,
-                                                  ipfs_service);
+                                                  ipfs_service, locale);
 }
 
 IpfsNavigationThrottle::IpfsNavigationThrottle(
     content::NavigationHandle* navigation_handle,
-    IpfsService* ipfs_service)
+    IpfsService* ipfs_service,
+    const std::string& locale)
     : content::NavigationThrottle(navigation_handle),
-      ipfs_service_(ipfs_service) {
+      ipfs_service_(ipfs_service),
+      locale_(locale) {
   content::BrowserContext* context =
       navigation_handle->GetWebContents()->GetBrowserContext();
   pref_service_ = user_prefs::UserPrefs::Get(context);
@@ -151,7 +154,7 @@ void IpfsNavigationThrottle::ShowInterstitial() {
   const GURL& request_url = handle->GetURL();
 
   auto controller_client = std::make_unique<IPFSInterstitialControllerClient>(
-      web_contents, request_url, pref_service_);
+      web_contents, request_url, pref_service_, locale_);
   auto page = std::make_unique<IPFSNotConnectedPage>(
       web_contents, handle->GetURL(), std::move(controller_client));
 

--- a/components/ipfs/ipfs_navigation_throttle.h
+++ b/components/ipfs/ipfs_navigation_throttle.h
@@ -30,7 +30,8 @@ class IpfsNavigationThrottle : public content::NavigationThrottle,
                                public IpfsServiceObserver {
  public:
   explicit IpfsNavigationThrottle(content::NavigationHandle* navigation_handle,
-                                  IpfsService* ipfs_service);
+                                  IpfsService* ipfs_service,
+                                  const std::string& locale);
   ~IpfsNavigationThrottle() override;
 
   IpfsNavigationThrottle(const IpfsNavigationThrottle&) = delete;
@@ -39,7 +40,8 @@ class IpfsNavigationThrottle : public content::NavigationThrottle,
   static std::unique_ptr<IpfsNavigationThrottle> MaybeCreateThrottleFor(
       content::NavigationHandle* navigation_handle,
       IpfsService* ipfs_service,
-      bool regular_profile);
+      bool regular_profile,
+      const std::string& locale);
 
   // content::NavigationThrottle implementation:
   ThrottleCheckResult WillStartRequest() override;
@@ -58,6 +60,7 @@ class IpfsNavigationThrottle : public content::NavigationThrottle,
   bool resume_pending_ = false;
   IpfsService* ipfs_service_ = nullptr;
   PrefService* pref_service_ = nullptr;
+  std::string locale_;
   base::WeakPtrFactory<IpfsNavigationThrottle> weak_ptr_factory_{this};
 };
 

--- a/components/ipfs/ipfs_navigation_throttle_unittest.cc
+++ b/components/ipfs/ipfs_navigation_throttle_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/ipfs/ipfs_navigation_throttle.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "base/test/bind_test_util.h"
@@ -75,6 +76,7 @@ class IpfsNavigationThrottleUnitTest : public testing::Test {
     web_contents_ =
         content::WebContentsTester::CreateTestWebContents(profile_, nullptr);
     ipfs_service_ = IpfsServiceFactory::GetForContext(profile_);
+    locale_ = "en-US";
   }
 
   void TearDown() override {
@@ -97,6 +99,8 @@ class IpfsNavigationThrottleUnitTest : public testing::Test {
 
   Profile* profile() { return profile_; }
 
+  const std::string& locale() { return locale_; }
+
  private:
   content::BrowserTaskEnvironment task_environment_;
   base::ScopedTempDir temp_dir_;
@@ -106,6 +110,7 @@ class IpfsNavigationThrottleUnitTest : public testing::Test {
   IpfsService* ipfs_service_;
   Profile* profile_;
   base::test::ScopedFeatureList feature_list_;
+  std::string locale_;
 
   DISALLOW_COPY_AND_ASSIGN(IpfsNavigationThrottleUnitTest);
 };
@@ -123,7 +128,8 @@ TEST_F(IpfsNavigationThrottleUnitTest, DeferUntilIpfsProcessLaunched) {
   content::MockNavigationHandle test_handle(web_contents());
   test_handle.set_url(GetIPFSURL());
   auto throttle = IpfsNavigationThrottle::MaybeCreateThrottleFor(
-      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()));
+      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()),
+      locale());
   ASSERT_TRUE(throttle != nullptr);
   bool was_navigation_resumed = false;
   throttle->set_resume_callback_for_testing(
@@ -165,7 +171,8 @@ TEST_F(IpfsNavigationThrottleUnitTest, ProceedForGatewayNodeMode) {
   content::MockNavigationHandle test_handle(web_contents());
   test_handle.set_url(GetIPFSURL());
   auto throttle = IpfsNavigationThrottle::MaybeCreateThrottleFor(
-      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()));
+      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()),
+      locale());
   ASSERT_TRUE(throttle != nullptr);
   EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
       << GetIPFSURL();
@@ -184,7 +191,8 @@ TEST_F(IpfsNavigationThrottleUnitTest, ProceedForAskNodeMode) {
   content::MockNavigationHandle test_handle(web_contents());
   test_handle.set_url(GetIPFSURL());
   auto throttle = IpfsNavigationThrottle::MaybeCreateThrottleFor(
-      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()));
+      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()),
+      locale());
   ASSERT_TRUE(throttle != nullptr);
   EXPECT_EQ(NavigationThrottle::PROCEED, throttle->WillStartRequest().action())
       << GetIPFSURL();
@@ -199,7 +207,8 @@ TEST_F(IpfsNavigationThrottleUnitTest, ProceedForAskNodeMode) {
 TEST_F(IpfsNavigationThrottleUnitTest, Instantiation) {
   content::MockNavigationHandle test_handle(web_contents());
   auto throttle = IpfsNavigationThrottle::MaybeCreateThrottleFor(
-      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()));
+      &test_handle, ipfs_service(), brave::IsRegularProfile(profile()),
+      locale());
   EXPECT_TRUE(throttle != nullptr);
 
   // Disable in OTR profile.
@@ -208,7 +217,7 @@ TEST_F(IpfsNavigationThrottleUnitTest, Instantiation) {
   content::MockNavigationHandle otr_test_handle(otr_web_contents.get());
   auto throttle_in_otr = IpfsNavigationThrottle::MaybeCreateThrottleFor(
       &otr_test_handle, ipfs_service(),
-      brave::IsRegularProfile(profile()->GetPrimaryOTRProfile()));
+      brave::IsRegularProfile(profile()->GetPrimaryOTRProfile()), locale());
   EXPECT_EQ(throttle_in_otr, nullptr);
 
   // Disable in guest sessions.
@@ -218,7 +227,7 @@ TEST_F(IpfsNavigationThrottleUnitTest, Instantiation) {
   content::MockNavigationHandle guest_test_handle(guest_web_contents.get());
   auto throttle_in_guest = IpfsNavigationThrottle::MaybeCreateThrottleFor(
       &guest_test_handle, ipfs_service(),
-      brave::IsRegularProfile(guest_profile.get()));
+      brave::IsRegularProfile(guest_profile.get()), locale());
   EXPECT_EQ(throttle_in_guest, nullptr);
 }
 
@@ -238,7 +247,7 @@ TEST_F(IpfsNavigationThrottleUnitTest, NotInstantiatedInTor) {
   content::MockNavigationHandle tor_reg_test_handle(tor_reg_web_contents.get());
   auto throttle_in_tor_reg = IpfsNavigationThrottle::MaybeCreateThrottleFor(
       &tor_reg_test_handle, ipfs_service(),
-      brave::IsRegularProfile(tor_reg_profile));
+      brave::IsRegularProfile(tor_reg_profile), locale());
   EXPECT_EQ(throttle_in_tor_reg, nullptr);
 
   auto tor_otr_web_contents = content::WebContentsTester::CreateTestWebContents(
@@ -246,7 +255,7 @@ TEST_F(IpfsNavigationThrottleUnitTest, NotInstantiatedInTor) {
   content::MockNavigationHandle tor_otr_test_handle(tor_otr_web_contents.get());
   auto throttle_in_tor_otr = IpfsNavigationThrottle::MaybeCreateThrottleFor(
       &tor_otr_test_handle, ipfs_service(),
-      brave::IsRegularProfile(tor_reg_profile));
+      brave::IsRegularProfile(tor_reg_profile), locale());
   EXPECT_EQ(throttle_in_tor_otr, nullptr);
 }
 #endif


### PR DESCRIPTION
The constructor used language::GetApplicationLocale which might call into
base::PathExists that may block. This PR fixes this problem by getting the
locale through g_browser_process directly instead when creating navigation
throttle and pass it down.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12148

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [x] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
Run `npm test brave_browser_tests -- --filter=IpfsNavigationThrottleBrowserTest.ShowInterstitialForEmptyConnectedPeers` on non-Mac platform with DCHECK on.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
