### PR TITLE
Test for BraveIdentityManager::GetAccountsInCookieJar

### DIFF
--- a/components/signin/public/identity_manager/BUILD.gn
+++ b/components/signin/public/identity_manager/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_identity_manager_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//base/test:test_support",
+    "//components/image_fetcher/core:test_support",
+    "//components/prefs",
+    "//components/prefs:test_support",
+    "//components/signin/internal/identity_manager",
+    "//components/signin/internal/identity_manager:test_support",
+    "//components/signin/public/base",
+    "//components/signin/public/base:test_support",
+    "//components/signin/public/identity_manager",
+    "//components/signin/public/identity_manager:test_support",
+    "//components/sync_preferences:test_support",
+    "//testing/gtest",
+  ]
+
+  if (is_ios) {
+    deps += [ "//components/signin/public/identity_manager/ios:test_support" ]
+  }
+}

--- a/components/signin/public/identity_manager/brave_identity_manager_unittest.cc
+++ b/components/signin/public/identity_manager/brave_identity_manager_unittest.cc
@@ -1,0 +1,267 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/signin/public/identity_manager/brave_identity_manager.h"
+
+#include <vector>
+
+#include "base/command_line.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/run_loop.h"
+#include "base/test/task_environment.h"
+#include "build/build_config.h"
+#include "components/image_fetcher/core/fake_image_decoder.h"
+#include "components/signin/internal/identity_manager/account_fetcher_service.h"
+#include "components/signin/internal/identity_manager/account_tracker_service.h"
+#include "components/signin/internal/identity_manager/accounts_cookie_mutator_impl.h"
+#include "components/signin/internal/identity_manager/accounts_mutator_impl.h"
+#include "components/signin/internal/identity_manager/device_accounts_synchronizer_impl.h"
+#include "components/signin/internal/identity_manager/diagnostics_provider_impl.h"
+#include "components/signin/internal/identity_manager/fake_profile_oauth2_token_service.h"
+#include "components/signin/internal/identity_manager/gaia_cookie_manager_service.h"
+#include "components/signin/internal/identity_manager/primary_account_manager.h"
+#include "components/signin/internal/identity_manager/primary_account_mutator_impl.h"
+#include "components/signin/internal/identity_manager/primary_account_policy_manager_impl.h"
+#include "components/signin/public/base/account_consistency_method.h"
+#include "components/signin/public/base/list_accounts_test_utils.h"
+#include "components/signin/public/base/signin_switches.h"
+#include "components/signin/public/base/test_signin_client.h"
+#include "components/signin/public/identity_manager/accounts_cookie_mutator.h"
+#include "components/signin/public/identity_manager/identity_manager.h"
+#include "components/signin/public/identity_manager/test_identity_manager_observer.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if defined(OS_ANDROID)
+#include "components/signin/internal/identity_manager/child_account_info_fetcher_android.h"
+#endif
+
+namespace signin {
+namespace {
+
+const char kTestGaiaId[] = "dummyId";
+const char kTestGaiaId2[] = "dummyId2";
+const char kTestEmail[] = "me@gmail.com";
+const char kTestEmail2[] = "me2@gmail.com";
+
+}  // namespace
+
+class BraveIdentityManagerTest : public testing::Test {
+ protected:
+  BraveIdentityManagerTest()
+      : signin_client_(&pref_service_, &test_url_loader_factory_) {
+    IdentityManager::RegisterProfilePrefs(pref_service_.registry());
+    IdentityManager::RegisterLocalStatePrefs(pref_service_.registry());
+
+    RecreateIdentityManager();
+  }
+
+  ~BraveIdentityManagerTest() override { signin_client_.Shutdown(); }
+
+  BraveIdentityManagerTest(const BraveIdentityManagerTest&) = delete;
+  BraveIdentityManagerTest& operator=(const BraveIdentityManagerTest&) = delete;
+
+  void SetUp() override {
+    primary_account_id_ =
+        identity_manager_->PickAccountIdForAccount(kTestGaiaId, kTestEmail);
+  }
+
+  IdentityManager* identity_manager() { return identity_manager_.get(); }
+
+  TestIdentityManagerObserver* identity_manager_observer() {
+    return identity_manager_observer_.get();
+  }
+
+  GaiaCookieManagerService* gaia_cookie_manager_service() {
+    return gaia_cookie_manager_service_;
+  }
+
+  // Recreates IdentityManager. This process destroys any existing
+  // IdentityManager and its dependencies, then remakes them. Dependencies that
+  // outlive PrimaryAccountManager (e.g. SigninClient) will be reused.
+  void RecreateIdentityManager() {
+    // Remove observer first, otherwise IdentityManager destruction might
+    // trigger a DCHECK because there are still living observers.
+    identity_manager_observer_.reset();
+    identity_manager_.reset();
+
+    ASSERT_TRUE(temp_profile_dir_.CreateUniqueTempDir());
+
+    auto account_tracker_service = std::make_unique<AccountTrackerService>();
+    account_tracker_service->Initialize(&pref_service_,
+                                        temp_profile_dir_.GetPath());
+    auto token_service =
+        std::make_unique<FakeProfileOAuth2TokenService>(&pref_service_);
+
+    auto gaia_cookie_manager_service =
+        std::make_unique<GaiaCookieManagerService>(token_service.get(),
+                                                   &signin_client_);
+    gaia_cookie_manager_service_ = gaia_cookie_manager_service.get();
+
+    auto account_fetcher_service = std::make_unique<AccountFetcherService>();
+    account_fetcher_service->Initialize(
+        &signin_client_, token_service.get(), account_tracker_service.get(),
+        std::make_unique<image_fetcher::FakeImageDecoder>());
+
+    std::unique_ptr<PrimaryAccountPolicyManager> policy_manager;
+    auto primary_account_manager = std::make_unique<PrimaryAccountManager>(
+        &signin_client_, token_service.get(), account_tracker_service.get(),
+        std::move(policy_manager));
+
+    // Passing this switch ensures that the new PrimaryAccountManager starts
+    // with a clean slate. Otherwise PrimaryAccountManager::Initialize will use
+    // the account id stored in prefs::kGoogleServicesAccountId.
+    base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+    cmd_line->AppendSwitch(switches::kClearTokenService);
+
+    primary_account_manager->Initialize(&pref_service_);
+
+    IdentityManager::InitParameters init_params;
+
+    init_params.accounts_cookie_mutator =
+        std::make_unique<AccountsCookieMutatorImpl>(
+            &signin_client_, token_service.get(),
+            gaia_cookie_manager_service.get(), account_tracker_service.get());
+
+    init_params.diagnostics_provider =
+        std::make_unique<DiagnosticsProviderImpl>(
+            token_service.get(), gaia_cookie_manager_service.get());
+
+    init_params.primary_account_mutator =
+        std::make_unique<PrimaryAccountMutatorImpl>(
+            account_tracker_service.get(), token_service.get(),
+            primary_account_manager.get(), &pref_service_,
+            AccountConsistencyMethod::kDisabled);
+
+#if defined(OS_ANDROID) || defined(OS_IOS)
+    init_params.device_accounts_synchronizer =
+        std::make_unique<DeviceAccountsSynchronizerImpl>(
+            token_service->GetDelegate());
+#else
+    init_params.accounts_mutator = std::make_unique<AccountsMutatorImpl>(
+        token_service.get(), account_tracker_service.get(),
+        primary_account_manager.get(), &pref_service_);
+#endif
+
+    init_params.account_fetcher_service = std::move(account_fetcher_service);
+    init_params.account_tracker_service = std::move(account_tracker_service);
+    init_params.gaia_cookie_manager_service =
+        std::move(gaia_cookie_manager_service);
+    init_params.primary_account_manager = std::move(primary_account_manager);
+    init_params.token_service = std::move(token_service);
+
+    identity_manager_.reset(new BraveIdentityManager(std::move(init_params)));
+    identity_manager_observer_.reset(
+        new TestIdentityManagerObserver(identity_manager_.get()));
+  }
+
+  void TriggerListAccounts() {
+    std::vector<gaia::ListedAccount> signed_in_accounts;
+    std::vector<gaia::ListedAccount> signed_out_accounts;
+    bool accounts_are_fresh = gaia_cookie_manager_service()->ListAccounts(
+        &signed_in_accounts, &signed_out_accounts);
+    static_cast<void>(accounts_are_fresh);
+  }
+
+  const CoreAccountId& primary_account_id() const {
+    return primary_account_id_;
+  }
+
+  TestSigninClient* signin_client() { return &signin_client_; }
+
+  network::TestURLLoaderFactory* test_url_loader_factory() {
+    return &test_url_loader_factory_;
+  }
+
+ private:
+  base::ScopedTempDir temp_profile_dir_;
+  base::test::TaskEnvironment task_environment_;
+  sync_preferences::TestingPrefServiceSyncable pref_service_;
+  network::TestURLLoaderFactory test_url_loader_factory_;
+  TestSigninClient signin_client_;
+  std::unique_ptr<IdentityManager> identity_manager_;
+  std::unique_ptr<TestIdentityManagerObserver> identity_manager_observer_;
+  CoreAccountId primary_account_id_;
+  GaiaCookieManagerService* gaia_cookie_manager_service_;
+};
+
+TEST_F(BraveIdentityManagerTest, GetAccountsInCookieJarWithNoAccounts) {
+  base::RunLoop run_loop;
+  identity_manager_observer()->SetOnAccountsInCookieUpdatedCallback(
+      run_loop.QuitClosure());
+
+  SetListAccountsResponseNoAccounts(test_url_loader_factory());
+
+  TriggerListAccounts();
+  const AccountsInCookieJarInfo& accounts_in_cookie_jar =
+      identity_manager()->GetAccountsInCookieJar();
+  EXPECT_FALSE(accounts_in_cookie_jar.accounts_are_fresh);
+  EXPECT_TRUE(accounts_in_cookie_jar.signed_in_accounts.empty());
+  EXPECT_TRUE(accounts_in_cookie_jar.signed_out_accounts.empty());
+
+  run_loop.Run();
+
+  TriggerListAccounts();
+  const AccountsInCookieJarInfo updated_accounts_in_cookie_jar =
+      identity_manager()->GetAccountsInCookieJar();
+
+  EXPECT_FALSE(updated_accounts_in_cookie_jar.accounts_are_fresh);
+  EXPECT_TRUE(updated_accounts_in_cookie_jar.signed_in_accounts.empty());
+  EXPECT_TRUE(updated_accounts_in_cookie_jar.signed_out_accounts.empty());
+}
+
+TEST_F(BraveIdentityManagerTest, GetAccountsInCookieJarWithOneAccount) {
+  base::RunLoop run_loop;
+  identity_manager_observer()->SetOnAccountsInCookieUpdatedCallback(
+      run_loop.QuitClosure());
+
+  SetListAccountsResponseOneAccount(kTestEmail, kTestGaiaId,
+                                    test_url_loader_factory());
+
+  TriggerListAccounts();
+  const AccountsInCookieJarInfo& accounts_in_cookie_jar =
+      identity_manager()->GetAccountsInCookieJar();
+  EXPECT_FALSE(accounts_in_cookie_jar.accounts_are_fresh);
+  EXPECT_TRUE(accounts_in_cookie_jar.signed_in_accounts.empty());
+  EXPECT_TRUE(accounts_in_cookie_jar.signed_out_accounts.empty());
+
+  run_loop.Run();
+
+  TriggerListAccounts();
+  const AccountsInCookieJarInfo& updated_accounts_in_cookie_jar =
+      identity_manager()->GetAccountsInCookieJar();
+
+  EXPECT_FALSE(updated_accounts_in_cookie_jar.accounts_are_fresh);
+  EXPECT_TRUE(updated_accounts_in_cookie_jar.signed_in_accounts.empty());
+  EXPECT_TRUE(updated_accounts_in_cookie_jar.signed_out_accounts.empty());
+}
+
+TEST_F(BraveIdentityManagerTest, GetAccountsInCookieJarWithTwoAccounts) {
+  base::RunLoop run_loop;
+  identity_manager_observer()->SetOnAccountsInCookieUpdatedCallback(
+      run_loop.QuitClosure());
+
+  SetListAccountsResponseTwoAccounts(kTestEmail, kTestGaiaId, kTestEmail2,
+                                     kTestGaiaId2, test_url_loader_factory());
+
+  TriggerListAccounts();
+  const AccountsInCookieJarInfo& accounts_in_cookie_jar =
+      identity_manager()->GetAccountsInCookieJar();
+  EXPECT_FALSE(accounts_in_cookie_jar.accounts_are_fresh);
+  EXPECT_TRUE(accounts_in_cookie_jar.signed_in_accounts.empty());
+  EXPECT_TRUE(accounts_in_cookie_jar.signed_out_accounts.empty());
+
+  run_loop.Run();
+
+  TriggerListAccounts();
+  const AccountsInCookieJarInfo& updated_accounts_in_cookie_jar =
+      identity_manager()->GetAccountsInCookieJar();
+
+  EXPECT_FALSE(updated_accounts_in_cookie_jar.accounts_are_fresh);
+  EXPECT_TRUE(updated_accounts_in_cookie_jar.signed_in_accounts.empty());
+  EXPECT_TRUE(updated_accounts_in_cookie_jar.signed_out_accounts.empty());
+}
+
+}  // namespace signin

