### PR TITLE
Fix crash on iOS when ledger asks for a favicon with an invalid URL (uplift to 1.16.x)

### DIFF
--- a/vendor/brave-ios/Ledger/BATBraveLedger.mm
+++ b/vendor/brave-ios/Ledger/BATBraveLedger.mm
@@ -1714,11 +1714,13 @@ BATLedgerBridge(BOOL,
 
 - (void)fetchFavIcon:(const std::string &)url faviconKey:(const std::string &)favicon_key callback:(ledger::client::FetchIconCallback)callback
 {
-  if (!self.faviconFetcher) {
-    callback(NO, std::string());
+  const auto pageURL = [NSURL URLWithString:[NSString stringWithUTF8String:url.c_str()]];
+  if (!self.faviconFetcher || !pageURL) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      callback(NO, std::string());
+    });
     return;
   }
-  const auto pageURL = [NSURL URLWithString:[NSString stringWithUTF8String:url.c_str()]];
   self.faviconFetcher(pageURL, ^(NSURL * _Nullable faviconURL) {
     dispatch_async(dispatch_get_main_queue(), ^{
       callback(faviconURL != nil,


### PR DESCRIPTION
Uplift of #7077

iOS only change to be tested in brave-ios

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.