### PR TITLE
Change BAP deprecation alert frequency to 1 day (uplift to 1.22.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -129,7 +129,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent>
     public static final String BRAVE_BETA_PACKAGE_NAME = "com.brave.browser_beta";
     public static final String BRAVE_NIGHTLY_PACKAGE_NAME = "com.brave.browser_nightly";
 
-    private static final int DAYS_3 = 3;
+    private static final int DAYS_1 = 1;
     private static final int DAYS_4 = 4;
     private static final int DAYS_5 = 5;
     private static final int DAYS_12 = 12;
@@ -457,7 +457,7 @@ public abstract class BraveActivity<C extends ChromeActivityComponent>
             }
             if (shouldSetNextDate) {
                 Calendar calender = toDayCalendar;
-                calender.add(Calendar.DATE, DAYS_3);
+                calender.add(Calendar.DATE, DAYS_1);
                 BraveRewardsHelper.setNextBAPModalDate(calender.getTimeInMillis());
             }
         }

--- a/components/brave_rewards/resources/shared/components/bap_deprecation/index.ts
+++ b/components/brave_rewards/resources/shared/components/bap_deprecation/index.ts
@@ -64,9 +64,9 @@ export function shouldShowBAPAlert (onlyAnonWallet: boolean, balance: number) {
   const { alertDismissed } = loadInteractionState()
 
   if (alertDismissed) {
-    // Do not show the modal if the user has dismissed it within the last 3 days
+    // Do not show the modal if the user has dismissed it within the last day
     // or if they have dismissed it and we are now past the BAP cutoff date
-    if (daysInPast(alertDismissed) < 3 || Date.now() >= bapCutoffBegins) {
+    if (daysInPast(alertDismissed) < 1 || Date.now() >= bapCutoffBegins) {
       return false
     }
   }


### PR DESCRIPTION
Uplift of #8177
Resolves https://github.com/brave/brave-browser/issues/14570

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.