### PR TITLE
Fix rewards browsertests that rely on monthly report modal

### DIFF
--- a/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
@@ -772,6 +772,10 @@ IN_PROC_BROWSER_TEST_F(
   ASSERT_EQ(statuses[0], ledger::type::Result::LEDGER_OK);
   ASSERT_EQ(statuses[1], ledger::type::Result::LEDGER_OK);
 
+  // Wait for UI to update with contribution
+  rewards_browsertest_util::WaitForElementToContain(
+      contents(), "[color=contribute]", "-50.000BAT");
+
   rewards_browsertest_util::WaitForElementThenClick(
       contents(),
       "[data-test-id='showMonthlyReport']");
@@ -789,12 +793,6 @@ IN_PROC_BROWSER_TEST_F(
       contents(),
       "#transactionTable",
       "-20.000BAT");
-
-  // Check that summary table shows the appropriate contribution
-  rewards_browsertest_util::WaitForElementToContain(
-      contents(),
-      "[color=contribute]",
-      "-50.000BAT");
 }
 
 IN_PROC_BROWSER_TEST_F(
@@ -883,6 +881,10 @@ IN_PROC_BROWSER_TEST_F(
 
   // Load rewards page
   context_helper_->LoadURL(rewards_browsertest_util::GetRewardsUrl());
+
+  // Wait for UI to update with contribution
+  rewards_browsertest_util::WaitForElementToContain(
+      contents(), "[color='contribute']", "-50.000BAT");
 
   rewards_browsertest_util::WaitForElementThenClick(
       contents(),


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15070

The monthly report modal does not automatically update when a contribution is completed. Tests that rely on the monthly report modal should wait for the contribution to be reflected in the page UI before opening the modal.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Browsertests should pass.