### PR TITLE
Separate origins and cookies for different IPFS CID

### DIFF
--- a/browser/ipfs/content_browser_client_helper_unittest.cc
+++ b/browser/ipfs/content_browser_client_helper_unittest.cc
@@ -49,7 +49,7 @@ const GURL& GetIPFSGatewayURL() {
 
 const GURL& GetIPFSLocalURL() {
   static const GURL ipfs_url(
-      "http://127.0.0.1:48080/ipfs/"
+      "http://localhost:48080/ipfs/"
       "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/"
       "Vincent_van_Gogh.html");  // NOLINT
   return ipfs_url;

--- a/browser/net/brave_network_delegate_browsertest.cc
+++ b/browser/net/brave_network_delegate_browsertest.cc
@@ -13,10 +13,10 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "components/content_settings/core/browser/cookie_settings.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/content_settings/core/common/pref_names.h"
 #include "components/network_session_configurator/common/network_switches.h"
-#include "components/content_settings/core/browser/cookie_settings.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
@@ -71,8 +71,7 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
     top_level_page_url_ = https_server_.GetURL("a.com", "/");
     https_top_level_page_url_ = https_server_.GetURL("a.com", "/");
 
-    cookie_iframe_url_ =
-        https_server_.GetURL("a.com", "/cookie_iframe.html");
+    cookie_iframe_url_ = https_server_.GetURL("a.com", "/cookie_iframe.html");
     https_cookie_iframe_url_ =
         https_server_.GetURL("a.com", "/cookie_iframe.html");
 
@@ -84,8 +83,8 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
         "subdomain.a.com",
         "/set-cookie?name=subdomainacom;SameSite=None;Secure");
 
-    domain_registry_url_ = https_server_.GetURL("mobile.twitter.com",
-                                                        "/cookie_iframe.html");
+    domain_registry_url_ =
+        https_server_.GetURL("mobile.twitter.com", "/cookie_iframe.html");
     iframe_domain_registry_url_ =
         https_server_.GetURL("blah.twitter.com",
                              "/set-cookie?name=blahtwittercom;domain=twitter."
@@ -99,19 +98,18 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
     first_party_pattern_ =
         ContentSettingsPattern::FromString("https://firstParty/*");
 
-    wordpress_top_url_ = https_server_
-        .GetURL("example.wordpress.com", "/cookie_iframe.html");
+    wordpress_top_url_ =
+        https_server_.GetURL("example.wordpress.com", "/cookie_iframe.html");
     wordpress_frame_url_ = https_server_.GetURL(
         "example.wordpress.com", "/set-cookie?frame=true;SameSite=None;Secure");
-    wp_top_url_ = https_server_
-        .GetURL("example.wp.com", "/cookie_iframe.html");
+    wp_top_url_ = https_server_.GetURL("example.wp.com", "/cookie_iframe.html");
     wp_frame_url_ = https_server_.GetURL(
         "example.wp.com", "/set-cookie?frame=true;SameSite=None;Secure");
     a_frame_url_ = https_server_.GetURL(
         "a.com", "/set-cookie?frame=true;SameSite=None;Secure");
 
-    ipfs_cid1_url_ = https_server_.GetURL(
-        "cid1.ipfs.localhost", "/ipfs_cookie_iframe.html");
+    ipfs_cid1_url_ =
+        https_server_.GetURL("cid1.ipfs.localhost", "/ipfs_cookie_iframe.html");
     ipfs_cid2_frame_url_ = https_server_.GetURL(
         "cid2.ipfs.localhost", "/set-cookie?frame=true;SameSite=None;Secure");
   }
@@ -128,57 +126,46 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
   }
 
   void DefaultBlockAllCookies() {
-    brave_shields::SetCookieControlType(content_settings(),
-                                        brave_shields::ControlType::BLOCK,
-                                        GURL());
+    brave_shields::SetCookieControlType(
+        content_settings(), brave_shields::ControlType::BLOCK, GURL());
   }
 
   void DefaultBlockThirdPartyCookies() {
     brave_shields::SetCookieControlType(
-        content_settings(),
-        brave_shields::ControlType::BLOCK_THIRD_PARTY,
+        content_settings(), brave_shields::ControlType::BLOCK_THIRD_PARTY,
         GURL());
   }
 
   void DefaultAllowAllCookies() {
-    brave_shields::SetCookieControlType(content_settings(),
-                                        brave_shields::ControlType::ALLOW,
-                                        GURL());
+    brave_shields::SetCookieControlType(
+        content_settings(), brave_shields::ControlType::ALLOW, GURL());
   }
 
   void AllowCookies(const GURL url) {
     brave_shields::SetCookieControlType(content_settings(),
-                                        brave_shields::ControlType::ALLOW,
-                                        url);
+                                        brave_shields::ControlType::ALLOW, url);
   }
 
   void BlockThirdPartyCookies(const GURL url) {
     brave_shields::SetCookieControlType(
-        content_settings(),
-        brave_shields::ControlType::BLOCK_THIRD_PARTY,
-        url);
+        content_settings(), brave_shields::ControlType::BLOCK_THIRD_PARTY, url);
   }
 
   void BlockCookies(const GURL url) {
     brave_shields::SetCookieControlType(content_settings(),
-                                        brave_shields::ControlType::BLOCK,
-                                        url);
+                                        brave_shields::ControlType::BLOCK, url);
   }
 
   void ShieldsDown(const GURL url) {
-    brave_shields::SetBraveShieldsEnabled(content_settings(),
-                                          false,
-                                          url);
+    brave_shields::SetBraveShieldsEnabled(content_settings(), false, url);
   }
 
   void NavigateToPageWithFrame(const GURL url) {
     ui_test_utils::NavigateToURL(browser(), url);
   }
 
