### PR TITLE
Fix potential plugin data inconsistency in UpdatePluginData.

### DIFF
--- a/patches/third_party-blink-renderer-modules-plugins-dom_plugin_array.cc.patch
+++ b/patches/third_party-blink-renderer-modules-plugins-dom_plugin_array.cc.patch
@@ -1,12 +1,20 @@
 diff --git a/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc b/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
-index 53c24628f1d406375413ab2d78272383594b4d57..4ce788b661f737bb71bdc2e3d075e46340537356 100644
+index 53c24628f1d406375413ab2d78272383594b4d57..458bfb2ff359e5e6b1bd8c667443a78409ec75e0 100644
 --- a/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
 +++ b/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
-@@ -159,6 +159,7 @@ void DOMPluginArray::UpdatePluginData() {
+@@ -138,6 +138,7 @@ void DOMPluginArray::UpdatePluginData() {
+     dom_plugins_.clear();
+     return;
+   }
++  BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__RESET_PLUGIN_DATA
+   PluginData* data = GetPluginData();
+   if (!data) {
+     dom_plugins_.clear();
+@@ -159,6 +160,7 @@ void DOMPluginArray::UpdatePluginData() {
        }
      }
    }
-+  BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA
++  BRAVE_DOM_PLUGINS_UPDATE_PLUGIN_DATA__FARBLE_PLUGIN_DATA
  }
  
  void DOMPluginArray::ContextDestroyed() {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
`GetPluginData()` can trigger a synchronous plugin request to the browser process when `PluginData` is empty, which happens every time we do `data->ResetPluginData();`. If the browser returns a different (empty) plugin list instead of the one that was used to fill `dom_plugins_`, then we will have an incorrect vector indexing and a crash in `FarblePlugins`.

This change moves the `ResetPluginData()` call before the initial `dom_plugins_` fill. It should fix our farbling routine at the end of `UpdatePluginData()`. Also added a clear use of the same `PluginData` instance that is used in `UpdatePluginData()`.

I tried to reproduce this, but no luck. Looking at the crash reports it frequently happens at frame detach followed by `onunload` handler that can request plugins. Assuming that this can be a shutdown, it's very likely that the browser can reply with empty plugins thus triggering the crash.

Resolves https://github.com/brave/brave-browser/issues/15145

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

