### PR TITLE
WIP TEST: Reverts Chromium signing change on Mac.

### DIFF
--- a/patches/build-apple-tweak_info_plist.py.patch
+++ b/patches/build-apple-tweak_info_plist.py.patch
@@ -1,0 +1,54 @@
+diff --git a/build/apple/tweak_info_plist.py b/build/apple/tweak_info_plist.py
+index 6dde0c48233b7201a911d737ad7fc09b186b47b4..2c2fd03eac16fd873099fe0026c5ad86d407cf50 100755
+--- a/build/apple/tweak_info_plist.py
++++ b/build/apple/tweak_info_plist.py
+@@ -189,7 +189,7 @@ def _TagSuffixes():
+   return tag_suffixes
+ 
+ 
+-def _AddKeystoneKeys(plist, bundle_identifier, base_tag):
++def _AddKeystoneKeys(plist, bundle_identifier):
+   """Adds the Keystone keys. This must be called AFTER _AddVersionKeys() and
+   also requires the |bundle_identifier| argument (com.example.product)."""
+   plist['KSVersion'] = plist['CFBundleShortVersionString']
+@@ -197,18 +197,16 @@ def _AddKeystoneKeys(plist, bundle_identifier, base_tag):
+   plist['KSUpdateURL'] = 'https://tools.google.com/service/update2'
+ 
+   _RemoveKeys(plist, 'KSChannelID')
+-  if base_tag != '':
+-    plist['KSChannelID'] = base_tag
+   for tag_suffix in _TagSuffixes():
+     if tag_suffix:
+-      plist['KSChannelID' + tag_suffix] = base_tag + tag_suffix
++      plist['KSChannelID' + tag_suffix] = tag_suffix
+ 
+ 
+ def _RemoveKeystoneKeys(plist):
+   """Removes any set Keystone keys."""
+   _RemoveKeys(plist, 'KSVersion', 'KSProductID', 'KSUpdateURL')
+ 
+-  tag_keys = ['KSChannelID']
++  tag_keys = []
+   for tag_suffix in _TagSuffixes():
+     tag_keys.append('KSChannelID' + tag_suffix)
+   _RemoveKeys(plist, *tag_keys)
+@@ -243,9 +241,6 @@ def Main(argv):
+                     type='int',
+                     default=False,
+                     help='Enable Keystone [1 or 0]')
+-  parser.add_option('--keystone-base-tag',
+-                    default='',
+-                    help='Base Keystone tag to set')
+   parser.add_option('--scm',
+                     dest='add_scm_info',
+                     action='store',
+@@ -383,8 +378,7 @@ def Main(argv):
+     if options.bundle_identifier is None:
+       print('Use of Keystone requires the bundle id.', file=sys.stderr)
+       return 1
+-    _AddKeystoneKeys(plist, options.bundle_identifier,
+-                     options.keystone_base_tag)
++    _AddKeystoneKeys(plist, options.bundle_identifier)
+   else:
+     _RemoveKeystoneKeys(plist)
+ 

--- a/patches/chrome-installer-mac-signing-modification.py.patch
+++ b/patches/chrome-installer-mac-signing-modification.py.patch
@@ -1,0 +1,33 @@
+diff --git a/chrome/installer/mac/signing/modification.py b/chrome/installer/mac/signing/modification.py
+index 62461b92268e722eaa091dbd4f5bdf1ba3f14585..5b18b0bcd6597d4aa59067caaff58e19b9b8164e 100644
+--- a/chrome/installer/mac/signing/modification.py
++++ b/chrome/installer/mac/signing/modification.py
+@@ -59,15 +59,8 @@ def _modify_plists(paths, dist, config):
+         elif _KS_BRAND_ID in app_plist:
+             del app_plist[_KS_BRAND_ID]
+ 
+-        base_tag = app_plist.get(_KS_CHANNEL_ID)
+-        base_channel_tag_components = []
+-        if base_tag:
+-            base_channel_tag_components.append(base_tag)
+         if dist.channel:
+-            base_channel_tag_components.append(dist.channel)
+-        base_channel_tag = '-'.join(base_channel_tag_components)
+-        if base_channel_tag:
+-            app_plist[_KS_CHANNEL_ID] = base_channel_tag
++            app_plist[_KS_CHANNEL_ID] = dist.channel
+         elif _KS_CHANNEL_ID in app_plist:
+             del app_plist[_KS_CHANNEL_ID]
+ 
+@@ -82,8 +75,9 @@ def _modify_plists(paths, dist, config):
+         for key in app_plist.keys():
+             if not key.startswith(_KS_CHANNEL_ID + '-'):
+                 continue
+-            ignore, extra = key.split('-')
+-            app_plist[key] = '{}-{}'.format(base_channel_tag, extra)
++            orig_channel, tag = key.split('-')
++            channel_str = dist.channel if dist.channel else ''
++            app_plist[key] = '{}-{}'.format(channel_str, tag)
+ 
+ 
+ def _replace_icons(paths, dist, config):


### PR DESCRIPTION
This reverts the meaningful bits of https://source.chromium.org/chromium/chromium/src/+/93f72e664af45c0deadc6a89af6e28811c9f10a7
to test if this is the cause of the missing KSChannelID.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
