### PR TITLE
Prevent devtools requests from getting intercepted by adblock (uplift to 1.23.x)

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -30,6 +30,7 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/common/url_constants.h"
 #include "extensions/common/url_pattern.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/network_context.h"
@@ -226,9 +227,10 @@ int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,
                                         std::shared_ptr<BraveRequestInfo> ctx) {
   // If the following info isn't available, then proper content settings can't
   // be looked up, so do nothing.
-  if (ctx->request_url.is_empty() || ctx->initiator_url.is_empty() ||
-      !ctx->initiator_url.has_host() || !ctx->allow_brave_shields ||
-      ctx->allow_ads ||
+  if (ctx->request_url.is_empty() ||
+      ctx->request_url.SchemeIs(content::kChromeDevToolsScheme) ||
+      ctx->initiator_url.is_empty() || !ctx->initiator_url.has_host() ||
+      !ctx->allow_brave_shields || ctx->allow_ads ||
       ctx->resource_type == BraveRequestInfo::kInvalidResourceType) {
     return net::OK;
   }

--- a/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper_unittest.cc
@@ -32,3 +32,14 @@ TEST(BraveAdBlockTPNetworkDelegateHelperTest, EmptyRequestURL) {
   EXPECT_TRUE(request_info->new_url_spec.empty());
   EXPECT_EQ(rc, net::OK);
 }
+
+TEST(BraveAdBlockTPNetworkDelegateHelperTest, DevToolURL) {
+  const GURL url("devtools://devtools/");
+  auto request_info = std::make_shared<brave::BraveRequestInfo>(url);
+  request_info->initiator_url =
+      GURL("devtools://devtools/bundled/root/root.js");
+  int rc =
+      OnBeforeURLRequest_AdBlockTPPreWork(ResponseCallback(), request_info);
+  EXPECT_TRUE(request_info->new_url_spec.empty());
+  EXPECT_EQ(rc, net::OK);
+}


### PR DESCRIPTION
Uplift of #8336
Resolves https://github.com/brave/brave-browser/issues/14880

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.