### PR TITLE
Forbid new empty cosmetic filters from being created via right click menu (uplift to 1.23.x)

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
+++ b/components/brave_extension/extension/brave_extension/background/events/cosmeticFilterEvents.ts
@@ -96,12 +96,16 @@ export async function onSelectorReturned (response: any) {
     rule.selector = window.prompt('CSS selector:', `${response}`) || ''
   }
 
-  if (rule.selector && rule.selector.length > 0) {
-    chrome.tabs.insertCSS({
-      code: `${rule.selector} {display: none !important;}`,
-      cssOrigin: 'user'
-    })
-  }
+  if (rule.selector) {
+    const selector: string = rule.selector.trim()
 
-  await addSiteCosmeticFilter(rule.host, rule.selector)
+    if (selector.length > 0) {
+      chrome.tabs.insertCSS({
+        code: `${selector} {display: none !important;}`,
+        cssOrigin: 'user'
+      })
+
+      await addSiteCosmeticFilter(rule.host, selector)
+    }
+  }
 }

--- a/components/brave_shields/browser/ad_block_custom_filters_service.cc
+++ b/components/brave_shields/browser/ad_block_custom_filters_service.cc
@@ -69,6 +69,10 @@ bool AdBlockCustomFiltersService::MigrateLegacyCosmeticFilters(
     const std::vector<std::string>& hostSelectors = hostEntry.second;
 
     for (const auto& selector : hostSelectors) {
+      if (selector.empty()) {
+        continue;
+      }
+
       const std::string rule = '\n' + host + "##" + selector;
 
       filters_update += rule;


### PR DESCRIPTION
Uplift of #8270
Resolves https://github.com/brave/brave-browser/issues/14763

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.