### PR TITLE
Re-enable kVideoPlaybackQuality to fix webcompat issue (uplift to 1.19.x)

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -232,7 +232,6 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
     features::kPrivacySettingsRedesign.name,
     features::kSignedExchangeSubresourcePrefetch.name,
     features::kSmsReceiver.name,
-    features::kVideoPlaybackQuality.name,
     features::kTabHoverCards.name,
     network_time::kNetworkTimeServiceQuerying.name,
     password_manager::features::kPasswordCheck.name,

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -71,7 +71,6 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
       &features::kPrivacySettingsRedesign,
       &features::kSignedExchangeSubresourcePrefetch,
       &features::kSmsReceiver,
-      &features::kVideoPlaybackQuality,
       &features::kTabHoverCards,
       &network_time::kNetworkTimeServiceQuerying,
       &password_manager::features::kPasswordCheck,


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7437
Fixes brave/brave-browser#13183

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.