### PR TITLE
Only load IPFS subresources within IPFS/IPNS schemes 

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -191,15 +191,6 @@ bool BraveContentBrowserClient::HandleExternalProtocol(
     return true;
   }
 #endif
-#if BUILDFLAG(IPFS_ENABLED)
-  if (ipfs::IsIPFSProtocol(url) && is_main_frame) {
-    ipfs::HandleIPFSProtocol(url,
-        std::move(web_contents_getter),
-        page_transition, has_user_gesture,
-        initiating_origin);
-    return true;
-  }
-#endif
 
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
   if (brave_rewards::IsRewardsProtocol(url)) {

--- a/browser/ipfs/content_browser_client_helper.h
+++ b/browser/ipfs/content_browser_client_helper.h
@@ -25,10 +25,6 @@ class Origin;
 
 namespace ipfs {
 
-bool ShouldNavigateIPFSURI(const GURL& url,
-    GURL* new_url,
-    content::BrowserContext* browser_context);
-
 bool HandleIPFSURLReverseRewrite(
     GURL* url,
     content::BrowserContext* browser_context);
@@ -42,15 +38,6 @@ void LoadOrLaunchIPFSURL(
 
 bool HandleIPFSURLRewrite(GURL* url,
     content::BrowserContext* browser_context);
-
-void HandleIPFSProtocol(
-    const GURL& url,
-    content::WebContents::OnceGetter web_contents_getter,
-    ui::PageTransition page_transition,
-    bool has_user_gesture,
-    const base::Optional<url::Origin>& initiating_origin);
-
-bool IsIPFSProtocol(const GURL& url);
 
 }  // namespace ipfs
 

--- a/browser/ipfs/content_browser_client_helper_unittest.cc
+++ b/browser/ipfs/content_browser_client_helper_unittest.cc
@@ -39,44 +39,9 @@ const GURL& GetIPFSURI() {
   return ipfs_url;
 }
 
-const GURL& GetIPFSGatewayURL() {
-  static const GURL ipfs_url(
-      "https://dweb.link/ipfs/"
-      "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/"
-      "Vincent_van_Gogh.html");  // NOLINT
-  return ipfs_url;
-}
-
-const GURL& GetIPFSLocalURL() {
-  static const GURL ipfs_url(
-      ipfs::GetDefaultIPFSLocalGateway(chrome::GetChannel()).spec() +
-      "ipfs/bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/"
-      "Vincent_van_Gogh.html");  // NOLINT
-  return ipfs_url;
-}
-
 const GURL& GetIPNSURI() {
   static const GURL ipns_url(
       "ipns://tr.wikipedia-on-ipfs.org/wiki/Anasayfa.html");  // NOLINT
-  return ipns_url;
-}
-
-const GURL& GetIPNSGatewayURL() {
-  static const GURL ipns_url(
-      "https://dweb.link/ipns/tr.wikipedia-on-ipfs.org/wiki/Anasayfa.html");  // NOLINT
-  return ipns_url;
-}
-
-const GURL& GetIPFSLocalhostURL() {
-  static const GURL ipfs_url(
-      "http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
-      "ipfs.localhost/wiki/Vincent_van_Gogh.html");
-  return ipfs_url;
-}
-
-const GURL& GetIPNSLocalhostURL() {
-  static const GURL ipns_url(
-      "http://tr.wikipedia-on-ipfs.org.ipns.localhost/wiki/Anasayfa.html");
   return ipns_url;
 }
 
@@ -171,74 +136,6 @@ TEST_F(ContentBrowserClientHelperUnitTest, HandleIPNSURLRewriteLocal) {
       kIPFSResolveMethod, static_cast<int>(IPFSResolveMethodTypes::IPFS_LOCAL));
   GURL ipns_uri(GetIPNSURI());
   ASSERT_TRUE(HandleIPFSURLRewrite(&ipns_uri, browser_context()));
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest, ShouldNavigateIPFSURIDisabled) {
-  profile()->GetPrefs()->SetInteger(
-      kIPFSResolveMethod,
-      static_cast<int>(IPFSResolveMethodTypes::IPFS_DISABLED));
-  GURL new_url;
-  ASSERT_FALSE(
-      ShouldNavigateIPFSURI(GetIPFSURI(), &new_url, browser_context()));
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest,
-       ShouldNavigateIPFSURIGatewayIPFSURI) {
-  profile()->GetPrefs()->SetInteger(
-      kIPFSResolveMethod,
-      static_cast<int>(IPFSResolveMethodTypes::IPFS_GATEWAY));
-  GURL new_url;
-  ASSERT_TRUE(ShouldNavigateIPFSURI(GetIPFSURI(), &new_url, browser_context()));
-  ASSERT_EQ(new_url, GetIPFSGatewayURL());
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest,
-       ShouldNavigateIPFSURIGatewayIPFSHTTPURI) {
-  profile()->GetPrefs()->SetInteger(
-      kIPFSResolveMethod,
-      static_cast<int>(IPFSResolveMethodTypes::IPFS_GATEWAY));
-  GURL new_url;
-  ASSERT_TRUE(
-      ShouldNavigateIPFSURI(GetIPFSGatewayURL(), &new_url, browser_context()));
-  ASSERT_EQ(new_url, GetIPFSGatewayURL());
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest, ShouldNavigateIPFSURILocalIPFSURI) {
-  profile()->GetPrefs()->SetInteger(
-      kIPFSResolveMethod, static_cast<int>(IPFSResolveMethodTypes::IPFS_LOCAL));
-  GURL new_url;
-  ASSERT_TRUE(ShouldNavigateIPFSURI(GetIPFSURI(), &new_url, browser_context()));
-  ASSERT_EQ(new_url, GetIPFSLocalURL());
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest,
-       ShouldNavigateIPFSURILocalIPFSHTTPURI) {
-  profile()->GetPrefs()->SetInteger(
-      kIPFSResolveMethod, static_cast<int>(IPFSResolveMethodTypes::IPFS_LOCAL));
-  GURL new_url;
-  ASSERT_TRUE(
-      ShouldNavigateIPFSURI(GetIPFSLocalURL(), &new_url, browser_context()));
-  ASSERT_EQ(new_url, GetIPFSLocalURL());
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest,
-       ShouldNavigateIPFSURIGatewayIPNSURI) {
-  profile()->GetPrefs()->SetInteger(
-      kIPFSResolveMethod,
-      static_cast<int>(IPFSResolveMethodTypes::IPFS_GATEWAY));
-  GURL new_url;
-  ASSERT_TRUE(ShouldNavigateIPFSURI(GetIPNSURI(), &new_url, browser_context()));
-  ASSERT_EQ(new_url, GetIPNSGatewayURL());
-}
-
-TEST_F(ContentBrowserClientHelperUnitTest, HandleIPFSURLReverseRewrite) {
-  GURL url = GetIPFSLocalhostURL();
-  ASSERT_TRUE(HandleIPFSURLReverseRewrite(&url, browser_context()));
-  ASSERT_EQ(url, GetIPFSURI());
-
-  url = GetIPNSLocalhostURL();
-  ASSERT_TRUE(HandleIPFSURLReverseRewrite(&url, browser_context()));
-  ASSERT_EQ(url, GetIPNSURI());
 }
 
 }  // namespace ipfs

