### PR TITLE
Fixes Polish l10n of a rewards string. (uplift to 1.19.x)

### DIFF
--- a/components/resources/strings/brave_components_resources_pl.xtb
+++ b/components/resources/strings/brave_components_resources_pl.xtb
@@ -107,7 +107,7 @@
 <translation id="2974339193389078578">Przeglądaj internet z Brave</translation>
 <translation id="7735138632831241257">Przygotuj się na szybsze i bezpieczniejsze przeglądanie stron, dzięki przeglądarce stworzonej w celu ochrony prywatności.</translation>
 <translation id="6001839398155993679">Zaczynamy</translation>
-<translation id="4225189922025976867"><ph name="BEGIN_BOLD"/>Earn tokens<ph name="END_BOLD"/> poprzez oglądanie Brave Private Ads oraz automatyczne wspieranie twórców treści.</translation>
+<translation id="4225189922025976867"><ph name="BEGIN_BOLD"/>Zarabiaj tokeny<ph name="END_BOLD"/> poprzez oglądanie Brave Private Ads oraz automatyczne wspieranie twórców treści.</translation>
 <translation id="5477721706074111257">Klikając, wyrażasz zgodę na <ph name="BEGIN_LINK"/>Warunki świadczenia usług<ph name="END_LINK"/> oraz <ph name="BEGIN_LINK"/>Politykę prywatności<ph name="END_LINK"/>.</translation>
 <translation id="3505541710659461355">Możesz to wyłączyć w każdym momencie w ustawieniach.</translation>
 <translation id="2965798296974325760">Rozpocznij korzystanie z Nagród</translation>


### PR DESCRIPTION
Fixes brave/brave-browser#13649
Uplift of #7658

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.