### PR TITLE
Fixes Brave Ads should retry payments balance endpoint after redeeming unblinded payment tokens if balance is not ready - 1.20.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
@@ -241,6 +241,23 @@ bool AdRewards::SetFromDictionary(
 
 ///////////////////////////////////////////////////////////////////////////////
 
+bool AdRewards::DidReconcile(
+    const std::string& json) const {
+  const double last_balance = payments_->GetBalance();
+
+  Payments payments;
+  if (!payments.SetFromJson(json)) {
+    return false;
+  }
+
+  if (!payments.DidReconcileBalance(last_balance,
+      unreconciled_estimated_pending_rewards_)) {
+    return false;
+  }
+
+  return true;
+}
+
 void AdRewards::Reconcile() {
   DCHECK(!is_processing_);
 
@@ -274,6 +291,12 @@ void AdRewards::OnGetPayments(
 
   if (url_response.status_code != net::HTTP_OK) {
     BLOG(1, "Failed to get payment balance");
+    OnFailedToReconcileAdRewards();
+    return;
+  }
+
+  if (!DidReconcile(url_response.body)) {
+    BLOG(0, "Payment balance is not ready");
     OnFailedToReconcileAdRewards();
     return;
   }

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include <memory>
+#include <string>
 
 #include "base/time/time.h"
 #include "base/values.h"
@@ -66,6 +67,9 @@ class AdRewards {
   double unreconciled_estimated_pending_rewards_ = 0.0;
 
   void Reconcile();
+
+  bool DidReconcile(
+      const std::string& json) const;
 
   void GetPayments();
   void OnGetPayments(

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
@@ -119,6 +119,21 @@ double Payments::GetBalance() const {
   return balance;
 }
 
+bool Payments::DidReconcileBalance(
+    const double last_balance,
+    const double unreconciled_estimated_pending_rewards) const {
+  if (unreconciled_estimated_pending_rewards == 0.0) {
+    return true;
+  }
+
+  const double delta = GetBalance() - last_balance;
+  if (delta >= unreconciled_estimated_pending_rewards) {
+    return true;
+  }
+
+  return false;
+}
+
 base::Time Payments::CalculateNextPaymentDate(
     const base::Time& time,
     const base::Time& next_token_redemption_date) const {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.h
@@ -30,6 +30,10 @@ class Payments {
 
   double GetBalance() const;
 
+  bool DidReconcileBalance(
+      const double balance,
+      const double unreconciled_estimated_pending_rewards) const;
+
   base::Time CalculateNextPaymentDate(
       const base::Time& time,
       const base::Time& token_redemption_date) const;

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments_unittest.cc
@@ -93,6 +93,84 @@ TEST_F(BatAdsPaymentsTest,
 }
 
 TEST_F(BatAdsPaymentsTest,
+    DidReconcileZeroBalance) {
+  // Arrange
+  const std::string json = R"(
+    [
+      {
+        "balance" : "0.0",
+        "month" : "2019-06",
+        "transactionCount" : "0"
+      }
+    ]
+  )";
+
+  payments_->SetFromJson(json);
+
+  const double previous_balance = 0.0;
+  const double unreconciled_estimated_pending_rewards = 0.0;
+
+  // Act
+  const bool did_reconcile = payments_->DidReconcileBalance(
+      previous_balance, unreconciled_estimated_pending_rewards);
+
+  // Assert
+  EXPECT_TRUE(did_reconcile);
+}
+
+TEST_F(BatAdsPaymentsTest,
+    DidReconcileBalance) {
+  // Arrange
+  const std::string json = R"(
+    [
+      {
+        "balance" : "0.5",
+        "month" : "2019-06",
+        "transactionCount" : "10"
+      }
+    ]
+  )";
+
+  payments_->SetFromJson(json);
+
+  const double previous_balance = 0.3;
+  const double unreconciled_estimated_pending_rewards = 0.2;
+
+  // Act
+  const bool did_reconcile = payments_->DidReconcileBalance(
+      previous_balance, unreconciled_estimated_pending_rewards);
+
+  // Assert
+  EXPECT_TRUE(did_reconcile);
+}
+
+TEST_F(BatAdsPaymentsTest,
+    DidNotReconcileBalance) {
+  // Arrange
+  const std::string json = R"(
+    [
+      {
+        "balance" : "0.3",
+        "month" : "2019-06",
+        "transactionCount" : "5"
+      }
+    ]
+  )";
+
+  payments_->SetFromJson(json);
+
+  const double previous_balance = 0.3;
+  const double unreconciled_estimated_pending_rewards = 0.2;
+
+  // Act
+  const bool did_reconcile = payments_->DidReconcileBalance(
+      previous_balance, unreconciled_estimated_pending_rewards);
+
+  // Assert
+  EXPECT_FALSE(did_reconcile);
+}
+
+TEST_F(BatAdsPaymentsTest,
     BalanceForMultiplePayments) {
   // Arrange
   const std::string json = R"(


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7680
Resolves https://github.com/brave/brave-browser/issues/13721

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.