### PR TITLE
Global autoplay content setting should be Allowed vs Blocked instead of Ask vs Blocked

### DIFF
--- a/patches/chrome-browser-resources-settings-site_settings-category_default_setting.js.patch
+++ b/patches/chrome-browser-resources-settings-site_settings-category_default_setting.js.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/resources/settings/site_settings/category_default_setting.js b/chrome/browser/resources/settings/site_settings/category_default_setting.js
-index 1f4e519bd6162c2a25e8fe5f97387797b4555d61..3c6fde5d024fd000bca05ecf466aba0e3047950b 100644
+index 1f4e519bd6162c2a25e8fe5f97387797b4555d61..e81f38992b403e2326231c4d7658a10cde3b3022 100644
 --- a/chrome/browser/resources/settings/site_settings/category_default_setting.js
 +++ b/chrome/browser/resources/settings/site_settings/category_default_setting.js
-@@ -171,6 +171,7 @@ Polymer({
-             this.categoryEnabled ? ContentSetting.ALLOW : ContentSetting.BLOCK);
-         break;
-       case ContentSettingsTypes.AUTOMATIC_DOWNLOADS:
+@@ -165,6 +165,7 @@ Polymer({
+       case ContentSettingsTypes.PAYMENT_HANDLER:
+       case ContentSettingsTypes.POPUPS:
+       case ContentSettingsTypes.PROTOCOL_HANDLERS:
 +      case ContentSettingsTypes.AUTOPLAY:
-       case ContentSettingsTypes.CAMERA:
-       case ContentSettingsTypes.CLIPBOARD:
-       case ContentSettingsTypes.FONT_ACCESS:
+         // "Allowed" vs "Blocked".
+         this.browserProxy.setDefaultValueForContentType(
+             this.category,


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12795

This PR patches `case ContentSettingsTypes.AUTOPLAY:` to the correct place. It was falling through 
```
        // "Ask" vs "Blocked".
        this.browserProxy.setDefaultValueForContentType(
            this.category,
            this.categoryEnabled ? ContentSetting.ASK : ContentSetting.BLOCK);
        break;
```
but what we need is 
```
        // "Allowed" vs "Blocked".
        this.browserProxy.setDefaultValueForContentType(
            this.category,
            this.categoryEnabled ? ContentSetting.ALLOW : ContentSetting.BLOCK);
        break;
```

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

STR of the issue