### PR TITLE
Handles sidebar web type item/settings buttons properly

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/components/sidebar/features.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "content/public/test/browser_test.h"
@@ -29,6 +30,7 @@ class SidebarBrowserTest : public InProcessBrowserTest,
   }
 
   SidebarModel* model() { return controller()->model(); }
+  TabStripModel* tab_model() { return browser()->tab_strip_model(); }
 
   SidebarController* controller() {
     return brave_browser()->sidebar_controller();
@@ -86,6 +88,43 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
   const size_t find_bar_host_view_index =
       browser_view->GetIndexOf(browser_view->find_bar_host_view());
   EXPECT_EQ(browser_view->children().size() - 1, find_bar_host_view_index);
+}
+
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, WebTypePanelTest) {
+  // By default, sidebar has 4 items.
+  EXPECT_EQ(4UL, model()->GetAllSidebarItems().size());
+  ui_test_utils::NavigateToURL(browser(), GURL("brave://settings/"));
+
+  EXPECT_TRUE(CanAddCurrentActiveTabToSidebar(browser()));
+  controller()->AddItemWithCurrentTab();
+  // have 5 items.
+  EXPECT_EQ(5UL, model()->GetAllSidebarItems().size());
+
+  int current_tab_index = tab_model()->active_index();
+  EXPECT_EQ(0, current_tab_index);
+
+  // Load NTP in newtab and activate it. (tab index 1)
+  ui_test_utils::NavigateToURLWithDisposition(
+      browser(), GURL("brave://newtab/"),
+      WindowOpenDisposition::NEW_FOREGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  current_tab_index = tab_model()->active_index();
+  EXPECT_EQ(1, tab_model()->active_index());
+
+  // Activate sidebar item(brave://settings) and check existing first tab is
+  // activated.
+  auto item = model()->GetAllSidebarItems()[4];
+  controller()->ActivateItemAt(4);
+  EXPECT_EQ(0, tab_model()->active_index());
+  EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL(), item.url);
+
+  // Activate second sidebar item(wallet) and check it's loaded at current tab.
+  item = model()->GetAllSidebarItems()[1];
+  controller()->ActivateItemAt(1);
+  EXPECT_EQ(0, tab_model()->active_index());
+  EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL(), item.url);
+  // New tab is not created.
+  EXPECT_EQ(2, tab_model()->count());
 }
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -54,7 +54,11 @@ void SidebarController::ActivateItemAt(int index) {
     return;
   }
 
-  auto params = GetSingletonTabNavigateParams(browser_, item.url);
+  LoadAtTab(item.url);
+}
+
+void SidebarController::LoadAtTab(const GURL& url) {
+  auto params = GetSingletonTabNavigateParams(browser_, url);
   int tab_index = GetIndexOfExistingTab(browser_, params);
   // If browser has a tab that already loaded |item.url|, just activate it.
   if (tab_index >= 0) {

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -12,6 +12,8 @@
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "chrome/browser/ui/browser_navigator.h"
+#include "chrome/browser/ui/browser_navigator_params.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/singleton_tabs.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
@@ -52,12 +54,15 @@ void SidebarController::ActivateItemAt(int index) {
     return;
   }
 
-  // If an item targets in new tab, it should not be an active item.
-  if (IsBuiltInType(item)) {
-    // Should we also always open built-in type in new tab?
-    ShowSingletonTab(browser_, item.url);
+  auto params = GetSingletonTabNavigateParams(browser_, item.url);
+  int tab_index = GetIndexOfExistingTab(browser_, params);
+  // If browser has a tab that already loaded |item.url|, just activate it.
+  if (tab_index >= 0) {
+    browser_->tab_strip_model()->ActivateTabAt(tab_index);
   } else {
-    chrome::AddTabAt(browser_, item.url, -1, true);
+    // Load on current tab.
+    params.disposition = WindowOpenDisposition::CURRENT_TAB;
+    Navigate(&params);
   }
 }
 

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -40,6 +40,9 @@ class SidebarController : public SidebarService::Observer {
   void ActivateItemAt(int index);
   void AddItemWithCurrentTab();
   void RemoveItemAt(int index);
+  // If current browser doesn't have a tab for |url|, active tab will load
+  // |url|. Otherwise, existing tab will be activated.
+  void LoadAtTab(const GURL& url);
 
   bool IsActiveIndex(int index) const;
 

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -17,6 +17,7 @@
 #include "brave/components/sidebar/sidebar_service.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "brave/grit/brave_theme_resources.h"
+#include "chrome/common/webui_url_constants.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/theme_provider.h"
@@ -201,8 +202,8 @@ void SidebarControlView::OnButtonPressed(views::View* view) {
   }
 
   if (view == sidebar_settings_view_) {
-    // TODO(simonhong): Handle settings button here.
-    NOTIMPLEMENTED();
+    browser_->sidebar_controller()->LoadAtTab(
+        GURL(chrome::kChromeUISettingsURL));
   }
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15084

When user clicks web type panel, load it to current tab.
If browser window already has a tab that loads that url, activate that tab.

<!-- Add brave-browser issue bellow that this PR will resolve -->

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=*SidebarBrowserTest*`

1. Launch browser and enable sidebar via brave://flags
2. Relaunch browser and create two tab - first one is NTP and second one is brave.com
3. Activate second sidebar item (wallet) and check wallet page loads at second tab(current tab)
4. Activate first browser tab(NTP) and activate second sidebar item(wallet) and check second tab is activated.