--- a/browser/ipfs/ipfs_policy_browsertest.cc
+++ b/browser/ipfs/ipfs_policy_browsertest.cc
@@ -159,16 +159,4 @@ IN_PROC_BROWSER_TEST_F(IpfsDisabledPolicyTest, HandleIPFSURLRewrite) {
   EXPECT_FALSE(ipfs::HandleIPFSURLRewrite(&url, browser_context()));
 }
 
-IN_PROC_BROWSER_TEST_F(IpfsEnabledPolicyTest, ShouldNavigateIPFSURI) {
-  GURL new_url;
-  EXPECT_TRUE(
-      ipfs::ShouldNavigateIPFSURI(ipfs_url(), &new_url, browser_context()));
-}
-
-IN_PROC_BROWSER_TEST_F(IpfsDisabledPolicyTest, ShouldNavigateIPFSURI) {
-  GURL new_url;
-  EXPECT_FALSE(
-      ipfs::ShouldNavigateIPFSURI(ipfs_url(), &new_url, browser_context()));
-}
-
 }  // namespace policy

--- a/browser/net/brave_request_handler.cc
+++ b/browser/net/brave_request_handler.cc
@@ -296,7 +296,8 @@ void BraveRequestHandler::RunNextCallback(
         IsRequestIdentifierValid(ctx->request_identifier)) {
       *ctx->new_url = GURL(ctx->new_url_spec);
     }
