### PR TITLE
Use brave community link for invalid NTP bg images credit link (uplift to 1.19.x)

### DIFF
--- a/components/brave_new_tab_ui/data/backgrounds.ts
+++ b/components/brave_new_tab_ui/data/backgrounds.ts
@@ -23,7 +23,7 @@ export const images: NewTab.Image[] = [
     'name': 'ntp-2020/2021-3',
     'source': 'corwin-prescott_olympic.avif',
     'author': 'Corwin Prescott',
-    'link': '',
+    'link': 'https://community.brave.com/',
     'originalUrl': 'Contributor sent the hi-res version through email',
     'license': 'used with permission'
   },
@@ -63,7 +63,7 @@ export const images: NewTab.Image[] = [
     'name': 'ntp-2020/2021-8',
     'source': 'zane-lee.avif',
     'author': 'Zane Lee',
-    'link': 'https://unsplash.com/@zane4004',
+    'link': 'https://community.brave.com/',
     'originalUrl': 'Contributor sent the hi-res version through email',
     'license': 'https://unsplash.com/photos/ZiDa9i7dY1E'
   }


### PR DESCRIPTION
Uplift of #7522
Resolves https://github.com/brave/brave-browser/issues/13207

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.