### PR TITLE
13778: Avoid crash while getting an accessibility string. (uplift to 1.20.x)

### DIFF
--- a/chromium_src/ui/accessibility/platform/ax_platform_node_mac.mm
+++ b/chromium_src/ui/accessibility/platform/ax_platform_node_mac.mm
@@ -1,0 +1,24 @@
+/* Copyright 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/debug/alias.h"
+#include "base/debug/dump_without_crashing.h"
+
+// Assumed to be a temporary fix for
+// https://github.com/brave/brave-browser/issues/13778
+#define BRAVE_ACCESSIBILITY_ATTRIBUTED_STRING_FOR_RANGE             \
+  id value = [self getAXValueAsString];                             \
+  if (![value isKindOfClass:[NSString class]]) {                    \
+    ax::mojom::Role role = _node->GetData().role;                   \
+    base::debug::Alias(&role);                                      \
+    LOG(ERROR) << __PRETTY_FUNCTION__;                              \
+    LOG(ERROR) << "Trying to get a range from a non-string object." \
+               << " Role: " << static_cast<int>(role)               \
+               << " Name: " << _node->GetName();                    \
+    base::debug::DumpWithoutCrashing();                             \
+    return nil;                                                     \
+  }
+
+#include "../../../../ui/accessibility/platform/ax_platform_node_mac.mm"

--- a/patches/ui-accessibility-platform-ax_platform_node_mac.mm.patch
+++ b/patches/ui-accessibility-platform-ax_platform_node_mac.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/ui/accessibility/platform/ax_platform_node_mac.mm b/ui/accessibility/platform/ax_platform_node_mac.mm
+index afd130143d7ca5440d9c971764fa038e6c153429..9ee9bff39d24fcf3a453d097914380e29216ca1b 100644
+--- a/ui/accessibility/platform/ax_platform_node_mac.mm
++++ b/ui/accessibility/platform/ax_platform_node_mac.mm
+@@ -1144,6 +1144,7 @@ bool AlsoUseShowMenuActionForDefaultAction(const ui::AXNodeData& data) {
+   if (!_node)
+     return nil;
+ 
++  BRAVE_ACCESSIBILITY_ATTRIBUTED_STRING_FOR_RANGE
+   // TODO(https://crbug.com/958811): Implement this for real.
+   base::scoped_nsobject<NSAttributedString> attributedString(
+       [[NSAttributedString alloc]


### PR DESCRIPTION
Uplift of #7708
Fix https://github.com/brave/brave-browser/issues/13778

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.