### PR TITLE
1.18.x - Brave Today production urls (Uplift #7300)

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/today/privateCDN.ts
+++ b/components/brave_extension/extension/brave_extension/background/today/privateCDN.ts
@@ -4,8 +4,8 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 export const URLS = {
-  braveTodayFeed: 'https://brave-today-cdn.bravesoftware.com/brave-today/feed.json',
-  braveTodayPublishers: 'https://brave-today-cdn.bravesoftware.com/sources.json'
+  braveTodayFeed: 'https://brave-today-cdn.brave.com/brave-today/feed.json',
+  braveTodayPublishers: 'https://brave-today-cdn.brave.com/sources.json'
 }
 
 export async function getUnpaddedAsDataUrl (buffer: ArrayBuffer, mimeType = 'image/jpg') {

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -78,7 +78,7 @@
     "*://*/*",
     "chrome://favicon/*"
   ],
-  "content_security_policy": "default-src 'self'; font-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'; img-src 'self' data: chrome://favicon/; connect-src https://pcdn.bravesoftware.com https://brave-today-cdn.bravesoftware.com https://api.twitter.com 'self';",
+  "content_security_policy": "default-src 'self'; font-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'; img-src 'self' data: chrome://favicon/; connect-src https://pcdn.brave.com https://brave-today-cdn.brave.com https://api.twitter.com 'self';",
   "incognito": "split",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAupOLMy5Fd4dCSOtjcApsAQOnuBdTs+OvBVt/3P93noIrf068x0xXkvxbn+fpigcqfNamiJ5CjGyfx9zAIs7zcHwbxjOw0Uih4SllfgtK+svNTeE0r5atMWE0xR489BvsqNuPSxYJUmW28JqhaSZ4SabYrRx114KcU6ko7hkjyPkjQa3P+chStJjIKYgu5tWBiMJp5QVLelKoM+xkY6S7efvJ8AfajxCViLGyDQPDviGr2D0VvIBob0D1ZmAoTvYOWafcNCaqaejPDybFtuLFX3pZBqfyOCyyzGhucyCmfBXJALKbhjRAqN5glNsUmGhhPK87TuGATQfVuZtenMvXMQIDAQAB"
 }


### PR DESCRIPTION
Uplift https://github.com/brave/brave-core/pull/7300 / https://github.com/brave/brave-browser/issues/12601 to 1.18.x
