### PR TITLE
Fix crash while relaunching after installing widevine

### DIFF
--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -94,8 +94,10 @@ void BraveDrmTabHelper::OnEvent(Events event, const std::string& id) {
       id == kWidevineComponentId) {
 #if defined(OS_LINUX)
     // Ask restart instead of reloading. Widevine is only usable after
-    // restarting on linux.
-    RequestWidevinePermission(web_contents(), true /* for_restart*/);
+    // restarting on linux. This restart permission request is only shown if
+    // this tab asks widevine explicitely.
+    if (is_widevine_requested_)
+      RequestWidevinePermission(web_contents(), true /* for_restart*/);
 #else
     // When widevine is ready to use, only active tab that requests widevine is
     // reloaded automatically.

--- a/browser/widevine/widevine_permission_request.cc
+++ b/browser/widevine/widevine_permission_request.cc
@@ -37,7 +37,9 @@ void WidevinePermissionRequest::PermissionGranted(bool is_one_time) {
   // Prevent relaunch during the browser test.
   // This will cause abnormal termination during the test.
   if (for_restart_ && !is_test_) {
-    chrome::AttemptRelaunch();
+    // Try relaunch after handling permission grant logics in this turn.
+    base::SequencedTaskRunnerHandle::Get()->PostTask(
+        FROM_HERE, base::BindOnce(&chrome::AttemptRelaunch));
   }
 #endif
   if (!for_restart_)


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/14146

It seems PermissionRequestManager is destroyed by calling
chrome::AttemptRelaunch() before PermissionRequest accept handler
is not finished. To fix this, post AttempRelaunch() instead of calling
it in current turn.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Crash log from component build.
```
[139247:139247:0215/101813.483104:FATAL:permission_request_manager.cc(707)] Check failed: 1 == base::STLCount(requests_, request) + base::STLCount(queued_requests_, request) (1 vs. 0)Only requests in [queued_[frame_]]requests_ can have duplicates
#0 0x7ff4baab0249 base::debug::CollectStackTrace()
#1 0x7ff4ba9b9b33 base::debug::StackTrace::StackTrace()
#2 0x7ff4ba9d9c73 logging::LogMessage::~LogMessage()
#3 0x7ff4ba9da5ce logging::LogMessage::~LogMessage()
#4 0x55fff02fadc5 permissions::PermissionRequestManager::PermissionGrantedIncludingDuplicates()
#5 0x55fff02fac9d permissions::PermissionRequestManager::Accept()
#6 0x7ff4b3435a3b views::DialogDelegate::RunCloseCallback()
#7 0x7ff4b3435ac0 views::DialogDelegate::Accept()
#8 0x7ff4b3436854 views::DialogDelegate::AcceptDialog()
#9 0x7ff4b3356f44 views::ButtonController::OnMouseReleased()

```

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [ ] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See issue's STR.