### PR TITLE
Fix build of upstream Chromium's unit_tests target

### DIFF
--- a/chromium_src/components/sync_device_info/fake_device_info_tracker.cc
+++ b/chromium_src/components/sync_device_info/fake_device_info_tracker.cc
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/sync_device_info/brave_device_info.h"
+
+#include "../../../../components/sync_device_info/fake_device_info_tracker.cc"
+
+namespace syncer {
+
+void FakeDeviceInfoTracker::DeleteDeviceInfo(const std::string& client_id,
+                                             base::OnceClosure callback) {}
+
+std::vector<std::unique_ptr<BraveDeviceInfo>>
+FakeDeviceInfoTracker::GetAllBraveDeviceInfo() const {
+  return std::vector<std::unique_ptr<BraveDeviceInfo>>();
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync_device_info/fake_device_info_tracker.h
+++ b/chromium_src/components/sync_device_info/fake_device_info_tracker.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_FAKE_DEVICE_INFO_TRACKER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_FAKE_DEVICE_INFO_TRACKER_H_
+
+#include "brave/components/sync_device_info/brave_device_info.h"
+#include "components/sync_device_info/device_info_tracker.h"
+
+#define ForcePulseForTest                                                    \
+  DeleteDeviceInfo(const std::string& client_id, base::OnceClosure callback) \
+      override;                                                              \
+  std::vector<std::unique_ptr<BraveDeviceInfo>> GetAllBraveDeviceInfo()      \
+      const override;                                                        \
+  void ForcePulseForTest
+
+#include "../../../../components/sync_device_info/fake_device_info_tracker.h"
+
+#undef ForcePulseForTest
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_FAKE_DEVICE_INFO_TRACKER_H_

--- a/patches/chrome-test-BUILD.gn.patch
+++ b/patches/chrome-test-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/test/BUILD.gn b/chrome/test/BUILD.gn
-index bbeda5c83d65a8280e3c1114793966b092a27929..263becedb204b5bd07796c8c82dceaa3b9c77b31 100644
+index 0096bead803507ffb0856548bae26431daf24d9d..6eb57b3e46fd59cb23595ef778bda80663eb8d39 100644
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
 @@ -878,6 +878,7 @@ if (!is_android) {
@@ -10,3 +10,11 @@ index bbeda5c83d65a8280e3c1114793966b092a27929..263becedb204b5bd07796c8c82dceaa3
      # Runtime dependencies
      data_deps = [
        "//chrome:browser_tests_pak",
+@@ -4215,6 +4216,7 @@ test("unit_tests") {
+     "//ui/web_dialogs:web_dialogs_unittests",
+     "//v8",
+   ]
++  deps += [ "//brave/test:brave_test_support_unit", ]
+ 
+   if (is_mac) {
+     data_deps += [ "//chrome:chrome_framework" ]


### PR DESCRIPTION
Two build failures are currently preventing us from building the
unit_tests binary from upstream:

1. A compilation error due to FakeDeviceInfoTracker not implementing
   Brave-specific's GetAllBraveDeviceInfo() and DeleteDeviceInfo()
   virtual methods from DeviceInfoTracker (added via an override).

2. A linking error due to push_messaging_service_unittest.cc requiring
   a dependency for BraveTestingProfile (also added via an override).

This CL fixes both errors adding an override for FakeDeviceInfoTracker
to implement those virtual methors + adding a missing dependency for
the unit_tests target to have access to BraveTestingProfile.

Resolves https://github.com/brave/brave-browser/issues/14001

## Submitter Checklist:

- [X] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [X] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [X] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [X] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A