### PR TITLE
Retry referral ping if the referral ping has an error on retry. (uplift to 1.23.x)

### DIFF
--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -626,6 +626,8 @@ void BraveReferralsService::InitReferral() {
   referral_init_loader_->SetAllowHttpErrorResults(true);
   referral_init_loader_->AttachStringForUpload(BuildReferralInitPayload(),
                                                "application/json");
+  referral_init_loader_->SetRetryOptions(
+      1, network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
   referral_init_loader_->DownloadToString(
       loader_factory,
       base::BindOnce(&BraveReferralsService::OnReferralInitLoadComplete,


### PR DESCRIPTION
Partial uplift of #8382. Only cherry pickes the commit 5f1630bd958bfaf797221ce7d49a907662a99374, which is relevant for the regressions we are seeing with Android referrals in stable.

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.