### PR TITLE
Add linear gradient to custom tip backgrounds

### DIFF
--- a/components/brave_rewards/resources/tip/components/publisher_banner.style.ts
+++ b/components/brave_rewards/resources/tip/components/publisher_banner.style.ts
@@ -13,12 +13,19 @@ import background5 from '../assets/background_5.svg'
 export const loading = styled.div``
 
 export const root = styled.div`
+  height: 100%;
+  color: var(--brave-palette-white);
+  background-color: var(--brave-palette-neutral900);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+`
+
+export const background = styled.div`
   display: flex;
   justify-content: center;
   padding: 64px 12px 10px;
   height: 100%;
-  color: var(--brave-palette-white);
-  background-color: var(--brave-palette-neutral900);
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
@@ -38,6 +45,14 @@ export const root = styled.div`
 
   &.background-style-5 {
     background-image: url('${background5}');
+  }
+
+  &.background-style-custom {
+    background-image: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.3) 42.84%,
+      rgba(0, 0, 0, 0.5) 100%)
   }
 `
 

--- a/components/brave_rewards/resources/tip/components/publisher_banner.tsx
+++ b/components/brave_rewards/resources/tip/components/publisher_banner.tsx
@@ -348,35 +348,34 @@ export function PublisherBanner () {
     : 'verified'
 
   return (
-    <style.root
-      className={getBackgroundClass(publisherInfo)}
-      style={{ backgroundImage }}
-    >
-      <style.card>
-        <style.header>
-          <style.logo>
-            <style.logoMask>
-              {getLogo(publisherInfo)}
-            </style.logoMask>
-            <style.verifiedIcon className={verifiedType}>
-              {getVerifiedIcon(publisherInfo)}
-            </style.verifiedIcon>
-          </style.logo>
-          <style.name>
-            {getPublisherName(locale, publisherInfo, mediaMetaData)}
-          </style.name>
-        </style.header>
-        <style.socialLinks>
-          {getSocialLinks(publisherInfo)}
-        </style.socialLinks>
-        {getUnverifiedNotice(locale, publisherInfo, balanceInfo, walletInfo)}
-        <style.title>
-          {getTitle(locale, publisherInfo, mediaMetaData)}
-        </style.title>
-        <style.description>
-          {getDescription(locale, publisherInfo, mediaMetaData)}
-        </style.description>
-      </style.card>
+    <style.root style={{ backgroundImage }}>
+      <style.background className={getBackgroundClass(publisherInfo)}>
+        <style.card>
+          <style.header>
+            <style.logo>
+              <style.logoMask>
+                {getLogo(publisherInfo)}
+              </style.logoMask>
+              <style.verifiedIcon className={verifiedType}>
+                {getVerifiedIcon(publisherInfo)}
+              </style.verifiedIcon>
+            </style.logo>
+            <style.name>
+              {getPublisherName(locale, publisherInfo, mediaMetaData)}
+            </style.name>
+          </style.header>
+          <style.socialLinks>
+            {getSocialLinks(publisherInfo)}
+          </style.socialLinks>
+          {getUnverifiedNotice(locale, publisherInfo, balanceInfo, walletInfo)}
+          <style.title>
+            {getTitle(locale, publisherInfo, mediaMetaData)}
+          </style.title>
+          <style.description>
+            {getDescription(locale, publisherInfo, mediaMetaData)}
+          </style.description>
+        </style.card>
+      </style.background>
     </style.root>
   )
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12057

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

- Open browser with clean profile, pointed to rewards prod.
- Click the rewards badge to activate rewards extension.
- Navigate to https://twitter.com/jonathansampson.
- Open the rewards panel.
- Click "Send a tip".
- Verify that banner background is darkened slightly and the white text is more readable.

Screenshot of custom background **before** this change:

<img width="621" alt="Screen Shot 2020-10-30 at 10 25 07 AM" src="https://user-images.githubusercontent.com/5995084/97717350-133dc380-1a9b-11eb-8132-33923faf0ade.png">

Screenshot of custom background **after** this change:

<img width="673" alt="Screen Shot 2020-10-30 at 10 28 44 AM" src="https://user-images.githubusercontent.com/5995084/97717400-20f34900-1a9b-11eb-80cc-ec476ab78f8c.png">

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
