### PR TITLE
Retry referral ping if the referral ping has an error on retry. (uplift to 1.22.x)

### DIFF
--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -382,6 +382,8 @@ void BraveStatsUpdater::SendServerPing() {
           ->GetURLLoaderFactory();
   simple_url_loader_ = network::SimpleURLLoader::Create(
       std::move(resource_request), traffic_annotation);
+  simple_url_loader_->SetRetryOptions(
+      1, network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE);
   simple_url_loader_->DownloadHeadersOnly(
       loader_factory,
       base::BindOnce(&BraveStatsUpdater::OnSimpleLoaderComplete,
@@ -412,6 +414,8 @@ void BraveStatsUpdater::SendUserTriggeredPing() {
           ->GetURLLoaderFactory();
   simple_url_loader_ = network::SimpleURLLoader::Create(
       std::move(resource_request), traffic_annotation);
+  simple_url_loader_->SetRetryOptions(
+      1, network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE);
   simple_url_loader_->DownloadHeadersOnly(
       loader_factory,
       base::BindOnce(&BraveStatsUpdater::OnThresholdLoaderComplete,

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -583,6 +583,8 @@ void BraveReferralsService::FetchReferralHeaders() {
   referral_headers_loader_ = network::SimpleURLLoader::Create(
       std::move(resource_request), traffic_annotation);
   referral_headers_loader_->SetAllowHttpErrorResults(true);
+  referral_headers_loader_->SetRetryOptions(
+      1, network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
   referral_headers_loader_->DownloadToString(
       loader_factory,
       base::BindOnce(&BraveReferralsService::OnReferralHeadersLoadComplete,
@@ -696,6 +698,8 @@ void BraveReferralsService::CheckForReferralFinalization() {
   referral_finalization_check_loader_->SetAllowHttpErrorResults(true);
   referral_finalization_check_loader_->AttachStringForUpload(
       BuildReferralFinalizationCheckPayload(), "application/json");
+  referral_finalization_check_loader_->SetRetryOptions(
+      1, network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
   referral_finalization_check_loader_->DownloadToString(
       loader_factory,
       base::BindOnce(

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -626,6 +626,8 @@ void BraveReferralsService::InitReferral() {
   referral_init_loader_->SetAllowHttpErrorResults(true);
   referral_init_loader_->AttachStringForUpload(BuildReferralInitPayload(),
                                                "application/json");
+  referral_init_loader_->SetRetryOptions(
+      1, network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
   referral_init_loader_->DownloadToString(
       loader_factory,
       base::BindOnce(&BraveReferralsService::OnReferralInitLoadComplete,


### PR DESCRIPTION
Partial uplift of #8382 and #8396. Only cherry pickes the commit 5f1630bd958bfaf797221ce7d49a907662a99374 from the first PR, which is relevant for the regressions we are seeing with Android referrals in stable.

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.