### PR TITLE
Only specify net::HostResolverSource::DNS when DoH is enabled

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -23,6 +23,8 @@
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/common/features.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/net/secure_dns_config.h"
+#include "chrome/browser/net/system_network_context_manager.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/render_frame_host.h"
@@ -144,10 +146,15 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
     network::mojom::ResolveHostParametersPtr optional_parameters =
         network::mojom::ResolveHostParameters::New();
     optional_parameters->include_canonical_name = true;
-    // Explicitly specify source to avoid using `HostResolverProc`
-    // which will be handled by system resolver
+
+    SecureDnsConfig secure_dns_config =
+        SystemNetworkContextManager::GetStubResolverConfigReader()
+            ->GetSecureDnsConfiguration(false);
+    // Explicitly specify source when DNS over HTTPS is enabled to avoid
+    // using `HostResolverProc` which will be handled by system resolver
     // See https://crbug.com/872665
-    optional_parameters->source = net::HostResolverSource::DNS;
+    if (secure_dns_config.mode() == net::SecureDnsMode::kSecure)
+      optional_parameters->source = net::HostResolverSource::DNS;
 
     network::mojom::NetworkContext* network_context =
         content::BrowserContext::GetDefaultStoragePartition(context)


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14755

When DoH setting is automatic or off, it should be using system resolver other than forcing it to use async resolver 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### No DoH leak
1. Launch Brave and go to `brave://settings/security`
2. Change DOH setting to secure not automatic by <img width="687" alt="Screen Shot 2021-01-27 at 16 33 44" src="https://user-images.githubusercontent.com/11330831/106072698-7c929a00-60bd-11eb-9c86-e8fedd9b66e9.png">
3. Open wireshark and use `dns filter` and start recording
4. Open a tab and navigate to `https://tools.ietf.org/`
5. There shouldn't be any UDP dns query of `tools.ietf.org` in wireshark

### CNAME adblock
test bellowed scenarios with 
* DoH off <img width="721" alt="Screen Shot 2021-03-17 at 14 25 37" src="https://user-images.githubusercontent.com/11330831/111540719-ba5e8700-872c-11eb-98cc-da7fe7a59d01.png">

*  DoH automatic <img width="697" alt="Screen Shot 2021-03-17 at 14 25 45" src="https://user-images.githubusercontent.com/11330831/111540779-cea28400-872c-11eb-9afb-e77ba156214d.png">
* DoH on <img width="687" alt="Screen Shot 2021-01-27 at 16 33 44" src="https://user-images.githubusercontent.com/11330831/106072698-7c929a00-60bd-11eb-9c86-e8fedd9b66e9.png">


1. visit https://pushbullet.com (there should be `1` request being blocked
2. add the following custom filer via `brave://adblock`

```
||stripecdn.map.fastly.net^$important
||d2rhbqunra2aep.cloudfront.net^$important
```

3. once the above custom filter has been applied, visit https://pushbullet.com (there should be `2` requests blocked)