### PR TITLE
Reenable types on CONFLICT or TRANSIENT error after commit

### DIFF
--- a/chromium_src/components/sync/driver/profile_sync_service.h
+++ b/chromium_src/components/sync/driver/profile_sync_service.h
@@ -7,10 +7,13 @@
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DRIVER_PROFILE_SYNC_SERVICE_H_
 
 FORWARD_DECLARE_TEST(BraveProfileSyncServiceTest, ReenableTypes);
+FORWARD_DECLARE_TEST(BraveProfileSyncServiceTest, ReenableTypesMaxPeriod);
 
 #define BRAVE_PROFILE_SYNC_SERVICE_H_                                   \
  private:                                                               \
   FRIEND_TEST_ALL_PREFIXES(BraveProfileSyncServiceTest, ReenableTypes); \
+  FRIEND_TEST_ALL_PREFIXES(BraveProfileSyncServiceTest,                 \
+                           ReenableTypesMaxPeriod);                     \
   friend class BraveProfileSyncService;
 
 // Forcing this include before define virtual to avoid error of

--- a/chromium_src/components/sync/driver/profile_sync_service.h
+++ b/chromium_src/components/sync/driver/profile_sync_service.h
@@ -6,8 +6,11 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DRIVER_PROFILE_SYNC_SERVICE_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DRIVER_PROFILE_SYNC_SERVICE_H_
 
-#define BRAVE_PROFILE_SYNC_SERVICE_H_ \
- private:                             \
+FORWARD_DECLARE_TEST(BraveProfileSyncServiceTest, ReenableTypes);
+
+#define BRAVE_PROFILE_SYNC_SERVICE_H_                                   \
+ private:                                                               \
+  FRIEND_TEST_ALL_PREFIXES(BraveProfileSyncServiceTest, ReenableTypes); \
   friend class BraveProfileSyncService;
 
 // Forcing this include before define virtual to avoid error of

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -59,6 +59,7 @@ constexpr uint64_t kDefaultUploadIntervalSeconds = 60;  // 1 minute.
 // TODO(iefremov): Provide moar histograms!
 // Whitelist for histograms that we collect. Will be replaced with something
 // updating on the fly.
+// clang-format off
 constexpr const char* kCollectedHistograms[] = {
     "Brave.Core.BookmarksCountOnProfileLoad.2",
     "Brave.Core.CrashReportsEnabled",
@@ -163,6 +164,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.P2A.AdImpressionsPerSegment.weather",
     "Brave.P2A.AdImpressionsPerSegment.untargeted"
 };
+// clang-format on
 
 bool IsSuspendedMetric(base::StringPiece metric_name,
                        uint64_t value_or_bucket) {

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -89,6 +89,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.Today.WeeklyMaxCardViewsCount",
     "Brave.Today.WeeklyMaxCardVisitsCount",
     "Brave.Sync.Status",
+    "Brave.Sync.TypesEverReenabled",
     "Brave.Uptime.BrowserOpenMinutes",
     "Brave.Welcome.InteractionStatus",
 

--- a/components/sync/driver/brave_sync_profile_sync_service.cc
+++ b/components/sync/driver/brave_sync_profile_sync_service.cc
@@ -152,4 +152,9 @@ bool BraveProfileSyncService::IsReenableTypesRequired(
   return failed_commit_times_ >= kNumberOfFailedCommitsToReenable;
 }
 
+/*static*/
+size_t BraveProfileSyncService::GetNumberOfFailedCommitsToReenableForTests() {
+  return kNumberOfFailedCommitsToReenable;
+}
+
 }  // namespace syncer

--- a/components/sync/driver/brave_sync_profile_sync_service.cc
+++ b/components/sync/driver/brave_sync_profile_sync_service.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/logging.h"
+#include "base/metrics/histogram_macros.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
 #include "brave/components/brave_sync/crypto/crypto.h"
