### PR TITLE
13837: Fix yet another a11y crash by properly checking a string range. (uplift to 1.21.x)

### DIFF
--- a/chromium_src/ui/accessibility/platform/ax_platform_node_mac.mm
+++ b/chromium_src/ui/accessibility/platform/ax_platform_node_mac.mm
@@ -8,8 +8,10 @@
 
 // Assumed to be a temporary fix for
 // https://github.com/brave/brave-browser/issues/13778
+// and
+// https://github.com/brave/brave-browser/issues/13837
 #define BRAVE_ACCESSIBILITY_ATTRIBUTED_STRING_FOR_RANGE             \
-  id value = [self getAXValueAsString];                             \
+  id value = [self AXValue];                                        \
   if (![value isKindOfClass:[NSString class]]) {                    \
     ax::mojom::Role role = _node->GetData().role;                   \
     base::debug::Alias(&role);                                      \
@@ -17,6 +19,12 @@
     LOG(ERROR) << "Trying to get a range from a non-string object." \
                << " Role: " << static_cast<int>(role)               \
                << " Name: " << _node->GetName();                    \
+    base::debug::DumpWithoutCrashing();                             \
+    return nil;                                                     \
+  }                                                                 \
+  NSString* str = value;                                            \
+  if (range.location == NSNotFound ||                               \
+      range.location + range.length > str.length) {                 \
     base::debug::DumpWithoutCrashing();                             \
     return nil;                                                     \
   }


### PR DESCRIPTION
Uplift of #7832
Fixes https://github.com/brave/brave-browser/issues/13837

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.