### PR TITLE
Fix bad formatting of l10n of plural strings. (uplift to 1.24.x)

### DIFF
--- a/app/resources/generated_resources_am.xtb
+++ b/app/resources/generated_resources_am.xtb
@@ -7277,13 +7277,13 @@ nil</translation>
 <translation id="7475335772460644497">{COUNT, plural,
 =0 {ሁሉንም በዚህ ይክፈቱ &amp;Private Window}
 =1 {በዚህ &amp;Private Window}
-ሌላ {Open All ({COUNT}) በዚህ ይክፈቱ &amp;Private Window}}</translation>
+other {Open All ({COUNT}) በዚህ ይክፈቱ &amp;Private Window}}</translation>
 <translation id="2431625704210501303">&amp;ማንነትን በማያሳውቅ መስኮት ውስጥ ክፈት</translation>
 <translation id="4620367155626060530">&amp;የዕልባቶች አሞሌ አሳይ</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {ሁሉንም በዚህ ይክፈቱ &amp;Private Window}
           =1 {በዚህ &amp;Private Window}
-          ሌላ {Open All ({COUNT}) በዚህ ይክፈቱ &amp;Private Window}}</translation>
+          other {Open All ({COUNT}) በዚህ ይክፈቱ &amp;Private Window}}</translation>
 <translation id="1985165269306590797">&amp;ማንነትን በማያሳውቅ መስኮት ውስጥ ክፈት</translation>
 <translation id="4680518314108745448">&amp;የዕልባቶች አሞሌ አሳይ</translation>
 <translation id="642436385689435488">ሁሉንም ማንነት በማያሳውቅ መስኮት ውስጥ ክፈት</translation>
