### PR TITLE
Fix Open in Tor in wrong window by

### DIFF
--- a/browser/tor/BUILD.gn
+++ b/browser/tor/BUILD.gn
@@ -113,6 +113,7 @@ source_set("browser_tests") {
       "//content/public/browser",
       "//content/test:test_support",
       "//net:test_support",
+      "//ui/views:test_support",
     ]
 
     if (enable_extensions) {

--- a/browser/tor/onion_location_navigation_throttle_browsertest.cc
+++ b/browser/tor/onion_location_navigation_throttle_browsertest.cc
@@ -23,6 +23,10 @@
 #include "content/public/test/test_navigation_observer.h"
 #include "net/test/embedded_test_server/http_request.h"
 #include "net/test/embedded_test_server/http_response.h"
+#include "ui/events/base_event_utils.h"
+#include "ui/events/event.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/views/test/button_test_api.h"
 
 namespace {
 
@@ -73,7 +77,7 @@ class OnionLocationNavigationThrottleBrowserTest : public InProcessBrowserTest {
     return test_http_server_.get();
   }
 
-  void CheckOnionLocationLabel(Browser* browser) {
+  void CheckOnionLocationLabel(Browser* browser, const GURL& url) {
     BrowserView* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
     ASSERT_NE(browser_view, nullptr);
     BraveLocationBarView* brave_location_bar_view =
@@ -84,6 +88,31 @@ class OnionLocationNavigationThrottleBrowserTest : public InProcessBrowserTest {
     EXPECT_TRUE(onion_button->GetVisible());
     EXPECT_EQ(onion_button->GetText(),
               l10n_util::GetStringUTF16((IDS_LOCATION_BAR_OPEN_IN_TOR)));
+
+    content::WindowedNotificationObserver tor_browser_creation_observer(
+        chrome::NOTIFICATION_BROWSER_OPENED,
+        content::NotificationService::AllSources());
+    // Click the button
+    ui::MouseEvent pressed(ui::ET_MOUSE_PRESSED, gfx::Point(), gfx::Point(),
+                           ui::EventTimeForNow(), ui::EF_LEFT_MOUSE_BUTTON,
+                           ui::EF_LEFT_MOUSE_BUTTON);
+    ui::MouseEvent released(ui::ET_MOUSE_RELEASED, gfx::Point(), gfx::Point(),
+                            ui::EventTimeForNow(), ui::EF_LEFT_MOUSE_BUTTON,
+                            ui::EF_LEFT_MOUSE_BUTTON);
+    views::test::ButtonTestApi(onion_button).NotifyClick(pressed);
+    views::test::ButtonTestApi(onion_button).NotifyClick(released);
+    tor_browser_creation_observer.Wait();
+    BrowserList* browser_list = BrowserList::GetInstance();
+    ASSERT_EQ(2U, browser_list->size());
+    Browser* tor_browser = browser_list->get(1);
+    ASSERT_TRUE(tor_browser->profile()->IsTor());
+    content::WebContents* tor_web_contents =
+        tor_browser->tab_strip_model()->GetActiveWebContents();
+    EXPECT_EQ(tor_web_contents->GetVisibleURL(), url);
+    // We don't close the original tab
+    EXPECT_EQ(browser->tab_strip_model()->count(), 1);
+    // No new tab in Tor window
+    EXPECT_EQ(tor_browser->tab_strip_model()->count(), 1);
   }
 
  private:
@@ -104,7 +133,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
       tor::OnionLocationTabHelper::FromWebContents(web_contents);
   EXPECT_TRUE(helper->should_show_icon());
   EXPECT_EQ(helper->onion_location(), GURL(kTestOnionURL));
-  CheckOnionLocationLabel(browser());
+  CheckOnionLocationLabel(browser(), GURL(kTestOnionURL));
 
   GURL url2 = test_server()->GetURL("/no_onion");
   ui_test_utils::NavigateToURL(browser(), url2);
@@ -127,7 +156,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
       tor::OnionLocationTabHelper::FromWebContents(web_contents);
   EXPECT_TRUE(helper->should_show_icon());
   EXPECT_EQ(helper->onion_location(), GURL(kTestOnionURL));
-  CheckOnionLocationLabel(browser());
+  CheckOnionLocationLabel(browser(), GURL(kTestOnionURL));
 
   ui_test_utils::NavigateToURL(browser(), GURL(kTestNotOnionURL));
   web_contents = browser()->tab_strip_model()->GetActiveWebContents();
@@ -162,7 +191,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
   ASSERT_TRUE(tor_browser->profile()->IsTor());
   content::WebContents* tor_web_contents =
       tor_browser->tab_strip_model()->GetActiveWebContents();
-  EXPECT_EQ(tor_web_contents->GetURL(), GURL(kTestOnionURL));
+  EXPECT_EQ(tor_web_contents->GetVisibleURL(), GURL(kTestOnionURL));
   // We don't close the original tab
   EXPECT_EQ(browser()->tab_strip_model()->count(), 1);
   // No new tab in Tor window
@@ -180,7 +209,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
 
   content::WebContents* web_contents =
       browser_list->get(0)->tab_strip_model()->GetActiveWebContents();
-  EXPECT_EQ(web_contents->GetURL(), GURL(kTestOnionURL));
+  EXPECT_EQ(web_contents->GetVisibleURL(), GURL(kTestOnionURL));
 }
 
 IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
@@ -208,7 +237,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
   Browser* tor_browser = browser_list->get(1);
   ASSERT_TRUE(tor_browser->profile()->IsTor());
   web_contents = tor_browser->tab_strip_model()->GetActiveWebContents();
-  EXPECT_EQ(web_contents->GetURL(), GURL(kTestOnionURL));
+  EXPECT_EQ(web_contents->GetVisibleURL(), GURL(kTestOnionURL));
 
   // Open a new tab and navigate to the url again
   NavigateParams params(
@@ -223,7 +252,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
   // No new tab in Tor window and unique one tab per site
   EXPECT_EQ(tor_browser->tab_strip_model()->count(), 1);
   web_contents = tor_browser->tab_strip_model()->GetWebContentsAt(0);
-  EXPECT_EQ(web_contents->GetURL(), GURL(kTestOnionURL));
+  EXPECT_EQ(web_contents->GetVisibleURL(), GURL(kTestOnionURL));
 }
 
 IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
@@ -273,7 +302,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest,
 
   web_contents =
       browser_list->get(0)->tab_strip_model()->GetActiveWebContents();
-  EXPECT_EQ(web_contents->GetURL(), url);
+  EXPECT_EQ(web_contents->GetVisibleURL(), url);
 }
 
 IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest, NotOnion) {
@@ -295,7 +324,7 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest, NotOnion) {
 
   web_contents =
       browser_list->get(0)->tab_strip_model()->GetActiveWebContents();
-  EXPECT_EQ(web_contents->GetURL(), url);
+  EXPECT_EQ(web_contents->GetVisibleURL(), url);
 }
 
 IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest, HTTPHost) {
@@ -317,5 +346,5 @@ IN_PROC_BROWSER_TEST_F(OnionLocationNavigationThrottleBrowserTest, HTTPHost) {
 
   web_contents =
       browser_list->get(0)->tab_strip_model()->GetActiveWebContents();
-  EXPECT_EQ(web_contents->GetURL(), url);
+  EXPECT_EQ(web_contents->GetVisibleURL(), url);
 }

--- a/browser/ui/views/location_bar/onion_location_view.cc
+++ b/browser/ui/views/location_bar/onion_location_view.cc
@@ -48,7 +48,7 @@ void OnTorProfileCreated(GURL onion_location,
                          Profile::CreateStatus status) {
   if (status != Profile::CreateStatus::CREATE_STATUS_INITIALIZED)
     return;
-  Browser* browser = chrome::FindTabbedBrowser(profile, true);
+  Browser* browser = chrome::FindTabbedBrowser(profile, false);
   if (!browser)
     return;
   content::OpenURLParams open_tor(onion_location, content::Referrer(),


### PR DESCRIPTION
calling `chrome::FindTabbedBrowser` with `match_original_profiles` equals false
Also adding clicking "Open in Tor" in browser tests
This is actually the leftover of https://github.com/brave/brave-core/pull/7713 which fix this for auto redirect

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14188

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)
- [x] Requested a security/privacy review as needed

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
STR in https://github.com/brave/brave-browser/issues/14188
