### PR TITLE
[NOT FOR MERGE] Partially Revert "update 1p-3p cosmetic filtering algorithm to handle unexecuted scripts"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
       "es7",
       "es2017",
       "es2018",
-      "es2019",
-      "esnext"
+      "es2019"
     ],
     "moduleResolution": "node",
     "baseUrl": ".",


### PR DESCRIPTION
Reverts brave/brave-core#7751

To check this this PR caused `AdBlockServiceTest.CosmeticFilteringProtect1p` test failure on Windows