### PR TITLE
Fix crash on BraveStatsUpdaterParams::GetFirstRunTime() running tests

### DIFF
--- a/browser/brave_stats/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats/brave_stats_updater_browsertest.cc
@@ -58,9 +58,6 @@ class BraveStatsUpdaterBrowserTest : public InProcessBrowserTest {
     brave::RegisterPrefsForBraveReferralsService(
         testing_local_state_.registry());
     SetBaseUpdateURLForTest();
-    // Simulate sentinel file creation as if chrome_browser_main.h was called,
-    // which reads in the sentinel value and caches it.
-    brave_stats::BraveStatsUpdaterParams::SetFirstRunForTest(true);
   }
 
   void SetUpCommandLine(base::CommandLine* command_line) override {

--- a/browser/brave_stats/brave_stats_updater_params.h
+++ b/browser/brave_stats/brave_stats_updater_params.h
@@ -12,7 +12,6 @@
 #include "base/time/time.h"
 #include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
 
-class BraveStatsUpdaterBrowserTest;
 class BraveStatsUpdaterTest;
 class PrefService;
 
@@ -44,7 +43,6 @@ class BraveStatsUpdaterParams {
   void SavePrefs();
 
  private:
-  friend class ::BraveStatsUpdaterBrowserTest;
   friend class ::BraveStatsUpdaterTest;
   PrefService* stats_pref_service_;
   PrefService* profile_pref_service_;


### PR DESCRIPTION
Fix crash on BraveStatsUpdaterParams::GetFirstRunTime() running tests

Use base::ScopedAllowBlockingForTesting to explicitly acknowledge for
the fact that first_run::GetFirstRunSentinelCreationTime() will indeed
attempt to perfom a blocking I/O operation when reading the time of the
first run while running tests, as those won't ever create a sentinel
file and, therefore, no cached value will be ever be used there and
zero will always be returned after failing to read the sentinel file.

Additionally, convert a DCHECK into a logged WARNING to prevent another
crash that would now happen when running DCHECK-enabled tests since, in
those cases, the time returned will always be zero.

Fixes https://github.com/brave/brave-browser/issues/14593

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

On a DCHECK-enabled build (either Component or Debug), doing `npm run test brave_browser_tests Debug -- --filter=BraveContentBrowserClientTest.CanLoadCustomBravePages` should not crash (and pass).