### PR TITLE
Speedreader heuristic: Improve final render

### DIFF
--- a/components/speedreader/rust/lib/src/readability/src/dom.rs
+++ b/components/speedreader/rust/lib/src/readability/src/dom.rs
@@ -1,8 +1,7 @@
 use markup5ever_rcdom::NodeData::{Element, Text};
 use markup5ever_rcdom::{Handle, Node};
 use html5ever::tendril::StrTendril;
-use html5ever::Attribute;
-use html5ever::LocalName;
+use html5ever::{Attribute, QualName, LocalName};
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -29,7 +28,7 @@ pub fn attr(attr_name: &str, attrs: &[Attribute]) -> Option<String> {
     None
 }
 
-pub fn set_attr(attr_name: &str, value: &str, handle: Handle) {
+pub fn set_attr(attr_name: &str, value: &str, handle: Handle, create_if_missing: bool) {
     if let Element { ref attrs, .. } = handle.data {
         let attrs = &mut attrs.borrow_mut();
         if let Some(index) = attrs.iter().position(|attr| {
@@ -42,7 +41,21 @@ pub fn set_attr(attr_name: &str, value: &str, handle: Handle) {
                     value,
                 }
             }
+        } else {
+            if create_if_missing {
+                append_attr(attr_name, value, attrs);
+            }
         }
+    }
+}
+
+pub fn append_attr(attr_name: &str, value: &str, attrs: &mut Vec<Attribute>) {
+    if let Ok(value) = StrTendril::from_str(value) {
+        let new_attr = Attribute {
+            name: QualName::new(None, ns!(), LocalName::from(attr_name)),
+            value: value,
+        };
+        attrs.push(new_attr);
     }
 }
 

--- a/components/speedreader/rust/lib/src/readability/src/dom.rs
+++ b/components/speedreader/rust/lib/src/readability/src/dom.rs
@@ -222,27 +222,21 @@ pub fn previous_element_sibling<'a>(
     prev
 }
 
