### PR TITLE
[iOS-Sync] Delete Other Devices (uplift to 1.19.x)

### DIFF
--- a/ios/browser/api/sync/BUILD.gn
+++ b/ios/browser/api/sync/BUILD.gn
@@ -21,6 +21,7 @@ source_set("sync") {
     "//brave/components/brave_sync",
     "//brave/components/brave_sync:crypto",
     "//brave/components/brave_sync:prefs",
+    "//brave/components/brave_sync:profile_sync_service_helper",
     "//components/sync/driver",
     "//components/sync_device_info",
     "//ios/chrome/browser",

--- a/ios/browser/api/sync/brave_sync_api.h
+++ b/ios/browser/api/sync/brave_sync_api.h
@@ -19,7 +19,9 @@ OBJC_EXPORT
 @property(nonatomic) bool syncEnabled;
 @property(nonatomic, readonly) bool isSyncFeatureActive;
 
-- (bool)resetSync;
+- (void)resetSync;
+
+- (void)deleteDevice:(NSString*)guid;
 
 - (bool)isValidSyncCode:(NSString*)syncCode;
 

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -244,15 +244,15 @@ bool BraveSyncWorker::IsFirstSetupComplete() {
 void BraveSyncWorker::ResetSync() {
   DCHECK_CURRENTLY_ON(web::WebThread::UI);
   auto* sync_service = GetSyncService();
-  
+
   if (!sync_service) {
     return;
   }
-  
+
   auto* device_info_service =
       DeviceInfoSyncServiceFactory::GetForBrowserState(browser_state_);
   DCHECK(device_info_service);
-  
+
   brave_sync::ResetSync(sync_service, device_info_service,
                         base::BindOnce(&BraveSyncWorker::OnResetDone,
                                         weak_ptr_factory_.GetWeakPtr()));
@@ -261,15 +261,15 @@ void BraveSyncWorker::ResetSync() {
 void BraveSyncWorker::DeleteDevice(const std::string& device_guid) {
   DCHECK_CURRENTLY_ON(web::WebThread::UI);
   auto* sync_service = GetSyncService();
-  
+
   if (!sync_service) {
     return;
   }
-  
+
   auto* device_info_service =
       DeviceInfoSyncServiceFactory::GetForBrowserState(browser_state_);
   DCHECK(device_info_service);
-  
+
   brave_sync::DeleteDevice(sync_service, device_info_service, device_guid);
 }
 

--- a/ios/browser/api/sync/brave_sync_worker.h
+++ b/ios/browser/api/sync/brave_sync_worker.h
@@ -22,6 +22,7 @@ class ChromeBrowserState;
 namespace syncer {
 class BraveProfileSyncService;
 class DeviceInfo;
+class BraveDeviceInfo;
 class ProfileSyncService;
 }  // namespace syncer
 
@@ -66,11 +67,12 @@ class BraveSyncWorker : public syncer::SyncServiceObserver {
   bool SetSyncCode(const std::string& sync_code);
   std::string GetSyncCodeFromHexSeed(const std::string& hex_seed);
   const syncer::DeviceInfo* GetLocalDeviceInfo();
-  std::vector<std::unique_ptr<syncer::DeviceInfo>> GetDeviceList();
+  std::vector<std::unique_ptr<syncer::BraveDeviceInfo>> GetDeviceList();
   bool IsSyncEnabled();
   bool IsSyncFeatureActive();
   bool IsFirstSetupComplete();
-  bool ResetSync();
+  void ResetSync();
+  void DeleteDevice(const std::string& device_guid);
 
  private:
   // syncer::SyncServiceObserver implementation.
@@ -79,7 +81,7 @@ class BraveSyncWorker : public syncer::SyncServiceObserver {
   void OnStateChanged(syncer::SyncService* service) override;
   void OnSyncShutdown(syncer::SyncService* service) override;
 
-  void OnLocalDeviceInfoDeleted();
+  void OnResetDone();
 
   ChromeBrowserState* browser_state_;  // NOT OWNED
   ScopedObserver<syncer::SyncService, syncer::SyncServiceObserver>


### PR DESCRIPTION
- Adds support for deleting other devices from the sync chain.
- Adds support for the current device being deleted from the chain, by another device.
- Fixes missing brave_services_key

Uplift of https://github.com/brave/brave-core/pull/7584
Resolves brave/brave-ios#3194 and brave/brave-ios#3195

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.