### PR TITLE
Fixed memory leak in UI views

### DIFF
--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -160,7 +160,7 @@ void SidebarItemsContentsView::OnItemAdded(const sidebar::SidebarItem& item,
 }
 
 void SidebarItemsContentsView::OnItemRemoved(int index) {
-  RemoveChildView(children()[index]);
+  RemoveChildViewT(children()[index]);
   InvalidateLayout();
 }
 

--- a/browser/ui/views/translate/brave_translate_bubble_view.cc
+++ b/browser/ui/views/translate/brave_translate_bubble_view.cc
@@ -36,8 +36,9 @@ BraveTranslateBubbleView::BraveTranslateBubbleView(
 BraveTranslateBubbleView::~BraveTranslateBubbleView() {
 }
 
-views::View* BraveTranslateBubbleView::BraveCreateViewBeforeTranslate() {
-  views::View* view = new views::View();
+std::unique_ptr<views::View>
+BraveTranslateBubbleView::BraveCreateViewBeforeTranslate() {
+  auto view = std::make_unique<views::View>();
   views::GridLayout* layout =
       view->SetLayoutManager(std::make_unique<views::GridLayout>());
   ChromeLayoutProvider* provider = ChromeLayoutProvider::Get();
@@ -180,6 +181,6 @@ bool BraveTranslateBubbleView::ShouldShowWindowTitle() const {
 
 void BraveTranslateBubbleView::Init() {
   TranslateBubbleView::Init();
-  RemoveChildView(translate_view_);
+  removed_translate_view_ = RemoveChildViewT(translate_view_);
   translate_view_ = AddChildView(BraveCreateViewBeforeTranslate());
 }

--- a/browser/ui/views/translate/brave_translate_bubble_view.h
+++ b/browser/ui/views/translate/brave_translate_bubble_view.h
@@ -41,9 +41,14 @@ class BraveTranslateBubbleView : public TranslateBubbleView {
 
  private:
   friend class BraveTranslateBubbleViewTest;
-  views::View* BraveCreateViewBeforeTranslate();
+  std::unique_ptr<views::View> BraveCreateViewBeforeTranslate();
   void DisableOfferTranslatePref();
   void ButtonPressed(ButtonID button_id);
+
+  // Remove this. As we replace |translate_view_|, we should destroy after
+  // replacing it. However, its child view(|tabbed_pane_|) is still referenced
+  // from TranslateBubbleView. Keep to prevent leak.
+  std::unique_ptr<views::View> removed_translate_view_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveTranslateBubbleView);
 };


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15407

Use View::RemoveChildViewT() to delete child view because it transfers
removed child view's ownersip via unique_ptr but View::RemoveChildView
returns raw pointer.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

