### PR TITLE
Hide NTP dashboard settings when blankpage option is used

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -255,8 +255,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(kNewTabPageShowTogether, false);
   registry->RegisterBooleanPref(kNewTabPageShowAddCard, true);
   registry->RegisterBooleanPref(kNewTabPageShowGemini, true);
-  registry->RegisterIntegerPref(kNewTabPageShowsOptions,
-                                NewTabPageShowsOptions::DASHBOARD);
+  registry->RegisterIntegerPref(
+      kNewTabPageShowsOptions,
+      static_cast<int>(NewTabPageShowsOptions::kDashboard));
 
   // Brave Wallet
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)

--- a/browser/new_tab/new_tab_shows_options.cc
+++ b/browser/new_tab/new_tab_shows_options.cc
@@ -82,4 +82,13 @@ bool ShouldUseNewTabURLForNewTab(Profile* profile) {
          NewTabUI::IsNewTab(url);
 }
 
+bool ShouldNewTabShowDashboard(Profile* profile) {
+  auto* prefs = profile->GetPrefs();
+  if (prefs->GetInteger(kNewTabPageShowsOptions) ==
+      brave::NewTabPageShowsOptions::BLANKPAGE)
+    return false;
+
+  return ShouldUseNewTabURLForNewTab(profile);
+}
+
 }  // namespace brave

