### PR TITLE
Be more restrictive for triggering IPFS infobar (uplift to 1.19.x)

### DIFF
--- a/browser/ipfs/ipfs_tab_helper.cc
+++ b/browser/ipfs/ipfs_tab_helper.cc
@@ -50,7 +50,8 @@ void IPFSTabHelper::DidFinishNavigation(content::NavigationHandle* handle) {
       pref_service_->GetInteger(kIPFSResolveMethod));
   if (resolve_method == ipfs::IPFSResolveMethodTypes::IPFS_ASK &&
       handle->GetResponseHeaders() &&
-      handle->GetResponseHeaders()->HasHeader("x-ipfs-path")) {
+      handle->GetResponseHeaders()->HasHeader("x-ipfs-path") &&
+      IsDefaultGatewayURL(handle->GetURL())) {
     InfoBarService* infobar_service =
         InfoBarService::FromWebContents(web_contents());
     if (infobar_service) {

--- a/browser/ipfs/ipfs_tab_helper_browsertest.cc
+++ b/browser/ipfs/ipfs_tab_helper_browsertest.cc
@@ -9,6 +9,7 @@
 #include "brave/common/brave_paths.h"
 #include "brave/components/ipfs/features.h"
 #include "brave/components/ipfs/ipfs_constants.h"
+#include "brave/components/ipfs/ipfs_gateway.h"
 #include "brave/components/ipfs/pref_names.h"
 #include "chrome/browser/infobars/infobar_service.h"
 #include "chrome/browser/profiles/profile.h"
@@ -70,6 +71,8 @@ class IPFSTabHelperTest : public InProcessBrowserTest,
     embedded_test_server()->RegisterRequestHandler(
         base::BindRepeating(&HandleRequest));
     ASSERT_TRUE(embedded_test_server()->Start());
+    ipfs::SetIPFSDefaultGatewayForTest(
+        embedded_test_server()->GetURL("cloudflare-ipfs.com", "/"));
   }
 
   ~IPFSTabHelperTest() override {}


### PR DESCRIPTION
Uplift of #7510
Resolves https://github.com/brave/brave-browser/issues/13240

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.