### PR TITLE
Fix #12347: Updating RUST_DEPS_PACKAGE_VERSION to 0.1.5 (Uplift to 1.16.x)

### DIFF
--- a/script/rust_deps_config.py
+++ b/script/rust_deps_config.py
@@ -6,4 +6,4 @@
 # Version number and URL for pre-configured rust dependency package
 # e.g. rust_deps_mac_0.1.0.gz
 RUST_DEPS_PACKAGES_URL = "https://rust-pkg-brave-core.s3.brave.com"
-RUST_DEPS_PACKAGE_VERSION = "0.1.4"
+RUST_DEPS_PACKAGE_VERSION = "0.1.5"


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/12347
Partial Uplift of: https://github.com/brave/brave-core/pull/6963

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.