### PR TITLE
Fix button color in IPFS interstitial page in light theme

### DIFF
--- a/components/ipfs/resources/interstitial_ipfs.css
+++ b/components/ipfs/resources/interstitial_ipfs.css
@@ -3,6 +3,10 @@
   text-decoration: none;
 }
 
+.ipfs button {
+  background: var(--primary-button-fill-color);
+}
+
 .ipfs .icon {
   background-image: -webkit-image-set(
       url(../../../../components/security_interstitials/core/browser/resources/images/1x/info.png) 1x,


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13599

Buttons in other interstitial pages are using this, this PR adds this for .ipfs button in our own css.
https://source.chromium.org/chromium/chromium/src/+/master:components/security_interstitials/core/common/resources/interstitial_common.css;l=33?q=interstitial_common&ss=chromium

With this, the page looks like below:
<img width="1201" alt="Screen Shot 2021-01-15 at 11 03 44 AM" src="https://user-images.githubusercontent.com/4730197/104768516-ad201e80-5722-11eb-972e-e0e1d26d6b82.png">
<img width="1198" alt="Screen Shot 2021-01-15 at 11 03 34 AM" src="https://user-images.githubusercontent.com/4730197/104768524-af827880-5722-11eb-8fcb-cddec904b7f0.png">


## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Pre-condition: In brave://settings, `Method to resolve IPFS resources` is set to Local Node, `IPFS public gateway fallback` switch is off.
1. Turn off wifi, open brave://ipfs to start the local node with 0 connected peers.
2. Visit ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR to see the interstitial page.