### PR TITLE
Only replace scheme, host, port, path when translating IPFS URI

### DIFF
--- a/components/ipfs/translate_ipfs_uri.cc
+++ b/components/ipfs/translate_ipfs_uri.cc
@@ -42,13 +42,13 @@ bool TranslateIPFSURI(const GURL& url, GURL* new_url, const GURL& gateway_url) {
       // new_url would be:
       // https://dweb.link/ipfs/[cid]//wiki/Vincent_van_Gogh.html
       if (new_url) {
-        std::string gateway_empty_path = gateway_url.spec();
-        if (gateway_empty_path.size() > 0 &&
-            gateway_empty_path[gateway_empty_path.size() - 1] == '/') {
-          gateway_empty_path.pop_back();
-        }
-        *new_url = GURL(gateway_empty_path +
-                        (ipfs_scheme ? "/ipfs/" : "/ipns/") + cid + path);
+        GURL::Replacements replacements;
+        replacements.SetSchemeStr(gateway_url.scheme_piece());
+        replacements.SetHostStr(gateway_url.host_piece());
+        replacements.SetPortStr(gateway_url.port_piece());
+        std::string new_path = (ipfs_scheme ? "ipfs/" : "ipns/") + cid + path;
+        replacements.SetPathStr(new_path);
+        *new_url = url.ReplaceComponents(replacements);
         VLOG(1) << "[IPFS] " << __func__ << " new URL: " << *new_url;
       }
 

--- a/components/ipfs/translate_ipfs_uri_unittest.cc
+++ b/components/ipfs/translate_ipfs_uri_unittest.cc
@@ -25,7 +25,7 @@
 
 namespace ipfs {
 
-class IPFSBraveContentBrowserClientTest : public testing::Test {
+class TranslateIPFSURITest : public testing::Test {
  protected:
   void SetUp() override {
     public_gateway_ = GURL(kDefaultIPFSGateway);
@@ -40,13 +40,13 @@ class IPFSBraveContentBrowserClientTest : public testing::Test {
   GURL public_gateway_;
 };
 
-TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURINotIPFSScheme) {
+TEST_F(TranslateIPFSURITest, TranslateIPFSURINotIPFSScheme) {
   GURL url("http://a.com/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   GURL new_url;
   ASSERT_FALSE(ipfs::TranslateIPFSURI(url, &new_url, public_gateway()));
 }
 
-TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSScheme) {
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSScheme) {
   GURL url("ipfs://QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   GURL new_url;
   ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, public_gateway()));
@@ -54,7 +54,7 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSScheme) {
                           "QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG"));
 }
 
-TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPNSScheme) {
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPNSScheme) {
   GURL url("ipns://QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd");
   GURL new_url;
   ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, public_gateway()));
@@ -62,7 +62,7 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPNSScheme) {
                           "QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd"));
 }
 
-TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSSchemeLocal) {
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeLocal) {
   GURL url("ipfs://QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG");
   GURL new_url;
   ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, local_gateway()));
@@ -70,7 +70,7 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSSchemeLocal) {
                           "QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG"));
 }
 
-TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPNSSchemeLocal) {
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPNSSchemeLocal) {
   GURL url("ipns://QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd");
   GURL new_url;
   ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, local_gateway()));
@@ -78,7 +78,7 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPNSSchemeLocal) {
                           "QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd"));
 }
 
-TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSSchemeWithPath) {
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeWithPath) {
   GURL url(
       "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
       "/wiki/Vincent_van_Gogh.html");
@@ -88,6 +88,78 @@ TEST_F(IPFSBraveContentBrowserClientTest, TranslateIPFSURIIPFSSchemeWithPath) {
             GURL("https://dweb.link/ipfs/"
                  "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
                  "/wiki/Vincent_van_Gogh.html"));
+}
+
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeWithPathAndHash) {
+  GURL url(
+      "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+      "/wiki/Vincent_van_Gogh.html#Emerging_artist");
+  GURL new_url;
+  ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, public_gateway()));
+  EXPECT_EQ(new_url,
+            GURL("https://dweb.link/ipfs/"
+                 "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+                 "/wiki/Vincent_van_Gogh.html#Emerging_artist"));
+}
+
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeLocalWithPathAndHash) {
+  GURL url(
+      "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+      "/wiki/Vincent_van_Gogh.html#Emerging_artist");
+  GURL new_url;
+  ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, local_gateway()));
+  EXPECT_EQ(new_url,
+            GURL("http://localhost:48080/ipfs/"
+                 "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+                 "/wiki/Vincent_van_Gogh.html#Emerging_artist"));
+}
+
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeWithPathAndQuery) {
+  GURL url(
+      "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+      "/wiki/Vincent_van_Gogh.html?test=true");
+  GURL new_url;
+  ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, public_gateway()));
+  EXPECT_EQ(new_url,
+            GURL("https://dweb.link/ipfs/"
+                 "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+                 "/wiki/Vincent_van_Gogh.html?test=true"));
+}
+
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeLocalWithPathAndQuery) {
+  GURL url(
+      "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+      "/wiki/Vincent_van_Gogh.html?test=true");
+  GURL new_url;
+  ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, local_gateway()));
+  EXPECT_EQ(new_url,
+            GURL("http://localhost:48080/ipfs/"
+                 "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+                 "/wiki/Vincent_van_Gogh.html?test=true"));
+}
+
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeWithPathQueryHash) {
+  GURL url(
+      "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+      "/wiki/Vincent_van_Gogh.html?test=true#test");
+  GURL new_url;
+  ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, public_gateway()));
+  EXPECT_EQ(new_url,
+            GURL("https://dweb.link/ipfs/"
+                 "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+                 "/wiki/Vincent_van_Gogh.html?test=true#test"));
+}
+
+TEST_F(TranslateIPFSURITest, TranslateIPFSURIIPFSSchemeLocalWithPathQueryHash) {
+  GURL url(
+      "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+      "/wiki/Vincent_van_Gogh.html?test=true#test");
+  GURL new_url;
+  ASSERT_TRUE(ipfs::TranslateIPFSURI(url, &new_url, local_gateway()));
+  EXPECT_EQ(new_url,
+            GURL("http://localhost:48080/ipfs/"
+                 "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+                 "/wiki/Vincent_van_Gogh.html?test=true#test"));
 }
 
 }  // namespace ipfs


### PR DESCRIPTION
This fixes the bug that query parameters and hash anchors were dropped in
TranslateIPFSURI.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13722

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
pre-condition: IPFS local node is started.
1. Visit ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_van_Gogh.html#Emerging_artist, it should jump to Emerging artist section.
2. Open a new tab, and open developer tools's Network tab.
3. Visit ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/I/m/Vincent_van_Gogh_-_Self-Portrait_-_Google_Art_Project_(454045).jpg?filename=test.jpg&download=true, filename=test.jpg&download=true should be kept in the address bar.
4. Examine the network response using developer tools's Network tab, you should see this `Content-Disposition: inline; filename*=UTF-8''test.jpg` in the header as below.
<img width="1226" alt="Screen Shot 2021-01-25 at 11 26 25 AM" src="https://user-images.githubusercontent.com/4730197/105755770-a05cb100-5f00-11eb-9ac9-26afce907779.png">
