### PR TITLE
Fix BAP date calculation (uplift to 1.21.x)

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1494,8 +1494,9 @@ bool RewardsServiceImpl::GetBooleanOption(const std::string& name) const {
       base::Time::Exploded cutoff_exploded{
           .year = 2021, .month = 3, .day_of_month = 13};
       base::Time cutoff;
-      DCHECK(base::Time::FromUTCExploded(cutoff_exploded, &cutoff));
-      if (base::Time::Now() >= cutoff) {
+      bool ok = base::Time::FromUTCExploded(cutoff_exploded, &cutoff);
+      DCHECK(ok);
+      if (ok && base::Time::Now() >= cutoff) {
         return true;
       }
     }

--- a/components/brave_rewards/browser/test/rewards_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_browsertest.cc
@@ -36,10 +36,11 @@ namespace {
 
 base::Time GetDate(int year, int month, int day_of_month) {
   base::Time time;
-  DCHECK(base::Time::FromUTCExploded(
+  bool ok = base::Time::FromUTCExploded(
       base::Time::Exploded{
           .year = year, .month = month, .day_of_month = day_of_month},
-      &time));
+      &time);
+  DCHECK(ok);
   return time;
 }
 
@@ -482,8 +483,7 @@ IN_PROC_BROWSER_TEST_F(RewardsBrowserTest, BAPCutoffBefore) {
 
   {
     base::subtle::ScopedTimeClockOverrides time_override(
-        []() { return GetDate(2021, 3, 13) - base::TimeDelta::FromSeconds(1); },
-        nullptr, nullptr);
+        []() { return GetDate(2021, 3, 12); }, nullptr, nullptr);
     ASSERT_EQ(FetchBalance(), 30.0);
   }
 }


### PR DESCRIPTION
Uplift of #7924
Resolves https://github.com/brave/brave-browser/issues/14092

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [x] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.