### PR TITLE
Hide the current extension popup when using ShowActionUI (uplift to 1.21.x)

### DIFF
--- a/browser/ui/brave_actions/brave_action_view_controller.cc
+++ b/browser/ui/brave_actions/brave_action_view_controller.cc
@@ -63,6 +63,11 @@ bool BraveActionViewController::TriggerPopupWithUrl(
     PopupShowAction show_action,
     const GURL& popup_url,
     bool grant_tab_permissions) {
+  // If this extension is currently showing a popup, hide it. This behavior is
+  // a bit different than ExtensionActionViewController, which will hide any
+  // popup, regardless of extension. Consider duplicating the original behavior.
+  HidePopup();
+
   std::unique_ptr<extensions::ExtensionViewHost> host =
       extensions::ExtensionViewHostFactory::CreatePopupHost(popup_url,
                                                             browser_);

--- a/components/brave_rewards/browser/test/rewards_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_browsertest.cc
@@ -12,6 +12,7 @@
 #include "base/time/time_override.h"
 #include "bat/ledger/internal/uphold/uphold_util.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
+#include "brave/browser/extensions/api/brave_action_api.h"
 #include "brave/common/brave_paths.h"
 #include "brave/components/brave_rewards/browser/rewards_service_impl.h"
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_context_helper.h"
@@ -503,6 +504,22 @@ IN_PROC_BROWSER_TEST_F(RewardsBrowserTest, BAPCutoffAfter) {
         []() { return GetDate(2021, 3, 13); }, nullptr, nullptr);
     ASSERT_EQ(FetchBalance(), 0.0);
   }
+}
+
+IN_PROC_BROWSER_TEST_F(RewardsBrowserTest, BAPPopup) {
+  // Open the rewards popup.
+  content::WebContents* popup_contents = context_helper_->OpenRewardsPopup();
+  ASSERT_TRUE(popup_contents);
+
+  // Attempt to open the BAP deprecation popup at the same time. The rewards
+  // panel popup should close. If both popups are shown at the same time, this
+  // test will crash on exit.
+  std::string error;
+  bool popup_shown = extensions::BraveActionAPI::ShowActionUI(
+      browser(), brave_rewards_extension_id,
+      std::make_unique<std::string>("brave_rewards_panel.html#bap-deprecation"),
+      &error);
+  EXPECT_TRUE(popup_shown);
 }
 
 }  // namespace rewards_browsertest


### PR DESCRIPTION
Uplift of #7935
Resolves https://github.com/brave/brave-browser/issues/14110
Resolves https://github.com/brave/brave-browser/issues/14108

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.