### PR TITLE
Remove extra dependency to fix component linking.

### DIFF
--- a/browser/brave_rewards/sources.gni
+++ b/browser/brave_rewards/sources.gni
@@ -33,7 +33,6 @@ if (brave_rewards_enabled) {
     "//components/keyed_service/content",
     "//components/prefs",
     "//components/sessions",
-    "//components/sessions:session_id",
     "//extensions/buildflags",
   ]
 


### PR DESCRIPTION
Follow up to fix linking in Component builds.

https://github.com/brave/brave-core/pull/8538

```
FAILED: chrome.dll chrome.dll.lib chrome.dll.pdb
ninja -t msvc -e environment.x64 -- ..\..\third_party\llvm-build\Release+Asserts\bin\lld-link.exe /OUT:./chrome.dll /nologo -libpath:..\..\third_party\llvm-build\Release+Asserts\lib\clang\13.0.0\lib\windows "-libpath:C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.28.29910\ATLMFC\lib\x64" "-libpath:C:\Program 
Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.28.29910\lib\x64" "-libpath:C:\Program Files (x86)\Windows Kits\10\lib\10.0.19041.0\ucrt\x64" "-libpath:C:\Program Files (x86)\Windows Kits\10\lib\10.0.19041.0\um\x64" /IMPLIB:./chrome.dll.lib /DLL /PDB:./chrome.dll.pdb @./chrome.dll.rsp
lld-link: error: duplicate symbol: public: static class SessionID __cdecl SessionID::NewUnique(void)
>>> defined at .\..\..\components\sessions\core\session_id.cc:12
>>>            obj/components/sessions/session_id/session_id.obj
>>> defined at sessions.dll

lld-link: error: duplicate symbol: public: static void __cdecl sessions::SessionIdGenerator::RegisterPrefs(class PrefRegistrySimple *)
>>> defined at .\..\..\components\sessions\core\session_id_generator.cc:34
>>>            obj/components/sessions/session_id/session_id_generator.obj
>>> defined at sessions.dll

lld-link: error: duplicate symbol: public: static class sessions::SessionIdGenerator * __cdecl sessions::SessionIdGenerator::GetInstance(void)
>>> defined at .\..\..\components\sessions\core\session_id_generator.cc:29
>>>            obj/components/sessions/session_id/session_id_generator.obj
>>> defined at sessions.dll

lld-link: error: duplicate symbol: public: void __cdecl sessions::SessionIdGenerator::Shutdown(void)
>>> defined at .\..\..\components\sessions\core\session_id_generator.cc:56
>>>            obj/components/sessions/session_id/session_id_generator.obj
>>> defined at sessions.dll

lld-link: error: duplicate symbol: class std::__1::basic_ostream<char, struct std::__1::char_traits<char>> & __cdecl operator<<(class std::__1::basic_ostream<char, struct std::__1::char_traits<char>> &, class SessionID)
>>> defined at .\..\..\components\sessions\core\session_id.cc:16
>>>            obj/components/sessions/session_id/session_id.obj
>>> defined at sessions.dll
ninja: build stopped: subcommand failed.
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

