### PR TITLE
Block .onion requests in non-Tor window 

### DIFF
--- a/browser/ui/views/location_bar/onion_location_view.cc
+++ b/browser/ui/views/location_bar/onion_location_view.cc
@@ -52,7 +52,7 @@ void OnTorProfileCreated(GURL onion_location,
   if (!browser)
     return;
   content::OpenURLParams open_tor(onion_location, content::Referrer(),
-                                  WindowOpenDisposition::NEW_FOREGROUND_TAB,
+                                  WindowOpenDisposition::SWITCH_TO_TAB,
                                   ui::PAGE_TRANSITION_TYPED, false);
   browser->OpenURL(open_tor);
 }


### PR DESCRIPTION
and show "Open in Tor" when auto redirect setting is off
Click "Open in Tor" now will have same window disposition as auto redirect

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14261

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [x] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Auto redirect off
1. Start Wireshark and filter for dns.
2. disable DoH in brave://settings/security (makes it easier to see requests in Wireshark)
3. Open a normal window and type https://brave5t5rjjg3s6k.onion/ in the URL bar.
4. Confirm that you get an error page and that the .onion didn't result in a DNS lookup.
5. There should be a "Open in Tor" button
6. Click it and confirm that it opens https://brave5t5rjjg3s6k.onion/  in Tor window
7. Go back to the tab of step 2 and type https://brave5t5rjjg3s6k.com/ in the URL bar.
8. "Open in Tor" button should be clear

### Auto redirect on
1. Start Wireshark and filter for dns.
2. disable DoH in brave://settings/security (makes it easier to see requests in Wireshark)
3. Go to brave://settings/extensions and turn on `Automatically redirect .onion sites`
4. Open a normal window and type https://brave5t5rjjg3s6k.onion/ in the URL bar.
5. Confirm that you get an error page and that the .onion didn't result in a DNS lookup.
6. Tor window should be opened automatically with `https://brave5t5rjjg3s6k.onion/`