### PR TITLE
Explicitly get circuit established status when Tor control is ready 

### DIFF
--- a/components/tor/tor_control.h
+++ b/components/tor/tor_control.h
@@ -90,12 +90,15 @@ class TorControl {
       base::OnceCallback<void(bool error,
                               const std::vector<std::string>& listeners)>
           callback);
+  void GetCircuitEstablished(
+      base::OnceCallback<void(bool error, bool established)> callback);
 
  protected:
   friend class TorControlTest;
   FRIEND_TEST_ALL_PREFIXES(TorControlTest, ParseQuoted);
   FRIEND_TEST_ALL_PREFIXES(TorControlTest, ParseKV);
   FRIEND_TEST_ALL_PREFIXES(TorControlTest, ReadLine);
+  FRIEND_TEST_ALL_PREFIXES(TorControlTest, GetCircuitEstablishedDone);
 
   static bool ParseKV(const std::string& string,
                       std::string* key,
@@ -134,6 +137,15 @@ class TorControl {
       std::unique_ptr<std::vector<std::string>> listeners,
       base::OnceCallback<
           void(bool error, const std::vector<std::string>& listeners)> callback,
+      bool error,
+      const std::string& status,
+      const std::string& reply);
+  void GetCircuitEstablishedLine(std::string* established,
+                                 const std::string& status,
+                                 const std::string& reply);
+  void GetCircuitEstablishedDone(
+      std::unique_ptr<std::string> established,
+      base::OnceCallback<void(bool error, bool established)> callback,
       bool error,
       const std::string& status,
       const std::string& reply);

--- a/components/tor/tor_launcher_factory.h
+++ b/components/tor/tor_launcher_factory.h
@@ -78,6 +78,7 @@ class TorLauncherFactory : public tor::TorControl::Delegate {
 
   void GotVersion(bool error, const std::string& version);
   void GotSOCKSListeners(bool error, const std::vector<std::string>& listeners);
+  void GotCircuitEstablished(bool error, bool established);
 
   void LaunchTorInternal();
   void RelaunchTor();


### PR DESCRIPTION
in case a circuit has already been established

This PR make sure we can get correct connected status no matter a circuit is established before tor control channel is ready or the other way around

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14461

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
STR in the issue
