### PR TITLE
Doing reset of progress marker for exact failed by conflict sync type

### DIFF
--- a/chromium_src/components/sync/engine_impl/DEPS
+++ b/chromium_src/components/sync/engine_impl/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+../../../../../components/sync/engine_impl",
+]

--- a/chromium_src/components/sync/engine_impl/model_type_registry.cc
+++ b/chromium_src/components/sync/engine_impl/model_type_registry.cc
@@ -1,0 +1,10 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine_impl/brave_model_type_worker.h"
+
+#define ModelTypeWorker BraveModelTypeWorker
+#include "../../../../../components/sync/engine_impl/model_type_registry.cc"
+#undef ModelTypeWorker

--- a/chromium_src/components/sync/engine_impl/model_type_worker.h
+++ b/chromium_src/components/sync/engine_impl/model_type_worker.h
@@ -6,9 +6,22 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_IMPL_MODEL_TYPE_WORKER_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_IMPL_MODEL_TYPE_WORKER_H_
 
-#define BRAVE_MODEL_TYPE_WORKER_H_ \
- private:                          \
-  friend class BraveModelTypeWorker;
+#include "base/gtest_prod_util.h"
+
+namespace syncer {
+
+FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest, ResetProgressMarker);
+FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest, ResetProgressMarkerMaxPeriod);
+
+}  // namespace syncer
+
+#define BRAVE_MODEL_TYPE_WORKER_H_                                         \
+ private:                                                                  \
+  friend class BraveModelTypeWorker;                                       \
+  friend class BraveModelTypeWorkerTest;                                   \
+  FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest, ResetProgressMarker); \
+  FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest,                       \
+                           ResetProgressMarkerMaxPeriod);
 
 #define OnCommitResponse virtual OnCommitResponse
 

--- a/chromium_src/components/sync/engine_impl/model_type_worker.h
+++ b/chromium_src/components/sync/engine_impl/model_type_worker.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_IMPL_MODEL_TYPE_WORKER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_IMPL_MODEL_TYPE_WORKER_H_
+
+#define BRAVE_MODEL_TYPE_WORKER_H_ \
+ private:                          \
+  friend class BraveModelTypeWorker;
+
+#define OnCommitResponse virtual OnCommitResponse
+
+#include "../../../../../components/sync/engine_impl/model_type_worker.h"
+
+#undef OnCommitResponse
+#undef BRAVE_MODEL_TYPE_WORKER_H_
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ENGINE_IMPL_MODEL_TYPE_WORKER_H_

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -59,6 +59,7 @@ constexpr uint64_t kDefaultUploadIntervalSeconds = 60;  // 1 minute.
 // TODO(iefremov): Provide moar histograms!
 // Whitelist for histograms that we collect. Will be replaced with something
 // updating on the fly.
+// clang-format off
 constexpr const char* kCollectedHistograms[] = {
     "Brave.Core.BookmarksCountOnProfileLoad.2",
     "Brave.Core.CrashReportsEnabled",
@@ -163,6 +164,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.P2A.AdImpressionsPerSegment.weather",
     "Brave.P2A.AdImpressionsPerSegment.untargeted"
 };
+// clang-format on
 
 bool IsSuspendedMetric(base::StringPiece metric_name,
                        uint64_t value_or_bucket) {

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -89,6 +89,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.Today.WeeklyMaxCardViewsCount",
     "Brave.Today.WeeklyMaxCardVisitsCount",
     "Brave.Sync.Status",
+    "Brave.Sync.ProgressTokenEverReset",
     "Brave.Uptime.BrowserOpenMinutes",
     "Brave.Welcome.InteractionStatus",
 

--- a/components/sync/engine_impl/BUILD.gn
+++ b/components/sync/engine_impl/BUILD.gn
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [
+    "//brave/components/sync/engine_impl/brave_model_type_worker_unittest.cc",
+  ]
+
+  deps = [
+    "//base",
+    "//base/test:test_support",
+    "//components/sync:sync",
+    "//components/sync:test_support_engine",
+    "//testing/gmock",
+    "//testing/gtest",
+    "//third_party/protobuf:protobuf_lite",
+  ]
+}

