### PR TITLE
Fixes Brave Ads NTP SI ad should only appear in 7-days ads history if we have unblinded tokens to redeem - 1.19.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/new_tab_page_ads/new_tab_page_ads_frequency_capping.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/new_tab_page_ads/new_tab_page_ads_frequency_capping.cc
@@ -11,6 +11,7 @@
 #include "bat/ads/internal/frequency_capping/permission_rules/new_tab_page_ads_per_day_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/permission_rules/new_tab_page_ads_per_hour_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/permission_rules/permission_rule_util.h"
+#include "bat/ads/internal/frequency_capping/permission_rules/unblinded_tokens_frequency_cap.h"
 #include "bat/ads/internal/logging.h"
 
 namespace ads {
@@ -24,6 +25,11 @@ FrequencyCapping::FrequencyCapping(
 FrequencyCapping::~FrequencyCapping() = default;
 
 bool FrequencyCapping::IsAdAllowed() {
+  UnblindedTokensFrequencyCap unblinded_tokens_frequency_cap;
+  if (!ShouldAllow(&unblinded_tokens_frequency_cap)) {
+    return false;
+  }
+
   NewTabPageAdsPerDayFrequencyCap ads_per_day_frequency_cap(ad_events_);
   if (!ShouldAllow(&ads_per_day_frequency_cap)) {
     return false;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7497
Resolves https://github.com/brave/brave-browser/issues/13289

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.