### PR TITLE
Fix asm patching for BraveCommandLineInitUtil (uplift to 1.21.x)

### DIFF
--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -1,6 +1,7 @@
 import("//build/config/python.gni")
 
 brave_bytecode_jars = [
+  "obj/chrome/android/base_module_java.javac.jar",
   "obj/chrome/android/chrome_java.javac.jar",
   "obj/chrome/browser/ui/android/appmenu/internal/java.javac.jar",
   "obj/chrome/browser/ui/android/toolbar/java.javac.jar",


### PR DESCRIPTION
Uplift of #8038
Resolves https://github.com/brave/brave-browser/issues/14288

Verified on Nightly apk from https://github.com/brave/brave-browser/releases/tag/v1.22.41

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.