@@ -7291,11 +7291,11 @@ nil</translation>
 <translation id="5463021359602611602">ማንነትን በማያሳውቅ መስኮት ክፈት</translation>
 <translation id="1850357845349976573">{0,plural,
 =1 {# ማንነትን የማያሳውቅ}
-ሌላ {# ማንነትን የማያሳውቁ መስኮቶች ክፈት}
+other {# ማንነትን የማያሳውቁ መስኮቶች ክፈት}
 }</translation>
 <translation id="8773965542687789581">{0,plural,
 =1 {# ማንነትን የማያሳውቅ}
-ሌላ {ማንነትን የማያሳውቅ (#)}
+other {ማንነትን የማያሳውቅ (#)}
 }</translation>
 <translation id="5070556616376997776">ይህ ማንነትን በማያሳውቅ መስኮት ነው</translation>
 <translation id="5832813618714645810">መገለጫዎች</translation>

--- a/app/resources/generated_resources_fi.xtb
+++ b/app/resources/generated_resources_fi.xtb
@@ -7282,13 +7282,13 @@ Paina määritettyä kytkintä, niin poistat sen määrityksen.</translation>
 <translation id="642436385689435488">Avaa kaikki yksityisessä ikkunassa</translation>
 <translation id="5074021236879527611">Avaa kaikki (<ph name="URL_COUNT"/>) yksityisessä ikkunassa</translation>
 <translation id="5463021359602611602">Avaa yksityisessä ikkunassa</translation>
-<translation id="1850357845349976573">{0, monikko,
+<translation id="1850357845349976573">{0, plural,
         =1 {Yksityinen}
-        muu {avoimien ikkunoiden lukumäärä}
+        other {avoimien ikkunoiden lukumäärä}
       }</translation>
-<translation id="8773965542687789581">{0, monikko,
+<translation id="8773965542687789581">{0, plural,
       =1 {Yksityinen}
-      muu {yksityinen (lukumäärä)}
+      other {yksityinen (lukumäärä)}
     }</translation>
 <translation id="5070556616376997776">Tämä on yksityinen ikkuna</translation>
 <translation id="5832813618714645810">Profiilit</translation>

--- a/app/resources/generated_resources_fr-CA.xtb
+++ b/app/resources/generated_resources_fr-CA.xtb
@@ -4176,7 +4176,7 @@ Souhaitez-vous lancer <ph name="CONTROL_PANEL_APPLET_NAME"/>?</translation>
 <translation id="5769519078756170258">Hôte ou domaine à exclure</translation>
 <translation id="5770125698810550803">Afficher les boutons de navigation</translation>
 <translation id="5771816112378578655">Configuration en cours...</translation>
-<translation id="5772114492540073460"><ph name="PARALLELS_NAME"/> vous permet d'utiliser des applications Windows🅫 sur votre Bravebook. <ph name="MINIMUM_SPACE"/> d'espace libre est recommandé pour l'installation.</translation>
+<translation id="5772114492540073460"><ph name="PARALLELS_NAME"/> vous permet d'utiliser des applications Windows? sur votre Bravebook. <ph name="MINIMUM_SPACE"/> d'espace libre est recommandé pour l'installation.</translation>
 <translation id="5772265531560382923">{NUM_PAGES,plural, =1{Vous pouvez attendre que la page réponde ou la quitter.}one{Vous pouvez attendre que la page réponde ou la quitter.}other{Vous pouvez attendre que les pages répondent ou les quitter.}}</translation>
 <translation id="577322787686508614">Opération de lecture non autorisée sur l'appareil « <ph name="DEVICE_NAME"/> ».</translation>
 <translation id="5774295353725270860">Ouvrir l'application Fichiers</translation>

--- a/app/resources/generated_resources_hi.xtb
+++ b/app/resources/generated_resources_hi.xtb
@@ -7274,13 +7274,13 @@
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Open all in &amp;private window}
           =1 {Open in &amp;private window}
-           अन्य {Open all ({COUNT}) in &amp;private window}}</translation>
+           other {Open all ({COUNT}) in &amp;private window}}</translation>
 <translation id="2431625704210501303">प्राइवेट &amp;विंडो में खोलें</translation>
 <translation id="4620367155626060530">बुकमार्क बार &amp;दिखाएं</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Open All in &amp;Private Window}
           =1 {Open in &amp;Private Window}
-          अन्य {Open All ({COUNT}) in &amp;Private Window}}</translation>
+          other {Open All ({COUNT}) in &amp;Private Window}}</translation>
 <translation id="1985165269306590797">प्राइवेट &amp;विंडो में खोलें</translation>
 <translation id="4680518314108745448">बुकमार्क बार &amp;दिखाएं</translation>
 <translation id="642436385689435488">सभी प्राइवेट विंडो में खोलें</translation>

--- a/app/resources/generated_resources_hr.xtb
+++ b/app/resources/generated_resources_hr.xtb
@@ -7276,13 +7276,13 @@ Pritisnite dodijeljeni prekidač da biste uklonili dodjelu.</translation>
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Otvori sve u &amp;privatnom prozoru}
           =1 {Otvori u &amp;privatnom prozoru}
-          drugo {Otvori sve ({COUNT}) u &amp;privatnom/ih prozoru/a}}</translation>
+          other {Otvori sve ({COUNT}) u &amp;privatnom/ih prozoru/a}}</translation>
 <translation id="2431625704210501303">Otvori u &amp;privatnom prozoru</translation>
 <translation id="4620367155626060530">&amp;Prikaži traku oznake</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Otvori sve u &amp;privatnom prozoru}
           =1 {Otvori u &amp;privatnom prozoru}
-          drugo {Otvori sve ({COUNT})) u &amp;privatnom/ih prozoru/a}}</translation>
+          other {Otvori sve ({COUNT}) u &amp;privatnom/ih prozoru/a}}</translation>
 <translation id="1985165269306590797">Otvori u &amp;privatnom prozoru</translation>
 <translation id="4680518314108745448">&amp;Prikaz trake oznake</translation>
 <translation id="642436385689435488">Otvori sve u privatnom prozoru</translation>

