### PR TITLE
Add advertiser split testing for Brave ads

### DIFF
--- a/components/brave_ads/test/BUILD.gn
+++ b/components/brave_ads/test/BUILD.gn
@@ -76,6 +76,7 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/per_day_frequency_cap_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/per_hour_frequency_cap_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/promoted_content_ad_uuid_frequency_cap_unittest.cc",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/subdivision_targeting_frequency_cap_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/total_max_frequency_cap_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/transferred_frequency_cap_unittest.cc",

--- a/vendor/bat-native-ads/BUILD.gn
+++ b/vendor/bat-native-ads/BUILD.gn
@@ -429,6 +429,8 @@ source_set("ads") {
     "src/bat/ads/internal/frequency_capping/exclusion_rules/per_hour_frequency_cap.h",
     "src/bat/ads/internal/frequency_capping/exclusion_rules/promoted_content_ad_uuid_frequency_cap.cc",
     "src/bat/ads/internal/frequency_capping/exclusion_rules/promoted_content_ad_uuid_frequency_cap.h",
+    "src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.cc",
+    "src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.h",
     "src/bat/ads/internal/frequency_capping/exclusion_rules/subdivision_targeting_frequency_cap.cc",
     "src/bat/ads/internal/frequency_capping/exclusion_rules/subdivision_targeting_frequency_cap.h",
     "src/bat/ads/internal/frequency_capping/exclusion_rules/total_max_frequency_cap.cc",

--- a/vendor/bat-native-ads/data/resources/catalog-schema.json
+++ b/vendor/bat-native-ads/data/resources/catalog-schema.json
@@ -131,7 +131,10 @@
                                 "segments",
                                 "creatives",
                                 "oses",
-                                "channels"
+                                "channels",
+                                "perMonth",
+                                "perWeek",
+                                "value"
                             ],
                             "properties": {
                                 "creativeSetId": {
@@ -142,6 +145,18 @@
                                 },
                                 "totalMax": {
                                     "type": "number"
+                                },
+                                "perMonth": {
+                                    "type": "number"
+                                },
+                                "perWeek": {
+                                    "type": "number"
+                                },
+                                "splitTestGroup": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
                                 },
                                 "conversions": {
                                     "type": "array",
@@ -165,6 +180,9 @@
                                             },
                                             "conversionPublicKey": {
                                                 "type": "string"
+                                            },
+                                            "extractExternalId": {
+                                                "type": "boolean"
                                             }
                                         }
                                     }
@@ -288,32 +306,6 @@
                                                     },
                                                     {
                                                         "properties": {
-                                                            "domain": {
-                                                                "type": "string"
-                                                            },
-                                                            "feed": {
-                                                                "type": "string"
-                                                            },
-                                                            "title": {
-                                                                "type": "string"
-                                                            },
-                                                            "category": {
-                                                                "type": "string"
-                                                            },
-                                                            "ogImages": {
-                                                                "type": "boolean"
-                                                            },
-                                                            "contentType": {
-                                                                "type": "string"
-                                                            },
-                                                            "description": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "additionalProperties": false
-                                                    },
-                                                    {
-                                                        "properties": {
                                                             "logo": {
                                                                 "type": "object",
                                                                 "required": [
@@ -363,6 +355,32 @@
                                                                         }
                                                                     }
                                                                 }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "domain": {
+                                                                "type": "string"
+                                                            },
+                                                            "feed": {
+                                                                "type": "string"
+                                                            },
+                                                            "title": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "category": {
+                                                                "type": "string"
+                                                            },
+                                                            "ogImages": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "contentType": {
+                                                                "type": "string"
                                                             }
                                                         },
                                                         "additionalProperties": false

--- a/vendor/bat-native-ads/data/test/catalog.json
+++ b/vendor/bat-native-ads/data/test/catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "issuers": [
     {
       "name": "confirmation",
@@ -82,7 +82,10 @@
           ],
           "creativeSetId": "340c927f-696e-4060-9933-3eafc56c3f31",
           "perDay": 5,
-          "totalMax": 100
+          "perMonth": 140,
+          "perWeek": 35,
+          "totalMax": 100,
+          "value": "value"
         }
       ],
       "dayParts": [
@@ -153,7 +156,10 @@
           ],
           "creativeSetId": "25a11ff2-5dd2-4629-95f0-b717454911e8",
           "perDay": 5,
