### PR TITLE
Fixed crash when fetching Rewards Widget estimated earnings - 1.22.x

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -1137,7 +1137,9 @@ BraveRewardsGetAdsEstimatedEarningsFunction::Run() {
     return RespondNow(Error("Ads service is not initialized"));
   }
 
-  ads_service_->GetStatement(base::Bind(
+  AddRef();  // Balanced in OnAdsEstimatedEarnings().
+
+  ads_service_->GetStatement(base::BindOnce(
       &BraveRewardsGetAdsEstimatedEarningsFunction::OnAdsEstimatedEarnings,
       this));
   return RespondLater();
@@ -1151,6 +1153,8 @@ void BraveRewardsGetAdsEstimatedEarningsFunction::OnAdsEstimatedEarnings(
     const double earnings_this_month,
     const double earnings_last_month) {
   Respond(OneArgument(base::Value(estimated_pending_rewards)));
+
+  Release();  // Balanced in Run()
 }
 
 BraveRewardsGetAdsSupportedFunction::


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/8114
Resolves brave/brave-browser#14447

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
