### PR TITLE
Use frame rather than tab as source URL for adblocking

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -272,7 +272,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByDefaultBlocker) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 1, 0, 0, 0);"
+                         "setExpectations(0, 1, 0, 0);"
                          "addImage('ad_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
@@ -292,7 +292,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(1, 0, 0, 0, 0, 0);"
+                         "setExpectations(1, 0, 0, 0);"
                          "addImage('logo.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
@@ -310,7 +310,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByCustomBlocker) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 1, 0, 0, 0);"
+                         "setExpectations(0, 1, 0, 0);"
                          "addImage('ad_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
@@ -331,7 +331,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(1, 0, 0, 0, 0, 0);"
+                         "setExpectations(1, 0, 0, 0);"
                          "addImage('logo.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
@@ -356,7 +356,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByRegionalBlocker) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 1, 0, 0, 0);"
+                         "setExpectations(0, 1, 0, 0);"
                          "addImage('ad_fr.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
@@ -382,7 +382,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(1, 0, 0, 0, 0, 0);"
+                         "setExpectations(1, 0, 0, 0);"
                          "addImage('logo.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
@@ -411,7 +411,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 1, 0, 0, 0);"
+                         "setExpectations(0, 1, 0, 0);"
                          "addImage('v4_specific_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
@@ -431,13 +431,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TwoSameAdsGetCountedAsOne) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 0, 0, 1);"
+                         "setExpectations(0, 0, 0, 1);"
                          "xhr('adbanner.js')"));
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 1, 0, 1);"
+                         "setExpectations(0, 0, 1, 1);"
                          "xhr('normal.js')"));
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 1, 0, 2);"
+                         "setExpectations(0, 0, 1, 2);"
                          "xhr('adbanner.js')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
@@ -456,13 +456,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TwoDiffAdsGetCountedAsTwo) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 0, 0, 1);"
+                         "setExpectations(0, 0, 0, 1);"
                          "xhr('adbanner.js?1')"));
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 1, 0, 1);"
+                         "setExpectations(0, 0, 1, 1);"
                          "xhr('normal.js')"));
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 1, 0, 2);"
+                         "setExpectations(0, 0, 1, 2);"
                          "xhr('adbanner.js?2')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
 }
@@ -481,7 +481,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NewTabContinuesToBlock) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 0, 0, 1);"
+                         "setExpectations(0, 0, 0, 1);"
                          "xhr('adbanner.js')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 
@@ -489,7 +489,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NewTabContinuesToBlock) {
   contents = browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(0, 0, 0, 0, 0, 1);"
+                         "setExpectations(0, 0, 0, 1);"
                          "xhr('adbanner.js')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
 
@@ -510,7 +510,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SubFrame) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents->GetAllFrames()[1],
-                         "setExpectations(0, 0, 0, 0, 0, 1);"
+                         "setExpectations(0, 0, 0, 1);"
                          "xhr('adbanner.js?1')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 