--- a/app/resources/generated_resources_hu.xtb
+++ b/app/resources/generated_resources_hu.xtb
@@ -7287,13 +7287,13 @@ A(z) <ph name="DOMAIN"/> megköveteli, hogy ne távolítsa el az intelligens ká
 <translation id="642436385689435488">Összes megnyitása privát ablakban</translation>
 <translation id="5074021236879527611">Összes megnyitása (<ph name="URL_COUNT"/>) privát ablakban</translation>
 <translation id="5463021359602611602">Megnyitás privát ablakban</translation>
-<translation id="1850357845349976573">{0, több,
+<translation id="1850357845349976573">{0, plural,
         =1 {Privát}
-        egyéb {megnyitott privát ablakok #}
+        other {megnyitott privát ablakok #}
       }</translation>
-<translation id="8773965542687789581">0, többes,
+<translation id="8773965542687789581">{0, plural,
       =1 {Privát}
-      más {Privát (#)}
+      other {Privát (#)}
     }</translation>
 <translation id="5070556616376997776">Ez egy privát ablak</translation>
 <translation id="5832813618714645810">Profilok</translation>

--- a/app/resources/generated_resources_id.xtb
+++ b/app/resources/generated_resources_id.xtb
@@ -7274,13 +7274,13 @@ Tekan kunci tombol akses yang telah ditetapkan untuk menghapus penetapan.</trans
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Buka semua di &amp;jendela privat}
           =1 {Buka di &amp;jendela privat}
-          lainnya {Buka semua ({COUNT}) di &amp;jendela privat}}</translation>
+          other {Buka semua ({COUNT}) di &amp;jendela privat}}</translation>
 <translation id="2431625704210501303">Buka di &amp;jendela pribadi</translation>
 <translation id="4620367155626060530">&amp;Tampilkan bilah bookmark</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Buka semua di &amp;Jendela Privat}
           =1 {Buka di &amp;Jendela Privat}
-          lainnya {Buka Semua ({COUNT}) di &amp;Jendela Privat}}</translation>
+          other {Buka Semua ({COUNT}) di &amp;Jendela Privat}}</translation>
 <translation id="1985165269306590797">Buka di &amp;Jendela Pribadi</translation>
 <translation id="4680518314108745448">&amp;Tampilkan Bilah Bookmark</translation>
 <translation id="642436385689435488">Buka semua di jendela pribadi</translation>

--- a/app/resources/generated_resources_ja.xtb
+++ b/app/resources/generated_resources_ja.xtb
@@ -7271,16 +7271,16 @@
 <translation id="5186185447130319458">プライベート</translation>
 <translation id="2579188629646253712">プライベートモードを終了する</translation>
 <translation id="1001131747196960052">プライベートウィンドウを閉じる</translation>
-<translation id="7475335772460644497">{COUNT, 複数,
+<translation id="7475335772460644497">{COUNT, plural,
           =0 {すべて&amp;プライベートウィンドウで開く}
           =1 {すべて&amp;プライベートウィンドウで開く}
-          その他{すべての ({COUNT}) を&amp;プライベートウィンドウで開く}}</translation>
+          other {すべての ({COUNT}) を&amp;プライベートウィンドウで開く}}</translation>
 <translation id="2431625704210501303">&amp;プライベートウィンドウで開く</translation>
 <translation id="4620367155626060530">ブックマーク バーを表示(&amp;S)</translation>
-<translation id="1448315815373449655">{COUNT, 複数,
+<translation id="1448315815373449655">{COUNT, plural,
           =0 {すべて&amp;プライベートウィンドウで開く}
           =1 {すべて&amp;プライベートウィンドウで開く}
-          その他{すべての ({COUNT}) を&amp;プライベートウィンドウで開く}}</translation>
+          other {すべての ({COUNT}) を&amp;プライベートウィンドウで開く}}</translation>
 <translation id="1985165269306590797">&amp;プライベートウィンドウで開く</translation>
 <translation id="4680518314108745448">ブックマーク バーを表示(&amp;S)</translation>
 <translation id="642436385689435488">すべてをプライベートウィンドウで開く</translation>
@@ -7288,11 +7288,11 @@
 <translation id="5463021359602611602">プライベートウィンドウで開く</translation>
 <translation id="1850357845349976573">{0, plural,
         =1 {Private}
-        その他 {# open private windows}
+        other {# open private windows}
       }</translation>
 <translation id="8773965542687789581">{0, plural,
       =1 {Private}
-      その他 {Private (#)}
+      other {Private (#)}
     }</translation>
 <translation id="5070556616376997776">これはプライベートウィンドウです</translation>
 <translation id="5832813618714645810">プロフィール</translation>

--- a/app/resources/generated_resources_nl.xtb
+++ b/app/resources/generated_resources_nl.xtb
@@ -7271,13 +7271,13 @@ Druk op een toegewezen schakelaar om de toewijzing te verwijderen.</translation>
 <translation id="5186185447130319458">Privé</translation>
 <translation id="2579188629646253712">Sluit Privé af</translation>
 <translation id="1001131747196960052">Privé sluiten</translation>
-<translation id="7475335772460644497">{AANTAL, meervoud,
+<translation id="7475335772460644497">{COUNT, plural,
           =0 {Open allen in &amp;privévenster}
           =1 {Open in &amp;privévenster}
           other {Open allen ({AANTAL}) in &amp;privévenster}}</translation>
 <translation id="2431625704210501303">Open in &amp;privéscherm</translation>
 <translation id="4620367155626060530">&amp;Bladwijzerbalk weergeven</translation>
-<translation id="1448315815373449655">{AANTAL, meervoud,
+<translation id="1448315815373449655">{COUNT, plural,
           =0 {Open Alen in &amp;Privéscherm}
           =1 {Open in &amp;Privéscherm}
           other {Open Allen ({AANTAL}) in &amp;Privéscherm}}</translation>

--- a/app/resources/generated_resources_no.xtb
+++ b/app/resources/generated_resources_no.xtb
@@ -7281,13 +7281,13 @@ Trykk på en tilordnet bryter for å fjerne tilordningen.</translation>
 <translation id="642436385689435488">Åpne alle i privat vindu</translation>
 <translation id="5074021236879527611">Åpne alle (<ph name="URL_COUNT"/>) i privat vindu</translation>
 <translation id="5463021359602611602">Åpne i privat vindu</translation>
-<translation id="1850357845349976573">{0, flertall,
+<translation id="1850357845349976573">{0, plural,
         =1 {Privat}
-        andre {# åpne private vinduer}
+        other {# åpne private vinduer}
       }</translation>
-<translation id="8773965542687789581">{0, flertall,
+<translation id="8773965542687789581">{0, plural,
       =1 {Privat}
-      andre {Private (#)}
+      other {Private (#)}
     }</translation>
 <translation id="5070556616376997776">Dette er et privat vindu</translation>
 <translation id="5832813618714645810">Profiler</translation>

--- a/app/resources/generated_resources_pt-PT.xtb
+++ b/app/resources/generated_resources_pt-PT.xtb
@@ -7274,13 +7274,13 @@ Prima um comutador atribuído para remover a atribuição.</translation>
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Abrir tudo em in &amp;janela privada}
           =1 {Abrir em &amp;janela privada}
-          outro {Abrir tudo ({COUNT}) em &amp;janela privada}}</translation>
+          other {Abrir tudo ({COUNT}) em &amp;janela privada}}</translation>
 <translation id="2431625704210501303">Abrir na janela de &amp;navegação privada</translation>
 <translation id="4620367155626060530">&amp;Mostrar barra de marcadores</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Abrir tudo em &amp;Janela Privada}
           =1 {Abrir em &amp;Janela Privada}
-          outro {Abrir Tudo ({COUNT}) em &amp;Janela Privada}}</translation>
+          other {Abrir Tudo ({COUNT}) em &amp;Janela Privada}}</translation>
 <translation id="1985165269306590797">Abrir na Janela de &amp;Navegação Privada</translation>
 <translation id="4680518314108745448">&amp;Mostrar Barra de Marcadores</translation>
 <translation id="642436385689435488">Abrir tudo numa janela de navegação privada</translation>

--- a/app/resources/generated_resources_ro.xtb
+++ b/app/resources/generated_resources_ro.xtb
@@ -7276,13 +7276,13 @@ Apasă o tastă de comutare atribuită pentru a elimina atribuirea.</translation
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Deschide tot în &amp;fereastră privată}
           =1 {Deschide în &amp;fereastră privată}
-          altul {Deschide tot ({COUNT}) în &amp;fereastră privată}}</translation>
+          other {Deschide tot ({COUNT}) în &amp;fereastră privată}}</translation>
 <translation id="2431625704210501303">Deschide în fereastră &amp;privată</translation>
 <translation id="4620367155626060530">&amp;Afișați bara de marcaje</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Deschide tot în &amp;Fereastră Privată}
           =1 {Deschide în &amp;Fereastră Privată}
-          altul {Deschide Tot ({COUNT}) în &amp;Fereastră Privată}}</translation>
+          other {Deschide Tot ({COUNT}) în &amp;Fereastră Privată}}</translation>
 <translation id="1985165269306590797">Deschide în Fereastră &amp;Privată</translation>
 <translation id="4680518314108745448">&amp;Afișați bara de marcaje</translation>
 <translation id="642436385689435488">Deschide to în fereastră privată</translation>

--- a/app/resources/generated_resources_sk.xtb
+++ b/app/resources/generated_resources_sk.xtb
@@ -7276,13 +7276,13 @@ Existujúce pridelenie odstránite stlačením prideleného prepínača.</transl
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Otvoriť všetky v &amp;súkromnom okne}
           =1 {Otvoriť v &amp;súkromnom okne}
-          iné {Otvoriť všetky ({COUNT}) v &amp;súkromnom okne}}</translation>
+          other {Otvoriť všetky ({COUNT}) v &amp;súkromnom okne}}</translation>
 <translation id="2431625704210501303">Otvoriť v &amp; súkromnom okne</translation>
 <translation id="4620367155626060530">&amp;Zobraziť panel so záložkami</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Otvoriť všetko v &amp;Súkromnom okne}
           =1 {Otvoriť v  &amp;Súkromnom okne}
-          iné {Otvoriť všetko ({COUNT}) v &amp;Súkromnom okne}}</translation>
+          other {Otvoriť všetko ({COUNT}) v &amp;Súkromnom okne}}</translation>
 <translation id="1985165269306590797">Otvoriť v &amp; Súkromnom okne</translation>
 <translation id="4680518314108745448">&amp;Zobraziť panel so záložkami</translation>
 <translation id="642436385689435488">Otvoriť všetko v súkromnom okne</translation>

