### PR TITLE
Get latest page always from wayback machine

### DIFF
--- a/components/brave_wayback_machine/brave_wayback_machine_utils.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils.cc
@@ -28,3 +28,15 @@ bool IsWaybackMachineDisabledFor(const GURL& url) {
 
   return false;
 }
+
+GURL FixupWaybackQueryURL(const GURL& url) {
+  // Get latest page always from wayback machine by invalidating timestamp
+  // value in query string.
+  GURL fixed_url = url;
+  std::string unused;
+  if (net::GetValueForKeyInQuery(fixed_url, "timestamp", &unused)) {
+    fixed_url = net::AppendOrReplaceQueryParameter(fixed_url, "timestamp", "");
+  }
+
+  return fixed_url;
+}

--- a/components/brave_wayback_machine/brave_wayback_machine_utils.h
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils.h
@@ -9,5 +9,6 @@
 class GURL;
 
 bool IsWaybackMachineDisabledFor(const GURL& url);
+GURL FixupWaybackQueryURL(const GURL& url);
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WAYBACK_MACHINE_BRAVE_WAYBACK_MACHINE_UTILS_H_

--- a/components/brave_wayback_machine/brave_wayback_machine_utils_unittest.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils_unittest.cc
@@ -3,7 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <string>
+
 #include "brave/components/brave_wayback_machine/brave_wayback_machine_utils.h"
+#include "brave/components/brave_wayback_machine/url_constants.h"
+#include "net/base/url_util.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
@@ -22,4 +26,19 @@ TEST(BraveWaybackMachineUtilsTest, LocalHostDisabledTest) {
   EXPECT_FALSE(IsWaybackMachineDisabledFor(GURL("http://www.brave.com")));
   EXPECT_FALSE(
       IsWaybackMachineDisabledFor(GURL("https://archive.org/foobar.html")));
+}
+
+TEST(BraveWaybackMachineUtilsTest, FixupQueryURLTest) {
+  GURL wayback_fetch_url(std::string(kWaybackQueryURL) +
+                         "https://www.example.com?&timestamp=20160101");
+  std::string timestamp_value;
+  EXPECT_TRUE(net::GetValueForKeyInQuery(wayback_fetch_url, "timestamp",
+                                         &timestamp_value));
+  EXPECT_EQ("20160101", timestamp_value);
+
+  wayback_fetch_url = FixupWaybackQueryURL(wayback_fetch_url);
+  EXPECT_TRUE(net::GetValueForKeyInQuery(wayback_fetch_url, "timestamp",
+                                         &timestamp_value));
+  // Check value is empty.
+  EXPECT_EQ("", timestamp_value);
 }

--- a/components/brave_wayback_machine/wayback_machine_url_fetcher.cc
+++ b/components/brave_wayback_machine/wayback_machine_url_fetcher.cc
@@ -9,9 +9,10 @@
 
 #include "base/bind.h"
 #include "base/json/json_reader.h"
+#include "brave/components/brave_wayback_machine/brave_wayback_machine_utils.h"
 #include "brave/components/brave_wayback_machine/url_constants.h"
-#include "net/traffic_annotation/network_traffic_annotation.h"
 #include "net/base/load_flags.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
@@ -52,14 +53,12 @@ WaybackMachineURLFetcher::WaybackMachineURLFetcher(
       url_loader_factory_(std::move(url_loader_factory)) {
 }
 
-WaybackMachineURLFetcher::~WaybackMachineURLFetcher() {
-}
+WaybackMachineURLFetcher::~WaybackMachineURLFetcher() = default;
 
 void WaybackMachineURLFetcher::Fetch(const GURL& url) {
   auto request = std::make_unique<network::ResourceRequest>();
-  std::string wayback_fetch_url =
-      std::string(kWaybackQueryURL) + url.spec();
-  request->url = GURL(wayback_fetch_url);
+  const GURL wayback_fetch_url(std::string(kWaybackQueryURL) + url.spec());
+  request->url = FixupWaybackQueryURL(wayback_fetch_url);
   request->credentials_mode = network::mojom::CredentialsMode::kOmit;
   request->load_flags = net::LOAD_DO_NOT_SAVE_COOKIES;
   wayback_url_loader_ = network::SimpleURLLoader::Create(


### PR DESCRIPTION
By deleting timestamp value from wayback query, we can get latest saved page.
fix https://github.com/brave/brave-browser/issues/14843

<!-- Add brave-browser issue bellow that this PR will resolve -->

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_unit_tests -- --filter=BraveWaybackMachineUtilsTest*`

1. Load https://en.wikipedia.org/wiki/1960%E2%80%9361_UE_Lleida_season?&timestamp=20160101
2. Press `Check for saved version`
3. Check https://web.archive.org/web/20210315191803/https://en.wikipedia.org/wiki/1960%E2%80%9361_UE_Lleida_season is loaded
   W/o this PR, https://web.archive.org/web/20161220105407/https://en.wikipedia.org/wiki/1960%E2%80%9361_UE_Lleida_season is loaded due to timestamp value
