### PR TITLE
Fix GN dependencies in //brave/utility

### DIFF
--- a/components/services/bat_ads/BUILD.gn
+++ b/components/services/bat_ads/BUILD.gn
@@ -1,7 +1,7 @@
 static_library("lib") {
   visibility = [
-    "//brave/utility:*",
     "//brave/test:*",
+    "//chrome/utility:*",
   ]
 
   sources = [

--- a/components/services/bat_ads/BUILD.gn
+++ b/components/services/bat_ads/BUILD.gn
@@ -14,8 +14,8 @@ static_library("lib") {
   ]
 
   public_deps = [
-    "//brave/vendor/bat-native-ads",
     "public/interfaces",
+    "//brave/vendor/bat-native-ads",
   ]
 
   deps = [

--- a/components/services/bat_ledger/BUILD.gn
+++ b/components/services/bat_ledger/BUILD.gn
@@ -14,11 +14,9 @@ static_library("lib") {
   ]
 
   public_deps = [
-    "//brave/vendor/bat-native-ledger",
     "public/interfaces",
+    "//brave/vendor/bat-native-ledger",
   ]
 
-  deps = [
-    "//mojo/public/cpp/system",
-  ]
+  deps = [ "//mojo/public/cpp/system" ]
 }

--- a/components/services/bat_ledger/BUILD.gn
+++ b/components/services/bat_ledger/BUILD.gn
@@ -1,7 +1,7 @@
 static_library("lib") {
   visibility = [
-    "//brave/utility:*",
     "//brave/test:*",
+    "//chrome/utility:*",
   ]
 
   sources = [

--- a/components/services/tor/BUILD.gn
+++ b/components/services/tor/BUILD.gn
@@ -10,8 +10,8 @@ source_set("tor") {
   ]
 
   deps = [
+    "public/interfaces",
     "//base",
     "//mojo/public/cpp/bindings",
-    "public/interfaces",
   ]
 }

--- a/components/services/tor/BUILD.gn
+++ b/components/services/tor/BUILD.gn
@@ -1,7 +1,7 @@
 source_set("tor") {
   visibility = [
-    "//brave/utility:*",
-    "//brave/test:*"
+    "//brave/test:*",
+    "//chrome/utility:*",
   ]
 
   sources = [

--- a/patches/chrome-utility-BUILD.gn.patch
+++ b/patches/chrome-utility-BUILD.gn.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/utility/BUILD.gn b/chrome/utility/BUILD.gn
-index 3c1c93059d71ce27125a67d49624cdadaf3078c8..0ea1995b1ef4b804c2be07556dad744895306556 100644
+index 3c1c93059d71ce27125a67d49624cdadaf3078c8..5b74db962a57545280bbeffda999b2723f2d4922 100644
 --- a/chrome/utility/BUILD.gn
 +++ b/chrome/utility/BUILD.gn
-@@ -29,6 +29,7 @@ static_library("utility") {
+@@ -66,6 +66,8 @@ static_library("utility") {
+     "//ui/base:buildflags",
+   ]
  
-   public_deps = []
-   deps = [
-+    "//brave/utility",
-     "//base",
-     "//build:chromeos_buildflags",
-     "//chrome:resources",
++  import("//brave/utility/sources.gni") sources += brave_utility_sources deps += brave_utility_deps public_deps += brave_utility_public_deps
++
+   if (is_win) {
+     deps += [
+       "//components/services/quarantine",

--- a/utility/BUILD.gn
+++ b/utility/BUILD.gn
@@ -1,61 +1,6 @@
-import("//brave/components/brave_ads/browser/buildflags/buildflags.gni")
-import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
-import("//brave/components/ipfs/buildflags/buildflags.gni")
-import("//brave/components/tor/buildflags/buildflags.gni")
-import("//build/config/features.gni")
-import("//build/config/ui.gni")
-
-source_set("utility") {
-  # Remove when https://github.com/brave/brave-browser/issues/10623 is resolved
-  check_includes = false
-  visibility = [
-    "//chrome/utility/*",
-    "//brave/utility/*",
-    "//brave:child_dependencies",
-    "//brave/test:*"
-  ]
-
-  sources = [
-    "brave_content_utility_client.cc",
-    "brave_content_utility_client.h",
-  ]
-
-  deps = []
-  public_deps = []
-
-  if (!is_android) {
-    sources += [
-      "importer/brave_external_process_importer_bridge.cc",
-      "importer/brave_external_process_importer_bridge.h",
-      "importer/brave_profile_import_impl.cc",
-      "importer/brave_profile_import_impl.h",
-      "importer/chrome_importer.cc",
-      "importer/chrome_importer.h",
-    ]
-
-    deps += [
-      "//base",
-      "//brave/common/importer:interfaces",
-      "//chrome/app:chromium_strings",
-      "//components/os_crypt",
-      "//components/password_manager/core/browser",
-      "//components/webdata/common",
-    ]
-  }
-
-  if (enable_tor) {
-    deps += [ "//brave/components/services/tor" ]
-  }
-
-  if (ipfs_enabled) {
-    deps += [ "//brave/components/services/ipfs" ]
-  }
-
-  if (brave_ads_enabled) {
-    public_deps += [ "//brave/components/services/bat_ads:lib" ]
-  }
-
-  if (brave_rewards_enabled) {
-    public_deps += [ "//brave/components/services/bat_ledger:lib" ]
-  }
+# Group depending on upstream's counterpart to make it easier to manage
+# dependencies in brave/ (//chrome/utility does not depend on //brave/utility,
+# so //brave/utility becomes essentially an alias for //chrome/utility now).
+group("utility") {
+  public_deps = [ "//chrome/utility" ]
 }

--- a/utility/importer/DEPS
+++ b/utility/importer/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "+brave/common/importer",
   "+components/favicon_base",
   "+components/os_crypt",
   "+components/password_manager/core/browser",

--- a/utility/importer/sources.gni
+++ b/utility/importer/sources.gni
@@ -1,0 +1,47 @@
+import("//brave/components/brave_ads/browser/buildflags/buildflags.gni")
+import("//brave/components/brave_rewards/browser/buildflags/buildflags.gni")
+import("//brave/components/ipfs/buildflags/buildflags.gni")
+import("//brave/components/tor/buildflags/buildflags.gni")
+
+brave_utility_importer_sources = []
+brave_utility_importer_deps = []
+brave_utility_importer_public_deps = []
+
+if (!is_android) {
+  brave_utility_importer_sources += [
+    "//brave/utility/importer/brave_external_process_importer_bridge.cc",
+    "//brave/utility/importer/brave_external_process_importer_bridge.h",
+    "//brave/utility/importer/brave_profile_import_impl.cc",
+    "//brave/utility/importer/brave_profile_import_impl.h",
+    "//brave/utility/importer/chrome_importer.cc",
+    "//brave/utility/importer/chrome_importer.h",
+  ]
+
+  brave_utility_importer_deps += [
+    "//base",
+    "//brave/common/importer:importer",
+    "//brave/common/importer:interfaces",
+    "//chrome/app:chromium_strings",
+    "//components/os_crypt",
+    "//components/password_manager/core/browser",
+    "//components/webdata/common",
+  ]
+}
+
+if (enable_tor) {
+  brave_utility_importer_deps += [ "//brave/components/services/tor" ]
+}
+
+if (ipfs_enabled) {
+  brave_utility_importer_deps += [ "//brave/components/services/ipfs" ]
+}
+
+if (brave_ads_enabled) {
+  brave_utility_importer_public_deps +=
+      [ "//brave/components/services/bat_ads:lib" ]
+}
+
+if (brave_rewards_enabled) {
+  brave_utility_importer_public_deps +=
+      [ "//brave/components/services/bat_ledger:lib" ]
+}

--- a/utility/sources.gni
+++ b/utility/sources.gni
@@ -1,0 +1,13 @@
+import("//brave/utility/importer/sources.gni")
+
+brave_utility_sources = [
+  "//brave/utility/brave_content_utility_client.cc",
+  "//brave/utility/brave_content_utility_client.h",
+]
+brave_utility_sources += brave_utility_importer_sources
+
+brave_utility_deps = []
+brave_utility_deps += brave_utility_importer_deps
+
+brave_utility_public_deps = []
+brave_utility_public_deps += brave_utility_importer_public_deps


### PR DESCRIPTION
We had made services.cc depend on //brave/utility via a chromium_src
override, but that caused a dependency cycle because //brave/utility
also depends on //chrome/utility (e.g. extend some upstream classes),
causing a gn check error.
    
To fix this, we can follow the pattern used in other places and make
upstream's //chrome/utility directly include the files from Brave that
it needs, and replace the oneliner patch to //chrome/utility/BUILD.gn
with one that would simply include those sources, instead of having it
depend on //brave/utility.
    
Last, we also add a missing dep on //brave/common/importer:importer
to avoid another gn check failure due to having some files from that
target included from brave_external_process_importer_bridge.h.
    
Resolves https://github.com/brave/brave-browser/issues/10623

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

