### PR TITLE
Fix 11581: Disable sign-in with brave in brave://apps

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/app_launcher_login_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/app_launcher_login_handler.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/webui/app_launcher_login_handler.h"
+#include "base/values.h"
+
+#define RegisterMessages RegisterMessages_ChromiumImpl
+#include "../../../../../../chrome/browser/ui/webui/app_launcher_login_handler.cc"
+#undef RegisterMessages
+
+namespace {
+void DummyCallback() {}
+void DummyWebUICallback(const base::ListValue* args) {}
+}  // namespace
+
+void AppLauncherLoginHandler::RegisterMessages() {
+  // WebUIMessageCallbacks are emplaced in the map
+  // if the key exists in the WebUIs message_callback_
+  // insertion will be ignored
+  web_ui()->RegisterMessageCallback("initializeSyncLogin",
+                                    base::BindRepeating(&DummyWebUICallback));
+
+  AppLauncherLoginHandler::RegisterMessages_ChromiumImpl();
+  profile_info_watcher_ = std::make_unique<ProfileInfoWatcher>(
+      Profile::FromWebUI(web_ui()), base::Bind(DummyCallback));
+}

--- a/chromium_src/chrome/browser/ui/webui/app_launcher_login_handler.h
+++ b/chromium_src/chrome/browser/ui/webui/app_launcher_login_handler.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_APP_LAUNCHER_LOGIN_HANDLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_APP_LAUNCHER_LOGIN_HANDLER_H_
+
+#include "content/public/browser/web_ui_message_handler.h"
+
+#define RegisterMessages           \
+  RegisterMessages_ChromiumImpl(); \
+  virtual void RegisterMessages
+#include "../../../../../../chrome/browser/ui/webui/app_launcher_login_handler.h"
+#undef RegisterMessages
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_APP_LAUNCHER_LOGIN_HANDLER_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/11581

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Navigate to brave://settings/extensions - Enable Google Login for extensions
2. Navigate to brave://apps and verify that `Sign-In with brave` does not show up on the top-right corner of the page
3. Navigate to https://chrome.google.com/webstore/detail/google-keep-chrome-extens/lpcaedmchfhocbbapmcbpinfpgnhiddi?hl=en and confirm `Google Login` works for Google Keep

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
