### PR TITLE
Fix re-appearing unwanted components

### DIFF
--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -12,7 +12,7 @@
 #undef Register
 #undef CRX3_WITH_PUBLISHER_PROOF
 
-#include "base/containers/contains.h"
+#include "base/stl_util.h"
 
 namespace component_updater {
 

--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -35,17 +35,27 @@ void ComponentInstaller::Register(ComponentUpdateService* cus,
 #endif
   };
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  VLOG(1) << "Brave ComponentInstaller::Register is on valid thread.";
   if (installer_policy_) {
+    VLOG(1) << "Brave ComponentInstaller::Register has installer_policy_.";
     std::vector<uint8_t> hash;
     installer_policy_->GetHash(&hash);
     const std::string id = update_client::GetCrxIdFromPublicKeyHash(hash);
+    VLOG(1) << "Brave ComponentInstaller::Register component id: " << id;
     if (base::Contains(disallowed_components, id.c_str())) {
       VLOG(1) << "Skipping registration of Brave-unsupported component "
               << id << ".";
       return;
+    } else {
+      VLOG(1) << "Brave ComponentInstaller::Register " << id
+              << " is not blocked.";
     }
+  } else {
+    VLOG(1) << "Brave ComponentInstaller::Register has no installer_policy_.";
   }
+  VLOG(1) << "Brave ComponentInstaller::Register calling base implementation.";
   Register_ChromiumImpl(cus, std::move(callback));
+  VLOG(1) << "Brave ComponentInstaller::Register base implementation complete.";
 }
 
 }  // namespace component_updater

--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -12,14 +12,13 @@
 #undef Register
 #undef CRX3_WITH_PUBLISHER_PROOF
 
-#include "base/stl_util.h"
+#include "base/containers/contains.h"
 
 namespace component_updater {
 
 void ComponentInstaller::Register(ComponentUpdateService* cus,
                                   base::OnceClosure callback) {
-  VLOG(1) << "Brave ComponentInstaller::Register override called.";
-  static const char* disallowed_components[] = {
+  static std::string disallowed_components[] = {
       "bklopemakmnopmghhmccadeonafabnal",  // Legacy TLS Deprecation Config
       "cmahhnpholdijhjokonmfdjbfmklppij",  // Federated Learning of Cohorts
       "eeigpngbgcognadeebkilcpcaedhellh",  // Autofill States Data
@@ -35,27 +34,17 @@ void ComponentInstaller::Register(ComponentUpdateService* cus,
 #endif
   };
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  VLOG(1) << "Brave ComponentInstaller::Register is on valid thread.";
   if (installer_policy_) {
-    VLOG(1) << "Brave ComponentInstaller::Register has installer_policy_.";
     std::vector<uint8_t> hash;
     installer_policy_->GetHash(&hash);
     const std::string id = update_client::GetCrxIdFromPublicKeyHash(hash);
-    VLOG(1) << "Brave ComponentInstaller::Register component id: " << id;
-    if (base::Contains(disallowed_components, id.c_str())) {
+    if (base::Contains(disallowed_components, id)) {
       VLOG(1) << "Skipping registration of Brave-unsupported component "
               << id << ".";
       return;
-    } else {
-      VLOG(1) << "Brave ComponentInstaller::Register " << id
-              << " is not blocked.";
     }
-  } else {
-    VLOG(1) << "Brave ComponentInstaller::Register has no installer_policy_.";
   }
-  VLOG(1) << "Brave ComponentInstaller::Register calling base implementation.";
   Register_ChromiumImpl(cus, std::move(callback));
-  VLOG(1) << "Brave ComponentInstaller::Register base implementation complete.";
 }
 
 }  // namespace component_updater

--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -18,6 +18,7 @@ namespace component_updater {
 
 void ComponentInstaller::Register(ComponentUpdateService* cus,
                                   base::OnceClosure callback) {
+  VLOG(1) << "Brave ComponentInstaller::Register override called.";
   static const char* disallowed_components[] = {
       "bklopemakmnopmghhmccadeonafabnal",  // Legacy TLS Deprecation Config
       "cmahhnpholdijhjokonmfdjbfmklppij",  // Federated Learning of Cohorts


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/8709.

The unwanted components on brave://components have re-appeared. The reason is that I introduced a bug when I implemented a suggestion by a reviewer on my original PR without thinking.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [x] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Open `brave://components` on Windows, Mac, Linux and Android and check that none of the components described in https://github.com/brave/brave-browser/issues/8709#issuecomment-737397247 are visible. The only exception is CRLSet on Android which @pj said should actually be there.