### PR TITLE
Exclude browser tests from upstream that are known to fail in Brave

### DIFF
--- a/chromium_src/apps/app_restore_service_browsertest.cc
+++ b/chromium_src/apps/app_restore_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/apps/load_and_launch_browsertest.cc
+++ b/chromium_src/apps/load_and_launch_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/accessibility/caption_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/accessibility/caption_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/apps/guest_view/app_view_browsertest.cc
+++ b/chromium_src/chrome/browser/apps/guest_view/app_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/apps/guest_view/web_view_browsertest.cc
+++ b/chromium_src/chrome/browser/apps/guest_view/web_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/apps/platform_apps/app_browsertest.cc
+++ b/chromium_src/chrome/browser/apps/platform_apps/app_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/apps/platform_apps/event_page_browsertest.cc
+++ b/chromium_src/chrome/browser/apps/platform_apps/event_page_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/apps/platform_apps/platform_app_navigation_redirector_browsertest.cc
+++ b/chromium_src/chrome/browser/apps/platform_apps/platform_app_navigation_redirector_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/autofill/autofill_browsertest.cc
+++ b/chromium_src/chrome/browser/autofill/autofill_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/autofill/form_structure_browsertest.cc
+++ b/chromium_src/chrome/browser/autofill/form_structure_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/background_fetch/background_fetch_browsertest.cc
+++ b/chromium_src/chrome/browser/background_fetch/background_fetch_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/banners/app_banner_manager_desktop_browsertest.cc
+++ b/chromium_src/chrome/browser/banners/app_banner_manager_desktop_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browser_encoding_browsertest.cc
+++ b/chromium_src/chrome/browser/browser_encoding_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browser_switcher/browser_switcher_browsertest.cc
+++ b/chromium_src/chrome/browser/browser_switcher/browser_switcher_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browser_switcher/browser_switcher_service_browsertest.cc
+++ b/chromium_src/chrome/browser/browser_switcher/browser_switcher_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browsing_data/access_context_audit_browsertest.cc
+++ b/chromium_src/chrome/browser/browsing_data/access_context_audit_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browsing_data/browsing_data_remover_browsertest.cc
+++ b/chromium_src/chrome/browser/browsing_data/browsing_data_remover_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browsing_data/counters/browsing_data_counter_utils_browsertest.cc
+++ b/chromium_src/chrome/browser/browsing_data/counters/browsing_data_counter_utils_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/browsing_data/counters/sync_aware_counter_browsertest.cc
+++ b/chromium_src/chrome/browser/browsing_data/counters/sync_aware_counter_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/captive_portal/captive_portal_browsertest.cc
+++ b/chromium_src/chrome/browser/captive_portal/captive_portal_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/chrome_back_forward_cache_browsertest.cc
+++ b/chromium_src/chrome/browser/chrome_back_forward_cache_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/chrome_find_request_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/chrome_find_request_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/chrome_main_browsertest.cc
+++ b/chromium_src/chrome/browser/chrome_main_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/chrome_navigation_browsertest.cc
+++ b/chromium_src/chrome/browser/chrome_navigation_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/chrome_security_exploit_browsertest.cc
+++ b/chromium_src/chrome/browser/chrome_security_exploit_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/chrome_web_platform_security_metrics_browsertest.cc
+++ b/chromium_src/chrome/browser/chrome_web_platform_security_metrics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/client_hints/client_hints_browsertest.cc
+++ b/chromium_src/chrome/browser/client_hints/client_hints_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/content_settings/content_settings_browsertest.cc
+++ b/chromium_src/chrome/browser/content_settings/content_settings_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/data_saver/data_saver_browsertest.cc
+++ b/chromium_src/chrome/browser/data_saver/data_saver_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/data_saver/lite_video_browsertest.cc
+++ b/chromium_src/chrome/browser/data_saver/lite_video_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/data_saver/subresource_redirect_browsertest.cc
+++ b/chromium_src/chrome/browser/data_saver/subresource_redirect_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/data_saver/subresource_redirect_login_robots_browsertest.cc
+++ b/chromium_src/chrome/browser/data_saver/subresource_redirect_login_robots_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/devtools/devtools_sanity_browsertest.cc
+++ b/chromium_src/chrome/browser/devtools/devtools_sanity_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/devtools/global_confirm_info_bar_browsertest.cc
+++ b/chromium_src/chrome/browser/devtools/global_confirm_info_bar_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/devtools/protocol/devtools_protocol_browsertest.cc
+++ b/chromium_src/chrome/browser/devtools/protocol/devtools_protocol_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/dom_distiller/distillable_page_utils_browsertest.cc
+++ b/chromium_src/chrome/browser/dom_distiller/distillable_page_utils_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/dom_distiller/tab_utils_browsertest.cc
+++ b/chromium_src/chrome/browser/dom_distiller/tab_utils_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/domain_reliability/browsertest.cc
+++ b/chromium_src/chrome/browser/domain_reliability/browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/download/download_browsertest.cc
+++ b/chromium_src/chrome/browser/download/download_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/download/download_browsertest.h
+++ b/chromium_src/chrome/browser/download/download_browsertest.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/download/download_frame_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/download/download_frame_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/download/save_page_browsertest.cc
+++ b/chromium_src/chrome/browser/download/save_page_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/enterprise/connectors/content_analysis_dialog_browsertest.cc
+++ b/chromium_src/chrome/browser/enterprise/connectors/content_analysis_dialog_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/error_reporting/webui_js_error_reporting_browsertest.cc
+++ b/chromium_src/chrome/browser/error_reporting/webui_js_error_reporting_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/active_tab_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/active_tab_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/all_urls_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/all_urls_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/activity_log_private/activity_log_private_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/activity_log_private/activity_log_private_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/automation/automation_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/automation/automation_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/browsing_data/browsing_data_test.cc
+++ b/chromium_src/chrome/browser/extensions/api/browsing_data/browsing_data_test.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/content_settings/content_settings_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/content_settings/content_settings_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/context_menus/context_menu_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/context_menus/context_menu_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/cookies/cookies_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/cookies/cookies_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/debugger/debugger_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/debugger/debugger_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative/declarative_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative/declarative_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_content/declarative_content_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_content/declarative_content_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_net_request/declarative_net_request_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_net_request/declarative_net_request_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/declarative_net_request/declarative_net_request_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/api/declarative_net_request/declarative_net_request_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/developer_private/developer_private_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/developer_private/developer_private_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/downloads/downloads_api_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/api/downloads/downloads_api_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/extension_action/browser_action_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/extension_action/browser_action_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/extension_action/extension_action_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/extension_action/extension_action_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/extension_action/page_action_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/extension_action/page_action_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/gcm/gcm_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/gcm/gcm_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/history/history_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/history/history_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/i18n/i18n_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/i18n/i18n_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/identity/identity_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/identity/identity_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/instance_id/instance_id_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/instance_id/instance_id_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/management/management_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/management/management_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/messaging/native_messaging_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/messaging/native_messaging_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/page_capture/page_capture_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/page_capture/page_capture_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/preference/preference_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/preference/preference_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/runtime/runtime_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/runtime/runtime_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/scripting/scripting_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/scripting/scripting_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/search/search_api_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/search/search_api_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/socket/socket_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/socket/socket_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/tabs/tabs_test.cc
+++ b/chromium_src/chrome/browser/extensions/api/tabs/tabs_test.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/web_navigation/web_navigation_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/web_navigation/web_navigation_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/web_request/web_request_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/web_request/web_request_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/webrtc_audio_private/webrtc_audio_private_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/api/webrtc_audio_private/webrtc_audio_private_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/webrtc_from_web_accessible_resource_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/api/webrtc_from_web_accessible_resource_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/api/webrtc_logging_private/webrtc_logging_private_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/app_background_page_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/app_background_page_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/app_process_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/app_process_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/autoplay_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/autoplay_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/chrome_app_api_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_app_api_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/chrome_test_extension_loader_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_test_extension_loader_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/chrome_theme_url_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/chrome_theme_url_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/content_capabilities_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/content_capabilities_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/content_script_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/content_script_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/content_verifier_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/content_verifier_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/corb_and_cors_extension_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/corb_and_cors_extension_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/crx_installer_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/crx_installer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/default_apps_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/default_apps_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/error_console/error_console_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/error_console/error_console_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/execute_script_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/execute_script_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_action_runner_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_action_runner_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_bindings_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_bindings_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_context_menu_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_context_menu_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_csp_bypass_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_csp_bypass_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_dom_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_dom_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_dom_clipboard_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_dom_clipboard_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_function_registration_test.cc
+++ b/chromium_src/chrome/browser/extensions/extension_function_registration_test.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_functional_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_functional_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_incognito_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_incognito_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_install_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_install_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_loading_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_loading_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_messages_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_messages_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_override_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_override_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_resource_request_policy_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_resource_request_policy_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_samesite_cookies_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_samesite_cookies_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_tab_util_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_tab_util_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_tabs_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_tabs_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_unload_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_unload_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_url_rewrite_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_url_rewrite_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/extension_webui_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/extension_webui_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/fetch_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/fetch_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/file_iframe_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/file_iframe_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/gpu_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/gpu_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/isolated_app_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/isolated_app_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/isolated_world_csp_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/isolated_world_csp_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/lazy_background_page_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/lazy_background_page_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/manifest_v3_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/manifest_v3_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/native_bindings_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/native_bindings_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/options_page_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/options_page_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/page_action_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/page_action_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/process_management_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/process_management_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/process_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/process_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/protocol_handler_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/protocol_handler_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/service_worker_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/service_worker_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/service_worker_messaging_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/service_worker_messaging_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/startup_helper_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/startup_helper_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/stubs_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/stubs_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/subscribe_page_action_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/subscribe_page_action_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/updater/update_service_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/updater/update_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/user_script_listener_browsertest.cc
+++ b/chromium_src/chrome/browser/extensions/user_script_listener_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/wake_event_page_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/wake_event_page_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/extensions/window_open_apitest.cc
+++ b/chromium_src/chrome/browser/extensions/window_open_apitest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/external_protocol/external_protocol_handler_browsertest.cc
+++ b/chromium_src/chrome/browser/external_protocol/external_protocol_handler_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/favicon/content_favicon_driver_browsertest.cc
+++ b/chromium_src/chrome/browser/favicon/content_favicon_driver_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/federated_learning/floc_eligibility_browsertest.cc
+++ b/chromium_src/chrome/browser/federated_learning/floc_eligibility_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/federated_learning/floc_id_provider_browsertest.cc
+++ b/chromium_src/chrome/browser/federated_learning/floc_id_provider_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/first_run/first_run_browsertest.cc
+++ b/chromium_src/chrome/browser/first_run/first_run_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/first_run/first_run_internal_posix_browsertest.cc
+++ b/chromium_src/chrome/browser/first_run/first_run_internal_posix_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/geolocation/geolocation_browsertest.cc
+++ b/chromium_src/chrome/browser/geolocation/geolocation_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/history/history_browsertest.cc
+++ b/chromium_src/chrome/browser/history/history_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/image_fetcher/image_fetcher_impl_browsertest.cc
+++ b/chromium_src/chrome/browser/image_fetcher/image_fetcher_impl_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/infobars/infobars_browsertest.cc
+++ b/chromium_src/chrome/browser/infobars/infobars_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/installable/installable_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/installable/installable_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/lifetime/browser_close_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/lifetime/browser_close_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/login_detection/password_store_sites_browsertest.cc
+++ b/chromium_src/chrome/browser/login_detection/password_store_sites_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/lookalikes/lookalike_url_navigation_throttle_browsertest.cc
+++ b/chromium_src/chrome/browser/lookalikes/lookalike_url_navigation_throttle_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/cast_mirroring_performance_browsertest.cc
+++ b/chromium_src/chrome/browser/media/cast_mirroring_performance_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/encrypted_media_browsertest.cc
+++ b/chromium_src/chrome/browser/media/encrypted_media_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/encrypted_media_supported_types_browsertest.cc
+++ b/chromium_src/chrome/browser/media/encrypted_media_supported_types_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/feeds/media_feeds_browsertest.cc
+++ b/chromium_src/chrome/browser/media/feeds/media_feeds_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/history/media_history_browsertest.cc
+++ b/chromium_src/chrome/browser/media/history/media_history_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/media_engagement_autoplay_browsertest.cc
+++ b/chromium_src/chrome/browser/media/media_engagement_autoplay_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/media_engagement_browsertest.cc
+++ b/chromium_src/chrome/browser/media/media_engagement_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/unified_autoplay_browsertest.cc
+++ b/chromium_src/chrome/browser/media/unified_autoplay_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/media_stream_devices_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/media_stream_devices_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/media_stream_permission_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/media_stream_permission_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_desktop_capture_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_desktop_capture_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_disable_encryption_flag_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_disable_encryption_flag_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_getdisplaymedia_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_getdisplaymedia_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_getmediadevices_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_getmediadevices_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/media/webrtc/webrtc_pan_tilt_zoom_browsertest.cc
+++ b/chromium_src/chrome/browser/media/webrtc/webrtc_pan_tilt_zoom_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/cloned_install_client_id_reset_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/cloned_install_client_id_reset_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/desktop_session_duration/audible_contents_tracker_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/desktop_session_duration/audible_contents_tracker_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/metrics_service_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/metrics_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/metrics_service_user_demographics_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/metrics_service_user_demographics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/process_memory_metrics_emitter_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/process_memory_metrics_emitter_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/ukm_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/ukm_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/metrics/variations/variations_http_headers_browsertest.cc
+++ b/chromium_src/chrome/browser/metrics/variations/variations_http_headers_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/navigation_predictor/navigation_predictor_browsertest.cc
+++ b/chromium_src/chrome/browser/navigation_predictor/navigation_predictor_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/navigation_predictor/navigation_predictor_preconnect_client_browsertest.cc
+++ b/chromium_src/chrome/browser/navigation_predictor/navigation_predictor_preconnect_client_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/navigation_predictor/search_engine_preconnector_browsertest.cc
+++ b/chromium_src/chrome/browser/navigation_predictor/search_engine_preconnector_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/chrome_mojo_proxy_resolver_factory_browsertest.cc
+++ b/chromium_src/chrome/browser/net/chrome_mojo_proxy_resolver_factory_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/cookie_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/net/cookie_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/dns_probe_browsertest.cc
+++ b/chromium_src/chrome/browser/net/dns_probe_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/errorpage_browsertest.cc
+++ b/chromium_src/chrome/browser/net/errorpage_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/ftp_browsertest.cc
+++ b/chromium_src/chrome/browser/net/ftp_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/load_timing_browsertest.cc
+++ b/chromium_src/chrome/browser/net/load_timing_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/network_context_configuration_browsertest.cc
+++ b/chromium_src/chrome/browser/net/network_context_configuration_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/network_request_metrics_browsertest.cc
+++ b/chromium_src/chrome/browser/net/network_request_metrics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/proxy_browsertest.cc
+++ b/chromium_src/chrome/browser/net/proxy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/reporting_browsertest.cc
+++ b/chromium_src/chrome/browser/net/reporting_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/net/websocket_browsertest.cc
+++ b/chromium_src/chrome/browser/net/websocket_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/optimization_guide/blink/blink_optimization_guide_browsertest.cc
+++ b/chromium_src/chrome/browser/optimization_guide/blink/blink_optimization_guide_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/optimization_guide/hints_fetcher_browsertest.cc
+++ b/chromium_src/chrome/browser/optimization_guide/hints_fetcher_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/optimization_guide/prediction/prediction_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/optimization_guide/prediction/prediction_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/integration_tests/smoothness_metric_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/integration_tests/smoothness_metric_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/ad_metrics/ads_page_load_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/ad_metrics/ads_page_load_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/back_forward_cache_page_load_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/back_forward_cache_page_load_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/core/amp_page_load_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/core/amp_page_load_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/data_saver_site_breakdown_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/data_saver_site_breakdown_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/live_tab_count_page_load_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/live_tab_count_page_load_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/security_state_page_load_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/security_state_page_load_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/third_party_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/third_party_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/observers/use_counter_page_load_metrics_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/observers/use_counter_page_load_metrics_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/page_load_metrics/page_load_metrics_browsertest.cc
+++ b/chromium_src/chrome/browser/page_load_metrics/page_load_metrics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/password_manager/credential_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/password_manager/credential_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/password_manager/password_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/password_manager/password_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/abort_payment_handler_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/abort_payment_handler_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/colocated_payment_manifests_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/colocated_payment_manifests_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/ignore_payment_method_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/ignore_payment_method_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/load_and_remove_iframe_with_many_payment_requests_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/load_and_remove_iframe_with_many_payment_requests_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/payment_handler_capabilities_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/payment_handler_capabilities_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/payment_handler_enforce_full_delegation_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/payment_handler_enforce_full_delegation_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/payment_request_can_make_payment_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/payment_request_can_make_payment_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/payment_request_can_make_payment_event_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/payment_request_can_make_payment_event_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/payment_request_minimal_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/payment_request_minimal_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/secure_payment_confirmation_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/secure_payment_confirmation_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/payments/service_worker_payment_app_finder_browsertest.cc
+++ b/chromium_src/chrome/browser/payments/service_worker_payment_app_finder_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/pdf/pdf_extension_test.cc
+++ b/chromium_src/chrome/browser/pdf/pdf_extension_test.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/performance_manager/background_tab_loading_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/performance_manager/background_tab_loading_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/performance_manager/frame_node_impl_browsertest.cc
+++ b/chromium_src/chrome/browser/performance_manager/frame_node_impl_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/performance_manager/page_load_tracker_decorator_browsertest.cc
+++ b/chromium_src/chrome/browser/performance_manager/page_load_tracker_decorator_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/permissions/permission_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/permissions/permission_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/permissions/permission_request_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/permissions/permission_request_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/picture_in_picture/picture_in_picture_window_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/picture_in_picture/picture_in_picture_window_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/certificate_transparency_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/certificate_transparency_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/cloud/chrome_browser_cloud_management_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/cloud/chrome_browser_cloud_management_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/cloud/user_policy_signin_service_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/cloud/user_policy_signin_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/component_updater_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/component_updater_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/content_settings_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/content_settings_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/developer_tools_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/developer_tools_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/extension_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/extension_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/force_google_safe_search_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/force_google_safe_search_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/hide_webstore_icon_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/hide_webstore_icon_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/policy_prefs_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/policy_prefs_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/policy_test_google_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/policy_test_google_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/restore_on_startup_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/restore_on_startup_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/safe_browsing_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/safe_browsing_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/signed_exchange_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/signed_exchange_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/policy/url_blacklist_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/policy/url_blacklist_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/portal/portal_browsertest.cc
+++ b/chromium_src/chrome/browser/portal/portal_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/portal/portal_recently_audible_browsertest.cc
+++ b/chromium_src/chrome/browser/portal/portal_recently_audible_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/predictors/loading_predictor_browsertest.cc
+++ b/chromium_src/chrome/browser/predictors/loading_predictor_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/prefetch/no_state_prefetch/prerender_nostate_prefetch_browsertest.cc
+++ b/chromium_src/chrome/browser/prefetch/no_state_prefetch/prerender_nostate_prefetch_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/prefetch/prefetch_browsertest.cc
+++ b/chromium_src/chrome/browser/prefetch/prefetch_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/prefetch/prefetch_proxy/prefetch_proxy_browsertest.cc
+++ b/chromium_src/chrome/browser/prefetch/prefetch_proxy/prefetch_proxy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/prefetch/search_prefetch/search_prefetch_service_browsertest.cc
+++ b/chromium_src/chrome/browser/prefetch/search_prefetch/search_prefetch_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/prefs/pref_functional_browsertest.cc
+++ b/chromium_src/chrome/browser/prefs/pref_functional_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/previews/defer_all_script_browsertest.cc
+++ b/chromium_src/chrome/browser/previews/defer_all_script_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/previews/defer_all_script_priority_browsertest.cc
+++ b/chromium_src/chrome/browser/previews/defer_all_script_priority_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/previews/lazyload_browsertest.cc
+++ b/chromium_src/chrome/browser/previews/lazyload_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/printing/print_browsertest.cc
+++ b/chromium_src/chrome/browser/printing/print_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/printing/print_preview_dialog_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/printing/print_preview_dialog_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_browsertest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_list_desktop_browsertest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_list_desktop_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_theme_update_service_browsertest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_theme_update_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/profiles/profile_window_browsertest.cc
+++ b/chromium_src/chrome/browser/profiles/profile_window_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/profiling_host/memlog_browsertest.cc
+++ b/chromium_src/chrome/browser/profiling_host/memlog_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/push_messaging/push_messaging_browsertest.cc
+++ b/chromium_src/chrome/browser/push_messaging/push_messaging_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/referrer_policy_browsertest.cc
+++ b/chromium_src/chrome/browser/referrer_policy_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/renderer_context_menu/accessibility_labels_menu_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/accessibility_labels_menu_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu_browsertest.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/renderer_context_menu/spelling_menu_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/spelling_menu_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/renderer_context_menu/spelling_options_submenu_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/spelling_options_submenu_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/renderer_host/render_process_host_chrome_browsertest.cc
+++ b/chromium_src/chrome/browser/renderer_host/render_process_host_chrome_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/resource_coordinator/tab_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/resource_coordinator/tab_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/certificate_reporting_service_browsertest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/certificate_reporting_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/chrome_password_protection_service_browsertest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/chrome_password_protection_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/chrome_password_protection_service_sync_browsertest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/chrome_password_protection_service_sync_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/download_protection/deep_scanning_browsertest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/download_protection/deep_scanning_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/download_protection/download_protection_service_browsertest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/download_protection/download_protection_service_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/safe_browsing_blocking_page_test.cc
+++ b/chromium_src/chrome/browser/safe_browsing/safe_browsing_blocking_page_test.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/safe_browsing/safe_browsing_navigation_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/safe_browsing/safe_browsing_navigation_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/search/local_ntp_navigation_browsertest.cc
+++ b/chromium_src/chrome/browser/search/local_ntp_navigation_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/sessions/better_session_restore_browsertest.cc
+++ b/chromium_src/chrome/browser/sessions/better_session_restore_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/sessions/closed_tab_cache_browsertest.cc
+++ b/chromium_src/chrome/browser/sessions/closed_tab_cache_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/sessions/session_restore_browsertest.cc
+++ b/chromium_src/chrome/browser/sessions/session_restore_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/sessions/session_restore_observer_browsertest.cc
+++ b/chromium_src/chrome/browser/sessions/session_restore_observer_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/sessions/tab_restore_browsertest.cc
+++ b/chromium_src/chrome/browser/sessions/tab_restore_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/signin/dice_browsertest.cc
+++ b/chromium_src/chrome/browser/signin/dice_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/signin/dice_web_signin_interceptor_browsertest.cc
+++ b/chromium_src/chrome/browser/signin/dice_web_signin_interceptor_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/site_isolation/chrome_site_per_process_browsertest.cc
+++ b/chromium_src/chrome/browser/site_isolation/chrome_site_per_process_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/site_isolation/site_details_browsertest.cc
+++ b/chromium_src/chrome/browser/site_isolation/site_details_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ssl/captive_portal_blocking_page_browsertest.cc
+++ b/chromium_src/chrome/browser/ssl/captive_portal_blocking_page_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ssl/known_interception_disclosure_infobar_browsertest.cc
+++ b/chromium_src/chrome/browser/ssl/known_interception_disclosure_infobar_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ssl/security_state_tab_helper_browsertest.cc
+++ b/chromium_src/chrome/browser/ssl/security_state_tab_helper_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ssl/ssl_browsertest.cc
+++ b/chromium_src/chrome/browser/ssl/ssl_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ssl/stateful_ssl_host_state_delegate_test.cc
+++ b/chromium_src/chrome/browser/ssl/stateful_ssl_host_state_delegate_test.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/storage/durable_storage_browsertest.cc
+++ b/chromium_src/chrome/browser/storage/durable_storage_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/storage_access_api/api_browsertest.cc
+++ b/chromium_src/chrome/browser/storage_access_api/api_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/ad_tagging_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/ad_tagging_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/subresource_filter_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/subresource_filter_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/subresource_filter_devtools_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/subresource_filter_devtools_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/subresource_filter_intercepting_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/subresource_filter_intercepting_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/subresource_filter_settings_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/subresource_filter_settings_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/subresource_filter_special_subframe_navigations_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/subresource_filter_special_subframe_navigations_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/subresource_filter/subresource_filter_worker_browsertest.cc
+++ b/chromium_src/chrome/browser/subresource_filter/subresource_filter_worker_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/tab_contents/navigation_metrics_recorder_browsertest.cc
+++ b/chromium_src/chrome/browser/tab_contents/navigation_metrics_recorder_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/tab_contents/view_source_browsertest.cc
+++ b/chromium_src/chrome/browser/tab_contents/view_source_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/providers/web_contents/background_contents_tag_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/providers/web_contents/background_contents_tag_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/providers/web_contents/devtools_tag_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/providers/web_contents/devtools_tag_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/providers/web_contents/extension_tag_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/providers/web_contents/extension_tag_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/providers/web_contents/subframe_task_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/providers/web_contents/subframe_task_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/providers/web_contents/tab_contents_tag_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/providers/web_contents/tab_contents_tag_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/providers/worker_task_provider_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/providers/worker_task_provider_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/task_manager/task_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/task_manager/task_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/translate/translate_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/translate/translate_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/blocked_content/popup_opener_tab_helper_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/blocked_content/popup_opener_tab_helper_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/blocked_content/popup_tracker_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/blocked_content/popup_tracker_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/blocked_content/safe_browsing_triggered_popup_blocker_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/blocked_content/safe_browsing_triggered_popup_blocker_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/blocked_content/tab_under_blocker_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/blocked_content/tab_under_blocker_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/browser_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/browser_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/browser_navigator_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/browser_tabrestore_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/browser_tabrestore_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/content_settings/content_setting_image_model_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/content_settings/content_setting_image_model_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/content_settings/framebust_block_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/content_settings/framebust_block_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/extensions/hosted_app_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/extensions/hosted_app_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/find_bar/find_bar_host_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/find_bar/find_bar_host_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/login/login_handler_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/login/login_handler_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/managed_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/managed_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/manifest_web_app_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/manifest_web_app_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/media_router/presentation_receiver_window_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/media_router/presentation_receiver_window_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/passwords/well_known_change_password_navigation_throttle_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/passwords/well_known_change_password_navigation_throttle_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/popup_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/popup_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/instant_theme_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/instant_theme_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/local_ntp_backgrounds_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/local_ntp_backgrounds_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/local_ntp_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/local_ntp_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/local_ntp_doodle_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/local_ntp_doodle_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/local_ntp_js_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/local_ntp_js_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/local_ntp_promos_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/local_ntp_promos_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/new_tab_page_navigation_throttle_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/new_tab_page_navigation_throttle_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/search/third_party_ntp_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/search/third_party_ntp_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/signin_reauth_view_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/signin_reauth_view_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/thumbnails/thumbnail_tab_helper_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/thumbnails/thumbnail_tab_helper_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/toolbar/browser_actions_bar_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/browser_actions_bar_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/toolbar/browser_actions_bar_browsertest.h
+++ b/chromium_src/chrome/browser/ui/toolbar/browser_actions_bar_browsertest.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/accessibility/accessibility_focus_highlight_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/accessibility/accessibility_focus_highlight_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/apps/app_info_dialog/app_info_dialog_views_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/apps/app_info_dialog/app_info_dialog_views_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/autofill/payments/local_card_migration_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/autofill/payments/local_card_migration_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/autofill/payments/save_card_bubble_views_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/autofill/payments/save_card_bubble_views_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bar_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bar_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_sign_in_delegate_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_sign_in_delegate_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/collected_cookies_views_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/collected_cookies_views_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/extensions/extension_dialog_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/extensions/extension_dialog_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/extensions/extension_message_bubble_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/extensions/extension_message_bubble_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/extensions/extensions_menu_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/extensions/extensions_menu_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/external_protocol_dialog_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/external_protocol_dialog_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/file_system_access/file_system_access_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/file_system_access/file_system_access_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_non_client_frame_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/frame/opaque_browser_frame_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/opaque_browser_frame_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/hats/hats_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/hats/hats_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/intent_picker_bubble_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/intent_picker_bubble_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/location_bar/content_setting_bubble_dialog_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/content_setting_bubble_dialog_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/location_bar/custom_tab_bar_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/custom_tab_bar_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/media_router/media_router_dialog_controller_views_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/media_router/media_router_dialog_controller_views_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/media_router/media_router_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/media_router/media_router_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/omnibox/omnibox_popup_contents_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/omnibox/omnibox_popup_contents_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/page_action/pwa_install_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/page_action/pwa_install_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/page_info/page_info_bubble_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/page_info/page_info_bubble_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/page_info/page_info_bubble_view_sync_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/page_info/page_info_bubble_view_sync_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/passwords/password_bubble_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/passwords/password_bubble_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/credit_card_editor_view_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/credit_card_editor_view_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/modifiers_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/modifiers_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_handler_header_view_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_handler_header_view_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_handler_icon_refetch_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_handler_icon_refetch_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_request_can_make_payment_metrics_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_request_can_make_payment_metrics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_request_journey_logger_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_request_journey_logger_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_request_missing_fields_metrics_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_request_missing_fields_metrics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_request_payment_app_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_request_payment_app_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_request_show_promise_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_request_show_promise_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/payment_sheet_view_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/payment_sheet_view_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/payments/shipping_address_editor_view_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/payments/shipping_address_editor_view_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/profiles/profile_menu_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/profiles/profile_menu_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/profiles/profile_picker_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/profiles/profile_picker_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/reader_mode/reader_mode_icon_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/reader_mode/reader_mode_icon_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/sharing/click_to_call_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/sharing/click_to_call_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/sharing/shared_clipboard_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/sharing/shared_clipboard_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/sync/inline_login_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/sync/inline_login_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/toolbar/browser_actions_container_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/browser_actions_container_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/translate/translate_language_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/translate/translate_language_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/views/web_apps/web_app_integration_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/web_apps/web_app_integration_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/create_shortcut_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/create_shortcut_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/pwa_mixed_content_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/pwa_mixed_content_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/test/system_web_app_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/test/system_web_app_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_badging_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_badging_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_file_handling_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_file_handling_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_link_capturing_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_link_capturing_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_metrics_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_metrics_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_navigate_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_navigate_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/web_applications/web_app_ui_manager_impl_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/web_applications/web_app_ui_manager_impl_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/autofill_and_password_manager_internals/password_manager_internals_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/autofill_and_password_manager_internals/password_manager_internals_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/chrome_url_data_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_url_data_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/extensions/extension_settings_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/extensions/extension_settings_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/inspect_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/inspect_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/interstitials/interstitial_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/interstitials/interstitial_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/log_web_ui_url_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/log_web_ui_url_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/new_tab_page/webui_ntp_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/new_tab_page/webui_ntp_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/ntp/new_tab_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/ntp/new_tab_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/policy/policy_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/policy/policy_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/prefs_internals_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/prefs_internals_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/signin/user_manager_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/signin/user_manager_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_ui_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/webui/webui_webview_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/webui/webui_webview_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ui/zoom/zoom_controller_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/zoom/zoom_controller_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/ukm_worker_browsertest.cc
+++ b/chromium_src/chrome/browser/ukm_worker_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/unified_consent/unified_consent_browsertest.cc
+++ b/chromium_src/chrome/browser/unified_consent/unified_consent_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/unload_browsertest.cc
+++ b/chromium_src/chrome/browser/unload_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/web_applications/manifest_update_manager_browsertest.cc
+++ b/chromium_src/chrome/browser/web_applications/manifest_update_manager_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/web_applications/web_app_audio_focus_browsertest.cc
+++ b/chromium_src/chrome/browser/web_applications/web_app_audio_focus_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/browser/web_applications/web_app_mover_browsertest.cc
+++ b/chromium_src/chrome/browser/web_applications/web_app_mover_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/base/in_process_browser_test_browsertest.cc
+++ b/chromium_src/chrome/test/base/in_process_browser_test_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_e2e_browsertest.cc
+++ b/chromium_src/chrome/test/media_router/media_router_e2e_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_e2e_browsertest.h
+++ b/chromium_src/chrome/test/media_router/media_router_e2e_browsertest.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_e2e_ui_browsertest.cc
+++ b/chromium_src/chrome/test/media_router/media_router_e2e_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_integration_browsertest.cc
+++ b/chromium_src/chrome/test/media_router/media_router_integration_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_integration_browsertest.h
+++ b/chromium_src/chrome/test/media_router/media_router_integration_browsertest.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_integration_ui_browsertest.cc
+++ b/chromium_src/chrome/test/media_router/media_router_integration_ui_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/media_router/media_router_one_ua_integration_browsertest.cc
+++ b/chromium_src/chrome/test/media_router/media_router_one_ua_integration_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/chrome/test/ppapi/ppapi_browsertest.cc
+++ b/chromium_src/chrome/test/ppapi/ppapi_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/chromium_src/extensions/browser/guest_view/mime_handler_view/mime_handler_view_browsertest.cc
+++ b/chromium_src/extensions/browser/guest_view/mime_handler_view/mime_handler_view_browsertest.cc
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// THIS FILE IS INTENTIONALLY EMPTY TO DISABLE TESTS FROM CHROMIUM UPSTREAM.
+// See https://github.com/brave/brave-browser/issues/8297 for more information.

