### PR TITLE
Add support for P3A wallet state (Q11)

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1708,7 +1708,8 @@ void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
     }
 
     // Record P3A.
-    brave_rewards::UpdateAdsP3AOnPreferenceChange(profile_->GetPrefs(), pref);
+    brave_rewards::p3a::UpdateAdsStateOnPreferenceChange(profile_->GetPrefs(),
+                                                         pref);
   } else if (pref == ads::prefs::kIdleTimeThreshold) {
     StartCheckIdleStateTimer();
   } else if (pref == brave_rewards::prefs::kWalletBrave) {

--- a/components/brave_rewards/browser/rewards_p3a.h
+++ b/components/brave_rewards/browser/rewards_p3a.h
@@ -21,25 +21,36 @@ class DictionaryValue;
 }
 
 namespace brave_rewards {
+namespace p3a {
 
-void RecordWalletBalanceP3A(bool wallet_created, bool rewards_enabled,
-                            size_t balance);
+struct WalletState {
+  bool wallet_created = false;
+  bool rewards_enabled = false;
+  bool grants_claimed = false;
+  bool funds_added = false;
+};
 
-enum class AutoContributionsP3AState {
+void RecordWalletState(const WalletState& state);
+
+void RecordWalletBalance(bool wallet_created,
+                         bool rewards_enabled,
+                         size_t balance);
+
+enum class AutoContributionsState {
   kNoWallet,
   kRewardsDisabled,
   kWalletCreatedAutoContributeOff,
   kAutoContributeOn,
 };
 
-void RecordAutoContributionsState(AutoContributionsP3AState state, int count);
+void RecordAutoContributionsState(AutoContributionsState state, int count);
 
 void RecordTipsState(bool wallet_created,
                      bool rewards_enabled,
                      int one_time_count,
                      int recurring_count);
 
-enum class AdsP3AState {
+enum class AdsState {
   kNoWallet,
   kRewardsDisabled,
   kAdsDisabled,
@@ -49,26 +60,25 @@ enum class AdsP3AState {
   kMaxValue = kAdsEnabledThenDisabledRewardsOff,
 };
 
-void RecordAdsState(AdsP3AState state);
+void RecordAdsState(AdsState state);
 
-void UpdateAdsP3AOnPreferenceChange(PrefService* prefs,
-                                    const std::string& pref);
+void UpdateAdsStateOnPreferenceChange(PrefService* prefs,
+                                      const std::string& pref);
 
 // Records an initial metric state ("disabled" or "enabled") if it was not done
 // before. Intended to be called if the user has already created a wallet.
-void MaybeRecordInitialAdsP3AState(PrefService* local_state);
+void MaybeRecordInitialAdsState(PrefService* local_state);
 
 void RecordNoWalletCreatedForAllMetrics();
 
 void RecordRewardsDisabledForSomeMetrics();
 
-double CalcWalletBalanceForP3A(base::flat_map<std::string, double> wallets,
-                               double user_funds);
+double CalcWalletBalance(base::flat_map<std::string, double> wallets,
+                         double user_funds);
 
-uint64_t RoundProbiToUint64(base::StringPiece probi);
+void ExtractAndLogStats(const base::DictionaryValue& dict);
 
-void ExtractAndLogP3AStats(const base::DictionaryValue& dict);
-
+}  // namespace p3a
 }  // namespace brave_rewards
 
 #endif  // BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_REWARDS_P3A_H_

--- a/components/brave_rewards/browser/rewards_service.cc
+++ b/components/brave_rewards/browser/rewards_service.cc
@@ -52,6 +52,7 @@ void RewardsService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
                                   base::TimeDelta::FromSeconds(30));
   registry->RegisterBooleanPref(prefs::kBackupSucceeded, false);
   registry->RegisterBooleanPref(prefs::kUserHasFunded, false);
+  registry->RegisterBooleanPref(prefs::kUserHasClaimedGrant, false);
   registry->RegisterTimePref(prefs::kAddFundsNotification, base::Time());
   registry->RegisterBooleanPref(prefs::kEnabled, false);
   registry->RegisterDictionaryPref(prefs::kExternalWallets);

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -91,8 +91,6 @@
 #include "brave/components/ipfs/ipfs_utils.h"
 #endif
 using net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES;
-using std::placeholders::_1;
-using std::placeholders::_2;
 
 namespace brave_rewards {
 
@@ -166,7 +164,7 @@ std::pair<std::string, base::Value> LoadStateOnFileTaskRunner(
     return result;
   }
 
-  ExtractAndLogP3AStats(*dict);
+  p3a::ExtractAndLogStats(*dict);
   result.second = std::move(*dict);
 
   return result;
@@ -418,8 +416,8 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
       StartLedgerProcessIfNecessary();
     } else {
       // Just record the disabled state.
-      RecordAutoContributionsState(
-          AutoContributionsP3AState::kWalletCreatedAutoContributeOff, 0);
+      p3a::RecordAutoContributionsState(
+          p3a::AutoContributionsState::kWalletCreatedAutoContributeOff, 0);
     }
   }
 
@@ -427,7 +425,8 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
     if (IsRewardsEnabled()) {
       RecordBackendP3AStats();
     } else {
-      RecordRewardsDisabledForSomeMetrics();
+      p3a::RecordRewardsDisabledForSomeMetrics();
+      p3a::RecordWalletState({.wallet_created = true});
     }
   }
 }
