### PR TITLE
check on render_frame_host is null (uplift to 1.16.x)

### DIFF
--- a/browser/android/brave_cosmetic_resources_tab_helper.cc
+++ b/browser/android/brave_cosmetic_resources_tab_helper.cc
@@ -98,7 +98,7 @@ BraveCosmeticResourcesTabHelper::~BraveCosmeticResourcesTabHelper() {
 void BraveCosmeticResourcesTabHelper::ProcessURL(
     content::WebContents* contents,
     content::RenderFrameHost* render_frame_host, const GURL& url) {
-  if (!ShouldDoCosmeticFiltering(contents, url)) {
+  if (!render_frame_host || !ShouldDoCosmeticFiltering(contents, url)) {
     return;
   }
   g_brave_browser_process->ad_block_service()->GetTaskRunner()->


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7083
Resolves https://github.com/brave/brave-browser/issues/12535
