### PR TITLE
Check auto onion redirect setting for onion domain and rename kAutoOnionLocation to kAutoOnionRedirect

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -209,7 +209,7 @@
         Automatically redirect .onion sites
       </message>
       <message name="IDS_SETTINGS_AUTO_ONION_LOCATION_DESC" desc="Text fragment for onion site component">
-        Brave will open onion service of the website in Tor window when available
+        Brave will open onion service of the website when available or .onion domain in Tor window
       </message>
       <if expr="is_linux">
         <message name="IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_INSTALL" desc="Text fragment for Widevine permission request. 'Widevine' is the name of a plugin and should not be translated.">

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -192,7 +192,7 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
   (*s_brave_allowlist)[omnibox::kPreventUrlElisionsInOmnibox] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
 #if BUILDFLAG(ENABLE_TOR)
-  (*s_brave_allowlist)[tor::prefs::kAutoOnionLocation] =
+  (*s_brave_allowlist)[tor::prefs::kAutoOnionRedirect] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
 #endif
   (*s_brave_allowlist)[prefs::kWebRTCIPHandlingPolicy] =

--- a/browser/tor/onion_location_navigation_throttle_browsertest.cc
+++ b/browser/tor/onion_location_navigation_throttle_browsertest.cc
@@ -100,7 +100,9 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
-                       OnionDomain) {
+                       OnionDomain_AutoOnionRedirect) {
+  browser()->profile()->GetPrefs()->SetBoolean(tor::prefs::kAutoOnionRedirect,
+                                               true);
   BrowserList* browser_list = BrowserList::GetInstance();
   ui_test_utils::NavigateToURL(browser(), GURL("https://brave.com"));
   EXPECT_EQ(1U, browser_list->size());
@@ -119,8 +121,22 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
-                       AutoOnionLocationPref) {
-  browser()->profile()->GetPrefs()->SetBoolean(tor::prefs::kAutoOnionLocation,
+                       OnionDomain_AutoOnionRedirect_OffByDefault) {
+  BrowserList* browser_list = BrowserList::GetInstance();
+  ui_test_utils::NavigateToURL(browser(), GURL("https://brave.com"));
+
+  ui_test_utils::NavigateToURL(browser(), GURL(kTestOnionURL));
+  EXPECT_EQ(1U, browser_list->size());
+  ASSERT_FALSE(browser_list->get(0)->profile()->IsTor());
+
+  content::WebContents* web_contents =
+      browser_list->get(0)->tab_strip_model()->GetActiveWebContents();
+  EXPECT_EQ(web_contents->GetURL(), GURL(kTestOnionURL));
+}
+
+IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
+                       OnionLocationHeader_AutoOnionRedirect) {
+  browser()->profile()->GetPrefs()->SetBoolean(tor::prefs::kAutoOnionRedirect,
                                                true);
   content::WindowedNotificationObserver tor_browser_creation_observer(
       chrome::NOTIFICATION_BROWSER_OPENED,
@@ -180,7 +196,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
   EXPECT_EQ(1U, browser_list->size());
 
   // AutoOnionLocationPref
-  browser()->profile()->GetPrefs()->SetBoolean(tor::prefs::kAutoOnionLocation,
+  browser()->profile()->GetPrefs()->SetBoolean(tor::prefs::kAutoOnionRedirect,
                                                true);
   ui_test_utils::NavigateToURL(browser(), url);
   EXPECT_EQ(1U, browser_list->size());

--- a/components/tor/onion_location_navigation_throttle.cc
+++ b/components/tor/onion_location_navigation_throttle.cc
@@ -71,7 +71,7 @@ OnionLocationNavigationThrottle::WillProcessResponse() {
   if (headers && GetOnionLocation(headers, &onion_location) &&
       !navigation_handle()->GetURL().DomainIs("onion")) {
     // If user prefers opening it automatically
-    if (pref_service_->GetBoolean(prefs::kAutoOnionLocation)) {
+    if (pref_service_->GetBoolean(prefs::kAutoOnionRedirect)) {
       delegate_->OpenInTorWindow(navigation_handle()->GetWebContents(),
                                  GURL(onion_location));
     } else {
@@ -90,7 +90,8 @@ OnionLocationNavigationThrottle::WillStartRequest() {
   // Open .onion site in Tor window
   if (!is_tor_profile_) {
     GURL url = navigation_handle()->GetURL();
-    if (url.SchemeIsHTTPOrHTTPS() && url.DomainIs("onion")) {
+    if (url.SchemeIsHTTPOrHTTPS() && url.DomainIs("onion") &&
+        pref_service_->GetBoolean(prefs::kAutoOnionRedirect)) {
       delegate_->OpenInTorWindow(navigation_handle()->GetWebContents(),
                                  std::move(url));
       return content::NavigationThrottle::CANCEL_AND_IGNORE;

--- a/components/tor/pref_names.cc
+++ b/components/tor/pref_names.cc
@@ -10,7 +10,7 @@ namespace prefs {
 
 const char kTorDisabled[] = "tor.tor_disabled";
 
-const char kAutoOnionLocation[] = "tor.auto_onion_location";
+const char kAutoOnionRedirect[] = "tor.auto_onion_location";
 
 }  // namespace prefs
 }  // namespace tor

--- a/components/tor/pref_names.h
+++ b/components/tor/pref_names.h
@@ -11,8 +11,8 @@ namespace prefs {
 
 extern const char kTorDisabled[];
 
-// Automatically open onion site in tor window when available
-extern const char kAutoOnionLocation[];
+// Automatically open onion available site or .onion domain in Tor window
+extern const char kAutoOnionRedirect[];
 
 }  // namespace prefs
 }  // namespace tor

--- a/components/tor/tor_profile_service.cc
+++ b/components/tor/tor_profile_service.cc
@@ -26,7 +26,7 @@ void TorProfileService::RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 
 // static
 void TorProfileService::RegisterPrefs(PrefRegistrySimple* registry) {
-  registry->RegisterBooleanPref(prefs::kAutoOnionLocation, false);
+  registry->RegisterBooleanPref(prefs::kAutoOnionRedirect, false);
 }
 
 void TorProfileService::AddObserver(TorLauncherServiceObserver* observer) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13236

This PR makes .onion domain redirect checking the same setting that onion-location auto redirect uses so users can customize it for advanced usage.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Launch Brave with fresh profile
2. Visit `brave://settings/?search=onion` and make sure `Automatically redirect .onion sites` is off
3. Open a tab in normal window and visit `https://brave5t5rjjg3s6k.onion/`
4. There will be no Tor window opened
5. Visit `brave://settings/?search=onion` and turn on `Automatically redirect .onion sites`
6. Open a tab in normal window and visit `https://brave5t5rjjg3s6k.onion/`
7. It will be opened in Tor window