### PR TITLE
Critical, updated inconsistent menu formatting

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -161,13 +161,13 @@
   <release seq="1">
     <messages fallback_to_english="true">
       <message name="IDS_SHOW_BRAVE_REWARDS" desc="The show Brave Rewards menu in the app menu">
-        Brave Rewards
+        Rewards
       </message>
       <message name="IDS_SHOW_BRAVE_ADBLOCK" desc="The show Brave Ad Block menu in the app menu">
-        Brave Ad Block
+        Ad block
       </message>
       <message name="IDS_SHOW_BRAVE_WEBCOMPAT_REPORTER" desc="The menu item to report a broken site in the app menu">
-        Report a Broken Site
+        Report a broken site
       </message>
       <message name="IDS_SHOW_BRAVE_SYNC" desc="The show brave sync menu in the app menu">
         Sync
@@ -176,10 +176,10 @@
         Wallet
       </message>
       <message name="IDS_ADD_NEW_PROFILE" desc="The app menu item to create a new User Profile">
-        Create a New Profile
+        Create a new profile
       </message>
       <message name="IDS_OPEN_GUEST_PROFILE" desc="The app menu item to create a new User Profile">
-        Open Guest Window
+        Open a guest window
       </message>
       <message name="IDS_OPEN_MORE_OTHER_DEVICES_SESSIONS" desc="The history sub-menu item to show sessions from other devices">
         More…
@@ -692,7 +692,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         None
       </message>
       <message name="IDS_BRAVE_WALLET_WEB3_PROVIDER_CRYPTO_WALLETS" desc="Select control value for which web3 provider to use">
-        Crypto Wallets
+        Crypto wallets
       </message>
       <message name="IDS_BRAVE_WALLET_WEB3_PROVIDER_CRYPTO_WALLETS_DEPRECATED" desc="Select control value for which web3 provider to use">
         Deprecated Crypto Wallets extension


### PR DESCRIPTION
Changed "Brave Rewards" to "Rewards," etc., because it isn't Brave Sync or Brave History.

Also updated casing for a few menu items: they were capitalized in an inconsistent format. The others are all capitalized in the same format as the update.