### PR TITLE
Clear IPFS cache when clearing browsing data

### DIFF
--- a/browser/browsing_data/BUILD.gn
+++ b/browser/browsing_data/BUILD.gn
@@ -1,3 +1,4 @@
+import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//extensions/buildflags/buildflags.gni")
 
 source_set("browsing_data") {
@@ -12,6 +13,7 @@ source_set("browsing_data") {
 
   deps = [
     "//base",
+    "//brave/components/ipfs/buildflags",
     "//chrome/common",
     "//components/browsing_data/core",
     "//components/content_settings/core/browser",
@@ -25,5 +27,9 @@ source_set("browsing_data") {
       "//brave/common/extensions/api",
       "//extensions/browser",
     ]
+  }
+
+  if (ipfs_enabled) {
+    deps += [ "//brave/components/ipfs" ]
   }
 }

--- a/browser/browsing_data/brave_browsing_data_remover_delegate.cc
+++ b/browser/browsing_data/brave_browsing_data_remover_delegate.cc
@@ -20,6 +20,19 @@
 #include "extensions/browser/event_router.h"
 #endif
 
+#if BUILDFLAG(IPFS_ENABLED)
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/process/launch.h"
+#include "base/process/process.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "base/threading/thread_restrictions.h"
+#include "base/time/time.h"
+#include "brave/browser/ipfs/ipfs_service_factory.h"
+#include "brave/components/ipfs/ipfs_service.h"
+#endif
+
 BraveBrowsingDataRemoverDelegate::BraveBrowsingDataRemoverDelegate(
     content::BrowserContext* browser_context)
     : ChromeBrowsingDataRemoverDelegate(browser_context),
@@ -46,6 +59,12 @@ void BraveBrowsingDataRemoverDelegate::RemoveEmbedderData(
   // shields settings with non-empty resource ids.
   if (remove_mask & DATA_TYPE_CONTENT_SETTINGS)
     ClearShieldsSettings(delete_begin, delete_end);
+
+#if BUILDFLAG(IPFS_ENABLED)
+  if (remove_mask & content::BrowsingDataRemover::DATA_TYPE_CACHE)
+    ClearIPFSCache();
+#endif
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   if (remove_mask & DATA_TYPE_HISTORY) {
     auto* event_router = extensions::EventRouter::Get(profile_);
@@ -91,3 +110,68 @@ void BraveBrowsingDataRemoverDelegate::ClearShieldsSettings(
     }
   }
 }
+
+#if BUILDFLAG(IPFS_ENABLED)
+void BraveBrowsingDataRemoverDelegate::WaitForIPFSRepoGC(
+    base::Process process) {
+  bool exited = false;
+
+  {
+    base::ScopedAllowBaseSyncPrimitives scoped_allow_base_sync_primitives;
+
+    // Because we set maximum IPFS storage size as 1GB in Brave, ipfs repo gc
+    // command should be finished in just a few seconds and we do not expect
+    // this child process would hang forever. To be safe, we will wait for 30
+    // seconds max here.
+    exited = process.WaitForExitWithTimeout(base::TimeDelta::FromSeconds(30),
+                                            nullptr);
+  }
+
+  if (!exited)
+    process.Terminate(0, false /* wait */);
+}
+
+// Run ipfs repo gc command to clear IPFS cache when IPFS executable path is
+// available. Because the command does not support time ranged cleanup, we will
+// always clear the whole cache expect for pinned files when clearing browsing
+// data.
+void BraveBrowsingDataRemoverDelegate::ClearIPFSCache() {
+  auto* service =
+      ipfs::IpfsServiceFactory::GetInstance()->GetForContext(profile_);
+  if (!service)
+    return;
+
+  base::FilePath path = service->GetIpfsExecutablePath();
+  if (path.empty())
+    return;
+
+  base::CommandLine cmdline(path);
+  cmdline.AppendArg("repo");
+  cmdline.AppendArg("gc");
+
+  base::FilePath data_path = service->GetDataPath();
+  base::LaunchOptions options;
+#if defined(OS_WIN)
+  options.environment[L"IPFS_PATH"] = data_path.value();
+#else
+  options.environment["IPFS_PATH"] = data_path.value();
+#endif
+#if defined(OS_LINUX)
+  options.kill_on_parent_death = true;
+#endif
+#if defined(OS_WIN)
+  options.start_hidden = true;
+#endif
+
+  base::Process process = base::LaunchProcess(cmdline, options);
+  if (!process.IsValid()) {
+    return;
+  }
+
+  base::ThreadPool::PostTaskAndReply(
+      FROM_HERE, {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
+      base::BindOnce(&BraveBrowsingDataRemoverDelegate::WaitForIPFSRepoGC,
+                     base::Unretained(this), base::Passed(&process)),
+      CreateTaskCompletionClosure(TracingDataType::kHostCache));
+}
+#endif  // BUILDFLAG(IPFS_ENABLED)

--- a/browser/browsing_data/brave_browsing_data_remover_delegate.h
+++ b/browser/browsing_data/brave_browsing_data_remover_delegate.h
@@ -7,7 +7,12 @@
 #define BRAVE_BROWSER_BROWSING_DATA_BRAVE_BROWSING_DATA_REMOVER_DELEGATE_H_
 
 #include "base/time/time.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h"
+
+namespace base {
+class Process;
+}  // namespace base
 
 namespace content_settings {
 class BravePrefProvider;
@@ -41,6 +46,10 @@ class BraveBrowsingDataRemoverDelegate
                           override;
 
   void ClearShieldsSettings(base::Time begin_time, base::Time end_time);
+#if BUILDFLAG(IPFS_ENABLED)
+  void ClearIPFSCache();
+  void WaitForIPFSRepoGC(base::Process process);
+#endif
 
   Profile* profile_;
 };

--- a/chromium_src/base/threading/thread_restrictions.h
+++ b/chromium_src/base/threading/thread_restrictions.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_BASE_THREADING_THREAD_RESTRICTIONS_H_
+#define BRAVE_CHROMIUM_SRC_BASE_THREADING_THREAD_RESTRICTIONS_H_
+
+class BraveBrowsingDataRemoverDelegate;
+
+#define BRAVE_SCOPED_ALLOW_BASE_SYNC_PRIMITIVES_H \
+  friend class ::BraveBrowsingDataRemoverDelegate;
+
+#include "../../../../base/threading/thread_restrictions.h"
+#undef BRAVE_SCOPED_ALLOW_BASE_SYNC_PRIMITIVES_H
+
+#endif  // BRAVE_CHROMIUM_SRC_BASE_THREADING_THREAD_RESTRICTIONS_H_

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_
+
+class BraveBrowsingDataRemoverDelegate;
+
+#define BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H \
+  friend class BraveBrowsingDataRemoverDelegate;
+
+#include "../../../../../chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h"
+#undef BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_

--- a/components/ipfs/ipfs_service.h
+++ b/components/ipfs/ipfs_service.h
@@ -70,6 +70,7 @@ class IpfsService : public KeyedService,
   bool IsIPFSExecutableAvailable() const;
   void RegisterIpfsClientUpdater();
   IPFSResolveMethodTypes GetIPFSResolveMethodType() const;
+  base::FilePath GetIpfsExecutablePath();
   base::FilePath GetDataPath() const;
   base::FilePath GetConfigFilePath() const;
 
@@ -88,7 +89,6 @@ class IpfsService : public KeyedService,
   void RunLaunchDaemonCallbackForTest(bool result);
 
  protected:
-  base::FilePath GetIpfsExecutablePath();
   void OnConfigLoaded(GetConfigCallback, const std::pair<bool, std::string>&);
 
  private:

--- a/patches/base-threading-thread_restrictions.h.patch
+++ b/patches/base-threading-thread_restrictions.h.patch
@@ -1,0 +1,12 @@
+diff --git a/base/threading/thread_restrictions.h b/base/threading/thread_restrictions.h
+index ac19eaecc4cc36c4376052c33314bc289bab7bcf..6e79d17b49ba84fa4ccbbfefd88c3aa1888a855b 100644
+--- a/base/threading/thread_restrictions.h
++++ b/base/threading/thread_restrictions.h
+@@ -433,6 +433,7 @@ INLINE_IF_DCHECK_IS_OFF void DisallowBaseSyncPrimitives()
+     EMPTY_BODY_IF_DCHECK_IS_OFF;
+ 
+ class BASE_EXPORT ScopedAllowBaseSyncPrimitives {
++  BRAVE_SCOPED_ALLOW_BASE_SYNC_PRIMITIVES_H
+  private:
+   // This can only be instantiated by friends. Use
+   // ScopedAllowBaseSyncPrimitivesForTesting in unit tests to avoid the friend

--- a/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate.h.patch
+++ b/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate.h.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
+index ae0d55606244bca6ac1a1fa0037e0dc286c36174..74bc2123ced2db3fcdfc8854aac5a61f6067bd62 100644
+--- a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
++++ b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
+@@ -195,6 +195,7 @@ class ChromeBrowsingDataRemoverDelegate
+   void OverrideDomainReliabilityClearerForTesting(
+       DomainReliabilityClearer clearer);
+ 
++  BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H
+  private:
+   using WebRtcEventLogManager = webrtc_event_logging::WebRtcEventLogManager;
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13302

This PR runs `ipfs repo gc` command when users clear browsing data via settings with cache type selected.
One thing to note here is that it will only be run if ipfs component is loaded (ex: user tries to launch local node during this browser session) and IPFS is not disabled, otherwise we won't have the executable path ready to use.

There are no new automatic tests added because we need to be able to run ipfs binary to have any meaningful tests, which is unlikely right now.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Pre-condition: IPFS resolve method is set to `Local node` in the settings. (If it's not, visit https://dweb.link/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR to trigger the infobar to enable local node support)

1. Go to brave://ipfs to launch IPFS local node.
2. After daemon is ready, find ipfs binary under your profile directory(For example,  /Users/yrliou/Library/Application Support/BraveSoftware/Brave-Browser-Development/nljcddpbnaianmglkpkneakjaapinabi/1.0.3 on mac), then run `/go-ipfs_v0.7.0_darwin-amd64 --api=/ip4/127.0.0.1/tcp/45001 repo stat` (Use port 45001 for development build, port 45002 on nightly, 45003 on dev, 45004 on beta, 45005 on release), to see the initial NumObjects.
Example of command result:
```
yrliou@jocelyn-imacpro ~/Library/Application Support/BraveSoftware/Brave-Browser-Development/nljcddpbnaianmglkpkneakjaapinabi/1.0.3 $ ./go-ipfs_v0.7.0_darwin-amd64 --api=/ip4/127.0.0.1/tcp/45001 repo stat
NumObjects: 13
RepoSize:   179314
StorageMax: 1000000000
RepoPath:   /Users/yrliou/Library/Application Support/BraveSoftware/Brave-Browser-Development/brave_ipfs
Version:    fs-repo@10
```
3. Visit ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_van_Gogh.html and run the command in step 2 again, you should see NumObjects & RepoSize increased.
4. Go to brave://settings and search for `Clear browsing data` setting, open the dialog and unselect `Cached images and files`.
5. Hit clear data and run the command in step 2 again, should have no changes from the previous result.
6. Open the dialog again and select `Cached images and files`.
<img width="515" alt="Screen Shot 2021-01-14 at 3 35 34 PM" src="https://user-images.githubusercontent.com/4730197/104661850-4cd7a100-567e-11eb-8179-067a2cbddd66.png">

7. Repeat step 5 and this time should see NumObjects drops from the previous result.
8. Visit ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_van_Gogh.html again and observe NumObjects & RepoSize increased using the command.
9. Open the `Clear browsing data` dialog again, choose `On Exit` and make sure `Cached images and files` is selected.
10. Exit the browser
11. Start the browser and visit brave://ipfs to launch IPFS local node.
12. Run `/go-ipfs_v0.7.0_darwin-amd64 --api=/ip4/127.0.0.1/tcp/45001 repo stat`, should see the numbers are dropped from what you observed in step 8.