--- a/components/sync/engine_impl/brave_model_type_worker.cc
+++ b/components/sync/engine_impl/brave_model_type_worker.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine_impl/brave_model_type_worker.h"
+
+#include <utility>
+
+#include "base/logging.h"
+#include "components/sync/engine/model_type_processor.h"
+
+namespace syncer {
+
+BraveModelTypeWorker::BraveModelTypeWorker(
+    ModelType type,
+    const sync_pb::ModelTypeState& initial_state,
+    bool trigger_initial_sync,
+    std::unique_ptr<Cryptographer> cryptographer,
+    PassphraseType passphrase_type,
+    NudgeHandler* nudge_handler,
+    std::unique_ptr<ModelTypeProcessor> model_type_processor,
+    CancelationSignal* cancelation_signal)
+    : ModelTypeWorker(type,
+                      initial_state,
+                      trigger_initial_sync,
+                      std::move(cryptographer),
+                      passphrase_type,
+                      nudge_handler,
+                      std::move(model_type_processor),
+                      cancelation_signal) {}
+
+BraveModelTypeWorker::~BraveModelTypeWorker() {}
+
+void BraveModelTypeWorker::OnCommitResponse(
+    const CommitResponseDataList& committed_response_list,
+    const FailedCommitResponseDataList& error_response_list) {
+  ModelTypeWorker::OnCommitResponse(committed_response_list,
+                                    error_response_list);
+}
+
+}  // namespace syncer

--- a/components/sync/engine_impl/brave_model_type_worker.cc
+++ b/components/sync/engine_impl/brave_model_type_worker.cc
@@ -55,6 +55,16 @@ void BraveModelTypeWorker::OnCommitResponse(
   }
 }
 
