### PR TITLE
Option to mute tab in the tab menu

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -961,6 +961,25 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         You can read <ph name="BEGIN_LINK_BUILD_INSTRUCTIONS">&lt;a target="_blank" rel="noopener noreferrer" href="$3"&gt;</ph>instructions on how to download and build for yourself<ph name="END_LINK_BUILD_INSTRUCTIONS">&lt;/a&gt;</ph> the specific <ph name="BEGIN_LINK_SOURCE_CODE">&lt;a target="_blank" rel="noopener noreferrer" href="$4"&gt;</ph>source code used to create this copy<ph name="END_LINK_SOURCE_CODE">&lt;/a&gt;</ph>.
       </message>
       <if expr="not use_titlecase">
+        <message name="IDS_TAB_CXMENU_MUTE_TAB" desc="The label of the tab context menu item for muting one or more tabs.">
+          {NUM_TABS, plural, =1 {Mute tab} other {Mute tabs}}
+        </message>
+      </if>
+      <if expr="use_titlecase">
+        <message name="IDS_TAB_CXMENU_MUTE_TAB" desc="In Title Case: The label of the tab context menu item for muting one or more tabs.">
+          {NUM_TABS, plural, =1 {Mute Tab} other {Mute Tabs}}
+        </message>
+      </if><if expr="not use_titlecase">
+        <message name="IDS_TAB_CXMENU_UNMUTE_TAB" desc="The label of the tab context menu item for unmuting one or more tabs.">
+          {NUM_TABS, plural, =1 {Unmute tab} other {Unmute tabs}}
+        </message>
+      </if>
+      <if expr="use_titlecase">
+        <message name="IDS_TAB_CXMENU_UNMUTE_TAB" desc="In Title Case: The label of the tab context menu item for unmuting one or more tabs.">
+          {NUM_TABS, plural, =1 {Unmute Tab} other {Unmute Tabs}}
+        </message>
+      </if>
+      <if expr="not use_titlecase">
         <message name="IDS_TAB_CXMENU_BOOKMARK_ALL_TABS" desc="The label of the tab context menu item for creating a bookmark folder containing an entry for each open tab.">
           Bookmark all tabs...
         </message>

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -60,11 +60,11 @@ void BraveTabMenuModel::Build(TabStripModel* tab_strip_model, int index) {
   const bool will_mute = !AreAllTabsMuted(*tab_strip_model, affected_indices);
 
   InsertItemAt(GetIndexOfCommandId(TabStripModel::CommandToggleSiteMuted),
-                           CommandMuteTab,
-                           will_mute ? l10n_util::GetPluralStringFUTF16(
-                                          IDS_TAB_CXMENU_MUTE_TAB, num_affected_tabs)
-                                     : l10n_util::GetPluralStringFUTF16(
-                                          IDS_TAB_CXMENU_UNMUTE_TAB, num_affected_tabs));
+               CommandMuteTab,
+               will_mute ? l10n_util::GetPluralStringFUTF16(
+                              IDS_TAB_CXMENU_MUTE_TAB, num_affected_tabs)
+                         : l10n_util::GetPluralStringFUTF16(
+                              IDS_TAB_CXMENU_UNMUTE_TAB, num_affected_tabs));
 
   AddSeparator(ui::NORMAL_SEPARATOR);
   AddItemWithStringId(CommandRestoreTab, GetRestoreTabCommandStringId());

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 
+#include <vector>
+
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
 #include "chrome/browser/ui/browser.h"