-    if (ctx->blocked_by == brave::kAdBlocked) {
+    if (ctx->blocked_by == brave::kAdBlocked ||
+        ctx->blocked_by == brave::kOtherBlocked) {
       if (!ctx->ShouldMockRequest()) {
         RunCallbackForRequestIdentifier(ctx->request_identifier,
                                         net::ERR_BLOCKED_BY_CLIENT);

--- a/browser/net/ipfs_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/ipfs_redirect_network_delegate_helper_unittest.cc
@@ -11,6 +11,9 @@
 
 #include "brave/browser/net/url_context.h"
 #include "brave/common/translate_network_constants.h"
+#include "brave/components/ipfs/ipfs_gateway.h"
+#include "brave/components/ipfs/ipfs_utils.h"
+#include "chrome/common/channel_info.h"
 #include "chrome/test/base/chrome_render_view_host_test_harness.h"
 #include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
 #include "net/url_request/url_request_test_util.h"
@@ -26,6 +29,9 @@ GURL GetPublicGateway() {
   return GURL("https://dweb.link");
 }
 
+const char initiator_cid[] =
+    "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq";
+
 TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIHTTPScheme) {
   GURL url("http://a.com/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   auto brave_request_info = std::make_shared<brave::BraveRequestInfo>(url);
@@ -39,6 +45,9 @@ TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIIPFSSchemeLocal) {
   GURL url("ipfs://QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   auto brave_request_info = std::make_shared<brave::BraveRequestInfo>(url);
   brave_request_info->ipfs_gateway_url = GetLocalGateway();
+  brave_request_info->initiator_url = ipfs::GetIPFSGatewayURL(
+      initiator_cid, "",
+      ipfs::GetDefaultIPFSLocalGateway(chrome::GetChannel()));
   int rc = ipfs::OnBeforeURLRequest_IPFSRedirectWork(brave::ResponseCallback(),
                                                      brave_request_info);
   EXPECT_EQ(rc, net::OK);
@@ -51,6 +60,8 @@ TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIIPFSScheme) {
   GURL url("ipfs://QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   auto brave_request_info = std::make_shared<brave::BraveRequestInfo>(url);
   brave_request_info->ipfs_gateway_url = GetPublicGateway();
+  brave_request_info->initiator_url =
+      ipfs::GetIPFSGatewayURL(initiator_cid, "", ipfs::GetDefaultIPFSGateway());
   int rc = ipfs::OnBeforeURLRequest_IPFSRedirectWork(brave::ResponseCallback(),
                                                      brave_request_info);
   EXPECT_EQ(rc, net::OK);
@@ -63,6 +74,9 @@ TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIIPNSSchemeLocal) {
   GURL url("ipns://QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd");
   auto brave_request_info = std::make_shared<brave::BraveRequestInfo>(url);
   brave_request_info->ipfs_gateway_url = GetLocalGateway();
+  brave_request_info->initiator_url = ipfs::GetIPFSGatewayURL(
+      initiator_cid, "",
+      ipfs::GetDefaultIPFSLocalGateway(chrome::GetChannel()));
   int rc = ipfs::OnBeforeURLRequest_IPFSRedirectWork(brave::ResponseCallback(),
                                                      brave_request_info);
   EXPECT_EQ(rc, net::OK);
@@ -75,6 +89,8 @@ TEST(IPFSRedirectNetworkDelegateHelperTest, TranslateIPFSURIIPNSScheme) {
   GURL url("ipns://QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd");
   auto brave_request_info = std::make_shared<brave::BraveRequestInfo>(url);
   brave_request_info->ipfs_gateway_url = GetPublicGateway();
+  brave_request_info->initiator_url =
+      ipfs::GetIPFSGatewayURL(initiator_cid, "", ipfs::GetDefaultIPFSGateway());
   int rc = ipfs::OnBeforeURLRequest_IPFSRedirectWork(brave::ResponseCallback(),
                                                      brave_request_info);
   EXPECT_EQ(rc, net::OK);

--- a/chromium_src/third_party/blink/common/loader/network_utils.cc
+++ b/chromium_src/third_party/blink/common/loader/network_utils.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/public/common/loader/network_utils.h"
+#include "base/feature_list.h"
+#include "build/build_config.h"
+#include "net/net_buildflags.h"
+#include "services/network/public/cpp/is_potentially_trustworthy.h"
+#include "third_party/blink/public/common/features.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+#define IsURLHandledByNetworkService IsURLHandledByNetworkService_ChromiumImpl
+#include "../../../../../../third_party/blink/common/loader/network_utils.cc"
+#undef IsURLHandledByNetworkService
+
+namespace blink {
+namespace network_utils {
+
+bool IsURLHandledByNetworkService(const GURL& url) {
+  if (url.SchemeIs("ipns") || url.SchemeIs("ipfs")) {
+    return true;
+  }
+  return IsURLHandledByNetworkService_ChromiumImpl(url);
+}
+
+}  // namespace network_utils
+}  // namespace blink

--- a/chromium_src/third_party/blink/common/loader/network_utils.cc
+++ b/chromium_src/third_party/blink/common/loader/network_utils.cc
@@ -4,13 +4,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/public/common/loader/network_utils.h"
-#include "base/feature_list.h"
-#include "build/build_config.h"
-#include "net/net_buildflags.h"
-#include "services/network/public/cpp/is_potentially_trustworthy.h"
-#include "third_party/blink/public/common/features.h"
-#include "url/gurl.h"
-#include "url/url_constants.h"
 
 #define IsURLHandledByNetworkService IsURLHandledByNetworkService_ChromiumImpl
 #include "../../../../../../third_party/blink/common/loader/network_utils.cc"

--- a/components/ipfs/ipfs_utils.cc
+++ b/components/ipfs/ipfs_utils.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/strings/stringprintf.h"
 #include "brave/components/ipfs/ipfs_constants.h"
 #include "brave/components/ipfs/ipfs_gateway.h"
 #include "brave/components/ipfs/translate_ipfs_uri.h"
@@ -74,8 +75,9 @@ GURL GetGatewayURL(const std::string& cid,
                    bool ipfs) {
   GURL uri(base_gateway_url);
   GURL::Replacements replacements;
-  replacements.SetHostStr(
-      (cid + (ipfs ? ".ipfs." : ".ipns.") + uri.host()).c_str());
+  std::string host = base::StringPrintf("%s.%s.%s",
+      cid.c_str(), ipfs? "ipfs" : "ipns", uri.host().c_str());
+  replacements.SetHostStr(host);
   replacements.SetPathStr(path);
   return uri.ReplaceComponents(replacements);
 }

--- a/components/ipfs/ipfs_utils.h
+++ b/components/ipfs/ipfs_utils.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_IPFS_IPFS_UTILS_H_
 #define BRAVE_COMPONENTS_IPFS_IPFS_UTILS_H_
 
+#include <string>
+
 class GURL;
 
 namespace ipfs {
@@ -15,6 +17,12 @@ bool IsDefaultGatewayURL(const GURL& url);
 bool IsLocalGatewayURL(const GURL& url);
 bool IsIPFSScheme(const GURL& url);
 GURL ToPublicGatewayURL(const GURL& url);
+GURL GetIPFSGatewayURL(const std::string& cid,
+                       const std::string& path,
+                       const GURL& base_gateway_url);
+GURL GetIPNSGatewayURL(const std::string& cid,
+                       const std::string& path,
+                       const GURL& base_gateway_url);
 
 }  // namespace ipfs
 

--- a/components/ipfs/ipfs_utils_unittest.cc
+++ b/components/ipfs/ipfs_utils_unittest.cc
@@ -7,6 +7,8 @@
 
 #include <vector>
 
+#include "brave/components/ipfs/ipfs_gateway.h"
+#include "chrome/common/channel_info.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
@@ -30,6 +32,9 @@ TEST_F(IpfsUtilsUnitTest, IsDefaultGatewayURL) {
       {GURL("https://dweb.link/ipfs/"
             "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/"
             "Vincent_van_Gogh.html"),
+       GURL("https://"
+            "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
+            "ipfs.dweb.link/wiki/Vincent_van_Gogh.html"),
        GURL("https://dweb.link/ipns/tr.wikipedia-on-ipfs.org/wiki/"
             "Anasayfa.html")});
 
@@ -56,6 +61,9 @@ TEST_F(IpfsUtilsUnitTest, IsLocalGatewayURL) {
       {GURL("http://localhost:48080/ipfs/"
             "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/"
             "Vincent_van_Gogh.html"),
+       GURL(
+           "http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
+           "ipfs.localhost:48080//wiki/Vincent_van_Gogh.html"),
        GURL("http://127.0.0.1:48080/ipfs/"
             "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/"
             "Vincent_van_Gogh.html")});
@@ -97,4 +105,36 @@ TEST_F(IpfsUtilsUnitTest, ToPublicGatewayURL) {
     GURL new_url = ipfs::ToPublicGatewayURL(url);
     EXPECT_EQ(new_url, expected_new_url) << url;
   }
+}
+
+TEST_F(IpfsUtilsUnitTest, GetIPFSGatewayURL) {
+  EXPECT_EQ(
+      ipfs::GetIPFSGatewayURL(
+          "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq", "",
+          ipfs::GetDefaultIPFSGateway()),
+      GURL(
+          "https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
+          "ipfs.dweb.link"));
+  EXPECT_EQ(
+      ipfs::GetIPFSGatewayURL(
+          "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq", "",
+          ipfs::GetDefaultIPFSGateway()),
+      GURL(
+          "https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
+          "ipfs.dweb.link"));
+}
+
+TEST_F(IpfsUtilsUnitTest, GetIPFSGatewayURLLocal) {
+  EXPECT_EQ(
+      ipfs::GetIPFSGatewayURL(
+          "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq", "",
+          ipfs::GetDefaultIPFSLocalGateway(chrome::GetChannel())),
+      GURL("http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
+           "ipfs.localhost:48080"));
+  EXPECT_EQ(
+      ipfs::GetIPFSGatewayURL(
+          "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq", "",
+          ipfs::GetDefaultIPFSLocalGateway(chrome::GetChannel())),
+      GURL("http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq."
+           "ipfs.localhost:48080"));
 }


### PR DESCRIPTION
When a local node is installed, by visiting a page that allows you to load IPFS resources, it will then make you a host of any resources that the page loads.  To avoid this, this PR makes ipfs:// and ipns subresources only load when the top level main frame is also ipfs:// or ipns://.

This PR also fixes a problem where iframes would not load at all that were ipfs scheme. 

It also removes the external protocol handler that existed. 

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12546
Resolves https://github.com/brave/brave-browser/issues/12931


## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

