### PR TITLE
[Android] Dynamically detect disable option for Tab Groups (uplift to 1.24.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/BraveFeatureList.java
+++ b/android/java/org/chromium/chrome/browser/BraveFeatureList.java
@@ -14,18 +14,16 @@ public abstract class BraveFeatureList {
     public static final String USE_DEV_UPDATER_URL = "UseDevUpdaterUrl";
     public static final String FORCE_WEB_CONTENTS_DARK_MODE = "WebContentsForceDark";
     public static final String ENABLE_FORCE_DARK = "enable-force-dark";
-    public static final String ENABLE_FORCE_DARK_DISABLED_VALUE = "0";
     public static final String ENABLE_TAB_GROUPS = "enable-tab-groups";
-    public static final String ENABLE_TAB_GROUPS_DISABLED_VALUE = "2";
     public static final String ENABLE_TAB_GRID = "enable-tab-grid-layout";
-    public static final String ENABLE_TAB_GRID_DISABLED_VALUE = "8";
 
-    public static void enableFeature(String featureName, boolean enabled, String disabledValue) {
-        BraveFeatureListJni.get().enableFeature(featureName, enabled, disabledValue);
+    public static void enableFeature(
+            String featureName, boolean enabled, boolean fallbackToDefault) {
+        BraveFeatureListJni.get().enableFeature(featureName, enabled, fallbackToDefault);
     }
 
     @NativeMethods
     interface Natives {
-        void enableFeature(String featureName, boolean enabled, String disabledValue);
+        void enableFeature(String featureName, boolean enabled, boolean fallbackToDefault);
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -69,20 +69,21 @@ public class AppearancePreferences extends BravePreferenceFragment
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        ChromeSwitchPreference hideBraveRewardsIconPref = (ChromeSwitchPreference) findPreference(PREF_HIDE_BRAVE_REWARDS_ICON);
+        ChromeSwitchPreference hideBraveRewardsIconPref =
+                (ChromeSwitchPreference) findPreference(PREF_HIDE_BRAVE_REWARDS_ICON);
         if (hideBraveRewardsIconPref != null) {
             SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
-            hideBraveRewardsIconPref.setChecked(sharedPreferences.getBoolean(PREF_HIDE_BRAVE_REWARDS_ICON, false));
+            hideBraveRewardsIconPref.setChecked(
+                    sharedPreferences.getBoolean(PREF_HIDE_BRAVE_REWARDS_ICON, false));
             hideBraveRewardsIconPref.setOnPreferenceChangeListener(this);
         }
 
-        Preference nightModeEnabled =
-                findPreference(PREF_BRAVE_NIGHT_MODE_ENABLED);
+        Preference nightModeEnabled = findPreference(PREF_BRAVE_NIGHT_MODE_ENABLED);
         nightModeEnabled.setOnPreferenceChangeListener(this);
         if (nightModeEnabled instanceof ChromeSwitchPreference) {
             ((ChromeSwitchPreference) nightModeEnabled)
                     .setChecked(ChromeFeatureList.isEnabled(
-                        BraveFeatureList.FORCE_WEB_CONTENTS_DARK_MODE));
+                            BraveFeatureList.FORCE_WEB_CONTENTS_DARK_MODE));
         }
 
         Preference enableBottomToolbar =
@@ -94,8 +95,7 @@ public class AppearancePreferences extends BravePreferenceFragment
             boolean isTablet = DeviceFormFactor.isNonMultiDisplayContextOnTablet(
                     ContextUtils.getApplicationContext());
             ((ChromeSwitchPreference) enableBottomToolbar)
-                    .setChecked(!isTablet
-                            && BottomToolbarConfiguration.isBottomToolbarEnabled());
+                    .setChecked(!isTablet && BottomToolbarConfiguration.isBottomToolbarEnabled());
         }
 
         Preference enableTabGroups = findPreference(PREF_BRAVE_ENABLE_TAB_GROUPS);
@@ -130,8 +130,8 @@ public class AppearancePreferences extends BravePreferenceFragment
             SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
             Boolean originalStatus = BottomToolbarConfiguration.isBottomToolbarEnabled();
             prefs.edit()
-                    .putBoolean(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY,
-                            !originalStatus)
+                    .putBoolean(
+                            BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY, !originalStatus)
                     .apply();
             BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_HIDE_BRAVE_REWARDS_ICON.equals(key)) {
@@ -141,14 +141,14 @@ public class AppearancePreferences extends BravePreferenceFragment
             sharedPreferencesEditor.apply();
             BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_BRAVE_NIGHT_MODE_ENABLED.equals(key)) {
-            BraveFeatureList.enableFeature(BraveFeatureList.ENABLE_FORCE_DARK, (boolean) newValue,
-                    BraveFeatureList.ENABLE_FORCE_DARK_DISABLED_VALUE);
+            BraveFeatureList.enableFeature(
+                    BraveFeatureList.ENABLE_FORCE_DARK, (boolean) newValue, true);
             BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_BRAVE_ENABLE_TAB_GROUPS.equals(key)) {
-            BraveFeatureList.enableFeature(BraveFeatureList.ENABLE_TAB_GROUPS, (boolean) newValue,
-                    BraveFeatureList.ENABLE_TAB_GROUPS_DISABLED_VALUE);
-            BraveFeatureList.enableFeature(BraveFeatureList.ENABLE_TAB_GRID, (boolean) newValue,
-                    BraveFeatureList.ENABLE_TAB_GRID_DISABLED_VALUE);
+            BraveFeatureList.enableFeature(
+                    BraveFeatureList.ENABLE_TAB_GROUPS, (boolean) newValue, false);
+            BraveFeatureList.enableFeature(
+                    BraveFeatureList.ENABLE_TAB_GRID, (boolean) newValue, false);
             SharedPreferencesManager.getInstance().writeBoolean(
                     BravePreferenceKeys.BRAVE_DOUBLE_RESTART, true);
             BraveRelaunchUtils.askForRelaunch(getActivity());

--- a/browser/android/brave_feature_list.cc
+++ b/browser/android/brave_feature_list.cc
@@ -10,18 +10,37 @@
 #include "brave/browser/brave_browser_process_impl.h"
 #include "brave/build/android/jni_headers/BraveFeatureList_jni.h"
 #include "chrome/browser/about_flags.h"
+#include "components/flags_ui/feature_entry.h"
 #include "components/flags_ui/pref_service_flags_storage.h"
 
 namespace chrome {
 namespace android {
 
+int GetNumberOfOptions(const std::string& internal_name) {
+  DCHECK(about_flags::GetCurrentFlagsState());
+  if (!about_flags::GetCurrentFlagsState()) {
+    return 0;
+  }
+  const flags_ui::FeatureEntry* entry =
+      about_flags::GetCurrentFlagsState()->FindFeatureEntryByName(
+          internal_name);
+  DCHECK(entry);
+  if (!entry) {
+    return 0;
+  }
+  return entry->NumOptions();
+}
+
 static void JNI_BraveFeatureList_EnableFeature(
     JNIEnv* env,
     const base::android::JavaParamRef<jstring>& featureName,
     jboolean enabled,
-    const base::android::JavaParamRef<jstring>& disabledValue) {
+    jboolean fallback_to_default) {
   std::string feature_name = ConvertJavaStringToUTF8(env, featureName);
-  std::string disabled_value = ConvertJavaStringToUTF8(env, disabledValue);
+  std::string disabled_value =
+      fallback_to_default
+          ? "0"
+          : std::to_string(GetNumberOfOptions(feature_name) - 1);
   enabled ? feature_name += "@1" : feature_name += "@" + disabled_value;
   flags_ui::PrefServiceFlagsStorage flags_storage(
       g_brave_browser_process->local_state());


### PR DESCRIPTION
Uplift of #8624
Resolves https://github.com/brave/brave-browser/issues/15463

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.