### PR TITLE
[iOS] Ensure all pref file writes are finished before shutting down ads

### DIFF
--- a/vendor/brave-ios/Ads/BATBraveAds.mm
+++ b/vendor/brave-ios/Ads/BATBraveAds.mm
@@ -85,6 +85,7 @@ ads::DBCommandResponsePtr RunDBTransactionOnTaskRunner(
 @property (nonatomic) BATCommonOperations *commonOps;
 @property (nonatomic) BOOL networkConnectivityAvailable;
 @property (nonatomic, copy) NSString *storagePath;
+@property (nonatomic) dispatch_group_t prefsWriteGroup;
 @property (nonatomic) dispatch_queue_t prefsWriteThread;
 @property (nonatomic) NSMutableDictionary *prefs;
 @property(nonatomic, copy) NSDictionary* adsResourceMetadata;
@@ -104,6 +105,7 @@ ads::DBCommandResponsePtr RunDBTransactionOnTaskRunner(
     adEventHistory = nullptr;
 
     self.prefsWriteThread = dispatch_queue_create("com.rewards.ads.prefs", DISPATCH_QUEUE_SERIAL);
+    self.prefsWriteGroup = dispatch_group_create();
     self.prefs = [[NSMutableDictionary alloc] initWithContentsOfFile:[self prefsPath]];
     if (!self.prefs) {
       self.prefs = [[NSMutableDictionary alloc] init];
@@ -273,26 +275,28 @@ BATClassAdsBridge(BOOL, isDebug, setDebug, g_is_debug)
 - (void)shutdown:(nullable void (^)())completion
 {
   if ([self isAdsServiceRunning]) {
-    ads->Shutdown(^(bool) {
-      if (ads != nil) {
-        delete ads;
-      }
-      if (adsClient != nil) {
-        delete adsClient;
-      }
-      if (adsDatabase != nil) {
-        delete adsDatabase;
-      }
-      if (adEventHistory != nil) {
-        delete adEventHistory;
-      }
-      ads = nil;
-      adsClient = nil;
-      adsDatabase = nil;
-      adEventHistory = nil;
-      if (completion) {
-        completion();
-      }
+    dispatch_group_notify(self.prefsWriteGroup, dispatch_get_main_queue(), ^{
+      self->ads->Shutdown(^(bool) {
+        if (ads != nil) {
+          delete ads;
+        }
+        if (adsClient != nil) {
+          delete adsClient;
+        }
+        if (adsDatabase != nil) {
+          delete adsDatabase;
+        }
+        if (adEventHistory != nil) {
+          delete adEventHistory;
+        }
+        ads = nil;
+        adsClient = nil;
+        adsDatabase = nil;
+        adEventHistory = nil;
+        if (completion) {
+          completion();
+        }
+      });
     });
   } else {
     if (completion) {
@@ -386,8 +390,10 @@ BATClassAdsBridge(BOOL, isDebug, setDebug, g_is_debug)
 {
   NSDictionary *prefs = [self.prefs copy];
   NSString *path = [[self prefsPath] copy];
+  dispatch_group_enter(self.prefsWriteGroup);
   dispatch_async(self.prefsWriteThread, ^{
     [prefs writeToURL:[NSURL fileURLWithPath:path isDirectory:NO] error:nil];
+    dispatch_group_leave(self.prefsWriteGroup);
   });
 }
 


### PR DESCRIPTION
Fixes a possible race condition where turning off/on ads would cause in newly created `BATBraveAds` objects to read old preferences resulting in the ads service not initializing correctly and thus have future "shutdowns" fail

Refs https://github.com/brave/brave-ios/issues/3591

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

