### PR TITLE
Fixed crash when default avatar is selected from manageProfile (uplift to 1.21.x)

### DIFF
--- a/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
+++ b/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
@@ -162,14 +162,12 @@ std::unique_ptr<base::ListValue> GetCustomProfileAvatarIconsAndLabels(
 #if !defined(OS_CHROMEOS) && !defined(OS_ANDROID)
   //  Insert the 'placeholder' item, so it is still selectable
   //  in the Settings and Profile Manager WebUI.
-  std::unique_ptr<base::DictionaryValue> avatar_info(
-      new base::DictionaryValue());
-  avatar_info->SetString("url", profiles::GetPlaceholderAvatarIconUrl());
-  avatar_info->SetString(
-      "label", l10n_util::GetStringUTF16(IDS_BRAVE_AVATAR_LABEL_PLACEHOLDER));
-  if (selected_avatar_idx == GetPlaceholderAvatarIndex())
-    avatar_info->SetBoolean("selected", true);
-  avatars->Insert(0, std::move(avatar_info));
+  avatars->Insert(
+      0, GetAvatarIconAndLabelDict(
+             profiles::GetPlaceholderAvatarIconUrl(),
+             l10n_util::GetStringUTF16(IDS_BRAVE_AVATAR_LABEL_PLACEHOLDER),
+             GetPlaceholderAvatarIndex(),
+             selected_avatar_idx == GetPlaceholderAvatarIndex(), false));
 #endif
   return avatars;
 }


### PR DESCRIPTION
Uplift of #7913
fix https://github.com/brave/brave-browser/issues/13762

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.