--- a/patches/chrome-test-include_js_tests.gni.patch
+++ b/patches/chrome-test-include_js_tests.gni.patch
@@ -1,0 +1,11 @@
+diff --git a/chrome/test/include_js_tests.gni b/chrome/test/include_js_tests.gni
+index 72a439884d2be78df848ceaddca6fe7237f30a6c..67212f0a7b902bec22a89d0fc56999fc7a510b6c 100644
+--- a/chrome/test/include_js_tests.gni
++++ b/chrome/test/include_js_tests.gni
+@@ -3,5 +3,6 @@ import("//build/config/sanitizers/sanitizers.gni")
+ if (!is_android) {
+   # js_tests don't work in cross builds, https://crbug.com/1010561
+   include_js_tests =
++      false &&
+       !(is_asan || is_msan || is_tsan || is_cfi || (is_win && host_os != "win"))
+ }


### PR DESCRIPTION
This patch disables entire *_browsertest.cc files by making them empty
via chromium_src overrides, as well as all the JS tests via a patch to
include_js_tests.gni, so that we avoid running any test that we know
are going to fail because of the many ways in which Brave is different
than Chromium upstream.

Note that it's possible that this way of excluding tests is a bit too
agressive (i.e. it's likely that some browser tests inside the excluded
files would pass), but for now it's a good enough initial approach as
it enables us to considerably increase test coverage without having
to maintain patches in a too intrusive way.

As a reference, a this time of this patch's writing (on top of Brave
1.23.30 / Chromium 89.0.4389.86), this are the stats when running
upstream's unit tests on a Linux/Debug build, without this patch:

  * Total run: 13355 tests
  * Passed: 10427 tests
  * Not passed: 2928 tests
    - Failed: 870 tests
    - Crashed: 1593 tests
    - Timed out: 465 tests

With this patch applied, the numbers look like this:

  * Total run: 2957 tests
  * Passed: 2957 tests
  * Not passed: 0 tests

That is, what we have with this patch applied looks as follows:

  * 2957/13355 -> 22.14% of ALL the original tests being run
  * 2957/10427 -> 28.36% of the PASSING TESTS still being run

In other words, we're increasing test coverage in 2957 browser tests
in a relatively clean way (i.e. no complex patching) while losing
71.64% of the browser tests that would run and pass if we were not
excluding them in such an agressive way. Not as good results as for
the case of unit tests, but still an improvement for test coverage.

Fix https://github.com/brave/brave-browser/issues/8297

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [ ] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Run all the enabled browser tests from upstream with npm run test -- browser_tests and check that they all pass