### PR TITLE
Fix compile error due to bad merge which re-introduced saveShowAddCard in New Tab Page

### DIFF
--- a/components/brave_new_tab_ui/containers/app.tsx
+++ b/components/brave_new_tab_ui/containers/app.tsx
@@ -53,7 +53,6 @@ function DefaultPage (props: Props) {
         saveShowRewards={PreferencesAPI.saveShowRewards}
         saveShowTogether={PreferencesAPI.saveShowTogether}
         saveShowBinance={PreferencesAPI.saveShowBinance}
-        saveShowAddCard={PreferencesAPI.saveShowAddCard}
         saveShowGemini={PreferencesAPI.saveShowGemini}
         saveShowBitcoinDotCom={PreferencesAPI.saveShowBitcoinDotCom}
         saveShowCryptoDotCom={PreferencesAPI.saveShowCryptoDotCom}


### PR DESCRIPTION
This should fix the build error introduced with the merge of https://github.com/brave/brave-core/pull/7111

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12961