--- a/app/resources/generated_resources_sl.xtb
+++ b/app/resources/generated_resources_sl.xtb
@@ -7282,13 +7282,13 @@ Domena <ph name="DOMAIN"/> zahteva, da je pametna kartica vstavljena.}}</transla
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Odpri vse v &amp;zasebnem oknu}
           =1 {Odpri v &amp;zasebnem oknu}
-          drugo {Odpri vse ({COUNT}) v &amp;zasebnem oknu}}</translation>
+          other {Odpri vse ({COUNT}) v &amp;zasebnem oknu}}</translation>
 <translation id="2431625704210501303">Odpri v oknu &amp;brez beleženja zgodovine</translation>
 <translation id="4620367155626060530">&amp;Pokaži vrstico z zaznamki</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Oodpri vse v zasebnem oknu &amp;}
           =1 {Odpri vse v zasebnem oknu &amp;}
-          drugo {Odpri vse ({COUNT}) v zasebnem oknu &amp;}}</translation>
+          other {Odpri vse ({COUNT}) v zasebnem oknu &amp;}}</translation>
 <translation id="1985165269306590797">Odpri v oknu &amp;brez beleženja zgodovine</translation>
 <translation id="4680518314108745448">&amp;Pokaži vrstico z zaznamki</translation>
 <translation id="642436385689435488">Odpri vse v oknu brez beleženja zgodovine</translation>

