### PR TITLE
Fixes "Estimated pending rewards" temporarily reseting to zero until the payments server endpoint is successful - 1.23.x

### DIFF
--- a/components/brave_ads/test/BUILD.gn
+++ b/components/brave_ads/test/BUILD.gn
@@ -16,6 +16,7 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_grants/ad_grants_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_delegate_mock.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_delegate_mock.h",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/ad_pacing/ad_notifications/ad_notification_pacing_unittest.cc",

--- a/vendor/bat-native-ads/data/test/confirmations.json
+++ b/vendor/bat-native-ads/data/test/confirmations.json
@@ -1,22 +1,24 @@
 {
-  "transaction_history": {
-    "transactions": [
-    ]
+  "ads_rewards": {
+    "grants_balance": 4.21,
+    "payments": [
+      {
+        "balance": 48.0,
+        "month": "2021-04",
+        "transaction_count": "16"
+      }
+    ],
+    "unreconciled_estimated_pending_rewards": 0
   },
   "catalog_issuers": {
   },
-  "unblinded_tokens": [
-  ],
-  "unblinded_payment_tokens": [
-  ],
   "confirmations": {
-    "failed_confirmations": [
-    ]
+    "failed_confirmations": []
   },
-  "next_token_redemption_date_in_seconds": "2147483647",
-  "ads_rewards": {
-    "payments": [
-    ],
-    "grants_balance": 0
-  }
+  "next_token_redemption_date_in_seconds": "4102444799",
+  "transaction_history": {
+    "transactions": []
+  },
+  "unblinded_payment_tokens": [],
+  "unblinded_tokens": []
 }

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
@@ -208,24 +208,13 @@ base::Value AdRewards::GetAsDictionary() {
 bool AdRewards::SetFromDictionary(base::Value* dictionary) {
   DCHECK(dictionary);
 
-  base::Value* ad_rewards = dictionary->FindDictKey("ads_rewards");
-  if (!ad_rewards) {
-    return false;
-  }
-
-  base::DictionaryValue* ads_rewards_dictionary;
-  if (!ad_rewards->GetAsDictionary(&ads_rewards_dictionary)) {
-    return false;
-  }
-
-  if (!ad_grants_->SetFromDictionary(ads_rewards_dictionary) ||
-      !payments_->SetFromDictionary(ads_rewards_dictionary)) {
+  if (!ad_grants_->SetFromDictionary(dictionary) ||
+      !payments_->SetFromDictionary(dictionary)) {
     return false;
   }
 
   const base::Optional<double> unreconciled_estimated_pending_rewards =
-      ads_rewards_dictionary->FindDoubleKey(
-          "unreconciled_estimated_pending_rewards");
+      dictionary->FindDoubleKey("unreconciled_estimated_pending_rewards");
   unreconciled_estimated_pending_rewards_ =
       unreconciled_estimated_pending_rewards.value_or(0.0);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc
@@ -1,0 +1,178 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/account/ad_rewards/ad_rewards.h"
+
+#include "bat/ads/internal/unittest_base.h"
+#include "bat/ads/internal/unittest_util.h"
+#include "net/http/http_status_code.h"
+
+// npm run test -- brave_unit_tests --filter=BatAds*
+
+namespace ads {
+
+class BatAdsAdRewardsIntegrationTest : public UnitTestBase {
+ protected:
+  BatAdsAdRewardsIntegrationTest() = default;
+
+  ~BatAdsAdRewardsIntegrationTest() override = default;
+
+  void SetUp() override {
+    UnitTestBase::SetUpForTesting(/* integration_test */ true);
+  }
+};
+
+TEST_F(BatAdsAdRewardsIntegrationTest, GetAdRewardsFromEndPoints) {
+  // Arrange
+  const URLEndpoints endpoints = {
+      {"/v1/confirmation/payment/c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_OK,
+         R"([
+              {
+                "balance" : "19.64",
+                "month" : "2021-05",
+                "transactionCount" : "28"
+              },
+              {
+                "balance" : "7.32",
+                "month" : "2021-04",
+                "transactionCount" : "9"
+              }
+            ])"}}},
+      {"/v1/promotions/ads/grants/"
+       "summary?paymentId=c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_OK,
+         R"({
+              "type" : "ads",
+              "amount" : "19.42",
+              "lastClaim" : "1945-06-10T12:34:56.789Z"
+            })"}}}};
+
+  MockUrlRequest(ads_client_mock_, endpoints);
+
+  InitializeAds();
+
+  AdvanceClock(TimeFromDateString("19 May 2021"));
+
+  // Act
+  GetAds()->GetAccountStatement(
+      [](const bool success, const StatementInfo& statement) {
+        ASSERT_TRUE(success);
+
+        StatementInfo expected_statement;
+        expected_statement.next_payment_date =
+            TimestampFromDateString("5 June 2021");
+
+        // Calculated by subtracting the ad grant balance from the accumulated
+        // payment balances
+        expected_statement.estimated_pending_rewards = 7.54;
+
+        // Calculated from the above payment balance for May
+        expected_statement.earnings_this_month = 19.64;
+
+        // Calculated from the above payment balance for April
+        expected_statement.earnings_last_month = 7.32;
+
+        EXPECT_EQ(expected_statement, statement);
+      });
+
+  // Assert
+}
+
+TEST_F(BatAdsAdRewardsIntegrationTest,
+       GetCachedAdRewardsIfGetPaymentsEndPointReturnsNonHttpOk) {
+  // Arrange
+  const URLEndpoints endpoints = {
+      {"/v1/confirmation/payment/c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_INTERNAL_SERVER_ERROR, ""}}}};
+
+  MockUrlRequest(ads_client_mock_, endpoints);
+
+  InitializeAds();
+
+  AdvanceClock(TimeFromDateString("1 April 2021"));
+
+  // Act
+  GetAds()->GetAccountStatement(
+      [](const bool success, const StatementInfo& statement) {
+        ASSERT_TRUE(success);
+
+        StatementInfo expected_statement;
+        expected_statement.next_payment_date =
+            TimestampFromDateString("5 May 2021");
+
+        // Calculated by subtracting the cached ad grant balance from the cached
+        // payment balance configured in |data/test/confirmations.json|
+        expected_statement.estimated_pending_rewards = 43.79;
+
+        // Calculated from earnings in April configured in
+        // |data/test/confirmations.json|
+        expected_statement.earnings_this_month = 48.0;
+
+        // Calculated from earnings in March configured in
+        // |data/test/confirmations.json|
+        expected_statement.earnings_last_month = 0.0;
+
+        EXPECT_EQ(expected_statement, statement);
+      });
+
+  // Assert
+}
+
+TEST_F(BatAdsAdRewardsIntegrationTest,
+       GetCachedAdRewardsIfGetAdGrantsEndPointReturnsNonHttpOk) {
+  // Arrange
+  const URLEndpoints endpoints = {
+      {"/v1/confirmation/payment/c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_OK,
+         R"([
+              {
+                "balance" : "19.70",
+                "month" : "2021-11",
+                "transactionCount" : "51"
+              },
+              {
+                "balance" : "6.66",
+                "month" : "2021-10",
+                "transactionCount" : "31"
+              }
+            ])"}}},
+      {"/v1/promotions/ads/grants/"
+       "summary?paymentId=c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_INTERNAL_SERVER_ERROR, ""}}}};
+
+  MockUrlRequest(ads_client_mock_, endpoints);
+
+  InitializeAds();
+
+  AdvanceClock(TimeFromDateString("18 November 2021"));
+
+  // Act
+  GetAds()->GetAccountStatement(
+      [](const bool success, const StatementInfo& statement) {
+        ASSERT_TRUE(success);
+
+        StatementInfo expected_statement;
+        expected_statement.next_payment_date =
+            TimestampFromDateString("5 December 2021");
+
+        // Calculated by subtracting the cached ad grant balance configured in
+        // |data/test/confirmations.json| from the above accumulated payment
+        // balances
+        expected_statement.estimated_pending_rewards = 22.15;
+
+        // Calculated from the above payment balance for November
+        expected_statement.earnings_this_month = 19.7;
+
+        // Calculated from the above payment balance for October
+        expected_statement.earnings_last_month = 6.66;
+
+        EXPECT_EQ(expected_statement, statement);
+      });
+
+  // Assert
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_base.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_base.cc
@@ -41,6 +41,21 @@ UnitTestBase::~UnitTestBase() {
       << "You have overridden TearDown but never called UnitTestBase::TearDown";
 }
 
+void UnitTestBase::InitializeAds() {
+  CHECK(integration_test_)
+      << "|InitializeAds| should only be called if "
+         "|SetUpForTesting| was initialized for integration testing";
+
+  ads_->Initialize(
+      [](const Result result) { ASSERT_EQ(Result::SUCCESS, result); });
+
+  task_environment_.RunUntilIdle();
+}
+
+AdsImpl* UnitTestBase::GetAds() const {
+  return ads_.get();
+}
+
 void UnitTestBase::SetUp() {
   // Code here will be called immediately after the constructor (right before
   // each test)
@@ -173,17 +188,6 @@ void UnitTestBase::Initialize() {
   // Fast forward until no tasks remain to ensure "EnsureSqliteInitialized"
   // tasks have fired before running tests
   task_environment_.FastForwardUntilNoTasksRemain();
-}
-
-void UnitTestBase::InitializeAds() {
-  CHECK(integration_test_)
-      << "|InitializeAds| should only be called if "
-         "|SetUpForTesting| was initialized for integration testing";
-
-  ads_->Initialize(
-      [](const Result result) { ASSERT_EQ(Result::SUCCESS, result); });
-
-  task_environment_.RunUntilIdle();
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_base.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_base.h
@@ -47,6 +47,8 @@ class UnitTestBase : public testing::Test {
 
   void InitializeAds();
 
+  AdsImpl* GetAds() const;
+
   // testing::Test implementation
   void SetUp() override;
   void TearDown() override;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/8630
Resolves https://github.com/brave/brave-browser/issues/15460

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