-          "totalMax": 100
+          "perMonth": 140,
+          "perWeek": 35,
+          "totalMax": 100,
+          "value": "value"
         }
       ],
       "dayParts": [
@@ -210,7 +216,10 @@
           ],
           "creativeSetId": "3e2e503a-dd38-42d1-9e26-1e5dbb66aada",
           "perDay": 5,
-          "totalMax": 100
+          "perMonth": 140,
+          "perWeek": 35,
+          "totalMax": 100,
+          "value": "value"
         }
       ],
       "dayParts": [

--- a/vendor/bat-native-ads/data/test/catalog_with_multiple_campaigns.json
+++ b/vendor/bat-native-ads/data/test/catalog_with_multiple_campaigns.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "issuers": [
     {
       "name": "confirmation",
@@ -117,7 +117,11 @@
           ],
           "creativeSetId": "340c927f-696e-4060-9933-3eafc56c3f31",
           "perDay": 5,
-          "totalMax": 100
+          "perMonth": 80,
+          "perWeek": 30,
+          "splitTestGroup": "GroupB",
+          "totalMax": 100,
+          "value": "0.05"
         }
       ],
       "dayParts": [
@@ -243,7 +247,10 @@
           ],
           "creativeSetId": "741cd2ba-3100-45f2-be1e-acedd24e0067",
           "perDay": 10,
