### PR TITLE
Use /etc/brave/policies as a policy dir path in linux

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -152,6 +152,13 @@ void BraveMainDelegate::PreSandboxStartup() {
   base::PathService::OverrideAndCreateIfNeeded(chrome::DIR_NATIVE_MESSAGING,
       native_messaging_dir, false, true);
 #endif  // defined(OS_LINUX) || defined(OS_MAC)
+
+#if defined(OS_POSIX) && !defined(OS_MAC)
+  base::PathService::Override(
+      chrome::DIR_POLICY_FILES,
+      base::FilePath(FILE_PATH_LITERAL("/etc/brave/policies")));
+#endif
+
   if (brave::SubprocessNeedsResourceBundle()) {
     brave::InitializeResourceBundle();
   }

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -3,11 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/path_service.h"
 #include "chrome/browser/domain_reliability/service_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/common/chrome_features.h"
+#include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_switches.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/autofill/core/common/autofill_features.h"
@@ -95,4 +97,14 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, EnabledFeatures) {
 
   for (const auto* feature : enabled_features)
     EXPECT_TRUE(base::FeatureList::IsEnabled(*feature));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, PathOverride) {
+#if defined(OS_POSIX) && !defined(OS_MAC)
+  base::FilePath policy_files_path;
+  EXPECT_TRUE(base::PathService::Get(chrome::DIR_POLICY_FILES,
+                                     &policy_files_path));
+  EXPECT_EQ(base::FilePath(FILE_PATH_LITERAL("/etc/brave/policies")),
+            policy_files_path);
+#endif
 }


### PR DESCRIPTION
Use our own policy dir path in linux. - `/etc/brave/policies` instead of using `/etc/chromium/policies`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12426
Resolves https://github.com/brave/brave-browser/issues/12137

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

