### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/14289

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -28,6 +28,8 @@ constexpr char kSonyentertainmentnetwork[] =
 constexpr char kSony[] = "https://[*.]sony.com/*";
 constexpr char kGoogle[] = "https://[*.]google.com/*";
 constexpr char kGoogleusercontent[] = "https://[*.]googleusercontent.com/*";
+constexpr char kFacebook[] = "https://[*.]facebook.com/*";
+constexpr char kInstagram[] = "https://[*.]instagram.com/*";
 
 bool BraveIsAllowedThirdParty(const GURL& url,
                               const GURL& first_party_url,
@@ -44,6 +46,10 @@ bool BraveIsAllowedThirdParty(const GURL& url,
             ContentSettingsPattern::FromString(kGoogleusercontent)},
            {ContentSettingsPattern::FromString(kGoogleusercontent),
             ContentSettingsPattern::FromString(kGoogle)},
+           {ContentSettingsPattern::FromString(kInstagram),
+            ContentSettingsPattern::FromString(kFacebook)},
+           {ContentSettingsPattern::FromString(kFacebook),
+            ContentSettingsPattern::FromString(kInstagram)},
            {ContentSettingsPattern::FromString(kPlaystation),
             ContentSettingsPattern::FromString(kSonyentertainmentnetwork)},
            {ContentSettingsPattern::FromString(kSonyentertainmentnetwork),


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14289

Instagram is owned by Facebook, currently the Facebook login will redirect to a blank page.

I had to rebase the previous PR. this will work. Will retest the CI build, but it'll allow instagram to use facebook logins.



