### PR TITLE
13464: Unrestrict referrer hiding for top-level navigations. (uplift to 1.20.x)

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -345,8 +345,6 @@ void BraveContentBrowserClient::MaybeHideReferrer(
     content::BrowserContext* browser_context,
     const GURL& request_url,
     const GURL& document_url,
-    bool is_main_frame,
-    const std::string& method,
     blink::mojom::ReferrerPtr* referrer) {
   DCHECK(referrer && !referrer->is_null());
 #if BUILDFLAG(ENABLE_EXTENSIONS)
@@ -368,19 +366,10 @@ void BraveContentBrowserClient::MaybeHideReferrer(
       HostContentSettingsMapFactory::GetForProfile(profile),
       document_url);
 
-  // Some top-level navigations get empty referrers (brave/brave-browser#3422).
-  network::mojom::ReferrerPolicy policy = (*referrer)->policy;
-  if (is_main_frame &&
-      brave_shields::ShouldCleanReferrerForTopLevelNavigation(method,
-                                                              (*referrer)->url,
-                                                              request_url)) {
-    policy = network::mojom::ReferrerPolicy::kNever;
-  }
-
   content::Referrer new_referrer;
-  if (brave_shields::MaybeChangeReferrer(
-          allow_referrers, shields_up, (*referrer)->url, request_url, policy,
-          &new_referrer)) {
+  if (brave_shields::MaybeChangeReferrer(allow_referrers, shields_up,
+                                         (*referrer)->url, request_url,
+                                         &new_referrer)) {
     (*referrer)->url = new_referrer.url;
     (*referrer)->policy = new_referrer.policy;
   }

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -90,8 +90,6 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
   void MaybeHideReferrer(content::BrowserContext* browser_context,
                          const GURL& request_url,
                          const GURL& document_url,
-                         bool is_main_frame,
-                         const std::string& method,
                          blink::mojom::ReferrerPtr* referrer) override;
 
   GURL GetEffectiveURL(content::BrowserContext* browser_context,

--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -496,41 +496,34 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientReferrerTest,
   blink::mojom::ReferrerPtr kReferrer = blink::mojom::Referrer::New(
       kDocumentUrl, network::mojom::ReferrerPolicy::kDefault);
 
-  // Cross-origin navigations don't get a referrer.
+  // Cross-origin navigations get an origin.
   blink::mojom::ReferrerPtr referrer = kReferrer.Clone();
   client()->MaybeHideReferrer(browser()->profile(), kRequestUrl, kDocumentUrl,
-                              true, "GET", &referrer);
-  EXPECT_EQ(referrer->url, GURL());
-
-  // Cross-origin navigations get a truncated referrer if method is not "GET" or
-  // "HEAD".
-  referrer = kReferrer.Clone();
-  client()->MaybeHideReferrer(browser()->profile(), kRequestUrl, kDocumentUrl,
-                              true, "POST", &referrer);
+                              &referrer);
   EXPECT_EQ(referrer->url, kDocumentUrl.GetOrigin());
 
   // Same-origin navigations get full referrers.
   referrer = kReferrer.Clone();
   client()->MaybeHideReferrer(browser()->profile(), kSameOriginRequestUrl,
-                              kDocumentUrl, true, "GET", &referrer);
+                              kDocumentUrl, &referrer);
   EXPECT_EQ(referrer->url, kDocumentUrl);
 
   // Same-site navigations get truncated referrers.
   referrer = kReferrer.Clone();
   client()->MaybeHideReferrer(browser()->profile(), kSameSiteRequestUrl,
-                              kDocumentUrl, true, "GET", &referrer);
+                              kDocumentUrl, &referrer);
   EXPECT_EQ(referrer->url, kDocumentUrl.GetOrigin());
 
   // Cross-origin iframe navigations get origins.
   referrer = kReferrer.Clone();
   client()->MaybeHideReferrer(browser()->profile(), kRequestUrl, kDocumentUrl,
-                              false, "GET", &referrer);
+                              &referrer);
   EXPECT_EQ(referrer->url, kDocumentUrl.GetOrigin().spec());
 
   // Same-origin iframe navigations get full referrers.
   referrer = kReferrer.Clone();
   client()->MaybeHideReferrer(browser()->profile(), kSameOriginRequestUrl,
-                              kDocumentUrl, false, "GET", &referrer);
+                              kDocumentUrl, &referrer);
   EXPECT_EQ(referrer->url, kDocumentUrl);
 
   // Special rule for extensions.
