### PR TITLE
Change ipfs scheme handling

### DIFF
--- a/browser/ipfs/content_browser_client_helper.cc
+++ b/browser/ipfs/content_browser_client_helper.cc
@@ -75,6 +75,10 @@ bool HandleIPFSURLReverseRewrite(
   if (ipfs_pos == std::string::npos && ipns_pos == std::string::npos)
     return false;
 
+  GURL configured_gateway =
+      GetConfiguredBaseGateway(browser_context, chrome::GetChannel());
+  if (configured_gateway.port() != url->port())
+    return false;
   GURL::Replacements scheme_replacements;
   GURL::Replacements host_replacements;
   if (ipfs_pos != std::string::npos) {

--- a/components/ipfs/ipfs_constants.cc
+++ b/components/ipfs/ipfs_constants.cc
@@ -23,4 +23,6 @@ const char kRepoStatsPath[] = "/api/v0/repo/stat";
 const char kRepoStatsHumanReadableParamName[] = "human";
 const char kRepoStatsHumanReadableParamValue[] = "true";
 const char kNodeInfoPath[] = "/api/v0/id";
+const char kLocalhostIP[] = "127.0.0.1";
+const char kLocalhostDomain[] = "localhost";
 }  // namespace ipfs

--- a/components/ipfs/ipfs_constants.h
+++ b/components/ipfs/ipfs_constants.h
@@ -22,6 +22,8 @@ extern const char kRepoStatsPath[];
 extern const char kRepoStatsHumanReadableParamName[];
 extern const char kRepoStatsHumanReadableParamValue[];
 extern const char kNodeInfoPath[];
+extern const char kLocalhostIP[];
+extern const char kLocalhostDomain[];
 
 enum class IPFSResolveMethodTypes {
   IPFS_ASK,

--- a/components/ipfs/ipfs_utils.cc
+++ b/components/ipfs/ipfs_utils.cc
@@ -183,7 +183,13 @@ GURL GetDefaultIPFSGateway(content::BrowserContext* context) {
 
   DCHECK(context);
   PrefService* prefs = user_prefs::UserPrefs::Get(context);
-  return GURL(prefs->GetString(kIPFSPublicGatewayAddress));
+  GURL gateway_url(prefs->GetString(kIPFSPublicGatewayAddress));
+  if (gateway_url.DomainIs(kLocalhostIP)) {
+    GURL::Replacements replacements;
+    replacements.SetHostStr(kLocalhostDomain);
+    return gateway_url.ReplaceComponents(replacements);
+  }
+  return gateway_url;
 }
 
 GURL GetAPIServer(version_info::Channel channel) {

--- a/components/ipfs/ipfs_utils_unittest.cc
+++ b/components/ipfs/ipfs_utils_unittest.cc
@@ -217,6 +217,13 @@ TEST_F(IpfsUtilsUnitTest, GetDefaultIPFSGateway) {
   prefs()->SetString(kIPFSPublicGatewayAddress, "https://example.com/");
   EXPECT_EQ(ipfs::GetDefaultIPFSGateway(context()),
             GURL("https://example.com/"));
+  prefs()->SetString(kIPFSPublicGatewayAddress, "https://127.0.0.1:8888/");
+  EXPECT_EQ(ipfs::GetDefaultIPFSGateway(context()),
+            GURL("https://localhost:8888/"));
+  prefs()->SetString(kIPFSPublicGatewayAddress, "https://127.0.0.1/");
+  EXPECT_EQ(ipfs::GetDefaultIPFSGateway(context()), GURL("https://localhost/"));
+  prefs()->SetString(kIPFSPublicGatewayAddress, "https://localhost/");
+  EXPECT_EQ(ipfs::GetDefaultIPFSGateway(context()), GURL("https://localhost/"));
 }
 
 TEST_F(IpfsUtilsUnitTest, TranslateIPFSURINotIPFSScheme) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13872

We should change this to only keep ipfs:// and ipns:// when the address being loaded when:
i) Using the Brave node and the port matches the Brave node's port.
ii) Using the public node and the port matches the public node, and it is localhost.
iii) When user enters custom public gateway Brave should always replace raw IP (127.0.0.1) with localhost, as that enables subdomains and origin isolation. Raw IP can't have subdomains and all content roots share the same origin, which we don't want in browser.


## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/13872) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Described here https://github.com/brave/brave-browser/issues/13872
