### PR TITLE
Fixed wrong channel id in Info.plist (uplift to 1.17.x)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -512,6 +512,10 @@ if (is_mac) {
       "--brave_version=" + brave_version,
     ]
 
+    if (skip_signing) {
+      args += [ "--skip_signing" ]
+    }
+
     deps = [
       "//chrome:chrome_app_plist",
     ]

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -79,6 +79,7 @@ def Main(argv):
   parser.add_option('--format', choices=('binary1', 'xml1', 'json'),
       default='xml1', help='Format to use when writing property list '
           '(default: %(default)s)')
+  parser.add_option('--skip_signing', dest='skip_signing', action='store_true')
   (options, args) = parser.parse_args(argv)
 
   if len(args) > 0:
@@ -101,8 +102,11 @@ def Main(argv):
   if options.plist_output is not None:
     output_path = options.plist_output
 
-  if options.brave_channel:
+  if options.skip_signing:
     plist['KSChannelID'] = options.brave_channel
+  elif 'KSChannelID' in plist:
+    # 'KSChannelID' is set at _modify_plists() of modification.py.
+    del plist['KSChannelID']
 
   plist['CrProductDirName'] = options.brave_product_dir_name
 


### PR DESCRIPTION
Uplift of #7103
Resolves https://github.com/brave/brave-browser/issues/12606

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.