### PR TITLE
Add don't ask again checkbox to default browser prompt

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -967,9 +967,10 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
           Set Brave as your default browser
         </message>
         <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_CONTENTS_TEXT" desc="The contents for default browser dialog">
-          Brave browser is currently not set as your default browser.
-Set Brave as your default to keep browsing the web faster -
-up to 6x faster on major news sites.
+          Keep browsing the web faster - up to 6x faster on major news sites.
+        </message>
+        <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_DONT_ASK" desc="The text for diabling default browser dialog checkbox">
+          Don't ask again
         </message>
         <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_OK_BUTTON_LABEL" desc="The text for default browser dialog ok button">
           Set as default

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -969,7 +969,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_CONTENTS_TEXT" desc="The contents for default browser dialog">
           Keep browsing the web faster - up to 6x faster on major news sites.
         </message>
-        <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_DONT_ASK" desc="The text for diabling default browser dialog checkbox">
+        <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_DONT_ASK" desc="The text for disabling default browser dialog checkbox">
           Don't ask again
         </message>
         <message name="IDS_BRAVE_DEFAULT_BROWSER_DIALOG_OK_BUTTON_LABEL" desc="The text for default browser dialog ok button">

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -94,6 +94,8 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   BraveWindowTracker::RegisterPrefs(registry);
   BraveUptimeTracker::RegisterPrefs(registry);
   dark_mode::RegisterBraveDarkModeLocalStatePrefs(registry);
+
+  registry->RegisterBooleanPref(kDefaultBrowserPromptEnabled, true);
 #endif
 
 #if BUILDFLAG(ENABLE_WIDEVINE)

--- a/browser/brave_prefs_browsertest.cc
+++ b/browser/brave_prefs_browsertest.cc
@@ -9,6 +9,7 @@
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/buildflags.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/net/prediction_options.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -36,6 +37,7 @@
 #endif
 
 using BraveProfilePrefsBrowserTest = InProcessBrowserTest;
