### PR TITLE
check on render_frame_host is null (uplift to 1.17.x)

### DIFF
--- a/browser/android/brave_cosmetic_resources_tab_helper.cc
+++ b/browser/android/brave_cosmetic_resources_tab_helper.cc
@@ -98,7 +98,7 @@ BraveCosmeticResourcesTabHelper::~BraveCosmeticResourcesTabHelper() {
 void BraveCosmeticResourcesTabHelper::ProcessURL(
     content::WebContents* contents,
     content::RenderFrameHost* render_frame_host, const GURL& url) {
-  if (!ShouldDoCosmeticFiltering(contents, url)) {
+  if (!render_frame_host || !ShouldDoCosmeticFiltering(contents, url)) {
     return;
   }
   g_brave_browser_process->ad_block_service()->GetTaskRunner()->


### PR DESCRIPTION
Uplift of #7083
Resolves https://github.com/brave/brave-browser/issues/12535

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.