### PR TITLE
Shows addSite tile by default on topSites favorites mode

### DIFF
--- a/components/brave_new_tab_ui/components/default/gridSites/index.ts
+++ b/components/brave_new_tab_ui/components/default/gridSites/index.ts
@@ -36,7 +36,11 @@ export const AddSiteTileImage = styled<{}, 'div'>('div')`
   }
 `
 
-export const AddSiteTile = styled<{}, 'button'>('button')`
+export interface AddSiteTileProps {
+  isDragging: boolean
+}
+
+export const AddSiteTile = styled<AddSiteTileProps, 'button'>('button')`
   background: transparent;
   width: 78px;
   height: 110px;
@@ -49,8 +53,11 @@ export const AddSiteTile = styled<{}, 'button'>('button')`
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  visibility: hidden;
   gap: 8px;
+
+  ${p => p.isDragging && css`
+    visibility: hidden;
+  `}
 
   &:focus-visible, :focus {
     gap: 4px;
@@ -67,7 +74,6 @@ export const AddSiteTile = styled<{}, 'button'>('button')`
 
 export interface ListProps {
   blockNumber: number
-  isDragging: boolean
 }
 
 export const List = styled<ListProps, 'div'>('div')`
@@ -86,14 +92,6 @@ export const List = styled<ListProps, 'div'>('div')`
   @media screen and (max-width: 390px) {
     grid-template-columns: repeat(${p => Math.min(p.blockNumber, 2).toString()}, 86px);
   }
-
-  ${p => !p.isDragging && css`
-    &:hover {
-      ${AddSiteTile} {
-        visibility: visible;
-      }
-    }
-  `}
 `
 
 export const TileActionsContainer = styled<{}, 'nav'>('nav')`

--- a/components/brave_new_tab_ui/containers/newTab/addSiteTile.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/addSiteTile.tsx
@@ -13,12 +13,16 @@ import AddSiteTileIcon from '../../components/default/gridSites/assets/add-site-
 
 interface Props {
   showEditTopSite: () => void
+  isDragging: boolean
 }
 
 class AddSite extends React.PureComponent<Props, {}> {
   render () {
     return (
-      <AddSiteTile onClick={this.props.showEditTopSite}>
+      <AddSiteTile
+        onClick={this.props.showEditTopSite}
+        isDragging={this.props.isDragging}
+      >
         <AddSiteTileImage>
           <AddSiteTileIcon/>
         </AddSiteTileImage>

--- a/components/brave_new_tab_ui/containers/newTab/gridSites.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/gridSites.tsx
@@ -89,7 +89,6 @@ class TopSitesList extends React.PureComponent<Props, State> {
       <>
         <DynamicList
           blockNumber={maxGridSize}
-          isDragging={this.state.isDragging}
           updateBeforeSortStart={this.updateBeforeSortStart}
           onSortEnd={this.onSortEnd}
           axis='xy'
@@ -122,6 +121,7 @@ class TopSitesList extends React.PureComponent<Props, State> {
             <AddSiteTile
               index={gridSites.length}
               disabled={true}
+              isDragging={this.state.isDragging}
               showEditTopSite={onShowEditTopSite}
             />
           }


### PR DESCRIPTION
fix: https://github.com/brave/brave-browser/issues/14480

It's only hidden when user dragging other tiles because it is moving by
other tile's dragging although it's position is not changed at the end.
There is an issue for it.
 (see https://github.com/clauderic/react-sortable-hoc/issues/648)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch browser and load NTP
2. Changes topsite mode to favorites
3. Checks add site tile is always visible