### PR TITLE
Specify resolver source to avoid using system resolver for CNAME adblocking (uplift to 1.20.x) 

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -54,11 +54,11 @@ source_set("net") {
     "//brave/components/brave_webtorrent/browser/buildflags",
     "//brave/components/ipfs/buildflags",
     "//brave/extensions:common",
+    "//components/content_settings/core/browser",
     "//components/prefs",
     "//components/user_prefs",
     "//content/public/browser",
     "//content/public/common",
-    "//components/content_settings/core/browser",
     "//extensions/common:common_constants",
     "//mojo/public/cpp/bindings",
     "//mojo/public/cpp/system",
@@ -88,9 +88,7 @@ source_set("net") {
       "brave_referrals_network_delegate_helper.h",
     ]
 
-    deps += [
-      "//brave/components/brave_referrals/browser",
-    ]
+    deps += [ "//brave/components/brave_referrals/browser" ]
   }
 
   if (enable_brave_webtorrent) {

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -133,6 +133,10 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
     network::mojom::ResolveHostParametersPtr optional_parameters =
         network::mojom::ResolveHostParameters::New();
     optional_parameters->include_canonical_name = true;
+    // Explicitly specify source to avoid using `HostResolverProc`
+    // which will be handled by system resolver
+    // See https://crbug.com/872665
+    optional_parameters->source = net::HostResolverSource::DNS;
 
     network::mojom::NetworkContext* network_context =
         content::BrowserContext::GetDefaultStoragePartition(context)

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -196,7 +196,16 @@ void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
   scoped_refptr<base::SequencedTaskRunner> task_runner =
       g_brave_browser_process->ad_block_service()->GetTaskRunner();
 
-  new AdblockCnameResolveHostClient(std::move(next_callback), task_runner, ctx);
+  DCHECK(ctx->browser_context);
+  // DoH or standard DNS quries won't be routed through Tor, so we need to skip
+  // it.
+  if (ctx->browser_context->IsTor()) {
+    ShouldBlockAdWithOptionalCname(task_runner, std::move(next_callback), ctx,
+                                   base::nullopt);
+  } else {
+    new AdblockCnameResolveHostClient(std::move(next_callback), task_runner,
+                                      ctx);
+  }
 }
 
 int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/7731 and Uplift of #7769

Resolves https://github.com/brave/brave-browser/issues/12575
Resolves brave/brave-browser#13527

Specify resolver source to avoid using system resolver for CNAME adblocking

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 

Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.