### PR TITLE
Update adblock-rust with CSP rule support

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -12,6 +12,8 @@ source_set("net") {
   check_includes = false
   configs += [ "//brave/build/geolocation" ]
   sources = [
+    "brave_ad_block_csp_network_delegate_helper.cc",
+    "brave_ad_block_csp_network_delegate_helper.h",
     "brave_ad_block_tp_network_delegate_helper.cc",
     "brave_ad_block_tp_network_delegate_helper.h",
     "brave_block_safebrowsing_urls.cc",

--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -53,6 +53,7 @@ source_set("net") {
     "//brave/components/brave_component_updater/browser",
     "//brave/components/brave_referrals/buildflags",
     "//brave/components/brave_shields/browser",
+    "//brave/components/brave_shields/common",
     "//brave/components/brave_webtorrent/browser/buildflags",
     "//brave/components/ipfs/buildflags",
     "//brave/extensions:common",

--- a/browser/net/brave_ad_block_csp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_csp_network_delegate_helper.cc
@@ -1,0 +1,102 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/net/brave_ad_block_csp_network_delegate_helper.h"
+
+#include <string>
+
+#include "brave/browser/brave_browser_process_impl.h"
+#include "brave/browser/net/url_context.h"
+#include "brave/components/brave_shields/browser/ad_block_service.h"
+#include "brave/components/brave_shields/browser/ad_block_service_helper.h"
+#include "net/http/http_response_headers.h"
+#include "url/gurl.h"
+
+namespace brave {
+
+base::Optional<std::string> GetCspDirectivesOnTaskRunner(
+    std::shared_ptr<BraveRequestInfo> ctx,
+    base::Optional<std::string> original_csp) {
+  std::string source_host;
+  if (ctx->initiator_url.is_valid()) {
+    source_host = ctx->initiator_url.host();
+  } else if (ctx->request_url.is_valid()) {
+    // Top-level document requests do not have a valid initiator URL, so we use
+    // the request URL as the initiator.
+    source_host = ctx->request_url.host();
+  } else {
+    return base::nullopt;
+  }
+
+  base::Optional<std::string> csp_directives =
+      g_brave_browser_process->ad_block_service()->GetCspDirectives(
+          ctx->request_url, ctx->resource_type, source_host);
+
+  brave_shields::MergeCspDirectiveInto(original_csp, &csp_directives);
+  return csp_directives;
+}
+
+void OnReceiveCspDirectives(
+    const ResponseCallback& next_callback,
+    std::shared_ptr<BraveRequestInfo> ctx,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    base::Optional<std::string> csp_directives) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  if (csp_directives) {
+    (*override_response_headers)
+        ->AddHeader("Content-Security-Policy", *csp_directives);
+  }
+
+  next_callback.Run();
+}
+
+int OnHeadersReceived_AdBlockCspWork(
+    const net::HttpResponseHeaders* response_headers,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    GURL* allowed_unsafe_redirect_url,
+    const brave::ResponseCallback& next_callback,
+    std::shared_ptr<brave::BraveRequestInfo> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  if (!response_headers) {
+    return net::OK;
+  }
+
+  if (ctx->resource_type == blink::mojom::ResourceType::kMainFrame ||
+      ctx->resource_type == blink::mojom::ResourceType::kSubFrame) {
+    // If the override_response_headers have already been populated, we should
+    // use those directly.  Otherwise, we populate them from the original
+    // headers.
+    if (!*override_response_headers) {
+      *override_response_headers =
+          new net::HttpResponseHeaders(response_headers->raw_headers());
+    }
+
+    scoped_refptr<base::SequencedTaskRunner> task_runner =
+        g_brave_browser_process->ad_block_service()->GetTaskRunner();
+
+    std::string original_csp_string;
+    base::Optional<std::string> original_csp = base::nullopt;
+    if ((*override_response_headers)
+            ->GetNormalizedHeader("Content-Security-Policy",
+                                  &original_csp_string)) {
+      original_csp = base::Optional<std::string>(original_csp_string);
+    }
+
+    (*override_response_headers)->RemoveHeader("Content-Security-Policy");
+
+    task_runner->PostTaskAndReplyWithResult(
+        FROM_HERE,
+        base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx, original_csp),
+        base::BindOnce(&OnReceiveCspDirectives, next_callback, ctx,
+                       override_response_headers));
+    return net::ERR_IO_PENDING;
+  }
+
+  return net::OK;
+}
+
+}  // namespace brave

--- a/browser/net/brave_ad_block_csp_network_delegate_helper.h
+++ b/browser/net/brave_ad_block_csp_network_delegate_helper.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_NET_BRAVE_AD_BLOCK_CSP_NETWORK_DELEGATE_HELPER_H_
+#define BRAVE_BROWSER_NET_BRAVE_AD_BLOCK_CSP_NETWORK_DELEGATE_HELPER_H_
+
+#include <memory>
+
+#include "base/memory/scoped_refptr.h"
+#include "brave/browser/net/url_context.h"
+
+namespace net {
+class HttpResponseHeaders;
+}  // namespace net
+
+class GURL;
+
+namespace brave {
+
+int OnHeadersReceived_AdBlockCspWork(
+    const net::HttpResponseHeaders* original_response_headers,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    GURL* allowed_unsafe_redirect_url,
+    const brave::ResponseCallback& next_callback,
+    std::shared_ptr<brave::BraveRequestInfo> ctx);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_NET_BRAVE_AD_BLOCK_CSP_NETWORK_DELEGATE_HELPER_H_

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -18,6 +18,7 @@
 #include "brave/common/network_constants.h"
 #include "brave/common/url_constants.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
+#include "brave/components/brave_shields/browser/ad_block_service_helper.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
@@ -253,6 +254,83 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
   OnBeforeURLRequestAdBlockTP(next_callback, ctx);
 
   return net::ERR_IO_PENDING;
+}
+
+base::Optional<std::string> GetCspDirectivesOnTaskRunner(
+    std::shared_ptr<BraveRequestInfo> ctx,
+    base::Optional<std::string> original_csp) {
+  std::string source_host;
+  if (ctx->initiator_url.is_valid()) {
+    source_host = ctx->initiator_url.host();
+  } else if (ctx->request_url.is_valid()) {
+    // Top-level document requests do not have a valid initiator URL, so we use
+    // the request URL as the initiator.
+    source_host = ctx->request_url.host();
+  } else {
+    return base::nullopt;
+  }
+
+  base::Optional<std::string> csp_directives =
+      g_brave_browser_process->ad_block_service()->GetCspDirectives(
+          ctx->request_url, ctx->resource_type, source_host);
+
+  brave_shields::MergeCspDirectiveInto(original_csp, &csp_directives);
+  return csp_directives;
+}
+
+void OnReceiveCspDirectives(
+    const ResponseCallback& next_callback,
+    std::shared_ptr<BraveRequestInfo> ctx,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    base::Optional<std::string> csp_directives) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  if (csp_directives) {
+    (*override_response_headers)
+        ->AddHeader("Content-Security-Policy", *csp_directives);
+  }
+
+  next_callback.Run();
+}
+
+int OnHeadersReceived_AdBlockCspWork(
+    const net::HttpResponseHeaders* response_headers,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    GURL* allowed_unsafe_redirect_url,
+    const brave::ResponseCallback& next_callback,
+    std::shared_ptr<brave::BraveRequestInfo> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  if (!response_headers) {
+    return net::OK;
+  }
+
+  if (ctx->resource_type == blink::mojom::ResourceType::kMainFrame ||
+      ctx->resource_type == blink::mojom::ResourceType::kSubFrame) {
+
+    scoped_refptr<base::SequencedTaskRunner> task_runner =
+        g_brave_browser_process->ad_block_service()->GetTaskRunner();
+
+    std::string original_csp_string;
+    base::Optional<std::string> original_csp = base::nullopt;
+    if (response_headers->GetNormalizedHeader("Content-Security-Policy",
+                                              &original_csp_string)) {
+      original_csp = base::Optional<std::string>(original_csp_string);
+    }
+
+    *override_response_headers =
+        new net::HttpResponseHeaders(response_headers->raw_headers());
+    (*override_response_headers)->RemoveHeader("Content-Security-Policy");
+
+    task_runner->PostTaskAndReplyWithResult(
+        FROM_HERE,
+        base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx, original_csp),
+        base::BindOnce(&OnReceiveCspDirectives, next_callback, ctx,
+                       override_response_headers));
+    return net::ERR_IO_PENDING;
+  }
+
+  return net::OK;
 }
 
 }  // namespace brave

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -18,7 +18,6 @@
 #include "brave/common/network_constants.h"
 #include "brave/common/url_constants.h"
 #include "brave/components/brave_shields/browser/ad_block_service.h"
