### PR TITLE
Fix login issues on https://www.doterra.com/

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -37,6 +37,8 @@ constexpr char kGoogleusercontent[] = "https://[*.]googleusercontent.com/*";
 constexpr char kBitbucket[] = "https://[*.]bitbucket.org/*";
 constexpr char kAtlassiannet[] = "https://[*.]atlassian.net/*";
 constexpr char kAtlassiancom[] = "https://[*.]atlassian.com/*";
+constexpr char kDoterra[] = "https://[*.]doterra.com/*";
+constexpr char kGigya[] = "https://[*.]gigya.com/*";
 
 bool BraveIsAllowedThirdParty(
     const GURL& url,
@@ -117,6 +119,14 @@ bool BraveIsAllowedThirdParty(
           {
             ContentSettingsPattern::FromString(kAtlassiannet),
             ContentSettingsPattern::FromString(kAtlassiancom)
+          },
+          {
+            ContentSettingsPattern::FromString(kDoterra),
+            ContentSettingsPattern::FromString(kGigya)
+          },
+          {
+            ContentSettingsPattern::FromString(kGigya),
+            ContentSettingsPattern::FromString(kDoterra)
           }
       });
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13331

`doterra.com` is redirecting its login details through a third-party `gigya.com`. Allowing cookies is a temp workaround gets around this issue.


When a user logins in, it'll go through this: 

`https://www.doterra.com/US/en` -> `https://fidm.us1.gigya.com/oidc/op/....` -> `https://login.doterra.com/`

Full 3rd-partyURL: ​`https://fidm.us1.gigya.com/oidc/op/v1.0/3_IeTHYO5iQqBz2VEw0sOh3dqMQj2cR0DamqynMcICUyquuiM8-63c7onnMkZyja7c/authorize?scope=openid+email+profile+region_US+language_en&nonce=2020-12-29%2016:12:21.298&response_type=id_token+token&redirect_uri=https://www.doterra.com/login/loading&client_id=RzFgRmPlegftl8RXu1awVaGy​​​​​`

2nd time lucky, didn't rebase correctly first time around.