### PR TITLE
Fix statistical voting for case where publisher receives no votes

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution.cc
@@ -644,9 +644,7 @@ void Contribution::OnResult(
     return;
   }
 
-  ledger_->contribution()->ContributionCompleted(
-      result,
-      std::move(contribution));
+  ContributionCompleted(result, std::move(contribution));
 }
 
 void Contribution::SetRetryTimer(
@@ -689,9 +687,8 @@ void Contribution::SetRetryCounter(type::ContributionInfoPtr contribution) {
   if (contribution->retry_count == 3 &&
       contribution->step != type::ContributionStep::STEP_PREPARE) {
     BLOG(0, "Contribution failed after 3 retries");
-    ledger_->contribution()->ContributionCompleted(
-        type::Result::TOO_MANY_RESULTS,
-        std::move(contribution));
+    ContributionCompleted(type::Result::TOO_MANY_RESULTS,
+                          std::move(contribution));
     return;
   }
 
@@ -738,9 +735,8 @@ void Contribution::Retry(
   if ((*shared_contribution)->type == type::RewardsType::AUTO_CONTRIBUTE &&
       !ledger_->state()->GetAutoContributeEnabled()) {
     BLOG(1, "AC is disabled, completing contribution");
-    ledger_->contribution()->ContributionCompleted(
-        type::Result::AC_OFF,
-        std::move(*shared_contribution));
+    ContributionCompleted(type::Result::AC_OFF,
+                          std::move(*shared_contribution));
     return;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_unblinded.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_unblinded.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVELEDGER_CONTRIBUTION_CONTRIBUTION_UNBLINDED_H_
-#define BRAVELEDGER_CONTRIBUTION_CONTRIBUTION_UNBLINDED_H_
+#ifndef BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_CONTRIBUTION_CONTRIBUTION_UNBLINDED_H_
+#define BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_CONTRIBUTION_CONTRIBUTION_UNBLINDED_H_
 
 #include <stdint.h>
 
@@ -23,9 +23,9 @@ namespace contribution {
 
 using GetContributionInfoAndUnblindedTokensCallback = std::function<void(
     type::ContributionInfoPtr contribution,
-    const std::vector<type::UnblindedToken>& list)>;
+    const std::vector<type::UnblindedToken>& unblinded_tokens)>;
 
-using Winners = std::map<std::string, uint32_t>;
+using StatisticalVotingWinners = std::map<std::string, uint32_t>;
 
 class Unblinded {
  public:
@@ -43,13 +43,15 @@ class Unblinded {
       ledger::ResultCallback callback);
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(UnblindedTest, GetStatisticalVotingWinner);
+
   void GetContributionInfoAndUnblindedTokens(
       const std::vector<type::CredsBatchType>& types,
       const std::string& contribution_id,
       GetContributionInfoAndUnblindedTokensCallback callback);
 
   void OnUnblindedTokens(
-      type::UnblindedTokenList list,
+      type::UnblindedTokenList unblinded_tokens,
       const std::string& contribution_id,
       GetContributionInfoAndUnblindedTokensCallback callback);
 
@@ -58,29 +60,28 @@ class Unblinded {
       GetContributionInfoAndUnblindedTokensCallback callback);
 
   void OnReservedUnblindedTokens(
-      type::UnblindedTokenList list,
+      type::UnblindedTokenList unblinded_tokens,
       const std::string& contribution_id,
       GetContributionInfoAndUnblindedTokensCallback callback);
 
   void OnGetContributionInfo(
       type::ContributionInfoPtr contribution,
-      const std::vector<type::UnblindedToken>& list,
+      const std::vector<type::UnblindedToken>& unblinded_tokens,
       GetContributionInfoAndUnblindedTokensCallback callback);
 
-  void PrepareTokens(
-      type::ContributionInfoPtr contribution,
-      const std::vector<type::UnblindedToken>& list,
-      const std::vector<type::CredsBatchType>& types,
-      ledger::ResultCallback callback);
+  void PrepareTokens(type::ContributionInfoPtr contribution,
+                     const std::vector<type::UnblindedToken>& unblinded_tokens,
+                     const std::vector<type::CredsBatchType>& types,
+                     ledger::ResultCallback callback);
 
   void PreparePublishers(
-      const std::vector<type::UnblindedToken>& list,
+      const std::vector<type::UnblindedToken>& unblinded_tokens,
       type::ContributionInfoPtr contribution,
       const std::vector<type::CredsBatchType>& types,
       ledger::ResultCallback callback);
 
   type::ContributionPublisherList PrepareAutoContribution(
-      const std::vector<type::UnblindedToken>& list,
+      const std::vector<type::UnblindedToken>& unblinded_tokens,
       type::ContributionInfoPtr contribution);
 
   void OnPrepareAutoContribution(
@@ -102,7 +103,7 @@ class Unblinded {
 
   void OnProcessTokens(
       type::ContributionInfoPtr contribution,
-      const std::vector<type::UnblindedToken>& list,
+      const std::vector<type::UnblindedToken>& unblinded_tokens,
       ledger::ResultCallback callback);
 
   void TokenProcessed(
@@ -120,16 +121,21 @@ class Unblinded {
 
   void OnMarkUnblindedTokensAsReserved(
       const type::Result result,
-      const std::vector<type::UnblindedToken>& list,
+      const std::vector<type::UnblindedToken>& unblinded_tokens,
       std::shared_ptr<type::ContributionInfoPtr> shared_contribution,
       const std::vector<type::CredsBatchType>& types,
       ledger::ResultCallback callback);
 
   void OnReservedUnblindedTokensForRetryAttempt(
-      const type::UnblindedTokenList& list,
+      const type::UnblindedTokenList& unblinded_tokens,
       const std::vector<type::CredsBatchType>& types,
       std::shared_ptr<type::ContributionInfoPtr> shared_contribution,
       ledger::ResultCallback callback);
+
+  std::string GetStatisticalVotingWinnerForTesting(
+      double dart,
+      double amount,
+      const ledger::type::ContributionPublisherList& publisher_list);
 
   LedgerImpl* ledger_;  // NOT OWNED
   std::unique_ptr<credential::Credentials> credentials_promotion_;
@@ -138,4 +144,4 @@ class Unblinded {
 
 }  // namespace contribution
 }  // namespace ledger
-#endif  // BRAVELEDGER_CONTRIBUTION_CONTRIBUTION_UNBLINDED_H_
+#endif  // BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_CONTRIBUTION_CONTRIBUTION_UNBLINDED_H_

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_unblinded_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_unblinded_unittest.cc
@@ -92,5 +92,51 @@ TEST_F(UnblindedTest, NotEnoughFunds) {
       });
 }
 
+TEST_F(UnblindedTest, GetStatisticalVotingWinner) {
+  ledger::type::ContributionPublisherList publisher_list;
+
+  auto publisher1 = type::ContributionPublisher::New();
+  publisher1->publisher_key = "publisher1";
+  publisher1->total_amount = 2.0;
+  publisher_list.push_back(std::move(publisher1));
+
+  auto publisher2 = type::ContributionPublisher::New();
+  publisher2->publisher_key = "publisher2";
+  publisher2->total_amount = 13.0;
+  publisher_list.push_back(std::move(publisher2));
+
+  auto publisher3 = type::ContributionPublisher::New();
+  publisher3->publisher_key = "publisher3";
+  publisher3->total_amount = 14.0;
+  publisher_list.push_back(std::move(publisher3));
+
+  auto publisher4 = type::ContributionPublisher::New();
+  publisher4->publisher_key = "publisher4";
+  publisher4->total_amount = 23.0;
+  publisher_list.push_back(std::move(publisher4));
+
+  auto publisher5 = type::ContributionPublisher::New();
+  publisher5->publisher_key = "publisher5";
+  publisher5->total_amount = 38.0;
+  publisher_list.push_back(std::move(publisher5));
+
+  struct {
+    double dart;
+    const char* publisher_key;
+  } cases[] = {
+      {0.01, "publisher1"}, {0.05, "publisher2"}, {0.10, "publisher2"},
+      {0.20, "publisher3"}, {0.30, "publisher4"}, {0.40, "publisher4"},
+      {0.50, "publisher4"}, {0.60, "publisher5"}, {0.70, "publisher5"},
+      {0.80, "publisher5"}, {0.90, "publisher5"},
+  };
+
+  for (size_t i = 0; i < base::size(cases); i++) {
+    const std::string publisher_key =
+        unblinded_->GetStatisticalVotingWinnerForTesting(cases[i].dart, 100.0,
+                                                         publisher_list);
+    EXPECT_STREQ(publisher_key.c_str(), cases[i].publisher_key);
+  }
+}
+
 }  // namespace contribution
 }  // namespace ledger


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15071

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Clean profile
- Enable Rewards
- Claim UGP grant
- Make sure AC is set to 1 BAT
- Visit 2 verified sites
- Wait for AC to process
- Go to brave://rewards-internals

The 1 BAT should be split correctly between the two sites (i.e., both contributions should add up to 1 BAT).

Ideally, since there's a random element to the voting process, we should repeat this test until one of the publishers receives a contribution of 0 BAT as that is the case this fix is addressing (publisher receiving 0 statistical votes and thus 0 BAT for their contribution). In that scenario, one publisher will receive a contribution of 0 BAT and the other publisher will receive a contribution of 1 BAT.