-          "totalMax": 1000
+          "perMonth": 90,
+          "perWeek": 40,
+          "totalMax": 1000,
+          "value": "0.1"
         }
       ],
       "dayParts": [

--- a/vendor/bat-native-ads/data/test/catalog_with_single_campaign.json
+++ b/vendor/bat-native-ads/data/test/catalog_with_single_campaign.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "issuers": [
     {
       "name": "confirmation",
@@ -117,7 +117,11 @@
           ],
           "creativeSetId": "340c927f-696e-4060-9933-3eafc56c3f31",
           "perDay": 5,
-          "totalMax": 100
+          "perMonth": 140,
+          "perWeek": 35,
+          "splitTestGroup": "GroupB",
+          "totalMax": 100,
+          "value": "0.05"
         }
       ],
       "dayParts": [

--- a/vendor/bat-native-ads/data/test/empty_catalog.json
+++ b/vendor/bat-native-ads/data/test/empty_catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "issuers": [
     {
       "name": "confirmation",

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_server/ad_server.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_server/ad_server.cc
@@ -60,7 +60,7 @@ void AdServer::Fetch() {
   DCHECK(!is_processing_);
 
   BLOG(1, "Get catalog");
-  BLOG(2, "GET /v6/catalog");
+  BLOG(2, "GET /v7/catalog");
 
   is_processing_ = true;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_server/get_catalog_url_request_builder.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_server/get_catalog_url_request_builder.cc
@@ -14,7 +14,7 @@ GetCatalogUrlRequestBuilder::GetCatalogUrlRequestBuilder() = default;
 
 GetCatalogUrlRequestBuilder::~GetCatalogUrlRequestBuilder() = default;
 
-// GET /v6/catalog
+// GET /v7/catalog
 
 UrlRequestPtr GetCatalogUrlRequestBuilder::Build() {
   UrlRequestPtr url_request = UrlRequest::New();
@@ -27,7 +27,7 @@ UrlRequestPtr GetCatalogUrlRequestBuilder::Build() {
 ///////////////////////////////////////////////////////////////////////////////
 
 std::string GetCatalogUrlRequestBuilder::BuildUrl() const {
-  return base::StringPrintf("%s/v6/catalog", server::GetHost().c_str());
+  return base::StringPrintf("%s/v7/catalog", server::GetHost().c_str());
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/bundle/bundle.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/bundle/bundle.cc
@@ -156,6 +156,7 @@ BundleState Bundle::FromCatalog(const Catalog& catalog) const {
         info.conversion = creative_set.conversions.size() != 0 ? true : false;
         info.per_day = creative_set.per_day;
         info.total_max = creative_set.total_max;
+        info.split_test_group = creative_set.split_test_group;
         info.dayparts = creative_dayparts;
         info.geo_targets = geo_targets;
         info.title = creative.payload.title;

--- a/vendor/bat-native-ads/src/bat/ads/internal/bundle/creative_ad_info.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/bundle/creative_ad_info.h
@@ -32,6 +32,7 @@ struct CreativeAdInfo {
   bool conversion = false;
   unsigned int per_day = 0;
   unsigned int total_max = 0;
+  std::string split_test_group;
   std::string segment;
   std::vector<std::string> geo_targets;
   std::string target_url;

--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_creative_set_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_creative_set_info.cc
@@ -18,7 +18,7 @@ bool CatalogCreativeSetInfo::operator==(
     const CatalogCreativeSetInfo& rhs) const {
   return creative_set_id == rhs.creative_set_id && per_day == rhs.per_day &&
          total_max == rhs.total_max && segments == rhs.segments &&
-         oses == rhs.oses &&
+         split_test_group == rhs.split_test_group && oses == rhs.oses &&
          creative_ad_notifications == rhs.creative_ad_notifications &&
          creative_new_tab_page_ads == rhs.creative_new_tab_page_ads &&
          conversions == rhs.conversions;

--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_creative_set_info.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_creative_set_info.h
@@ -29,6 +29,7 @@ struct CatalogCreativeSetInfo {
   std::string creative_set_id;
   unsigned int per_day = 0;
   unsigned int total_max = 0;
+  std::string split_test_group;
   CatalogSegmentList segments;
   CatalogOsList oses;
   CatalogCreativeAdNotificationList creative_ad_notifications;

--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_state.cc
@@ -42,7 +42,7 @@ Result CatalogState::FromJson(const std::string& json,
   new_catalog_id = document["catalogId"].GetString();
 
   new_version = document["version"].GetInt();
-  if (new_version != 6) {
+  if (new_version != 7) {
     return FAILED;
   }
 
@@ -96,6 +96,11 @@ Result CatalogState::FromJson(const std::string& json,
       creative_set_info.per_day = creative_set["perDay"].GetUint();
 
       creative_set_info.total_max = creative_set["totalMax"].GetUint();
+
+      if (creative_set.HasMember("splitTestGroup")) {
+        creative_set_info.split_test_group =
+            creative_set["splitTestGroup"].GetString();
+      }
 
       // Segments
       auto segments = creative_set["segments"].GetArray();

--- a/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/catalog/catalog_unittest.cc
@@ -136,6 +136,7 @@ class BatAdsCatalogTest : public UnitTestBase {
     catalog_creative_set.creative_set_id =
         "340c927f-696e-4060-9933-3eafc56c3f31";
     catalog_creative_set.per_day = 5;
+    catalog_creative_set.split_test_group = "GroupB";
     catalog_creative_set.total_max = 100;
     catalog_creative_set.segments = catalog_segments;
     catalog_creative_set.oses = catalog_oses;
@@ -451,7 +452,7 @@ TEST_F(BatAdsCatalogTest, GetVersion) {
   const int version = catalog.GetVersion();
 
   // Assert
-  EXPECT_EQ(6, version);
+  EXPECT_EQ(7, version);
 }
 
 TEST_F(BatAdsCatalogTest, GetPing) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/database_version.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/database_version.cc
@@ -9,11 +9,11 @@ namespace ads {
 namespace database {
 
 int32_t version() {
-  return 11;
+  return 12;
 }
 
 int32_t compatible_version() {
-  return 11;
+  return 12;
 }
 
 }  // namespace database

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/campaigns_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/campaigns_database_table.cc
@@ -61,7 +61,7 @@ void Campaigns::Migrate(DBTransaction* transaction, const int to_version) {
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -113,7 +113,7 @@ std::string Campaigns::BuildInsertOrUpdateQuery(
       BuildBindingParameterPlaceholders(7, count).c_str());
 }
 
-void Campaigns::CreateTableV10(DBTransaction* transaction) {
+void Campaigns::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -134,12 +134,12 @@ void Campaigns::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void Campaigns::MigrateToV10(DBTransaction* transaction) {
+void Campaigns::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/campaigns_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/campaigns_database_table.h
@@ -38,8 +38,8 @@ class Campaigns : public Table {
   std::string BuildInsertOrUpdateQuery(DBCommand* command,
                                        const CreativeAdList& creative_ads);
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 };
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/conversions_database_table_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/conversions_database_table_test.cc
@@ -28,7 +28,7 @@ TEST_F(BatAdsConversionsDatabaseTableIntegrationTest,
        GetConversionsFromCatalogEndpoint) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.cc
@@ -103,6 +103,7 @@ void CreativeAdNotifications::GetForSegments(
       "ca.conversion, "
       "ca.per_day, "
       "ca.total_max, "
+      "ca.split_test_group, "
       "s.segment, "
       "gt.geo_target, "
       "ca.target_url, "
@@ -151,6 +152,7 @@ void CreativeAdNotifications::GetForSegments(
       DBCommand::RecordBindingType::BOOL_TYPE,    // conversion
       DBCommand::RecordBindingType::INT_TYPE,     // per_day
       DBCommand::RecordBindingType::INT_TYPE,     // total_max
+      DBCommand::RecordBindingType::STRING_TYPE,  // split_test_group
       DBCommand::RecordBindingType::STRING_TYPE,  // segment
       DBCommand::RecordBindingType::STRING_TYPE,  // geo_target
       DBCommand::RecordBindingType::STRING_TYPE,  // target_url
@@ -186,6 +188,7 @@ void CreativeAdNotifications::GetAll(
       "ca.conversion, "
       "ca.per_day, "
       "ca.total_max, "
+      "ca.split_test_group, "
       "s.segment, "
       "gt.geo_target, "
       "ca.target_url, "
@@ -226,6 +229,7 @@ void CreativeAdNotifications::GetAll(
       DBCommand::RecordBindingType::BOOL_TYPE,    // conversion
       DBCommand::RecordBindingType::INT_TYPE,     // per_day
       DBCommand::RecordBindingType::INT_TYPE,     // total_max
+      DBCommand::RecordBindingType::STRING_TYPE,  // split_test_group
       DBCommand::RecordBindingType::STRING_TYPE,  // segment
       DBCommand::RecordBindingType::STRING_TYPE,  // geo_target
       DBCommand::RecordBindingType::STRING_TYPE,  // target_url
@@ -261,7 +265,7 @@ void CreativeAdNotifications::Migrate(DBTransaction* transaction,
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -393,23 +397,24 @@ CreativeAdNotificationInfo CreativeAdNotifications::GetFromRecord(
   creative_ad_notification.conversion = ColumnBool(record, 8);
   creative_ad_notification.per_day = ColumnInt(record, 9);
   creative_ad_notification.total_max = ColumnInt(record, 10);
-  creative_ad_notification.segment = ColumnString(record, 11);
-  creative_ad_notification.geo_targets.push_back(ColumnString(record, 12));
-  creative_ad_notification.target_url = ColumnString(record, 13);
-  creative_ad_notification.title = ColumnString(record, 14);
-  creative_ad_notification.body = ColumnString(record, 15);
-  creative_ad_notification.ptr = ColumnDouble(record, 16);
+  creative_ad_notification.split_test_group = ColumnString(record, 11);
+  creative_ad_notification.segment = ColumnString(record, 12);
+  creative_ad_notification.geo_targets.push_back(ColumnString(record, 13));
+  creative_ad_notification.target_url = ColumnString(record, 14);
+  creative_ad_notification.title = ColumnString(record, 15);
+  creative_ad_notification.body = ColumnString(record, 16);
+  creative_ad_notification.ptr = ColumnDouble(record, 17);
 
   CreativeDaypartInfo daypart;
-  daypart.dow = ColumnString(record, 17);
-  daypart.start_minute = ColumnInt(record, 18);
-  daypart.end_minute = ColumnInt(record, 19);
+  daypart.dow = ColumnString(record, 18);
+  daypart.start_minute = ColumnInt(record, 19);
+  daypart.end_minute = ColumnInt(record, 20);
   creative_ad_notification.dayparts.push_back(daypart);
 
   return creative_ad_notification;
 }
 
-void CreativeAdNotifications::CreateTableV10(DBTransaction* transaction) {
+void CreativeAdNotifications::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -429,12 +434,12 @@ void CreativeAdNotifications::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void CreativeAdNotifications::MigrateToV10(DBTransaction* transaction) {
+void CreativeAdNotifications::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table.h
@@ -76,8 +76,8 @@ class CreativeAdNotifications : public Table {
 
   CreativeAdNotificationInfo GetFromRecord(DBRecord* record) const;
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 
   int batch_size_;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ad_notifications_database_table_test.cc
@@ -30,7 +30,7 @@ TEST_F(BatAdsCreativeAdNotificationsDatabaseTableIntegrationTest,
        GetCreativeAdNotificationsFromCatalogEndpoint) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.cc
@@ -59,8 +59,8 @@ void CreativeAds::Migrate(DBTransaction* transaction, const int to_version) {
   DCHECK(transaction);
 
   switch (to_version) {
-    case 10: {
-      MigrateToV10(transaction);
+    case 12: {
+      MigrateToV12(transaction);
       break;
     }
 
@@ -84,6 +84,7 @@ int CreativeAds::BindParameters(DBCommand* command,
     BindBool(command, index++, creative_ad.conversion);
     BindInt(command, index++, creative_ad.per_day);
     BindInt(command, index++, creative_ad.total_max);
+    BindString(command, index++, creative_ad.split_test_group);
     BindString(command, index++, creative_ad.target_url);
 
     count++;
@@ -103,12 +104,13 @@ std::string CreativeAds::BuildInsertOrUpdateQuery(
       "conversion, "
       "per_day, "
       "total_max, "
+      "split_test_group, "
       "target_url) VALUES %s",
       get_table_name().c_str(),
-      BuildBindingParameterPlaceholders(5, count).c_str());
+      BuildBindingParameterPlaceholders(6, count).c_str());
 }
 
-void CreativeAds::CreateTableV10(DBTransaction* transaction) {
+void CreativeAds::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -118,6 +120,7 @@ void CreativeAds::CreateTableV10(DBTransaction* transaction) {
       "conversion INTEGER NOT NULL DEFAULT 0, "
       "per_day INTEGER NOT NULL DEFAULT 0, "
       "total_max INTEGER NOT NULL DEFAULT 0, "
+      "split_test_group TEXT, "
       "target_url TEXT NOT NULL)",
       get_table_name().c_str());
 
@@ -128,12 +131,12 @@ void CreativeAds::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void CreativeAds::MigrateToV10(DBTransaction* transaction) {
+void CreativeAds::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_ads_database_table.h
@@ -38,8 +38,8 @@ class CreativeAds : public Table {
   std::string BuildInsertOrUpdateQuery(DBCommand* command,
                                        const CreativeAdList& creative_ads);
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 };
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table.cc
@@ -342,7 +342,7 @@ void CreativeNewTabPageAds::Migrate(DBTransaction* transaction,
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -514,7 +514,7 @@ CreativeNewTabPageAdInfo CreativeNewTabPageAds::GetFromRecord(
   return creative_new_tab_page_ad;
 }
 
-void CreativeNewTabPageAds::CreateTableV10(DBTransaction* transaction) {
+void CreativeNewTabPageAds::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -534,12 +534,12 @@ void CreativeNewTabPageAds::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void CreativeNewTabPageAds::MigrateToV10(DBTransaction* transaction) {
+void CreativeNewTabPageAds::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table.h
@@ -87,8 +87,8 @@ class CreativeNewTabPageAds : public Table {
 
   CreativeNewTabPageAdInfo GetFromRecord(DBRecord* record) const;
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 
   int batch_size_;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_new_tab_page_ads_database_table_test.cc
@@ -29,7 +29,7 @@ TEST_F(BatAdsCreativeNewTabPageAdsDatabaseTableIntegrationTest,
        GetCreativeNewTabPageAdsFromCatalogEndpoint) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_promoted_content_ads_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_promoted_content_ads_database_table.cc
@@ -344,7 +344,7 @@ void CreativePromotedContentAds::Migrate(DBTransaction* transaction,
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -518,7 +518,7 @@ CreativePromotedContentAdInfo CreativePromotedContentAds::GetFromRecord(
   return creative_promoted_content_ad;
 }
 
-void CreativePromotedContentAds::CreateTableV10(DBTransaction* transaction) {
+void CreativePromotedContentAds::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -538,12 +538,12 @@ void CreativePromotedContentAds::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void CreativePromotedContentAds::MigrateToV10(DBTransaction* transaction) {
+void CreativePromotedContentAds::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_promoted_content_ads_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_promoted_content_ads_database_table.h
@@ -89,8 +89,8 @@ class CreativePromotedContentAds : public Table {
 
   CreativePromotedContentAdInfo GetFromRecord(DBRecord* record) const;
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 
   int batch_size_;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_promoted_content_ads_database_table_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/creative_promoted_content_ads_database_table_test.cc
@@ -30,7 +30,7 @@ TEST_F(BatAdsCreativePromotedContentAdsDatabaseTableIntegrationTest,
        GetCreativePromotedContentAdsFromCatalogEndpoint) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/dayparts_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/dayparts_database_table.cc
@@ -63,7 +63,7 @@ void Dayparts::Migrate(DBTransaction* transaction, const int to_version) {
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -111,7 +111,7 @@ std::string Dayparts::BuildInsertOrUpdateQuery(
       BuildBindingParameterPlaceholders(4, count).c_str());
 }
 
-void Dayparts::CreateTableV10(DBTransaction* transaction) {
+void Dayparts::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -132,12 +132,12 @@ void Dayparts::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void Dayparts::MigrateToV10(DBTransaction* transaction) {
+void Dayparts::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/dayparts_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/dayparts_database_table.h
@@ -38,8 +38,8 @@ class Dayparts : public Table {
   std::string BuildInsertOrUpdateQuery(DBCommand* command,
                                        const CreativeAdList& creative_ads);
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 };
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/geo_targets_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/geo_targets_database_table.cc
@@ -60,7 +60,7 @@ void GeoTargets::Migrate(DBTransaction* transaction, const int to_version) {
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -104,7 +104,7 @@ std::string GeoTargets::BuildInsertOrUpdateQuery(
       BuildBindingParameterPlaceholders(2, count).c_str());
 }
 
-void GeoTargets::CreateTableV10(DBTransaction* transaction) {
+void GeoTargets::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -122,12 +122,12 @@ void GeoTargets::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void GeoTargets::MigrateToV10(DBTransaction* transaction) {
+void GeoTargets::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/geo_targets_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/geo_targets_database_table.h
@@ -38,8 +38,8 @@ class GeoTargets : public Table {
   std::string BuildInsertOrUpdateQuery(DBCommand* command,
                                        const CreativeAdList& creative_ads);
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 };
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/segments_database_table.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/segments_database_table.cc
@@ -61,7 +61,7 @@ void Segments::Migrate(DBTransaction* transaction, const int to_version) {
 
   switch (to_version) {
     case 10: {
-      MigrateToV10(transaction);
+      MigrateToV12(transaction);
       break;
     }
 
@@ -103,7 +103,7 @@ std::string Segments::BuildInsertOrUpdateQuery(
       BuildBindingParameterPlaceholders(2, count).c_str());
 }
 
-void Segments::CreateTableV10(DBTransaction* transaction) {
+void Segments::CreateTableV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   const std::string query = base::StringPrintf(
@@ -121,12 +121,12 @@ void Segments::CreateTableV10(DBTransaction* transaction) {
   transaction->commands.push_back(std::move(command));
 }
 
-void Segments::MigrateToV10(DBTransaction* transaction) {
+void Segments::MigrateToV12(DBTransaction* transaction) {
   DCHECK(transaction);
 
   util::Drop(transaction, get_table_name());
 
-  CreateTableV10(transaction);
+  CreateTableV12(transaction);
 }
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/database/tables/segments_database_table.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/database/tables/segments_database_table.h
@@ -38,8 +38,8 @@ class Segments : public Table {
   std::string BuildInsertOrUpdateQuery(DBCommand* command,
                                        const CreativeAdList& creative_ads);
 
-  void CreateTableV10(DBTransaction* transaction);
-  void MigrateToV10(DBTransaction* transaction);
+  void CreateTableV12(DBTransaction* transaction);
+  void MigrateToV12(DBTransaction* transaction);
 };
 
 }  // namespace table

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/ad_notifications/ad_notifications_frequency_capping.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/ad_notifications/ad_notifications_frequency_capping.cc
@@ -17,6 +17,7 @@
 #include "bat/ads/internal/frequency_capping/exclusion_rules/marked_to_no_longer_receive_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/exclusion_rules/per_day_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/exclusion_rules/per_hour_frequency_cap.h"
+#include "bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/exclusion_rules/subdivision_targeting_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/exclusion_rules/total_max_frequency_cap.h"
 #include "bat/ads/internal/frequency_capping/exclusion_rules/transferred_frequency_cap.h"
@@ -161,6 +162,11 @@ bool FrequencyCapping::ShouldExcludeAd(const CreativeAdInfo& ad) {
 
   MarkedAsInappropriateFrequencyCap marked_as_inappropriate_frequency_cap;
   if (ShouldExclude(ad, &marked_as_inappropriate_frequency_cap)) {
+    should_exclude = true;
+  }
+
+  SplitTestFrequencyCap split_test_frequency_cap;
+  if (ShouldExclude(ad, &split_test_frequency_cap)) {
     should_exclude = true;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.cc
@@ -1,0 +1,71 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.h"
+
+#include "base/metrics/field_trial.h"
+#include "base/optional.h"
+#include "base/strings/stringprintf.h"
+#include "bat/ads/internal/bundle/creative_ad_info.h"
+
+namespace ads {
+
+namespace {
+
+const char kStudyName[] = "AdvertiserSplitTestStudy";
+
+base::Optional<std::string> GetSplitTestGroup(const std::string study_name) {
+  base::FieldTrial* field_trial = base::FieldTrialList::Find(study_name);
+  if (!field_trial) {
+    return base::nullopt;
+  }
+
+  return field_trial->group_name();
+}
+
+}  // namespace
+
+SplitTestFrequencyCap::SplitTestFrequencyCap() = default;
+
+SplitTestFrequencyCap::~SplitTestFrequencyCap() = default;
+
+bool SplitTestFrequencyCap::ShouldExclude(const CreativeAdInfo& ad) {
+  if (!DoesRespectCap(ad)) {
+    last_message_ = base::StringPrintf(
+        "creativeSetId %s excluded as not "
+        "associated with advertiser split test group",
+        ad.creative_set_id.c_str());
+
+    return true;
+  }
+
+  return false;
+}
+
+std::string SplitTestFrequencyCap::get_last_message() const {
+  return last_message_;
+}
+
+bool SplitTestFrequencyCap::DoesRespectCap(const CreativeAdInfo& ad) const {
+  const base::Optional<std::string> split_test_group =
+      GetSplitTestGroup(kStudyName);
+  if (!split_test_group) {
+    // Always respect cap if browser didn't sign up to field trial
+    return true;
+  }
+
+  if (ad.split_test_group.empty()) {
+    // Always respect cap if there is no split testing group in the catalog
+    return true;
+  }
+
+  if (ad.split_test_group == split_test_group) {
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_FREQUENCY_CAPPING_EXCLUSION_RULES_SPLIT_TEST_FREQUENCY_CAP_H_
+#define BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_FREQUENCY_CAPPING_EXCLUSION_RULES_SPLIT_TEST_FREQUENCY_CAP_H_
+
+#include <string>
+
+#include "bat/ads/internal/frequency_capping/exclusion_rules/exclusion_rule.h"
+
+namespace ads {
+
+struct CreativeAdInfo;
+
+class SplitTestFrequencyCap : public ExclusionRule<CreativeAdInfo> {
+ public:
+  SplitTestFrequencyCap();
+
+  ~SplitTestFrequencyCap() override;
+
+  SplitTestFrequencyCap(const SplitTestFrequencyCap&) = delete;
+  SplitTestFrequencyCap& operator=(const SplitTestFrequencyCap&) = delete;
+
+  bool ShouldExclude(const CreativeAdInfo& ad) override;
+
+  std::string get_last_message() const override;
+
+ private:
+  std::string last_message_;
+
+  bool DoesRespectCap(const CreativeAdInfo& ad) const;
+};
+
+}  // namespace ads
+
+#endif  // BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_FREQUENCY_CAPPING_EXCLUSION_RULES_SPLIT_TEST_FREQUENCY_CAP_H_

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap_unittest.cc
@@ -1,0 +1,102 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/frequency_capping/exclusion_rules/split_test_frequency_cap.h"
+
+#include "base/metrics/field_trial.h"
+#include "base/strings/string_number_conversions.h"
+#include "bat/ads/internal/unittest_base.h"
+#include "bat/ads/internal/unittest_util.h"
+
+// npm run test -- brave_unit_tests --filter=BatAds*
+
+namespace ads {
+
+namespace {
+const char kTrial[] = "AdvertiserSplitTestStudy";
+const char kGroup[] = "GroupA";
+const char kCreativeSetId[] = "654f10df-fbc4-4a92-8d43-2edf73734a60";
+
+scoped_refptr<base::FieldTrial> CreateFieldTrial(
+    const std::string& trial_name) {
+  return base::FieldTrialList::FactoryGetFieldTrial(
+      trial_name, 100, "default", base::FieldTrial::ONE_TIME_RANDOMIZED,
+      nullptr);
+}
+
+}  // namespace
+
+class BatAdsSplitTestFrequencyCapTest : public UnitTestBase {
+ protected:
+  BatAdsSplitTestFrequencyCapTest() = default;
+
+  ~BatAdsSplitTestFrequencyCapTest() override = default;
+};
+
+TEST_F(BatAdsSplitTestFrequencyCapTest, AllowIfNoGroupInCatalog) {
+  // Arrange
+  CreativeAdInfo ad;
+  ad.creative_set_id = kCreativeSetId;
+
+  scoped_refptr<base::FieldTrial> trial = CreateFieldTrial(kTrial);
+  trial->AppendGroup(kGroup, 100);
+
+  // Act
+  SplitTestFrequencyCap frequency_cap;
+  const bool should_exclude = frequency_cap.ShouldExclude(ad);
+
+  // Assert
+  EXPECT_FALSE(should_exclude);
+}
+
+TEST_F(BatAdsSplitTestFrequencyCapTest, AllowIfNoFieldTrial) {
+  // Arrange
+  CreativeAdInfo ad;
+  ad.creative_set_id = kCreativeSetId;
+  ad.split_test_group = "GroupA";
+
+  // Act
+  SplitTestFrequencyCap frequency_cap;
+  const bool should_exclude = frequency_cap.ShouldExclude(ad);
+
+  // Assert
+  EXPECT_FALSE(should_exclude);
+}
+
+TEST_F(BatAdsSplitTestFrequencyCapTest, AllowIfGroupsMatch) {
+  // Arrange
+  CreativeAdInfo ad;
+  ad.creative_set_id = kCreativeSetId;
+  ad.split_test_group = "GroupA";
+
+  scoped_refptr<base::FieldTrial> trial = CreateFieldTrial(kTrial);
+  trial->AppendGroup(kGroup, 100);
+
+  // Act
+  SplitTestFrequencyCap frequency_cap;
+  const bool should_exclude = frequency_cap.ShouldExclude(ad);
+
+  // Assert
+  EXPECT_FALSE(should_exclude);
+}
+
+TEST_F(BatAdsSplitTestFrequencyCapTest, DoNotAllowIfGroupsDoNotMatch) {
+  // Arrange
+  CreativeAdInfo ad;
+  ad.creative_set_id = kCreativeSetId;
+  ad.split_test_group = "GroupB";
+
+  scoped_refptr<base::FieldTrial> trial = CreateFieldTrial(kTrial);
+  trial->AppendGroup(kGroup, 100);
+
+  // Act
+  SplitTestFrequencyCap frequency_cap;
+  const bool should_exclude = frequency_cap.ShouldExclude(ad);
+
+  // Assert
+  EXPECT_TRUE(should_exclude);
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/catalog_frequency_cap_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/permission_rules/catalog_frequency_cap_unittest.cc
@@ -28,7 +28,7 @@ class BatAdsCatalogFrequencyCapTest : public UnitTestBase {
 TEST_F(BatAdsCatalogFrequencyCapTest, AllowAd) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 
@@ -46,7 +46,7 @@ TEST_F(BatAdsCatalogFrequencyCapTest,
        AllowAdIfCatalogWasLastUpdated23HoursAnd59MinutesAgo) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 
@@ -67,7 +67,7 @@ TEST_F(BatAdsCatalogFrequencyCapTest,
        DoNotAllowAdIfCatalogWasLastUpdated1DayAgo) {
   // Arrange
   const URLEndpoints endpoints = {
-      {"/v6/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
+      {"/v7/catalog", {{net::HTTP_OK, "/catalog.json"}}}};
 
   MockUrlRequest(ads_client_mock_, endpoints);
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14613

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Run with `npm start -- --enable-logging=stderr --vmodule="*/variations/*"=6,"*/bat-native-ads/*"=6,"*/brave_ads/*"=6,"*/brave_user_model/*"=6,"*/bat_ads/*"=6 --use-dev-goupdater-url --brave-ads-staging --rewards=staging=true --variations-server-url=https://variations.bravesoftware.com/seed --fake-variations-channel=beta`

- Inject test catalog that has a creative set with field `"splitTestGroup": "GroupA"` set.
- Start browser without enabling ads and quit. Then start a second time with enabling ads (**This is important since `seed` will only be initialised on restart!**)
- Verify in logs that study loaded correctly with `[10210:775:0313/084147.162484:VERBOSE1:study_filtering.cc(346)] Kept study AdvertiserSplitTestingStudy.`
- trigger ad and verify it is being served and not filtered out.
- Change the test catalog to contain the field `"splitTestGroup": "GroupB"` and wipe profile.
- Re-run test and verify the frequency cap is now excluding this ad.
