### PR TITLE
Fix version shown in auto-update popup on Mac

### DIFF
--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -57,6 +57,12 @@ def _OverrideVersionKey(plist, brave_version):
     adjusted_minor = int(version_values[1]) + (100 * int(version_values[0]))
     plist['CFBundleVersion'] = str(adjusted_minor) + '.' + version_values[2]
 
+  # The "short" version is only used for display purposes. Chromium uses four
+  # numbers w.x.y.z while Brave uses only three. So override the entry with our
+  # value. This is in particular displayed in Brave's (/Sparkle's) update
+  # notification popup: "Version X is available. You have version Y."
+  plist['CFBundleShortVersionString'] = brave_version
+
 
 def Main(argv):
   parser = optparse.OptionParser('%prog [options]')


### PR DESCRIPTION
Previously, this popup showed the Chromium version:

![image](https://user-images.githubusercontent.com/1076393/116119792-1b2f9680-a6bf-11eb-805b-e00c194afeed.png)

After this PR, it will show Brave's version `x.y.z`.

This commit is only part of the solution. The other half is to also change the first version (`119.88` in the screenshot above). This can be achieved via a change to the Sparkle Appcast on the update server. A separate PR is already in progress in the relevant server repository.

Resolves brave/brave-browser#13819.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Steps to get the popup to appear:

1. Install Brave as Admin
2. Start Brave at least once.
2. Change `CFBundleVersion` in `Contents/Info.plist` in Brave's installation directory to an old version, e.g. `121.46`.
3. Log in as a non-Admin user.
4. Start Brave.
5. Navigate to `brave://settings/help`.
6. After a few seconds, the update popup should appear. In it, you can check that the _right hand version_ (i.e. the version you have) is shown correctly as eg. `1.25.45` and not as `90.1.25.46`. The left hand version should also change as soon as a corresponding fix is implemented on the update server side.