### PR TITLE
Fixes Customize Dashboard title when dark theme is active

### DIFF
--- a/components/brave_new_tab_ui/components/default/settings/index.ts
+++ b/components/brave_new_tab_ui/components/default/settings/index.ts
@@ -246,7 +246,6 @@ export const SettingsTitle = styled('div')<{}>`
     font-size: 20px;
     line-height: 30px;
     letter-spacing: 0.02em;
-    color: ${p => p.theme.palette.neutral900};
   }
 `
 


### PR DESCRIPTION
Fixes brave/brave-browser#14785 - Removes title specific color rule

I removed the specific color directive from `SettingsTitle`, as I see that the correct rule is inherited from `SettingsMenu` per: https://github.com/brave/brave-core/blob/master/components/brave_new_tab_ui/components/default/settings/index.ts#L47

From the storybook with the fix:
Light:
<img width="395" alt="Screen Shot 2021-04-21 at 5 32 21 PM" src="https://user-images.githubusercontent.com/8732757/115641130-53089980-a2cd-11eb-87d9-c3630aa1d226.png">
Dark:
<img width="405" alt="Screen Shot 2021-04-21 at 5 31 46 PM" src="https://user-images.githubusercontent.com/8732757/115641168-64ea3c80-a2cd-11eb-96dd-801f924a20bc.png">


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

cc: @petemill @bsclifton 
