### PR TITLE
New Tab Page: Prompt for Brave Together 

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -221,6 +221,11 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "torStatusDisconnected", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_DISCONNECTED },   // NOLINT
         { "torStatusInitializing", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_INITIALIZING },   // NOLINT
 
+        // Together prompt
+        { "togetherPromptTitle", IDS_BRAVE_TOGETHER_PROMPT_TITLE },
+        { "togetherPromptDescription", IDS_BRAVE_TOGETHER_PROMPT_DESCRIPTION },
+        { "togetherPromptAction", IDS_BRAVE_TOGETHER_PROMPT_ACTION },
+
         // Rewards widget
         { "rewardsWidgetBap", IDS_BRAVE_UI_BAP_REWARDS_TEXT },
         { "rewardsWidgetBat", IDS_BRAVE_UI_BAT_REWARDS_TEXT },

--- a/components/brave_new_tab_ui/actions/new_tab_actions.ts
+++ b/components/brave_new_tab_ui/actions/new_tab_actions.ts
@@ -20,6 +20,8 @@ export const statsUpdated = (stats: Stats) =>
 
 export const init = createAction<void>('page init')
 
+export const dismissTogetherPrompt = createAction('dismiss together prompt')
+
 export const privateTabDataUpdated = (data: PrivateTabData) =>
   action(types.NEW_TAB_PRIVATE_TAB_DATA_UPDATED, data)
 

--- a/components/brave_new_tab_ui/brave_new_tab.html
+++ b/components/brave_new_tab_ui/brave_new_tab.html
@@ -1,5 +1,5 @@
 ﻿<!doctype html>
-<html data-test-id="brave-new-tab-page">
+<html data-test-id="brave-new-tab-page" dir="$i18n{textdirection}">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">

--- a/components/brave_new_tab_ui/components/default/footer/footer.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/footer.tsx
@@ -14,34 +14,40 @@ import {
   IconButtonSideText,
   IconLink,
   PhotoName
-} from '../../components/default'
-import * as S from '../../components/default/page'
+} from '..'
+import * as S from '../page'
 
-// Icons
+// Items
 import {
   SettingsIcon,
   SettingsAdvancedIcon,
   BookmarkBook,
   HistoryIcon
 } from 'brave-ui/components/icons'
+import TogetherTooltip from './togetherTooltip'
+import TogetherIcon from './togetherTooltip/togetherIcon'
 
 // Helpers
