### PR TITLE
Use rewards enabled pref to track opt-in status

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -1230,31 +1230,16 @@ BraveRewardsShouldShowOnboardingFunction::Run() {
   return RespondNow(OneArgument(base::Value(should_show)));
 }
 
-BraveRewardsSaveOnboardingResultFunction::
-~BraveRewardsSaveOnboardingResultFunction() = default;
+BraveRewardsEnableRewardsFunction::~BraveRewardsEnableRewardsFunction() =
+    default;
 
-ExtensionFunction::ResponseAction
-BraveRewardsSaveOnboardingResultFunction::Run() {
-  using ::brave_rewards::OnboardingResult;
-
-  std::unique_ptr<brave_rewards::SaveOnboardingResult::Params> params(
-      brave_rewards::SaveOnboardingResult::Params::Create(*args_));
-  EXTENSION_FUNCTION_VALIDATE(params.get());
-
-  Profile* profile = Profile::FromBrowserContext(browser_context());
+ExtensionFunction::ResponseAction BraveRewardsEnableRewardsFunction::Run() {
+  auto* profile = Profile::FromBrowserContext(browser_context());
   auto* rewards_service = RewardsServiceFactory::GetForProfile(profile);
-  if (!rewards_service) {
+  if (!rewards_service)
     return RespondNow(Error("Rewards service is not initialized"));
-  }
 
-  if (params->result == "opted-in") {
-    rewards_service->SaveOnboardingResult(OnboardingResult::kOptedIn);
-  } else if (params->result == "dismissed") {
-    rewards_service->SaveOnboardingResult(OnboardingResult::kDismissed);
-  } else {
-    NOTREACHED();
-  }
-
+  rewards_service->EnableRewards();
   return RespondNow(NoArguments());
 }
 

--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -465,12 +465,12 @@ class BraveRewardsShouldShowOnboardingFunction : public ExtensionFunction {
   ResponseAction Run() override;
 };
 
-class BraveRewardsSaveOnboardingResultFunction : public ExtensionFunction {
+class BraveRewardsEnableRewardsFunction : public ExtensionFunction {
  public:
-  DECLARE_EXTENSION_FUNCTION("braveRewards.saveOnboardingResult", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("braveRewards.enableRewards", UNKNOWN)
 
  protected:
-  ~BraveRewardsSaveOnboardingResultFunction() override;
+  ~BraveRewardsEnableRewardsFunction() override;
 
   ResponseAction Run() override;
 };

--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -1954,21 +1954,12 @@ void RewardsDOMHandler::GetOnboardingStatus(const base::ListValue* args) {
 }
 
 void RewardsDOMHandler::SaveOnboardingResult(const base::ListValue* args) {
-  using brave_rewards::OnboardingResult;
-
   CHECK_EQ(1U, args->GetSize());
-  if (!rewards_service_) {
+  if (!rewards_service_)
     return;
-  }
 
-  const std::string result_type = args->GetList()[0].GetString();
-  if (result_type == "opted-in") {
-    rewards_service_->SaveOnboardingResult(OnboardingResult::kOptedIn);
-  } else if (result_type == "dismissed") {
-    rewards_service_->SaveOnboardingResult(OnboardingResult::kDismissed);
-  } else {
-    NOTREACHED();
-  }
+  if (args->GetList()[0].GetString() == "opted-in")
+    rewards_service_->EnableRewards();
 }
 
 }  // namespace

--- a/browser/ui/webui/brave_tip_ui.cc
+++ b/browser/ui/webui/brave_tip_ui.cc
@@ -324,21 +324,12 @@ void TipMessageHandler::GetOnboardingStatus(const base::ListValue* args) {
 }
 
 void TipMessageHandler::SaveOnboardingResult(const base::ListValue* args) {
-  using brave_rewards::OnboardingResult;
-
   CHECK_EQ(1U, args->GetSize());
-  if (!rewards_service_) {
+  if (!rewards_service_)
     return;
-  }
 
-  const std::string result_type = args->GetList()[0].GetString();
-  if (result_type == "opted-in") {
-    rewards_service_->SaveOnboardingResult(OnboardingResult::kOptedIn);
-  } else if (result_type == "dismissed") {
-    rewards_service_->SaveOnboardingResult(OnboardingResult::kDismissed);
-  } else {
-    NOTREACHED();
-  }
+  if (args->GetList()[0].GetString() == "opted-in")
+    rewards_service_->EnableRewards();
 }
 
 void TipMessageHandler::OnTip(const base::ListValue* args) {

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -1222,15 +1222,10 @@
         ]
       },
       {
-        "name": "saveOnboardingResult",
+        "name": "enableRewards",
         "type": "function",
-        "description": "Saves the rewards user onboarding result.",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "result"
-          }
-        ]
+        "description": "Enables rewards for the current profile.",
+        "parameters": []
       },
       {
         "name": "getPrefs",

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -91,7 +91,7 @@ class MockRewardsService : public RewardsService {
                void(brave_rewards::GetAutoContributeEnabledCallback));
   MOCK_METHOD1(SetAutoContributeEnabled, void(bool));
   MOCK_CONST_METHOD0(ShouldShowOnboarding, bool());
-  MOCK_METHOD1(SaveOnboardingResult, void(brave_rewards::OnboardingResult));
+  MOCK_METHOD0(EnableRewards, void());
   MOCK_METHOD2(SetTimer, void(uint64_t, uint32_t*));
   MOCK_METHOD4(GetPublisherActivityFromUrl,
                void(uint64_t,

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -389,7 +389,7 @@ class NewTabPage extends React.Component<Props, State> {
   }
 
   startRewards = () => {
-    chrome.braveRewards.saveOnboardingResult('opted-in')
+    chrome.braveRewards.enableRewards()
   }
 
   dismissBrandedWallpaperNotification = (isUserAction: boolean) => {

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -61,7 +61,6 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
 #if defined(OS_ANDROID)
   registry->RegisterBooleanPref(prefs::kUseRewardsStagingServer, false);
 #endif
-  registry->RegisterTimePref(prefs::kOnboarded, base::Time());
   registry->RegisterUint64Pref(prefs::kPromotionLastFetchStamp, 0ull);
   registry->RegisterBooleanPref(prefs::kPromotionCorruptedMigrated, false);
   registry->RegisterBooleanPref(prefs::kAnonTransferChecked, false);

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -132,11 +132,6 @@ using GetBraveWalletCallback =
 
 using GetWalletPassphraseCallback = base::Callback<void(const std::string&)>;
 
-enum class OnboardingResult {
-  kOptedIn,
-  kDismissed
-};
-
 class RewardsService : public KeyedService {
  public:
   RewardsService();
@@ -203,7 +198,12 @@ class RewardsService : public KeyedService {
       GetAutoContributeEnabledCallback callback) = 0;
   virtual void SetAutoContributeEnabled(bool enabled) = 0;
   virtual bool ShouldShowOnboarding() const = 0;
-  virtual void SaveOnboardingResult(OnboardingResult result) = 0;
+
+  // Enables Rewards for the current profile. Enabling Rewards for the first
+  // time will turn on both Ads and auto-contribute. Subsequent calls will only
+  // turn on Ads.
+  virtual void EnableRewards() = 0;
+
   virtual void GetBalanceReport(
       const uint32_t month,
       const uint32_t year,

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -1648,7 +1648,7 @@ void RewardsServiceImpl::SetAutoContributeEnabled(bool enabled) {
 }
 
 bool RewardsServiceImpl::ShouldShowOnboarding() const {
-  const bool legacy_enabled = profile_->GetPrefs()->GetBoolean(prefs::kEnabled);
+  const bool enabled = profile_->GetPrefs()->GetBoolean(prefs::kEnabled);
 
   bool ads_enabled = false;
   bool ads_supported = true;
@@ -1658,24 +1658,39 @@ bool RewardsServiceImpl::ShouldShowOnboarding() const {
     ads_supported = ads_service->IsSupportedLocale();
   }
 
-  return !legacy_enabled && !ads_enabled && ads_supported;
+  return !enabled && !ads_enabled && ads_supported;
 }
 
-void RewardsServiceImpl::SaveOnboardingResult(OnboardingResult result) {
-  PrefService* prefs = profile_->GetPrefs();
-  prefs->SetTime(prefs::kOnboarded, base::Time::Now());
+void RewardsServiceImpl::EnableRewards() {
+  StartProcess(base::BindOnce(
+      &RewardsServiceImpl::OnStartProcessForEnableRewards, AsWeakPtr()));
+}
 
-  if (result != OnboardingResult::kOptedIn) {
-    return;
+void RewardsServiceImpl::OnStartProcessForEnableRewards() {
+  auto* prefs = profile_->GetPrefs();
+  if (!prefs->GetBoolean(prefs::kEnabled)) {
+    // Store the user's opt-in in prefs. The enabled pref was discontinued after
+    // 1.18 when the Rewards toggle was removed from the UI. However, this
+    // created problems in scenarios where we need to know whether the user
+    // has previously consented to background Rewards functionality.
+    prefs->SetBoolean(prefs::kEnabled, true);
+
+    // If Rewards are not currently enabled, fetch the user's balance before
+    // turning on AC.
+    FetchBalance(base::BindOnce(
+        &RewardsServiceImpl::OnFetchBalanceForEnableRewards, AsWeakPtr()));
   }
 
-  StartProcess(base::BindOnce(&RewardsServiceImpl::OnStartProcessForOnboarding,
-                              AsWeakPtr()));
+  SetAdsEnabled(true);
 }
 
-void RewardsServiceImpl::OnStartProcessForOnboarding() {
-  SetAutoContributeEnabled(true);
-  SetAdsEnabled(true);
+void RewardsServiceImpl::OnFetchBalanceForEnableRewards(
+    ledger::type::Result result,
+    ledger::type::BalancePtr balance) {
+  // Do not enable AC on Rewards opt-in if the user has a non-zero balance, as
+  // this could result in unintentional BAT transfers.
+  if (balance && balance->total == 0)
+    SetAutoContributeEnabled(true);
 }
 
 void RewardsServiceImpl::OnAdsEnabled(bool ads_enabled) {
@@ -3373,9 +3388,9 @@ void RewardsServiceImpl::SetAdsEnabled(const bool is_enabled) {
 }
 
 bool RewardsServiceImpl::IsRewardsEnabled() const {
-  if (profile_->GetPrefs()->GetBoolean(prefs::kEnabled))
-    return true;
-
+  // This method will return true if either Ads or AC are enabled. We do not
+  // currently check the value of the "enabled" pref because users do not have
+  // a way to set that pref to false.
   if (profile_->GetPrefs()->GetBoolean(prefs::kAutoContributeEnabled))
     return true;
 

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -313,7 +313,7 @@ class RewardsServiceImpl : public RewardsService,
 
   bool ShouldShowOnboarding() const override;
 
-  void SaveOnboardingResult(OnboardingResult result) override;
+  void EnableRewards() override;
 
   void GetMonthlyReport(
       const uint32_t month,
@@ -528,7 +528,10 @@ class RewardsServiceImpl : public RewardsService,
 
   void OnWalletCreatedForSetAdsEnabled(const ledger::type::Result result);
 
-  void OnStartProcessForOnboarding();
+  void OnStartProcessForEnableRewards();
+
+  void OnFetchBalanceForEnableRewards(ledger::type::Result result,
+                                      ledger::type::BalancePtr balance);
 
   // ledger::LedgerClient
   void OnReconcileComplete(

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_util.cc
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_util.cc
@@ -115,8 +115,7 @@ void CreateWallet(brave_rewards::RewardsServiceImpl* rewards_service) {
 
 void SetOnboardingBypassed(Browser* browser, bool bypassed) {
   DCHECK(browser);
-  // Rewards onboarding will be skipped if the legacy "enabled" pref
-  // is set to true.
+  // Rewards onboarding will be skipped if the rewards enabled flag is set
   PrefService* prefs = browser->profile()->GetPrefs();
   prefs->SetBoolean(brave_rewards::prefs::kEnabled, bypassed);
 }

--- a/components/brave_rewards/browser/test/rewards_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_browsertest.cc
@@ -555,4 +555,25 @@ IN_PROC_BROWSER_TEST_F(RewardsBrowserTest, BAPReporting) {
   EXPECT_TRUE(prefs->GetBoolean(brave_rewards::prefs::kBAPReported));
 }
 
+IN_PROC_BROWSER_TEST_F(RewardsBrowserTest, EnableRewardsWithBalance) {
+  // Make sure rewards, ads, and AC prefs are off
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_rewards::prefs::kEnabled, false);
+  prefs->SetBoolean(brave_rewards::prefs::kAutoContributeEnabled, false);
+
+  // Load a balance into the user's wallet
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_browsertest_util::CreateWallet(rewards_service_);
+  rewards_service_->FetchPromotions();
+  promotion_->WaitForPromotionInitialization();
+  promotion_->ClaimPromotionViaCode();
+
+  rewards_service_->EnableRewards();
+  base::RunLoop().RunUntilIdle();
+
+  // Ensure that AC is not enabled
+  EXPECT_TRUE(prefs->GetBoolean(brave_rewards::prefs::kEnabled));
+  EXPECT_FALSE(prefs->GetBoolean(brave_rewards::prefs::kAutoContributeEnabled));
+}
+
 }  // namespace rewards_browsertest

--- a/components/brave_rewards/browser/test/rewards_state_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_state_browsertest.cc
@@ -66,10 +66,6 @@ class RewardsStateBrowserTest : public InProcessBrowserTest {
             &RewardsStateBrowserTest::GetTestResponse,
             base::Unretained(this)));
     rewards_service_->SetLedgerEnvForTesting();
-
-    // Bypass onboarding UX by default
-    rewards_service_->SaveOnboardingResult(
-        brave_rewards::OnboardingResult::kDismissed);
   }
 
   void GetTestResponse(

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -28,7 +28,6 @@ const char kUpholdAnonAddress[] =
     "brave.rewards.uphold_anon_address";
 const char kBadgeText[] = "brave.rewards.badge_text";
 const char kUseRewardsStagingServer[] = "brave.rewards.use_staging_server";
-const char kOnboarded[] = "brave.rewards.onboarded";
 const char kPromotionLastFetchStamp[] =
     "brave.rewards.promotion_last_fetch_stamp";
 const char kPromotionCorruptedMigrated[] =

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -21,7 +21,6 @@ extern const char kNotificationStartupDelay[];
 extern const char kExternalWallets[];  // DEPRECATED
 extern const char kBadgeText[];
 extern const char kUseRewardsStagingServer[];
-extern const char kOnboarded[];
 
 // Defined in native-ledger
 extern const char kServerPublisherListStamp[];

--- a/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
+++ b/components/brave_rewards/resources/extension/brave_rewards/background/reducers/rewards_panel_reducer.ts
@@ -256,7 +256,9 @@ export const rewardsPanelReducer: Reducer<RewardsExtension.State | undefined> = 
     }
     case types.SAVE_ONBOARDING_RESULT: {
       state = { ...state, showOnboarding: false }
-      chrome.braveRewards.saveOnboardingResult(payload.result)
+      if (payload.result === 'opted-in') {
+        chrome.braveRewards.enableRewards()
+      }
       onboardingCompletedStore.save()
       break
     }

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -155,7 +155,8 @@ declare namespace chrome.braveRewards {
   }
   const isInitialized: (callback: (initialized: boolean) => void) => {}
   const shouldShowOnboarding: (callback: (showOnboarding: boolean) => void) => {}
-  const saveOnboardingResult: (result: 'opted-in' | 'dismissed') => {}
+
+  function enableRewards (): void
 
   interface RewardsPrefs {
     adsEnabled: boolean


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14414
Resolves https://github.com/brave/brave-browser/issues/14735

- Removes the "onboarded" pref, which is not currently used.
- Removes the `SaveOnboardingResult` method from `RewardsService` and supporting data structures.
- Adds a `EnableRewards` to `RewardsService`, which will turn on Ads and potentially AC.
  - AC will not be enabled if rewards is already enabled.
  - AC will not be enabled if the user has a non-zero balance.
  - Both of these conditions are intended to prevent accidental auto-contribute.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

*TODO*