### PR TITLE
Handle the conversion tracking pref in iOS (uplift to 1.21.x)

### DIFF
--- a/vendor/brave-ios/Ads/BATBraveAds.mm
+++ b/vendor/brave-ios/Ads/BATBraveAds.mm
@@ -1066,6 +1066,9 @@ BATClassAdsBridge(BOOL, isDebug, setDebug, g_is_debug)
 - (bool)getBooleanPref:(const std::string&)path
 {
   const auto key = [NSString stringWithUTF8String:path.c_str()];
+  if (path == ads::prefs::kShouldAllowConversionTracking) {
+    return [self shouldAllowAdConversionTracking];
+  }
   return [self.prefs[key] boolValue];
 }
 


### PR DESCRIPTION
iOS 1.24 is releasing with 1.21.x which is no longer maintained, please close if we want to use an alternate method of getting this code into 1.21.x

Uplift of #8352 
Refs brave/brave-ios#3458

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 

Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.