### PR TITLE
Restore Chromium command line handler and fix QA command line append.

### DIFF
--- a/android/java/org/chromium/base/BraveCommandLineInitUtil.java
+++ b/android/java/org/chromium/base/BraveCommandLineInitUtil.java
@@ -9,6 +9,8 @@ import android.content.SharedPreferences;
 
 import androidx.annotation.Nullable;
 
+import org.chromium.base.CommandLine;
+import org.chromium.base.CommandLineInitUtil;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.supplier.Supplier;
 
@@ -19,7 +21,13 @@ public abstract class BraveCommandLineInitUtil {
     private static final String PREF_QA_VLOG_REWARDS = "qa_vlog_rewards";
     private static final String PREF_QA_COMMAND_LINE = "qa_command_line";
 
-    public static void initCommandLine(String fileName) {
+    public static void initCommandLine(
+            String fileName, @Nullable Supplier<Boolean> shouldUseDebugFlags) {
+        CommandLineInitUtil.initCommandLine(fileName, shouldUseDebugFlags);
+        appendBraveSwitchesAndArguments();
+    }
+
+    private static void appendBraveSwitchesAndArguments() {
         SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
         String qaCommandLine = sharedPreferences.getString(PREF_QA_COMMAND_LINE, "");
         if (sharedPreferences.getBoolean(PREF_QA_VLOG_REWARDS, false)) {
@@ -28,11 +36,6 @@ public abstract class BraveCommandLineInitUtil {
                     " --vmodule=*/bat-native-ads/*=6,*/brave_ads/*=6,*/brave_user_model/*=6,*/bat_ads/*=6,*/bat-native-ledger/*=6,*/brave_rewards/*=6";
         }
         String[] args = CommandLine.tokenizeQuotedArguments(qaCommandLine.toCharArray());
-        CommandLine.init(args == null ? null : args);
-    }
-
-    public static void initCommandLine(
-            String fileName, @Nullable Supplier<Boolean> shouldUseDebugFlags) {
-        initCommandLine(fileName);
+        CommandLine.getInstance().appendSwitchesAndArguments(args);
     }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
This restores Chromium command line handler on Android and makes Brave-specific command line QA interface usable without adding the first underscore parameter `_` manually (it is treated as `argv[0]`, that's why it is ignored). 

Example to set args and launch the browser:
```
build/android/apk_operations.py launch --args='--enable-features=SomeFeature' --command-line-flags-file=chrome-command-line --apk=${workspaceFolder}/out/android_Component_arm64/apks/BraveMonoarm64.apk
```

Resolves https://github.com/brave/brave-browser/issues/15540

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

