### PR TITLE
14780: Always show full variation names.

### DIFF
--- a/chromium_src/components/version_ui/DEPS
+++ b/chromium_src/components/version_ui/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+../../../../components/version_ui",
+  "+components/version_ui",
+]

--- a/chromium_src/components/version_ui/version_handler_helper.cc
+++ b/chromium_src/components/version_ui/version_handler_helper.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define GetVariationsList GetVariationsList_ChromiumImpl
+#include "../../../../components/version_ui/version_handler_helper.cc"
+#undef GetVariationsList
+
+namespace version_ui {
+
+// Brave always shows full variations names instead of hashes.
+std::unique_ptr<base::Value> GetVariationsList() {
+  std::vector<std::string> variations;
+  base::FieldTrial::ActiveGroups active_groups;
+  base::FieldTrialList::GetActiveFieldTrialGroups(&active_groups);
+
+  const unsigned char kNonBreakingHyphenUTF8[] = {0xE2, 0x80, 0x91, '\0'};
+  const std::string kNonBreakingHyphenUTF8String(
+      reinterpret_cast<const char*>(kNonBreakingHyphenUTF8));
+  for (const auto& group : active_groups) {
+    std::string line = group.trial_name + ":" + group.group_name;
+    base::ReplaceChars(line, "-", kNonBreakingHyphenUTF8String, &line);
+    variations.push_back(line);
+  }
+
+  std::unique_ptr<base::ListValue> variations_list(new base::ListValue);
+  for (std::vector<std::string>::const_iterator it = variations.begin();
+       it != variations.end(); ++it) {
+    variations_list->AppendString(*it);
+  }
+
+  return std::move(variations_list);
+}
+
+}  // namespace version_ui


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/14780

<!-- Add brave-browser issue bellow that this PR will resolve -->
 
## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
(for production builds)
1. Run Brave, then restart
2. Open brave://version. In the bottom you should see `Variations: EphemeralStorageStudy-Enabled` and maybe any other variations, but not cryptic hash values

for developer builds:
run with `--variations-server-url=http://variations.bravesoftware.com/seed --fake-variations-channel=canary` and check production steps