-#include "brave/components/brave_shields/browser/ad_block_service_helper.h"
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
@@ -254,89 +253,6 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
   OnBeforeURLRequestAdBlockTP(next_callback, ctx);
 
   return net::ERR_IO_PENDING;
-}
-
-base::Optional<std::string> GetCspDirectivesOnTaskRunner(
-    std::shared_ptr<BraveRequestInfo> ctx,
-    base::Optional<std::string> original_csp) {
-  std::string source_host;
-  if (ctx->initiator_url.is_valid()) {
-    source_host = ctx->initiator_url.host();
-  } else if (ctx->request_url.is_valid()) {
-    // Top-level document requests do not have a valid initiator URL, so we use
-    // the request URL as the initiator.
-    source_host = ctx->request_url.host();
-  } else {
-    return base::nullopt;
-  }
-
-  base::Optional<std::string> csp_directives =
-      g_brave_browser_process->ad_block_service()->GetCspDirectives(
-          ctx->request_url, ctx->resource_type, source_host);
-
-  brave_shields::MergeCspDirectiveInto(original_csp, &csp_directives);
-  return csp_directives;
-}
-
-void OnReceiveCspDirectives(
-    const ResponseCallback& next_callback,
-    std::shared_ptr<BraveRequestInfo> ctx,
-    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
-    base::Optional<std::string> csp_directives) {
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-
-  if (csp_directives) {
-    (*override_response_headers)
-        ->AddHeader("Content-Security-Policy", *csp_directives);
-  }
-
-  next_callback.Run();
-}
-
-int OnHeadersReceived_AdBlockCspWork(
-    const net::HttpResponseHeaders* response_headers,
-    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
-    GURL* allowed_unsafe_redirect_url,
-    const brave::ResponseCallback& next_callback,
-    std::shared_ptr<brave::BraveRequestInfo> ctx) {
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-
-  if (!response_headers) {
-    return net::OK;
-  }
-
-  if (ctx->resource_type == blink::mojom::ResourceType::kMainFrame ||
-      ctx->resource_type == blink::mojom::ResourceType::kSubFrame) {
-    // If the override_response_headers have already been populated, we should
-    // use those directly.  Otherwise, we populate them from the original
-    // headers.
-    if (!*override_response_headers) {
-      *override_response_headers =
-          new net::HttpResponseHeaders(response_headers->raw_headers());
-    }
-
-    scoped_refptr<base::SequencedTaskRunner> task_runner =
-        g_brave_browser_process->ad_block_service()->GetTaskRunner();
-
-    std::string original_csp_string;
-    base::Optional<std::string> original_csp = base::nullopt;
-    if ((*override_response_headers)
-            ->GetNormalizedHeader("Content-Security-Policy",
-                                  &original_csp_string)) {
-      original_csp = base::Optional<std::string>(original_csp_string);
-    }
-
-    (*override_response_headers)->RemoveHeader("Content-Security-Policy");
-
-    task_runner->PostTaskAndReplyWithResult(
-        FROM_HERE,
-        base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx, original_csp),
-        base::BindOnce(&OnReceiveCspDirectives, next_callback, ctx,
-                       override_response_headers));
-    return net::ERR_IO_PENDING;
-  }
-
-  return net::OK;
 }
 
 }  // namespace brave

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.h
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.h
@@ -16,6 +16,13 @@ int OnBeforeURLRequest_AdBlockTPPreWork(
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 
+int OnHeadersReceived_AdBlockCspWork(
+    const net::HttpResponseHeaders* original_response_headers,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    GURL* allowed_unsafe_redirect_url,
+    const brave::ResponseCallback& next_callback,
+    std::shared_ptr<brave::BraveRequestInfo> ctx);
+
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_NET_BRAVE_AD_BLOCK_TP_NETWORK_DELEGATE_HELPER_H_

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.h
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.h
@@ -16,13 +16,6 @@ int OnBeforeURLRequest_AdBlockTPPreWork(
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx);
 
-int OnHeadersReceived_AdBlockCspWork(
-    const net::HttpResponseHeaders* original_response_headers,
-    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
-    GURL* allowed_unsafe_redirect_url,
-    const brave::ResponseCallback& next_callback,
-    std::shared_ptr<brave::BraveRequestInfo> ctx);
-
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_NET_BRAVE_AD_BLOCK_TP_NETWORK_DELEGATE_HELPER_H_

--- a/browser/net/brave_request_handler.cc
+++ b/browser/net/brave_request_handler.cc
@@ -122,6 +122,10 @@ void BraveRequestHandler::SetupCallbacks() {
       base::Bind(webtorrent::OnHeadersReceived_TorrentRedirectWork);
   headers_received_callbacks_.push_back(headers_received_callback);
 #endif
+
+  brave::OnHeadersReceivedCallback headers_received_callback2 =
+      base::Bind(brave::OnHeadersReceived_AdBlockCspWork);
+  headers_received_callbacks_.push_back(headers_received_callback2);
 }
 
 void BraveRequestHandler::InitPrefChangeRegistrar() {

--- a/browser/net/brave_request_handler.cc
+++ b/browser/net/brave_request_handler.cc
@@ -11,6 +11,7 @@
 #include "base/feature_list.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/task/post_task.h"
+#include "brave/browser/net/brave_ad_block_csp_network_delegate_helper.h"
 #include "brave/browser/net/brave_ad_block_tp_network_delegate_helper.h"
 #include "brave/browser/net/brave_common_static_redirect_network_delegate_helper.h"
 #include "brave/browser/net/brave_httpse_network_delegate_helper.h"

--- a/browser/net/brave_request_handler.cc
+++ b/browser/net/brave_request_handler.cc
@@ -22,6 +22,7 @@
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_referrals/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
+#include "brave/components/brave_shields/common/features.h"
 #include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "chrome/browser/browser_process.h"
@@ -124,9 +125,12 @@ void BraveRequestHandler::SetupCallbacks() {
   headers_received_callbacks_.push_back(headers_received_callback);
 #endif
 
-  brave::OnHeadersReceivedCallback headers_received_callback2 =
-      base::Bind(brave::OnHeadersReceived_AdBlockCspWork);
-  headers_received_callbacks_.push_back(headers_received_callback2);
+  if (base::FeatureList::IsEnabled(
+          ::brave_shields::features::kBraveAdblockCspRules)) {
+    brave::OnHeadersReceivedCallback headers_received_callback2 =
+        base::Bind(brave::OnHeadersReceived_AdBlockCspWork);
+    headers_received_callbacks_.push_back(headers_received_callback2);
+  }
 }
 
 void BraveRequestHandler::InitPrefChangeRegistrar() {

--- a/build/rust/Cargo.lock
+++ b/build/rust/Cargo.lock
@@ -31,8 +31,9 @@ dependencies = [
 
 [[package]]
 name = "adblock"
-version = "0.3.5"
-source = "git+https://github.com/brave/adblock-rust?rev=732994bf57f4a5c7f3a2a7b873a97571737def42#732994bf57f4a5c7f3a2a7b873a97571737def42"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84ccc600a2619fbba5aef0f59b45fa8959ff2a9991e104bab96e55c327197df"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
@@ -54,7 +55,7 @@ dependencies = [
 name = "adblock-ffi"
 version = "0.1.0"
 dependencies = [
- "adblock 0.3.5",
+ "adblock 0.3.10",
  "libc",
  "serde_json",
 ]

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -26,6 +26,7 @@
 
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockCosmeticFilteringNative;
+using brave_shields::features::kBraveAdblockCspRules;
 using brave_shields::features::kBraveDomainBlock;
 using brave_shields::features::kBraveExtensionNetworkBlocking;
 using ntp_background_images::features::kBraveNTPBrandedWallpaper;
@@ -133,6 +134,10 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      flag_descriptions::kBraveAdblockCosmeticFilteringNativeDescription,   \
      kOsMac | kOsWin | kOsLinux,                                           \
      FEATURE_VALUE_TYPE(kBraveAdblockCosmeticFilteringNative)},            \
+    {"brave-adblock-csp-rules",                                            \
+     flag_descriptions::kBraveAdblockCspRulesName,                         \
+     flag_descriptions::kBraveAdblockCspRulesDescription, kOsAll,          \
+     FEATURE_VALUE_TYPE(kBraveAdblockCspRules)},                           \
     {"brave-domain-block",                                                 \
      flag_descriptions::kBraveDomainBlockName,                             \
      flag_descriptions::kBraveDomainBlockDescription, kOsAll,              \

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -28,6 +28,10 @@ const char kBraveAdblockCosmeticFilteringNativeName[] =
     "Use native implementation for cosmetic filtering";
 const char kBraveAdblockCosmeticFilteringNativeDescription[] =
     "Uses native implementation for cosmetic filtering instead of extension";
+const char kBraveAdblockCspRulesName[] = "Enable support for CSP rules";
+const char kBraveAdblockCspRulesDescription[] =
+    "Applies additional CSP rules to pages for which a $csp rule has been "
+    "loaded from a filter list";
 const char kBraveDomainBlockName[] = "Enable domain blocking";
 const char kBraveDomainBlockDescription[] =
     "Enable support for blocking domains with an interstitial page";

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -19,6 +19,8 @@ extern const char kBraveAdblockCosmeticFilteringName[];
 extern const char kBraveAdblockCosmeticFilteringNativeName[];
 extern const char kBraveAdblockCosmeticFilteringDescription[];
 extern const char kBraveAdblockCosmeticFilteringNativeDescription[];
+extern const char kBraveAdblockCspRulesDescription[];
+extern const char kBraveAdblockCspRulesName[];
 extern const char kBraveDomainBlockName[];
 extern const char kBraveDomainBlockDescription[];
 extern const char kBraveExtensionNetworkBlockingName[];

--- a/components/adblock_rust_ffi/Cargo.lock
+++ b/components/adblock_rust_ffi/Cargo.lock
@@ -2,8 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adblock"
-version = "0.3.5"
-source = "git+https://github.com/brave/adblock-rust?rev=732994bf57f4a5c7f3a2a7b873a97571737def42#732994bf57f4a5c7f3a2a7b873a97571737def42"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84ccc600a2619fbba5aef0f59b45fa8959ff2a9991e104bab96e55c327197df"
 dependencies = [
  "base64",
  "bitflags",

--- a/components/adblock_rust_ffi/Cargo.toml
+++ b/components/adblock_rust_ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock = { version = "~0.3.5", git = "https://github.com/brave/adblock-rust", rev = "732994bf57f4a5c7f3a2a7b873a97571737def42", default-features = false, features = ["full-regex-handling", "object-pooling"] }
+adblock = { version = "~0.3.10", default-features = false, features = ["full-regex-handling", "object-pooling"] }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/components/adblock_rust_ffi/src/lib.h
+++ b/components/adblock_rust_ffi/src/lib.h
@@ -51,6 +51,17 @@ void engine_match(struct C_Engine *engine,
                   char **redirect);
 
 /**
+ * Returns any CSP directives that should be added to a subdocument or document request's response
+ * headers.
+ */
+char *engine_get_csp_directives(struct C_Engine *engine,
+                                const char *url,
+                                const char *host,
+                                const char *tab_host,
+                                bool third_party,
+                                const char *resource_type);
+
+/**
  * Adds a tag to the engine for consideration
  */
 void engine_add_tag(struct C_Engine *engine, const char *tag);

--- a/components/adblock_rust_ffi/src/lib.rs
+++ b/components/adblock_rust_ffi/src/lib.rs
@@ -98,6 +98,38 @@ pub unsafe extern "C" fn engine_match(
     };
 }
 
+/// Returns any CSP directives that should be added to a subdocument or document request's response
+/// headers.
+#[no_mangle]
+pub unsafe extern "C" fn engine_get_csp_directives(
+    engine: *mut Engine,
+    url: *const c_char,
+    host: *const c_char,
+    tab_host: *const c_char,
+    third_party: bool,
+    resource_type: *const c_char,
+) -> *mut c_char {
+    let url = CStr::from_ptr(url).to_str().unwrap();
+    let host = CStr::from_ptr(host).to_str().unwrap();
+    let tab_host = CStr::from_ptr(tab_host).to_str().unwrap();
+    let resource_type = CStr::from_ptr(resource_type).to_str().unwrap();
+    assert!(!engine.is_null());
+    let engine = Box::leak(Box::from_raw(engine));
+    if let Some(directive) = engine.get_csp_directives(url, host, tab_host, resource_type, Some(third_party)) {
+        let ptr = CString::new(directive)
+            .expect("Error: CString::new()")
+            .into_raw();
+        std::mem::forget(ptr);
+        ptr
+    } else {
+        let ptr = CString::new("")
+            .expect("Error: CString::new()")
+            .into_raw();
+        std::mem::forget(ptr);
+        ptr
+    }
+}
+
 /// Adds a tag to the engine for consideration
 #[no_mangle]
 pub unsafe extern "C" fn engine_add_tag(engine: *mut Engine, tag: *const c_char) {

--- a/components/adblock_rust_ffi/src/wrapper.cc
+++ b/components/adblock_rust_ffi/src/wrapper.cc
@@ -65,6 +65,20 @@ void Engine::matches(const std::string& url,
   }
 }
 
+std::string Engine::getCspDirectives(const std::string& url,
+                                     const std::string& host,
+                                     const std::string& tab_host,
+                                     bool is_third_party,
+                                     const std::string& resource_type) {
+  char* csp_raw = engine_get_csp_directives(raw, url.c_str(), host.c_str(),
+                                            tab_host.c_str(), is_third_party,
+                                            resource_type.c_str());
+  const std::string csp = std::string(csp_raw);
+
+  c_char_buffer_destroy(csp_raw);
+  return csp;
+}
+
 bool Engine::deserialize(const char* data, size_t data_size) {
   return engine_deserialize(raw, data, data_size);
 }

--- a/components/adblock_rust_ffi/src/wrapper.h
+++ b/components/adblock_rust_ffi/src/wrapper.h
@@ -77,6 +77,11 @@ class ADBLOCK_EXPORT Engine {
                bool* did_match_exception,
                bool* did_match_important,
                std::string* redirect);
+  std::string getCspDirectives(const std::string& url,
+                               const std::string& host,
+                               const std::string& tab_host,
+                               bool is_third_party,
+                               const std::string& resource_type);
   bool deserialize(const char* data, size_t data_size);
   void addTag(const std::string& tag);
   void addResource(const std::string& key,

--- a/components/brave_shields/browser/ad_block_base_service.h
+++ b/components/brave_shields/browser/ad_block_base_service.h
@@ -47,6 +47,10 @@ class AdBlockBaseService : public BaseBraveShieldsService {
                           bool* did_match_exception,
                           bool* did_match_important,
                           std::string* mock_data_url) override;
+  base::Optional<std::string> GetCspDirectives(
+      const GURL& url,
+      blink::mojom::ResourceType resource_type,
+      const std::string& tab_host);
   void AddResources(const std::string& resources);
   void EnableTag(const std::string& tag, bool enabled);
   bool TagExists(const std::string& tag);

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -134,6 +134,21 @@ void AdBlockRegionalServiceManager::ShouldStartRequest(
   }
 }
 
+base::Optional<std::string> AdBlockRegionalServiceManager::GetCspDirectives(
+    const GURL& url,
+    blink::mojom::ResourceType resource_type,
+    const std::string& tab_host) {
+  base::Optional<std::string> csp_directives = base::nullopt;
+
+  for (const auto& regional_service : regional_services_) {
+    const auto directive =
+        regional_service.second->GetCspDirectives(url, resource_type, tab_host);
+    MergeCspDirectiveInto(directive, &csp_directives);
+  }
+
+  return csp_directives;
+}
+
 void AdBlockRegionalServiceManager::EnableTag(const std::string& tag,
                                               bool enabled) {
   base::AutoLock lock(regional_services_lock_);

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -54,6 +54,10 @@ class AdBlockRegionalServiceManager {
                           bool* did_match_exception,
                           bool* did_match_important,
                           std::string* mock_data_url);
+  base::Optional<std::string> GetCspDirectives(
+      const GURL& url,
+      blink::mojom::ResourceType resource_type,
+      const std::string& tab_host);
   void EnableTag(const std::string& tag, bool enabled);
   void AddResources(const std::string& resources);
   void EnableFilterList(const std::string& uuid, bool enabled);

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -102,6 +102,24 @@ void AdBlockService::ShouldStartRequest(
       did_match_important, mock_data_url);
 }
 
+base::Optional<std::string> AdBlockService::GetCspDirectives(
+    const GURL& url,
+    blink::mojom::ResourceType resource_type,
+    const std::string& tab_host) {
+  auto csp_directives =
+      AdBlockBaseService::GetCspDirectives(url, resource_type, tab_host);
+
+  const auto regional_csp = regional_service_manager()->GetCspDirectives(
+      url, resource_type, tab_host);
+  MergeCspDirectiveInto(regional_csp, &csp_directives);
+
+  const auto custom_csp =
+      custom_filters_service()->GetCspDirectives(url, resource_type, tab_host);
+  MergeCspDirectiveInto(custom_csp, &csp_directives);
+
+  return csp_directives;
+}
+
 base::Optional<base::Value> AdBlockService::UrlCosmeticResources(
     const std::string& url) {
   base::Optional<base::Value> resources =

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -56,6 +56,10 @@ class AdBlockService : public AdBlockBaseService {
                           bool* did_match_exception,
                           bool* did_match_important,
                           std::string* mock_data_url) override;
+  base::Optional<std::string> GetCspDirectives(
+      const GURL& url,
+      blink::mojom::ResourceType resource_type,
+      const std::string& tab_host);
   base::Optional<base::Value> UrlCosmeticResources(
       const std::string& url) override;
   base::Optional<base::Value> HiddenClassIdSelectors(

--- a/components/brave_shields/browser/ad_block_service_helper.cc
+++ b/components/brave_shields/browser/ad_block_service_helper.cc
@@ -115,7 +115,30 @@ std::vector<FilterList> RegionalCatalogFromJSON(
   return catalog;
 }
 
-// Merges the contents of the second UrlCosmeticResources Value into the first
+// Merges the first CSP directive into the second one provided, if they exist.
+//
+// Distinct policies are merged with comma separators, according to
+// https://www.w3.org/TR/CSP2/#implementation-considerations
+void MergeCspDirectiveInto(base::Optional<std::string> from,
+                           base::Optional<std::string>* into) {
+  DCHECK(into);
+
+  if (!from) {
+    return;
+  }
+
+  if (!*into) {
+    *into = from;
+    return;
+  }
+
+  const std::string from_str = *from;
+  const std::string into_str = **into;
+
+  *into = base::Optional<std::string>(from_str + ", " + into_str);
+}
+
+// Merges the contents of the first UrlCosmeticResources Value into the second
 // one provided.
 //
 // If `force_hide` is true, the contents of `from`'s `hide_selectors` field

--- a/components/brave_shields/browser/ad_block_service_helper.h
+++ b/components/brave_shields/browser/ad_block_service_helper.h
@@ -25,6 +25,9 @@ std::vector<adblock::FilterList>::const_iterator FindAdBlockFilterListByLocale(
 std::vector<adblock::FilterList> RegionalCatalogFromJSON(
     const std::string& catalog_json);
 
+void MergeCspDirectiveInto(base::Optional<std::string> from,
+                           base::Optional<std::string>* into);
+
 void MergeResourcesInto(base::Value from, base::Value* into, bool force_hide);
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/csp_merge_unittest.cc
+++ b/components/brave_shields/browser/csp_merge_unittest.cc
@@ -1,0 +1,59 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_shields/browser/ad_block_service_helper.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_shields {
+
+const base::Optional<std::string> NO_POLICY = base::nullopt;
+
+const auto POLICY1 =
+    base::Optional<std::string>("script-src 'self' 'unsafe-inline'");
+const auto POLICY2 =
+    base::Optional<std::string>("media-src 'self' https://example.com");
+
+TEST(CspMergeTest, MergeTwoEmptyPolicies) {
+  const auto a = NO_POLICY;
+  auto b = NO_POLICY;
+
+  MergeCspDirectiveInto(a, &b);
+
+  ASSERT_EQ(b, NO_POLICY);
+}
+
+TEST(CspMergeTest, MergeEmptyIntoNonEmpty) {
+  const auto a = POLICY1;
+  auto b = NO_POLICY;
+
+  MergeCspDirectiveInto(a, &b);
+
+  ASSERT_EQ(b, POLICY1);
+}
+
+TEST(CspMergeTest, MergeNonEmptyIntoEmpty) {
+  const auto a = NO_POLICY;
+  auto b = POLICY1;
+
+  MergeCspDirectiveInto(a, &b);
+
+  ASSERT_EQ(b, POLICY1);
+}
+
+TEST(CspMergeTest, MergeNonEmptyIntoNonEmpty) {
+  const auto a = POLICY1;
+  auto b = POLICY2;
+
+  const std::string expected =
+      "script-src 'self' 'unsafe-inline', media-src 'self' https://example.com";
+
+  MergeCspDirectiveInto(a, &b);
+
+  ASSERT_TRUE(b);
+  ASSERT_EQ(*b, expected);
+}
+
+}  // namespace brave_shields

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -15,6 +15,8 @@ const base::Feature kBraveAdblockCosmeticFiltering{
     base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveAdblockCosmeticFilteringNative{
     "BraveAdblockCosmeticFilteringNative", base::FEATURE_DISABLED_BY_DEFAULT};
+const base::Feature kBraveAdblockCspRules{
+    "BraveAdblockCspRules", base::FEATURE_ENABLED_BY_DEFAULT};
 // When enabled, Brave will block domains listed in the user's selected adblock
 // filters and present a security interstitial with choice to proceed and
 // optionally whitelist the domain.

--- a/components/brave_shields/common/features.h
+++ b/components/brave_shields/common/features.h
@@ -14,6 +14,7 @@ namespace brave_shields {
 namespace features {
 extern const base::Feature kBraveAdblockCosmeticFiltering;
 extern const base::Feature kBraveAdblockCosmeticFilteringNative;
+extern const base::Feature kBraveAdblockCspRules;
 extern const base::Feature kBraveDomainBlock;
 extern const base::Feature kBraveExtensionNetworkBlocking;
 }  // namespace features

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -96,6 +96,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_shields/browser/ad_block_regional_service_unittest.cc",
     "//brave/components/brave_shields/browser/adblock_stub_response_unittest.cc",
     "//brave/components/brave_shields/browser/cosmetic_merge_unittest.cc",
+    "//brave/components/brave_shields/browser/csp_merge_unittest.cc",
     "//brave/components/brave_shields/browser/https_everywhere_recently_used_cache_unittest.cpp",
     "//brave/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc",
     "//brave/components/content_settings/core/browser/brave_content_settings_utils_unittest.cc",

--- a/test/data/csp_rules.html
+++ b/test/data/csp_rules.html
@@ -1,0 +1,60 @@
+<html>
+<head>
+<script nonce="abcdef">
+    window.loadedNonceScript = true;
+
+    eval('window.loadedEvalScript = true');
+
+    const samePartyScriptPromise = new Promise(resolve => {
+        const samePartyScript = document.createElement('script');
+        samePartyScript.src = '/adbanner.js';
+        samePartyScript.onload = (r) => {
+            window.loadedSamePartyScript = true;
+            resolve();
+        }
+        samePartyScript.onerror = (r) => {
+            resolve();
+        }
+        document.documentElement.appendChild(samePartyScript);
+    });
+
+    const thirdPartyScriptPromise = new Promise(resolve => {
+        const thirdPartyScript = document.createElement('script');
+        thirdPartyScript.src = 'https://thirdparty.com/adbanner.js';
+        thirdPartyScript.onload = (r) => {
+            window.loadedThirdPartyScript = true;
+            resolve();
+        }
+        thirdPartyScript.onerror = (r) => {
+            resolve();
+        }
+        document.documentElement.appendChild(thirdPartyScript);
+    });
+
+    const unsafeInlineScript = document.createElement('script');
+    unsafeInlineScript.text = 'window.loadedUnsafeInlineScript = true';
+    document.documentElement.appendChild(unsafeInlineScript);
+
+    const dataImagePromise = new Promise(resolve => {
+        const dataImage = document.createElement('img');
+        // transparent 1x1 pixel
+        dataImage.src = '/ad_banner.png';
+        dataImage.onload = (r) => {
+            console.error(dataImage.height)
+            if (dataImage.height == 212) {
+                window.loadedDataImage = true;
+            }
+            resolve();
+        }
+        dataImage.onerror = (r) => {
+            resolve();
+        }
+        document.documentElement.appendChild(dataImage);
+    });
+
+    window.allLoaded = Promise.all([samePartyScriptPromise, thirdPartyScriptPromise, dataImagePromise]);
+</script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14792

Security/privacy review at https://github.com/brave/security/issues/374

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Visit http://pirateiro.com/. Refresh the page while the developer console is open, and check in the console to verify that the browser refused to load scripts violating the policy `script-src 'self' 'unsafe-inline' https://hcaptcha.com *.hcaptcha.com`.

On Android, it will be sufficient to observe 0 blocked items in the Shields panel rather than 5 (the requests are still blocked, but will not increment the counter).