### PR TITLE
Improve rewards onboarding experience

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1640,8 +1640,7 @@ void RewardsServiceImpl::SetAutoContributeEnabled(bool enabled) {
 }
 
 bool RewardsServiceImpl::ShouldShowOnboarding() const {
-  PrefService* prefs = profile_->GetPrefs();
-  const base::Time onboard_time = prefs->GetTime(prefs::kOnboarded);
+  const bool legacy_enabled = profile_->GetPrefs()->GetBoolean(prefs::kEnabled);
 
   bool ads_enabled = false;
   bool ads_supported = true;
@@ -1651,7 +1650,7 @@ bool RewardsServiceImpl::ShouldShowOnboarding() const {
     ads_supported = ads_service->IsSupportedLocale();
   }
 
-  return onboard_time.is_null() && !ads_enabled && ads_supported;
+  return !legacy_enabled && !ads_enabled && ads_supported;
 }
 
 void RewardsServiceImpl::SaveOnboardingResult(OnboardingResult result) {

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_util.cc
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_util.cc
@@ -120,4 +120,12 @@ void CreateWallet(brave_rewards::RewardsServiceImpl* rewards_service) {
   ASSERT_TRUE(success);
 }
 
+void SetOnboardingBypassed(Browser* browser, bool bypassed) {
+  DCHECK(browser);
+  // Rewards onboarding will be skipped if the legacy "enabled" pref
+  // is set to true.
+  PrefService* prefs = browser->profile()->GetPrefs();
+  prefs->SetBoolean(brave_rewards::prefs::kEnabled, bypassed);
+}
+
 }  // namespace rewards_browsertest_util

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_util.h
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_util.h
@@ -50,6 +50,8 @@ void WaitForLedgerStop(brave_rewards::RewardsServiceImpl* rewards_service);
 
 void CreateWallet(brave_rewards::RewardsServiceImpl* rewards_service);
 
+void SetOnboardingBypassed(Browser* browser, bool bypassed = true);
+
 }  // namespace rewards_browsertest_util
 
 #endif  // BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_TEST_COMMON_REWARDS_BROWSERTEST_UTIL_H_

