### PR TITLE
New Tab Page WebUI: restrict Together item to supported channel and region

### DIFF
--- a/components/brave_new_tab_ui/components/default/footer/footer.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/footer.tsx
@@ -32,21 +32,39 @@ import { getLocale } from '../../../../common/locale'
 
 interface Props {
   textDirection: string
-  togetherPrmoptDismissed: boolean
+  supportsTogether: boolean
+  togetherPromptDismissed: boolean
   backgroundImageInfo: any
   showPhotoInfo: boolean
   onClickSettings: () => any
   onDismissTogetherPrompt: () => any
 }
 
+function TogetherItem (props: Props) {
+  if (!props.togetherPromptDismissed) {
+    return (
+      <TogetherTooltip onClose={props.onDismissTogetherPrompt}>
+        <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+          <TogetherIcon />
+        </IconLink>
+      </TogetherTooltip>
+    )
+  }
+
+  return (
+    <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+      <TogetherIcon />
+    </IconLink>
+  )
+}
+
 export default class FooterInfo extends React.PureComponent<Props, {}> {
   render () {
     const {
       textDirection,
-      togetherPrmoptDismissed,
+      supportsTogether,
       backgroundImageInfo,
       showPhotoInfo,
-      onDismissTogetherPrompt,
       onClickSettings
     } = this.props
 
@@ -84,15 +102,8 @@ export default class FooterInfo extends React.PureComponent<Props, {}> {
             <IconLink title={getLocale('historyPageTitle')} href='chrome://history'>
               <HistoryIcon />
             </IconLink>
-            { !togetherPrmoptDismissed
-              ? <TogetherTooltip onClose={onDismissTogetherPrompt}>
-                  <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
-                    <TogetherIcon />
-                  </IconLink>
-                </TogetherTooltip>
-              : <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
-                  <TogetherIcon />
-                </IconLink>
+            {supportsTogether &&
+              <TogetherItem {...this.props} />
             }
           </Navigation>
         </S.GridItemNavigation>

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -1084,7 +1084,8 @@ class NewTabPage extends React.Component<Props, State> {
             </Page.GridItemBrandedLogo>}
             <FooterInfo
               textDirection={newTabData.textDirection}
-              togetherPrmoptDismissed={newTabData.togetherPromptDismissed}
+              supportsTogether={newTabData.togetherSupported}
+              togetherPromptDismissed={newTabData.togetherPromptDismissed}
               backgroundImageInfo={newTabData.backgroundImage}
               showPhotoInfo={!isShowingBrandedWallpaper && newTabData.showBackgroundImage}
               onClickSettings={this.openSettings}


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Restricts https://github.com/brave/brave-browser/issues/12776 to nightly channel (and regions which support Brave Together).
Resolves https://github.com/brave/brave-browser/issues/13905

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- `npm run storybook` has a "together supported" toggle which can be used.
- Otherwise, check the icon and tooltip aren't shown on non-nightly or development channel