--- a/components/sync/driver/brave_sync_profile_sync_service_unittest.cc
+++ b/components/sync/driver/brave_sync_profile_sync_service_unittest.cc
@@ -148,41 +148,4 @@ TEST_F(BraveProfileSyncServiceTest, ValidPassphraseLeadingTrailingWhitespace) {
   OSCryptMocker::TearDown();
 }
 
-TEST_F(BraveProfileSyncServiceTest, NoIdentityManagerCalls) {
-  OSCryptMocker::SetUp();
-
-  CreateSyncService(ProfileSyncService::MANUAL_START);
-  brave_sync_service()->Initialize();
-  component_factory()->AllowFakeEngineInitCompletion(false);
-
-  bool set_code_result = brave_sync_service()->SetSyncCode(kValidSyncCode);
-  EXPECT_TRUE(set_code_result);
-
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(), kValidSyncCode);
-
-  EXPECT_TRUE(engine());
-  engine()->TriggerInitializationCompletion(/*success=*/true);
-
-  // We need to test that during `ProfileSyncService::OnEngineInitialized`
-  // the stubbed call identity_manager_->GetAccountsInCookieJar() is invoked.
-  // We can do it indirectly. The stubbed method returns result where
-  // `accounts_in_cookie_jar_info.accounts_are_fresh` is set to `false`,
-  // this makes following sequence of calls:
-  //   `ProfileSyncService::OnAccountsInCookieUpdated`,
-  //   `ProfileSyncService::OnAccountsInCookieUpdatedWithCallback`,
-  //   `engine_->OnCookieJarChanged`
-  // will not be invoked.
-  // So the indirect way to ensure is to see there is no call of
-  // `SyncEngine::OnCookieJarChanged`
-
-  // TODO: Migrate this EXPECT_CALL
-  //EXPECT_CALL(*engine(), OnCookieJarChanged(_, _)).Times(0);
-
-  brave_sync_service()->OnEngineInitialized(
-      WeakHandle<JsBackend>(), WeakHandle<DataTypeDebugInfoListener>(),
-      /*success=*/true, /*is_first_time_sync_configure=*/false);
-
-  OSCryptMocker::TearDown();
-}
-
 }  // namespace syncer

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -408,6 +408,7 @@ test("brave_unit_tests") {
     deps += [
       "//brave/components/brave_sync:crypto",
       "//brave/components/brave_sync:network_time_helper",
+      "//brave/components/signin/public/identity_manager:unit_tests",
       "//brave/components/sync/driver:unit_tests",
       "//components/signin/public/identity_manager:test_support",
     ]


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14217

The test `BraveProfileSyncServiceTest.NoIdentityManagerCalls` hadn't be possible to keep on CR90, see https://github.com/brave/brave-browser/issues/14217. 

During attempts to fix it I found that it actually didn't test what it supposed to test, because `ProfileSyncServiceBundle::identity_test_env_::FinishBuildIdentityManagerForTests` builds the instance of `IdentityManager` and the test succeeded because it actually didn't fetch any accounts.

So I removed `BraveProfileSyncServiceTest.NoIdentityManagerCalls` and introduced `BraveIdentityManagerTest.GetAccountsInCookieJar***` which succeed with `BraveIdentityManager` and fails with Chromium's `IdentityManager`.

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint` // get `13 tests crashed: of BraveAds*` for unit tests; got lint complains on file `chromium_src/chrome/common/url_constants.cc` which is not in the PR; `npm run gn_check` failed for some files outside of the PR;
- [x] Ran `git rebase cr90` (if needed)
- [ ] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test -- brave_unit_tests --filter=BraveIdentityManagerTest.*`
