### PR TITLE
Fix crash while relaunching after installing widevine (uplift to 1.21.x)

### DIFF
--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -94,8 +94,10 @@ void BraveDrmTabHelper::OnEvent(Events event, const std::string& id) {
       id == kWidevineComponentId) {
 #if defined(OS_LINUX)
     // Ask restart instead of reloading. Widevine is only usable after
-    // restarting on linux.
-    RequestWidevinePermission(web_contents(), true /* for_restart*/);
+    // restarting on linux. This restart permission request is only shown if
+    // this tab asks widevine explicitely.
+    if (is_widevine_requested_)
+      RequestWidevinePermission(web_contents(), true /* for_restart*/);
 #else
     // When widevine is ready to use, only active tab that requests widevine is
     // reloaded automatically.

--- a/browser/widevine/widevine_permission_request.cc
+++ b/browser/widevine/widevine_permission_request.cc
@@ -41,7 +41,9 @@ void WidevinePermissionRequest::PermissionGranted(bool is_one_time) {
   // Prevent relaunch during the browser test.
   // This will cause abnormal termination during the test.
   if (for_restart_ && !is_test_) {
-    chrome::AttemptRelaunch();
+    // Try relaunch after handling permission grant logics in this turn.
+    base::SequencedTaskRunnerHandle::Get()->PostTask(
+        FROM_HERE, base::BindOnce(&chrome::AttemptRelaunch));
   }
 #endif
   if (!for_restart_)


### PR DESCRIPTION
Uplift of #7959
fix https://github.com/brave/brave-browser/issues/14146

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.