### PR TITLE
Set load flags to prevent reading from HTTP cache

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_rewards/browser/rewards_service_impl.h"
 
 #include <stdint.h>
+#include <string>
 
 #include <algorithm>
 #include <functional>
@@ -981,6 +982,7 @@ void RewardsServiceImpl::LoadURL(
   auto net_request = std::make_unique<network::ResourceRequest>();
   net_request->url = parsed_url;
   net_request->method = URLMethodToRequestType(request->method);
+  net_request->load_flags = request->load_flags;
 
   // Loading Twitter requires credentials
   if (net_request->url.DomainIs("twitter.com")) {

--- a/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger.mojom
+++ b/vendor/bat-native-ledger/include/bat/ledger/public/interfaces/ledger.mojom
@@ -521,6 +521,7 @@ struct UrlRequest {
   string content;
   string content_type;
   bool skip_log;
+  uint32 load_flags = 0;
 };
 
 struct UrlResponse {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.cc
@@ -14,6 +14,7 @@
 #include "bat/ledger/internal/ledger_impl.h"
 #include "bat/ledger/internal/publisher/protos/channel_response.pb.h"
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
+#include "net/base/load_flags.h"
 #include "net/http/http_status_code.h"
 
 using std::placeholders::_1;
@@ -219,6 +220,7 @@ void GetPublisher::Request(
 
   auto request = type::UrlRequest::New();
   request->url = GetUrl(hash_prefix);
+  request->load_flags = net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE;
   ledger_->LoadURL(std::move(request), url_callback);
 }
 


### PR DESCRIPTION
Will now show the channel as not verified with this patch if there's no connection.

Before patch:
![before_patch](https://user-images.githubusercontent.com/8647607/115136764-c8772000-9fd6-11eb-86ba-7495ddd429d8.png)

After patch:
![after_patch](https://user-images.githubusercontent.com/8647607/115136760-bf864e80-9fd6-11eb-892a-1ac7493e2773.png)

Resolves https://github.com/brave/brave-browser/issues/15154

## Submitter Checklist:

- [X] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [X] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [X] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [X] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
On all OS's, please visit yachtcaptain23.github.io or another Rewards connected domain and make sure the Rewards check mark appears. Then disable the WiFi/internet connection and click refresh, and please observer that the Rewards check mark does not appear (or it says it's not verified)
