### PR TITLE
Fixes Brave Ads should not open the same target url for all creatives in a creative set - 1.17.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/database/database_version.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/database_version.cc
@@ -9,11 +9,11 @@ namespace ads {
 namespace database {
 
 int32_t version() {
-  return 3;
+  return 4;
 }
 
 int32_t compatible_version() {
-  return 3;
+  return 4;
 }
 
 }  // namespace database

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.cc
@@ -120,7 +120,7 @@ void CreativeAdNotifications::GetForCategories(
           "INNER JOIN categories AS c "
               "ON c.creative_set_id = can.creative_set_id "
           "INNER JOIN creative_ads AS ca "
-              "ON ca.creative_set_id = can.creative_set_id "
+              "ON ca.creative_instance_id = can.creative_instance_id "
           "INNER JOIN geo_targets AS gt "
               "ON gt.campaign_id = can.campaign_id "
       "WHERE c.category IN %s "
@@ -194,7 +194,7 @@ void CreativeAdNotifications::GetAll(
           "INNER JOIN categories AS c "
               "ON c.creative_set_id = can.creative_set_id "
           "INNER JOIN creative_ads AS ca "
-              "ON ca.creative_set_id = can.creative_set_id "
+              "ON ca.creative_instance_id = can.creative_instance_id "
           "INNER JOIN geo_targets AS gt "
               "ON gt.campaign_id = can.campaign_id "
       "WHERE %s BETWEEN cam.start_at_timestamp AND cam.end_at_timestamp",

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.cc
@@ -73,6 +73,11 @@ void CreativeAds::Migrate(
       break;
     }
 
+    case 4: {
+      MigrateToV4(transaction);
+      break;
+    }
+
     default: {
       break;
     }
@@ -90,7 +95,7 @@ int CreativeAds::BindParameters(
 
   int index = 0;
   for (const auto& creative_ad : creative_ads) {
-    BindString(command, index++, creative_ad.creative_set_id);
+    BindString(command, index++, creative_ad.creative_instance_id);
     BindBool(command, index++, creative_ad.conversion);
     BindInt(command, index++, creative_ad.per_day);
     BindInt(command, index++, creative_ad.total_max);
@@ -109,7 +114,7 @@ std::string CreativeAds::BuildInsertOrUpdateQuery(
 
   return base::StringPrintf(
       "INSERT OR REPLACE INTO %s "
-          "(creative_set_id, "
+          "(creative_instance_id, "
           "conversion, "
           "per_day, "
           "total_max, "
@@ -154,6 +159,44 @@ void CreativeAds::MigrateToV3(
 
   CreateTableV3(transaction);
   CreateIndexV3(transaction);
+}
+
+void CreativeAds::CreateTableV4(
+    DBTransaction* transaction) {
+  DCHECK(transaction);
+
+  const std::string query = base::StringPrintf(
+      "CREATE TABLE %s "
+          "(creative_instance_id TEXT NOT NULL PRIMARY KEY UNIQUE "
+              "ON CONFLICT REPLACE, "
+          "conversion INTEGER NOT NULL DEFAULT 0, "
+          "per_day INTEGER NOT NULL DEFAULT 0, "
+          "total_max INTEGER NOT NULL DEFAULT 0, "
+          "target_url TEXT NOT NULL)",
+      get_table_name().c_str());
+
+  DBCommandPtr command = DBCommand::New();
+  command->type = DBCommand::Type::EXECUTE;
+  command->command = query;
+
+  transaction->commands.push_back(std::move(command));
+}
+
+void CreativeAds::CreateIndexV4(
+    DBTransaction* transaction) {
+  DCHECK(transaction);
+
+  util::CreateIndex(transaction, get_table_name(), "creative_instance_id");
+}
+
+void CreativeAds::MigrateToV4(
+    DBTransaction* transaction) {
+  DCHECK(transaction);
+
+  util::Drop(transaction, get_table_name());
+
+  CreateTableV4(transaction);
+  CreateIndexV4(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.h
@@ -55,6 +55,13 @@ class CreativeAds : public Table {
   void MigrateToV3(
       DBTransaction* transaction);
 
+  void CreateTableV4(
+      DBTransaction* transaction);
+  void CreateIndexV4(
+      DBTransaction* transaction);
+  void MigrateToV4(
+      DBTransaction* transaction);
+
   AdsImpl* ads_;  // NOT OWNED
 };
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table.cc
@@ -122,7 +122,7 @@ void CreativeNewTabPageAds::GetForCreativeInstanceId(
           "INNER JOIN categories AS c "
               "ON c.creative_set_id = can.creative_set_id "
           "INNER JOIN creative_ads AS ca "
-              "ON ca.creative_set_id = can.creative_set_id "
+              "ON ca.creative_instance_id = can.creative_instance_id "
           "INNER JOIN geo_targets AS gt "
               "ON gt.campaign_id = can.campaign_id "
       "WHERE can.creative_instance_id = '%s'",
@@ -194,7 +194,7 @@ void CreativeNewTabPageAds::GetForCategories(
           "INNER JOIN categories AS c "
               "ON c.creative_set_id = can.creative_set_id "
           "INNER JOIN creative_ads AS ca "
-              "ON ca.creative_set_id = can.creative_set_id "
+              "ON ca.creative_instance_id = can.creative_instance_id "
           "INNER JOIN geo_targets AS gt "
               "ON gt.campaign_id = can.campaign_id "
       "WHERE c.category IN %s "
@@ -268,7 +268,7 @@ void CreativeNewTabPageAds::GetAll(
           "INNER JOIN categories AS c "
               "ON c.creative_set_id = can.creative_set_id "
           "INNER JOIN creative_ads AS ca "
-              "ON ca.creative_set_id = can.creative_set_id "
+              "ON ca.creative_instance_id = can.creative_instance_id "
           "INNER JOIN geo_targets AS gt "
               "ON gt.campaign_id = can.campaign_id "
       "WHERE %s BETWEEN cam.start_at_timestamp AND cam.end_at_timestamp",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7127/files
Resolves https://github.com/brave/brave-browser/issues/12653

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
