### PR TITLE
Disable Make a Call From option

### DIFF
--- a/chromium_src/chrome/browser/DEPS
+++ b/chromium_src/chrome/browser/DEPS
@@ -44,6 +44,7 @@ include_rules = [
   "+../../../../../../chrome/browser/flags/android",
   "+../../../../../../chrome/browser/media/router",
   "+../../../../../../chrome/browser/safe_browsing/download_protection",
+  "+../../../../../../chrome/browser/sharing/click_to_call",
   "+../../../../../../chrome/browser/ui/bookmarks",
   "+../../../../../../chrome/browser/ui/cocoa",
   "+../../../../../../chrome/browser/ui/content_settings",

--- a/chromium_src/chrome/browser/sharing/click_to_call/click_to_call_utils.cc
+++ b/chromium_src/chrome/browser/sharing/click_to_call/click_to_call_utils.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#define ShouldOfferClickToCallForURL ShouldOfferClickToCallForURL_ChromiumImpl
+
+#include "../../../../../../chrome/browser/sharing/click_to_call/click_to_call_utils.cc"
+
+#undef ShouldOfferClickToCallForURL
+
+bool ShouldOfferClickToCallForURL(content::BrowserContext* browser_context,
+                                  const GURL& url) {
+  return false;
+}


### PR DESCRIPTION

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14601, https://github.com/brave/brave-browser/issues/11526

Share call Chromium feature uses sync to get devices list and uses Google Cloud Messaging to push the call to the Android device. Therefore it is not supported by Brave browser.

The proper way would be to use gn variable `enable_click_to_call`, but setting it to false gives compile errors:
```
../../chrome/browser/sharing/click_to_call/phone_number_regex.cc:43:37: error: use of undeclared identifier 'kClickToCallUI'
  if (!base::FeatureList::IsEnabled(kClickToCallUI))


../../chrome/browser/sharing/click_to_call/click_to_call_utils.cc:40:58: error: no member named 'kClickToCallEnabled' in namespace 'prefs'
  if (profile && !profile->GetPrefs()->GetBoolean(prefs::kClickToCallEnabled))
                                                  ~~~~~~~^
../../chrome/browser/sharing/click_to_call/click_to_call_utils.cc:45:58: error: use of undeclared identifier 'kClickToCallUI'
  return sharing_service && base::FeatureList::IsEnabled(kClickToCallUI);
                                                         ^

../../brave/chromium_src/chrome/browser/ui/views/location_bar/../../../../../../../chrome/browser/ui/views/location_bar/location_bar_view.cc:266:38: error: use of undeclared identifier 'kClickToCallUI'
    if (base::FeatureList::IsEnabled(kClickToCallUI))
```
By this reason override of `ShouldOfferClickToCallForURL` is used.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`// tested lint only
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Put the desktop into the same sync chain with an Android device
2. Open the website which contains `tel:` link, like https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_link_phoneto
3. Click the link with phone number
4. Expected: there is no dialog which choose the device to call from like 
![image](https://user-images.githubusercontent.com/24739341/113779394-4feea480-9736-11eb-9153-085e5b810326.png)


