### PR TITLE
chrome.ipfs.launch should not allow install of component (uplift to 1.19.x)

### DIFF
--- a/browser/extensions/api/ipfs_api.cc
+++ b/browser/extensions/api/ipfs_api.cc
@@ -94,6 +94,16 @@ ExtensionFunction::ResponseAction IpfsLaunchFunction::Run() {
   if (!IsIpfsEnabled(browser_context())) {
     return RespondNow(Error("IPFS not enabled"));
   }
+
+  if (!GetIpfsService(browser_context())) {
+    return RespondNow(Error("Could not obtain IPFS service"));
+  }
+
+  if (!GetIpfsService(browser_context())->IsIPFSExecutableAvailable()) {
+    return RespondNow(
+        OneArgument(std::make_unique<base::Value>(base::Value(false))));
+  }
+
   GetIpfsService(browser_context())
       ->LaunchDaemon(base::BindOnce(&IpfsLaunchFunction::OnLaunch, this));
   return RespondLater();

--- a/browser/extensions/api/ipfs_apitest.cc
+++ b/browser/extensions/api/ipfs_apitest.cc
@@ -129,7 +129,7 @@ IN_PROC_BROWSER_TEST_F(IpfsExtensionApiTest, GetConfig) {
 }
 
 // No great way to test launch and shutdown succeeding easily, so at least
-// just make sure the API call works. IpfsService::SetIpfsLaunchedForTest
+// just make sure the API call works. IpfsService::SetAllowIpfsLaunchForTest
 // is used to short-circuit the launch and shutdown process.
 IN_PROC_BROWSER_TEST_F(IpfsExtensionApiTest, LaunchShutdownSuccess) {
   ResultCatcher catcher;
@@ -141,14 +141,32 @@ IN_PROC_BROWSER_TEST_F(IpfsExtensionApiTest, LaunchShutdownSuccess) {
           browser()->profile());
   ASSERT_TRUE(service);
 
-  service->SetIpfsLaunchedForTest(true);
+  GetPrefs()->SetBoolean(kIPFSBinaryAvailable, true);
+  service->SetAllowIpfsLaunchForTest(true);
   ASSERT_TRUE(browsertest_util::ExecuteScriptInBackgroundPageNoWait(
       browser()->profile(), ipfs_companion_extension_id, "launchSuccess()"));
   ASSERT_TRUE(catcher.GetNextResult()) << message_;
 
-  service->SetIpfsLaunchedForTest(false);
+  service->SetAllowIpfsLaunchForTest(false);
   ASSERT_TRUE(browsertest_util::ExecuteScriptInBackgroundPageNoWait(
       browser()->profile(), ipfs_companion_extension_id, "shutdownSuccess()"));
+  ASSERT_TRUE(catcher.GetNextResult()) << message_;
+}
+
+IN_PROC_BROWSER_TEST_F(IpfsExtensionApiTest, LaunchFailWhenNotInstalled) {
+  ResultCatcher catcher;
+  const Extension* extension =
+      LoadExtension(extension_dir_.AppendASCII("ipfsCompanion"));
+  ASSERT_TRUE(extension);
+  ipfs::IpfsService* service =
+      ipfs::IpfsServiceFactory::GetInstance()->GetForContext(
+          browser()->profile());
+  ASSERT_TRUE(service);
+
+  service->SetAllowIpfsLaunchForTest(true);
+  GetPrefs()->SetBoolean(kIPFSBinaryAvailable, false);
+  ASSERT_TRUE(browsertest_util::ExecuteScriptInBackgroundPageNoWait(
+      browser()->profile(), ipfs_companion_extension_id, "launchFail()"));
   ASSERT_TRUE(catcher.GetNextResult()) << message_;
 }
 

--- a/components/ipfs/ipfs_navigation_throttle_browsertest.cc
+++ b/components/ipfs/ipfs_navigation_throttle_browsertest.cc
@@ -86,7 +86,7 @@ class IpfsNavigationThrottleBrowserTest : public InProcessBrowserTest {
     ipfs_service_ =
         IpfsServiceFactory::GetInstance()->GetForContext(browser()->profile());
     ASSERT_TRUE(ipfs_service_);
-    ipfs_service_->SetIpfsLaunchedForTest(true);
+    ipfs_service_->SetAllowIpfsLaunchForTest(true);
 
     ipfs_url_ = GURL(
         "http://127.0.0.1:48080/ipfs/"

--- a/components/ipfs/ipfs_navigation_throttle_unittest.cc
+++ b/components/ipfs/ipfs_navigation_throttle_unittest.cc
@@ -144,7 +144,7 @@ TEST_F(IpfsNavigationThrottleUnitTest, DeferUntilIpfsProcessLaunched) {
       base::BindLambdaForTesting([&]() { was_navigation_resumed = true; }));
   EXPECT_EQ(NavigationThrottle::DEFER, throttle->WillStartRequest().action())
       << GetIPFSURL();
-  service->SetIpfsLaunchedForTest(true);
+  service->SetAllowIpfsLaunchForTest(true);
   service->RunLaunchDaemonCallbackForTest(true);
   EXPECT_TRUE(was_navigation_resumed);
 
@@ -154,13 +154,13 @@ TEST_F(IpfsNavigationThrottleUnitTest, DeferUntilIpfsProcessLaunched) {
   throttle->OnGetConnectedPeers(true, peers);
   EXPECT_TRUE(was_navigation_resumed);
 
-  service->SetIpfsLaunchedForTest(false);
+  service->SetAllowIpfsLaunchForTest(false);
 
   was_navigation_resumed = false;
   test_handle.set_url(GetIPNSURL());
   EXPECT_EQ(NavigationThrottle::DEFER, throttle->WillStartRequest().action())
       << GetIPNSURL();
-  service->SetIpfsLaunchedForTest(true);
+  service->SetAllowIpfsLaunchForTest(true);
   service->RunLaunchDaemonCallbackForTest(true);
   EXPECT_TRUE(was_navigation_resumed);
 

--- a/components/ipfs/ipfs_service.cc
+++ b/components/ipfs/ipfs_service.cc
@@ -317,9 +317,9 @@ void IpfsService::OnGetAddressesConfig(
 }
 
 bool IpfsService::IsDaemonLaunched() const {
-  if (is_ipfs_launched_for_test_)
+  if (allow_ipfs_launch_for_test_) {
     return true;
-
+  }
   return ipfs_pid_ > 0;
 }
 
@@ -327,10 +327,17 @@ void IpfsService::LaunchDaemon(LaunchDaemonCallback callback) {
   // Reject if previous launch request in progress.
   if (launch_daemon_callback_) {
     std::move(callback).Run(false);
+    return;
+  }
+
+  if (allow_ipfs_launch_for_test_) {
+    std::move(callback).Run(true);
+    return;
   }
 
   if (IsDaemonLaunched()) {
     std::move(callback).Run(true);
+    return;
   }
 
   launch_daemon_callback_ = std::move(callback);
@@ -387,8 +394,8 @@ void IpfsService::RegisterIpfsClientUpdater() {
   }
 }
 
-void IpfsService::SetIpfsLaunchedForTest(bool launched) {
-  is_ipfs_launched_for_test_ = launched;
+void IpfsService::SetAllowIpfsLaunchForTest(bool launched) {
+  allow_ipfs_launch_for_test_ = launched;
 }
 
 void IpfsService::SetServerEndpointForTest(const GURL& gurl) {

--- a/components/ipfs/ipfs_service.h
+++ b/components/ipfs/ipfs_service.h
@@ -83,7 +83,7 @@ class IpfsService : public KeyedService,
   void ShutdownDaemon(ShutdownDaemonCallback callback);
   void GetConfig(GetConfigCallback);
 
-  void SetIpfsLaunchedForTest(bool launched);
+  void SetAllowIpfsLaunchForTest(bool launched);
   void SetServerEndpointForTest(const GURL& gurl);
   void SetSkipGetConnectedPeersCallbackForTest(bool skip);
   void RunLaunchDaemonCallbackForTest(bool result);
@@ -129,7 +129,7 @@ class IpfsService : public KeyedService,
 
   LaunchDaemonCallback launch_daemon_callback_;
 
-  bool is_ipfs_launched_for_test_ = false;
+  bool allow_ipfs_launch_for_test_ = false;
   bool skip_get_connected_peers_callback_for_test_ = false;
   GURL server_endpoint_;
 

--- a/components/ipfs/ipfs_service_browsertest.cc
+++ b/components/ipfs/ipfs_service_browsertest.cc
@@ -39,7 +39,7 @@ class IpfsServiceBrowserTest : public InProcessBrowserTest {
     ipfs_service_ =
         IpfsServiceFactory::GetInstance()->GetForContext(browser()->profile());
     ASSERT_TRUE(ipfs_service_);
-    ipfs_service_->SetIpfsLaunchedForTest(true);
+    ipfs_service_->SetAllowIpfsLaunchForTest(true);
     host_resolver()->AddRule("*", "127.0.0.1");
     InProcessBrowserTest::SetUpOnMainThread();
   }

--- a/test/data/extensions/api_test/ipfsCompanion/background.js
+++ b/test/data/extensions/api_test/ipfsCompanion/background.js
@@ -42,6 +42,16 @@ function launchSuccess() {
   })
 }
 
+function launchFail() {
+  chrome.ipfs.launch((success) => {
+    if (success) {
+      chrome.test.fail();
+    } else {
+      chrome.test.succeed();
+    }
+  })
+}
+
 function shutdownSuccess() {
   chrome.ipfs.shutdown((success) => {
     if (success) {


### PR DESCRIPTION
Uplift of #7489
Resolves https://github.com/brave/brave-browser/issues/13239

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.