### PR TITLE
Don't pass async override_response_headers ptr

### DIFF
--- a/browser/net/brave_ad_block_csp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_csp_network_delegate_helper.cc
@@ -41,12 +41,12 @@ base::Optional<std::string> GetCspDirectivesOnTaskRunner(
 void OnReceiveCspDirectives(
     const ResponseCallback& next_callback,
     std::shared_ptr<BraveRequestInfo> ctx,
-    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    scoped_refptr<net::HttpResponseHeaders> override_response_headers,
     base::Optional<std::string> csp_directives) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
   if (csp_directives) {
-    (*override_response_headers)
+    override_response_headers
         ->AddHeader("Content-Security-Policy", *csp_directives);
   }
 
@@ -92,7 +92,7 @@ int OnHeadersReceived_AdBlockCspWork(
         FROM_HERE,
         base::BindOnce(&GetCspDirectivesOnTaskRunner, ctx, original_csp),
         base::BindOnce(&OnReceiveCspDirectives, next_callback, ctx,
-                       override_response_headers));
+                       *override_response_headers));
     return net::ERR_IO_PENDING;
   }
 


### PR DESCRIPTION
Don't pass async override_response_headers ptr

I have tried all day to consistently repproduce this locally to no avail. I got
it once with an asan build. It points to us using the raw pointer.  So let's
pass the scoped_refpointer itself which should keep it alive.

We don't actually need the headers as a pointer after setting it in
OnHeadersReceived_AdBlockCspWork() anyway.

==2285653==ERROR: AddressSanitizer: heap-use-after-free on address
0x61d001294be8 at pc 0x5580b69e17e9 bp 0x7ffdf4686370 sp 0x7ffdf4686368 READ of
size 8 at 0x61d001294be8 thread T0 (brave) #0 0x5580b69e17e8 in operator->
base/memory/scoped_refptr.h:235:5 #1 0x5580b69e17e8 in
brave::OnReceiveCspDirectives(base::RepeatingCallback<void ()> const&,
std::__Cr::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders>*,
base::Optional<std::__Cr::basic_string<char, std::__Cr::char_traits<char>,
std::__Cr::allocator<char> > >)
brave/browser/net/brave_ad_block_csp_network_delegate_helper.cc:52:5 #2
0x5580b69e3c72 in Invoke<void (*)(const base::RepeatingCallback<void ()> &,
std::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders> *, base::Optional<std::string>),
base::RepeatingCallback<void ()>, std::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders> *, base::Optional<std::string> >
base/bind_internal.h:393:12 #3 0x5580b69e3c72 in MakeItSo<void (*)(const
base::RepeatingCallback<void ()> &, std::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders> *, base::Optional<std::string>),
base::RepeatingCallback<void ()>, std::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders> *, base::Optional<std::string> >
base/bind_internal.h:637:12 #4 0x5580b69e3c72 in RunImpl<void (*)(const
base::RepeatingCallback<void ()> &, std::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders> *, base::Optional<std::string>),
std::tuple<base::RepeatingCallback<void ()>,
std::shared_ptr<brave::BraveRequestInfo>,
scoped_refptr<net::HttpResponseHeaders> *>, 0, 1, 2>
base/bind_internal.h:710:12

Maybe Resolves https://github.com/brave/brave-browser/issues/15445