+// static
+size_t BraveModelTypeWorker::GetFailuresToResetMarkerForTests() {
+  return kFailuresToResetMarker;
+}
+
+// static
+base::TimeDelta BraveModelTypeWorker::MinimalTimeBetweenResetForTests() {
+  return kMinimalTimeBetweenResetMarker;
+}
+
 bool BraveModelTypeWorker::IsResetProgressMarkerRequired(
     const FailedCommitResponseDataList& error_response_list) {
   if (!last_reset_marker_time_.is_null() &&

--- a/components/sync/engine_impl/brave_model_type_worker.cc
+++ b/components/sync/engine_impl/brave_model_type_worker.cc
@@ -7,11 +7,20 @@
 
 #include <utility>
 
+#include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "components/sync/engine/model_type_processor.h"
 
 namespace syncer {
+
+namespace features {
+
+// Enables the option of resetting progress marker.
+const base::Feature kBraveSyncResetProgressMarker{
+    "ResetProgressMarkerOnCommitFailures", base::FEATURE_ENABLED_BY_DEFAULT};
+
+}  // namespace features
 
 namespace {
 // Between each failed commit the timeout is randomly increased,
@@ -50,6 +59,10 @@ void BraveModelTypeWorker::OnCommitResponse(
     const FailedCommitResponseDataList& error_response_list) {
   ModelTypeWorker::OnCommitResponse(committed_response_list,
                                     error_response_list);
+
+  if (!base::FeatureList::IsEnabled(features::kBraveSyncResetProgressMarker)) {
+    return;
+  }
 
   if (IsResetProgressMarkerRequired(error_response_list)) {
     ResetProgressMarker();

--- a/components/sync/engine_impl/brave_model_type_worker.cc
+++ b/components/sync/engine_impl/brave_model_type_worker.cc
@@ -12,6 +12,18 @@
 
 namespace syncer {
 
+namespace {
+// Between each failed commit the timeout is randomly increased,
+// see |BackoffDelayProvider|.
+// 7 attemps gives near 2..5 minutes before resetting progress marker
+// and new get updates
+
+size_t kFailuresToResetMarker = 7;
+// Allow reset progress marker for type not often than once in 30 minutes
+base::TimeDelta kMinimalTimeBetweenResetMarker =
+    base::TimeDelta::FromMinutes(30);
+}  // namespace
+
 BraveModelTypeWorker::BraveModelTypeWorker(
     ModelType type,
     const sync_pb::ModelTypeState& initial_state,
@@ -37,6 +49,48 @@ void BraveModelTypeWorker::OnCommitResponse(
     const FailedCommitResponseDataList& error_response_list) {
   ModelTypeWorker::OnCommitResponse(committed_response_list,
                                     error_response_list);
+
+  if (IsResetProgressMarkerRequired(error_response_list)) {
+    ResetProgressMarker();
+  }
+}
+
+bool BraveModelTypeWorker::IsResetProgressMarkerRequired(
+    const FailedCommitResponseDataList& error_response_list) {
+  if (!last_reset_marker_time_.is_null() &&
+      base::Time::Now() - last_reset_marker_time_ <
+          kMinimalTimeBetweenResetMarker) {
+    // Reset progress marker due to 7th failure happening twice in a row
+    // in less than 30mins
+    // P3A sample is 2
+    return false;
+  }
+
+  bool found_conflict_or_transient = false;
+  for (const syncer::FailedCommitResponseData& failed_response_entry :
+       error_response_list) {
+    if (failed_response_entry.response_type ==
+            sync_pb::CommitResponse_ResponseType_CONFLICT ||
+        failed_response_entry.response_type ==
+            sync_pb::CommitResponse_ResponseType_TRANSIENT_ERROR) {
+      found_conflict_or_transient = true;
+      break;
+    }
+  }
+
+  if (found_conflict_or_transient) {
+    ++failed_commit_times_;
+  } else {
+    failed_commit_times_ = 0;
+  }
+
+  return failed_commit_times_ >= kFailuresToResetMarker;
+}
+
+void BraveModelTypeWorker::ResetProgressMarker() {
+  VLOG(1) << "Reset progress marker for type " << ModelTypeToString(type_);
+  last_reset_marker_time_ = base::Time::Now();
+  model_type_state_.mutable_progress_marker()->clear_token();
 }
 
 }  // namespace syncer

--- a/components/sync/engine_impl/brave_model_type_worker.cc
+++ b/components/sync/engine_impl/brave_model_type_worker.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/logging.h"
+#include "base/metrics/histogram_functions.h"
 #include "components/sync/engine/model_type_processor.h"
 
 namespace syncer {
@@ -72,7 +73,8 @@ bool BraveModelTypeWorker::IsResetProgressMarkerRequired(
           kMinimalTimeBetweenResetMarker) {
     // Reset progress marker due to 7th failure happening twice in a row
     // in less than 30mins
-    // P3A sample is 2
+    // P3A sample is 1
+    base::UmaHistogramExactLinear("Brave.Sync.ProgressTokenEverReset", 1, 1);
     return false;
   }
 
@@ -99,6 +101,9 @@ bool BraveModelTypeWorker::IsResetProgressMarkerRequired(
 
 void BraveModelTypeWorker::ResetProgressMarker() {
   VLOG(1) << "Reset progress marker for type " << ModelTypeToString(type_);
+  // Normal reset of progress marker due to 7th failure
+  // P3A sample is 0
+  base::UmaHistogramExactLinear("Brave.Sync.ProgressTokenEverReset", 0, 1);
   last_reset_marker_time_ = base::Time::Now();
   model_type_state_.mutable_progress_marker()->clear_token();
 }

--- a/components/sync/engine_impl/brave_model_type_worker.h
+++ b/components/sync/engine_impl/brave_model_type_worker.h
@@ -38,6 +38,13 @@ class BraveModelTypeWorker : public ModelTypeWorker {
   void OnCommitResponse(
       const CommitResponseDataList& committed_response_list,
       const FailedCommitResponseDataList& error_response_list) override;
+
+  bool IsResetProgressMarkerRequired(
+      const FailedCommitResponseDataList& error_response_list);
+  void ResetProgressMarker();
+
+  size_t failed_commit_times_ = 0;
+  base::Time last_reset_marker_time_;
 };
 
 }  // namespace syncer

--- a/components/sync/engine_impl/brave_model_type_worker.h
+++ b/components/sync/engine_impl/brave_model_type_worker.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SYNC_ENGINE_IMPL_BRAVE_MODEL_TYPE_WORKER_H_
+#define BRAVE_COMPONENTS_SYNC_ENGINE_IMPL_BRAVE_MODEL_TYPE_WORKER_H_
+
+#include <memory>
+
+#include "components/sync/base/model_type.h"
+#include "components/sync/base/passphrase_enums.h"
+#include "components/sync/engine/commit_and_get_updates_types.h"
+#include "components/sync/engine_impl/model_type_worker.h"
+
+namespace syncer {
+
+class CancelationSignal;
+class Cryptographer;
+class NudgeHandler;
+class ModelTypeProcessor;
+
+class BraveModelTypeWorker : public ModelTypeWorker {
+ public:
+  BraveModelTypeWorker(ModelType type,
+                       const sync_pb::ModelTypeState& initial_state,
+                       bool trigger_initial_sync,
+                       std::unique_ptr<Cryptographer> cryptographer,
+                       PassphraseType passphrase_type,
+                       NudgeHandler* nudge_handler,
+                       std::unique_ptr<ModelTypeProcessor> model_type_processor,
+                       CancelationSignal* cancelation_signal);
+  ~BraveModelTypeWorker() override;
+  BraveModelTypeWorker(const BraveModelTypeWorker&) = delete;
+  BraveModelTypeWorker& operator=(const BraveModelTypeWorker&) = delete;
+
+ private:
+  void OnCommitResponse(
+      const CommitResponseDataList& committed_response_list,
+      const FailedCommitResponseDataList& error_response_list) override;
+};
+
+}  // namespace syncer
+
+#endif  // BRAVE_COMPONENTS_SYNC_ENGINE_IMPL_BRAVE_MODEL_TYPE_WORKER_H_

--- a/components/sync/engine_impl/brave_model_type_worker.h
+++ b/components/sync/engine_impl/brave_model_type_worker.h
@@ -20,6 +20,9 @@ class Cryptographer;
 class NudgeHandler;
 class ModelTypeProcessor;
 
+FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest, ResetProgressMarker);
+FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest, ResetProgressMarkerMaxPeriod);
+
 class BraveModelTypeWorker : public ModelTypeWorker {
  public:
   BraveModelTypeWorker(ModelType type,
@@ -35,6 +38,10 @@ class BraveModelTypeWorker : public ModelTypeWorker {
   BraveModelTypeWorker& operator=(const BraveModelTypeWorker&) = delete;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest, ResetProgressMarker);
+  FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest,
+                           ResetProgressMarkerMaxPeriod);
+
   void OnCommitResponse(
       const CommitResponseDataList& committed_response_list,
       const FailedCommitResponseDataList& error_response_list) override;
@@ -45,6 +52,8 @@ class BraveModelTypeWorker : public ModelTypeWorker {
 
   size_t failed_commit_times_ = 0;
   base::Time last_reset_marker_time_;
+  static size_t GetFailuresToResetMarkerForTests();
+  static base::TimeDelta MinimalTimeBetweenResetForTests();
 };
 
 }  // namespace syncer

--- a/components/sync/engine_impl/brave_model_type_worker.h
+++ b/components/sync/engine_impl/brave_model_type_worker.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/feature_list.h"
 #include "components/sync/base/model_type.h"
 #include "components/sync/base/passphrase_enums.h"
 #include "components/sync/engine/commit_and_get_updates_types.h"
@@ -20,8 +21,16 @@ class Cryptographer;
 class NudgeHandler;
 class ModelTypeProcessor;
 
+namespace features {
+
+extern const base::Feature kBraveSyncResetProgressMarker;
+
+}  // namespace features
+
 FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest, ResetProgressMarker);
 FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest, ResetProgressMarkerMaxPeriod);
+FORWARD_DECLARE_TEST(BraveModelTypeWorkerTest,
+                     ResetProgressMarkerDisabledFeature);
 
 class BraveModelTypeWorker : public ModelTypeWorker {
  public:
@@ -41,6 +50,8 @@ class BraveModelTypeWorker : public ModelTypeWorker {
   FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest, ResetProgressMarker);
   FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest,
                            ResetProgressMarkerMaxPeriod);
+  FRIEND_TEST_ALL_PREFIXES(BraveModelTypeWorkerTest,
+                           ResetProgressMarkerDisabledFeature);
 
   void OnCommitResponse(
       const CommitResponseDataList& committed_response_list,

--- a/components/sync/engine_impl/brave_model_type_worker_unittest.cc
+++ b/components/sync/engine_impl/brave_model_type_worker_unittest.cc
@@ -1,0 +1,196 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sync/engine_impl/brave_model_type_worker.h"
+
+#include <utility>
+
+#include "base/bind.h"
+#include "base/time/time_override.h"
+#include "components/sync/engine_impl/cancelation_signal.h"
+#include "components/sync/nigori/cryptographer_impl.h"
+#include "components/sync/protocol/sync.pb.h"
+#include "components/sync/test/engine/mock_model_type_processor.h"
+#include "components/sync/test/engine/mock_nudge_handler.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using base::subtle::ScopedTimeClockOverrides;
+using base::subtle::TimeNowIgnoringOverride;
+using sync_pb::CommitResponse_ResponseType;
+using sync_pb::CommitResponse_ResponseType_CONFLICT;
+using sync_pb::CommitResponse_ResponseType_TRANSIENT_ERROR;
+using sync_pb::ModelTypeState;
+
+namespace syncer {
+
+class BraveModelTypeWorkerTest : public ::testing::Test {
+ protected:
+  explicit BraveModelTypeWorkerTest(ModelType model_type = PREFERENCES)
+      : model_type_(model_type), is_processor_disconnected_(false) {}
+
+  ~BraveModelTypeWorkerTest() override {}
+
+  void NormalInitialize() {
+    ModelTypeState initial_state;
+    initial_state.mutable_progress_marker()->set_data_type_id(
+        GetSpecificsFieldNumberFromModelType(model_type_));
+    initial_state.mutable_progress_marker()->set_token(
+        "some_saved_progress_token");
+
+    initial_state.set_initial_sync_done(true);
+
+    InitializeWithState(model_type_, initial_state);
+
+    nudge_handler()->ClearCounters();
+  }
+
+  void InitializeWithState(const ModelType type, const ModelTypeState& state) {
+    DCHECK(!worker());
+
+    auto processor = std::make_unique<MockModelTypeProcessor>();
+    processor->SetDisconnectCallback(
+        base::BindOnce(&BraveModelTypeWorkerTest::DisconnectProcessor,
+                       base::Unretained(this)));
+
+    std::unique_ptr<Cryptographer> cryptographer_copy;
+    if (cryptographer_) {
+      cryptographer_copy = cryptographer_->Clone();
+    }
+
+    worker_ = std::make_unique<BraveModelTypeWorker>(
+        type, state, !state.initial_sync_done(), std::move(cryptographer_copy),
+        PassphraseType::kImplicitPassphrase, &mock_nudge_handler_,
+        std::move(processor), &cancelation_signal_);
+  }
+
+  // Callback when processor got disconnected with sync.
+  void DisconnectProcessor() {
+    DCHECK(!is_processor_disconnected_);
+    is_processor_disconnected_ = true;
+  }
+
+  BraveModelTypeWorker* worker() { return worker_.get(); }
+  MockNudgeHandler* nudge_handler() { return &mock_nudge_handler_; }
+
+  bool IsProgressMarkerEmpty() {
+    return worker()->model_type_state_.progress_marker().token().empty();
+  }
+
+  void FillProgressMarker() {
+    worker()->model_type_state_.mutable_progress_marker()->set_token("TOKEN1");
+  }
+
+ private:
+  const ModelType model_type_;
+  std::unique_ptr<CryptographerImpl> cryptographer_;
+  CancelationSignal cancelation_signal_;
+  std::unique_ptr<BraveModelTypeWorker> worker_;
+  MockNudgeHandler mock_nudge_handler_;
+  bool is_processor_disconnected_;
+};
+
+namespace {
+
+base::TimeDelta g_overridden_time_delta;
+base::Time g_overridden_now;
+
+std::unique_ptr<ScopedTimeClockOverrides> OverrideForTimeDelta(
+    base::TimeDelta overridden_time_delta,
+    const base::Time& now = TimeNowIgnoringOverride()) {
+  g_overridden_time_delta = overridden_time_delta;
+  g_overridden_now = now;
+  return std::make_unique<ScopedTimeClockOverrides>(
+      []() { return g_overridden_now + g_overridden_time_delta; }, nullptr,
+      nullptr);
+}
+
+base::TimeDelta g_minimal_time_between_reset_marker;
+
+std::unique_ptr<ScopedTimeClockOverrides> AdvanceTimeToAllowResetMarker() {
+  DCHECK(!g_minimal_time_between_reset_marker.is_zero());
+  static base::TimeDelta override_total_delta;
+  override_total_delta += g_minimal_time_between_reset_marker;
+  return OverrideForTimeDelta(override_total_delta);
+}
+
+FailedCommitResponseDataList MakeErrorResponseList(
+    CommitResponse_ResponseType err_code) {
+  FailedCommitResponseData data;
+  data.response_type = err_code;
+  return FailedCommitResponseDataList({data});
+}
+
+}  // namespace
+
+TEST_F(BraveModelTypeWorkerTest, ResetProgressMarker) {
+  g_minimal_time_between_reset_marker =
+      BraveModelTypeWorker::MinimalTimeBetweenResetForTests();
+
+  NormalInitialize();
+
+  CommitResponse_ResponseType err_codes[] = {
+      CommitResponse_ResponseType_CONFLICT,
+      CommitResponse_ResponseType_TRANSIENT_ERROR};
+
+  std::unique_ptr<ScopedTimeClockOverrides> time_override;
+  for (const auto& err : err_codes) {
+    {
+      auto time_override = AdvanceTimeToAllowResetMarker();
+      // Cleanup failures counter and setup progress marker
+      worker()->OnCommitResponse(CommitResponseDataList(),
+                                 FailedCommitResponseDataList());
+      FillProgressMarker();
+    }
+
+    for (size_t i = 0;
+         i < BraveModelTypeWorker::GetFailuresToResetMarkerForTests() - 1;
+         ++i) {
+      auto time_override = AdvanceTimeToAllowResetMarker();
+      worker()->OnCommitResponse(CommitResponseDataList(),
+                                 MakeErrorResponseList(err));
+      EXPECT_FALSE(IsProgressMarkerEmpty());
+    }
+
+    auto time_override = AdvanceTimeToAllowResetMarker();
+    worker()->OnCommitResponse(CommitResponseDataList(),
+                               MakeErrorResponseList(err));
+    EXPECT_TRUE(IsProgressMarkerEmpty());
+  }
+}
+
+TEST_F(BraveModelTypeWorkerTest, ResetProgressMarkerMaxPeriod) {
+  NormalInitialize();
+  auto error_response_list =
+      MakeErrorResponseList(CommitResponse_ResponseType_CONFLICT);
+
+  for (size_t i = 0;
+       i < BraveModelTypeWorker::GetFailuresToResetMarkerForTests() - 1; ++i) {
+    worker()->OnCommitResponse(CommitResponseDataList(), error_response_list);
+    EXPECT_FALSE(IsProgressMarkerEmpty());
+  }
+
+  worker()->OnCommitResponse(CommitResponseDataList(), error_response_list);
+  EXPECT_TRUE(IsProgressMarkerEmpty());
+
+  // Doing the same, expecting reset marker will not happened because the
+  // allowed period not yet passed
+
+  // Cleanup failures counter and setup progress marker
+  worker()->OnCommitResponse(CommitResponseDataList(),
+                             FailedCommitResponseDataList());
+  FillProgressMarker();
+
+  for (size_t i = 0;
+       i < BraveModelTypeWorker::GetFailuresToResetMarkerForTests() - 1; ++i) {
+    worker()->OnCommitResponse(CommitResponseDataList(), error_response_list);
+    EXPECT_FALSE(IsProgressMarkerEmpty());
+  }
+
+  // Expect reset progress marker types not happened
+  worker()->OnCommitResponse(CommitResponseDataList(), error_response_list);
+  EXPECT_FALSE(IsProgressMarkerEmpty());
+}
+
+}  // namespace syncer

--- a/components/sync/sources.gni
+++ b/components/sync/sources.gni
@@ -4,6 +4,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 brave_components_sync_sources = [
+  "//brave/components/sync/engine_impl/brave_model_type_worker.cc",
+  "//brave/components/sync/engine_impl/brave_model_type_worker.h",
   "//brave/components/sync/engine_impl/brave_sync_manager_impl.cc",
   "//brave/components/sync/engine_impl/brave_sync_manager_impl.h",
 ]

--- a/patches/components-sync-engine_impl-model_type_worker.h.patch
+++ b/patches/components-sync-engine_impl-model_type_worker.h.patch
@@ -1,0 +1,12 @@
+diff --git a/components/sync/engine_impl/model_type_worker.h b/components/sync/engine_impl/model_type_worker.h
+index f3ef9da0d7a80b4dfa7e833a803e87da854a55ab..ffbe4112379b8866c12a6408afc2eb0b5ab32947 100644
+--- a/components/sync/engine_impl/model_type_worker.h
++++ b/components/sync/engine_impl/model_type_worker.h
+@@ -123,6 +123,7 @@ class ModelTypeWorker : public UpdateHandler,
+     min_gu_responses_to_ignore_key_ = min_gu_responses_to_ignore_key;
+   }
+ 
++ BRAVE_MODEL_TYPE_WORKER_H_
+  private:
+   struct UnknownEncryptionKeyInfo {
+     // Not increased if the cryptographer knows it's in a pending state

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -417,6 +417,7 @@ test("brave_unit_tests") {
       "//brave/components/brave_sync:crypto",
       "//brave/components/brave_sync:network_time_helper",
       "//brave/components/sync/driver:unit_tests",
+      "//brave/components/sync/engine_impl:unit_tests",
       "//components/signin/public/identity_manager:test_support",
     ]
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14681

This PR is similar to https://github.com/brave/brave-core/pull/7805, but is less heavy, because:
1. Only failed type is touched;
2. The type is not disabled/enabled, it is forced to re-fetch all the records.

This PR resets the progress marker for the sync type which has 7 commit errors in row, TRANSIENT_ERROR or CONFLICT. This recovers sync client from the "yellow" status, where the client send/receives data once in 10 minutes eventually. 

This PR introduces a new P3A metric `Brave.Sync.ProgressTokenEverReset`. Possible values:
0 - Progress token marker has been reset in a normal way due to 7th commit failure;
1 - Progress token marker has not been reset because from the previous reset had passed less than 30 minutes.

Value (0) will help us to understand how many browser are affected by the issue of failed commits.

Value (1) is supposed to see if the commit failure keeps happen even after reset progress token. High value of this metric will give say that the procedure is not effective so it needs to be reverted.

This PR must be reverted when the real reason of TRANSIENT_ERROR or CONFLICT will be found.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
P3A review request is opened in #p3a and https://github.com/brave/security/issues/370
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Run this PR browser build against the profile with "yellow" sync status, caused by errors on commit of TRANSIENT_ERROR or CONFLICT - we don't know how to put the client into such state.
2. Ensure sync status is "green" in less than 10 minutes, usually 2..5.

