### PR TITLE
Add missing call to brave::SetSafeBrowsingEndpointForTesting(true)

### DIFF
--- a/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_static_redirect_network_delegate_helper_unittest.cc
@@ -270,6 +270,7 @@ TEST(BraveStaticRedirectNetworkDelegateHelperTest,
 
 TEST(BraveStaticRedirectNetworkDelegateHelperTest,
      ModifySafeBrowsingFileCheckURL) {
+  brave::SetSafeBrowsingEndpointForTesting(true);
   const GURL url(
       "https://sb-ssl.google.com/safebrowsing/clientreport/download?"
       "key=DUMMY_KEY");


### PR DESCRIPTION
BraveStaticRedirectNetworkDelegateHelperTest.ModifySafeBrowsingFileCheckURL
was not calling this testing-specific helper at the beginning of its
scope like other SafeBrowsing-related tests from the same test suite,
so the "test.safebrowsing.com" endpoint was not being used unless those
other tests were run before, causing ModifySafeBrowsingFileCheckURL to
fail otherwise.

This patch adds a call brave::SetSafeBrowsingEndpointForTesting(true)
therefore to make sure the test can correctly run regardless of what
other tests have been run prior to it.

Resolves https://github.com/brave/brave-browser/issues/14925

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Run the previously failing testing test and check it passes:
```
testing/xvfb.py npm run test brave_unit_tests -- \
    --filter=BraveStaticRedirectNetworkDelegateHelperTest.ModifySafeBrowsingFileCheckURL.
```