### PR TITLE
Fixes cookie issues on login https://eple.sanity.studio/desk

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -30,6 +30,8 @@ constexpr char kGoogle[] = "https://[*.]google.com/*";
 constexpr char kGoogleusercontent[] = "https://[*.]googleusercontent.com/*";
 constexpr char kFacebook[] = "https://[*.]facebook.com/*";
 constexpr char kInstagram[] = "https://[*.]instagram.com/*";
+constexpr char kSanitystudio[] = "https://[*.]sanity.studio/*";
+constexpr char kSanityio[] = "https://[*.]sanity.io/*";
 
 bool BraveIsAllowedThirdParty(const GURL& url,
                               const GURL& first_party_url,
@@ -50,6 +52,10 @@ bool BraveIsAllowedThirdParty(const GURL& url,
             ContentSettingsPattern::FromString(kFacebook)},
            {ContentSettingsPattern::FromString(kFacebook),
             ContentSettingsPattern::FromString(kInstagram)},
+           {ContentSettingsPattern::FromString(kSanitystudio),
+            ContentSettingsPattern::FromString(kSanityio)},
+           {ContentSettingsPattern::FromString(kSanityio),
+            ContentSettingsPattern::FromString(kSanitystudio)},
            {ContentSettingsPattern::FromString(kPlaystation),
             ContentSettingsPattern::FromString(kSonyentertainmentnetwork)},
            {ContentSettingsPattern::FromString(kSonyentertainmentnetwork),


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/6099

Both domains are owned by the same company, seems `sanity.io` is used as a cookie check for `sanity.studio`

Tested in Brave Beta + Enable Ephemeral Storage enabled. Still unable to login without allowing cookies for this site

![studio](https://user-images.githubusercontent.com/1659004/112079794-a6f86380-8be5-11eb-98a2-45c7b2db8be5.png)