@@ -842,11 +841,21 @@ void RewardsServiceImpl::OnLedgerInitialized(ledger::type::Result result) {
   if (IsRewardsEnabled()) {
     RecordBackendP3AStats();
   } else {
-    RecordRewardsDisabledForSomeMetrics();
+    p3a::RecordRewardsDisabledForSomeMetrics();
   }
+
+  GetBraveWallet(
+      base::BindOnce(&RewardsServiceImpl::OnGetBraveWalletForP3A, AsWeakPtr()));
 
   for (auto& observer : observers_) {
     observer.OnRewardsInitialized(this);
+  }
+}
+
+void RewardsServiceImpl::OnGetBraveWalletForP3A(
+    ledger::type::BraveWalletPtr wallet) {
+  if (!wallet) {
+    p3a::RecordNoWalletCreatedForAllMetrics();
   }
 }
 
@@ -921,10 +930,10 @@ void RewardsServiceImpl::OnLedgerStateLoaded(
   if (state.second.is_dict()) {
     // Record stats.
     RecordBackendP3AStats();
-    MaybeRecordInitialAdsP3AState(profile_->GetPrefs());
+    p3a::MaybeRecordInitialAdsState(profile_->GetPrefs());
   }
   if (state.first.empty()) {
-    RecordNoWalletCreatedForAllMetrics();
+    p3a::RecordNoWalletCreatedForAllMetrics();
   }
 
   // Run callbacks.
@@ -1311,6 +1320,9 @@ void RewardsServiceImpl::OnAttestPromotion(
     std::move(callback).Run(result, nullptr);
     return;
   }
+
+  PrefService* pref_service = profile_->GetPrefs();
+  pref_service->SetBoolean(prefs::kUserHasClaimedGrant, true);
 
   for (auto& observer : observers_) {
     observer.OnPromotionFinished(this, result, promotion->Clone());
@@ -2767,19 +2779,29 @@ void RewardsServiceImpl::OnFetchBalance(
     FetchBalanceCallback callback,
     const ledger::type::Result result,
     ledger::type::BalancePtr balance) {
+  PrefService* pref_service = profile_->GetPrefs();
+
+  // Record wallet state stats
+  if (IsRewardsEnabled()) {
+    const bool grants_claimed =
+        pref_service->GetBoolean(prefs::kUserHasClaimedGrant);
+    p3a::RecordWalletState(
+        {.wallet_created = true,
+         .rewards_enabled = true,
+         .grants_claimed = grants_claimed,
+         .funds_added = balance && balance->user_funds > 0});
+  }
+
   if (balance) {
     if (balance->total > 0) {
-      profile_->GetPrefs()->SetBoolean(prefs::kUserHasFunded, true);
+      pref_service->SetBoolean(prefs::kUserHasFunded, true);
     }
 
-    // Record stats.
-    double balance_minus_grant = CalcWalletBalanceForP3A(
-        balance->wallets,
-        balance->user_funds);
-    RecordWalletBalanceP3A(
-        true,
-        true,
-        static_cast<size_t>(balance_minus_grant));
+    // Record wallet balance stats
+    double balance_minus_grant =
+        p3a::CalcWalletBalance(balance->wallets, balance->user_funds);
+    p3a::RecordWalletBalance(true, true,
+                             static_cast<size_t>(balance_minus_grant));
   }
 
   std::move(callback).Run(result, std::move(balance));
@@ -3012,7 +3034,7 @@ void RewardsServiceImpl::OnRecordBackendP3AStatsContributions(
     queued_recurring = recurring_donation_size;
   }
 
-  RecordTipsState(true, true, tips, queued_recurring);
+  p3a::RecordTipsState(true, true, tips, queued_recurring);
 
   GetAutoContributeEnabled(base::BindOnce(
     &RewardsServiceImpl::OnRecordBackendP3AStatsAC,
@@ -3023,10 +3045,11 @@ void RewardsServiceImpl::OnRecordBackendP3AStatsContributions(
 void RewardsServiceImpl::OnRecordBackendP3AStatsAC(
     const int auto_contributions,
     bool ac_enabled) {
-  const auto auto_contributions_state = ac_enabled ?
-        AutoContributionsP3AState::kAutoContributeOn :
-        AutoContributionsP3AState::kWalletCreatedAutoContributeOff;
-  RecordAutoContributionsState(auto_contributions_state, auto_contributions);
+  const auto auto_contributions_state =
+      ac_enabled ? p3a::AutoContributionsState::kAutoContributeOn
+                 : p3a::AutoContributionsState::kWalletCreatedAutoContributeOff;
+  p3a::RecordAutoContributionsState(auto_contributions_state,
+                                    auto_contributions);
 }
 
 #if defined(OS_ANDROID)

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2785,11 +2785,10 @@ void RewardsServiceImpl::OnFetchBalance(
   if (IsRewardsEnabled()) {
     const bool grants_claimed =
         pref_service->GetBoolean(prefs::kUserHasClaimedGrant);
-    p3a::RecordWalletState(
-        {.wallet_created = true,
-         .rewards_enabled = true,
-         .grants_claimed = grants_claimed,
-         .funds_added = balance && balance->user_funds > 0});
+    p3a::RecordWalletState({.wallet_created = true,
+                            .rewards_enabled = true,
+                            .grants_claimed = grants_claimed,
+                            .funds_added = balance && balance->user_funds > 0});
   }
 
   if (balance) {

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -688,6 +688,8 @@ class RewardsServiceImpl : public RewardsService,
       const std::string& publisher_key,
       const std::string& publisher_name) override;
 
+  void OnGetBraveWalletForP3A(ledger::type::BraveWalletPtr wallet);
+
   bool Connected() const;
   void ConnectionClosed();
   void AddPrivateObserver(RewardsServicePrivateObserver* observer) override;

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.h
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.h
@@ -14,6 +14,7 @@
 #include "bat/ledger/mojom_structs.h"
 #include "brave/components/brave_rewards/browser/rewards_service_impl.h"
 #include "brave/components/brave_rewards/browser/rewards_service_observer.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_context_helper.h"
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
 #include "chrome/browser/ui/browser.h"
 

--- a/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc
@@ -1,0 +1,222 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "base/containers/flat_map.h"
+#include "base/test/bind.h"
+#include "base/test/metrics/histogram_tester.h"
+#include "brave/browser/brave_rewards/rewards_service_factory.h"
+#include "brave/common/brave_paths.h"
+#include "brave/components/brave_rewards/browser/rewards_service_impl.h"
+#include "brave/components/brave_rewards/browser/rewards_service_observer.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_context_util.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_network_util.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_promotion.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_response.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/network_session_configurator/common/network_switches.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+
+// npm run test -- brave_browser_tests --filter=RewardsP3ABrowserTest.*
+
+namespace rewards_browsertest {
+
+class RewardsP3ABrowserTest : public InProcessBrowserTest,
+                              public brave_rewards::RewardsServiceObserver {
+ public:
+  RewardsP3ABrowserTest() {
+    contribution_ = std::make_unique<RewardsBrowserTestContribution>();
+    promotion_ = std::make_unique<RewardsBrowserTestPromotion>();
+    response_ = std::make_unique<RewardsBrowserTestResponse>();
+    histogram_tester_.reset(new base::HistogramTester);
+  }
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    context_helper_ =
+        std::make_unique<RewardsBrowserTestContextHelper>(browser());
+
+    // HTTP resolver
+    host_resolver()->AddRule("*", "127.0.0.1");
+    https_server_.reset(new net::EmbeddedTestServer(
+        net::test_server::EmbeddedTestServer::TYPE_HTTPS));
+    https_server_->SetSSLConfig(net::EmbeddedTestServer::CERT_OK);
+    https_server_->RegisterRequestHandler(
+        base::BindRepeating(&rewards_browsertest_util::HandleRequest));
+    ASSERT_TRUE(https_server_->Start());
+
+    // Rewards service
+    brave::RegisterPathProvider();
+    auto* profile = browser()->profile();
+    rewards_service_ = static_cast<brave_rewards::RewardsServiceImpl*>(
+        brave_rewards::RewardsServiceFactory::GetForProfile(profile));
+    rewards_service_->AddObserver(this);
+
+    // Response mock
+    base::ScopedAllowBlockingForTesting allow_blocking;
+    response_->LoadMocks();
+    rewards_service_->ForTestingSetTestResponseCallback(base::BindRepeating(
+        &RewardsP3ABrowserTest::GetTestResponse, base::Unretained(this)));
+    rewards_service_->SetLedgerEnvForTesting();
+
+    // Other
+    promotion_->Initialize(browser(), rewards_service_);
+    contribution_->Initialize(browser(), rewards_service_);
+
+    rewards_browsertest_util::SetOnboardingBypassed(browser());
+  }
+
+  void TearDown() override { InProcessBrowserTest::TearDown(); }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    // HTTPS server only serves a valid cert for localhost, so this is needed
+    // to load pages from other hosts without an error
+    command_line->AppendSwitch(switches::kIgnoreCertificateErrors);
+  }
+
+  void GetTestResponse(const std::string& url,
+                       int32_t method,
+                       int* response_status_code,
+                       std::string* response,
+                       base::flat_map<std::string, std::string>* headers) {
+    response_->SetExternalBalance(contribution_->GetExternalBalance());
+    response_->Get(url, method, response_status_code, response);
+  }
+
+  void FetchBalance() {
+    base::RunLoop run_loop;
+    rewards_service_->FetchBalance(base::BindLambdaForTesting(
+        [&](ledger::type::Result result, ledger::type::BalancePtr balance) {
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+  }
+
+  void WaitForRewardsInitialization() {
+    if (rewards_initialized_) {
+      return;
+    }
+
+    wait_for_rewards_initialization_loop_.reset(new base::RunLoop);
+    wait_for_rewards_initialization_loop_->Run();
+  }
+
+  content::WebContents* contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  void OnRewardsInitialized(
+      brave_rewards::RewardsService* rewards_service) override {
+    rewards_initialized_ = true;
+  }
+
+  brave_rewards::RewardsServiceImpl* rewards_service_;
+  std::unique_ptr<net::EmbeddedTestServer> https_server_;
+  std::unique_ptr<RewardsBrowserTestContribution> contribution_;
+  std::unique_ptr<RewardsBrowserTestPromotion> promotion_;
+  std::unique_ptr<RewardsBrowserTestResponse> response_;
+  std::unique_ptr<RewardsBrowserTestContextHelper> context_helper_;
+  std::unique_ptr<base::HistogramTester> histogram_tester_;
+
+  bool rewards_initialized_ = false;
+  std::unique_ptr<base::RunLoop> wait_for_rewards_initialization_loop_;
+};
+
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, RewardsDisabled) {
+  rewards_browsertest_util::StartProcess(rewards_service_);
+
+  WaitForRewardsInitialization();
+
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.WalletBalance.2", 1, 1);
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.AutoContributionsState.2",
+                                       1, 1);
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.TipsState.2", 1, 1);
+}
+
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest,
+                       WalletStateWalletCreatedNoGrantsClaimedNoFundsAdded) {
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_browsertest_util::CreateWallet(rewards_service_);
+
+  rewards_service_->SetAutoContributeEnabled(true);
+  rewards_service_->SetAdsEnabled(true);
+
+  FetchBalance();
+
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.WalletState", 1, 1);
+}
+
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest,
+                       WalletStateWalletCreatedGrantsClaimedNoFundsAdded) {
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_browsertest_util::CreateWallet(rewards_service_);
+
+  context_helper_->LoadURL(rewards_browsertest_util::GetRewardsUrl());
+
+  rewards_service_->SetAutoContributeEnabled(true);
+  rewards_service_->SetAdsEnabled(true);
+
+  contribution_->AddBalance(promotion_->ClaimPromotionViaCode());
+
+  FetchBalance();
+
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.WalletState", 2, 1);
+}
+
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest,
+                       WalletStateWalletCreatedNoGrantsClaimedFundsAdded) {
+  response_->SetUserFundsBalance(true);
+
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_browsertest_util::CreateWallet(rewards_service_);
+
+  context_helper_->LoadURL(rewards_browsertest_util::GetRewardsUrl());
+
+  rewards_service_->SetAutoContributeEnabled(true);
+  rewards_service_->SetAdsEnabled(true);
+
+  FetchBalance();
+
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.WalletState", 3, 1);
+}
+
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest,
+                       WalletStateWalletCreatedGrantsClaimedFundsAdded) {
+  response_->SetUserFundsBalance(true);
+
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_browsertest_util::CreateWallet(rewards_service_);
+
+  context_helper_->LoadURL(rewards_browsertest_util::GetRewardsUrl());
+
+  rewards_service_->SetAutoContributeEnabled(true);
+  rewards_service_->SetAdsEnabled(true);
+
+  contribution_->AddBalance(promotion_->ClaimPromotionViaCode());
+
+  FetchBalance();
+
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.WalletState", 4, 1);
+}
+
+IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest,
+                       WalletStateWalletDisabledAfterCreation) {
+  rewards_browsertest_util::StartProcess(rewards_service_);
+  rewards_browsertest_util::CreateWallet(rewards_service_);
+
+  rewards_service_->SetAdsEnabled(false);
+  rewards_service_->SetAutoContributeEnabled(false);
+
+  histogram_tester_->ExpectBucketCount("Brave.Rewards.WalletState", 5, 1);
+}
+
+}  // namespace rewards_browsertest

--- a/components/brave_rewards/common/pref_names.cc
+++ b/components/brave_rewards/common/pref_names.cc
@@ -17,6 +17,7 @@ const char kBackupNotificationInterval[] =
     "brave.rewards.backup_notification_interval";
 const char kBackupSucceeded[] = "brave.rewards.backup_succeeded";
 const char kUserHasFunded[] = "brave.rewards.user_has_funded";
+const char kUserHasClaimedGrant[] = "brave.rewards.user_has_claimed_grant";
 const char kAddFundsNotification[] =
     "brave.rewards.add_funds_notification";
 const char kNotificationStartupDelay[] =

--- a/components/brave_rewards/common/pref_names.h
+++ b/components/brave_rewards/common/pref_names.h
@@ -16,6 +16,7 @@ extern const char kNotificationTimerInterval[];
 extern const char kBackupNotificationInterval[];
 extern const char kBackupSucceeded[];
 extern const char kUserHasFunded[];
+extern const char kUserHasClaimedGrant[];
 extern const char kAddFundsNotification[];
 extern const char kNotificationStartupDelay[];
 extern const char kExternalWallets[];  // DEPRECATED

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -20,12 +20,12 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/task/post_task.h"
 #include "base/trace_event/trace_event.h"
-#include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
 #include "brave/browser/version_info.h"
 #include "brave/common/brave_channel_info.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_prochlo/prochlo_message.pb.h"
 #include "brave/components/brave_referrals/common/pref_names.h"
+#include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
 #include "brave/components/p3a/brave_p2a_protocols.h"
 #include "brave/components/p3a/brave_p3a_log_store.h"
 #include "brave/components/p3a/brave_p3a_scheduler.h"
@@ -80,6 +80,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.Rewards.AutoContributionsState.2",
     "Brave.Rewards.TipsState.2",
     "Brave.Rewards.WalletBalance.2",
+    "Brave.Rewards.WalletState",
     "Brave.Savings.BandwidthSavingsMB",
     "Brave.Search.DefaultEngine.4",
     "Brave.Shields.UsageStatus",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -726,6 +726,7 @@ if (!is_android) {
         "//brave/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc",
         "//brave/components/brave_rewards/browser/test/rewards_flag_browsertest.cc",
         "//brave/components/brave_rewards/browser/test/rewards_notification_browsertest.cc",
+        "//brave/components/brave_rewards/browser/test/rewards_p3a_browsertest.cc",
         "//brave/components/brave_rewards/browser/test/rewards_promotion_browsertest.cc",
         "//brave/components/brave_rewards/browser/test/rewards_publisher_browsertest.cc",
         "//brave/components/brave_rewards/browser/test/rewards_state_browsertest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/7634
Resolves https://github.com/brave/brave-browser/issues/13996

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Grants test

- Clean profile, staging server
- Visit brave://rewards
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `0` in brave://local-state
- Enable Rewards
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `1` in brave://local-state
- Claim UGP grant
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `2` in brave://local-state
- Disable Rewards by turning off ads and auto-contribute
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `5` in brave://local-state

### Funds test

- Clean profile, staging server
- Visit brave://rewards
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `0` in brave://local-state
- Enable Rewards
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `1` in brave://local-state
- Restore wallet with user funds
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `3` in brave://local-state
- Claim UGP grant
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `4` in brave://local-state
- Disable Rewards by turning off ads and auto-contribute
- Wait 10 or so seconds
- Verify that `Brave.Rewards.WalletState` is set to `5` in brave://local-state