--- a/app/resources/generated_resources_sr.xtb
+++ b/app/resources/generated_resources_sr.xtb
@@ -7282,7 +7282,7 @@
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Otvorite sve u &amp;privatnom prozoru}
           =1 {Otvorite u &amp;privatnom prozoru}
-          drugo {Otvorite sve ({COUNT}) u &amp;privatnom prozoru}}</translation>
+          other {Otvorite sve ({COUNT}) u &amp;privatnom prozoru}}</translation>
 <translation id="1985165269306590797">Otvoreno u &amp;privatni prozor</translation>
 <translation id="4680518314108745448">&amp;Прикажи траку са обележивачима</translation>
 <translation id="642436385689435488">Otvori sve u privatnom prozoru</translation>

--- a/app/resources/generated_resources_uk.xtb
+++ b/app/resources/generated_resources_uk.xtb
@@ -7280,25 +7280,25 @@
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Відкрити все у &amp;приватному вікні}
           =1 {Відкрити у &amp;приватному вікні}
-          інше {Відкрити ({COUNT}) у &amp;приватному вікні}}</translation>
+          other {Відкрити ({COUNT}) у &amp;приватному вікні}}</translation>
 <translation id="2431625704210501303">Відкрити у &amp;приватному вікні</translation>
 <translation id="4620367155626060530">&amp;Показати панель закладок</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Відкрити все у &amp;Приватному вікні}
           =1 {Відкрити у &amp;Приватному вікні}
