### PR TITLE
Properly check for empty stats updater URL in GN (uplift to 1.20.x)

### DIFF
--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -4,6 +4,8 @@ declare_args() {
   brave_stats_updater_url = ""
 }
 
+if (is_official_build) { assert(brave_stats_updater_url != "") }
+
 source_set("stats_updater") {
   # Remove when https://github.com/brave/brave-browser/issues/10657 is resolved
   check_includes = false

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -173,11 +173,7 @@ void BraveStatsUpdater::SetStatsThresholdCallback(
 }
 
 GURL BraveStatsUpdater::BuildStatsEndpoint(const std::string& path) {
-  auto stats_updater_url = GURL(usage_server_ + path);
-#if defined(OFFICIAL_BUILD)
-  CHECK(stats_updater_url.is_valid());
-#endif
-  return stats_updater_url;
+  return GURL(usage_server_ + path);
 }
 
 void BraveStatsUpdater::OnSimpleLoaderComplete(


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7789
Resolves https://github.com/brave/brave-browser/issues/13858

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.