### PR TITLE
Add command line switch to start in Tor mode.

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -243,7 +243,7 @@ source_set("ui") {
     "//brave/components/ntp_widget_utils/browser",
     "//brave/components/p3a:buildflags",
     "//brave/components/sidebar/buildflags",
-    "//brave/components/tor:pref_names",
+    "//brave/components/tor",
     "//brave/components/vector_icons",
     "//brave/components/webcompat_reporter/browser",
     "//brave/components/webcompat_reporter/ui:generated_resources",

--- a/chromium_src/chrome/browser/chrome_browser_main.cc
+++ b/chromium_src/chrome/browser/chrome_browser_main.cc
@@ -1,10 +1,30 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/browser/chrome_browser_main.h"
 #include "brave/browser/brave_browser_process_impl.h"
 
+namespace {
+#if !defined(OS_ANDROID) && !BUILDFLAG(IS_CHROMEOS_ASH)
+void AddFirstRunNewTabs(StartupBrowserCreator* browser_creator,
+                        const std::vector<GURL>& new_tabs);
+#endif  // !defined(OS_ANDROID) && !BUILDFLAG(IS_CHROMEOS_ASH)
+}  // namespace
+
+#define StartupBrowserCreator BraveStartupBrowserCreator
 #define BrowserProcessImpl BraveBrowserProcessImpl
 #include "../../../../chrome/browser/chrome_browser_main.cc"
 #undef BrowserProcessImpl
+#undef StartupBrowserCreator
+
+namespace {
+#if !defined(OS_ANDROID) && !BUILDFLAG(IS_CHROMEOS_ASH)
+void AddFirstRunNewTabs(StartupBrowserCreator* browser_creator,
+                        const std::vector<GURL>& new_tabs) {
+  AddFirstRunNewTabs(
+      reinterpret_cast<BraveStartupBrowserCreator*>(browser_creator), new_tabs);
+}
+#endif  // !defined(OS_ANDROID) && !BUILDFLAG(IS_CHROMEOS_ASH)
+}  // namespace

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/tor/tor_profile_manager.h"
+#include "brave/browser/tor/tor_profile_service_factory.h"
+#include "brave/common/brave_switches.h"
+#include "brave/components/tor/tor_profile_service.h"
+
+#include "chrome/browser/ui/startup/startup_browser_creator.h"
+
+#include "../../../../../../chrome/browser/ui/startup/startup_browser_creator.cc"  // NOLINT
+
+Profile* BraveStartupBrowserCreator::GetPrivateProfileIfRequested(
+    const base::CommandLine& command_line,
+    Profile* profile) {
+  if (command_line.HasSwitch(switches::kTor)) {
+    LOG(INFO) << "Selecting Tor profile";
+    profile = TorProfileManager::GetInstance().GetTorProfile(profile);
+    tor::TorProfileService* service =
+        TorProfileServiceFactory::GetForContext(profile);
+    service->RegisterTorClientUpdater();
+    return profile;
+  }
+
+  return StartupBrowserCreator::GetPrivateProfileIfRequested(command_line,
+                                                             profile);
+}

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator.h
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_STARTUP_BROWSER_CREATOR_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_STARTUP_BROWSER_CREATOR_H_
+
+#define GetPrivateProfileIfRequested     \
+  GetPrivateProfileIfRequested_Unused(); \
+  virtual Profile* GetPrivateProfileIfRequested
+
+class BraveStartupBrowserCreator;
+
+#include "../../../../../../chrome/browser/ui/startup/startup_browser_creator.h"
+
+#undef GetPrivateProfileIfRequested
+
+// Declare our subclass with the overridden method.
+class BraveStartupBrowserCreator final : public StartupBrowserCreator {
+ public:
+  Profile* GetPrivateProfileIfRequested(const base::CommandLine& command_line,
+                                        Profile* profile) override;
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_STARTUP_STARTUP_BROWSER_CREATOR_H_

--- a/common/brave_switches.cc
+++ b/common/brave_switches.cc
@@ -46,4 +46,7 @@ const char kComponentUpdateIntervalInSec[] = "component-update-interval-in-sec";
 
 // Disables DOH using a runtime flag mainly for network audit
 const char kDisableDnsOverHttps[] = "disable-doh";
+
+// Starts Brave in Tor mode.
+const char kTor[] = "tor";
 }  // namespace switches

--- a/common/brave_switches.h
+++ b/common/brave_switches.h
@@ -34,6 +34,8 @@ extern const char kComponentUpdateIntervalInSec[];
 
 extern const char kDisableDnsOverHttps[];
 
+extern const char kTor[];
+
 }  // namespace switches
 
 #endif  // BRAVE_COMMON_BRAVE_SWITCHES_H_

--- a/patches/chrome-browser-ui-startup-startup_browser_creator.h.patch
+++ b/patches/chrome-browser-ui-startup-startup_browser_creator.h.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/startup/startup_browser_creator.h b/chrome/browser/ui/startup/startup_browser_creator.h
+index 95f6bbefd18d3c2c47f0907f5cb7a7141146e7ea..e947d6b8d7f16f722df5d0af10aa4ab88e8c3130 100644
+--- a/chrome/browser/ui/startup/startup_browser_creator.h
++++ b/chrome/browser/ui/startup/startup_browser_creator.h
+@@ -38,7 +38,7 @@ class StartupBrowserCreator {
+   StartupBrowserCreator();
+   StartupBrowserCreator(const StartupBrowserCreator&) = delete;
+   StartupBrowserCreator& operator=(const StartupBrowserCreator&) = delete;
+-  ~StartupBrowserCreator();
++  virtual ~StartupBrowserCreator();
+ 
+   // Adds a url to be opened during first run. This overrides the standard
+   // tabs shown at first run.


### PR DESCRIPTION
This patch makes it possible to start Brave in Tor mode by running:

    brave-browser --tor

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/2105

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test 1
1. Open a website in browser window 1 and another website in browser window 2
2. Quit Brave and launch it with `--tor` command line flag
3. Open a normal window by pressing Ctrl + n or by clicking on Menu -> New window
4. Windows from step 1 should be restored

### Test 2
1. Open a website in browser window 1 and another website in browser window 2
2. Quit Brave and launch it with `--tor` command line flag
3. Quit Brave
4. Launch Brave without `--tor`
5. Windows from step 1 should be restored

### Test 3
1. Open a website in browser window 1 and another website in browser window 2
2. Crash browser using chrome://inducebrowsercrashforrealz/
3. Launch Brave with `--tor`
4. Open a normal window by pressing Ctrl + n or by clicking on Menu -> New window
5. Windows from step 1 should be restored

### Test 4
1. Open a website in browser window 1 and another website in browser window 2
2. Crash browser using chrome://inducebrowsercrashforrealz/
3. Launch Brave with `--tor`
4. Quit Brave
5. Launch Brave without `--tor`
6. Windows from step 1 should be restored

### Test 5
1. Launch Brave with `--tor`
2. Visit https://check.torproject.org/api/ip
3. Make sure that the page contains the string `"IsTor":true`.