-import { getLocale } from '../../../common/locale'
+import { getLocale } from '../../../../common/locale'
 
 interface Props {
   textDirection: string
-  onClickSettings: () => any
+  togetherPrmoptDismissed: boolean
   backgroundImageInfo: any
   showPhotoInfo: boolean
+  onClickSettings: () => any
+  onDismissTogetherPrompt: () => any
 }
 
 export default class FooterInfo extends React.PureComponent<Props, {}> {
   render () {
     const {
       textDirection,
-      onClickSettings,
+      togetherPrmoptDismissed,
       backgroundImageInfo,
-      showPhotoInfo
+      showPhotoInfo,
+      onDismissTogetherPrompt,
+      onClickSettings
     } = this.props
 
     return (
@@ -78,6 +84,16 @@ export default class FooterInfo extends React.PureComponent<Props, {}> {
             <IconLink title={getLocale('historyPageTitle')} href='chrome://history'>
               <HistoryIcon />
             </IconLink>
+            { !togetherPrmoptDismissed
+              ? <TogetherTooltip onClose={onDismissTogetherPrompt}>
+                  <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+                    <TogetherIcon />
+                  </IconLink>
+                </TogetherTooltip>
+              : <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+                  <TogetherIcon />
+                </IconLink>
+            }
           </Navigation>
         </S.GridItemNavigation>
       </>

--- a/components/brave_new_tab_ui/components/default/footer/togetherTooltip/button.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/togetherTooltip/button.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import styled from 'brave-ui/theme'
+
+const Button = styled('button')`
+  --outer-border-size: 0px;
+  --inner-border-size: 1px;
+  appearance: none;
+  cursor: pointer;
+  background: none;
+  border-radius: 24px;
+  border: solid var(--border-size);
+  padding: 14px 25px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: white;
+  font-family: Poppins;
+  font-size: 15px;
+  font-weight: 600;
+  /* Use box-shadow for borders so we get a smooth (and layout-free performance-cheap)
+    animation as well as multiple borders. */
+  box-shadow: 0 0 0 var(--outer-border-size) rgba(255, 255, 255, .6),
+              inset 0 0 0 var(--inner-border-size) white;
+  transition: box-shadow .12s ease-in-out;
+  outline: none;
+
+  :focus {
+    outline: none;
+  }
+
+  :hover {
+    --inner-border-size: 2px;
+  }
+
+  :focus-visible {
+    --inner-border-size: 1px;
+    --outer-border-size: 2px;
+  }
+
+  :active {
+    --inner-border-size: 1px;
+    --outer-border-size: 4px;
+  }
+`
+
+export const LinkButton = styled(Button.withComponent('a'))`
+  text-decoration: none;
+  :hover {
+    text-decoration: none;
+  }
+`
+
+export default Button

--- a/components/brave_new_tab_ui/components/default/footer/togetherTooltip/closeIcon.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/togetherTooltip/closeIcon.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+function CloseIcon () {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 13 13'>
+      <path
+        fill='#fff'
+        fillRule='evenodd'
+        d='M2.28.4a.87.87 0 10-1.23 1.22l4.5 4.5-4.5 4.5a.87.87 0 101.23 1.22l4.5-4.5 4.36 4.37a.87.87 0 101.23-1.22L8 6.12l4.37-4.37A.87.87 0 1011.14.53L6.77 4.89 2.28.4z'
+        clipRule='evenodd'
+      />
+    </svg>
+  )
+}
+
+export default CloseIcon

--- a/components/brave_new_tab_ui/components/default/footer/togetherTooltip/index.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/togetherTooltip/index.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { getLocale } from '../../../../../common/locale'
+import TogetherIcon from './togetherIcon'
+import CloseIcon from './closeIcon'
+import { LinkButton } from './button'
+import * as S from './style'
+
+type Props = {
+  onClose: () => any
+}
+
+const TogetherTooltip: React.FunctionComponent<Props> = function (props) {
+  return (
+    <S.Anchor>
+      <S.Tooltip>
+        <S.Title>
+          <S.TitleIcon><TogetherIcon /></S.TitleIcon>
+          {getLocale('togetherPromptTitle')}
+        </S.Title>
+        <S.Body>
+          {getLocale('togetherPromptDescription')}
+        </S.Body>
+        <LinkButton href='https://brave.com/together'>
+          {getLocale('togetherPromptAction')}
+        </LinkButton>
+        <S.CloseButton
+          onClick={props.onClose}
+          aria-label={getLocale('close')}
+        >
+          <CloseIcon />
+        </S.CloseButton>
+      </S.Tooltip>
+      {props.children}
+    </S.Anchor>
+  )
+}
+
+export default TogetherTooltip

--- a/components/brave_new_tab_ui/components/default/footer/togetherTooltip/style.ts
+++ b/components/brave_new_tab_ui/components/default/footer/togetherTooltip/style.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import styled from 'brave-ui/theme'
+
+export const Anchor = styled('div')`
+  position: relative;
+`
+
+export const Tooltip = styled('div').attrs({
+  role: 'tooltip'
+})`
+  --arrow-size: 17px;
+  --arrow-width: calc(var(--arrow-size) * 1.41421356237);
+  --arrow-width-half: calc(var(--arrow-width) * .5);
+  --arrow-start: calc(100% - 50px);
+  --arrow-bottom-clip: calc(100% - var(--arrow-width-half));
+  position: absolute;
+  bottom: calc(100% + 20px);
+  right: -20px;
+  border-radius: 6px;
+  min-width: 250px;
+  background: linear-gradient(305.95deg, #BF14A2 0%, #F73A1C 98.59%);
+  padding: 24px 26px;
+  color: white;
+
+  [dir=rtl] & {
+    --arrow-start: 14px;
+    left: -5px;
+    right: unset;
+  }
+
+  /* An arrow that supports any linear-gradient or background-image flowing
+    in to the arrow area. We accomplish this using a clip-path. We use a copy
+    of the element (via a pseudo element) so that we can keep the rounded corners
+    on the original and clip the copy to only the "arrow". */
+  &:before {
+    content: " ";
+    position: absolute;
+    top: 0;
+    bottom: calc(-1 * var(--arrow-width-half));
+    left: 0;
+    right: 0;
+    background: linear-gradient(305.95deg, #BF14A2 0%, #F73A1C 98.59%);
+    clip-path: polygon(
+      calc(var(--arrow-start) + var(--arrow-width)) var(--arrow-bottom-clip),
+      calc(var(--arrow-start) + var(--arrow-width-half)) 100%,
+      var(--arrow-start) var(--arrow-bottom-clip)
+    );
+  }
+`
+
+export const Title = styled('h3')`
+  font-family: Poppins;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 133%;
+  letter-spacing: 0.04em;
+  margin: 0 0 4px 0;
+`
+
+export const TitleIcon = styled('div')`
+  display: inline-block;
+  vertical-align: sub;
+  margin-inline-end: 6px;
+  width: 18px;
+  height: 18px;
+`
+
+export const Body = styled('p')`
+  font-family: Poppins;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 150%;
+  letter-spacing: 0.01em;
+  margin-bottom: 16px;
+  a {
+    text-decoration: underline;
+    color: inherit;
+  }
+`
+
+export const CloseButton = styled('button')`
+  appearance: none;
+  background: none;
+  border: none;
+  position: absolute;
+  padding: 4px;
+  box-sizing: content-box;
+  margin: 0;
+  right: 12px;
+  top: 12px;
+  width: 12px;
+  height: 12px;
+  cursor: pointer;
+  border-radius: 100%;
+  outline: none;
+  transition: background .12s ease-in-out, box-shadow .12s ease-in-out;
+
+  [dir=rtl] & {
+    right: unset;
+    left: 12px;
+  }
+
+  :hover, :focus-visible {
+    background: rgba(255, 255, 255, .3);
+  }
+
+  :active {
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, .6);
+  }
+`

--- a/components/brave_new_tab_ui/components/default/footer/togetherTooltip/togetherIcon.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/togetherTooltip/togetherIcon.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+export default function Icon () {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
+      <path
+        fill='#fff'
+        fillRule='evenodd'
+        d='M23.5 20.18a.95.95 0 01-.99-.05l-4.26-2.84v1.09c0 1.05-.86 1.91-1.92 1.91H2.92A1.92 1.92 0 011 18.38V5.92C1 4.86 1.86 4 2.92 4h13.41c1.06 0 1.92.86 1.92 1.92V7l4.26-2.84a.96.96 0 011.49.8v14.37c0 .36-.2.68-.5.85zM22.07 6.75l-4.26 2.84c-.02.02-.05.02-.08.03a.93.93 0 01-.36.11l-.09.02-.1-.02a.91.91 0 01-.64-.34c-.01-.03-.04-.04-.06-.07l-.03-.08a.92.92 0 01-.11-.37l-.02-.08V5.92H2.92v12.5h13.41V15.5l.02-.09a.9.9 0 01.04-.18.91.91 0 01.07-.18l.03-.08.07-.07a.93.93 0 01.64-.34l.1-.02.07.02a.93.93 0 01.37.11l.08.03 4.26 2.84V6.75z'
+        clipRule='evenodd'
+      />
+    </svg>
+  )
+}

--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -218,7 +218,7 @@ export const GridItemBrandedLogo = styled(GridItemCredits)`
 `
 
 export const GridItemNavigation = styled('section')`
-  grid-column: 3 / span 1;
+  grid-column: 2 / span 2;
   grid-row: -2 / span 1;
   align-self: end;
   margin: 0 24px 24px 0;

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -8,7 +8,7 @@ import * as React from 'react'
 // Components
 import Stats from './stats'
 import TopSitesGrid from './gridSites'
-import FooterInfo from './footerInfo'
+import FooterInfo from '../../components/default/footer/footer'
 import SiteRemovalNotification from './notification'
 import {
   ClockWidget as Clock,
@@ -1079,9 +1079,11 @@ class NewTabPage extends React.Component<Props, State> {
             </Page.GridItemBrandedLogo>}
             <FooterInfo
               textDirection={newTabData.textDirection}
-              onClickSettings={this.openSettings}
+              togetherPrmoptDismissed={newTabData.togetherPromptDismissed}
               backgroundImageInfo={newTabData.backgroundImage}
               showPhotoInfo={!isShowingBrandedWallpaper && newTabData.showBackgroundImage}
+              onClickSettings={this.openSettings}
+              onDismissTogetherPrompt={this.props.actions.dismissTogetherPrompt}
             />
             </Page.FooterContent>
           </Page.Footer>

--- a/components/brave_new_tab_ui/reducers/new_tab_reducer.ts
+++ b/components/brave_new_tab_ui/reducers/new_tab_reducer.ts
@@ -10,6 +10,7 @@ import { types, DismissBrandedWallpaperNotificationPayload } from '../constants/
 import { Stats } from '../api/stats'
 import { PrivateTabData } from '../api/privateTabData'
 import { TorTabData } from '../api/torTabData'
+import * as Actions from '../actions/new_tab_actions'
 
 // API
 import * as backgroundAPI from '../api/background'
@@ -183,6 +184,14 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
       performSideEffect(async function (state) {
         chrome.send('customizeClicked', [])
       })
+      break
+    }
+
+    case Actions.dismissTogetherPrompt.getType(): {
+      state = {
+        ...state,
+        togetherPromptDismissed: true
+      }
       break
     }
 

--- a/components/brave_new_tab_ui/storage/new_tab_storage.ts
+++ b/components/brave_new_tab_ui/storage/new_tab_storage.ts
@@ -46,6 +46,7 @@ export const defaultState: NewTab.State = {
     bandwidthSavedStat: 0,
     fingerprintingBlockedStat: 0
   },
+  togetherPromptDismissed: false,
   rewardsState: {
     adsEstimatedEarnings: 0,
     balance: {
@@ -266,6 +267,7 @@ export const debouncedSave = debounce<NewTab.State>((data: NewTab.State) => {
   if (data) {
     const dataToSave = {
       togetherSupported: data.togetherSupported,
+      togetherPromptDismissed: data.togetherPromptDismissed,
       binanceSupported: data.binanceSupported,
       geminiSupported: data.geminiSupported,
       bitcoinDotComSupported: data.bitcoinDotComSupported,

--- a/components/brave_new_tab_ui/stories/default.tsx
+++ b/components/brave_new_tab_ui/stories/default.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { Dispatch } from 'redux'
 import { Provider as ReduxProvider } from 'react-redux'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, select } from '@storybook/addon-knobs/react'
+import { withKnobs, select, boolean } from '@storybook/addon-knobs/react'
 import Theme from 'brave-ui/theme/brave-default'
 import DarkTheme from 'brave-ui/theme/brave-dark'
 import BraveCoreThemeProvider from '../../common/BraveCoreThemeProvider'
@@ -72,6 +72,7 @@ function dismissBraveTodayIntroCard () {
 
 storiesOf('New Tab/Containers', module)
   .addDecorator(withKnobs)
+  .addDecorator(story => <div dir={boolean('rtl?', false) ? 'rtl' : ''}>{story()}</div>)
   .addDecorator(story => <StoreProvider story={story()} />)
   .addDecorator(story => <ThemeProvider story={story()} />)
   .add('Default', () => {

--- a/components/brave_new_tab_ui/stories/default/data/storybookState.ts
+++ b/components/brave_new_tab_ui/stories/default/data/storybookState.ts
@@ -74,6 +74,7 @@ export const getNewTabData = (state: NewTab.State = defaultState): NewTab.State 
   showRewards: boolean('Show rewards?', true),
   showTogether: boolean('Show together?', true),
   togetherSupported: boolean('Together supported?', true),
+  togetherPromptDismissed: !boolean('Together prompt?', false),
   geminiSupported: boolean('Gemini Supported?', true),
   cryptoDotComSupported: boolean('Crypto.com supported?', true),
   showBinance: boolean('Show Binance?', true),

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -76,6 +76,7 @@ declare namespace NewTab {
   }
 
   export interface PersistentState {
+    togetherPromptDismissed: boolean
     togetherSupported: boolean
     geminiSupported: boolean
     binanceSupported: boolean

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -212,6 +212,16 @@
         Back
       </message>
 
+      <message name="IDS_BRAVE_TOGETHER_PROMPT_TITLE" desc="Title for prompt about Brave Together">
+        You can start a private call in Brave.
+      </message>
+      <message name="IDS_BRAVE_TOGETHER_PROMPT_DESCRIPTION" desc="Description for prompt about Brave Together">
+        Start unlimited calls with friends and colleagues in Brave Together.
+      </message>
+      <message name="IDS_BRAVE_TOGETHER_PROMPT_ACTION" desc="Button text for prompt about Brave Together">
+        Try it out
+      </message>
+
       <message name="IDS_BRAVE_TODAY_TITLE" translateable="false" desc="Title for Brave Today news feed section">
         Brave Today
       </message>

--- a/ui/webui/resources/css/text_defaults.css
+++ b/ui/webui/resources/css/text_defaults.css
@@ -15,6 +15,7 @@
 @import url(chrome://brave-resources/fonts/poppins.css);
 
 html {
+  /* TODO(dbeam): remove this soon. Prefer dir= in HTML. */
   direction: $i18n{textDirection};
 }
 


### PR DESCRIPTION
- Button in footer always shows
- Prompt (anchored to button) shows like a tooltip until the user manually closes via button.
- _(Also adds dir="rtl" as attribute in instead of stylesheet so that it's targetable as a css selector. This is done in most chromium webui now.)_

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/12776

![image](https://user-images.githubusercontent.com/741836/103858837-e9da7e80-506d-11eb-9281-1f96075ee5fd.png)

![image](https://user-images.githubusercontent.com/741836/103858937-1098b500-506e-11eb-8824-f5d120ddc5c3.png)

### Button Transitions

![button-transitions](https://user-images.githubusercontent.com/741836/103929181-c3e6c580-50d1-11eb-929f-78d431c9f4fd.gif)


## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