@@ -538,7 +531,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientReferrerTest,
   referrer = kReferrer.Clone();
   referrer->url = kExtensionUrl;
   client()->MaybeHideReferrer(browser()->profile(), kRequestUrl, kExtensionUrl,
-                              true, "GET", &referrer);
+                              &referrer);
   EXPECT_EQ(referrer->url, kExtensionUrl);
 
   // Allow referrers for certain URL.
@@ -548,6 +541,6 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientReferrerTest,
       CONTENT_SETTING_ALLOW);
   referrer = kReferrer.Clone();
   client()->MaybeHideReferrer(browser()->profile(), kRequestUrl, kDocumentUrl,
-                              true, "GET", &referrer);
+                              &referrer);
   EXPECT_EQ(referrer->url, kDocumentUrl);
 }

--- a/browser/net/brave_site_hacks_network_delegate_helper.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper.cc
@@ -134,10 +134,8 @@ bool ApplyPotentialReferrerBlock(std::shared_ptr<BraveRequestInfo> ctx) {
 
   content::Referrer new_referrer;
   if (brave_shields::MaybeChangeReferrer(
-          ctx->allow_referrers, ctx->allow_brave_shields,
-          GURL(ctx->referrer), ctx->request_url,
-          blink::ReferrerUtils::NetToMojoReferrerPolicy(ctx->referrer_policy),
-          &new_referrer)) {
+          ctx->allow_referrers, ctx->allow_brave_shields, GURL(ctx->referrer),
+          ctx->request_url, &new_referrer)) {
     ctx->new_referrer = new_referrer.url;
     return true;
   }
@@ -179,14 +177,14 @@ int OnBeforeStartTransaction_SiteHacksWork(
   // will affect performance).
   // Note that this code only affects "Referer" header sent via network - we
   // handle document.referer in content::NavigationRequest (see also
-  // BraveContentBrowserClient::MaybeHideReferrer).
+  // |BraveContentBrowserClient::MaybeHideReferrer|).
   if (!ctx->allow_referrers && ctx->allow_brave_shields &&
       ctx->redirect_source.is_valid() &&
       ctx->resource_type == blink::mojom::ResourceType::kMainFrame &&
-      brave_shields::ShouldCleanReferrerForTopLevelNavigation(
-          ctx->method, ctx->redirect_source, ctx->request_url)) {
-    // This is hack that notifies the patched code in net::URLRequest.
-    ctx->removed_headers.insert("X-Brave-Clear-Referer");
+      !brave_shields::IsSameOriginNavigation(ctx->redirect_source,
+                                             ctx->request_url)) {
+    // This is a hack that notifies the network layer.
+    ctx->removed_headers.insert("X-Brave-Cap-Referrer");
   }
   return net::OK;
 }

--- a/chromium_src/content/browser/renderer_host/navigation_request.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_request.cc
@@ -32,19 +32,17 @@ GURL GetTopDocumentGURL(content::FrameTreeNode* frame_tree_node) {
 
 }  // namespace
 
