### PR TITLE
Fix Include in Auto-Contribute toggle

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -142,7 +142,8 @@ void BraveRewardsGetPublisherInfoFunction::OnGetPublisherInfo(
   dict.SetStringKey("name", info->name);
   dict.SetIntKey("percentage", info->percent);
   dict.SetIntKey("status", static_cast<int>(info->status));
-  dict.SetIntKey("excluded", static_cast<int>(info->excluded));
+  dict.SetIntKey("excluded",
+                 info->excluded == ledger::type::PublisherExclude::EXCLUDED);
   dict.SetStringKey("url", info->url);
   dict.SetStringKey("provider", info->provider);
   dict.SetStringKey("favIconUrl", info->favicon_url);
@@ -189,7 +190,8 @@ void BraveRewardsGetPublisherPanelInfoFunction::OnGetPublisherPanelInfo(
   dict.SetStringKey("name", info->name);
   dict.SetIntKey("percentage", info->percent);
   dict.SetIntKey("status", static_cast<int>(info->status));
-  dict.SetIntKey("excluded", static_cast<int>(info->excluded));
+  dict.SetIntKey("excluded",
+                 info->excluded == ledger::type::PublisherExclude::EXCLUDED);
   dict.SetStringKey("url", info->url);
   dict.SetStringKey("provider", info->provider);
   dict.SetStringKey("favIconUrl", info->favicon_url);

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -394,7 +394,7 @@
                     "type": "number"
                   },
                   "excluded": {
-                    "type": "number"
+                    "type": "boolean"
                   },
                   "url": {
                     "type": "string"
@@ -438,7 +438,7 @@
                     "description": "publisher attention score"
                   },
                   "excluded": {
-                    "type": "number",
+                    "type": "boolean",
                     "description": "is site excluded from auto contribute"
                   },
                   "provider": {

--- a/components/definitions/rewards.d.ts
+++ b/components/definitions/rewards.d.ts
@@ -170,12 +170,6 @@ declare namespace Rewards {
     promotion?: Promotion
   }
 
-  export enum ExcludeStatus {
-    DEFAULT = 0,
-    EXCLUDED = 1,
-    INCLUDED = 2
-  }
-
   export enum PublisherStatus {
     NOT_VERIFIED = 0,
     CONNECTED = 1,
@@ -186,7 +180,7 @@ declare namespace Rewards {
     publisherKey: string
     percentage: number
     status: PublisherStatus
-    excluded: ExcludeStatus
+    excluded: boolean
     url: string
     name: string
     provider: string


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14413

Internally, we store the publisher exclusion state as an integer-based enumeration. However, some of our publisher-related extension API functions send this value as a `boolean` while others send it as a `number`. This was causing confusion in the UI as any non-zero number was causing the state to be interpreted as excluded.

Since we only use this state as a Boolean in the UI (i.e., nothing in the UI cares about anything other than two states: exclude or include), I standardized on always sending it to the UI as a Boolean.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Visit https://twitter.com/bravelaurenwags
- Open Rewards panel a few times and verify that toggle state of "Include in Auto-Contribution" doesn't change
- Toggle the state of the button
- Open Rewards panel a few times and verify that toggle state of "Include in Auto-Contribution" doesn't change

I'd repeat these steps a few times and also try with a clean profile. There are also useful STR in https://github.com/brave/brave-browser/issues/14413 that we should also check.