### PR TITLE
Brave Today: move from staging to production URLs

### DIFF
--- a/build/commands/lib/whitelistedUrlPrefixes.js
+++ b/build/commands/lib/whitelistedUrlPrefixes.js
@@ -35,6 +35,6 @@ module.exports = [
   'https://sync-v2.bravesoftware.com/v2', // brave sync v2 staging
   'https://sync-v2.brave.software/v2', // brave sync v2 dev
   'https://variations.brave.com/seed',
-  'https://brave-today-cdn.bravesoftware.com/', // Brave Today (staging)
-  'https://pcdn.bravesoftware.com/', // Brave's Privacy-focused CDN
+  'https://brave-today-cdn.brave.com/', // Brave Today (production)
+  'https://pcdn.brave.com/', // Brave's Privacy-focused CDN
 ]

--- a/components/brave_extension/extension/brave_extension/background/today/privateCDN.ts
+++ b/components/brave_extension/extension/brave_extension/background/today/privateCDN.ts
@@ -4,8 +4,8 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 export const URLS = {
-  braveTodayFeed: 'https://brave-today-cdn.bravesoftware.com/brave-today/feed.json',
-  braveTodayPublishers: 'https://brave-today-cdn.bravesoftware.com/sources.json'
+  braveTodayFeed: 'https://brave-today-cdn.brave.com/brave-today/feed.json',
+  braveTodayPublishers: 'https://brave-today-cdn.brave.com/sources.json'
 }
 
 export async function fetchResource (url: string) {

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -78,7 +78,7 @@
     "*://*/*",
     "chrome://favicon/*"
   ],
-  "content_security_policy": "default-src 'self'; font-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'; img-src 'self' data: chrome://favicon/; connect-src https://pcdn.bravesoftware.com https://brave-today-cdn.bravesoftware.com https://api.twitter.com 'self';",
+  "content_security_policy": "default-src 'self'; font-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'; img-src 'self' data: chrome://favicon/; connect-src https://pcdn.brave.com https://brave-today-cdn.brave.com https://api.twitter.com 'self';",
   "incognito": "split",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAupOLMy5Fd4dCSOtjcApsAQOnuBdTs+OvBVt/3P93noIrf068x0xXkvxbn+fpigcqfNamiJ5CjGyfx9zAIs7zcHwbxjOw0Uih4SllfgtK+svNTeE0r5atMWE0xR489BvsqNuPSxYJUmW28JqhaSZ4SabYrRx114KcU6ko7hkjyPkjQa3P+chStJjIKYgu5tWBiMJp5QVLelKoM+xkY6S7efvJ8AfajxCViLGyDQPDviGr2D0VvIBob0D1ZmAoTvYOWafcNCaqaejPDybFtuLFX3pZBqfyOCyyzGhucyCmfBXJALKbhjRAqN5glNsUmGhhPK87TuGATQfVuZtenMvXMQIDAQAB"
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Fix https://github.com/brave/brave-browser/issues/12601

## Test plan
0. Fresh profile
1. Brave Today still works

### Verify content is actually from production URL
0. Fresh profile
1. Visit chrome://inspect, choose "Extensions" section and click _Inspect_ under **Brave**.
2. Switch to _Network_ tab in DevTools
3. Open NTP and scroll down to content.
--> After content and images load, verify that 1 of the feed.json and 1 of the image entries in network load from x.brave.com URLs
![image](https://user-images.githubusercontent.com/741836/100949914-1bd15180-34c0-11eb-957d-fa8304a343a5.png)