-  void ExpectCookiesOnHost(const GURL url,
-                           const std::string& expected) {
-    EXPECT_EQ(expected, content::GetCookies(browser()->profile(),
-                                            url));
+  void ExpectCookiesOnHost(const GURL url, const std::string& expected) {
+    EXPECT_EQ(expected, content::GetCookies(browser()->profile(), url));
   }
 
   void NavigateFrameTo(const GURL url, const std::string& id = "test") {
@@ -297,18 +284,16 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
 
   auto* web_contents = browser()->tab_strip_model()->GetActiveWebContents();
 
-  NavigateFrameTo(
-      https_server_.GetURL("b.com", "/iframe_cookie.html"),
-      "nested_iframe");
+  NavigateFrameTo(https_server_.GetURL("b.com", "/iframe_cookie.html"),
+                  "nested_iframe");
 
   content::RenderFrameHost* child_frame =
       content::ChildFrameAt(web_contents->GetMainFrame(), 0);
   NavigateRenderFrameToURL(child_frame, "iframe_cookie",
-      subdomain_first_party_cookie_url_);
+                           subdomain_first_party_cookie_url_);
 
   ExpectCookiesOnHost(subdomain_first_party_cookie_url_, "name=subdomainacom");
 }
-
 
 IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
                        PrefToggleBlockAllToBlockThirdParty) {
@@ -316,8 +301,9 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultBlockThirdPartyCookies();
 
   EXPECT_EQ(static_cast<content_settings::CookieControlsMode>(
-      browser()->profile()->GetPrefs()->GetInteger(prefs::kCookieControlsMode)),
-      content_settings::CookieControlsMode::kBlockThirdParty);
+                browser()->profile()->GetPrefs()->GetInteger(
+                    prefs::kCookieControlsMode)),
+            content_settings::CookieControlsMode::kBlockThirdParty);
 
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
                 "profile.default_content_setting_values.cookies"),
@@ -339,8 +325,9 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultAllowAllCookies();
 
   EXPECT_EQ(static_cast<content_settings::CookieControlsMode>(
-      browser()->profile()->GetPrefs()->GetInteger(prefs::kCookieControlsMode)),
-      content_settings::CookieControlsMode::kOff);
+                browser()->profile()->GetPrefs()->GetInteger(
+                    prefs::kCookieControlsMode)),
+            content_settings::CookieControlsMode::kOff);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
                 "profile.default_content_setting_values.cookies"),
             ContentSetting::CONTENT_SETTING_ALLOW);
@@ -358,8 +345,9 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultAllowAllCookies();
 
   EXPECT_EQ(static_cast<content_settings::CookieControlsMode>(
-      browser()->profile()->GetPrefs()->GetInteger(prefs::kCookieControlsMode)),
-      content_settings::CookieControlsMode::kOff);
+                browser()->profile()->GetPrefs()->GetInteger(
+                    prefs::kCookieControlsMode)),
+            content_settings::CookieControlsMode::kOff);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
                 "profile.default_content_setting_values.cookies"),
             ContentSetting::CONTENT_SETTING_ALLOW);
