### PR TITLE
Always notify when browser confirms this install is not SR anymore

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc
@@ -338,6 +338,8 @@ TEST_F(NTPBackgroundImagesServiceTest, BasicSuperReferralTest) {
 // Sponsored Images component will be run after promo code set to pref.
 TEST_F(NTPBackgroundImagesServiceTest, WithDefaultReferralCodeTest1) {
   Init();
+  TestObserver observer;
+  service_->AddObserver(&observer);
 
   // Initially, only SI is started and pref is monitored to get referral code.
   EXPECT_TRUE(service_->sponsored_images_component_started_);
@@ -347,9 +349,12 @@ TEST_F(NTPBackgroundImagesServiceTest, WithDefaultReferralCodeTest1) {
   EXPECT_FALSE(service_->super_referral_component_started_);
   EXPECT_FALSE(service_->marked_this_install_is_not_super_referral_forever_);
 
-  // If default code is set, SI component is started.
+  observer.on_super_referral_ended_ = false;
   pref_service_.SetString(kReferralPromoCode, "BRV001");
   EXPECT_TRUE(service_->marked_this_install_is_not_super_referral_forever_);
+  // We should notify OnSuperReferralEnded() if this is not NTP SR
+  // (default promo code).
+  EXPECT_TRUE(observer.on_super_referral_ended_);
 }
 
 // Test default referral code and not first run.
@@ -395,10 +400,10 @@ TEST_F(NTPBackgroundImagesServiceTest, WithNonSuperReferralCodeTest) {
   // complete. Only gives NTP SI data when browser confirms this is not NTP SR.
   EXPECT_EQ(nullptr, service_->GetBackgroundImagesData(false));
 
-  observer.on_updated_ = false;
+  observer.on_super_referral_ended_ = false;
   service_->OnGetMappingTableData(kTestMappingTable);
-  // We should notify OnUpdated if this is not NTP SR.
-  EXPECT_TRUE(observer.on_updated_);
+  // We should notify OnSuperReferralEnded() if this is not NTP SR.
+  EXPECT_TRUE(observer.on_super_referral_ended_);
 
   // If it's not super-referral, we mark this install is not a valid SR.
   EXPECT_TRUE(service_->marked_this_install_is_not_super_referral_forever_);


### PR DESCRIPTION
When browser confirms this install is not SR, OnSuperReferralEnded() should be called always.
With this, Observers of NTPBackgroundImagesService can handle that situation.
ViewCounterService resets it's model with proper data when SR is ended.

This is improved version of https://github.com/brave/brave-core/pull/6888.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/9728

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:
`npm run test brave_unit_tests -- --filter=*NTPBackground*`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