@@ -553,7 +553,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_EQ(true, EvalJs(contents,
-                         "setExpectations(1, 0, 0, 0, 0, 0);"
+                         "setExpectations(1, 0, 0, 0);"
                          "addImage('ad_fr.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
@@ -570,7 +570,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdBlockThirdPartyWorksByETLDP1) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_EQ(true, EvalJs(contents,
-                         base::StringPrintf("setExpectations(1, 0, 0, 0, 0, 0);"
+                         base::StringPrintf("setExpectations(1, 0, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str())));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
@@ -587,7 +587,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_EQ(true, EvalJs(contents,
-                         base::StringPrintf("setExpectations(0, 0, 1, 0, 0, 0);"
+                         base::StringPrintf("setExpectations(0, 1, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str())));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
@@ -604,9 +604,33 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, BlockNYP) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_EQ(true, EvalJs(contents,
-                         base::StringPrintf("setExpectations(0, 0, 1, 0, 0, 0);"
+                         base::StringPrintf("setExpectations(0, 1, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str())));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+}
+
+// Frame root URL is used for context rather than the tab URL
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, FrameSourceURL) {
+  UpdateAdBlockInstanceWithRules("adbanner.js$domain=a.com");
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+  GURL url = embedded_test_server()->GetURL("a.com", "/iframe_blocking.html");
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  ASSERT_EQ(true, EvalJs(contents->GetAllFrames()[1],
+                         "setExpectations(0, 0, 1, 0);"
+                         "xhr('adbanner.js?1')"));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  UpdateAdBlockInstanceWithRules("adbanner.js$domain=b.com");
+  ui_test_utils::NavigateToURL(browser(), url);
+  contents = browser()->tab_strip_model()->GetActiveWebContents();
+
+  ASSERT_EQ(true, EvalJs(contents->GetAllFrames()[1],
+                         "setExpectations(0, 0, 0, 1);"
+                         "xhr('adbanner.js?1')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
@@ -627,7 +651,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SocialButttonAdBlockTagTest) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_EQ(true, EvalJs(contents,
-                         base::StringPrintf("setExpectations(0, 0, 1, 0, 0, 0);"
+                         base::StringPrintf("setExpectations(0, 1, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str())));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
@@ -647,7 +671,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SocialButttonAdBlockDiffTagTest) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_EQ(true, EvalJs(contents,
-                         base::StringPrintf("setExpectations(1, 0, 0, 0, 0, 0);"
+                         base::StringPrintf("setExpectations(1, 0, 0, 0);"
                                             "addImage('%s')",
                                             resource_url.spec().c_str())));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
@@ -738,7 +762,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, RedirectRulesAreRespected) {
       embedded_test_server()->GetURL("example.com", "/js_mock_me.js");
   ASSERT_EQ(true,
             EvalJs(contents, base::StringPrintf(
-                                 "setExpectations(0, 0, 0, 1, 0, 0);"
+                                 "setExpectations(0, 0, 1, 0);"
                                  "xhr_expect_content('%s', '%s');",
                                  resource_url.spec().c_str(), noopjs.c_str())));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);

--- a/test/data/blocking.html
+++ b/test/data/blocking.html
@@ -2,16 +2,12 @@
 <head>
 <script>
 let expectedImgLoaded = 0
-let expectedImgLoadedBlank = 0
 let expectedImgBlocked = 0
 let expectedXHRLoaded = 0
-let expectedXHRLoadedBlank = 0
 let expectedXHRBlocked = 0
 let numXHRLoaded = 0
-let numXHRLoadedBlank = 0
 let numXHRBlocked = 0
 let numImgLoaded = 0
-let numImgLoadedBlank = 0
 let numImgBlocked = 0
 
 // Performs an XHR for the specified src
@@ -20,11 +16,7 @@ function xhr(src) {
     const xhr = new XMLHttpRequest();
     xhr.open('GET', src, true);
     xhr.onload = function(e) {
-      if (xhr.response.length !== 0) {
-        numXHRLoaded++
-      } else {
-        numXHRLoadedBlank++
-      }
+      numXHRLoaded++
       resolve(onLoad())
     }
     xhr.onerror = function(e) {
@@ -64,12 +56,7 @@ function addImage(src) {
     img.className = 'adImage'
 
     img.addEventListener('load', () => {
-      if (img.complete &&
-          (img.naturalHeight !== 1 || img.naturalWidth !== 1)) {
-        numImgLoaded++
-      } else {
-        numImgLoadedBlank++
-      }
+      numImgLoaded++
       resolve(onLoad())
     })
     img.addEventListener('error', () => {
@@ -81,29 +68,25 @@ function addImage(src) {
 }
 
 // Sets the expectation for the number of images and XHR loaded and blocked
-function setExpectations(numImgLoaded, numImgLoadedBlank, numImgBlocked, numXHRLoaded, numXHRLoadedBlank, numXHRBlocked) {
+function setExpectations(numImgLoaded, numImgBlocked, numXHRLoaded, numXHRBlocked) {
   expectedImgLoaded = numImgLoaded
-  expectedImgLoadedBlank = numImgLoadedBlank
   expectedImgBlocked = numImgBlocked
   expectedXHRLoaded = numXHRLoaded
-  expectedXHRLoadedBlank = numXHRLoadedBlank
   expectedXHRBlocked = numXHRBlocked
 }
 
 function onLoad() {
-  if (numImgLoaded + numImgLoadedBlank + numImgBlocked !== expectedImgLoaded + expectedImgBlocked + expectedImgLoadedBlank ||
-      numXHRLoaded + numXHRLoadedBlank + numXHRBlocked !== expectedXHRLoaded + expectedXHRLoadedBlank + expectedXHRBlocked) {
+  if (numImgLoaded + numImgBlocked !== expectedImgLoaded + expectedImgBlocked ||
+      numXHRLoaded + numXHRBlocked !== expectedXHRLoaded + expectedXHRBlocked) {
     return;
   }
   const result = numImgLoaded == expectedImgLoaded &&
-      expectedImgLoadedBlank == numImgLoadedBlank &&
       expectedImgBlocked == numImgBlocked &&
       numXHRLoaded === expectedXHRLoaded &&
-      numXHRLoadedBlank === expectedXHRLoadedBlank &&
       numXHRBlocked === expectedXHRBlocked
   // For debugging:
-  // console.log('sending: ' + JSON.stringify({result, expectedImgLoaded, expectedImgLoadedBlank, expectedImgBlocked, numImgLoadedBlank, numImgBlocked,
-  //   numXHRLoaded, expectedXHRLoaded, numXHRLoadedBlank, numXHRBlocked, expectedXHRLoadedBlank, expectedXHRBlocked}))
+  // console.log('sending: ' + JSON.stringify({result, expectedImgLoaded, expectedImgBlocked, numImgBlocked,
+  //   numXHRLoaded, expectedXHRLoaded, numXHRBlocked, expectedXHRBlocked}))
   return result;
 }
 </script>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12737

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Visit `brave://components`, and ensure "**Brave Ad Block Updater**" is up to date.
- Close the browser
- In the profile directory, replace `cffkpbalmllkdoenhmdmpbkajipdjfam/{latest Brave Ad Block Updater version}/rs-ABPFilterParserData.dat` with the custom-made one in this archive: 
[motorsport-frame-url-adblock-dat.zip](https://github.com/brave/brave-core/files/5597555/motorsport-frame-url-adblock-dat.zip)
- Reopen the browser
- Navigate to https://www.motorsport.com/f1/news/wolff-hamilton-contract-talks-2021/4911380/
- Ensure that clicking the play button on either of the two in-article videos actually plays the video rather than bringing up a warning.

### About the custom DAT
The DAT above was created by running the `data-files-ad-block-rust` script from https://github.com/brave/brave-core-crx-packager, with the `Brave Unbreak` list excluded.