### PR TITLE
Fixes Brave Ads fail to migrate confirmations.json if upgrading from builds prior to 1.14.20 if ads were switched off - 1.16.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -579,8 +579,20 @@ bool MigrateConfirmationsStateOnFileTaskRunner(
       rewards_service_base_path.AppendASCII("confirmations.json");
 
   if (base::PathExists(legacy_confirmations_state_path)) {
+    const base::FilePath ads_service_base_path =
+        path.AppendASCII("ads_service");
+
+    if (!base::DirectoryExists(ads_service_base_path)) {
+      if (!base::CreateDirectory(ads_service_base_path)) {
+        VLOG(0) << "Failed to create " << ads_service_base_path.value();
+        return false;
+      }
+
+      VLOG(1) << "Created " << ads_service_base_path.value();
+    }
+
     base::FilePath confirmations_state_path =
-        path.AppendASCII("ads_service").AppendASCII("confirmations.json");
+        ads_service_base_path.AppendASCII("confirmations.json");
 
     VLOG(1) << "Migrating " << legacy_confirmations_state_path.value()
         << " to " << confirmations_state_path.value();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/6917
Resolves https://github.com/brave/brave-browser/issues/12260

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