-          інше {Відкрити Всі ({COUNT}) у  &amp;Приватному вікні}}</translation>
+          other {Відкрити Всі ({COUNT}) у  &amp;Приватному вікні}}</translation>
 <translation id="1985165269306590797">Відкрити у &amp;Приватному вікні</translation>
 <translation id="4680518314108745448">&amp;Показати панель закладок</translation>
 <translation id="642436385689435488">Відкрити все у приватному вікні</translation>
 <translation id="5074021236879527611">Відкрити все (<ph name="URL_COUNT"/>) у приватному вікні</translation>
 <translation id="5463021359602611602">Відкрити у приватному вікні</translation>
-<translation id="1850357845349976573">{0, множина,
+<translation id="1850357845349976573">{0, plural,
         =1 {Приватне}
-        інше {# відкрити приватні вікна}
+        other {# відкрити приватні вікна}
       }</translation>
-<translation id="8773965542687789581">{0, множина,
+<translation id="8773965542687789581">{0, plural,
       =1 {Приватне}
-      інше {Приватне (#)}
+      other {Приватне (#)}
     }</translation>
 <translation id="5070556616376997776">Це приватне вікно</translation>
 <translation id="5832813618714645810">Профілі</translation>

--- a/app/resources/generated_resources_zh-CN.xtb
+++ b/app/resources/generated_resources_zh-CN.xtb
@@ -7268,13 +7268,13 @@
 <translation id="7475335772460644497">{COUNT, plural,
           =0 {Open all in &amp;private window}
           =1 {Open in &amp;private window}
-          其他 {Open all ({COUNT}) in &amp;private window}}</translation>
+          other {Open all ({COUNT}) in &amp;private window}}</translation>
 <translation id="2431625704210501303">在隐身窗口中打开(&amp;I)</translation>
 <translation id="4620367155626060530">显示书签栏(&amp;S)</translation>
 <translation id="1448315815373449655">{COUNT, plural,
           =0 {Open All in &amp;Private Window}
           =1 {Open in &amp;Private Window}
-          其他 {Open All ({COUNT}) in &amp;Private Window}}</translation>
+          other {Open All ({COUNT}) in &amp;Private Window}}</translation>
 <translation id="1985165269306590797">在隐身窗口中打开(&amp;I)</translation>
 <translation id="4680518314108745448">显示书签栏(&amp;S)</translation>
 <translation id="642436385689435488">在无痕式窗口中打开所有网址</translation>

--- a/script/lib/transifex.py
+++ b/script/lib/transifex.py
@@ -28,12 +28,14 @@ transifex_handled_slugs = [
 ]
 # List of HTML tags that we allowed to be present inside the translated text.
 allowed_html_tags = [
-  'a', 'abbr', 'b', 'b1', 'b2', 'br', 'code', 'h4', 'learnmore', 'li', 'li1', 'li2', 'ol', 'p', 'span', 'strong', 'ul'
+    'a', 'abbr', 'b', 'b1', 'b2', 'br', 'code', 'h4', 'learnmore', 'li', 'li1',
+    'li2', 'ol', 'p', 'span', 'strong', 'ul'
 ]
 
 
 def transifex_name_from_greaselion_script_name(script_name):
-    match = re.search('brave-site-specific-scripts/scripts/(.*)/_locales/en_US/messages.json$', script_name)
+    match = re.search(
+        'brave-site-specific-scripts/scripts/(.*)/_locales/en_US/messages.json$', script_name)
     if match:
         return 'greaselion_' + match.group(1).replace('-', '_').replace('/', '_')
     return ''
@@ -150,13 +152,13 @@ def get_transifex_translation_file_content(source_file_path, filename,
 
 def process_bad_ph_tags_for_one_string(val):
     val = (val.replace('\r\n', '\n')
-              .replace('\r', '\n'))
+           .replace('\r', '\n'))
     if val.find('&lt;ph') == -1:
         return val
     val = (val.replace('&lt;', '<')
-              .replace('&gt;', '>')
-              .replace('>  ', '> ')
-              .replace('  <', ' <'))
+           .replace('&gt;', '>')
+           .replace('>  ', '> ')
+           .replace('  <', ' <'))
     return val
 
 
@@ -208,7 +210,7 @@ def validate_tags_in_one_string(string_tag):
     lxml.etree.strip_tags(string_tag, 'ph')
     string_text = textify_from_transifex(string_tag)
     string_text = (string_text.replace('&lt;', '<')
-                              .replace('&gt;', '>'))
+                   .replace('&gt;', '>'))
     # print 'Validating: {}'.format(string_text.encode('utf-8'))
     try:
         string_xml = lxml.etree.fromstring('<string>' + string_text + '</string>')
@@ -420,17 +422,19 @@ def textify(t):
 
 
 def replace_string_from_transifex(val):
-    """Returns the text of a node from Transifex which also fixes up common problems that localizers do"""
+    """Returns the text of a node from Transifex which also fixes up common
+       problems that localizers do"""
     if val is None:
         return val
     val = (val.replace('&amp;lt;', '&lt;')
-              .replace('&amp;gt;', '&gt;')
-              .replace('&amp;amp;', '&amp;'))
+           .replace('&amp;gt;', '&gt;')
+           .replace('&amp;amp;', '&amp;'))
     return val
 
 
 def textify_from_transifex(t):
-    """Returns the text of a node from Transifex which also fixes up common problems that localizers do"""
+    """Returns the text of a node from Transifex which also fixes up common
+       problems that localizers do"""
     return replace_string_from_transifex(textify(t))
 
 
@@ -570,6 +574,30 @@ def generate_source_strings_xml_from_grd(output_xml_file_handle,
     return xml_string
 
 
+def check_plural_string_formatting(grd_string_content, translation_content):
+    """Checks 'plurar' string formatting in translations"""
+    pattern = re.compile(
+        r"\s*{.*,\s*plural,(\s*offset:[0-2])?(\s*(=[0-2]|[zero|one|two|few|many])"
+        r"\s*{(.*)})+\s*other\s*{(.*)}\s*}\s*")
+    if (pattern.match(grd_string_content) != None):
+        if (pattern.match(translation_content) == None):
+            error = ('Translation of plural string:\n'
+                     '-----------\n{0}\n-----------\n'
+                     'does not match:\n'
+                     '-----------\n{1}\n-----------\n').format(
+                         grd_string_content.encode('utf-8'),
+                         translation_content.encode('utf-8'))
+            raise ValueError(error)
+    else:
+        # This finds plural strings that the pattern above doesn't catch
+        leading_pattern = re.compile(r"\s*{.*,\s*plural,.*")
+        if (leading_pattern.match(grd_string_content) != None):
+            error = ('Uncaught plural pattern:\n'
+                     '-----------\n{0}\n-----------\n').format(
+                         grd_string_content.encode('utf-8'))
+            raise ValueError(error)
+
+
 def generate_xtb_content(lang_code, grd_strings, translations):
     """Generates an XTB file from a set of translations and GRD strings"""
     # Used to make sure duplicate fingerprint stringsa re not made
@@ -585,6 +613,7 @@ def generate_xtb_content(lang_code, grd_strings, translations):
             all_string_fps.add(fingerprint)
             translation = translations[string[0]]
             if len(translation) != 0:
+                check_plural_string_formatting(string[1], translation)
                 translationbundle_tag.append(
                     create_xtb_format_translation_tag(
                         fingerprint, translation))
@@ -662,7 +691,8 @@ def braveify(string_value):
             .replace('Brave Drive', 'Google Drive')
             .replace('Brave Play', 'Google Play')
             .replace('Brave Safe', 'Google Safe')
-            .replace('Sends URLs of some pages you visit to Brave', 'Sends URLs of some pages you visit to Google')
+            .replace('Sends URLs of some pages you visit to Brave',
+                     'Sends URLs of some pages you visit to Google')
             .replace('Brave Account', 'Brave sync chain'))
 
 
@@ -699,8 +729,8 @@ def upload_missing_json_translations_to_transifex(source_string_path):
     for lang_code in lang_codes:
         l10n_path = os.path.join(langs_dir_path, lang_code, 'messages.json')
         l10n_strings = get_json_strings(l10n_path)
-        l10n_dict = {string_name: string_value for idx, (string_name,
-                     string_value, desc) in enumerate(l10n_strings)}
+        l10n_dict = {string_name: string_value for idx,
+                     (string_name, string_value, desc) in enumerate(l10n_strings)}
         for idx, (
                 string_name, string_value, desc) in enumerate(source_strings):
             if string_name not in l10n_dict:
@@ -910,7 +940,7 @@ def pull_xtb_without_transifex(grd_file_path, brave_source_root):
                                                                 brave_source_root)
     chromium_xtb_files = get_xtb_files(grd_file_path)
     if len(xtb_files) != len(chromium_xtb_files):
-        assert false, 'XTB files and Chromium XTB file length mismatch.'
+        assert False, 'XTB files and Chromium XTB file length mismatch.'
 
     grd_base_path = os.path.dirname(grd_file_path)
     chromium_grd_base_path = os.path.dirname(chromium_grd_file_path)
@@ -918,7 +948,7 @@ def pull_xtb_without_transifex(grd_file_path, brave_source_root):
     # Update XTB FPs so it uses the branded source string
     grd_strings = get_grd_strings(grd_file_path, validate_tags=False)
     chromium_grd_strings = get_grd_strings(chromium_grd_file_path, validate_tags=False)
-    assert(len(grd_strings) == len(chromium_grd_strings))
+    assert len(grd_strings) == len(chromium_grd_strings)
 
     fp_map = {chromium_grd_strings[idx][2]: grd_strings[idx][2] for
               (idx, grd_string) in enumerate(grd_strings)}


### PR DESCRIPTION
Fixes brave/brave-browser#15268
Uplift of #8530

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [x] This contains text which needs to be translated. 
    - [x] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.