@@ -377,8 +365,9 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultBlockAllCookies();
 
   EXPECT_EQ(static_cast<content_settings::CookieControlsMode>(
-      browser()->profile()->GetPrefs()->GetInteger(prefs::kCookieControlsMode)),
-      content_settings::CookieControlsMode::kBlockThirdParty);
+                browser()->profile()->GetPrefs()->GetInteger(
+                    prefs::kCookieControlsMode)),
+            content_settings::CookieControlsMode::kBlockThirdParty);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
                 "profile.default_content_setting_values.cookies"),
             ContentSetting::CONTENT_SETTING_BLOCK);
@@ -396,8 +385,9 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultBlockThirdPartyCookies();
 
   EXPECT_EQ(static_cast<content_settings::CookieControlsMode>(
-      browser()->profile()->GetPrefs()->GetInteger(prefs::kCookieControlsMode)),
-      content_settings::CookieControlsMode::kBlockThirdParty);
+                browser()->profile()->GetPrefs()->GetInteger(
+                    prefs::kCookieControlsMode)),
+            content_settings::CookieControlsMode::kBlockThirdParty);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
                 "profile.default_content_setting_values.cookies"),
             ContentSetting::CONTENT_SETTING_ALLOW);
@@ -415,8 +405,9 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
   DefaultBlockAllCookies();
 
   EXPECT_EQ(static_cast<content_settings::CookieControlsMode>(
-      browser()->profile()->GetPrefs()->GetInteger(prefs::kCookieControlsMode)),
-      content_settings::CookieControlsMode::kBlockThirdParty);
+                browser()->profile()->GetPrefs()->GetInteger(
+                    prefs::kCookieControlsMode)),
+            content_settings::CookieControlsMode::kBlockThirdParty);
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetInteger(
                 "profile.default_content_setting_values.cookies"),
             ContentSetting::CONTENT_SETTING_BLOCK);

--- a/browser/net/brave_network_delegate_browsertest.cc
+++ b/browser/net/brave_network_delegate_browsertest.cc
@@ -109,6 +109,11 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
         "example.wp.com", "/set-cookie?frame=true;SameSite=None;Secure");
     a_frame_url_ = https_server_.GetURL(
         "a.com", "/set-cookie?frame=true;SameSite=None;Secure");
+
+    ipfs_cid1_url_ = https_server_.GetURL(
+        "cid1.ipfs.localhost", "/ipfs_cookie_iframe.html");
+    ipfs_cid2_frame_url_ = https_server_.GetURL(
+        "cid2.ipfs.localhost", "/set-cookie?frame=true;SameSite=None;Secure");
   }
 
   HostContentSettingsMap* content_settings() {
@@ -205,6 +210,8 @@ class BraveNetworkDelegateBrowserTest : public InProcessBrowserTest {
   GURL wp_top_url_;
   GURL wp_frame_url_;
   GURL a_frame_url_;
+  GURL ipfs_cid1_url_;
+  GURL ipfs_cid2_frame_url_;
   net::test_server::EmbeddedTestServer https_server_;
 
  private:
@@ -661,4 +668,24 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
 
   NavigateFrameTo(wordpress_frame_url_);
   ExpectCookiesOnHost(GURL("https://example.wordpress.com"), "frame=true");
+}
+
+IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
+                       BlockThirdPartyCookiesIPFSLocalhost) {
+  DefaultBlockThirdPartyCookies();
+
+  NavigateToPageWithFrame(ipfs_cid1_url_);
+  NavigateFrameTo(ipfs_cid2_frame_url_);
+  ExpectCookiesOnHost(ipfs_cid1_url_, "name=Good");
+  ExpectCookiesOnHost(ipfs_cid2_frame_url_, "");
+}
+
+IN_PROC_BROWSER_TEST_F(BraveNetworkDelegateBrowserTest,
+                       AllowAllCookiesIPFSLocalhost) {
+  DefaultAllowAllCookies();
+
+  NavigateToPageWithFrame(ipfs_cid1_url_);
+  NavigateFrameTo(ipfs_cid2_frame_url_);
+  ExpectCookiesOnHost(ipfs_cid1_url_, "name=Good");
+  ExpectCookiesOnHost(ipfs_cid2_frame_url_, "frame=true");
 }

