### PR TITLE
Make Windows silent installer truly silent

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
-  "vendor/omaha":  "https://github.com/brave/omaha.git@c78f0143a6f196f710a4b7c0b28c64014dcfe183",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@c4d182221784734c3ffc8cfc48f708ba936e6e64",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@07933da3e178265d0f0ba86e02bbde38e701a04d",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@f5676241d4fdb01807708f0ac67b809d739905bd",

--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
-  "vendor/omaha":  "https://github.com/brave/omaha.git@c29e92d80c1ace02d3f9129f2993eedd3206e494",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@919eccd3b6e98f819a8616e814fc1aaeeb230cf0",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@07933da3e178265d0f0ba86e02bbde38e701a04d",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@f5676241d4fdb01807708f0ac67b809d739905bd",

--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
-  "vendor/omaha":  "https://github.com/brave/omaha.git@c4d182221784734c3ffc8cfc48f708ba936e6e64",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@c29e92d80c1ace02d3f9129f2993eedd3206e494",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@07933da3e178265d0f0ba86e02bbde38e701a04d",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@f5676241d4fdb01807708f0ac67b809d739905bd",

--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
-  "vendor/omaha":  "https://github.com/brave/omaha.git@919eccd3b6e98f819a8616e814fc1aaeeb230cf0",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@f1407b11524f110d87fdb7496e153724a9f8d9e4",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@07933da3e178265d0f0ba86e02bbde38e701a04d",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@f5676241d4fdb01807708f0ac67b809d739905bd",

