### PR TITLE
Handle "Allow in private" for Crypto Wallet and Greaselion

### DIFF
--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -64,6 +64,8 @@ class BraveComponentLoader : public ComponentLoader {
   void CheckRewardsStatus();
 #endif
 
+  void ReinstallAsNonComponent(std::string extension_id);
+
   Profile* profile_;
   PrefService* profile_prefs_;
   PrefChangeRegistrar pref_change_registrar_;

--- a/components/greaselion/browser/greaselion_service_impl.cc
+++ b/components/greaselion/browser/greaselion_service_impl.cc
@@ -108,6 +108,8 @@ scoped_refptr<Extension> ConvertGreaselionRuleToExtensionOnTaskRunner(
   root->SetStringPath(extensions::manifest_keys::kVersion, "1.0");
   root->SetStringPath(extensions::manifest_keys::kDescription, "");
   root->SetStringPath(extensions::manifest_keys::kPublicKey, key);
+  root->SetStringPath("incognito",
+                      extensions::manifest_values::kIncognitoNotAllowed);
 
   std::vector<std::string> matches;
   matches.reserve(rule->url_patterns().size());


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13279
Resolves https://github.com/brave/brave-browser/issues/13506

This PR
1. Reinstall crypto wallet as non component extension while still leverage component updater's update mechanism
2. Add "not_allowed" to manifest of Greaselion
(https://developer.chrome.com/docs/extensions/mv2/manifest/incognito/#not_allowed)

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Crypto Wallet
1. Launch Brave without `--show-component-extenstion-options`
2. Open brave://wallet and install wallet
3. Go to brave://extensions and go to details for Crypto Wallet extension
4. `Allow in private` option is available and disabled by default

Crypto Wallet: dApp
1. Launch Brave without `--show-component-extenstion-options`
2. Open brave://wallet and install wallet
3. Open https://www.cryptokitties.co/ in regular window and setup
4. The page should display<img width="380" alt="Screen Shot 2021-01-12 at 17 30 59" src="https://user-images.githubusercontent.com/11330831/104394687-f7738680-54fb-11eb-96f4-51b3a218f070.png">
5. Open https://www.cryptokitties.co/ in private window
6. The page should show<img width="287" alt="Screen Shot 2021-01-12 at 17 31 51" src="https://user-images.githubusercontent.com/11330831/104394750-15d98200-54fc-11eb-8f6f-1bf8b9efdd71.png">
7. Open brave://extensions/?id=odbfpeeihdkbihmopkbjmoonfanlbfcl and toggle on "Allow in private"
8. Open https://www.cryptokitties.co/ in private window again
9. We should be able to see locked wallet waiting to be unlocked

Crypto Wallet: Migration
1. Launch with older Brave
2. Open brave://wallet and install wallet
3. Go to https://goerli-faucet.slock.it/ and request 0.05 ETH
4. Make sure the balance shows 0.05ETH on goerli test network
5. Exit and Launch newer Brave with the profile
6. Open brave://wallet
7. It should still show 0.05 ETH

Greaselion
1. Launch Brave with `--show-component-extenstion-options`
2. Open brave://extensions and go to details for any greaselion
3. There is no `Allow in private` option because it is off by default and can not be toggled on