--- a/browser/net/ipfs_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/ipfs_redirect_network_delegate_helper_unittest.cc
@@ -35,7 +35,7 @@ TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIIPFSSchemeLocal) {
                                                      brave_request_info);
   EXPECT_EQ(rc, net::OK);
   EXPECT_EQ(brave_request_info->new_url_spec,
-            "http://127.0.0.1:48080/ipfs/"
+            "http://localhost:48080/ipfs/"
             "QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
 }
 
@@ -59,7 +59,7 @@ TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIIPNSSchemeLocal) {
                                                      brave_request_info);
   EXPECT_EQ(rc, net::OK);
   EXPECT_EQ(brave_request_info->new_url_spec,
-            "http://127.0.0.1:48080/ipns/"
+            "http://localhost:48080/ipns/"
             "QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd");
 }
 

--- a/chromium_src/net/base/lookup_string_in_fixed_set.cc
+++ b/chromium_src/net/base/lookup_string_in_fixed_set.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define LookupSuffixInReversedSet LookupSuffixInReversedSet_ChromiumImpl
+#include "../../../../net/base/lookup_string_in_fixed_set.cc"
+#undef LookupSuffixInReversedSet
+
+#include "base/strings/string_util.h"
+
+namespace net {
+
+int LookupSuffixInReversedSet(const unsigned char* graph,
+                              size_t length,
+                              bool include_private,
+                              base::StringPiece host,
+                              size_t* suffix_length) {
+  // Special cases to be treated as public suffixes for security concern.
+  // With this, {CID}.ipfs.localhost with different CIDs cannot share cookies.
+  if (base::EndsWith(host, ".ipfs.localhost") ||
+      base::EndsWith(host, ".ipns.localhost")) {
+    *suffix_length = 14;
+    return kDafsaFound;
+  }
+
+  return LookupSuffixInReversedSet_ChromiumImpl(
+      graph, length, include_private, host, suffix_length);
+}
+
+}  // namespace net

--- a/chromium_src/net/base/lookup_string_in_fixed_set.cc
+++ b/chromium_src/net/base/lookup_string_in_fixed_set.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "net/base/lookup_string_in_fixed_set.h"
+
 #define LookupSuffixInReversedSet LookupSuffixInReversedSet_ChromiumImpl
 #include "../../../../net/base/lookup_string_in_fixed_set.cc"
 #undef LookupSuffixInReversedSet
