### PR TITLE
Log Rewards errors by default and add a feature flag for verbose logging

### DIFF
--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -174,6 +174,10 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      flag_descriptions::kBravePermissionLifetimeName,                       \
      flag_descriptions::kBravePermissionLifetimeDescription, kOsAll,        \
      FEATURE_VALUE_TYPE(permissions::features::kPermissionLifetime)},       \
+    {"brave-rewards-verbose-logging",                                       \
+     flag_descriptions::kBraveRewardsVerboseLoggingName,                    \
+     flag_descriptions::kBraveRewardsVerboseLoggingDescription, kOsDesktop, \
+     FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature)},  \
     {"brave-rewards-bitflyer",                                              \
      flag_descriptions::kBraveRewardsBitflyerName,                          \
      flag_descriptions::kBraveRewardsBitflyerDescription, kOsDesktop,       \

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -57,6 +57,14 @@ const char kBraveSyncDescription[] =
 const char kBraveIpfsName[] = "Enable IPFS";
 const char kBraveIpfsDescription[] =
     "Enable native support of IPFS.";
+const char kBraveRewardsVerboseLoggingName[] =
+    "Enable Brave Rewards verbose logging";
+const char kBraveRewardsVerboseLoggingDescription[] =
+    "Enables detailed logging of Brave Rewards system events to a log file "
+    "stored on your device. Please note that this log file could include "
+    "information such as browsing history and credentials such as passwords "
+    "and access tokens depending on your activity. Please do not share it "
+    "unless asked to by Brave staff.";
 const char kBraveRewardsBitflyerName[] = "Enable bitFlyer for Brave Rewards";
 const char kBraveRewardsBitflyerDescription[] =
     "Enables support for bitFlyer as an external wallet provider for Brave "

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -35,6 +35,8 @@ extern const char kBraveSyncName[];
 extern const char kBraveSyncDescription[];
 extern const char kBraveIpfsName[];
 extern const char kBraveIpfsDescription[];
+extern const char kBraveRewardsVerboseLoggingName[];
+extern const char kBraveRewardsVerboseLoggingDescription[];
 extern const char kBraveRewardsBitflyerName[];
 extern const char kBraveRewardsBitflyerDescription[];
 extern const char kNativeBraveWalletName[];

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -334,6 +334,9 @@ RewardsServiceImpl::RewardsServiceImpl(Profile* profile)
   content::URLDataSource::Add(profile_,
                               std::make_unique<BraveRewardsSource>(profile_));
   ready_ = std::make_unique<base::OneShotEvent>();
+
+  if (base::FeatureList::IsEnabled(features::kVerboseLoggingFeature))
+    persist_log_level_ = kDiagnosticLogMaxVerboseLevel;
 }
 
 RewardsServiceImpl::~RewardsServiceImpl() {
@@ -2263,15 +2266,12 @@ void RewardsServiceImpl::WriteDiagnosticLog(const std::string& file,
                                             const int line,
                                             const int verbose_level,
                                             const std::string& message) {
-  if (ledger_for_testing_ || !should_persist_logs_) {
+  if (ledger_for_testing_ || resetting_rewards_) {
     return;
   }
 
-  if (resetting_rewards_) {
-    return;
-  }
-
-  if (verbose_level > kDiagnosticLogMaxVerboseLevel) {
+  if (verbose_level > kDiagnosticLogMaxVerboseLevel ||
+      verbose_level > persist_log_level_) {
     return;
   }
 
@@ -2414,13 +2414,13 @@ void RewardsServiceImpl::HandleFlags(const std::string& options) {
       continue;
     }
 
+    // The "persist-logs" command-line flag is deprecated and will be removed
+    // in a future version. Use --enable-features=BraveRewardsVerboseLogging
+    // instead.
     if (name == "persist-logs") {
       const std::string lower = base::ToLowerASCII(value);
-
       if (lower == "true" || lower == "1") {
-        should_persist_logs_ = true;
-      } else {
-        should_persist_logs_ = false;
+        persist_log_level_ = kDiagnosticLogMaxVerboseLevel;
       }
     }
 

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -790,7 +790,7 @@ class RewardsServiceImpl : public RewardsService,
   bool reset_states_;
   bool ledger_for_testing_ = false;
   bool resetting_rewards_ = false;
-  bool should_persist_logs_ = false;
+  int persist_log_level_ = 0;
 
   GetTestResponseCallback test_response_callback_;
 

--- a/components/brave_rewards/common/features.cc
+++ b/components/brave_rewards/common/features.cc
@@ -13,5 +13,8 @@ namespace features {
 const base::Feature kBitflyerFeature{"BraveRewardsBitflyer",
                                      base::FEATURE_DISABLED_BY_DEFAULT};
 
+const base::Feature kVerboseLoggingFeature{"BraveRewardsVerboseLogging",
+                                           base::FEATURE_DISABLED_BY_DEFAULT};
+
 }  // namespace features
 }  // namespace brave_rewards

--- a/components/brave_rewards/common/features.h
+++ b/components/brave_rewards/common/features.h
@@ -14,6 +14,7 @@ namespace brave_rewards {
 namespace features {
 
 extern const base::Feature kBitflyerFeature;
+extern const base::Feature kVerboseLoggingFeature;
 
 }  // namespace features
 }  // namespace brave_rewards

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
@@ -283,7 +283,8 @@ void AdRewards::OnGetPayments(const UrlResponse& url_response) {
   }
 
   if (!payments_->SetFromJson(url_response.body)) {
-    BLOG(0, "Failed to parse payment balance: " << url_response.body);
+    BLOG(0, "Failed to parse payment balance");
+    BLOG(6, "Payment balance response body: " << url_response.body);
     OnFailedToReconcileAdRewards();
     return;
   }
@@ -324,7 +325,8 @@ void AdRewards::OnGetAdGrants(const UrlResponse& url_response) {
   }
 
   if (!ad_grants_->SetFromJson(url_response.body)) {
-    BLOG(0, "Failed to parse ad grants: " << url_response.body);
+    BLOG(0, "Failed to parse ad grants");
+    BLOG(6, "Ad grants response body: " << url_response.body);
     OnFailedToReconcileAdRewards();
     return;
   }

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/api/get_parameters/get_parameters.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/api/get_parameters/get_parameters.cc
@@ -50,6 +50,7 @@ type::Result GetParameters::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/bitflyer/get_balance/get_balance_bitflyer.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/bitflyer/get_balance/get_balance_bitflyer.cc
@@ -34,10 +34,12 @@ type::Result GetBalance::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED ||
       status_code == net::HTTP_NOT_FOUND ||
       status_code == net::HTTP_FORBIDDEN) {
+    BLOG(0, "Invalid authorization HTTP status: " << status_code);
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/bitflyer/post_oauth/post_oauth_bitflyer.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/bitflyer/post_oauth/post_oauth_bitflyer.cc
@@ -58,10 +58,12 @@ std::string PostOauth::GeneratePayload(const std::string& external_account_id,
 
 type::Result PostOauth::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/bitflyer/post_transaction/post_transaction_bitflyer.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/bitflyer/post_transaction/post_transaction_bitflyer.cc
@@ -55,6 +55,7 @@ std::string PostTransaction::GeneratePayload(
 
 type::Result PostTransaction::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
@@ -64,6 +65,7 @@ type::Result PostTransaction::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/get_credentials/get_credentials.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/get_credentials/get_credentials.cc
@@ -59,6 +59,7 @@ type::Result GetCredentials::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::RETRY;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_credentials/post_credentials.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_credentials/post_credentials.cc
@@ -66,6 +66,7 @@ type::Result PostCredentials::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_order/post_order.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_order/post_order.cc
@@ -63,6 +63,7 @@ type::Result PostOrder::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_CREATED) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_transaction_anon/post_transaction_anon.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_transaction_anon/post_transaction_anon.cc
@@ -110,6 +110,7 @@ type::Result PostTransactionAnon::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_CREATED) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_transaction_uphold/post_transaction_uphold.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_transaction_uphold/post_transaction_uphold.cc
@@ -69,6 +69,7 @@ type::Result PostTransactionUphold::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_CREATED) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_votes/post_votes.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_votes/post_votes.cc
@@ -75,6 +75,7 @@ type::Result PostVotes::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.cc
@@ -163,6 +163,7 @@ type::Result GetPublisher::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_available/get_available.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_available/get_available.cc
@@ -66,6 +66,7 @@ type::Result GetAvailable::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_captcha/get_captcha.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_captcha/get_captcha.cc
@@ -50,6 +50,7 @@ type::Result GetCaptcha::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_drain/get_drain.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_drain/get_drain.cc
@@ -42,6 +42,7 @@ type::Result GetDrain::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_recover_wallet/get_recover_wallet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_recover_wallet/get_recover_wallet.cc
@@ -45,6 +45,7 @@ type::Result GetRecoverWallet::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_signed_creds/get_signed_creds.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_signed_creds/get_signed_creds.cc
@@ -58,6 +58,7 @@ type::Result GetSignedCreds::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_wallet_balance/get_wallet_balance.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/get_wallet_balance/get_wallet_balance.cc
@@ -57,6 +57,7 @@ type::Result GetWalletBalance::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_bat_loss/post_bat_loss.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_bat_loss/post_bat_loss.cc
@@ -51,6 +51,7 @@ type::Result PostBatLoss::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_captcha/post_captcha.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_captcha/post_captcha.cc
@@ -55,6 +55,7 @@ type::Result PostCaptcha::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_bitflyer/post_claim_bitflyer.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_bitflyer/post_claim_bitflyer.cc
@@ -79,6 +79,7 @@ type::Result PostClaimBitflyer::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_brave/post_claim_brave.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_brave/post_claim_brave.cc
@@ -79,6 +79,7 @@ type::Result PostClaimBrave::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_uphold/post_claim_uphold.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_uphold/post_claim_uphold.cc
@@ -129,6 +129,7 @@ type::Result PostClaimUphold::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_clobbered_claims/post_clobbered_claims.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_clobbered_claims/post_clobbered_claims.cc
@@ -50,6 +50,7 @@ type::Result PostClobberedClaims::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_creds/post_creds.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_creds/post_creds.cc
@@ -80,6 +80,7 @@ type::Result PostCreds::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_devicecheck/post_devicecheck.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_devicecheck/post_devicecheck.cc
@@ -58,6 +58,7 @@ type::Result PostDevicecheck::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_safetynet/post_safetynet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_safetynet/post_safetynet.cc
@@ -61,6 +61,7 @@ type::Result PostSafetynet::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions/post_suggestions.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions/post_suggestions.cc
@@ -79,6 +79,7 @@ type::Result PostSuggestions::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions_claim/post_suggestions_claim.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions_claim/post_suggestions_claim.cc
@@ -66,6 +66,7 @@ type::Result PostSuggestionsClaim::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_wallet_brave/post_wallet_brave.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_wallet_brave/post_wallet_brave.cc
@@ -43,6 +43,7 @@ type::Result PostWalletBrave::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_CREATED) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/put_captcha/put_captcha.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/put_captcha/put_captcha.cc
@@ -62,6 +62,7 @@ type::Result PutCaptcha::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/put_devicecheck/put_devicecheck.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/put_devicecheck/put_devicecheck.cc
@@ -62,6 +62,7 @@ type::Result PutDevicecheck::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/put_safetynet/put_safetynet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/put_safetynet/put_safetynet.cc
@@ -59,6 +59,7 @@ type::Result PutSafetynet::CheckStatusCode(const int status_code) {
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/rewards/get_prefix_list/get_prefix_list.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/rewards/get_prefix_list/get_prefix_list.cc
@@ -30,6 +30,7 @@ std::string GetPrefixList::GetUrl() {
 
 type::Result GetPrefixList::CheckStatusCode(const int status_code) {
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/get_card/get_card.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/get_card/get_card.cc
@@ -36,10 +36,12 @@ type::Result GetCard::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED ||
       status_code == net::HTTP_NOT_FOUND ||
       status_code == net::HTTP_FORBIDDEN) {
+    BLOG(0, "Unauthorized access HTTP status: " << status_code);
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/get_cards/get_cards.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/get_cards/get_cards.cc
@@ -33,10 +33,12 @@ std::string GetCards::GetUrl() {
 
 type::Result GetCards::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/get_me/get_me.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/get_me/get_me.cc
@@ -56,10 +56,12 @@ std::string GetMe::GetUrl() {
 
 type::Result GetMe::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/patch_card/patch_card.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/patch_card/patch_card.cc
@@ -52,10 +52,12 @@ std::string PatchCard::GeneratePayload(
 
 type::Result PatchCard::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_cards/post_cards.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_cards/post_cards.cc
@@ -43,10 +43,12 @@ std::string PostCards::GeneratePayload() {
 
 type::Result PostCards::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_oauth/post_oauth.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_oauth/post_oauth.cc
@@ -38,10 +38,12 @@ std::string PostOauth::GeneratePayload(const std::string& code) {
 
 type::Result PostOauth::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_transaction/post_transaction.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_transaction/post_transaction.cc
@@ -55,10 +55,12 @@ std::string PostTransaction::GeneratePayload(
 
 type::Result PostTransaction::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_ACCEPTED) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_transaction_commit/post_transaction_commit.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/uphold/post_transaction_commit/post_transaction_commit.cc
@@ -38,10 +38,12 @@ std::string PostTransactionCommit::GetUrl(
 
 type::Result PostTransactionCommit::CheckStatusCode(const int status_code) {
   if (status_code == net::HTTP_UNAUTHORIZED) {
+    BLOG(0, "Unauthorized access");
     return type::Result::EXPIRED_TOKEN;
   }
 
   if (status_code != net::HTTP_OK) {
+    BLOG(0, "Unexpected HTTP status: " << status_code);
     return type::Result::LEDGER_ERROR;
   }
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/bat_state.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/legacy/bat_state.cc
@@ -45,7 +45,8 @@ void LegacyBatState::OnLoad(
   ledger::ClientProperties state;
   const ledger::ClientState client_state;
   if (!client_state.FromJson(data, &state)) {
-    BLOG(0, "Failed to load client state: " << data);
+    BLOG(0, "Failed to load client state");
+    BLOG(6, "Client state contents: " << data);
     callback(ledger::type::Result::LEDGER_ERROR);
     return;
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15500

- Enables logging of "error" level messages by default.
- Adds a feature flag `BraveRewardsVerboseLogging` which can be used to turn on verbose logging.
- Removes arbitrary data from existing error logging calls.
- Adds logging of unexpected HTTP response status codes.
- The existing `--rewards=persist-logs=1` command line option is still supported, but deprecated in favor of specifying the feature flag on the command line with `--enable-features=BraveRewardsVerboseLogging`

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

## Error logging

- Given that verbose logging is not enabled
- When Rewards encounters an error condition and logs an error
- Then the error should be visible in the "Logs" tab of `brave://rewards-internals`

**Possible test steps:**

- Open browser with clean profile pointed to staging.
- Trigger a Rewards error:
  - Open the Rewards panel and solve UGP captcha incorrectly
- Go to `brave://rewards-internals`
- Select the "Logs" tab and click "Refresh"
- Verify that an error has been logged
- Verify that non-error messages do not appear

## Verbose logging

- Given that the user has enabled verbose logging from `brave://flags`
- When the user interacts with Rewards
- Then detailed logging should be visible in the "Logs" tab of `brave://rewards-internals`

**Possible test steps**

- Open browser with clean profile pointed to staging.
- Go to `brave://flags` and enable BraveRewardsVerboseLogging.
- Relaunch the browser.
- Go to `brave://rewards-internals`
- Select the "Logs" tab and click "Refresh"
- Verify that detailed information is logged.