### PR TITLE
speedreader: Add --speedreader-backend switch

### DIFF
--- a/components/speedreader/speedreader_rewriter_service.cc
+++ b/components/speedreader/speedreader_rewriter_service.cc
@@ -8,11 +8,12 @@
 #include <utility>
 
 #include "base/bind.h"
+#include "base/command_line.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/task/post_task.h"
-#include "brave/components/speedreader/rust/ffi/speedreader.h"
 #include "brave/components/speedreader/speedreader_component.h"
+#include "brave/components/speedreader/speedreader_switches.h"
 #include "components/grit/brave_components_resources.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "url/gurl.h"
@@ -40,6 +41,16 @@ SpeedreaderRewriterService::SpeedreaderRewriterService(
     brave_component_updater::BraveComponent::Delegate* delegate)
     : component_(new speedreader::SpeedreaderComponent(delegate)),
       speedreader_(new speedreader::SpeedReader) {
+  const base::CommandLine& cmd_line = *base::CommandLine::ForCurrentProcess();
+  if (cmd_line.HasSwitch(speedreader::kSpeedreaderBackend)) {
+    // @pes mentioned we might want to experiment with several backends, so this
+    // will give us the most flexibility.
+    std::string backend = cmd_line.GetSwitchValueASCII(kSpeedreaderBackend);
+    if (backend == "heuristics") {
+      backend_ = RewriterType::RewriterHeuristics;
+    }
+  }
+
   // Load the built-in stylesheet as the default
   content_stylesheet_ =
       "<style id=\"brave_speedreader_style\">" +
@@ -84,12 +95,14 @@ void SpeedreaderRewriterService::OnStylesheetReady(const base::FilePath& path) {
 }
 
 bool SpeedreaderRewriterService::IsWhitelisted(const GURL& url) {
-  return speedreader_->IsReadableURL(url.spec());
+  return backend_ == RewriterType::RewriterStreaming
+             ? speedreader_->IsReadableURL(url.spec())
+             : true;
 }
 
 std::unique_ptr<Rewriter> SpeedreaderRewriterService::MakeRewriter(
     const GURL& url) {
-  return speedreader_->MakeRewriter(url.spec());
+  return speedreader_->MakeRewriter(url.spec(), backend_);
 }
 
 const std::string& SpeedreaderRewriterService::GetContentStylesheet() {

--- a/components/speedreader/speedreader_rewriter_service.h
+++ b/components/speedreader/speedreader_rewriter_service.h
@@ -12,6 +12,7 @@
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_component_updater/browser/brave_component.h"
 #include "brave/components/brave_component_updater/browser/dat_file_util.h"
+#include "brave/components/speedreader/rust/ffi/speedreader.h"
 #include "brave/components/speedreader/speedreader_component.h"
 
 namespace base {
@@ -52,6 +53,10 @@ class SpeedreaderRewriterService : public SpeedreaderComponent::Observer {
 
   void OnLoadDATFileData(GetDATFileDataResult result);
   void OnLoadStylesheet(std::string stylesheet);
+
+  // This is currently the only backend reachable from browser code, so
+  // let's make it the default.
+  RewriterType backend_ = RewriterType::RewriterStreaming;
 
   std::string content_stylesheet_;
   std::unique_ptr<speedreader::SpeedreaderComponent> component_;

--- a/components/speedreader/speedreader_switches.h
+++ b/components/speedreader/speedreader_switches.h
@@ -10,6 +10,7 @@ namespace speedreader {
 
 constexpr char kSpeedreaderWhitelist[] = "speedreader-whitelist";
 constexpr char kSpeedreaderWhitelistPath[] = "speedreader-whitelist-path";
+constexpr char kSpeedreaderBackend[] = "speedreader-backend";
 
 }  // namespace speedreader
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/14959

This is so @pes10k and @rebron can test the changes we make on nightly. Not particularly relevant until https://github.com/brave/brave-core/pull/8349 is merged because the current readability backend in master is very incomplete.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