+using BraveLocalStatePrefsBrowserTest = InProcessBrowserTest;
 
 // Check download prompt preference is set to true by default.
 IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, DownloadPromptDefault) {
@@ -122,4 +124,9 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest,
       prefs::kNtpUseMostVisitedTiles));
   EXPECT_TRUE(
       browser()->profile()->GetPrefs()->GetBoolean(prefs::kHideWebStoreIcon));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveLocalStatePrefsBrowserTest, DefaultLocalStateTest) {
+  EXPECT_TRUE(g_browser_process->local_state()->GetBoolean(
+      kDefaultBrowserPromptEnabled));
 }

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -250,6 +250,7 @@ source_set("ui") {
     "//brave/ui/brave_ads/public/cpp",
     "//chrome/app:command_ids",
     "//chrome/app/vector_icons:vector_icons",
+    "//chrome/browser:browser_process",
     "//chrome/common",
     "//chrome/services/qrcode_generator",
     "//components/content_settings/browser",

--- a/browser/ui/startup/default_brave_browser_prompt.cc
+++ b/browser/ui/startup/default_brave_browser_prompt.cc
@@ -139,14 +139,17 @@ void ShowDefaultBraveBrowserPrompt(Profile* profile) {
   return;
 #endif
 
+  PrefService* local_prefs = g_browser_process->local_state();
   // Do not check if Chrome is the default browser if there is a policy in
   // control of this setting.
-  if (g_browser_process->local_state()->IsManagedPreference(
-          prefs::kDefaultBrowserSettingEnabled)) {
+  if (local_prefs->IsManagedPreference(prefs::kDefaultBrowserSettingEnabled)) {
     // Handling of the browser.default_browser_setting_enabled policy setting is
     // taken care of in BrowserProcessImpl.
     return;
   }
+
+  if (!local_prefs->GetBoolean(kDefaultBrowserPromptEnabled))
+    return;
 
   PrefService* prefs = profile->GetPrefs();
   // Reset preferences if kResetCheckDefaultBrowser is true.

--- a/browser/ui/views/brave_default_browser_dialog_view.cc
+++ b/browser/ui/views/brave_default_browser_dialog_view.cc
@@ -10,12 +10,17 @@
 #include "base/bind.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/browser/ui/browser_dialogs.h"
+#include "brave/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/shell_integration.h"
+#include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "components/constrained_window/constrained_window_views.h"
+#include "components/prefs/pref_service.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/views/bubble/bubble_frame_view.h"
+#include "ui/views/controls/button/checkbox.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/layout/layout_provider.h"
@@ -105,7 +110,10 @@ void BraveDefaultBrowserDialogView::CreateChildViews() {
       contents_font));
   contents_label_->SetHorizontalAlignment(gfx::ALIGN_LEFT);
   contents_label_->SetMultiLine(true);
-  contents_label_->SetMaxLines(3);
+  contents_label_->SetMaximumWidth(350);
+
+  dont_ask_again_checkbox_ = AddChildView(std::make_unique<views::Checkbox>(
+      l10n_util::GetStringUTF16(IDS_BRAVE_DEFAULT_BROWSER_DIALOG_DONT_ASK)));
 }
 
 std::unique_ptr<views::NonClientFrameView>
@@ -143,7 +151,8 @@ void BraveDefaultBrowserDialogView::OnDialogInitialized() {
 }
 
 void BraveDefaultBrowserDialogView::OnCancelButtonClicked() {
-  // Do nothing.
+  g_browser_process->local_state()->SetBoolean(
+      kDefaultBrowserPromptEnabled, !dont_ask_again_checkbox_->GetChecked());
 }
 
 void BraveDefaultBrowserDialogView::OnAcceptButtonClicked() {

--- a/browser/ui/views/brave_default_browser_dialog_view.h
+++ b/browser/ui/views/brave_default_browser_dialog_view.h
@@ -11,6 +11,7 @@
 #include "ui/views/window/dialog_delegate.h"
 
 namespace views {
+class Checkbox;
 class Label;
 }  // namespace views
 
@@ -37,6 +38,7 @@ class BraveDefaultBrowserDialogView : public views::DialogDelegateView {
 
   views::Label* header_label_ = nullptr;
   views::Label* contents_label_ = nullptr;
+  views::Checkbox* dont_ask_again_checkbox_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_DEFAULT_BROWSER_DIALOG_VIEW_H_

--- a/common/pref_names.cc
+++ b/common/pref_names.cc
@@ -87,6 +87,8 @@ const char kBraveSuggestedSiteSuggestionsEnabled[] =
 const char kBraveDarkMode[] = "brave.dark_mode";
 const char kOtherBookmarksMigrated[] = "brave.other_bookmarks_migrated";
 const char kBraveShieldsSettingsVersion[] = "brave.shields_settings_version";
+const char kDefaultBrowserPromptEnabled[] =
+    "brave.default_browser_prompot_enabled";
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
 const char kBraveGCMChannelStatus[] = "brave.gcm.channel_status";
 #endif

--- a/common/pref_names.h
+++ b/common/pref_names.h
@@ -74,6 +74,7 @@ extern const char kOtherBookmarksMigrated[];
 extern const char kBraveShieldsSettingsVersion[];
 extern const char kBinanceAccessToken[];
 extern const char kBinanceRefreshToken[];
+extern const char kDefaultBrowserPromptEnabled[];
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
 extern const char kBraveGCMChannelStatus[];
 #endif

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -539,7 +539,7 @@ if (!is_android) {
       "//brave/app/brave_main_delegate_browsertest.cc",
       "//brave/app/brave_main_delegate_runtime_flags_browsertest.cc",
       "//brave/browser/brave_content_browser_client_browsertest.cc",
-      "//brave/browser/brave_profile_prefs_browsertest.cc",
+      "//brave/browser/brave_prefs_browsertest.cc",
       "//brave/browser/brave_resources_browsertest.cc",
       "//brave/browser/brave_scheme_load_browsertest.cc",
       "//brave/browser/brave_search/brave_search_browsertest.cc",


### PR DESCRIPTION
Default browser prompot is disabled if it's checked.

fix https://github.com/brave/brave-browser/issues/14469

<!-- Add brave-browser issue bellow that this PR will resolve -->
![image](https://user-images.githubusercontent.com/6786187/111151817-4fe60380-85d3-11eb-831f-d6b6aba1bb70.png)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=*BraveLocalStatePref*`

1. Launch with clean profile
2. Close welcome page and create NTP
3. Re-launch and check default prompt is visible
4. Re-launch more than 20 times and check prompt is not visible anymore (Previously, prompt was launched at 20th launch)
5. Create new profile and close all other profiles
6. Launch browser and check it uses new profile
7. Check prompt is not launched also for this new profile
