### PR TITLE
Set promotion status to active if promotion is available on server

### DIFF
--- a/components/brave_rewards/browser/test/rewards_promotion_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_promotion_browsertest.cc
@@ -245,4 +245,22 @@ IN_PROC_BROWSER_TEST_F(
   CheckPromotionStatus("Over");
 }
 
+IN_PROC_BROWSER_TEST_F(RewardsPromotionBrowserTest, PromotionNotQuiteOver) {
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_service_->FetchPromotions();
+  promotion_->WaitForPromotionInitialization();
+
+  removed_ = true;
+  rewards_service_->FetchPromotions();
+  promotion_->WaitForPromotionInitialization();
+
+  CheckPromotionStatus("Over");
+
+  removed_ = false;
+  rewards_service_->FetchPromotions();
+  promotion_->WaitForPromotionInitialization();
+
+  CheckPromotionStatus("Active");
+}
+
 }  // namespace rewards_browsertest

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion.cc
@@ -210,7 +210,10 @@ void Promotion::OnGetAllPromotions(
     if (it != promotions.end()) {
       const auto status = it->second->status;
       promotions.erase(item->id);
-      if (status != type::PromotionStatus::ACTIVE) {
+      // Skip any promotions that are in the database and have been processed
+      // in some way.
+      if (status != type::PromotionStatus::ACTIVE &&
+          status != type::PromotionStatus::OVER) {
         continue;
       }
     }
@@ -241,7 +244,7 @@ void Promotion::OnGetAllPromotions(
   // but are not available on the server anymore
   for (const auto& promotion : promotions) {
     if (promotion.second->status != type::PromotionStatus::ACTIVE) {
-      break;
+      continue;
     }
 
     bool found =


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14741

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

## Scenario: A promotion in "Over" status can be reactivated and claimed

- Given that an unattested promotion is in the "Over" state in the user's rewards database
- When the browser fetches promotions and the server returns the promotion as active
- Then the promotion will be marked as "Active" in the user's database and the user will be able to claim the promotion

### Possible test steps:

- Start the browser with a clean profile pointed to staging.
- Click the rewards icon to initialize rewards and download a UGP promotion.
- Close the browser.
- Open the rewards database in a SQLite database browser and view the contents of the "promotions" table. Find the promotion record corresponding to the UGP and set the status field to 5.
- Start the browser.
- Navigate to the rewards page.
  - This should trigger a refresh of available promotions.
- Verify that the UGP promotion can be claimed.