-#define BRAVE_ONREQUESTREDIRECTED_MAYBEHIDEREFERRER                          \
-  BrowserContext* browser_context =                                          \
-      frame_tree_node_->navigator().GetController()->GetBrowserContext();    \
-  GetContentClient()->browser()->MaybeHideReferrer(                          \
-      browser_context, common_params_->url,                                  \
-      GetTopDocumentGURL(frame_tree_node_), frame_tree_node_->IsMainFrame(), \
-      common_params_->method, &common_params_->referrer);
+#define BRAVE_ONREQUESTREDIRECTED_MAYBEHIDEREFERRER                       \
+  BrowserContext* browser_context =                                       \
+      frame_tree_node_->navigator().GetController()->GetBrowserContext(); \
+  GetContentClient()->browser()->MaybeHideReferrer(                       \
+      browser_context, common_params_->url,                               \
+      GetTopDocumentGURL(frame_tree_node_), &common_params_->referrer);
 
-#define BRAVE_ONSTARTCHECKSCOMPLETE_MAYBEHIDEREFERRER                        \
-  GetContentClient()->browser()->MaybeHideReferrer(                          \
-      browser_context, common_params_->url,                                  \
-      GetTopDocumentGURL(frame_tree_node_), frame_tree_node_->IsMainFrame(), \
-      common_params_->method, &common_params_->referrer);
+#define BRAVE_ONSTARTCHECKSCOMPLETE_MAYBEHIDEREFERRER \
+  GetContentClient()->browser()->MaybeHideReferrer(   \
+      browser_context, common_params_->url,           \
+      GetTopDocumentGURL(frame_tree_node_), &common_params_->referrer);
 
 #include "../../../../../content/browser/renderer_host/navigation_request.cc"
 

--- a/chromium_src/content/public/browser/content_browser_client.h
+++ b/chromium_src/content/public/browser/content_browser_client.h
@@ -13,9 +13,7 @@
 #define BRAVE_CONTENT_BROWSER_CLIENT_H                          \
   virtual void MaybeHideReferrer(                               \
       BrowserContext* browser_context, const GURL& request_url, \
-      const GURL& document_url, bool is_main_frame,             \
-      const std::string& method,                                \
-      blink::mojom::ReferrerPtr* referrer) {}
+      const GURL& document_url, blink::mojom::ReferrerPtr* referrer) {}
 
 #include "../../../../../content/public/browser/content_browser_client.h"
 

--- a/components/brave_shields/browser/brave_shields_util.h
+++ b/components/brave_shields/browser/brave_shields_util.h
@@ -93,16 +93,13 @@ void DispatchBlockedEvent(const GURL& request_url,
                           int frame_tree_node_id,
                           const std::string& block_type);
 
-bool ShouldCleanReferrerForTopLevelNavigation(const std::string& method,
-                                              const GURL& referrer_url,
-                                              const GURL& request_url);
+bool IsSameOriginNavigation(const GURL& referrer, const GURL& target_url);
 
 bool MaybeChangeReferrer(
     bool allow_referrers,
     bool shields_up,
     const GURL& current_referrer,
     const GURL& target_url,
-    network::mojom::ReferrerPolicy policy,
     content::Referrer* output_referrer);
 
 

--- a/components/content_settings/renderer/brave_content_settings_agent_impl_browsertest.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl_browsertest.cc
@@ -622,10 +622,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsAgentImplBrowserTest,
             link_url().GetOrigin().spec());
   EXPECT_EQ(GetLastReferrer(same_site_url()), link_url().GetOrigin().spec());
 
-  // Cross-site navigations get no referrer.
+  // Cross-site navigations should follow the default referrer policy.
   NavigateDirectlyToPageWithLink(cross_site_url());
-  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
-  EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()),
+            link_url().GetOrigin().spec());
+  EXPECT_EQ(GetLastReferrer(cross_site_url()), link_url().GetOrigin().spec());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentSettingsAgentImplBrowserTest,
@@ -655,10 +656,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsAgentImplBrowserTest,
             url().GetOrigin().spec());
   EXPECT_EQ(GetLastReferrer(cross_site_url()), url().GetOrigin().spec());
 
