### PR TITLE
Don't enable ads on iOS by default when a wallet is created (uplift to 1.19.x)

### DIFF
--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -123,6 +123,7 @@ def AddBraveCredits(prune_paths, special_cases, prune_dirs, additional_paths):
     prune_list += [
         'chromium_src',  # Brave's overrides, covered by main notice.
         'node_modules',  # See brave/third_party/npm-* instead.
+        '.vscode',       # Automatically added by Visual Studio.
     ]
     prune_dirs = tuple(prune_list)
 

--- a/vendor/brave-ios/Ledger/BATBraveLedger.mm
+++ b/vendor/brave-ios/Ledger/BATBraveLedger.mm
@@ -450,7 +450,6 @@ BATClassLedgerBridge(BOOL, useShortRetries, setUseShortRetries, short_retries)
       error = [NSError errorWithDomain:BATBraveLedgerErrorDomain code:static_cast<NSInteger>(result) userInfo:userInfo];
     }
 
-    strongSelf.ads.enabled = [BATBraveAds isCurrentLocaleSupported];
     [strongSelf startNotificationTimers];
     strongSelf.initializingWallet = NO;
 


### PR DESCRIPTION
Uplift of #7542
Fixes https://github.com/brave/brave-ios/issues/3188

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.