--- a/components/brave_rewards/browser/test/rewards_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_browsertest.cc
@@ -71,9 +71,7 @@ class RewardsBrowserTest : public InProcessBrowserTest {
     contribution_->Initialize(browser(), rewards_service_);
     promotion_->Initialize(browser(), rewards_service_);
 
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
   }
 
   void TearDown() override {

--- a/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
@@ -72,9 +72,7 @@ class RewardsContributionBrowserTest : public InProcessBrowserTest {
     promotion_->Initialize(browser(), rewards_service_);
     contribution_->Initialize(browser(), rewards_service_);
 
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
   }
 
   void TearDown() override {

--- a/components/brave_rewards/browser/test/rewards_flag_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_flag_browsertest.cc
@@ -55,9 +55,7 @@ class RewardsFlagBrowserTest : public InProcessBrowserTest {
             base::Unretained(this)));
     rewards_service_->SetLedgerEnvForTesting();
 
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
   }
 
   void GetTestResponse(

--- a/components/brave_rewards/browser/test/rewards_notification_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_notification_browsertest.cc
@@ -75,9 +75,7 @@ class RewardsNotificationBrowserTest
     rewards_notification_service_ = rewards_service_->GetNotificationService();
     rewards_notification_service_->AddObserver(this);
 
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
   }
 
   void TearDown() override {

--- a/components/brave_rewards/browser/test/rewards_promotion_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_promotion_browsertest.cc
@@ -61,9 +61,7 @@ class RewardsPromotionBrowserTest : public InProcessBrowserTest {
     // Other
     promotion_->Initialize(browser(), rewards_service_);
 
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
   }
 
   void TearDown() override {

--- a/components/brave_rewards/browser/test/rewards_publisher_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_publisher_browsertest.cc
@@ -59,9 +59,7 @@ class RewardsPublisherBrowserTest : public InProcessBrowserTest {
             base::Unretained(this)));
     rewards_service_->SetLedgerEnvForTesting();
 
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
   }
 
   void TearDown() override {

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -2,10 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { OnboardingCompletedStore } from '../../../../shared/lib/onboarding_completed_store'
 import { types } from '../../constants/rewards_panel_types'
 import { Reducer } from 'redux'
 import { setBadgeText } from '../browserAction'
 import { isPublisherConnectedOrVerified } from '../../utils'
+
+const onboardingCompletedStore = new OnboardingCompletedStore()
 
 const getTabKey = (id: number) => {
   return `key_${id}`
@@ -242,12 +245,17 @@ export const rewardsPanelReducer: Reducer<RewardsExtension.State | undefined> = 
       break
     }
     case types.ON_SHOULD_SHOW_ONBOARDING: {
-      state = { ...state, showOnboarding: payload.showOnboarding }
+      const completed = onboardingCompletedStore.load()
+      state = {
+        ...state,
+        showOnboarding: payload.showOnboarding && !completed
+      }
       break
     }
     case types.SAVE_ONBOARDING_RESULT: {
       state = { ...state, showOnboarding: false }
       chrome.braveRewards.saveOnboardingResult(payload.result)
+      onboardingCompletedStore.save()
       break
     }
     case types.ON_PUBLISHER_LIST_NORMALIZED: {

--- a/components/brave_rewards/resources/page/reducers/rewards_reducer.ts
+++ b/components/brave_rewards/resources/page/reducers/rewards_reducer.ts
@@ -4,9 +4,13 @@
 
 import { Reducer } from 'redux'
 
+import { OnboardingCompletedStore } from '../../shared/lib/onboarding_completed_store'
+
 // Constant
 import { types } from '../constants/rewards_types'
 import { defaultState } from '../storage'
+
+const onboardingCompletedStore = new OnboardingCompletedStore()
 
 const rewardsReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State, action) => {
   if (!state) {
@@ -439,15 +443,17 @@ const rewardsReducer: Reducer<Rewards.State | undefined> = (state: Rewards.State
       break
     }
     case types.ON_ONBOARDING_STATUS: {
+      const completed = onboardingCompletedStore.load()
       state = {
         ...state,
-        showOnboarding: action.payload.showOnboarding
+        showOnboarding: action.payload.showOnboarding && !completed
       }
       break
     }
     case types.SAVE_ONBOARDING_RESULT: {
       chrome.send('brave_rewards.saveOnboardingResult', [action.payload.result])
       chrome.send('brave_rewards.getAutoContributeProperties')
+      onboardingCompletedStore.save()
       state = {
         ...state,
         showOnboarding: false

--- a/components/brave_rewards/resources/shared/lib/onboarding_completed_store.ts
+++ b/components/brave_rewards/resources/shared/lib/onboarding_completed_store.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// An OnboardingCompletedStore can be used by apps that include
+// rewards onboarding UX to store whether the user has interacted
+// with the onboarding experience.
+export class OnboardingCompletedStore {
+
+  load () {
+    return Boolean(localStorage.rewardsOnboardingComplete)
+  }
+
+  save () {
+    localStorage.rewardsOnboardingComplete = String(Date.now())
+  }
+}

--- a/components/brave_rewards/resources/tip/lib/host.ts
+++ b/components/brave_rewards/resources/tip/lib/host.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { OnboardingCompletedStore } from '../../shared/lib/onboarding_completed_store'
+
 import { createStateManager } from './state_manager'
 
 import {
@@ -58,6 +60,7 @@ function addWebUIListeners (listeners: Record<string, any>) {
 export function createHost (): Host {
   const stateManager = createStateManager<HostState>({})
   const dialogArgs = getDialogArgs()
+  const onboardingCompleted = new OnboardingCompletedStore()
 
   addWebUIListeners({
 
@@ -95,7 +98,7 @@ export function createHost (): Host {
 
     onboardingStatusUpdated (result: { showOnboarding: boolean }) {
       stateManager.update({
-        showOnboarding: result.showOnboarding
+        showOnboarding: result.showOnboarding && !onboardingCompleted.load()
       })
     },
 
@@ -193,6 +196,7 @@ export function createHost (): Host {
     saveOnboardingResult (result: OnboardingResult) {
       chrome.send('saveOnboardingResult', [result])
       stateManager.update({ showOnboarding: false })
+      onboardingCompleted.save()
     },
 
     processTip (amount: number, kind: TipKind) {


### PR DESCRIPTION
This PR introduces the following changes:

- Show rewards onboarding UX in various entry points independently.
- Do not show rewards onboarding to existing opted-in rewards users.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12675
Resolves https://github.com/brave/brave-browser/issues/12612

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Verified that all lint errors/warnings are resolved (`npm run lint`, `npm run gn_check`)
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Added appropriate QA labels (`QA/Yes` or `QA/No`) to the associated issue
- [ ] Added appropriate release note labels (`release-notes/include` or `release-notes/exclude`) to the associated issue
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:

### Showing onboarding at different entry points independently

Note: the following steps should demonstrate the same behavior, regardless of the order of the entry points visited (the rewards page, the rewards panel, or the tip dialog).

- Start the browser with a clean profile.
- Open the rewards panel.
  - Verify that an onboarding modal is displayed.
- Click the "X" to close the modal.
- Close the rewards panel.
- Navigate to a publisher URL (e.g. https://laurenwags.github.io)
- Open the rewards panel.
  - Verify that on onboarding modal is **not** displayed.
- Click "Send a tip".
  - Verify that an onboarding screen is displayed in the tip dialog.
- Click the "X" to close the tip dialog.
- Open the rewards panel and click "Send a tip".
  - Verify that an onboarding screen is **not** displayed in the tip dialog.
- Navigate to the rewards page.
  - Verify that an onboarding modal is displayed.
- Click the "X" to close the modal.
- Reload the page.
  - Verify that an onboarding modal is **not** displayed.

### Onboarding is not displayed for upgraded users with Rewards enabled

- Start a 1.17 browser with a clean profile.
- Navigate to the rewards page.
- Enable rewards and turn Ads off.
- Close the browser.
- With the same profile, start the browser (with this change).
- Navigate to the rewards page.
  - Verify that the oboarding modal is **not** displayed.
- Open the rewards panel.
  - Verify that the onboarding modal is **not** displayed.
- Navigate to a publisher page.
- Open the rewards panel and click "Send a tip".
  - Verify that the onboarding screen is **not** displayed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
