### PR TITLE
Longer term stats URL crash fix

### DIFF
--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -175,8 +175,6 @@ void BraveStatsUpdater::SetStatsThresholdCallback(
 GURL BraveStatsUpdater::BuildStatsEndpoint(const std::string& path) {
   auto stats_updater_url = GURL(usage_server_ + path);
 #if defined(OFFICIAL_BUILD)
-  // Urgent fix for https://github.com/brave/brave-browser/issues/13858
-  stats_updater_url = GURL("https://laptop-updates.brave.com" + path);
   CHECK(stats_updater_url.is_valid());
 #endif
   return stats_updater_url;

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -175,7 +175,9 @@ void BraveStatsUpdater::SetStatsThresholdCallback(
 GURL BraveStatsUpdater::BuildStatsEndpoint(const std::string& path) {
   auto stats_updater_url = GURL(usage_server_ + path);
 #if defined(OFFICIAL_BUILD)
-  CHECK(stats_updater_url.is_valid());
+  if(!stats_updater_url.is_valid()) {
+    LOG(ERROR) << "stats_updater_url is not valid! " << stats_updater_url;
+  }
 #endif
   return stats_updater_url;
 }


### PR DESCRIPTION
Proper fix for https://github.com/brave/brave-browser/issues/13858

Change behavior introduced with https://github.com/brave/brave-core/pull/6834

While talking it out with @bridiver, we changed the behavior from just a DCHECK to a CHECK with the intent that we don't want to be releasing builds which don't have stats URL set.  This PR updates the behavior to just log an error instead (which QA can look for during testing / release)

Longer term fix was agreed to be catching this in the pipeline. We need to make sure the pipeline has this set and if it's not set, we should fail the job

## Submitter Checklist:

- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

