### PR TITLE
Strict autoplay blocking

### DIFF
--- a/browser/autoplay/autoplay_permission_context_browsertest.cc
+++ b/browser/autoplay/autoplay_permission_context_browsertest.cc
@@ -57,22 +57,14 @@ class AutoplayPermissionContextBrowserTest : public InProcessBrowserTest {
 
     ASSERT_TRUE(embedded_test_server()->Start());
 
-    autoplay_method_url_ =
-        embedded_test_server()->GetURL("a.com", "/autoplay_by_method.html");
-    autoplay_attr_url_ =
-        embedded_test_server()->GetURL("a.com", "/autoplay_by_attr.html");
-    autoplay_method_muted_url_ = embedded_test_server()->GetURL(
-        "a.com", "/autoplay_by_method_muted.html");
-    autoplay_attr_muted_url_ =
-        embedded_test_server()->GetURL("a.com", "/autoplay_by_attr_muted.html");
     file_autoplay_method_url_ = GURL("file://" + test_data_dir.AsUTF8Unsafe() +
                                      "/autoplay_by_method.html");
     file_autoplay_attr_url_ = GURL("file://" + test_data_dir.AsUTF8Unsafe() +
                                    "/autoplay_by_attr.html");
 
-    GURL pattern_url = embedded_test_server()->GetURL("a.com", "/index.html");
+    index_url_ = embedded_test_server()->GetURL("a.com", "/index.html");
     top_level_page_pattern_ =
-        ContentSettingsPattern::FromString(pattern_url.spec());
+        ContentSettingsPattern::FromString(index_url_.spec());
   }
 
   void TearDown() override {
@@ -80,10 +72,7 @@ class AutoplayPermissionContextBrowserTest : public InProcessBrowserTest {
     content_client_.reset();
   }
 
-  const GURL& autoplay_method_url() { return autoplay_method_url_; }
-  const GURL& autoplay_attr_url() { return autoplay_attr_url_; }
-  const GURL& autoplay_method_muted_url() { return autoplay_method_muted_url_; }
-  const GURL& autoplay_attr_muted_url() { return autoplay_attr_muted_url_; }
+  const GURL& index_url() { return index_url_; }
   const GURL& file_autoplay_method_url() { return file_autoplay_method_url_; }
   const GURL& file_autoplay_attr_url() { return file_autoplay_attr_url_; }
 
@@ -122,20 +111,49 @@ class AutoplayPermissionContextBrowserTest : public InProcessBrowserTest {
     return WaitForLoadStop(contents());
   }
 
-  void WaitForPlaying(const GURL& url) {
+  void GotoAutoplayByAttr(bool muted) {
+    bool clicked;
+    if (muted)
+    ASSERT_TRUE(ExecuteScriptAndExtractBool(
+        contents(),
+        "window.domAutomationController.send(clickAutoplayByAttrMuted())",
+        &clicked));
+    else
+    ASSERT_TRUE(ExecuteScriptAndExtractBool(
+        contents(),
+        "window.domAutomationController.send(clickAutoplayByAttr())",
+        &clicked));
+    ASSERT_TRUE(WaitForLoadStop(contents()));
+    WaitForCanPlay();
+    ASSERT_TRUE(clicked);
+  }
+
+  void GotoAutoplayByMethod(bool muted) {
+    bool clicked;
+    if (muted)
+    ASSERT_TRUE(ExecuteScriptAndExtractBool(
+        contents(),
+        "window.domAutomationController.send(clickAutoplayByMethodMuted())",
+        &clicked));
+    else
+    ASSERT_TRUE(ExecuteScriptAndExtractBool(
+        contents(),
+        "window.domAutomationController.send(clickAutoplayByMethod())",
+        &clicked));
+    ASSERT_TRUE(WaitForLoadStop(contents()));
+    WaitForCanPlay();
+    ASSERT_TRUE(clicked);
+  }
+
+  void WaitForCanPlay() {
     std::string msg_from_renderer;
     ASSERT_TRUE(ExecuteScriptAndExtractString(
-        contents(), "notifyWhenPlaying();", &msg_from_renderer))
-        << url.spec();
-    ASSERT_EQ("PLAYING", msg_from_renderer)
-        << url.spec() + " says: " + msg_from_renderer;
+        contents(), "notifyWhenCanPlay();", &msg_from_renderer));
+    ASSERT_EQ("CANPLAY", msg_from_renderer);
   }
 
  private:
