### PR TITLE
Initialize data in Brotli output vector to avoid ASAN errors

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/common/brotli_util.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/common/brotli_util.cc
@@ -15,7 +15,7 @@ class BrotliStreamDecoder {
  public:
   explicit BrotliStreamDecoder(size_t buffer_size) {
     brotli_state_ = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
-    out_vector_.reserve(buffer_size);
+    out_vector_.resize(buffer_size);
   }
 
   BrotliStreamDecoder(const BrotliStreamDecoder&) = delete;
@@ -38,7 +38,7 @@ class BrotliStreamDecoder {
     }
 
     uint8_t* output_buffer = out_vector_.data();
-    size_t output_length = out_vector_.capacity();
+    size_t output_length = out_vector_.size();
 
     for (;;) {
       auto brotli_result = BrotliDecoderDecompressStream(
@@ -51,13 +51,13 @@ class BrotliStreamDecoder {
 
       switch (brotli_result) {
         case BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: {
-          callback(out_vector_.data(), out_vector_.capacity() - output_length);
+          callback(out_vector_.data(), out_vector_.size() - output_length);
           output_buffer = out_vector_.data();
-          output_length = out_vector_.capacity();
+          output_length = out_vector_.size();
           break;
         }
         case BROTLI_DECODER_RESULT_SUCCESS: {
-          callback(out_vector_.data(), out_vector_.capacity() - output_length);
+          callback(out_vector_.data(), out_vector_.size() - output_length);
           return Result::Done;
         }
         case BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/13075

This change uses `resize` instead of `reserve` for the Brotli output vector buffer in order to avoid `container-overflow` ASAN warnings.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For this change, we need to regression test that publisher data is correctly downloaded and decoded on staging and production environments.

- Start browser with a clean profile.
- Open rewards panel and dismiss onboarding.
  - Note: this will trigger a download of the publisher list.
- Visit several publishers and verify that correct publisher info is being displayed.