### PR TITLE
Exclude unit tests from upstream that are known to fail in Brave

### DIFF
--- a/chromium_src/apps/saved_files_service_unittest.cc
+++ b/chromium_src/apps/saved_files_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/about_flags_unittest.cc
+++ b/chromium_src/chrome/browser/about_flags_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client_unittest.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/autocomplete/keyword_extensions_delegate_impl_unittest.cc
+++ b/chromium_src/chrome/browser/autocomplete/keyword_extensions_delegate_impl_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/autocomplete/search_provider_unittest.cc
+++ b/chromium_src/chrome/browser/autocomplete/search_provider_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/background/background_application_list_model_unittest.cc
+++ b/chromium_src/chrome/browser/background/background_application_list_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/background_sync/periodic_background_sync_permission_context_unittest.cc
+++ b/chromium_src/chrome/browser/background_sync/periodic_background_sync_permission_context_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/browser_commands_unittest.cc
+++ b/chromium_src/chrome/browser/browser_commands_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_unittest.cc
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/browsing_data/counters/site_settings_counter_unittest.cc
+++ b/chromium_src/chrome/browser/browsing_data/counters/site_settings_counter_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/chrome_content_browser_client_unittest.cc
+++ b/chromium_src/chrome/browser/chrome_content_browser_client_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/component_updater/chrome_component_updater_configurator_unittest.cc
+++ b/chromium_src/chrome/browser/component_updater/chrome_component_updater_configurator_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/component_updater/floc_component_installer_unittest.cc
+++ b/chromium_src/chrome/browser/component_updater/floc_component_installer_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/component_updater/subresource_filter_component_installer_unittest.cc
+++ b/chromium_src/chrome/browser/component_updater/subresource_filter_component_installer_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/content_settings/host_content_settings_map_unittest.cc
+++ b/chromium_src/chrome/browser/content_settings/host_content_settings_map_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/devtools/devtools_ui_bindings_unittest.cc
+++ b/chromium_src/chrome/browser/devtools/devtools_ui_bindings_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/devtools/protocol/cast_handler_unittest.cc
+++ b/chromium_src/chrome/browser/devtools/protocol/cast_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/download/chrome_download_manager_delegate_unittest.cc
+++ b/chromium_src/chrome/browser/download/chrome_download_manager_delegate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/download/download_target_determiner_unittest.cc
+++ b/chromium_src/chrome/browser/download/download_target_determiner_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/enterprise/reporting/extension_request/extension_request_notification_unittest.cc
+++ b/chromium_src/chrome/browser/enterprise/reporting/extension_request/extension_request_notification_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/enterprise/reporting/extension_request/extension_request_observer_unittest.cc
+++ b/chromium_src/chrome/browser/enterprise/reporting/extension_request/extension_request_observer_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/active_tab_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/active_tab_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/activity_log/activity_log_enabled_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/activity_log/activity_log_enabled_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/activity_log/activity_log_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/activity_log/activity_log_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/activity_log/counting_policy_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/activity_log/counting_policy_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/activity_log/fullstream_ui_policy_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/activity_log/fullstream_ui_policy_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/cryptotoken_private/cryptotoken_private_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/cryptotoken_private/cryptotoken_private_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative/rules_registry_with_cache_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative/rules_registry_with_cache_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_content/chrome_content_rules_registry_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_content/chrome_content_rules_registry_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_content/content_action_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_content/content_action_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_net_request/action_tracker_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_net_request/action_tracker_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_net_request/declarative_net_request_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_net_request/declarative_net_request_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_net_request/ruleset_manager_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_net_request/ruleset_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/developer_private/developer_private_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/developer_private/developer_private_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/device_permissions_manager_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/device_permissions_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/extension_action/extension_action_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/extension_action/extension_action_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/management/management_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/management/management_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/permissions/permissions_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/permissions/permissions_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/safe_browsing_private/safe_browsing_private_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/safe_browsing_private/safe_browsing_private_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/search/search_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/search/search_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/socket/tcp_socket_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/socket/tcp_socket_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/tab_groups/tab_groups_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/tab_groups/tab_groups_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/api/tabs/tabs_api_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/api/tabs/tabs_api_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/chrome_app_icon_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_app_icon_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/chrome_content_verifier_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_content_verifier_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/component_loader_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/component_loader_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_action_icon_factory_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_action_icon_factory_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_action_runner_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_action_runner_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_allowlist_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_allowlist_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_context_menu_model_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_context_menu_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_garbage_collector_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_garbage_collector_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_gcm_app_handler_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_gcm_app_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_install_prompt_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_install_prompt_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_message_bubble_controller_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_message_bubble_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_migrator_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_migrator_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_protocols_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_protocols_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_service_sync_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_service_sync_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_service_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_web_ui_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_web_ui_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/external_policy_loader_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/external_policy_loader_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/external_provider_impl_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/external_provider_impl_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/permission_message_combinations_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/permission_message_combinations_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/permission_messages_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/permission_messages_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/scripting_permissions_modifier_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/scripting_permissions_modifier_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/shared_module_service_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/shared_module_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/tab_helper_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/tab_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/update_install_gate_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/update_install_gate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/user_script_listener_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/user_script_listener_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/extensions/zipfile_installer_unittest.cc
+++ b/chromium_src/chrome/browser/extensions/zipfile_installer_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/federated_learning/floc_id_provider_unittest.cc
+++ b/chromium_src/chrome/browser/federated_learning/floc_id_provider_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media/router/media_router_feature_unittest.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/tab_desktop_media_list_unittest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/tab_desktop_media_list_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_event_log_uploader_impl_unittest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_event_log_uploader_impl_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media_galleries/gallery_watch_manager_unittest.cc
+++ b/chromium_src/chrome/browser/media_galleries/gallery_watch_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media_galleries/media_file_system_registry_unittest.cc
+++ b/chromium_src/chrome/browser/media_galleries/media_file_system_registry_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media_galleries/media_galleries_permission_controller_unittest.cc
+++ b/chromium_src/chrome/browser/media_galleries/media_galleries_permission_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/media_galleries/media_galleries_preferences_unittest.cc
+++ b/chromium_src/chrome/browser/media_galleries/media_galleries_preferences_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/metrics/chrome_metrics_services_manager_client_unittest.cc
+++ b/chromium_src/chrome/browser/metrics/chrome_metrics_services_manager_client_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/net/net_error_tab_helper_unittest.cc
+++ b/chromium_src/chrome/browser/net/net_error_tab_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/notifications/notification_permission_context_unittest.cc
+++ b/chromium_src/chrome/browser/notifications/notification_permission_context_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/password_manager/multi_profile_credentials_filter_unittest.cc
+++ b/chromium_src/chrome/browser/password_manager/multi_profile_credentials_filter_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/prefetch/no_state_prefetch/prerender_unittest.cc
+++ b/chromium_src/chrome/browser/prefetch/no_state_prefetch/prerender_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/prefetch/prefetch_proxy/prefetch_proxy_tab_helper_unittest.cc
+++ b/chromium_src/chrome/browser/prefetch/prefetch_proxy/prefetch_proxy_tab_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/printing/cloud_print/cloud_print_proxy_service_unittest.cc
+++ b/chromium_src/chrome/browser/printing/cloud_print/cloud_print_proxy_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/printing/print_preview_dialog_controller_unittest.cc
+++ b/chromium_src/chrome/browser/printing/print_preview_dialog_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/printing/print_view_manager_unittest.cc
+++ b/chromium_src/chrome/browser/printing/print_view_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/privacy_sandbox/privacy_sandbox_settings_unittest.cc
+++ b/chromium_src/chrome/browser/privacy_sandbox/privacy_sandbox_settings_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/profile_resetter/profile_resetter_unittest.cc
+++ b/chromium_src/chrome/browser/profile_resetter/profile_resetter_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/profiles/gaia_info_update_service_unittest.cc
+++ b/chromium_src/chrome/browser/profiles/gaia_info_update_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_attributes_storage_unittest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_attributes_storage_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_info_cache_unittest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_info_cache_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_list_desktop_unittest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_list_desktop_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_manager_unittest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu_unittest.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/resource_coordinator/tab_activity_watcher_unittest.cc
+++ b/chromium_src/chrome/browser/resource_coordinator/tab_activity_watcher_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/resource_coordinator/tab_load_tracker_unittest.cc
+++ b/chromium_src/chrome/browser/resource_coordinator/tab_load_tracker_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/resource_coordinator/tab_manager_unittest.cc
+++ b/chromium_src/chrome/browser/resource_coordinator/tab_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/resource_coordinator/tab_metrics_logger_unittest.cc
+++ b/chromium_src/chrome/browser/resource_coordinator/tab_metrics_logger_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/chrome_enterprise_url_lookup_service_unittest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/chrome_enterprise_url_lookup_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/chrome_password_protection_service_unittest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/chrome_password_protection_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/download_protection/download_protection_service_unittest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/download_protection/download_protection_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/safe_browsing_navigation_observer_unittest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/safe_browsing_navigation_observer_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/search/chrome_colors/chrome_colors_service_unittest.cc
+++ b/chromium_src/chrome/browser/search/chrome_colors/chrome_colors_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/search/instant_service_unittest.cc
+++ b/chromium_src/chrome/browser/search/instant_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/search/promos/promo_service_unittest.cc
+++ b/chromium_src/chrome/browser/search/promos/promo_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/search/search_unittest.cc
+++ b/chromium_src/chrome/browser/search/search_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/search_engines/template_url_service_unittest.cc
+++ b/chromium_src/chrome/browser/search_engines/template_url_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/send_tab_to_self/desktop_notification_handler_unittest.cc
+++ b/chromium_src/chrome/browser/send_tab_to_self/desktop_notification_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/send_tab_to_self/send_tab_to_self_desktop_util_unittest.cc
+++ b/chromium_src/chrome/browser/send_tab_to_self/send_tab_to_self_desktop_util_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/send_tab_to_self/send_tab_to_self_util_unittest.cc
+++ b/chromium_src/chrome/browser/send_tab_to_self/send_tab_to_self_util_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/sessions/session_service_unittest.cc
+++ b/chromium_src/chrome/browser/sessions/session_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/shell_integration_linux_unittest.cc
+++ b/chromium_src/chrome/browser/shell_integration_linux_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/signin/dice_web_signin_interceptor_unittest.cc
+++ b/chromium_src/chrome/browser/signin/dice_web_signin_interceptor_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/signin/process_dice_header_delegate_impl_unittest.cc
+++ b/chromium_src/chrome/browser/signin/process_dice_header_delegate_impl_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/signin/signin_manager_unittest.cc
+++ b/chromium_src/chrome/browser/signin/signin_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/signin/signin_ui_util_unittest.cc
+++ b/chromium_src/chrome/browser/signin/signin_ui_util_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/sync/sessions/browser_list_router_helper_unittest.cc
+++ b/chromium_src/chrome/browser/sync/sessions/browser_list_router_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/themes/theme_service_unittest.cc
+++ b/chromium_src/chrome/browser/themes/theme_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/themes/theme_syncable_service_unittest.cc
+++ b/chromium_src/chrome/browser/themes/theme_syncable_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/translate/translate_manager_render_view_host_unittest.cc
+++ b/chromium_src/chrome/browser/translate/translate_manager_render_view_host_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/autofill/payments/local_card_migration_bubble_controller_impl_unittest.cc
+++ b/chromium_src/chrome/browser/ui/autofill/payments/local_card_migration_bubble_controller_impl_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl_unittest.cc
+++ b/chromium_src/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/bookmarks/bookmark_unittest.cc
+++ b/chromium_src/chrome/browser/ui/bookmarks/bookmark_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/browser_instant_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/browser_instant_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/browser_unittest.cc
+++ b/chromium_src/chrome/browser/ui/browser_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/content_settings/content_setting_image_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/content_settings/content_setting_image_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/cookie_controls/cookie_controls_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/cookie_controls/cookie_controls_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/exclusive_access/fullscreen_controller_state_unittest.cc
+++ b/chromium_src/chrome/browser/ui/exclusive_access/fullscreen_controller_state_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/extensions/extension_action_view_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/extensions/extension_action_view_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/extensions/extension_installed_bubble_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/extensions/extension_installed_bubble_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/extensions/extension_message_bubble_bridge_unittest.cc
+++ b/chromium_src/chrome/browser/ui/extensions/extension_message_bubble_bridge_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/extensions/settings_overridden_params_providers_unittest.cc
+++ b/chromium_src/chrome/browser/ui/extensions/settings_overridden_params_providers_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/media_router/media_router_ui_service_factory_unittest.cc
+++ b/chromium_src/chrome/browser/ui/media_router/media_router_ui_service_factory_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/media_router/media_router_ui_unittest.cc
+++ b/chromium_src/chrome/browser/ui/media_router/media_router_ui_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/passwords/bubble_controllers/move_to_account_store_bubble_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/passwords/bubble_controllers/move_to_account_store_bubble_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/passwords/bubble_controllers/save_update_bubble_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/passwords/bubble_controllers/save_update_bubble_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/passwords/well_known_change_password_navigation_throttle_unittest.cc
+++ b/chromium_src/chrome/browser/ui/passwords/well_known_change_password_navigation_throttle_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/search/ntp_user_data_logger_unittest.cc
+++ b/chromium_src/chrome/browser/ui/search/ntp_user_data_logger_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/search/search_ipc_router_policy_unittest.cc
+++ b/chromium_src/chrome/browser/ui/search/search_ipc_router_policy_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/search/search_ipc_router_unittest.cc
+++ b/chromium_src/chrome/browser/ui/search/search_ipc_router_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/search/search_tab_helper_unittest.cc
+++ b/chromium_src/chrome/browser/ui/search/search_tab_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/send_tab_to_self/send_tab_to_self_sub_menu_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/send_tab_to_self/send_tab_to_self_sub_menu_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/startup/startup_tab_provider_unittest.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_tab_provider_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/sync/profile_signin_confirmation_helper_unittest.cc
+++ b/chromium_src/chrome/browser/ui/sync/profile_signin_confirmation_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/sync/sync_promo_ui_unittest.cc
+++ b/chromium_src/chrome/browser/ui/sync/sync_promo_ui_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tab_contents/chrome_web_contents_menu_helper_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tab_contents/chrome_web_contents_menu_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tab_contents/tab_contents_iterator_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tab_contents/tab_contents_iterator_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tab_sharing/tab_sharing_infobar_delegate_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tab_sharing/tab_sharing_infobar_delegate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tabs/existing_tab_group_sub_menu_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/existing_tab_group_sub_menu_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tabs/existing_window_sub_menu_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/existing_window_sub_menu_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tabs/pinned_tab_codec_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/pinned_tab_codec_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tabs/pinned_tab_service_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/pinned_tab_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tabs/tab_menu_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_menu_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/toolbar/location_bar_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/location_bar_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/toolbar/toolbar_actions_bar_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/toolbar_actions_bar_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/toolbar/toolbar_actions_model_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/toolbar_actions_model_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/user_education/reopen_tab_in_product_help_unittest.cc
+++ b/chromium_src/chrome/browser/ui/user_education/reopen_tab_in_product_help_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/apps/app_info_dialog/app_info_dialog_views_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/apps/app_info_dialog/app_info_dialog_views_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bar_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bar_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/desktop_capture/get_current_browsing_context_media_dialog_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/desktop_capture/get_current_browsing_context_media_dialog_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/extensions/extensions_menu_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/extensions/extensions_menu_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/webui_tab_strip_container_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/webui_tab_strip_container_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/infobars/infobar_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/infobars/infobar_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/intent_picker_bubble_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/intent_picker_bubble_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/media_router/cast_toolbar_button_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/media_router/cast_toolbar_button_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/profiles/avatar_toolbar_button_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/profiles/avatar_toolbar_button_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/relaunch_notification/relaunch_notification_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/relaunch_notification/relaunch_notification_controller_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/sharing/sharing_dialog_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/sharing/sharing_dialog_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/toolbar/chrome_labs_bubble_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/chrome_labs_bubble_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/toolbar/chrome_labs_button_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/chrome_labs_button_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/toolbar/webui_tab_counter_button_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/webui_tab_counter_button_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/user_education/feature_promo_bubble_view_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/user_education/feature_promo_bubble_view_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/views/user_education/feature_promo_controller_views_unittest.cc
+++ b/chromium_src/chrome/browser/ui/views/user_education/feature_promo_controller_views_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/customize_themes/chrome_customize_themes_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/customize_themes/chrome_customize_themes_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/devtools_ui_data_source_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/devtools_ui_data_source_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/print_preview/extension_printer_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/print_preview/extension_printer_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/read_later/read_later_page_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/read_later/read_later_page_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/settings/people_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/people_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/settings/safety_check_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/safety_check_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_manage_profile_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_manage_profile_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/signin/dice_turn_sync_on_helper_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/signin/dice_turn_sync_on_helper_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/signin/login_ui_service_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/signin/login_ui_service_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/signin/profile_picker_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/signin/profile_picker_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/signin/signin_error_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/signin/signin_error_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/signin/sync_confirmation_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/signin/sync_confirmation_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/tab_strip/tab_strip_ui_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_strip/tab_strip_ui_handler_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/theme_source_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/theme_source_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/ui/webui/web_dialog_web_contents_delegate_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/web_dialog_web_contents_delegate_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/usb/web_usb_detector_unittest.cc
+++ b/chromium_src/chrome/browser/usb/web_usb_detector_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/web_applications/components/web_app_shortcut_linux_unittest.cc
+++ b/chromium_src/chrome/browser/web_applications/components/web_app_shortcut_linux_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/web_applications/extensions/bookmark_app_install_finalizer_unittest.cc
+++ b/chromium_src/chrome/browser/web_applications/extensions/bookmark_app_install_finalizer_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/web_applications/extensions/externally_installed_web_app_prefs_unittest.cc
+++ b/chromium_src/chrome/browser/web_applications/extensions/externally_installed_web_app_prefs_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/browser/web_applications/external_web_app_manager_unittest.cc
+++ b/chromium_src/chrome/browser/web_applications/external_web_app_manager_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/common/chrome_paths_unittest.cc
+++ b/chromium_src/chrome/common/chrome_paths_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/common/extensions/manifest_tests/extension_manifests_homepage_unittest.cc
+++ b/chromium_src/chrome/common/extensions/manifest_tests/extension_manifests_homepage_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/common/extensions/permissions/permission_set_unittest.cc
+++ b/chromium_src/chrome/common/extensions/permissions/permission_set_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.

