### PR TITLE
breakpad: Patch breakpad to accept backtrace ids

### DIFF
--- a/patches/components-crash-core-app-breakpad_linux.cc.patch
+++ b/patches/components-crash-core-app-breakpad_linux.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/components/crash/core/app/breakpad_linux.cc b/components/crash/core/app/breakpad_linux.cc
+index 9e850c0380b8a856dace5f68c80dd11a5b95a671..2726278ed03fa6c474ef96853f02bb0c6317c5c8 100644
+--- a/components/crash/core/app/breakpad_linux.cc
++++ b/components/crash/core/app/breakpad_linux.cc
+@@ -1458,7 +1458,7 @@ bool IsValidCrashReportId(const char* buf, size_t bytes_read,
+   return my_strcmp(buf, "_sys_cr_finished") == 0;
+ #else
+   for (size_t i = 0; i < bytes_read; ++i) {
+-    if (!my_isxdigit(buf[i]))
++    if (!my_isxdigit(buf[i]) && buf[i] != '-')
+       return false;
+   }
+   return true;
+@@ -1953,7 +1953,7 @@ void HandleCrashDump(const BreakpadInfo& info) {
+       if (upload_child > 0) {
+         IGNORE_RET(sys_close(fds[1]));  // Close write end of pipe.
+ 
+-        const size_t kCrashIdLength = 16;
++        const size_t kCrashIdLength = 36;
+         char id_buf[kCrashIdLength + 1];
+         size_t bytes_read =
+             WaitForCrashReportUploadProcess(fds[0], kCrashIdLength, id_buf);


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/14326

This patch fixes breakpad to write crash ids to the file
Crash\ Reports/uploads.log. The old behavior was to silently fail at
this step since the backtrace crash Ids don't match Google crash ids.

Fixes:
  * Increase the size of the string kCrashIdLength from 16 to 36 because
    backtrace crash ids are longer than chromium crash ids.
  * Allow a dash in the id since the backtrace crash id format is:
    xxxxxxxx-xxxx-xxxx-0000-000000000000, where "x" is a hexadecimal
    character.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [ ] Requested a security/privacy review as needed

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Follow the steps in the linked issue.
