### PR TITLE
1.19.x: Uplift pull request #7335 from brave/today-fix-history-search

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/today/feedToData.ts
+++ b/components/brave_extension/extension/brave_extension/background/today/feedToData.ts
@@ -247,7 +247,8 @@ async function weightArticles (articles: BraveToday.FeedItem[]): Promise<BraveTo
     ? await new Promise(
         resolve => chrome.history.search({
           text: '',
-          startTime: Date.now() - (14 * MS_IN_DAY)
+          startTime: Date.now() - (14 * MS_IN_DAY),
+          maxResults: 2000
         }, resolve)
       )
     : []


### PR DESCRIPTION
Brave Today: do not limit history search to the default of 100 items

Uplifts issue https://github.com/brave/brave-browser/issues/13041