--- a/chromium_src/chrome/test/views/accessibility_checker_unittest.cc
+++ b/chromium_src/chrome/test/views/accessibility_checker_unittest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8376 for more information.


### PR DESCRIPTION
This patch disables entire *_unittests.cc files by making them empty
via chromium_src overrides, so that we avoid running any test that
we know are going to fail because of the many ways in which Brave is
different than Chromium upstream.

Note that it's possible that this way of excluding tests is a bit too
agressive (i.e. it's likely that some unit tests inside the excluded
files would pass), but for now it's a good enough initial approach as
it enables us to considerably increase test coverage without having
to maintain patches in a too intrusive way.

As a reference, a this time of this patch's writing (on top of Brave
1.23.30 / Chromium 89.0.4389.86), this are the stats when running
upstream's unit tests on a Linux/Debug build, without this patch:

  * Total run: 13504 tests
  * Passed: 11585 tests
  * Not passed: 1919 tests
    - Failed: 182 tests
    - Crashed: 1737 tests
    - Timed out: 0 tests

With this patch applied, the numbers look like this:

  * Total run: 10045 tests
  * Passed: 10045 tests
  * Not passed: 0 tests

That is, what we have with this patch applied looks as follows:

  * 10045/13504 -> 74.39% of ALL the original tests being run
  * 10045/11585 -> 86.71% of the PASSING TESTS still being run

In other words, we're increasing test coverage in 10045 unit tests
in a relatively clean way (i.e. no complex patching) while "only"
losing 13.29% of the unit tests that would run and pass if we were
not excluding them in such an agressive way.

Fix https://github.com/brave/brave-browser/issues/8376

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [ ] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Run all the enabled unit tests from upstream with `npm run test -- unit_tests` and check that they all pass