### PR TITLE
1.18.x: Uplift #7392 from brave/today-fix-p3a-keys

### DIFF
--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -609,7 +609,7 @@ void BraveNewTabMessageHandler::HandleTodayOnCardVisits(
       std::lower_bound(kBuckets, std::end(kBuckets),
                       total);
   int answer = it_count - kBuckets;
-  UMA_HISTOGRAM_EXACT_LINEAR("Brave.Today.WeeklyCardVisitsCount", answer,
+  UMA_HISTOGRAM_EXACT_LINEAR("Brave.Today.WeeklyMaxCardVisitsCount", answer,
                              base::size(kBuckets) + 1);
 }
 
@@ -629,7 +629,7 @@ void BraveNewTabMessageHandler::HandleTodayOnCardViews(
       std::lower_bound(kBuckets, std::end(kBuckets),
                       total);
   int answer = it_count - kBuckets;
-  UMA_HISTOGRAM_EXACT_LINEAR("Brave.Today.WeeklyCardViewsCount", answer,
+  UMA_HISTOGRAM_EXACT_LINEAR("Brave.Today.WeeklyMaxCardViewsCount", answer,
                              base::size(kBuckets) + 1);
 }
 


### PR DESCRIPTION
Today: fix p3a key mismatch

Fix brave/brave-browser#13096
Fix brave/brave-browser#13097