### PR TITLE
Uplift #7787 to 1.20.x - New Tab Page WebUI: restrict Together item to supported channel and region

### DIFF
--- a/components/brave_new_tab_ui/components/default/footer/footer.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/footer.tsx
@@ -32,21 +32,39 @@ import { getLocale } from '../../../../common/locale'
 
 interface Props {
   textDirection: string
-  togetherPrmoptDismissed: boolean
+  supportsTogether: boolean
+  togetherPromptDismissed: boolean
   backgroundImageInfo: any
   showPhotoInfo: boolean
   onClickSettings: () => any
   onDismissTogetherPrompt: () => any
 }
 
+function TogetherItem (props: Props) {
+  if (!props.togetherPromptDismissed) {
+    return (
+      <TogetherTooltip onClose={props.onDismissTogetherPrompt}>
+        <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+          <TogetherIcon />
+        </IconLink>
+      </TogetherTooltip>
+    )
+  }
+
+  return (
+    <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+      <TogetherIcon />
+    </IconLink>
+  )
+}
+
 export default class FooterInfo extends React.PureComponent<Props, {}> {
   render () {
     const {
       textDirection,
-      togetherPrmoptDismissed,
+      supportsTogether,
       backgroundImageInfo,
       showPhotoInfo,
-      onDismissTogetherPrompt,
       onClickSettings
     } = this.props
 
@@ -84,15 +102,8 @@ export default class FooterInfo extends React.PureComponent<Props, {}> {
             <IconLink title={getLocale('historyPageTitle')} href='chrome://history'>
               <HistoryIcon />
             </IconLink>
-            { !togetherPrmoptDismissed
-              ? <TogetherTooltip onClose={onDismissTogetherPrompt}>
-                  <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
-                    <TogetherIcon />
-                  </IconLink>
-                </TogetherTooltip>
-              : <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
-                  <TogetherIcon />
-                </IconLink>
+            {supportsTogether &&
+              <TogetherItem {...this.props} />
             }
           </Navigation>
         </S.GridItemNavigation>

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -1079,7 +1079,8 @@ class NewTabPage extends React.Component<Props, State> {
             </Page.GridItemBrandedLogo>}
             <FooterInfo
               textDirection={newTabData.textDirection}
-              togetherPrmoptDismissed={newTabData.togetherPromptDismissed}
+              supportsTogether={newTabData.togetherSupported}
+              togetherPromptDismissed={newTabData.togetherPromptDismissed}
               backgroundImageInfo={newTabData.backgroundImage}
               showPhotoInfo={!isShowingBrandedWallpaper && newTabData.showBackgroundImage}
               onClickSettings={this.openSettings}


### PR DESCRIPTION
Uplift https://github.com/brave/brave-core/pull/7787 (https://github.com/brave/brave-browser/issues/13905)