### PR TITLE
Fix sync includes

### DIFF
--- a/browser/sync/BUILD.gn
+++ b/browser/sync/BUILD.gn
@@ -10,6 +10,5 @@ source_set("sync") {
     "//base",
     "//components/sync/driver",
     "//components/sync_device_info",
-    "//components/webapps/services/web_app_origin_association:lib"
   ]
 }

--- a/chromium_src/chrome/browser/sync/chrome_sync_client.cc
+++ b/chromium_src/chrome/browser/sync/chrome_sync_client.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "build/buildflag.h"
+#include "extensions/buildflags/buildflags.h"
+
+#if !BUILDFLAG(ENABLE_EXTENSIONS)
+
+#define CHROME_BROWSER_WEB_APPLICATIONS_WEB_APP_PROVIDER_H_
+#define CHROME_BROWSER_WEB_APPLICATIONS_WEB_APP_SYNC_BRIDGE_H_
+
+#endif  // !BUILDFLAG(ENABLE_EXTENSIONS)
+
+#include "../../../../../chrome/browser/sync/chrome_sync_client.cc"


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15115


`chrome/browser/sync/chrome_sync_client.cc` is in  `//chrome/browser:browser` target, 
`web_app_sync_bridge.h` is in  `//chrome/browser/web_applications:web_applications` target,
`//chrome/browser:browser` has dependency from `//chrome/browser/web_applications` , but it is under the flag `if (enable_extensions) {` .

In file  `src/chrome/browser/sync/chrome_sync_client.cc`

references to classes  `WebAppSyncBridge` и `WebAppProvider` are guarded by  
```
#if BUILDFLAG(ENABLE_EXTENSIONS)
#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
```
but at the same time  the includes 
```
#include "chrome/browser/web_applications/web_app_provider.h"
#include "chrome/browser/web_applications/web_app_sync_bridge.h"
```
are not guarded.

This PR excludes those includes  when build does not support extensions.

Chromium builds well by some coincidence.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint` // lint reports issues beyond the PR
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run build -- Release --target_os=android --target_arch=arm64 --target_apk_base=mono`
