### PR TITLE
speedreader: Remove <svg> elements inside <figure>

### DIFF
--- a/components/speedreader/rust/lib/src/readability/src/dom.rs
+++ b/components/speedreader/rust/lib/src/readability/src/dom.rs
@@ -85,7 +85,7 @@ pub fn is_empty(handle: &Handle) -> bool {
             Element(ref value) => {
                 let tag_name = value.name.local.as_ref();
                 match tag_name.to_lowercase().as_ref() {
-                    "li" | "dt" | "dd" | "p" | "div" => {
+                    "li" | "dt" | "dd" | "p" | "div" | "span" => {
                         if !is_empty(&child) {
                             return false;
                         }
@@ -102,6 +102,7 @@ pub fn is_empty(handle: &Handle) -> bool {
         | Some(&local_name!("dd"))
         | Some(&local_name!("p"))
         | Some(&local_name!("div"))
+        | Some(&local_name!("span"))
         | Some(&local_name!("canvas")) => true,
         _ => false,
     }

--- a/components/speedreader/rust/lib/src/readability/src/extractor.rs
+++ b/components/speedreader/rust/lib/src/readability/src/extractor.rs
@@ -814,6 +814,43 @@ mod tests {
     }
 
     #[test]
+    fn remove_svg_in_figure() {
+        // Test test case is based off Kotaku. Notice that if you hover over the
+        // image a zoom SVG appears, which we want removed.
+        // https://kotaku.com/watch-dogs-legion-will-eventually-get-60-fps-on-next-g-1846603174
+        let input = r#"
+        <body>
+          <p>Some Text Some text some text and some more text</p>
+          <figure class="element-image">
+            <picture>
+              <img alt="some text" src="some-image.jpg">
+            </picture>
+            <span class="inline-expand-image">
+            <svg class="centered-icon__svg" height="22" viewBox="0 0 22 22" width="22">
+                <path d="M3.4 20.2L9 14.5 7.5 13l-5.7 5.6L1 14H0v7.5l.5.5H8v-1l-4.6-.8M18.7 1.9L13 7.6 14.4 9l5.7-5.7.5 4.7h1.2V.6l-.5-.5H14v1.2l4.7.6"></path>
+            </svg>
+            </span>
+          </figure>
+        </body>"#;
+        let expected = r#"
+        <body id="article">
+          <p>Some Text Some text some text and some more text</p>
+          <figure class="element-image">
+            <picture>
+              <img alt="some text" src="some-image.jpg">
+            </picture>
+          </figure>
+        </body>"#;
+
+        let mut cursor = Cursor::new(input);
+        let product = extract(&mut cursor, None).unwrap();
+        assert_eq!(
+            normalize_output(expected),
+            normalize_output(&product.content)
+        );
+    }
+
+    #[test]
     fn test_clean_title_colon() {
         let input = "The SoCal Weekly Digest: Welcome to our wonderful page";
         let expected = "Welcome to our wonderful page";

--- a/components/speedreader/rust/lib/src/readability/src/scorer.rs
+++ b/components/speedreader/rust/lib/src/readability/src/scorer.rs
@@ -773,6 +773,22 @@ pub fn clean<S: ::std::hash::BuildHasher>(
                         false
                     }
                 }
+                local_name!("svg") => {
+                    // If the SVG has a parent that is a <figure> it is probably
+                    // an icon to resize the image. This will not format
+                    // correctly in speedreader since images are styled as
+                    // "display: inline".
+                    for ancestor in handle.ancestors() {
+                        if ancestor
+                            .as_element()
+                            .map(|e| e.name.local == local_name!("figure"))
+                            .unwrap_or(false)
+                        {
+                            return true;
+                        }
+                    }
+                    false
+                }
                 _ => false,
             };
             if !delete {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/15571

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

