### PR TITLE
1.19.x - Brave Today: move from staging to production URLs

### DIFF
--- a/build/commands/lib/whitelistedUrlPrefixes.js
+++ b/build/commands/lib/whitelistedUrlPrefixes.js
@@ -35,6 +35,6 @@ module.exports = [
   'https://sync-v2.bravesoftware.com/v2', // brave sync v2 staging
   'https://sync-v2.brave.software/v2', // brave sync v2 dev
   'https://variations.brave.com/seed',
-  'https://brave-today-cdn.bravesoftware.com/', // Brave Today (staging)
-  'https://pcdn.bravesoftware.com/', // Brave's Privacy-focused CDN
+  'https://brave-today-cdn.brave.com/', // Brave Today (production)
+  'https://pcdn.brave.com/', // Brave's Privacy-focused CDN
 ]


### PR DESCRIPTION
Allows audit-network to pass, part 2 of #7300 uplift to 1.18.x