@@ -11,21 +13,35 @@
 
 namespace net {
 
+// Chromium pulls upstream public suffix list in effective_tld_names.dat and
+// generate effective_tld_names.gperf from it. The list is processed by
+// net/tools/dafsa/make_dafsa.py which will generate a byte array in
+// effective_tld_names-reversed-inc.cc from the list to be used for comparison
+// in the run-time. This function is the only function which looks up entries
+// in the public suffix list, so we add our special case handling here to avoid
+// patching effective_tld_names.gperf directly.
 int LookupSuffixInReversedSet(const unsigned char* graph,
                               size_t length,
                               bool include_private,
                               base::StringPiece host,
                               size_t* suffix_length) {
+  constexpr char kIpfsLocalhost[] = ".ipfs.localhost";
+  constexpr char kIpnsLocalhost[] = ".ipns.localhost";
+
+  static_assert(sizeof(kIpfsLocalhost) == sizeof(kIpnsLocalhost),
+                "size should be equal");
+
   // Special cases to be treated as public suffixes for security concern.
   // With this, {CID}.ipfs.localhost with different CIDs cannot share cookies.
-  if (base::EndsWith(host, ".ipfs.localhost") ||
-      base::EndsWith(host, ".ipns.localhost")) {
-    *suffix_length = 14;
+  if (base::EndsWith(host, kIpfsLocalhost) ||
+      base::EndsWith(host, kIpnsLocalhost)) {
+    //  Don't count the leading dot.
+    *suffix_length = strlen(kIpfsLocalhost) - 1;
     return kDafsaFound;
   }
 
-  return LookupSuffixInReversedSet_ChromiumImpl(
-      graph, length, include_private, host, suffix_length);
+  return LookupSuffixInReversedSet_ChromiumImpl(graph, length, include_private,
+                                                host, suffix_length);
 }
 
 }  // namespace net

--- a/components/ipfs/ipfs_constants.cc
+++ b/components/ipfs/ipfs_constants.cc
@@ -16,7 +16,7 @@ const char kShutdownPath[] = "/api/v0/shutdown";
 const char kIPFSScheme[] = "ipfs";
 const char kIPNSScheme[] = "ipns";
 const char kDefaultIPFSGateway[] = "https://dweb.link";
-const char kDefaultIPFSLocalGateway[] = "http://127.0.0.1:48080";
+const char kDefaultIPFSLocalGateway[] = "http://localhost:48080";
 const char kIPFSLearnMoreURL[] =
     "https://support.brave.com/hc/en-us/articles/360051406452";
 

--- a/components/ipfs/ipfs_cookie_store_unittest.cc
+++ b/components/ipfs/ipfs_cookie_store_unittest.cc
@@ -1,0 +1,83 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "net/cookies/cookie_monster_store_test.h"  // For CookieStore mock
+#include "net/cookies/cookie_store.h"
+#include "net/cookies/cookie_store_unittest.h"
+#include "net/log/test_net_log.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace net {
+
+struct IPFSCookieStoreTestTraits {
+  static std::unique_ptr<CookieStore> Create() {
+    return std::make_unique<CookieMonster>(nullptr /* store */,
+                                           nullptr /* netlog */);
+  }
+
+  static void DeliverChangeNotifications() { base::RunLoop().RunUntilIdle(); }
+
+  static const bool supports_http_only = true;
+  static const bool supports_non_dotted_domains = true;
+  static const bool preserves_trailing_dots = true;
+  static const bool filters_schemes = true;
+  static const bool has_path_prefix_bug = false;
+  static const bool forbids_setting_empty_name = false;
+  static const int creation_time_granularity_in_ms = 0;
+  static const bool supports_cookie_access_semantics = true;
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(IPFSCookieStore,
+                               CookieStoreTest,
+                               IPFSCookieStoreTestTraits);
+
+class IPFSCookieStoreTest : public CookieStoreTest<IPFSCookieStoreTestTraits> {
+ protected:
+  GURL GetIPFSURL(const std::string& cid) {
+    return GURL("http://" + cid + ".ipfs.localhost:48080");
+  }
+
+  GURL GetIPNSURL(const std::string& cid) {
+    return GURL("http://" + cid + ".ipns.localhost:48080");
+  }
+
+  RecordingTestNetLog net_log_;
+};
+
+TEST_F(IPFSCookieStoreTest, SetCookie) {
+  scoped_refptr<MockPersistentCookieStore> store(new MockPersistentCookieStore);
+  std::unique_ptr<CookieMonster> cm(new CookieMonster(store.get(), &net_log_));
+
+  // Verify
+  // 1. {CID}.ipfs.localhost can set cookies for itself
+  // 2. {CID}.ipfs.localhost cannot set cookies for ipfs.localhost
+  // 3. cid1.ipfs.localhost cannot access cookies set for cid2.ipfs.localhost,
+  //    and vise virsa.
+  GURL ipfs_url_cid1("http://cid1.ipfs.localhost:48080");
+  GURL ipfs_url_cid2("http://cid2.ipfs.localhost:48080");
+
+  EXPECT_TRUE(SetCookie(cm.get(), ipfs_url_cid1, "A=B"));
+  EXPECT_TRUE(SetCookie(cm.get(), ipfs_url_cid2, "C=D"));
+  EXPECT_FALSE(
+      SetCookie(cm.get(), ipfs_url_cid2, "E=F; domain=ipfs.localhost"));
+  MatchCookieLines("A=B", GetCookies(cm.get(), ipfs_url_cid1));
+  MatchCookieLines("C=D", GetCookies(cm.get(), ipfs_url_cid2));
+  MatchCookieLines("", GetCookies(cm.get(), GURL("http://ipfs.localhost")));
+
+  // Verify above for IPNS too.
+  GURL ipns_url_cid1("http://cid1.ipns.localhost:48080");
+  GURL ipns_url_cid2("http://cid2.ipns.localhost:48080");
+
+  EXPECT_TRUE(SetCookie(cm.get(), ipns_url_cid1, "G=H"));
+  EXPECT_TRUE(SetCookie(cm.get(), ipns_url_cid2, "I=J"));
+  EXPECT_FALSE(
+      SetCookie(cm.get(), ipns_url_cid2, "L=M; domain=ipns.localhost"));
+  MatchCookieLines("G=H", GetCookies(cm.get(), ipns_url_cid1));
+  MatchCookieLines("I=J", GetCookies(cm.get(), ipns_url_cid2));
+  MatchCookieLines("", GetCookies(cm.get(), GURL("http://ipns.localhost")));
+}
+
+}  // namespace net

--- a/components/ipfs/test/BUILD.gn
+++ b/components/ipfs/test/BUILD.gn
@@ -11,6 +11,7 @@ source_set("brave_ipfs_unit_tests") {
   testonly = true
   if (ipfs_enabled) {
     sources = [
+      "//brave/components/ipfs/ipfs_cookie_store_unittest.cc",
       "//brave/components/ipfs/ipfs_json_parser_unittest.cc",
       "//brave/components/ipfs/ipfs_navigation_throttle_unittest.cc",
       "//brave/components/ipfs/ipfs_p3a_unittest.cc",
@@ -29,6 +30,8 @@ source_set("brave_ipfs_unit_tests") {
       "//chrome/test:test_support",
       "//content/public/browser",
       "//content/test:test_support",
+      "//net",
+      "//net:test_support",
       "//testing/gtest",
       "//url",
     ]

--- a/components/ipfs/translate_ipfs_uri_unittest.cc
+++ b/components/ipfs/translate_ipfs_uri_unittest.cc
@@ -53,7 +53,7 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSSchemeLocal) {
   GURL url("ipfs://QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   GURL new_url;
   ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, true));
-  EXPECT_EQ(new_url, GURL("http://127.0.0.1:48080/ipfs/"
+  EXPECT_EQ(new_url, GURL("http://localhost:48080/ipfs/"
                           "QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG"));
 }
 
@@ -61,7 +61,7 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPNSSchemeLocal) {
   GURL url("ipns://QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd");
   GURL new_url;
   ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, true));
-  EXPECT_EQ(new_url, GURL("http://127.0.0.1:48080/ipns/"
+  EXPECT_EQ(new_url, GURL("http://localhost:48080/ipns/"
                           "QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd"));
 }
 

--- a/test/data/ipfs_cookie_iframe.html
+++ b/test/data/ipfs_cookie_iframe.html
@@ -1,0 +1,5 @@
+<html><head><title>IPFS cookie test</title></head>
+<body>
+<script src="/cross-site/cid1.ipfs.localhost/script_cookies.js"></script>
+<iframe src="simple.html" id="test"></iframe>
+</body></html>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12367

With this PR, visit ipfs://{CID} will receive HTTP 301 Moved from the local daemon gateway to redirect us to http://{CID}.ipfs.localhost:48080 to separate origins between different CIDs. And ipfs.localhost and ipns.localhost would be considered as a match in public suffix list for not sharing cookies between different CIDs through their parent domain.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [x] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
1. Make sure IPFS feature is enabled in brave://flags
2. Visit ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR, if it triggers the infobar for enabling IPFS support, accept it.
3. Verify that `Method to resolve IPFS locations` is set to `Local node` in brave://settings
4. Verify daemon is launched in brave://ipfs
5. Open a new tab and visit ipfs://bafkreifik2tbj5esf74sf2qwft2x3vuxaqmthwh3d2qx6abpcroirqpt7i, verify that the origin should be shown as http://bafkreifik2tbj5esf74sf2qwft2x3vuxaqmthwh3d2qx6abpcroirqpt7i.ipfs.localhost:48080 on the page.
6. Open a dev console in page `ipfs://bafkreifik2tbj5esf74sf2qwft2x3vuxaqmthwh3d2qx6abpcroirqpt7i`, run `document.cookie = "A=B; domain=ipfs.localhost"`, run `document.cookie` again, cookie result should remain empty.
7. Open a dev console in page `ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR`, run `dockment.cookie` should return empty result too.
8. Open a new tab and visit `ipns://en.wikipedia-on-ipfs.org/wiki/Vincent_van_Gogh.html#Style_and_works`, open a dev console and run `window.location`, origin should be `http://en.wikipedia-on-ipfs.org.ipns.localhost:48080`
9. Run `document.cookie = "A=B; domain=ipns.localhost"` and run `document.cookie` again, the last result should be empty.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
