### PR TITLE
Disables Safe Browsing Enhanced Protection message in interstitials.

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -231,6 +231,7 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
     features::kWebOTP.name,
     network_time::kNetworkTimeServiceQuerying.name,
     safe_browsing::kEnhancedProtection.name,
+    safe_browsing::kEnhancedProtectionMessageInInterstitials.name,
 #if defined(OS_ANDROID)
     features::kWebNfc.name,
     feed::kInterestFeedContentSuggestions.name,

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -78,6 +78,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
       &features::kWebOTP,
       &network_time::kNetworkTimeServiceQuerying,
       &safe_browsing::kEnhancedProtection,
+      &safe_browsing::kEnhancedProtectionMessageInInterstitials,
   };
 
   for (const auto* feature : disabled_features)


### PR DESCRIPTION
Fixes brave/brave-browser#14235

Chromium change:

https://source.chromium.org/chromium/chromium/src/+/fc0d1b93b039972a96eead77dd4d6f359762afcc

commit fc0d1b93b039972a96eead77dd4d6f359762afcc
Author: Xinghui Lu <xinghuilu@chromium.org>
Date:   Thu Jan 14 03:21:12 2021 +0000

    Enable enhanced protection message in interstitials by default.

    To fully replace the old SBER checkbox with the new enhanced protection
    message, some tests are removed entirely because the SBER checkbox
    doesn't exist anymore:
    SafeBrowsingBlockingPageBrowserTest.VisitWhitePaper
    SafeBrowsingBlockingPageBrowserTest.ToggleSBEROn
    SafeBrowsingBlockingPageBrowserTest.ToggleSBEROff

    Some tests are slightly modified by removing the old
    extended-reporting-opt-in element:
    SafeBrowsingBlockingPageBrowserTest.
      MainFrameBlockedShouldHaveNoDOMDetails
    SafeBrowsingBlockingPageBrowserTest.ReloadWhileInterstitialShowing
    SafeBrowsingBlockingPageBrowserTest.VerifyHitReportNotSentOnIncognito

    For PolicyTest, remove the check of opt-in checkbox in
    SafeBrowsingExtendedReportingPolicyManaged and add a new test for
    checking the new enhanced-protection-message message with the
    kSafeBrowsingProtectionLevel policy.

    Bug: 1130721

## Submitter Checklist:

- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)
- [ ] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

