### PR TITLE
Fix infinite OpenInTorWindow looping when auto redirect through navigation throttle.

### DIFF
--- a/browser/tor/onion_location_navigation_throttle_delegate.cc
+++ b/browser/tor/onion_location_navigation_throttle_delegate.cc
@@ -22,11 +22,11 @@ void OnTorProfileCreated(GURL onion_location,
                          Profile::CreateStatus status) {
   if (status != Profile::CreateStatus::CREATE_STATUS_INITIALIZED)
     return;
-  Browser* browser = chrome::FindTabbedBrowser(profile, true);
+  Browser* browser = chrome::FindTabbedBrowser(profile, false);
   if (!browser)
     return;
   content::OpenURLParams open_tor(onion_location, content::Referrer(),
-                                  WindowOpenDisposition::NEW_FOREGROUND_TAB,
+                                  WindowOpenDisposition::SWITCH_TO_TAB,
                                   ui::PAGE_TRANSITION_TYPED, false);
   browser->OpenURL(open_tor);
 }
@@ -46,11 +46,6 @@ void OnionLocationNavigationThrottleDelegate::OpenInTorWindow(
       Profile::FromBrowserContext(web_contents->GetBrowserContext());
   TorProfileManager::SwitchToTorProfile(profile,
       base::BindRepeating(&OnTorProfileCreated, std::move(onion_location)));
-
-  // We do not close last tab of the window
-  Browser* browser = chrome::FindBrowserWithProfile(profile);
-  if (browser && browser->tab_strip_model()->count() > 1)
-    web_contents->ClosePage();
 }
 
 }  // namespace tor

--- a/components/tor/onion_location_navigation_throttle.cc
+++ b/components/tor/onion_location_navigation_throttle.cc
@@ -94,7 +94,6 @@ OnionLocationNavigationThrottle::WillStartRequest() {
         pref_service_->GetBoolean(prefs::kAutoOnionRedirect)) {
       delegate_->OpenInTorWindow(navigation_handle()->GetWebContents(),
                                  std::move(url));
-      return content::NavigationThrottle::CANCEL_AND_IGNORE;
     }
   }
   return content::NavigationThrottle::PROCEED;


### PR DESCRIPTION
Also change window disposition to SWITCH_TO_TAB to avoid redundant new
tab. 
We no longer close the original tab to avoid confusion and lots of users complained about this behavior.

The crash cause is calling `chrome::FindTabbedBrowser` with `match_original_profiles` equals true so `OnionLocationNavigationThrottle::WillStartRequest` got triggered endlessly.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13736

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Crash
https://github.com/brave/brave-browser/issues/13736#issuecomment-767221753

### Window disposition and original tab
1. Clean profile
2. Turn on Automatically redirect .onion sites in brave://settings/extensions
3. In normal window open: `brave.com`
4. There will be only one tab opened which is `ttps://brave5t5rjjg3s6k.onion` and no new tab in Tor window
5. The original tab in normal window won't be closed
6. In normal window open: `https://www.torproject.org/`
7. The second tab `http://expyuzz4wqqyqhjn.onion/index.html` will be opened in Tor window
8. Repeat step 3 and step 6
9. There will still be two tabs, `https://brave5t5rjjg3s6k.onion` and `http://expyuzz4wqqyqhjn.onion/index.html`