-  GURL autoplay_method_url_;
-  GURL autoplay_attr_url_;
-  GURL autoplay_method_muted_url_;
-  GURL autoplay_attr_muted_url_;
+  GURL index_url_;
   GURL file_autoplay_method_url_;
   GURL file_autoplay_attr_url_;
   ContentSettingsPattern top_level_page_pattern_;
@@ -151,7 +169,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, AskAutoplay) {
   permissions::PermissionRequestManager* manager =
       permissions::PermissionRequestManager::FromWebContents(contents());
 
-  NavigateToURLUntilLoadStop(autoplay_method_url());
+  NavigateToURLUntilLoadStop(index_url());
+  GotoAutoplayByMethod(false);
   // should prompt
   EXPECT_TRUE(manager->IsRequestInProgress());
   EXPECT_TRUE(
@@ -168,7 +187,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest,
   permissions::PermissionRequestManager* manager =
       permissions::PermissionRequestManager::FromWebContents(contents());
 
-  NavigateToURLUntilLoadStop(autoplay_method_muted_url());
+  NavigateToURLUntilLoadStop(index_url());
+  GotoAutoplayByMethod(true);
   // should prompt
   EXPECT_TRUE(manager->IsRequestInProgress());
   EXPECT_TRUE(
@@ -186,7 +206,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, AllowAutoplay) {
 
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
 
-  NavigateToURLUntilLoadStop(autoplay_method_url());
+  NavigateToURLUntilLoadStop(index_url());
+  GotoAutoplayByMethod(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -194,13 +215,12 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, AllowAutoplay) {
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
   EXPECT_TRUE(
       ExecuteScriptAndExtractString(contents(), kVideoPlayingDetect, &result));
-  // should fail to play because a user gesture is required and we're not
-  // simulating one when calling the play() method
-  EXPECT_NE(result, kVideoPlaying);
+  EXPECT_EQ(result, kVideoPlaying);
 
   result.clear();
 
-  NavigateToURLUntilLoadStop(autoplay_attr_url());
+  NavigateToURLUntilLoadStop(index_url());
+  GotoAutoplayByAttr(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -208,9 +228,7 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest, AllowAutoplay) {
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
   EXPECT_TRUE(
       ExecuteScriptAndExtractString(contents(), kVideoPlayingDetect, &result));
-  // should fail to play because a user gesture is required, so autoplay
-  // attribute will be ignored
-  EXPECT_NE(result, kVideoPlaying);
+  EXPECT_EQ(result, kVideoPlaying);
 }
 
 // If content setting = BLOCK, ignore play() method call and do not show
@@ -226,7 +244,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest,
 
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
 
-  NavigateToURLUntilLoadStop(autoplay_method_url());
+  NavigateToURLUntilLoadStop(index_url());
+  GotoAutoplayByMethod(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -249,7 +268,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest,
   auto popup_prompt_factory =
       std::make_unique<permissions::MockPermissionPromptFactory>(manager);
 
-  NavigateToURLUntilLoadStop(autoplay_attr_url());
+  ASSERT_TRUE(NavigateToURLUntilLoadStop(index_url()));
+  GotoAutoplayByAttr(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -274,7 +294,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest,
 
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
 
-  NavigateToURLUntilLoadStop(autoplay_method_url());
+  NavigateToURLUntilLoadStop(index_url());
+  GotoAutoplayByMethod(true);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -299,7 +320,8 @@ IN_PROC_BROWSER_TEST_F(AutoplayPermissionContextBrowserTest,
 
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
 
-  NavigateToURLUntilLoadStop(autoplay_attr_url());
+  ASSERT_TRUE(NavigateToURLUntilLoadStop(index_url()));
+  GotoAutoplayByAttr(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -336,13 +358,13 @@ IN_PROC_BROWSER_TEST_F(AutoplayNoUserGestureRequiredBrowserTest,
 
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
 
-  NavigateToURLUntilLoadStop(autoplay_method_url());
+  ASSERT_TRUE(NavigateToURLUntilLoadStop(index_url()));
+  GotoAutoplayByMethod(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
       permissions::PermissionRequestType::PERMISSION_AUTOPLAY));
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
-  WaitForPlaying(autoplay_method_url());
   EXPECT_TRUE(
       ExecuteScriptAndExtractString(contents(), kVideoPlayingDetect, &result));
   // should play
@@ -350,13 +372,13 @@ IN_PROC_BROWSER_TEST_F(AutoplayNoUserGestureRequiredBrowserTest,
 
   result.clear();
 
-  NavigateToURLUntilLoadStop(autoplay_attr_url());
+  ASSERT_TRUE(NavigateToURLUntilLoadStop(index_url()));
+  GotoAutoplayByAttr(false);
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
       permissions::PermissionRequestType::PERMISSION_AUTOPLAY));
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
-  WaitForPlaying(autoplay_attr_url());
   EXPECT_TRUE(
       ExecuteScriptAndExtractString(contents(), kVideoPlayingDetect, &result));
   // should play
@@ -374,6 +396,7 @@ IN_PROC_BROWSER_TEST_F(AutoplayNoUserGestureRequiredBrowserTest, FileAutoplay) {
   EXPECT_EQ(0, popup_prompt_factory->TotalRequestCount());
 
   NavigateToURLUntilLoadStop(file_autoplay_method_url());
+  WaitForCanPlay();
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(
@@ -387,6 +410,7 @@ IN_PROC_BROWSER_TEST_F(AutoplayNoUserGestureRequiredBrowserTest, FileAutoplay) {
   result.clear();
 
   NavigateToURLUntilLoadStop(file_autoplay_attr_url());
+  WaitForCanPlay();
   // should not prompt
   EXPECT_FALSE(popup_prompt_factory->is_visible());
   EXPECT_FALSE(popup_prompt_factory->RequestTypeSeen(

--- a/chromium_src/third_party/blink/renderer/core/html/media/autoplay_policy.cc
+++ b/chromium_src/third_party/blink/renderer/core/html/media/autoplay_policy.cc
@@ -7,24 +7,44 @@
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/html/media/html_media_element.h"
 
+namespace blink {
 namespace {
 
-bool IsAutoplayAllowedForElement(
-    blink::Member<blink::HTMLMediaElement> element) {
-  blink::LocalFrame* frame = element->GetDocument().GetFrame();
+bool IsAutoplayAllowedForFrame(LocalFrame* frame) {
   if (!frame)
     return false;
-  if (auto* settings_client = frame->GetContentSettingsClient())
-    return settings_client->AllowAutoplay(true /* default_value */);
+  if (auto* settings_client = frame->GetContentSettingsClient()) {
+    bool allow_autoplay =
+        settings_client->AllowAutoplay(true /* default_value */);
+    // Clear it in order to block media when refresh or navigate
+    if (!allow_autoplay) {
+      frame->ClearUserActivation();
+    }
+    return allow_autoplay;
+  }
   return true;
 }
 
+bool IsAutoplayAllowedForDocument(const Document& document) {
+  return IsAutoplayAllowedForFrame(document.GetFrame());
+}
+
+bool IsAutoplayAllowedForElement(Member<HTMLMediaElement> element) {
+  return IsAutoplayAllowedForFrame(element->GetDocument().GetFrame());
+}
+
 }  // namespace
+}  // namespace blink
 
 #define BRAVE_AUTOPLAY_POLICY_IS_GESTURE_NEEDED_FOR_PLAYBACK \
   if (!IsAutoplayAllowedForElement(element_))                \
     return true;
 
+#define BRAVE_GET_AUTOPLAY_POLICY_FOR_DOCUMENT \
+  if (!IsAutoplayAllowedForDocument(document)) \
+    return Type::kUserGestureRequired;
+
 #include "../../../../../../../../third_party/blink/renderer/core/html/media/autoplay_policy.cc"
 
 #undef BRAVE_AUTOPLAY_POLICY_IS_GESTURE_NEEDED_FOR_PLAYBACK
+#undef BRAVE_GET_AUTOPLAY_POLICY_FOR_DOCUMENT

--- a/components/content_settings/renderer/brave_content_settings_agent_impl.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl.cc
@@ -235,6 +235,7 @@ bool BraveContentSettingsAgentImpl::AllowAutoplay(bool default_value) {
                                    frame, url::Origin(origin).GetURL());
     if (setting == CONTENT_SETTING_BLOCK) {
       VLOG(1) << "AllowAutoplay=false because rule=CONTENT_SETTING_BLOCK";
+      DidBlockContentType(ContentSettingsType::AUTOPLAY);
       return false;
     } else if (setting == CONTENT_SETTING_ASK) {
       VLOG(1) << "AllowAutoplay=ask because rule=CONTENT_SETTING_ASK";
@@ -267,12 +268,14 @@ bool BraveContentSettingsAgentImpl::AllowAutoplay(bool default_value) {
   }
 
   bool allow = ContentSettingsAgentImpl::AllowAutoplay(default_value);
-  if (allow)
+  if (allow) {
     VLOG(1) << "AllowAutoplay=true because "
                "ContentSettingsAgentImpl::AllowAutoplay says so";
-  else
+  } else {
+    DidBlockContentType(ContentSettingsType::AUTOPLAY);
     VLOG(1) << "AllowAutoplay=false because "
                "ContentSettingsAgentImpl::AllowAutoplay says so";
+  }
   return allow;
 }
 

--- a/patches/third_party-blink-renderer-core-html-media-autoplay_policy.cc.patch
+++ b/patches/third_party-blink-renderer-core-html-media-autoplay_policy.cc.patch
@@ -1,12 +1,20 @@
 diff --git a/third_party/blink/renderer/core/html/media/autoplay_policy.cc b/third_party/blink/renderer/core/html/media/autoplay_policy.cc
-index 8ae33d3b689fd9888fca3861b6ac4ed18c9595bb..f6b1986e4406ac9bba6d245a710eeb953cf7c893 100644
+index 8ae33d3b689fd9888fca3861b6ac4ed18c9595bb..d0dc3b62b7a3f0951cfa8b6fb54a9ff11d4b77c4 100644
 --- a/third_party/blink/renderer/core/html/media/autoplay_policy.cc
 +++ b/third_party/blink/renderer/core/html/media/autoplay_policy.cc
-@@ -309,6 +309,7 @@ bool AutoplayPolicy::IsGestureNeededForPlayback() const {
+@@ -62,6 +62,7 @@ bool ComputeLockPendingUserGestureRequired(const Document& document) {
+ // static
+ AutoplayPolicy::Type AutoplayPolicy::GetAutoplayPolicyForDocument(
+     const Document& document) {
++  BRAVE_GET_AUTOPLAY_POLICY_FOR_DOCUMENT
+   if (!document.GetSettings())
+     return Type::kNoUserGestureRequired;
+ 
+@@ -308,6 +309,7 @@ void AutoplayPolicy::TryUnlockingUserGesture() {
+ bool AutoplayPolicy::IsGestureNeededForPlayback() const {
    if (!IsLockedPendingUserGesture())
      return false;
- 
 +  BRAVE_AUTOPLAY_POLICY_IS_GESTURE_NEEDED_FOR_PLAYBACK
+ 
    // We want to allow muted video to autoplay if the element is allowed to
    // autoplay muted.
-   return !IsEligibleForAutoplayMuted();

--- a/test/data/autoplay/autoplay_by_attr.html
+++ b/test/data/autoplay/autoplay_by_attr.html
@@ -6,23 +6,26 @@
   </head>
   <body>
 
-    <video width="320" height="240" controls autoplay onplay="onPlay()">
+    <video width="320" height="240" controls autoplay onplay="onPlay()"
+                                                      oncanplay="onCanPlay()">
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function onPlay () {
+      function onPlay() {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
-        window.playing = true;
-        if (window.notifyBrowser)
-          notifyWhenPlaying();
       }
-      function notifyWhenPlaying() {
-        if (window.playing)
-          window.domAutomationController.send("PLAYING");
+      function onCanPlay() {
+        window.canPlay = true;
+        if (window.notifyBrowser)
+          notifyWhenCanPlay();
+      }
+      function notifyWhenCanPlay() {
+        if (window.canPlay)
+          window.domAutomationController.send("CANPLAY");
         else
           window.notifyBrowser = true;
       }

--- a/test/data/autoplay/autoplay_by_attr_muted.html
+++ b/test/data/autoplay/autoplay_by_attr_muted.html
@@ -6,23 +6,26 @@
   </head>
   <body>
 
-    <video width="320" height="240" controls autoplay onplay="onPlay()" muted>
+    <video width="320" height="240" controls autoplay muted onplay="onPlay()"
+                                                            oncanplay="onCanPlay()">
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function onPlay () {
+      function onPlay() {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
-        window.playing = true;
-        if (window.notifyBrowser)
-          notifyWhenPlaying();
       }
-      function notifyWhenPlaying() {
-        if (this.playing)
-          window.domAutomationController.send("PLAYING");
+      function onCanPlay() {
+        window.canPlay = true;
+        if (window.notifyBrowser)
+          notifyWhenCanPlay();
+      }
+      function notifyWhenCanPlay() {
+        if (window.canPlay)
+          window.domAutomationController.send("CANPLAY");
         else
           window.notifyBrowser = true;
       }

--- a/test/data/autoplay/autoplay_by_method.html
+++ b/test/data/autoplay/autoplay_by_method.html
@@ -6,23 +6,26 @@
   </head>
   <body onload="autoplay()">
 
-    <video id="autoplay" width="320" height="240" controls onplay="onPlay()">
+    <video id="autoplay" width="320" height="240" controls onplay="onPlay()"
+                                                           oncanplay="onCanPlay()">
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function onPlay () {
+      function onPlay() {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
-        window.playing = true;
-        if (window.notifyBrowser)
-          notifyWhenPlaying();
       }
-      function notifyWhenPlaying() {
-        if (window.playing)
-          window.domAutomationController.send("PLAYING");
+      function onCanPlay() {
+        window.canPlay = true;
+        if (window.notifyBrowser)
+          notifyWhenCanPlay();
+      }
+      function notifyWhenCanPlay() {
+        if (window.canPlay)
+          window.domAutomationController.send("CANPLAY");
         else
           window.notifyBrowser = true;
       }

--- a/test/data/autoplay/autoplay_by_method_muted.html
+++ b/test/data/autoplay/autoplay_by_method_muted.html
@@ -6,23 +6,26 @@
   </head>
   <body onload="autoplay()">
 
-    <video id="autoplay" width="320" height="240" controls onplay="onPlay()" muted>
+    <video id="autoplay" width="320" height="240" controls muted onplay="onPlay()"
+                                                                 oncanplay="onCanPlay()">
       <source src="autoplay.mp4" type="video/mp4">
     </video>
 
     <div id='status'>Video not playing</div>
 
     <script>
-      function onPlay () {
+      function onPlay() {
         let status = document.getElementById('status')
         status.textContent = 'Video playing'
-        window.playing = true;
-        if (window.notifyBrowser)
-          notifyWhenPlaying();
       }
-      function notifyWhenPlaying() {
-        if (window.playing)
-          window.domAutomationController.send("PLAYING");
+      function onCanPlay() {
+        window.canPlay = true;
+        if (window.notifyBrowser)
+          notifyWhenCanPlay();
+      }
+      function notifyWhenCanPlay() {
+        if (window.canPlay)
+          window.domAutomationController.send("CANPLAY");
         else
           window.notifyBrowser = true;
       }

--- a/test/data/autoplay/index.html
+++ b/test/data/autoplay/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<script>
+  function clickAutoplayByAttr() {
+    document.getElementById("gotoAutoplayByAttr").click();
+    window.domAutomationController.send(true);
+  }
+  function clickAutoplayByMethod() {
+    document.getElementById("gotoAutoplayByMethod").click();
+    window.domAutomationController.send(true);
+  }
+  function clickAutoplayByAttrMuted() {
+    document.getElementById("gotoAutoplayByAttrMuted").click();
+    window.domAutomationController.send(true);
+  }
+  function clickAutoplayByMethodMuted() {
+    document.getElementById("gotoAutoplayByMethodMuted").click();
+    window.domAutomationController.send(true);
+  }
+</script>
+
+<body>
+  <a href="./autoplay_by_attr.html" id="gotoAutoplayByAttr">Autoplay by attr</a>
+  <a href="./autoplay_by_method.html" id="gotoAutoplayByMethod">Autoplay by method</a>
+  <a href="./autoplay_by_attr_muted.html" id="gotoAutoplayByAttrMuted">Autoplay by attr muted</a>
+  <a href="./autoplay_by_method_muted.html" id="gotoAutoplayByMethodMuted">Autoplay by method muted</a>
+</body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/10811

This PR enforce autoplay blocking by setting policy to `kUserGestureRequired` and clear user activation(this is required for navigation and reloading) when autoplay setting is blocked. Also brings back autoplay blocked indicator.
The test is updated so that we can catch autoplay is not blocked in the future

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Go to youtube.com
2. Set autoplay to blocked (globally or site specifically)
3. Click any videos
4. It should not autoplay and there should be a autoplay blocked indicator on url bar
5. Click the video to play, it can be played
6. Refresh the page, it still should not autoplay
7. Navigate to other videos, it should not autoplay
 
## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