--- a/browser/new_tab/new_tab_shows_options.cc
+++ b/browser/new_tab/new_tab_shows_options.cc
@@ -30,16 +30,17 @@ GURL GetNewTabPageURL(Profile* profile) {
 
   auto* prefs = profile->GetPrefs();
 
-  int option = prefs->GetInteger(kNewTabPageShowsOptions);
-  if (option == brave::NewTabPageShowsOptions::HOMEPAGE) {
+  NewTabPageShowsOptions option = static_cast<NewTabPageShowsOptions>(
+      prefs->GetInteger(kNewTabPageShowsOptions));
+  if (option == NewTabPageShowsOptions::kHomepage) {
     if (prefs->GetBoolean(prefs::kHomePageIsNewTabPage))
       return GURL();
     return GURL(prefs->GetString(prefs::kHomePage));
-  } else if (option == brave::NewTabPageShowsOptions::BLANKPAGE) {
+  } else if (option == NewTabPageShowsOptions::kBlankpage) {
     // NewTab route will handle for blank page.
     return GURL();
   } else {
-    DCHECK_EQ(brave::NewTabPageShowsOptions::DASHBOARD, option);
+    DCHECK_EQ(NewTabPageShowsOptions::kDashboard, option);
     return GURL();
   }
 
@@ -50,7 +51,9 @@ base::Value GetNewTabShowsOptionsList(Profile* profile) {
   base::Value list(base::Value::Type::LIST);
 
   base::Value dashboard_option(base::Value::Type::DICTIONARY);
-  dashboard_option.SetIntKey("value", DASHBOARD);
+  dashboard_option.SetIntKey(
+      "value",
+      static_cast<int>(NewTabPageShowsOptions::kDashboard));
   dashboard_option.SetStringKey(
       "name",
       l10n_util::GetStringUTF8(
@@ -58,7 +61,9 @@ base::Value GetNewTabShowsOptionsList(Profile* profile) {
   list.Append(std::move(dashboard_option));
 
   base::Value homepage_option(base::Value::Type::DICTIONARY);
-  homepage_option.SetIntKey("value", HOMEPAGE);
+  homepage_option.SetIntKey(
+      "value",
+      static_cast<int>(NewTabPageShowsOptions::kHomepage));
   homepage_option.SetStringKey(
       "name",
       l10n_util::GetStringUTF8(
@@ -66,7 +71,9 @@ base::Value GetNewTabShowsOptionsList(Profile* profile) {
   list.Append(std::move(homepage_option));
 
   base::Value blankpage_option(base::Value::Type::DICTIONARY);
-  blankpage_option.SetIntKey("value", BLANKPAGE);
+  blankpage_option.SetIntKey(
+      "value",
+      static_cast<int>(NewTabPageShowsOptions::kBlankpage));
   blankpage_option.SetStringKey(
       "name",
       l10n_util::GetStringUTF8(
@@ -84,8 +91,9 @@ bool ShouldUseNewTabURLForNewTab(Profile* profile) {
 
 bool ShouldNewTabShowDashboard(Profile* profile) {
   auto* prefs = profile->GetPrefs();
-  if (prefs->GetInteger(kNewTabPageShowsOptions) ==
-      brave::NewTabPageShowsOptions::BLANKPAGE)
+  if (static_cast<NewTabPageShowsOptions>(
+          prefs->GetInteger(kNewTabPageShowsOptions)) ==
+      NewTabPageShowsOptions::kBlankpage)
     return false;
 
   return ShouldUseNewTabURLForNewTab(profile);

--- a/browser/new_tab/new_tab_shows_options.h
+++ b/browser/new_tab/new_tab_shows_options.h
@@ -25,6 +25,7 @@ enum NewTabPageShowsOptions {
 GURL GetNewTabPageURL(Profile* profile);
 base::Value GetNewTabShowsOptionsList(Profile* profile);
 bool ShouldUseNewTabURLForNewTab(Profile* profile);
+bool ShouldNewTabShowDashboard(Profile* profile);
 
 }  // namespace brave
 

--- a/browser/new_tab/new_tab_shows_options.h
+++ b/browser/new_tab/new_tab_shows_options.h
@@ -16,10 +16,10 @@ class Value;
 
 namespace brave {
 
-enum NewTabPageShowsOptions {
-  DASHBOARD,
-  HOMEPAGE,
-  BLANKPAGE
+enum class NewTabPageShowsOptions {
+  kDashboard,
+  kHomepage,
+  kBlankpage
 };
 
 GURL GetNewTabPageURL(Profile* profile);

--- a/browser/new_tab/new_tab_shows_options_unittest.cc
+++ b/browser/new_tab/new_tab_shows_options_unittest.cc
@@ -41,8 +41,9 @@ TEST_F(BraveNewTabTest, BasicTest) {
   auto* prefs = profile->GetPrefs();
 
   // Check NTP url is empty for DASHBOARD.
-  prefs->SetInteger(kNewTabPageShowsOptions,
-                    brave::NewTabPageShowsOptions::DASHBOARD);
+  prefs->SetInteger(
+      kNewTabPageShowsOptions,
+      static_cast<int>(brave::NewTabPageShowsOptions::kDashboard));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(profile));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(otr_profile));
   EXPECT_TRUE(brave::ShouldUseNewTabURLForNewTab(profile));
@@ -50,8 +51,9 @@ TEST_F(BraveNewTabTest, BasicTest) {
 
   // Check NTP url is empty when option is HOMEPAGE and kHomePageIsNewTabPage
   // is true.
-  prefs->SetInteger(kNewTabPageShowsOptions,
-                    brave::NewTabPageShowsOptions::HOMEPAGE);
+  prefs->SetInteger(
+      kNewTabPageShowsOptions,
+      static_cast<int>(brave::NewTabPageShowsOptions::kHomepage));
   prefs->SetString(prefs::kHomePage, "https://www.brave.com/");
   prefs->SetBoolean(prefs::kHomePageIsNewTabPage, true);
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(profile));
@@ -74,8 +76,9 @@ TEST_F(BraveNewTabTest, BasicTest) {
 
   // Check NTP url is used when option is BLANKPAGE.
   // Blank page will go NTP route and BraveNewTabUI will handle it.
-  prefs->SetInteger(kNewTabPageShowsOptions,
-                    brave::NewTabPageShowsOptions::BLANKPAGE);
+  prefs->SetInteger(
+      kNewTabPageShowsOptions,
+      static_cast<int>(brave::NewTabPageShowsOptions::kBlankpage));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(profile));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(otr_profile));
   EXPECT_TRUE(brave::ShouldUseNewTabURLForNewTab(profile));

--- a/browser/new_tab/new_tab_shows_options_unittest.cc
+++ b/browser/new_tab/new_tab_shows_options_unittest.cc
@@ -46,6 +46,7 @@ TEST_F(BraveNewTabTest, BasicTest) {
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(profile));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(otr_profile));
   EXPECT_TRUE(brave::ShouldUseNewTabURLForNewTab(profile));
+  EXPECT_TRUE(brave::ShouldNewTabShowDashboard(profile));
 
   // Check NTP url is empty when option is HOMEPAGE and kHomePageIsNewTabPage
   // is true.
@@ -56,6 +57,7 @@ TEST_F(BraveNewTabTest, BasicTest) {
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(profile));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(otr_profile));
   EXPECT_TRUE(brave::ShouldUseNewTabURLForNewTab(profile));
+  EXPECT_TRUE(brave::ShouldNewTabShowDashboard(profile));
 
   // Check NTP url is configured url when option is HOMEPAGE and
   // kHomePageIsNewTabPage is false.
@@ -63,10 +65,12 @@ TEST_F(BraveNewTabTest, BasicTest) {
   EXPECT_EQ(GURL("https://www.brave.com/"), brave::GetNewTabPageURL(profile));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(otr_profile));
   EXPECT_FALSE(brave::ShouldUseNewTabURLForNewTab(profile));
+  EXPECT_FALSE(brave::ShouldNewTabShowDashboard(profile));
 
   // If homepage url is newtab url, dashboard settings should be shown.
   prefs->SetString(prefs::kHomePage, "chrome://newtab/");
   EXPECT_TRUE(brave::ShouldUseNewTabURLForNewTab(profile));
+  EXPECT_TRUE(brave::ShouldNewTabShowDashboard(profile));
 
   // Check NTP url is used when option is BLANKPAGE.
   // Blank page will go NTP route and BraveNewTabUI will handle it.
@@ -75,4 +79,5 @@ TEST_F(BraveNewTabTest, BasicTest) {
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(profile));
   EXPECT_EQ(GURL(), brave::GetNewTabPageURL(otr_profile));
   EXPECT_TRUE(brave::ShouldUseNewTabURLForNewTab(profile));
+  EXPECT_FALSE(brave::ShouldNewTabShowDashboard(profile));
 }

--- a/browser/ui/webui/brave_new_tab_ui.cc
+++ b/browser/ui/webui/brave_new_tab_ui.cc
@@ -28,7 +28,7 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui, const std::string& name)
 
   const bool show_blank_page_for_newtab =
       profile->GetPrefs()->GetInteger(kNewTabPageShowsOptions) ==
-          brave::NewTabPageShowsOptions::BLANKPAGE;
+          static_cast<int>(brave::NewTabPageShowsOptions::kBlankpage);
 
   if (show_blank_page_for_newtab) {
     content::WebUIDataSource* source =

--- a/browser/ui/webui/settings/brave_appearance_handler.cc
+++ b/browser/ui/webui/settings/brave_appearance_handler.cc
@@ -286,10 +286,9 @@ void BraveAppearanceHandler::OnPreferenceChanged(const std::string& pref_name) {
     if (pref_name == kNewTabPageShowsOptions ||
         pref_name == prefs::kHomePage ||
         pref_name == prefs::kHomePageIsNewTabPage) {
-      const bool show_dashboard_settings =
-          brave::ShouldUseNewTabURLForNewTab(profile_);
-      FireWebUIListener("show-new-tab-dashboard-settings-changed",
-                        base::Value(show_dashboard_settings));
+      FireWebUIListener(
+          "show-new-tab-dashboard-settings-changed",
+          base::Value(brave::ShouldNewTabShowDashboard(profile_)));
       return;
     }
   }
@@ -339,7 +338,7 @@ void BraveAppearanceHandler::ShouldShowNewTabDashboardSettings(
     const base::ListValue* args) {
   CHECK_EQ(args->GetSize(), 1U);
   AllowJavascript();
-  bool show_dashboard_settings = brave::ShouldUseNewTabURLForNewTab(profile_);
-  ResolveJavascriptCallback(args->GetList()[0],
-                            base::Value(show_dashboard_settings));
+  ResolveJavascriptCallback(
+      args->GetList()[0],
+      base::Value(brave::ShouldNewTabShowDashboard(profile_)));
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/2999

<img width="770" alt="Screen Shot 2020-10-23 at 5 41 29 PM" src="https://user-images.githubusercontent.com/6786187/96976677-13980500-1557-11eb-87df-7ddc4208da83.png">

F/U PR for https://github.com/brave/brave-core/pull/6879
In the first PR, it worked initially. but broken after using NTP url for blank page also.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [x] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_unit_tests -- --filter=*BraveNewTabTest*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
