### PR TITLE
Notify NTP SI data is ready when browser confirms it's not NTP SR.

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service.cc
@@ -378,6 +378,13 @@ void NTPBackgroundImagesService::OnGetMappingTableData(
 
   DVLOG(2) << __func__ << ": This is non super referral.";
   MarkThisInstallIsNotSuperReferralForever();
+
+  // When we know this install is not SR, notify about si data is ready.
+  // If si data is not ready yet, noti will be fired when it's ready.
+  if (si_images_data_) {
+    for (auto& observer : observer_list_)
+      observer.OnUpdated(si_images_data_.get());
+  }
 }
 
 void NTPBackgroundImagesService::AddObserver(Observer* observer) {


### PR DESCRIPTION
With this, ViewCounterService can initialize ViewCounterModel for
displaying NTP SI properly.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9728

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [x] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_unit_tests -- --filter=NTPBackgroundImagesServiceTest.WithNonSuperReferralCodeTest`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
