### PR TITLE
Disable cosmetic filtering test temporarily (uplift to 1.21.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -919,7 +919,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringSimple) {
 }
 
 // Test cosmetic filtering ignores content determined to be 1st party
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringProtect1p) {
+// This is disabled due to https://github.com/brave/brave-browser/issues/13882
+#if defined(OS_WIN)
+#define MAYBE_CosmeticFilteringProtect1p DISABLED_CosmeticFilteringProtect1p
+#else
+#define MAYBE_CosmeticFilteringProtect1p CosmeticFilteringProtect1p
+#endif
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, MAYBE_CosmeticFilteringProtect1p) {
   UpdateAdBlockInstanceWithRules("b.com##.fpsponsored\n");
 
   WaitForBraveExtensionShieldsDataReady();


### PR DESCRIPTION
Uplift of #7777
Resolves https://github.com/brave/brave-browser/issues/13887

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.