--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ deps = {
   "vendor/requests": "https://github.com/kennethreitz/requests@e4d59bedfd3c7f4f254f4f5d036587bcd8152458",
   "vendor/boto": "https://github.com/boto/boto@f7574aa6cc2c819430c1f05e9a1a1a666ef8169b",
   "vendor/python-patch": "https://github.com/brave/python-patch@d8880110be6554686bc08261766538c2926d4e82",
-  "vendor/omaha":  "https://github.com/brave/omaha.git@cd2499ce23b2f8c532e1c504adf41d3e946780d2",
+  "vendor/omaha":  "https://github.com/brave/omaha.git@c78f0143a6f196f710a4b7c0b28c64014dcfe183",
   "vendor/sparkle": "https://github.com/brave/Sparkle.git@07933da3e178265d0f0ba86e02bbde38e701a04d",
   "vendor/bat-native-rapidjson": "https://github.com/brave-intl/bat-native-rapidjson.git@86aafe2ef89835ae71c9ed7c2527e3bb3000930e",
   "vendor/bip39wally-core-native": "https://github.com/brave-intl/bip39wally-core-native.git@f5676241d4fdb01807708f0ac67b809d739905bd",

--- a/build/config.gni
+++ b/build/config.gni
@@ -49,7 +49,9 @@ if (brave_exe == "") {
 brave_dist_dir = "$root_out_dir/dist"
 if (is_win) {
   brave_exe = "$brave_exe.exe"
-  brave_underline_full_version = "_$chrome_version_major" + "_$brave_version_major" + "_$brave_version_minor" + "_$brave_version_build"
+  brave_underline_full_version =
+      "_$chrome_version_major" + "_$brave_version_major" +
+      "_$brave_version_minor" + "_$brave_version_build"
   _channel = ""
   brave_app_guid = "{AFE6A462-C574-4B8A-AF43-4CC60DF4563B}"
   if (is_official_build) {
@@ -73,11 +75,18 @@ if (is_win) {
     _arch = "32"
   }
   brave_installer_exe = "brave_installer$brave_underline_full_version.exe"
-  brave_stub_installer_exe = "BraveBrowser$_channel" + "Setup$_arch$brave_underline_full_version.exe"
-  brave_untagged_stub_installer_exe = "BraveBrowserUntagged$_channel" + "Setup$_arch$brave_underline_full_version.exe"
-  brave_standalone_installer_exe = "BraveBrowserStandalone$_channel" + "Setup$_arch$brave_underline_full_version.exe"
-  brave_silent_installer_exe = "BraveBrowserStandaloneSilent$_channel" + "Setup$_arch$brave_underline_full_version.exe"
-  brave_untagged_installer_exe = "BraveBrowserStandaloneUntagged$_channel" + "Setup$_arch$brave_underline_full_version.exe"
+  brave_stub_installer_exe =
+      "BraveBrowser$_channel" + "Setup$_arch$brave_underline_full_version.exe"
+  brave_untagged_stub_installer_exe =
+      "BraveBrowserUntagged$_channel" +
+      "Setup$_arch$brave_underline_full_version.exe"
+  brave_standalone_installer_exe =
+      "BraveBrowserStandalone$_channel" +
+      "Setup$_arch$brave_underline_full_version.exe"
+  brave_silent_installer_exe = "BraveBrowserStandaloneSilent$_channel" +
+                               "Setup$_arch$brave_underline_full_version.exe"
+  brave_untagged_installer_exe = "BraveBrowserStandaloneUntagged$_channel" +
+                                 "Setup$_arch$brave_underline_full_version.exe"
 } else if (is_mac) {
   brave_exe = "$chrome_product_full_name.app"
   brave_dmg = "$chrome_product_full_name.dmg"
@@ -98,10 +107,12 @@ if (is_win) {
   } else {
     brave_product_dir_name_suffix = "-Development"
   }
-  brave_product_dir_name = "BraveSoftware/Brave-Browser$brave_product_dir_name_suffix"
+  brave_product_dir_name =
+      "BraveSoftware/Brave-Browser$brave_product_dir_name_suffix"
 
   if (base_sparkle_update_url == "") {
-    base_sparkle_update_url = "https://updates.bravesoftware.com/sparkle/Brave-Browser"
+    base_sparkle_update_url =
+        "https://updates.bravesoftware.com/sparkle/Brave-Browser"
   }
   _update_channel = brave_channel
   if (_update_channel == "") {
@@ -129,7 +140,7 @@ if (is_android) {
     assert(target_cpu != "arm64" && target_cpu != "x64")
     brave_apk_output += "Modern"
   } else if (target_cpu == "arm64" || target_cpu == "x64" ||
-      target_apk_base == "mono") {
+             target_apk_base == "mono") {
     brave_apk_output += "Mono"
   }
 

--- a/build/config.gni
+++ b/build/config.gni
@@ -74,7 +74,6 @@ if (is_win) {
   }
   brave_installer_exe = "brave_installer$brave_underline_full_version.exe"
   brave_stub_installer_exe = "BraveBrowser$_channel" + "Setup$_arch$brave_underline_full_version.exe"
-  brave_silent_stub_installer_exe = "BraveBrowserSilent$_channel" + "Setup$_arch$brave_underline_full_version.exe"
   brave_untagged_stub_installer_exe = "BraveBrowserUntagged$_channel" + "Setup$_arch$brave_underline_full_version.exe"
   brave_standalone_installer_exe = "BraveBrowserStandalone$_channel" + "Setup$_arch$brave_underline_full_version.exe"
   brave_silent_installer_exe = "BraveBrowserStandaloneSilent$_channel" + "Setup$_arch$brave_underline_full_version.exe"

--- a/script/test/test_upload.py
+++ b/script/test/test_upload.py
@@ -242,7 +242,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-x64.exe',
                           'BraveBrowserNightlySetup.exe',
-                          'BraveBrowserSilentNightlySetup.exe',
                           'BraveBrowserStandaloneNightlySetup.exe',
                           'BraveBrowserStandaloneSilentNightlySetup.exe',
                           'BraveBrowserStandaloneUntaggedNightlySetup.exe',
@@ -255,7 +254,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-ia32.exe',
                           'BraveBrowserNightlySetup32.exe',
-                          'BraveBrowserSilentNightlySetup32.exe',
                           'BraveBrowserStandaloneNightlySetup32.exe',
                           'BraveBrowserStandaloneSilentNightlySetup32.exe',
                           'BraveBrowserStandaloneUntaggedNightlySetup32.exe',
@@ -268,7 +266,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-ia32.exe',
                           'BraveBrowserNightlySetup32.exe',
-                          'BraveBrowserSilentNightlySetup32.exe',
                           'BraveBrowserStandaloneNightlySetup32.exe',
                           'BraveBrowserStandaloneSilentNightlySetup32.exe',
                           'BraveBrowserStandaloneUntaggedNightlySetup32.exe',
@@ -281,7 +278,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-x64.exe',
                           'BraveBrowserDevSetup.exe',
-                          'BraveBrowserSilentDevSetup.exe',
                           'BraveBrowserStandaloneDevSetup.exe',
                           'BraveBrowserStandaloneSilentDevSetup.exe',
                           'BraveBrowserStandaloneUntaggedDevSetup.exe',
@@ -294,7 +290,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-ia32.exe',
                           'BraveBrowserDevSetup32.exe',
-                          'BraveBrowserSilentDevSetup32.exe',
                           'BraveBrowserStandaloneDevSetup32.exe',
                           'BraveBrowserStandaloneSilentDevSetup32.exe',
                           'BraveBrowserStandaloneUntaggedDevSetup32.exe',
@@ -307,7 +302,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-ia32.exe',
                           'BraveBrowserDevSetup32.exe',
-                          'BraveBrowserSilentDevSetup32.exe',
                           'BraveBrowserStandaloneDevSetup32.exe',
                           'BraveBrowserStandaloneSilentDevSetup32.exe',
                           'BraveBrowserStandaloneUntaggedDevSetup32.exe',
@@ -321,7 +315,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-x64.exe',
                           'BraveBrowserBetaSetup.exe',
-                          'BraveBrowserSilentBetaSetup.exe',
                           'BraveBrowserStandaloneBetaSetup.exe',
                           'BraveBrowserStandaloneSilentBetaSetup.exe',
                           'BraveBrowserStandaloneUntaggedBetaSetup.exe',
@@ -335,7 +328,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-ia32.exe',
                           'BraveBrowserBetaSetup32.exe',
-                          'BraveBrowserSilentBetaSetup32.exe',
                           'BraveBrowserStandaloneBetaSetup32.exe',
                           'BraveBrowserStandaloneSilentBetaSetup32.exe',
                           'BraveBrowserStandaloneUntaggedBetaSetup32.exe',
@@ -349,7 +341,6 @@ class TestGetBravePackages(unittest.TestCase):
         self.assertEquals(
             pkgs, sorted(['brave_installer-ia32.exe',
                           'BraveBrowserBetaSetup32.exe',
-                          'BraveBrowserSilentBetaSetup32.exe',
                           'BraveBrowserStandaloneBetaSetup32.exe',
                           'BraveBrowserStandaloneSilentBetaSetup32.exe',
                           'BraveBrowserStandaloneUntaggedBetaSetup32.exe',
@@ -362,7 +353,6 @@ class TestGetBravePackages(unittest.TestCase):
             'release', '1.5.8', 'win32'))
         self.assertEquals(pkgs, sorted(['brave_installer-x64.exe',
                                         'BraveBrowserSetup.exe',
-                                        'BraveBrowserSilentSetup.exe',
                                         'BraveBrowserStandaloneSetup.exe',
                                         'BraveBrowserStandaloneSilentSetup.exe',
                                         'BraveBrowserStandaloneUntaggedSetup.exe',
@@ -375,7 +365,6 @@ class TestGetBravePackages(unittest.TestCase):
             'release', '1.5.8', 'win32', 'ia32'))
         self.assertEquals(pkgs, sorted(['brave_installer-ia32.exe',
                                         'BraveBrowserSetup32.exe',
-                                        'BraveBrowserSilentSetup32.exe',
                                         'BraveBrowserStandaloneSetup32.exe',
                                         'BraveBrowserStandaloneSilentSetup32.exe',
                                         'BraveBrowserStandaloneUntaggedSetup32.exe',
@@ -388,7 +377,6 @@ class TestGetBravePackages(unittest.TestCase):
             'release', '1.5.8', 'win32', 'x86'))
         self.assertEquals(pkgs, sorted(['brave_installer-ia32.exe',
                                         'BraveBrowserSetup32.exe',
-                                        'BraveBrowserSilentSetup32.exe',
                                         'BraveBrowserStandaloneSetup32.exe',
                                         'BraveBrowserStandaloneSilentSetup32.exe',
                                         'BraveBrowserStandaloneUntaggedSetup32.exe',

--- a/script/upload.py
+++ b/script/upload.py
@@ -199,7 +199,6 @@ def get_brave_packages(dir, channel, version, target_os, target_arch='x64', targ
                 arch = '32' if (target_arch == 'ia32') else ''
                 channel_arch_extension = channel_capitalized + 'Setup' + arch + '.exe'
                 file_stub = 'BraveBrowser' + channel_arch_extension
-                file_stub_silent = 'BraveBrowserSilent' + channel_arch_extension
                 file_stub_untagged = 'BraveBrowserUntagged' + channel_arch_extension
                 file_stn = 'BraveBrowserStandalone' + channel_arch_extension
                 file_stn_silent = 'BraveBrowserStandaloneSilent' + channel_arch_extension
@@ -209,9 +208,6 @@ def get_brave_packages(dir, channel, version, target_os, target_arch='x64', targ
                 if re.match(r'BraveBrowser' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
                     filecopy(file_path, file_stub)
                     pkgs.append(file_stub)
-                elif re.match(r'BraveBrowserSilent' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
-                    filecopy(file_path, file_stub_silent)
-                    pkgs.append(file_stub_silent)
                 elif re.match(r'BraveBrowserUntagged' + channel_capitalized + r'Setup' + arch + r'_.*\.exe', file):
                     filecopy(file_path, file_stub_untagged)
                     pkgs.append(file_stub_untagged)


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/6240

Before this PR, there were two silent installers: a 1 MB online ("stub") installer that fetched the latest version of Brave from the update server, and a full, offline installer. Both of these installers were not truly silent because they opened Brave.

In implementing this PR, it was [decided](https://github.com/brave/brave-browser/issues/6240#issuecomment-808859155) that a 1 MB silent online installer is not needed. Part of the work thus consisted of removing this installer.

The remaining work was to make sure that the standalone silent installer does not open a browser window. This was achieved by updating Brave's Omaha update client to pass the flag `--do-not-launch-chrome` to Brave's installer. The corresponding PR was https://github.com/brave/omaha/pull/31.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [x] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [x] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Test that all Windows installers work as expected.