### PR TITLE
removes notification on Android on upgrade (uplift to 1.16.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/upgrade/BravePackageReplacedBroadcastReceiver.java
+++ b/android/java/org/chromium/chrome/browser/upgrade/BravePackageReplacedBroadcastReceiver.java
@@ -23,11 +23,15 @@ public final class BravePackageReplacedBroadcastReceiver extends BroadcastReceiv
     public void onReceive(final Context context, Intent intent) {
         if (!Intent.ACTION_MY_PACKAGE_REPLACED.equals(intent.getAction())) return;
         BraveUpgradeJobIntentService.maybePerformUpgradeTasks(context);
-        SharedPreferencesManager.getInstance().writeInt(BravePreferenceKeys.BRAVE_APP_OPEN_COUNT, 0);
         try {
-            NotificationIntent.fireNotificationIfNecessary(context);
+            SharedPreferencesManager.getInstance().writeInt(BravePreferenceKeys.BRAVE_APP_OPEN_COUNT, 0);
         } catch (Exception exc) {
-            // Just ignore if we could not send a notification
+            // Sometimes the pref is not registered yet in the app
         }
+        // try {
+        //     NotificationIntent.fireNotificationIfNecessary(context);
+        // } catch (Exception exc) {
+        //     // Just ignore if we could not send a notification
+        // }
     }
 }


### PR DESCRIPTION
Uplift of #7047
Resolves https://github.com/brave/brave-browser/issues/12507

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.