### PR TITLE
Make default browser prompt consider other channels

### DIFF
--- a/browser/ui/startup/default_brave_browser_prompt.cc
+++ b/browser/ui/startup/default_brave_browser_prompt.cc
@@ -90,7 +90,8 @@ void OnCheckIsDefaultBrowserFinished(
     const base::FilePath& profile_path,
     bool show_prompt,
     shell_integration::DefaultWebClientState state) {
-  if (state == shell_integration::IS_DEFAULT) {
+  if (state == shell_integration::IS_DEFAULT ||
+      state == shell_integration::OTHER_MODE_IS_DEFAULT) {
     // Notify the user in the future if Chrome ceases to be the user's chosen
     // default browser.
     ResetCheckDefaultBrowserPref(profile_path);

--- a/chromium_src/chrome/browser/shell_integration_linux.cc
+++ b/chromium_src/chrome/browser/shell_integration_linux.cc
@@ -1,0 +1,38 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GetDefaultBrowser GetDefaultBrowser_ChromiumImpl
+#include "../../../../chrome/browser/shell_integration_linux.cc"
+#undef GetDefaultBrowser
+
+namespace shell_integration {
+
+bool IsAnyBraveBrowserDefaultBrowser() {
+  base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                base::BlockingType::MAY_BLOCK);
+
+  std::vector<std::string> argv;
+  argv.push_back(shell_integration_linux::kXdgSettings);
+  argv.push_back("get");
+  argv.push_back(shell_integration_linux::kXdgSettingsDefaultBrowser);
+
+  std::string browser;
+  // We don't care about the return value here.
+  base::GetAppOutput(base::CommandLine(argv), &browser);
+  return browser.find("brave-browser") != std::string::npos;
+}
+
+DefaultWebClientState GetDefaultBrowser() {
+  // Check whether current install is default.
+  auto state = GetDefaultBrowser_ChromiumImpl();
+  if (state == IS_DEFAULT)
+    return state;
+
+  // Check Other channel installs are default.
+  return IsAnyBraveBrowserDefaultBrowser() ? OTHER_MODE_IS_DEFAULT
+                                           : NOT_DEFAULT;
+}
+
+}  // namespace shell_integration

--- a/chromium_src/chrome/browser/shell_integration_mac.mm
+++ b/chromium_src/chrome/browser/shell_integration_mac.mm
@@ -3,9 +3,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/mac/bundle_locations.h"
+#include "base/mac/foundation_util.h"
+#include "base/mac/mac_util.h"
+#include "base/mac/scoped_cftyperef.h"
+#include "base/strings/sys_string_conversions.h"
+#include "build/branding_buildflags.h"
+#include "chrome/common/channel_info.h"
+#include "components/version_info/version_info.h"
+#import "third_party/mozilla/NSWorkspace+Utils.h"
+
+// All above headers copied from original shell_integration_mac.mm are
+// included to prevent below GOOGLE_CHROME_BUILD affect them.
+
+#undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
+#define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
+
 #define GetDefaultWebClientSetPermission GetDefaultWebClientSetPermission_Unused
 #include "../../../../chrome/browser/shell_integration_mac.mm"  // NOLINT
 #undef GetDefaultWebClientSetPermission
+#undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
 
 namespace shell_integration {
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/13980

macOS checks other installs here. disabled by google guard and it's enabled by this PR.
https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/shell_integration_mac.mm;l=141

windows checks:
https://source.chromium.org/chromium/chromium/src/+/master:chrome/installer/util/shell_util.cc;l=1246

If other channels are already default browser, `OTHER_MODE_IS_DEFAULT` is returned.
Linux doesn't have similar probing logic.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Set brave stable as a default browser
2. Launch beta /nightly with clean profile
3. Check default browser prompt is not shown
4. Set chrome as a default browser
5. Launch browser used above step 2
6. Check default browser prompt is shown