### PR TITLE
Fix farbled user agent on mobile

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -181,7 +181,11 @@ std::string GetUserAgentPlatform() {
 }
 
 std::string GetMinimalProduct() {
-  return version_info::GetProductNameAndVersionForUserAgent();
+  std::string product = version_info::GetProductNameAndVersionForUserAgent();
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kUseMobileUserAgent))
+    product += " Mobile";
+  return product;
 }
 
 std::string GetMinimalOSVersion() {
@@ -523,6 +527,16 @@ void BraveContentBrowserClient::MaybeHideReferrer(
   }
 }
 
+std::string BraveContentBrowserClient::GetMinimalUserAgent() {
+  std::string minimal_os_info;
+  base::StringAppendF(&minimal_os_info, "%s%s", GetUserAgentPlatform().c_str(),
+                      content::BuildOSCpuInfoFromOSVersionAndCpuType(
+                          GetMinimalOSVersion(), content::BuildCpuInfo())
+                          .c_str());
+  return content::BuildUserAgentFromOSAndProduct(minimal_os_info,
+                                                 GetMinimalProduct());
+}
+
 std::string BraveContentBrowserClient::GetEffectiveUserAgent(
     content::BrowserContext* browser_context,
     const GURL& url) {
@@ -538,16 +552,8 @@ std::string BraveContentBrowserClient::GetEffectiveUserAgent(
     // respect it.
     if (GetBraveShieldsEnabled(map, url) &&
         (GetFingerprintingControlType(map, url) != ControlType::ALLOW) &&
-        (ua == content::BuildUserAgentFromProduct(
-                   version_info::GetProductNameAndVersionForUserAgent()))) {
-      std::string minimal_os_info;
-      base::StringAppendF(&minimal_os_info, "%s%s",
-                          GetUserAgentPlatform().c_str(),
-                          content::BuildOSCpuInfoFromOSVersionAndCpuType(
-                              GetMinimalOSVersion(), content::BuildCpuInfo())
-                              .c_str());
-      ua = content::BuildUserAgentFromOSAndProduct(minimal_os_info,
-                                                   GetMinimalProduct());
+        (ua == content::BuildUserAgentFromProduct(GetMinimalProduct()))) {
+      ua = GetMinimalUserAgent();
     }
   }
   return ua;

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -18,6 +18,7 @@
 #include "services/metrics/public/cpp/ukm_source_id.h"
 #include "third_party/blink/public/mojom/loader/referrer.mojom.h"
 
+class BraveNavigatorUserAgentFarblingBrowserTest;
 class PrefChangeRegistrar;
 
 namespace content {
@@ -100,19 +101,23 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
 
   GURL GetEffectiveURL(content::BrowserContext* browser_context,
                        const GURL& url) override;
-  static bool HandleURLOverrideRewrite(GURL* url,
+  static bool HandleURLOverrideRewrite(
+      GURL* url,
       content::BrowserContext* browser_context);
   std::vector<std::unique_ptr<content::NavigationThrottle>>
-      CreateThrottlesForNavigation(content::NavigationHandle* handle) override;
+  CreateThrottlesForNavigation(content::NavigationHandle* handle) override;
 
   std::string GetEffectiveUserAgent(content::BrowserContext* browser_context,
                                     const GURL& url) override;
 
  private:
+  friend class ::BraveNavigatorUserAgentFarblingBrowserTest;
+
   uint64_t session_token_;
   uint64_t incognito_session_token_;
 
   void OnAllowGoogleAuthChanged();
+  std::string GetMinimalUserAgent();
 
   std::unique_ptr<PrefChangeRegistrar, content::BrowserThread::DeleteOnUIThread>
       pref_change_registrar_;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14740

Logic within upstream UA building code appends " Mobile" to the UA at a specific place if `kUseMobileUserAgent` switch is on, which it is for the Android build. This confused our test for whether the UA had been overridden by something we wanted to respect (like a command line flag or a user-modifiable runtime flag), resulting in never farbling the UA on Android. This fix replicates the `kUseMobileUserAgent` logic within `BraveContentBrowserClient` so that we properly minimize/farble the UA on all platforms, while still respecting relevant commandline/runtime flags.

Includes a new test to ensure that we are sending our minimized UA over the wire when `kUseMobileUserAgent` switch is on. (For Android, this means no build number or model name.)

Also migrates UA farbling tests to `EvalJs`.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

