### PR TITLE
[Android] Removed homepage setting when bottom toolbar is disabled (uplift to 1.19.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -28,10 +28,11 @@ import org.chromium.chrome.browser.rate.RateDialogFragment;
 import org.chromium.chrome.browser.rate.RateUtils;
 import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
 import org.chromium.chrome.browser.settings.BravePreferenceFragment;
+import org.chromium.chrome.browser.settings.BraveStatsPreferences;
+import org.chromium.chrome.browser.toolbar.bottom.BottomToolbarConfiguration;
 import org.chromium.components.browser_ui.settings.ChromeBasePreference;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 import org.chromium.ui.base.DeviceFormFactor;
-import org.chromium.chrome.browser.settings.BraveStatsPreferences;
 
 import java.util.HashMap;
 
@@ -154,7 +155,12 @@ public class BraveMainPreferencesBase extends BravePreferenceFragment {
 
         // If gn flag enable_brave_sync is false, hide Sync pref
         if (BraveConfig.SYNC_ENABLED == false) {
-          removePreferenceIfPresent(PREF_SYNC);
+            removePreferenceIfPresent(PREF_SYNC);
+        }
+
+        // We don't have home button on top toolbar at the moment
+        if (!BottomToolbarConfiguration.isBottomToolbarEnabled()) {
+            removePreferenceIfPresent(PREF_HOMEPAGE);
         }
     }
 

--- a/android/java/org/chromium/chrome/browser/toolbar/BraveToolbarManager.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/BraveToolbarManager.java
@@ -133,11 +133,12 @@ public class BraveToolbarManager extends ToolbarManager {
         mActivity = activity;
 
         mBraveHomepageStateListener = () -> {
-            assert (mBottomControlsCoordinatorSupplier != null);
-            assert (mBottomControlsCoordinatorSupplier.get()
-                            instanceof BraveBottomControlsCoordinator);
-            ((BraveBottomControlsCoordinator) mBottomControlsCoordinatorSupplier.get())
-                    .updateHomeButtonState();
+            if (mBottomControlsCoordinatorSupplier != null
+                    && mBottomControlsCoordinatorSupplier.get()
+                                    instanceof BraveBottomControlsCoordinator) {
+                ((BraveBottomControlsCoordinator) mBottomControlsCoordinatorSupplier.get())
+                        .updateHomeButtonState();
+            }
         };
         HomepageManager.getInstance().addListener(mBraveHomepageStateListener);
     }


### PR DESCRIPTION
Uplift of #7737
Resolves https://github.com/brave/brave-browser/issues/13809

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [ ] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.