### PR TITLE
Fix build of upstream Chromium's unit_tests & browser_tests targets

### DIFF
--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -38,7 +38,20 @@ GURL GetSelectionNavigationURL(Profile* profile, const base::string16& text) {
   return match.destination_url;
 }
 
+base::OnceCallback<void(BraveRenderViewContextMenu*)>*
+BraveGetMenuShownCallback() {
+  static base::NoDestructor<
+      base::OnceCallback<void(BraveRenderViewContextMenu*)>>
+      callback;
+  return callback.get();
+}
+
 }  // namespace
+
+void RenderViewContextMenu::RegisterMenuShownCallbackForTesting(
+    base::OnceCallback<void(BraveRenderViewContextMenu*)> cb) {
+  *BraveGetMenuShownCallback() = std::move(cb);
+}
 
 #define BRAVE_APPEND_SEARCH_PROVIDER \
   if (GetProfile()->IsOffTheRecord()) { \
@@ -50,10 +63,13 @@ GURL GetSelectionNavigationURL(Profile* profile, const base::string16& text) {
 
 // Use our subclass to initialize SpellingOptionsSubMenuObserver.
 #define SpellingOptionsSubMenuObserver BraveSpellingOptionsSubMenuObserver
+#define RegisterMenuShownCallbackForTesting \
+  RegisterMenuShownCallbackForTesting_unused
 
 #include "../../../../../chrome/browser/renderer_context_menu/render_view_context_menu.cc"
 
 #undef SpellingOptionsSubMenuObserver
+#undef RegisterMenuShownCallbackForTesting
 
 // Make it clear which class we mean here.
 #undef RenderViewContextMenu

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.h
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.h
@@ -13,7 +13,15 @@
 
 // Get the Chromium declaration.
 #define RenderViewContextMenu RenderViewContextMenu_Chromium
+
+class BraveRenderViewContextMenu;
+
+#define RegisterMenuShownCallbackForTesting                      \
+  RegisterMenuShownCallbackForTesting(                           \
+      base::OnceCallback<void(BraveRenderViewContextMenu*)> cb); \
+  static void RegisterMenuShownCallbackForTesting_unused
 #include "../../../../../chrome/browser/renderer_context_menu/render_view_context_menu.h"
+#undef RegisterMenuShownCallbackForTesting
 #undef RenderViewContextMenu
 
 // Declare our own subclass with overridden methods.

--- a/chromium_src/chrome/test/base/testing_profile.cc
+++ b/chromium_src/chrome/test/base/testing_profile.cc
@@ -1,0 +1,8 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "../../../../../chrome/test/base/testing_profile.cc"
+
+#include "brave/test/base/brave_testing_profile.cc"

--- a/chromium_src/chrome/test/base/testing_profile.h
+++ b/chromium_src/chrome/test/base/testing_profile.h
@@ -1,0 +1,13 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_TEST_BASE_TESTING_PROFILE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_TEST_BASE_TESTING_PROFILE_H_
+
+#include "../../../../../chrome/test/base/testing_profile.h"
+
+#include "brave/test/base/brave_testing_profile.h"
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_TEST_BASE_TESTING_PROFILE_H_

--- a/chromium_src/components/sync_device_info/fake_device_info_tracker.cc
+++ b/chromium_src/components/sync_device_info/fake_device_info_tracker.cc
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/components/sync_device_info/brave_device_info.h"
+
+#include "../../../../components/sync_device_info/fake_device_info_tracker.cc"
+
+namespace syncer {
+
+void FakeDeviceInfoTracker::DeleteDeviceInfo(const std::string& client_id,
+                                             base::OnceClosure callback) {}
+
+std::vector<std::unique_ptr<BraveDeviceInfo>>
+FakeDeviceInfoTracker::GetAllBraveDeviceInfo() const {
+  return std::vector<std::unique_ptr<BraveDeviceInfo>>();
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync_device_info/fake_device_info_tracker.h
+++ b/chromium_src/components/sync_device_info/fake_device_info_tracker.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_FAKE_DEVICE_INFO_TRACKER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_FAKE_DEVICE_INFO_TRACKER_H_
+
+#include "brave/components/sync_device_info/brave_device_info.h"
+#include "components/sync_device_info/device_info_tracker.h"
+
+#define ForcePulseForTest                                                    \
+  DeleteDeviceInfo(const std::string& client_id, base::OnceClosure callback) \
+      override;                                                              \
+  std::vector<std::unique_ptr<BraveDeviceInfo>> GetAllBraveDeviceInfo()      \
+      const override;                                                        \
+  void ForcePulseForTest
+
+#include "../../../../components/sync_device_info/fake_device_info_tracker.h"
+
+#undef ForcePulseForTest
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_FAKE_DEVICE_INFO_TRACKER_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -32,8 +32,8 @@ static_library("brave_test_support_unit") {
   testonly = true
 
   sources = [
-    "base/brave_testing_profile.cc",
-    "base/brave_testing_profile.h",
+    # Not including brave_testing_profile.{h,cc} here, they need to be pulled
+    # via an override for testing_profile.{h,cc} for upstream tests to build.
     "base/brave_unit_test_suite.cc",
     "base/brave_unit_test_suite.h",
     "base/run_all_unittests.cc",


### PR DESCRIPTION
Three build failures are currently preventing us from building these
unit_tests & browser_test binaries from upstream:

1. A compilation error due to FakeDeviceInfoTracker not implementing
   Brave-specific's GetAllBraveDeviceInfo() and DeleteDeviceInfo()
   virtual methods from DeviceInfoTracker (added via an override).

2. A compilation error in //c/b/apps/guest_view/web_view_browsertest.cc 
   because of testing code using RenderViewContextMenu's static method
   RegisterMenuShownCallbackForTesting(), which would expect a callback
   |base::OnceCallback<void(RenderViewContextMenu_Chromium*>| because   
   of the source override in chromium_src/c/b/renderer_context_menu, but
   a |base::OnceCallback<void(BraveRenderViewContextMenu*)>| will be 
   passed instead due to the redefinition set in that source override. 

3. A linking error due to push_messaging_service_unittest.cc requiring
   a dependency for BraveTestingProfile (also added via an override).

This patches fixes all those three errors via chromium overrides and
a small patch to //chrome/test/BUILD.gn to add a missing dependency.

Fix https://github.com/brave/brave-browser/issues/14001

Resolves https://github.com/brave/brave-browser/issues/14001

## Submitter Checklist:

- [X] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [X] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [X] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [X] Ran `git rebase master` (if needed).
- [ ] Requested a security/privacy review as needed.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A