### PR TITLE
[cr88] Fix build of sync tests

### DIFF
--- a/chromium_src/ios/chrome/browser/prefs/browser_prefs.mm
+++ b/chromium_src/ios/chrome/browser/prefs/browser_prefs.mm
@@ -5,7 +5,7 @@
 
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 
-void BraveRegisterBrowserStatePrefs(user_prefs::PrefRegistrySyncable* registry) {
+void BraveRegisterBrowserStatePrefs(PrefRegistrySimple* registry) {
   brave_sync::Prefs::RegisterProfilePrefs(registry);
 }
 

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -10,7 +10,7 @@
 #include "base/base64.h"
 #include "base/logging.h"
 #include "components/os_crypt/os_crypt.h"
-#include "components/pref_registry/pref_registry_syncable.h"
+#include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
 
@@ -64,7 +64,7 @@ Prefs::Prefs(PrefService* pref_service) : pref_service_(pref_service) {}
 Prefs::~Prefs() {}
 
 // static
-void Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+void Prefs::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterStringPref(kSyncV2Seed, std::string());
   registry->RegisterBooleanPref(kSyncV1Migrated, false);
   registry->RegisterBooleanPref(kSyncV1MetaInfoCleared, false);

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -13,14 +13,11 @@
 #include "base/macros.h"
 #include "base/values.h"
 
+class PrefRegistrySimple;
 class PrefService;
 
 namespace base {
 class Time;
-}
-
-namespace user_prefs {
-class PrefRegistrySyncable;
 }
 
 namespace brave_sync {
@@ -30,7 +27,7 @@ class Prefs {
   explicit Prefs(PrefService* pref_service);
   virtual ~Prefs();
 
-  static void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
+  static void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
   static std::string GetSeedPath();
 


### PR DESCRIPTION
Related chromium change https://source.chromium.org/chromium/chromium/src/+/a92324d8c227f732ee66a3bafab77e75227d03ca

Description of what happened:
```
    // C88
    // void brave_sync::Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry)

    // ProfileSyncServiceBundle profile_sync_service_bundle_
    // TestingPrefServiceSimple* pref_service()
    // PrefRegistrySimple* TestingPrefServiceSimple::registry();
    // class COMPONENTS_PREFS_EXPORT PrefRegistrySimple : public PrefRegistry
    // class COMPONENTS_PREFS_EXPORT PrefRegistry : public base::RefCounted<PrefRegistry> {

    // master (C87)
    // void brave_sync::Prefs::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry)
    //
    // ProfileSyncServiceBundle profile_sync_service_bundle_;
    // sync_preferences::TestingPrefServiceSyncable* pref_service()
    // user_prefs::PrefRegistrySyncable* registry();
    // class PrefRegistrySyncable : public PrefRegistrySimple {
```

So now it is enough to use `PrefRegistrySimple` for `brave_sync::Prefs::RegisterProfilePrefs`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13060

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [+/-] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test -- brave_unit_tests` in C88 branch