### PR TITLE
Change default ads per hour via variations service

### DIFF
--- a/build/rust/Cargo.lock
+++ b/build/rust/Cargo.lock
@@ -1554,18 +1554,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",

--- a/components/brave_ads/browser/ads_service.cc
+++ b/components/brave_ads/browser/ads_service.cc
@@ -44,8 +44,7 @@ void AdsService::RegisterProfilePrefs(
   registry->RegisterBooleanPref(ads::prefs::kShouldAllowConversionTracking,
                                 true);
 
-  registry->RegisterUint64Pref(ads::prefs::kAdsPerHour,
-                               ads::kDefaultAdNotificationsPerHour);
+  registry->RegisterUint64Pref(ads::prefs::kAdsPerHour, 0);
 
   registry->RegisterIntegerPref(ads::prefs::kIdleTimeThreshold, 15);
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -12,6 +12,7 @@
 #include "base/bind.h"
 #include "base/command_line.h"
 #include "base/containers/flat_map.h"
+#include "base/feature_list.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/files/important_file_writer.h"
@@ -20,6 +21,7 @@
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
+#include "base/metrics/field_trial_params.h"
 #include "base/numerics/ranges.h"
 #include "base/path_service.h"
 #include "base/sequenced_task_runner.h"
@@ -491,9 +493,18 @@ bool AdsServiceImpl::IsEnabled() const {
 }
 
 uint64_t AdsServiceImpl::GetAdsPerHour() const {
+  uint64_t ads_per_hour = GetUint64Pref(ads::prefs::kAdsPerHour);
+  if (ads_per_hour == 0) {
+    const base::Feature kAdServing{"AdServing",
+                                   base::FEATURE_ENABLED_BY_DEFAULT};
+
+    ads_per_hour = base::GetFieldTrialParamByFeatureAsInt(
+        kAdServing, "default_ad_notifications_per_hour",
+        ads::kDefaultAdNotificationsPerHour);
+  }
+
   return base::ClampToRange(
-      GetUint64Pref(ads::prefs::kAdsPerHour),
-      static_cast<uint64_t>(ads::kMinimumAdNotificationsPerHour),
+      ads_per_hour, static_cast<uint64_t>(ads::kMinimumAdNotificationsPerHour),
       static_cast<uint64_t>(ads::kMaximumAdNotificationsPerHour));
 }
 

--- a/components/brave_ads/test/BUILD.gn
+++ b/components/brave_ads/test/BUILD.gn
@@ -115,6 +115,7 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/server/confirmations_server_util_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/server/rewards_server_util_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/server/via_header_util_unittest.cc",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/settings/settings_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/string_util_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/tab_manager/tab_manager_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/tokens/redeem_unblinded_payment_tokens/redeem_unblinded_payment_tokens_delegate_mock.cc",

--- a/components/speedreader/rust/ffi/Cargo.lock
+++ b/components/speedreader/rust/ffi/Cargo.lock
@@ -1356,18 +1356,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",

--- a/vendor/bat-native-ads/BUILD.gn
+++ b/vendor/bat-native-ads/BUILD.gn
@@ -524,6 +524,8 @@ source_set("ads") {
     "src/bat/ads/internal/server/url_request_builder.h",
     "src/bat/ads/internal/server/via_header_util.cc",
     "src/bat/ads/internal/server/via_header_util.h",
+    "src/bat/ads/internal/settings/settings.cc",
+    "src/bat/ads/internal/settings/settings.h",
     "src/bat/ads/internal/string_util.cc",
     "src/bat/ads/internal/string_util.h",
     "src/bat/ads/internal/tab_manager/tab_info.cc",

--- a/vendor/bat-native-ads/include/bat/ads/pref_names.h
+++ b/vendor/bat-native-ads/include/bat/ads/pref_names.h
@@ -10,10 +10,10 @@
 
 namespace ads {
 
-// Ads per hour are user configurable with the brave://rewards ads UI
+// Ads per hour are user configurable within the brave://rewards ads UI
 const uint64_t kMinimumAdNotificationsPerHour = 1;
 const uint64_t kMaximumAdNotificationsPerHour = 5;
-const uint64_t kDefaultAdNotificationsPerHour = 2;
+const uint64_t kDefaultAdNotificationsPerHour = 5;
 
 namespace prefs {
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/ad_notifications/ad_notification_serving.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/ad_notifications/ad_notification_serving.cc
@@ -19,7 +19,6 @@
 #include "bat/ads/internal/ad_serving/ad_targeting/models/contextual/text_classification/text_classification_model.h"
 #include "bat/ads/internal/ad_targeting/ad_targeting_segment_util.h"
 #include "bat/ads/internal/ad_targeting/ad_targeting_values.h"
-#include "bat/ads/internal/ads_client_helper.h"
 #include "bat/ads/internal/client/client.h"
 #include "bat/ads/internal/database/tables/ad_events_database_table.h"
 #include "bat/ads/internal/database/tables/creative_ad_notifications_database_table.h"
@@ -29,8 +28,8 @@
 #include "bat/ads/internal/p2a/p2a.h"
 #include "bat/ads/internal/p2a/p2a_util.h"
 #include "bat/ads/internal/platform/platform_helper.h"
+#include "bat/ads/internal/settings/settings.h"
 #include "bat/ads/internal/time_formatting_util.h"
-#include "bat/ads/pref_names.h"
 
 namespace ads {
 namespace ad_notifications {
@@ -315,8 +314,7 @@ void AdServing::DeliveredAd() {
   }
 
   const int64_t seconds =
-      base::Time::kSecondsPerHour /
-      AdsClientHelper::Get()->GetUint64Pref(prefs::kAdsPerHour);
+      base::Time::kSecondsPerHour / settings::GetAdsPerHour();
 
   const base::TimeDelta delay = base::TimeDelta::FromSeconds(seconds);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/features/ad_serving/ad_serving_features.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/features/ad_serving/ad_serving_features.cc
@@ -6,6 +6,7 @@
 #include "bat/ads/internal/features/ad_serving/ad_serving_features.h"
 
 #include "base/metrics/field_trial_params.h"
+#include "bat/ads/pref_names.h"
 
 namespace ads {
 namespace features {
@@ -14,6 +15,10 @@ namespace {
 
 const char kFeatureName[] = "AdServing";
 
+const char kFieldTrialParameterDefaultAdNotificationsPerHour[] =
+    "default_ad_notifications_per_hour";
+const int kDefaultDefaultAdNotificationsPerHour =
+    kDefaultAdNotificationsPerHour;
 const char kFieldTrialParameterMaximumAdNotificationsPerDay[] =
     "maximum_ad_notifications_per_day";
 const int kDefaultMaximumAdNotificationsPerDay = 40;
@@ -38,6 +43,12 @@ const base::Feature kAdServing{kFeatureName, base::FEATURE_ENABLED_BY_DEFAULT};
 
 bool IsAdServingEnabled() {
   return base::FeatureList::IsEnabled(kAdServing);
+}
+
+int GetDefaultAdNotificationsPerHour() {
+  return GetFieldTrialParamByFeatureAsInt(
+      kAdServing, kFieldTrialParameterDefaultAdNotificationsPerHour,
+      kDefaultDefaultAdNotificationsPerHour);
 }
 
 int GetMaximumAdNotificationsPerDay() {

--- a/vendor/bat-native-ads/src/bat/ads/internal/features/ad_serving/ad_serving_features.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/features/ad_serving/ad_serving_features.h
@@ -15,6 +15,7 @@ extern const base::Feature kAdServing;
 
 bool IsAdServingEnabled();
 
+int GetDefaultAdNotificationsPerHour();
 int GetMaximumAdNotificationsPerDay();
 int GetMaximumNewTabPageAdsPerHour();
 int GetMaximumNewTabPageAdsPerDay();

--- a/vendor/bat-native-ads/src/bat/ads/internal/features/ad_serving/ad_serving_features_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/features/ad_serving/ad_serving_features_unittest.cc
@@ -44,6 +44,71 @@ TEST(BatAdsAdServingFeaturesTest, AdServingDisabled) {
   EXPECT_FALSE(is_enabled);
 }
 
+TEST(BatAdsAdServingFeaturesTest, DefaultAdNotificationsPerHour) {
+  // Arrange
+  std::vector<base::test::ScopedFeatureList::FeatureAndParams> enabled_features;
+  base::FieldTrialParams kAdServingParameters;
+  kAdServingParameters["default_ad_notifications_per_hour"] = "2";
+  enabled_features.push_back({features::kAdServing, kAdServingParameters});
+
+  const std::vector<base::Feature> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+  const int default_ad_notifications_per_hour =
+      features::GetDefaultAdNotificationsPerHour();
+
+  // Assert
+  const int expected_default_ad_notifications_per_hour = 2;
+  EXPECT_EQ(expected_default_ad_notifications_per_hour,
+            default_ad_notifications_per_hour);
+}
+
+TEST(BatAdsAdServingFeaturesTest, DefaultDefaultAdNotificationsPerHour) {
+  // Arrange
+  const std::vector<base::test::ScopedFeatureList::FeatureAndParams>
+      enabled_features;
+
+  const std::vector<base::Feature> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+  // Act
+  const int default_ad_notifications_per_hour =
+      features::GetDefaultAdNotificationsPerHour();
+
+  // Assert
+  const int expected_default_ad_notifications_per_hour = 5;
+  EXPECT_EQ(expected_default_ad_notifications_per_hour,
+            default_ad_notifications_per_hour);
+}
+
+TEST(BatAdsAdServingFeaturesTest, DisabledDefaultAdNotificationsPerHour) {
+  // Arrange
+  const std::vector<base::test::ScopedFeatureList::FeatureAndParams>
+      enabled_features;
+
+  std::vector<base::Feature> disabled_features;
+  disabled_features.push_back(features::kAdServing);
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+  const int default_ad_notifications_per_hour =
+      features::GetDefaultAdNotificationsPerHour();
+
+  // Assert
+  const int expected_default_ad_notifications_per_hour = 5;
+  EXPECT_EQ(expected_default_ad_notifications_per_hour,
+            default_ad_notifications_per_hour);
+}
+
 TEST(BatAdsAdServingFeaturesTest, MaximumAdNotificationsPerDay) {
   // Arrange
   std::vector<base::test::ScopedFeatureList::FeatureAndParams> enabled_features;

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/ads_per_day_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/ads_per_day_frequency_cap_unittest.cc
@@ -13,7 +13,6 @@
 #include "bat/ads/internal/frequency_capping/frequency_capping_unittest_util.h"
 #include "bat/ads/internal/unittest_base.h"
 #include "bat/ads/internal/unittest_util.h"
-#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/ads_per_hour_frequency_cap.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/ads_per_hour_frequency_cap.cc
@@ -10,10 +10,9 @@
 #include <deque>
 
 #include "base/time/time.h"
-#include "bat/ads/internal/ads_client_helper.h"
 #include "bat/ads/internal/frequency_capping/frequency_capping_util.h"
 #include "bat/ads/internal/platform/platform_helper.h"
-#include "bat/ads/pref_names.h"
+#include "bat/ads/internal/settings/settings.h"
 
 namespace ads {
 
@@ -46,8 +45,7 @@ bool AdsPerHourFrequencyCap::DoesRespectCap(const AdEventList& ad_events) {
 
   const uint64_t time_constraint = base::Time::kSecondsPerHour;
 
-  const uint64_t cap =
-      AdsClientHelper::Get()->GetUint64Pref(prefs::kAdsPerHour);
+  const uint64_t cap = settings::GetAdsPerHour();
 
   return DoesHistoryRespectCapForRollingTimeConstraint(history, time_constraint,
                                                        cap);

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/ads_per_hour_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/ads_per_hour_frequency_cap_unittest.cc
@@ -8,7 +8,6 @@
 #include "bat/ads/internal/frequency_capping/frequency_capping_unittest_util.h"
 #include "bat/ads/internal/unittest_base.h"
 #include "bat/ads/internal/unittest_util.h"
-#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 
@@ -44,10 +43,12 @@ TEST_F(BatAdsAdsPerHourFrequencyCapTest, AlwaysAllowAdOnAndroid) {
   CreativeAdInfo ad;
   ad.creative_instance_id = kCreativeInstanceId;
 
+  const uint64_t ads_per_hour = 5;
+
   const AdEventInfo ad_event =
       GenerateAdEvent(AdType::kAdNotification, ad, ConfirmationType::kViewed);
 
-  const AdEventList ad_events(kDefaultAdNotificationsPerHour, ad_event);
+  const AdEventList ad_events(ads_per_hour, ad_event);
 
   // Act
   AdsPerHourFrequencyCap frequency_cap(ad_events);
@@ -64,10 +65,12 @@ TEST_F(BatAdsAdsPerHourFrequencyCapTest, AlwaysAllowAdOnIOS) {
   CreativeAdInfo ad;
   ad.creative_instance_id = kCreativeInstanceId;
 
+  const uint64_t ads_per_hour = 5;
+
   const AdEventInfo ad_event =
       GenerateAdEvent(AdType::kAdNotification, ad, ConfirmationType::kViewed);
 
-  const AdEventList ad_events(kDefaultAdNotificationsPerHour, ad_event);
+  const AdEventList ad_events(ads_per_hour, ad_event);
 
   // Act
   AdsPerHourFrequencyCap frequency_cap(ad_events);
@@ -82,10 +85,12 @@ TEST_F(BatAdsAdsPerHourFrequencyCapTest, AllowAdIfDoesNotExceedCap) {
   CreativeAdInfo ad;
   ad.creative_instance_id = kCreativeInstanceId;
 
+  const uint64_t ads_per_hour = 5;
+
   const AdEventInfo ad_event =
       GenerateAdEvent(AdType::kAdNotification, ad, ConfirmationType::kViewed);
 
-  const AdEventList ad_events(kDefaultAdNotificationsPerHour - 1, ad_event);
+  const AdEventList ad_events(ads_per_hour - 1, ad_event);
 
   // Act
   AdsPerHourFrequencyCap frequency_cap(ad_events);
@@ -100,10 +105,12 @@ TEST_F(BatAdsAdsPerHourFrequencyCapTest, AllowAdIfDoesNotExceedCapAfter1Hour) {
   CreativeAdInfo ad;
   ad.creative_instance_id = kCreativeInstanceId;
 
+  const uint64_t ads_per_hour = 5;
+
   const AdEventInfo ad_event =
       GenerateAdEvent(AdType::kAdNotification, ad, ConfirmationType::kViewed);
 
-  const AdEventList ad_events(kDefaultAdNotificationsPerHour, ad_event);
+  const AdEventList ad_events(ads_per_hour, ad_event);
 
   FastForwardClockBy(base::TimeDelta::FromHours(1));
 
@@ -120,10 +127,12 @@ TEST_F(BatAdsAdsPerHourFrequencyCapTest, DoNotAllowAdIfExceedsCapWithin1Hour) {
   CreativeAdInfo ad;
   ad.creative_instance_id = kCreativeInstanceId;
 
+  const uint64_t ads_per_hour = 5;
+
   const AdEventInfo ad_event =
       GenerateAdEvent(AdType::kAdNotification, ad, ConfirmationType::kViewed);
 
-  const AdEventList ad_events(kDefaultAdNotificationsPerHour, ad_event);
+  const AdEventList ad_events(ads_per_hour, ad_event);
 
   FastForwardClockBy(base::TimeDelta::FromMinutes(59));
 
@@ -133,15 +142,6 @@ TEST_F(BatAdsAdsPerHourFrequencyCapTest, DoNotAllowAdIfExceedsCapWithin1Hour) {
 
   // Assert
   EXPECT_FALSE(is_allowed);
-}
-
-TEST_F(BatAdsAdsPerHourFrequencyCapTest, DefaultAdsPerHour) {
-  // Arrange
-
-  // Act
-
-  // Assert
-  EXPECT_EQ(2UL, kDefaultAdNotificationsPerHour);
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/minimum_wait_time_frequency_cap.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/minimum_wait_time_frequency_cap.cc
@@ -10,10 +10,9 @@
 #include <deque>
 
 #include "base/time/time.h"
-#include "bat/ads/internal/ads_client_helper.h"
 #include "bat/ads/internal/frequency_capping/frequency_capping_util.h"
 #include "bat/ads/internal/platform/platform_helper.h"
-#include "bat/ads/pref_names.h"
+#include "bat/ads/internal/settings/settings.h"
 
 namespace ads {
 
@@ -49,8 +48,7 @@ bool MinimumWaitTimeFrequencyCap::DoesRespectCap(const AdEventList& ad_events) {
   const std::deque<uint64_t> history =
       GetTimestampHistoryForAdEvents(ad_events);
 
-  const uint64_t ads_per_hour =
-      AdsClientHelper::Get()->GetUint64Pref(prefs::kAdsPerHour);
+  const uint64_t ads_per_hour = settings::GetAdsPerHour();
 
   const uint64_t time_constraint = base::Time::kSecondsPerHour / ads_per_hour;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/new_tab_page_ads_per_day_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/new_tab_page_ads_per_day_frequency_cap_unittest.cc
@@ -13,7 +13,6 @@
 #include "bat/ads/internal/frequency_capping/frequency_capping_unittest_util.h"
 #include "bat/ads/internal/unittest_base.h"
 #include "bat/ads/internal/unittest_util.h"
-#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/new_tab_page_ads_per_hour_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/new_tab_page_ads_per_hour_frequency_cap_unittest.cc
@@ -13,7 +13,6 @@
 #include "bat/ads/internal/frequency_capping/frequency_capping_unittest_util.h"
 #include "bat/ads/internal/unittest_base.h"
 #include "bat/ads/internal/unittest_util.h"
-#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/promoted_content_ads_per_day_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/promoted_content_ads_per_day_frequency_cap_unittest.cc
@@ -13,7 +13,6 @@
 #include "bat/ads/internal/frequency_capping/frequency_capping_unittest_util.h"
 #include "bat/ads/internal/unittest_base.h"
 #include "bat/ads/internal/unittest_util.h"
-#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/promoted_content_ads_per_hour_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/promoted_content_ads_per_hour_frequency_cap_unittest.cc
@@ -13,7 +13,6 @@
 #include "bat/ads/internal/frequency_capping/frequency_capping_unittest_util.h"
 #include "bat/ads/internal/unittest_base.h"
 #include "bat/ads/internal/unittest_util.h"
-#include "bat/ads/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/settings/settings.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/settings/settings.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/settings/settings.h"
+
+#include "base/numerics/ranges.h"
+#include "bat/ads/internal/ads_client_helper.h"
+#include "bat/ads/internal/features/ad_serving/ad_serving_features.h"
+#include "bat/ads/pref_names.h"
+
+namespace ads {
+namespace settings {
+
+uint64_t GetAdsPerHour() {
+  uint64_t ads_per_hour =
+      AdsClientHelper::Get()->GetUint64Pref(prefs::kAdsPerHour);
+
+  if (ads_per_hour == 0) {
+    ads_per_hour =
+        static_cast<uint64_t>(features::GetDefaultAdNotificationsPerHour());
+  }
+
+  return base::ClampToRange(
+      ads_per_hour, static_cast<uint64_t>(kMinimumAdNotificationsPerHour),
+      static_cast<uint64_t>(kMaximumAdNotificationsPerHour));
+}
+
+}  // namespace settings
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/settings/settings.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/settings/settings.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_SETTINGS_SETTINGS_H_
+#define BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_SETTINGS_SETTINGS_H_
+
+#include <stdint.h>
+
+namespace ads {
+namespace settings {
+
+uint64_t GetAdsPerHour();
+
+}  // namespace settings
+}  // namespace ads
+
+#endif  // BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_SETTINGS_SETTINGS_H_

--- a/vendor/bat-native-ads/src/bat/ads/internal/settings/settings_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/settings/settings_unittest.cc
@@ -1,0 +1,118 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/settings/settings.h"
+
+#include <vector>
+
+#include "base/feature_list.h"
+#include "base/test/scoped_feature_list.h"
+#include "bat/ads/internal/features/ad_serving/ad_serving_features.h"
+#include "bat/ads/internal/unittest_base.h"
+#include "bat/ads/internal/unittest_util.h"
+#include "bat/ads/pref_names.h"
+
+// npm run test -- brave_unit_tests --filter=BatAds*
+
+namespace ads {
+
+class BatAdsSettingsTest : public UnitTestBase {
+ protected:
+  BatAdsSettingsTest() = default;
+
+  ~BatAdsSettingsTest() override = default;
+};
+
+TEST_F(BatAdsSettingsTest, AdsPerHourWhenUserHasChangedDefaultSetting) {
+  // Arrange
+  std::vector<base::test::ScopedFeatureList::FeatureAndParams> enabled_features;
+  base::FieldTrialParams kParameters;
+  kParameters["default_ad_notifications_per_hour"] = "2";
+  enabled_features.push_back({features::kAdServing, kParameters});
+
+  const std::vector<base::Feature> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  AdsClientHelper::Get()->SetUint64Pref(prefs::kAdsPerHour, 3);
+
+  // Act
+  const uint64_t ads_per_hour = settings::GetAdsPerHour();
+
+  // Assert
+  const uint64_t expected_ads_per_hour = 3;
+
+  EXPECT_EQ(expected_ads_per_hour, ads_per_hour);
+}
+
+TEST_F(BatAdsSettingsTest, AdsPerHourWhenUserHasNotChangedDefaultSetting) {
+  // Arrange
+  std::vector<base::test::ScopedFeatureList::FeatureAndParams> enabled_features;
+  base::FieldTrialParams kParameters;
+  kParameters["default_ad_notifications_per_hour"] = "2";
+  enabled_features.push_back({features::kAdServing, kParameters});
+
+  const std::vector<base::Feature> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+  const uint64_t ads_per_hour = settings::GetAdsPerHour();
+
+  // Assert
+  const uint64_t expected_ads_per_hour = 2;
+
+  EXPECT_EQ(expected_ads_per_hour, ads_per_hour);
+}
+
+TEST_F(BatAdsSettingsTest, ClampMinAdsPerHour) {
+  // Arrange
+  std::vector<base::test::ScopedFeatureList::FeatureAndParams> enabled_features;
+  base::FieldTrialParams kParameters;
+  kParameters["default_ad_notifications_per_hour"] = "0";
+  enabled_features.push_back({features::kAdServing, kParameters});
+
+  const std::vector<base::Feature> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+  const uint64_t ads_per_hour = settings::GetAdsPerHour();
+
+  // Assert
+  const uint64_t expected_ads_per_hour = 1;
+
+  EXPECT_EQ(expected_ads_per_hour, ads_per_hour);
+}
+
+TEST_F(BatAdsSettingsTest, ClampMaxAdsPerHour) {
+  // Arrange
+  std::vector<base::test::ScopedFeatureList::FeatureAndParams> enabled_features;
+  base::FieldTrialParams kParameters;
+  kParameters["default_ad_notifications_per_hour"] = "6";
+  enabled_features.push_back({features::kAdServing, kParameters});
+
+  const std::vector<base::Feature> disabled_features;
+
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeaturesAndParameters(enabled_features,
+                                                    disabled_features);
+
+  // Act
+  const uint64_t ads_per_hour = settings::GetAdsPerHour();
+
+  // Assert
+  const uint64_t expected_ads_per_hour = 5;
+
+  EXPECT_EQ(expected_ads_per_hour, ads_per_hour);
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
@@ -385,7 +385,7 @@ void MockClearPref(const std::unique_ptr<AdsClientMock>& mock) {
 void MockDefaultPrefs(const std::unique_ptr<AdsClientMock>& mock) {
   mock->SetBooleanPref(prefs::kEnabled, true);
 
-  mock->SetUint64Pref(prefs::kAdsPerHour, kDefaultAdNotificationsPerHour);
+  mock->SetUint64Pref(prefs::kAdsPerHour, 0);
 
   mock->SetIntegerPref(prefs::kIdleTimeThreshold, 15);
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14377

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm ads per hour in brave://rewards ads UI defaults to 5 when enabling ads on a fresh install
- Confirm ads per hour in brave://rewards ads UI does not default to 5 if a user has previously changed this setting
- Confirm ads per hour in brave://rewards ads UI defaults to 5 if a user has not previously changed this setting
- Confirm ad notifications adhere to the new setting

This change is not required for iOS.