### PR TITLE
Remove dapp detection for calendar.brave.com and nytimes.com [Uplift 1.19.x] 

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/reducers/dappDetectionReducer.ts
+++ b/components/brave_extension/extension/brave_extension/background/reducers/dappDetectionReducer.ts
@@ -9,7 +9,18 @@ import { Actions } from '../../types/actions/index'
 export default function dappDetectionReducer (state = {}, action: Actions) {
   switch (action.type) {
     case webNavigationTypes.ON_COMMITTED: {
-      if (chrome.braveWallet && action.isMainFrame && isHttpOrHttps(action.url)) {
+      let blacklistedHost
+      try {
+        // The Dapp detection will be gone soon, but this will remove some false positives.
+        const host = new URL(action.url).host
+        blacklistedHost = ['google.com', 'nytimes.com']
+            .reduce((accumulator, currentValue) => accumulator || host.endsWith(currentValue), false)
+      } catch (e) {
+        blacklistedHost = true
+      }
+
+      if (chrome.braveWallet && action.isMainFrame && isHttpOrHttps(action.url) &&
+          !blacklistedHost) {
         chrome.braveWallet.shouldCheckForDapps((dappDetection) => {
           if (!dappDetection) {
             return


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/12709
Fixes https://github.com/brave/brave-browser/issues/12942

Uplift from https://github.com/brave/brave-core/pull/7342
Reason for uplift: Crypto Wallet infobar prompts are coming up wrongly on calendar.brave.com and nytimes. 

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.