### PR TITLE
Use empty implementation of PrimaryAccountMutatorImpl::RevokeSyncConsent

### DIFF
--- a/chromium_src/components/signin/internal/identity_manager/primary_account_manager.cc
+++ b/chromium_src/components/signin/internal/identity_manager/primary_account_manager.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/signin/internal/identity_manager/primary_account_manager.h"
+
+#define RevokeSyncConsent RevokeSyncConsent_ChromiumImpl
+#include "../../../../../../components/signin/internal/identity_manager/primary_account_manager.cc"
+#undef RevokeSyncConsent
+
+void PrimaryAccountManager::RevokeSyncConsent(
+    signin_metrics::ProfileSignout source_metric,
+    signin_metrics::SignoutDelete delete_metric) {}

--- a/chromium_src/components/signin/internal/identity_manager/primary_account_manager.h
+++ b/chromium_src/components/signin/internal/identity_manager/primary_account_manager.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SIGNIN_INTERNAL_IDENTITY_MANAGER_PRIMARY_ACCOUNT_MANAGER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SIGNIN_INTERNAL_IDENTITY_MANAGER_PRIMARY_ACCOUNT_MANAGER_H_
+
+#define RevokeSyncConsent                                   \
+  RevokeSyncConsent_ChromiumImpl(                           \
+      signin_metrics::ProfileSignout signout_source_metric, \
+      signin_metrics::SignoutDelete signout_delete_metric); \
+  void RevokeSyncConsent
+
+#include "../../../../../../components/signin/internal/identity_manager/primary_account_manager.h"
+
+#undef RevokeSyncConsent
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SIGNIN_INTERNAL_IDENTITY_MANAGER_PRIMARY_ACCOUNT_MANAGER_H_

--- a/chromium_src/components/signin/internal/identity_manager/primary_account_mutator_impl.cc
+++ b/chromium_src/components/signin/internal/identity_manager/primary_account_mutator_impl.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "components/signin/internal/identity_manager/primary_account_mutator_impl.h"
+#include "components/signin/internal/identity_manager/primary_account_manager.h"
+
+#define RevokeSyncConsent RevokeSyncConsent_ChromiumImpl
+#include "../../../../../../components/signin/internal/identity_manager/primary_account_mutator_impl.cc"
+#undef RevokeSyncConsent
+
+namespace signin {
+
+void PrimaryAccountMutatorImpl::RevokeSyncConsent(
+    signin_metrics::ProfileSignout source_metric,
+    signin_metrics::SignoutDelete delete_metric) {}
+
+}  // namespace signin

--- a/chromium_src/components/signin/internal/identity_manager/primary_account_mutator_impl.h
+++ b/chromium_src/components/signin/internal/identity_manager/primary_account_mutator_impl.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SIGNIN_INTERNAL_IDENTITY_MANAGER_PRIMARY_ACCOUNT_MUTATOR_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SIGNIN_INTERNAL_IDENTITY_MANAGER_PRIMARY_ACCOUNT_MUTATOR_IMPL_H_
+
+#include "components/signin/internal/identity_manager/primary_account_manager.h"
+#include "components/signin/public/identity_manager/primary_account_mutator.h"
+
+#define RevokeSyncConsent                                                      \
+  RevokeSyncConsent_ChromiumImpl(signin_metrics::ProfileSignout source_metric, \
+                                 signin_metrics::SignoutDelete delete_metric); \
+  void RevokeSyncConsent
+
+#include "../../../../../../components/signin/internal/identity_manager/primary_account_mutator_impl.h"
+
+#undef RevokeSyncConsent
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SIGNIN_INTERNAL_IDENTITY_MANAGER_PRIMARY_ACCOUNT_MUTATOR_IMPL_H_

--- a/components/signin/internal/identity_manager/brave_primary_account_mutator_impl.h
+++ b/components/signin/internal/identity_manager/brave_primary_account_mutator_impl.h
@@ -20,7 +20,7 @@ class BravePrimaryAccountMutatorImpl : public PrimaryAccountMutatorImpl {
       signin::AccountConsistencyMethod account_consistency);
   ~BravePrimaryAccountMutatorImpl() override;
 
-#if !defined(OS_CHROMEOS)
+#if !BUILDFLAG(IS_CHROMEOS_ASH)
   bool ClearPrimaryAccount(
       signin_metrics::ProfileSignout source_metric,
       signin_metrics::SignoutDelete delete_metric) override;


### PR DESCRIPTION
... to avoid DCHECK during leaving sync chain



Related Chromium change: https://source.chromium.org/chromium/chromium/src/+/3a5fd2389a1459ad2e60ca4e8ab5dfbb78f6252e

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13699

Here is a place where `DCHECK` failed:
```
void PrimaryAccountMutatorImpl::RevokeSyncConsent(
    signin_metrics::ProfileSignout source_metric,
    signin_metrics::SignoutDelete delete_metric) {
  DCHECK(primary_account_manager_->HasPrimaryAccount(ConsentLevel::kSync));
  if (RevokeConsentShouldClearPrimaryAccount()) {
    ClearPrimaryAccount(source_metric, delete_metric);
    return;
  }
  primary_account_manager_->RevokeSyncConsent(source_metric, delete_metric);
}

bool PrimaryAccountMutatorImpl::ClearPrimaryAccount(
    signin_metrics::ProfileSignout source_metric,
    signin_metrics::SignoutDelete delete_metric) {
  if (!primary_account_manager_->HasPrimaryAccount(ConsentLevel::kNotRequired))
    return false;
...
```

There are two reasons to get rid of this DCHECK:
1) Even with `primary_account_manager_->HasPrimaryAccount` gives false, then `PrimaryAccountMutatorImpl::ClearPrimaryAccount` does nothing
2) Brave sync gives mock account and there is no actual sign in and consent to use account for sync.

So it would be enough to comment out that `DCHECK`, but this is done by new `chromium_src` overrides.

```
#define RevokeSyncConsent RevokeSyncConsent_ChromiumImpl
#include "../../../../../../components/signin/internal/identity_manager/primary_account_mutator_impl.cc"
#undef RevokeSyncConsent
```
made at `src/components/signin/internal/identity_manager/primary_account_mutator_impl.cc`
```
primary_account_manager_->RevokeSyncConsent(source_metric, delete_metric);
```
the macro also applied, so `PrimaryAccountManager::RevokeSyncConsent_ChromiumImpl` was introdued at `chromium_src/components/signin/internal/identity_manager/primary_account_manager.cc`.


## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Take CR89 build of 2020-01-25
2. Create sync chain
3. Leave sync chain
4. Should not be failed DCHECK