-pub fn parse_inner(contents: StrTendril) -> Option<Handle> {
+pub fn parse_inner(contents: &str) -> Option<Handle> {
     let dom = parse_document(RcDom::default(), ParseOpts::default()).one(contents);
-    let document = dom.document.clone();
-    let html = document.children.borrow().get(0)?.clone();
-    let body = html.children.borrow().get(1)?.clone();
-    let img = body.children.borrow().get(0)?.clone();
-    Some(img)
+    let document_children = dom.document.children.borrow();
+    let html = document_children.get(0)?;
+    let html_children = html.children.borrow();
+    let body = html_children.get(1)?;
+    let body_children = body.children.borrow();
+    let elem = body_children.get(0)?;
+    Some(elem.clone())
 }
 
 pub fn is_single_image(handle: &Handle) -> bool {
     match handle.data {
-        Element { ref name, .. } => {
-            if name.local == local_name!("img") {
-                return true;
-            }
-        }
-        Text { ref contents } => {
-            if !contents.borrow().trim().is_empty() {
-                return false;
-            }
-        }
+        Element { ref name, .. } if name.local == local_name!("img") => return true,
+        Text { ref contents } if !contents.borrow().trim().is_empty() => return false,
         Comment { .. } => (),
         _ => {
             return false;

--- a/components/speedreader/rust/lib/src/readability/src/extractor.rs
+++ b/components/speedreader/rust/lib/src/readability/src/extractor.rs
@@ -1,3 +1,4 @@
+use dom;
 use markup5ever_rcdom::RcDom;
 use markup5ever_rcdom::SerializableHandle;
 use html5ever::tendril::TendrilSink;
@@ -86,8 +87,15 @@ pub fn extract_dom<S: ::std::hash::BuildHasher>(
         &candidates,
     );
 
+    // Our CSS formats based on id="article".
+    dom::set_attr("id", "article", top_candidate.node.clone(), true);
+    let serialize_opts = serialize::SerializeOpts {
+        traversal_scope: serialize::TraversalScope::IncludeNode,
+        ..Default::default()
+    };
+
     let document: SerializableHandle = top_candidate.node.clone().into();
-    serialize(&mut bytes, &document, Default::default())?;
+    serialize(&mut bytes, &document, serialize_opts)?;
     let content = String::from_utf8(bytes).unwrap_or_default();
 
     Ok(Product { title, content })

--- a/components/speedreader/rust/lib/src/readability/src/extractor.rs
+++ b/components/speedreader/rust/lib/src/readability/src/extractor.rs
@@ -1,4 +1,4 @@
-use dom;
+use crate::dom;
 use html5ever::tendril::StrTendril;
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeSink;
@@ -53,7 +53,7 @@ where
     let content = String::from_utf8(bytes).unwrap_or_default();
     Ok(Product {
         title: title.title,
-        content: content,
+        content,
     })
 }
 
@@ -152,7 +152,7 @@ pub fn extract_dom<S: ::std::hash::BuildHasher>(
 
     Ok(Product {
         title: title.title,
-        content: content,
+        content,
     })
 }
 

--- a/components/speedreader/rust/lib/src/readability/src/scorer.rs
+++ b/components/speedreader/rust/lib/src/readability/src/scorer.rs
@@ -1,5 +1,4 @@
-use dom;
-use html5ever::tendril::StrTendril;
+use crate::dom;
 use html5ever::tree_builder::TreeSink;
 use html5ever::tree_builder::{ElementFlags, NodeOrText};
 use html5ever::{LocalName, QualName};
@@ -205,8 +204,7 @@ fn get_inner_img(dom: &mut RcDom, handle: &Handle) -> Option<Handle> {
     let children = handle.children.borrow();
     let child = children.get(0)?;
     if let Text { ref contents } = child.data {
-        let s: StrTendril = contents.borrow().clone();
-        let inner = dom::parse_inner(s)?;
+        let inner = dom::parse_inner(&contents.borrow())?;
         if dom::is_single_image(&inner) {
             if let Element {
                 ref name,

--- a/components/speedreader/rust/lib/src/readability/src/scorer.rs
+++ b/components/speedreader/rust/lib/src/readability/src/scorer.rs
@@ -58,7 +58,7 @@ pub fn fix_img_path(handle: Handle, url: &Url) -> bool {
     if let Some(src) = dom::get_attr("src", &handle) {
         if !src.starts_with("//") && !src.starts_with("http://") && src.starts_with("https://") {
             if let Ok(new_url) = url.join(&src) {
-                dom::set_attr("src", new_url.as_str(), handle);
+                dom::set_attr("src", new_url.as_str(), handle, false);
                 true
             } else {
                 // failed to fix


### PR DESCRIPTION
This patch set ensures that the rendered DOM has the speedreader CSS applied. It also properly extracts the title and includes that in the render.

Since these changes may be hard to grok, I've included some before / afters. Important to note: these are modifications to the Speedreader rewriter based on the paper. The Speedreader rewriter deployed on Nightly rewrites adblock rules into [LOL HTML](https://github.com/cloudflare/lol-html) compatible rules in the `SpeedreaderStreaming` backend. These changes only affect the `SpeedreaderHeuristics` backend.

### Huffington post before
![huffington_post_before](https://user-images.githubusercontent.com/28680078/110186520-62d62800-7dca-11eb-911d-eb891bd6aeb1.png)

### Huffington post after
![huffington_post_after](https://user-images.githubusercontent.com/28680078/110186525-679adc00-7dca-11eb-9f9f-2c601e8dd761.png)



### Vanity fair before
![vanity_fair_before](https://user-images.githubusercontent.com/28680078/110186567-9022d600-7dca-11eb-9b71-b0f0d7c200b4.png)

### Vanity fair after
![vanity_fair_after](https://user-images.githubusercontent.com/28680078/110186573-987b1100-7dca-11eb-8894-57a688fbce3e.png)



