### PR TITLE
Increase rewards browsertest timeout values

### DIFF
--- a/components/brave_rewards/browser/test/common/rewards_browsertest_context_util.cc
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_context_util.cc
@@ -10,7 +10,7 @@ namespace rewards_browsertest_util {
 
 static const char kWaitForElementToAppearScript[] = R"(
     const waitForElementToAppear = (selector) => {
-      const TIMEOUT_SECONDS = 5;
+      const TIMEOUT_SECONDS = 10;
 
       return new Promise((resolve, reject) => {
         let element = document.querySelector(selector);


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12295
Resolves https://github.com/brave/brave-browser/issues/12396

This PR increases the amount of time that rewards browser tests will wait for a particular element to be rendered within a document, from the current 5 seconds to 10 seconds. Doubling the time should not have an adverse impact on CI since many of the tests which current exceed this timeout will timeout at the gtest level as well.

I ran CI on macOS and Windows twice with this change and did not see a rewards browsertest timeout.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [x] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

CI should fail less often on rewards browser tests.