@@ -69,7 +71,6 @@ void BraveTabMenuModel::Build(TabStripModel* tab_strip_model, int index) {
   AddSeparator(ui::NORMAL_SEPARATOR);
   AddItemWithStringId(CommandRestoreTab, GetRestoreTabCommandStringId());
   AddItemWithStringId(CommandBookmarkAllTabs, IDS_TAB_CXMENU_BOOKMARK_ALL_TABS);
-
 }
 
 bool BraveTabMenuModel::AreAllTabsMuted(const TabStripModel& tab_strip_model,

--- a/browser/ui/tabs/brave_tab_menu_model.h
+++ b/browser/ui/tabs/brave_tab_menu_model.h
@@ -23,6 +23,7 @@ class BraveTabMenuModel : public TabMenuModel {
     CommandStart = TabStripModel::CommandLast,
     CommandRestoreTab,
     CommandBookmarkAllTabs,
+    CommandMuteTab,
     CommandLast,
   };
 
@@ -31,8 +32,10 @@ class BraveTabMenuModel : public TabMenuModel {
                     int index);
   ~BraveTabMenuModel() override;
 
+  bool AreAllTabsMuted(const TabStripModel& tab_strip_model, const std::vector<int>& indices) const;
+  
  private:
-  void Build();
+  void Build(TabStripModel* tab_strip_model, int index);
   int GetRestoreTabCommandStringId() const;
 
   content::WebContents* web_contents_;

--- a/browser/ui/tabs/brave_tab_menu_model.h
+++ b/browser/ui/tabs/brave_tab_menu_model.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_TABS_BRAVE_TAB_MENU_MODEL_H_
 #define BRAVE_BROWSER_UI_TABS_BRAVE_TAB_MENU_MODEL_H_
 
+#include <vector>
+
 #include "chrome/browser/ui/tabs/tab_menu_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 
@@ -32,8 +34,9 @@ class BraveTabMenuModel : public TabMenuModel {
                     int index);
   ~BraveTabMenuModel() override;
 
-  bool AreAllTabsMuted(const TabStripModel& tab_strip_model, const std::vector<int>& indices) const;
-  
+  bool AreAllTabsMuted(const TabStripModel& tab_strip_model,
+                       const std::vector<int>& indices) const;
+
  private:
   void Build(TabStripModel* tab_strip_model, int index);
   int GetRestoreTabCommandStringId() const;

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -5,6 +5,9 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab_context_menu_contents.h"
 
+#include <string>
+#include <vector>
+
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 #include "chrome/browser/defaults.h"
@@ -121,7 +124,8 @@ void BraveTabContextMenuContents::ExecuteBraveCommand(int command_id) {
       std::vector<int> affected_indices = tab_strip_model->IsTabSelected(index_)
           ? tab_strip_model->selection_model().selected_indices()
           : std::vector<int>{index_};
-      const bool mute = !model_->AreAllTabsMuted(*tab_strip_model, affected_indices);
+      const bool mute = !model_->AreAllTabsMuted(*tab_strip_model,
+                                                 affected_indices);
 
       for (int tab_index : affected_indices) {
         chrome::SetTabAudioMuted(tab_strip_model->GetWebContentsAt(tab_index),

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.h
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.h
@@ -54,6 +54,7 @@ class BraveTabContextMenuContents : public ui::SimpleMenuModel::Delegate {
   Browser* browser_;
   sessions::TabRestoreService* restore_service_ = nullptr;
   BraveBrowserTabStripController* controller_;
+  int index_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveTabContextMenuContents);
 };


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#11314

This PR adds a new context-menu action for tabs which allows the user to mute the tab (not the entire site) just like he can now by clicking in the 'sound' icon that appears in the tab, the advantages in using the context menu entry instead of the icon are that you can mute the tab proactively (meaning you don't need to wait for a sound to play to be able to mute the tab) and you can now mute pinned tabs (on which the sound icon doesn't work). This is a feature that have been request several times [1] and that i think will be useful for a lot of people.

Preview:
![demo1](https://user-images.githubusercontent.com/75501361/101356376-be9a1f00-3876-11eb-8ec6-dda9c6232dc5.png)

This is my first time working with the chromium/brave codebase and i also don't work with c++ usually so excuse me for any mistakes i may have made.

Let me know if you guys are interested in this feature and, if you are, any changes i need to make in the code :)

[1] https://community.brave.com/t/mute-unmute-pinned-tab-is-difficult-annoying/88889 - https://www.reddit.com/r/brave_browser/comments/biubtc/mute_tab/f3quy5x/?utm_source=reddit&utm_medium=web2x&context=3 - brave/brave-browser#11314

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