-  // Cross-site navigations get no referrer.
+  // Cross-site navigations  should follow the default referrer policy.
   RedirectToPageWithLink(redirect_to_cross_site_url(), cross_site_url());
-  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
-  EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()),
+            redirect_to_cross_site_url().GetOrigin().spec());
+  EXPECT_EQ(GetLastReferrer(cross_site_url()),
+            redirect_to_cross_site_url().GetOrigin().spec());
   EXPECT_EQ(GetLastReferrer(redirect_to_cross_site_url()),
             link_url().spec());
 }
@@ -696,28 +699,28 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsAgentImplBrowserTest,
             url().GetOrigin().spec());
   EXPECT_EQ(GetLastReferrer(cross_site_url()), url().GetOrigin().spec());
 
-  // Same-origin navigations get the original page origin as the referrer.
+  // Same-origin navigations get the original page URL as the referrer.
   NavigateDirectlyToPageWithLink(same_origin_url());
   EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), link_url().spec());
   EXPECT_EQ(GetLastReferrer(same_origin_url()), link_url().spec());
 
   // Same-site but cross-origin navigations get the original page origin as the
   // referrer.
+  const std::string expected_referrer = link_url().GetOrigin().spec();
   NavigateDirectlyToPageWithLink(same_site_url());
-  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()),
-            link_url().GetOrigin().spec());
-  EXPECT_EQ(GetLastReferrer(same_site_url()), link_url().GetOrigin().spec());
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), expected_referrer);
+  EXPECT_EQ(GetLastReferrer(same_site_url()), expected_referrer);
 
-  // Cross-site navigations get no referrer.
+  // Cross-site navigations should follow the default referrer policy.
   NavigateDirectlyToPageWithLink(cross_site_url());
-  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
-  EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), expected_referrer);
+  EXPECT_EQ(GetLastReferrer(cross_site_url()), expected_referrer);
 
   // Check that a less restrictive policy is not respected.
   NavigateDirectlyToPageWithLink(cross_site_url(),
                                  "no-referrer-when-downgrade");
-  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
-  EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), expected_referrer);
+  EXPECT_EQ(GetLastReferrer(cross_site_url()), expected_referrer);
 
   // Check that "no-referrer" policy is respected as more restrictive.
   NavigateDirectlyToPageWithLink(same_origin_url(), "no-referrer");
@@ -725,6 +728,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsAgentImplBrowserTest,
   EXPECT_EQ(GetLastReferrer(same_origin_url()), "");
 
   NavigateDirectlyToPageWithLink(cross_site_url(), "no-referrer");
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
+  EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
+
+  // Check that "same-origin" policy is respected as more restrictive.
+  NavigateDirectlyToPageWithLink(cross_site_url(), "same-origin");
   EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
   EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
 }
@@ -752,10 +760,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsAgentImplBrowserTest,
             url().GetOrigin().spec());
   EXPECT_EQ(GetLastReferrer(cross_site_url()), url().GetOrigin().spec());
 
-  // Cross-site navigations get no referrer.
+  // Cross-site navigations should follow the default referrer policy.
   RedirectToPageWithLink(redirect_to_cross_site_url(), cross_site_url());
-  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()), "");
-  EXPECT_EQ(GetLastReferrer(cross_site_url()), "");
+  EXPECT_EQ(ExecScriptGetStr(kReferrerScript, contents()),
+            redirect_to_cross_site_url().GetOrigin().spec());
+  EXPECT_EQ(GetLastReferrer(cross_site_url()),
+            redirect_to_cross_site_url().GetOrigin().spec());
   // Intermidiate same-origin navigation gets full referrer.
   EXPECT_EQ(GetLastReferrer(redirect_to_cross_site_url()),
             link_url().spec());


### PR DESCRIPTION
Uplift of #7591
Fix https://github.com/brave/brave-browser/issues/13464

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.