### PR TITLE
Fixes custom Brave ad notifications should not be shown on Dev channel builds - 1.20.x

### DIFF
--- a/common/brave_channel_info.cc
+++ b/common/brave_channel_info.cc
@@ -23,10 +23,13 @@ std::string GetChannelName() {
 #endif  // !OFFICIAL_BUILD
 }
 
-bool IsDevOrCanaryBuild() {
-  return chrome::GetChannel() == version_info::Channel::DEV ||
-    chrome::GetChannel() == version_info::Channel::CANARY ||
-    chrome::GetChannel() == version_info::Channel::UNKNOWN;
+bool IsNightlyOrDeveloperBuild() {
+#if defined(OFFICIAL_BUILD)
+  return chrome::GetChannel() == version_info::Channel::CANARY ||
+      chrome::GetChannel() == version_info::Channel::UNKNOWN;
+#else  // OFFICIAL_BUILD
+  return true;
+#endif  // !OFFICIAL_BUILD
 }
 
 }  // namespace brave

--- a/common/brave_channel_info.h
+++ b/common/brave_channel_info.h
@@ -11,7 +11,7 @@
 namespace brave {
 
 std::string GetChannelName();
-bool IsDevOrCanaryBuild();
+bool IsNightlyOrDeveloperBuild();
 
 }
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -661,7 +661,7 @@ void AdsServiceImpl::OnInitialize(
 
   is_initialized_ = true;
 
-  if (!brave::IsDevOrCanaryBuild()) {
+  if (!brave::IsNightlyOrDeveloperBuild()) {
     SetAdsServiceForNotificationHandler();
   }
 
@@ -1216,10 +1216,6 @@ void AdsServiceImpl::OnGetAdsHistory(
 }
 
 bool AdsServiceImpl::CanShowBackgroundNotifications() const {
-  if (brave::IsDevOrCanaryBuild()) {
-    return true;
-  }
-
   return NotificationHelper::GetInstance()->CanShowBackgroundNotifications();
 }
 
@@ -1732,7 +1728,7 @@ std::string AdsServiceImpl::LoadDataResourceAndDecompressIfNeeded(
 // types of notification.h
 void AdsServiceImpl::ShowNotification(
     const ads::AdNotificationInfo& ad_notification) {
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     auto notification = CreateAdNotification(ad_notification);
 
     std::unique_ptr<PlatformBridge> platform_bridge =
@@ -1751,7 +1747,7 @@ void AdsServiceImpl::ShowNotification(
 void AdsServiceImpl::StartNotificationTimeoutTimer(
     const std::string& uuid) {
 #if defined(OS_ANDROID)
-  if (!brave::IsDevOrCanaryBuild()) {
+  if (!brave::IsNightlyOrDeveloperBuild()) {
     return;
   }
 #endif
@@ -1792,7 +1788,7 @@ bool AdsServiceImpl::ShouldShowNotifications() {
 
 void AdsServiceImpl::CloseNotification(
     const std::string& uuid) {
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     std::unique_ptr<PlatformBridge>
       platform_bridge = std::make_unique<PlatformBridge>(profile_);
     platform_bridge->Close(profile_, uuid);

--- a/components/brave_ads/browser/notification_helper_android.cc
+++ b/components/brave_ads/browser/notification_helper_android.cc
@@ -34,7 +34,7 @@ NotificationHelperAndroid::NotificationHelperAndroid() = default;
 NotificationHelperAndroid::~NotificationHelperAndroid() = default;
 
 bool NotificationHelperAndroid::ShouldShowNotifications() {
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     return true;
   }
 
@@ -58,7 +58,7 @@ bool NotificationHelperAndroid::ShowMyFirstAdNotification() {
     return false;
   }
 
-  const bool use_custom_notifications = brave::IsDevOrCanaryBuild();
+  const bool use_custom_notifications = brave::IsNightlyOrDeveloperBuild();
 
   JNIEnv* env = base::android::AttachCurrentThread();
   Java_BraveAdsSignupDialog_enqueueOnboardingNotificationNative(
@@ -69,6 +69,10 @@ bool NotificationHelperAndroid::ShowMyFirstAdNotification() {
 }
 
 bool NotificationHelperAndroid::CanShowBackgroundNotifications() const {
+  if (brave::IsNightlyOrDeveloperBuild()) {
+    return true;
+  }
+
   JNIEnv* env = base::android::AttachCurrentThread();
   return Java_BraveAdsSignupDialog_showAdsInBackground(env);
 }

--- a/components/brave_ads/browser/notification_helper_linux.cc
+++ b/components/brave_ads/browser/notification_helper_linux.cc
@@ -21,7 +21,7 @@ bool NotificationHelperLinux::ShouldShowNotifications() {
     return false;
   }
 
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     return true;
   }
 

--- a/components/brave_ads/browser/notification_helper_mac.mm
+++ b/components/brave_ads/browser/notification_helper_mac.mm
@@ -31,7 +31,7 @@ bool NotificationHelperMac::ShouldShowNotifications() {
     return false;
   }
 
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     return true;
   }
 

--- a/components/brave_ads/browser/notification_helper_win.cc
+++ b/components/brave_ads/browser/notification_helper_win.cc
@@ -71,7 +71,7 @@ bool NotificationHelperWin::ShouldShowNotifications() {
     return false;
   }
 
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     return true;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_notifications/ad_notifications.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_notifications/ad_notifications.cc
@@ -189,9 +189,10 @@ uint64_t AdNotifications::Count() const {
 
 #if defined(OS_ANDROID)
 void AdNotifications::RemoveAllAfterReboot() {
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     return;
   }
+
   database::table::AdEvents database_table;
   database_table.GetAll([=](
       const Result result,
@@ -217,9 +218,10 @@ void AdNotifications::RemoveAllAfterReboot() {
 }
 
 void AdNotifications::RemoveAllAfterUpdate() {
-  if (brave::IsDevOrCanaryBuild()) {
+  if (brave::IsNightlyOrDeveloperBuild()) {
     return;
   }
+
   const std::string current_version_code =
       base::android::BuildInfo::GetInstance()->package_version_code();
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7608
Resolves https://github.com/brave/brave-browser/issues/13592

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.