@@ -128,7 +129,9 @@ void BraveProfileSyncService::OnSyncCycleCompleted(
 }
 
 void BraveProfileSyncService::ReenableSyncTypes() {
-  // TODO(alexeybarabash): P3A
+  // Normal reenabling types due to 7th failure
+  // P3A sample is 1
+  UMA_HISTOGRAM_EXACT_LINEAR("Brave.Sync.TypesEverReenabled", 1, 2);
   last_reenable_types_time_ = base::Time::Now();
   SyncUserSettings* sync_user_settings = GetUserSettings();
   const UserSelectableTypeSet selected_types =
@@ -146,7 +149,10 @@ bool BraveProfileSyncService::IsReenableTypesRequired(
   if (!last_reenable_types_time_.is_null() &&
       base::Time::Now() - last_reenable_types_time_ <
           kMinimalTimeBetweenReenable) {
-    // Can't do reenable more often than once in a specified amount
+    // Reenabling types aborted due to 7th failure happening twice in a row
+    // in less than 30mins
+    // P3A sample is 2
+    UMA_HISTOGRAM_EXACT_LINEAR("Brave.Sync.TypesEverReenabled", 2, 2);
     return false;
   }
 

--- a/components/sync/driver/brave_sync_profile_sync_service.h
+++ b/components/sync/driver/brave_sync_profile_sync_service.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "base/memory/weak_ptr.h"
+#include "base/time/time.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/sync/driver/profile_sync_service.h"
@@ -17,6 +18,7 @@
 class Profile;
 
 FORWARD_DECLARE_TEST(BraveProfileSyncServiceTest, ReenableTypes);
+FORWARD_DECLARE_TEST(BraveProfileSyncServiceTest, ReenableTypesMaxPeriod);
 
 namespace syncer {
 
@@ -50,6 +52,8 @@ class BraveProfileSyncService : public ProfileSyncService {
 
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveProfileSyncServiceTest, ReenableTypes);
+  FRIEND_TEST_ALL_PREFIXES(BraveProfileSyncServiceTest, ReenableTypesMaxPeriod);
+
   BraveSyncAuthManager* GetBraveSyncAuthManager();
 
   void OnBraveSyncPrefsChanged(const std::string& path);
@@ -60,7 +64,9 @@ class BraveProfileSyncService : public ProfileSyncService {
   void ReenableSyncTypes();
   bool IsReenableTypesRequired(const SyncCycleSnapshot& snapshot);
   size_t failed_commit_times_ = 0;
+  base::Time last_reenable_types_time_;
   static size_t GetNumberOfFailedCommitsToReenableForTests();
+  static base::TimeDelta MinimalTimeBetweenReenableForTests();
 
   brave_sync::Prefs brave_sync_prefs_;
 

--- a/components/sync/driver/brave_sync_profile_sync_service.h
+++ b/components/sync/driver/brave_sync_profile_sync_service.h
@@ -51,6 +51,13 @@ class BraveProfileSyncService : public ProfileSyncService {
 
   void OnBraveSyncPrefsChanged(const std::string& path);
 
+  void OnSyncCycleCompleted(const SyncCycleSnapshot& snapshot) override;
+  // Re-enables current sync types to to recover state from being
+  // SERVER_RETURN_CONFLICT or SERVER_RETURN_TRANSIENT_ERROR
+  void ReenableSyncTypes();
+  bool IsReenableTypesRequired(const SyncCycleSnapshot& snapshot);
+  size_t failed_commit_times_ = 0;
+
   brave_sync::Prefs brave_sync_prefs_;
 
   PrefChangeRegistrar brave_sync_prefs_change_registrar_;

--- a/components/sync/driver/brave_sync_profile_sync_service.h
+++ b/components/sync/driver/brave_sync_profile_sync_service.h
@@ -16,6 +16,8 @@
 
 class Profile;
 
+FORWARD_DECLARE_TEST(BraveProfileSyncServiceTest, ReenableTypes);
+
 namespace syncer {
 
 class BraveSyncAuthManager;
@@ -47,6 +49,7 @@ class BraveProfileSyncService : public ProfileSyncService {
   void Initialize() override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(BraveProfileSyncServiceTest, ReenableTypes);
   BraveSyncAuthManager* GetBraveSyncAuthManager();
 
   void OnBraveSyncPrefsChanged(const std::string& path);
@@ -57,6 +60,7 @@ class BraveProfileSyncService : public ProfileSyncService {
   void ReenableSyncTypes();
   bool IsReenableTypesRequired(const SyncCycleSnapshot& snapshot);
   size_t failed_commit_times_ = 0;
+  static size_t GetNumberOfFailedCommitsToReenableForTests();
 
   brave_sync::Prefs brave_sync_prefs_;
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13960

This PR re-enables all sync types when commit status is permanently TRANSIENT_ERROR or CONFLICT error  to trigger resend all interesting objects and fix sync work. Must be reverted when the real reason of TRANSIENT_ERROR or CONFLICT will be found.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint` // lint wants me to change `components/p3a/brave_p3a_service.cc` - but it will be hard to read 
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Make the sync to be in yellow state because of TRANSIENT_ERROR or CONFLICT by steps from issue https://github.com/brave/brave-browser/issues/13960 on the old browser version. Or ask me for zipped profile with that state.
It should be yellow statuses on page `brave://sync-internals`
2. Run browser containing this PR merged
3. Wait for 3 minutes or less, yellow statuses on page `brave://sync-internals` should be changed to green
