### PR TITLE
Forbid new empty cosmetic filters from being created via right click menu

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -96,12 +96,16 @@ export async function onSelectorReturned (response: any) {
     rule.selector = window.prompt('CSS selector:', `${response}`) || ''
   }
 
-  if (rule.selector && rule.selector.length > 0) {
-    chrome.tabs.insertCSS({
-      code: `${rule.selector} {display: none !important;}`,
-      cssOrigin: 'user'
-    })
-  }
+  if (rule.selector) {
+    const selector: string = rule.selector.trim()
 
-  await addSiteCosmeticFilter(rule.host, rule.selector)
+    if (selector.length > 0) {
+      chrome.tabs.insertCSS({
+        code: `${selector} {display: none !important;}`,
+        cssOrigin: 'user'
+      })
+
+      await addSiteCosmeticFilter(rule.host, selector)
+    }
+  }
 }

--- a/components/brave_shields/browser/ad_block_custom_filters_service.cc
+++ b/components/brave_shields/browser/ad_block_custom_filters_service.cc
@@ -69,6 +69,10 @@ bool AdBlockCustomFiltersService::MigrateLegacyCosmeticFilters(
     const std::vector<std::string>& hostSelectors = hostEntry.second;
 
     for (const auto& selector : hostSelectors) {
+      if (selector.empty()) {
+        continue;
+      }
+
       const std::string rule = '\n' + host + "##" + selector;
 
       filters_update += rule;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14763

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

These are mostly identical to the steps in https://github.com/brave/brave-core/pull/8156, but with additional care given to cases which may generate "empty" rules. Differences are highlighted in **bold**.

### Migration

Using a _previous_ browser version (1.22.x or earlier):
1. Visit brave://adblock in a new tab
2. Add some text of your choice to the "Custom filters" box
3. Visit a website of your choice
4. Right-click on a page element of your choice
5. Select "Brave > Block element via selector"
6. Confirm the block
7. Repeat steps 3-6 a few times to block a variety of items through the legacy system. Block multiple items on the same page at least once. Keep track of what is being blocked. **Be sure to close the prompt window, press cancel, or just press OK with an empty rule each at least once.**

Then, testing the same profile _after_ the version upgrade:
1. Visit brave://adblock in a new tab
2. Verify that any text previously added to the "Custom filters" box is still present
3. Verify that new lines have been added to the "Custom filters" box, including one corresponding to each item previously blocked using the right click menu, **and that no rules were generated that are empty after the `##`**
4. Revisit some of the websites and confirm that any previously blocked items are still hidden

### Adding new filters

Just on the new version:
1. Visit a website of your choice
2. Right-click on a page element of your choice
3. Select "Brave > Block element via selector"
4. Confirm the block
5. Verify that the blocked item is hidden, and remains hidden after a page refresh
6. Reopen or refresh brave://adblock and verify that a new line has been added corresponding to the newly blocked item
7. Repeat steps 1-6 at least one more time
8. **Repeat steps 1-6 for each of the following, and ensure that _no_ new lines are created in brave://adblock: closing the prompt window, pressing cancel on the prompt window, and pressing OK with an empty rule in the prompt window**