### PR TITLE
Add brave to list of apps for ipfs/ipns protocols

### DIFF
--- a/chromium_src/chrome/installer/DEPS
+++ b/chromium_src/chrome/installer/DEPS
@@ -1,6 +1,7 @@
 include_rules = [
   "+../../../../../chrome/installer/mini_installer",
   "+../../../../../chrome/installer/setup",
+  "+../../../../../chrome/installer/util",
   "+chrome/installer",
   "+chrome/install_static",
 ]

--- a/chromium_src/chrome/installer/util/shell_util.cc
+++ b/chromium_src/chrome/installer/util/shell_util.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define BRAVE_IPFS L"ipfs"
+#define BRAVE_IPNS L"ipns"
+
+#define BRAVE_GET_TARGET_FOR_DEFAULT_APP_SETTINGS                         \
+  if (base::EqualsCaseInsensitiveASCII(protocol, BRAVE_IPFS))             \
+    return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"IPFS"); \
+  if (base::EqualsCaseInsensitiveASCII(protocol, BRAVE_IPNS))             \
+    return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"IPNS");
+
+#include "../../../../../chrome/installer/util/shell_util.cc"
+#undef BRAVE_GET_TARGET_FOR_DEFAULT_APP_SETTINGS
+#undef BRAVE_IPFS
+#undef BRAVE_IPNS

--- a/patches/chrome-installer-util-shell_util.cc.patch
+++ b/patches/chrome-installer-util-shell_util.cc.patch
@@ -1,0 +1,30 @@
+diff --git a/chrome/installer/util/shell_util.cc b/chrome/installer/util/shell_util.cc
+index bba833d2f3abeb8f0a6fefa59ace416db3dc2b63..ca3604b2ab8fcd9a74718e54fb1263d4ba32be26 100644
+--- a/chrome/installer/util/shell_util.cc
++++ b/chrome/installer/util/shell_util.cc
+@@ -748,6 +748,10 @@ base::string16 GetTargetForDefaultAppsSettings(const wchar_t* protocol) {
+     return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"Browser");
+   if (base::EqualsCaseInsensitiveASCII(protocol, L"mailto"))
+     return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"Email");
++  if (base::EqualsCaseInsensitiveASCII(protocol, L"ipfs"))
++    return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"IPFS");
++  if (base::EqualsCaseInsensitiveASCII(protocol, L"ipns"))
++    return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"IPNS");
+   return L"SettingsPageAppsDefaultsProtocolView";
+ }
+ 
+@@ -1619,10 +1623,12 @@ const wchar_t* ShellUtil::kPotentialFileAssociations[] = {
+     L".htm", L".html",  L".pdf",  L".shtml", L".svg",
+     L".xht", L".xhtml", L".webp", nullptr};
+ const wchar_t* ShellUtil::kBrowserProtocolAssociations[] = {L"ftp", L"http",
+-                                                            L"https", nullptr};
++                                                            L"https", L"ipfs",
++                                                            L"ipns", nullptr};
+ const wchar_t* ShellUtil::kPotentialProtocolAssociations[] = {
+     L"ftp", L"http",  L"https", L"irc", L"mailto", L"mms",    L"news", L"nntp",
+-    L"sms", L"smsto", L"snews", L"tel", L"urn",    L"webcal", nullptr};
++    L"sms", L"smsto", L"snews", L"tel", L"urn",    L"webcal", L"ipfs", L"ipns",
++     nullptr};
+ const wchar_t* ShellUtil::kRegUrlProtocol = L"URL Protocol";
+ const wchar_t* ShellUtil::kRegApplication = L"\\Application";
+ const wchar_t* ShellUtil::kRegAppUserModelId = L"AppUserModelId";

--- a/patches/chrome-installer-util-shell_util.cc.patch
+++ b/patches/chrome-installer-util-shell_util.cc.patch
@@ -1,30 +1,23 @@
 diff --git a/chrome/installer/util/shell_util.cc b/chrome/installer/util/shell_util.cc
-index bba833d2f3abeb8f0a6fefa59ace416db3dc2b63..ca3604b2ab8fcd9a74718e54fb1263d4ba32be26 100644
+index bba833d2f3abeb8f0a6fefa59ace416db3dc2b63..956f251527c4728ae51d934b46e64cb6d20ff3f2 100644
 --- a/chrome/installer/util/shell_util.cc
 +++ b/chrome/installer/util/shell_util.cc
-@@ -748,6 +748,10 @@ base::string16 GetTargetForDefaultAppsSettings(const wchar_t* protocol) {
+@@ -748,6 +748,7 @@ base::string16 GetTargetForDefaultAppsSettings(const wchar_t* protocol) {
      return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"Browser");
    if (base::EqualsCaseInsensitiveASCII(protocol, L"mailto"))
      return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"Email");
-+  if (base::EqualsCaseInsensitiveASCII(protocol, L"ipfs"))
-+    return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"IPFS");
-+  if (base::EqualsCaseInsensitiveASCII(protocol, L"ipns"))
-+    return base::StringPrintf(kSystemSettingsDefaultAppsFormat, L"IPNS");
++  BRAVE_GET_TARGET_FOR_DEFAULT_APP_SETTINGS
    return L"SettingsPageAppsDefaultsProtocolView";
  }
  
-@@ -1619,10 +1623,12 @@ const wchar_t* ShellUtil::kPotentialFileAssociations[] = {
+@@ -1619,8 +1620,10 @@ const wchar_t* ShellUtil::kPotentialFileAssociations[] = {
      L".htm", L".html",  L".pdf",  L".shtml", L".svg",
      L".xht", L".xhtml", L".webp", nullptr};
  const wchar_t* ShellUtil::kBrowserProtocolAssociations[] = {L"ftp", L"http",
--                                                            L"https", nullptr};
-+                                                            L"https", L"ipfs",
-+                                                            L"ipns", nullptr};
++                                                            BRAVE_IPFS, BRAVE_IPNS,
+                                                             L"https", nullptr};
  const wchar_t* ShellUtil::kPotentialProtocolAssociations[] = {
++    BRAVE_IPFS, BRAVE_IPNS,
      L"ftp", L"http",  L"https", L"irc", L"mailto", L"mms",    L"news", L"nntp",
--    L"sms", L"smsto", L"snews", L"tel", L"urn",    L"webcal", nullptr};
-+    L"sms", L"smsto", L"snews", L"tel", L"urn",    L"webcal", L"ipfs", L"ipns",
-+     nullptr};
+     L"sms", L"smsto", L"snews", L"tel", L"urn",    L"webcal", nullptr};
  const wchar_t* ShellUtil::kRegUrlProtocol = L"URL Protocol";
- const wchar_t* ShellUtil::kRegApplication = L"\\Application";
- const wchar_t* ShellUtil::kRegAppUserModelId = L"AppUserModelId";


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14161

In order to setup protocol handlers we rely on chromium implementation. In case of win10 it shows Windows UI Settings to allow user to choose protocol handlers from the list. After short discussion we decided leave it as is but add Brave to the list of apps.

![image](https://user-images.githubusercontent.com/2965009/107987597-58045080-6fdf-11eb-942c-815d2ebb3b87.png)

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [ ] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Remove default protocols handler for ipfs/ipns
- Clean profile
- Open ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_van_Gogh.html
- Enable IPFS to use local node
- Browser opens a settings window and brave should be in the list of handlers for ipfs/ipns protocols
