### PR TITLE
Only specify net::HostResolverSource::DNS when DoH is enabled (uplift to 1.22.x)

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -21,6 +21,8 @@
 #include "brave/components/brave_shields/browser/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/net/secure_dns_config.h"
+#include "chrome/browser/net/system_network_context_manager.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/render_frame_host.h"
@@ -142,10 +144,15 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
     network::mojom::ResolveHostParametersPtr optional_parameters =
         network::mojom::ResolveHostParameters::New();
     optional_parameters->include_canonical_name = true;
-    // Explicitly specify source to avoid using `HostResolverProc`
-    // which will be handled by system resolver
+
+    SecureDnsConfig secure_dns_config =
+        SystemNetworkContextManager::GetStubResolverConfigReader()
+            ->GetSecureDnsConfiguration(false);
+    // Explicitly specify source when DNS over HTTPS is enabled to avoid
+    // using `HostResolverProc` which will be handled by system resolver
     // See https://crbug.com/872665
-    optional_parameters->source = net::HostResolverSource::DNS;
+    if (secure_dns_config.mode() == net::SecureDnsMode::kSecure)
+      optional_parameters->source = net::HostResolverSource::DNS;
 
     network::mojom::NetworkContext* network_context =
         content::BrowserContext::GetDefaultStoragePartition(context)


### PR DESCRIPTION
Uplift of #8279
Resolves https://github.com/brave/brave-browser/issues/14755

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.