### PR TITLE
execute js script only when render_frame_host is still alive (uplift to 1.17.x)

### DIFF
--- a/browser/android/brave_cosmetic_resources_tab_helper.cc
+++ b/browser/android/brave_cosmetic_resources_tab_helper.cc
@@ -19,6 +19,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
 #include "content/browser/web_contents/web_contents_impl.h"
+#include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/renderer/render_frame.h"
 
@@ -64,7 +65,7 @@ std::unique_ptr<base::ListValue> GetUrlCosmeticResourcesOnTaskRunner(
   return result_list;
 }
 
-void GetUrlCosmeticResourcesOnUI(content::RenderFrameHost* render_frame_host,
+void GetUrlCosmeticResourcesOnUI(content::GlobalFrameRoutingId frame_id,
   std::unique_ptr<base::ListValue> resources) {
   if (!resources) {
     return;
@@ -78,7 +79,10 @@ void GetUrlCosmeticResourcesOnUI(content::RenderFrameHost* render_frame_host,
     std::string to_inject;
     resources_dict->GetString("injected_script", &to_inject);
     if (to_inject.length() > 1) {
-      render_frame_host->ExecuteJavaScriptInIsolatedWorld(
+      auto* frame_host = content::RenderFrameHost::FromID(frame_id);
+      if (!frame_host)
+        return;
+      frame_host->ExecuteJavaScriptInIsolatedWorld(
           base::UTF8ToUTF16(to_inject),
           base::NullCallback(), ISOLATED_WORLD_ID_CHROME_INTERNAL);
     }
@@ -104,7 +108,10 @@ void BraveCosmeticResourcesTabHelper::ProcessURL(
   g_brave_browser_process->ad_block_service()->GetTaskRunner()->
       PostTaskAndReplyWithResult(FROM_HERE,
           base::BindOnce(&GetUrlCosmeticResourcesOnTaskRunner, url.spec()),
-          base::BindOnce(&GetUrlCosmeticResourcesOnUI, render_frame_host));
+          base::BindOnce(&GetUrlCosmeticResourcesOnUI,
+              content::GlobalFrameRoutingId(
+                  render_frame_host->GetProcess()->GetID(),
+                  render_frame_host->GetRoutingID())));
 }
 
 void BraveCosmeticResourcesTabHelper::DidFinishNavigation(


### PR DESCRIPTION
Uplift of #7171
Resolves https://github.com/brave/brave-browser/issues/12745

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.