### PR TITLE
Fix crash when clearing IPFS cache

### DIFF
--- a/browser/browsing_data/brave_browsing_data_remover_delegate.cc
+++ b/browser/browsing_data/brave_browsing_data_remover_delegate.cc
@@ -172,6 +172,6 @@ void BraveBrowsingDataRemoverDelegate::ClearIPFSCache() {
       FROM_HERE, {base::TaskPriority::USER_VISIBLE, base::MayBlock()},
       base::BindOnce(&BraveBrowsingDataRemoverDelegate::WaitForIPFSRepoGC,
                      base::Unretained(this), base::Passed(&process)),
-      CreateTaskCompletionClosure(TracingDataType::kHostCache));
+      CreateTaskCompletionClosure(TracingDataType::kIPFSCache));
 }
 #endif  // BUILDFLAG(IPFS_ENABLED)

--- a/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate.h.patch
+++ b/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
-index ae0d55606244bca6ac1a1fa0037e0dc286c36174..74bc2123ced2db3fcdfc8854aac5a61f6067bd62 100644
+index ae0d55606244bca6ac1a1fa0037e0dc286c36174..59cf1f0592fb0d20c607b59201030676e30bb1a1 100644
 --- a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
 +++ b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
 @@ -195,6 +195,7 @@ class ChromeBrowsingDataRemoverDelegate
@@ -10,3 +10,13 @@ index ae0d55606244bca6ac1a1fa0037e0dc286c36174..74bc2123ced2db3fcdfc8854aac5a61f
   private:
    using WebRtcEventLogManager = webrtc_event_logging::WebRtcEventLogManager;
  
+@@ -241,7 +242,8 @@ class ChromeBrowsingDataRemoverDelegate
+     kAccountPasswords = 37,
+     kAccountPasswordsSynced = 38,
+     kAccountCompromisedCredentials = 39,
+-    kMaxValue = kAccountCompromisedCredentials,
++    kIPFSCache = 40,
++    kMaxValue = kIPFSCache,
+   };
+ 
+   // Called by CreateTaskCompletionClosure().


### PR DESCRIPTION
The problem is the TracingDataTypes are stored in a set, so if you re-use one of them that's already used it will crash.
See `std::set<TracingDataType> pending_sub_tasks_`.

So I just patched in a new tracing data type and now the crash is gone.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13625

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Load an ipfs:// URI so go-ipfs is running
- Go to chrome://settings and clear browsing data
- Turn ON all 3 checkboxes and clear
Before it would crash, now it should not crash.