### PR TITLE
Only check CNAME for unblocked requests

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -652,15 +652,98 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsGetBlocked) {
   ASSERT_EQ(4ULL, inner_resolver->num_resolve());
 
   // XHR request directly to a blocked third-party endpoint.
-  // The resolver should still be queried once for this request, although it
-  // doesn't need to be.
-  // See https://github.com/brave/brave-browser/issues/15302
+  // The resolver should not be queried for this request.
   ASSERT_EQ(true, EvalJs(contents,
                          base::StringPrintf("setExpectations(0, 1, 1, 2);"
                                             "xhr('%s')",
                                             bad_resource_url.spec().c_str())));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 3ULL);
-  ASSERT_EQ(5ULL, inner_resolver->num_resolve());
+  ASSERT_EQ(4ULL, inner_resolver->num_resolve());
+
+  // Unset the host resolver so as not to interfere with later tests.
+  brave::SetAdblockCnameHostResolverForTesting(nullptr);
+}
+
+// Make sure that an exception for a URL can apply to a blocking decision made
+// to its CNAME-uncloaked equivalent.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsCanBeExcepted) {
+  UpdateAdBlockInstanceWithRules(
+      "||cname-cloak-endpoint.tracking.com^\n"
+      "@@||a.com/logo-unblock.png|");
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+  GURL tab_url = embedded_test_server()->GetURL("a.com", kAdBlockTestPage);
+  GURL direct_resource_url =
+      embedded_test_server()->GetURL("a83idbka2e.a.com", "/logo.png");
+  GURL chain_resource_url =
+      embedded_test_server()->GetURL("b94jeclb3f.a.com", "/logo.png");
+  GURL safe_resource_url = embedded_test_server()->GetURL("a.com", "/logo.png");
+  GURL bad_resource_url = embedded_test_server()->GetURL(
+      "cname-cloak-endpoint.tracking.com", "/logo.png");
+
+  auto inner_resolver = std::make_unique<net::MockHostResolver>();
+
+  const std::vector<std::string> kDnsAliasesDirect(
+      {"cname-cloak-endpoint.tracking.com"});
+  const std::vector<std::string> kDnsAliasesChain(
+      {"cname-cloak-endpoint.tracking.com",
+       "cname-cloak-endpoint.tracking.com.redirectservice.net", "cname.a.com"});
+  const std::vector<std::string> kDnsAliasesSafe({"assets.cdn.net"});
+  inner_resolver->rules()->AddIPLiteralRuleWithDnsAliases(
+      "a83idbka2e.a.com", "127.0.0.1", kDnsAliasesDirect);
+  inner_resolver->rules()->AddIPLiteralRuleWithDnsAliases(
+      "b94jeclb3f.a.com", "127.0.0.1", kDnsAliasesChain);
+  inner_resolver->rules()->AddIPLiteralRuleWithDnsAliases("a.com", "127.0.0.1",
+                                                          kDnsAliasesSafe);
+  inner_resolver->rules()->AddIPLiteralRuleWithDnsAliases(
+      "cname-cloak-endpoint.tracking.com", "127.0.0.1", {});
+
+  network::HostResolver resolver(inner_resolver.get(), net::NetLog::Get());
+
+  brave::SetAdblockCnameHostResolverForTesting(&resolver);
+
+  ui_test_utils::NavigateToURL(browser(), tab_url);
+
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  // Image request to an unblocked first-party endpoint that is CNAME cloaked
+  // with 1 alias. The alias has a matching rule, so the request should be
+  // blocked.
+  ASSERT_EQ(true, EvalJs(contents, base::StringPrintf(
+                                       "setExpectations(0, 1, 0, 0);"
+                                       "addImage('%s')",
+                                       direct_resource_url.spec().c_str())));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+  // Note one resolution for the root document
+  ASSERT_EQ(2ULL, inner_resolver->num_resolve());
+
+  // XHR request to an unblocked first-party endpoint that is CNAME cloaked with
+  // multiple intermediate aliases. The canonical alias has a matching rule, so
+  // the request should be blocked.
+  ASSERT_EQ(true, EvalJs(contents, base::StringPrintf(
+                                       "setExpectations(0, 1, 0, 1);"
+                                       "xhr('%s')",
+                                       chain_resource_url.spec().c_str())));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+  ASSERT_EQ(3ULL, inner_resolver->num_resolve());
+
+  // XHR request to an unblocked first-party endpoint that is CNAME cloaked.
+  // The canonical alias has no matching rule, so the request should be allowed.
+  ASSERT_EQ(true, EvalJs(contents,
+                         base::StringPrintf("setExpectations(0, 1, 1, 1);"
+                                            "xhr('%s')",
+                                            safe_resource_url.spec().c_str())));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+  ASSERT_EQ(4ULL, inner_resolver->num_resolve());
+
+  // XHR request directly to a blocked third-party endpoint.
+  // The resolver should not be queried for this request.
+  ASSERT_EQ(true, EvalJs(contents,
+                         base::StringPrintf("setExpectations(0, 1, 1, 2);"
+                                            "xhr('%s')",
+                                            bad_resource_url.spec().c_str())));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 3ULL);
+  ASSERT_EQ(4ULL, inner_resolver->num_resolve());
 
   // Unset the host resolver so as not to interfere with later tests.
   brave::SetAdblockCnameHostResolverForTesting(nullptr);

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -46,44 +46,37 @@ void SetAdblockCnameHostResolverForTesting(
   g_testing_host_resolver = host_resolver;
 }
 
-void ShouldBlockAdOnTaskRunner(std::shared_ptr<BraveRequestInfo> ctx,
-                               base::Optional<std::string> canonical_name) {
-  bool did_match_rule = false;
-  bool did_match_exception = false;
-  bool did_match_important = false;
+// If `canonical_url` is specified, this will only check if the CNAME-uncloaked
+// response should be blocked. Otherwise, it will run the check for the
+// original request URL.
+void ShouldBlockRequestOnTaskRunner(std::shared_ptr<BraveRequestInfo> ctx,
+                                    base::Optional<GURL> canonical_url) {
   if (!ctx->initiator_url.is_valid()) {
     return;
   }
   std::string source_host = ctx->initiator_url.host();
 
+  GURL url_to_check;
+  if (canonical_url.has_value()) {
+    url_to_check = *canonical_url;
+  } else {
+    url_to_check = ctx->request_url;
+  }
+
   g_brave_browser_process->ad_block_service()->ShouldStartRequest(
-      ctx->request_url, ctx->resource_type, source_host, &did_match_rule,
-      &did_match_exception, &did_match_important, &ctx->mock_data_url);
-  if (did_match_important) {
-    ctx->blocked_by = kAdBlocked;
-    return;
-  }
+      url_to_check, ctx->resource_type, source_host, &ctx->did_match_rule,
+      &ctx->did_match_exception, &ctx->did_match_important,
+      &ctx->mock_data_url);
 
-  if (canonical_name.has_value() &&
-      ctx->request_url.host() != *canonical_name && *canonical_name != "") {
-    GURL::Replacements replacements = GURL::Replacements();
-    replacements.SetHost(
-        canonical_name->c_str(),
-        url::Component(0, static_cast<int>(canonical_name->length())));
-    const GURL canonical_url = ctx->request_url.ReplaceComponents(replacements);
-
-    g_brave_browser_process->ad_block_service()->ShouldStartRequest(
-        canonical_url, ctx->resource_type, source_host, &did_match_rule,
-        &did_match_exception, &did_match_important, &ctx->mock_data_url);
-  }
-
-  if (did_match_important || (did_match_rule && !did_match_exception)) {
+  if (ctx->did_match_important ||
+      (ctx->did_match_rule && !ctx->did_match_exception)) {
     ctx->blocked_by = kAdBlocked;
   }
 }
 
-void OnShouldBlockAdResult(const ResponseCallback& next_callback,
-                           std::shared_ptr<BraveRequestInfo> ctx) {
+void OnShouldBlockUncloakedRequestResult(
+    const ResponseCallback& next_callback,
+    std::shared_ptr<BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   if (ctx->blocked_by == kAdBlocked) {
     brave_shields::BraveShieldsWebContentsObserver::DispatchBlockedEvent(
@@ -92,15 +85,28 @@ void OnShouldBlockAdResult(const ResponseCallback& next_callback,
   next_callback.Run();
 }
 
-void ShouldBlockAdWithOptionalCname(
-    scoped_refptr<base::SequencedTaskRunner> task_runner,
-    const ResponseCallback& next_callback,
-    std::shared_ptr<BraveRequestInfo> ctx,
-    const base::Optional<std::string> cname) {
+void UseCnameResult(scoped_refptr<base::SequencedTaskRunner> task_runner,
+                    const ResponseCallback& next_callback,
+                    std::shared_ptr<BraveRequestInfo> ctx,
+                    const base::Optional<std::string> cname) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  task_runner->PostTaskAndReply(
-      FROM_HERE, base::BindOnce(&ShouldBlockAdOnTaskRunner, ctx, cname),
-      base::BindOnce(&OnShouldBlockAdResult, next_callback, ctx));
+
+  if (cname.has_value() && ctx->request_url.host() != *cname &&
+      !cname->empty()) {
+    GURL::Replacements replacements;
+    replacements.SetHost(cname->c_str(),
+                         url::Component(0, static_cast<int>(cname->length())));
+    const GURL canonical_url = ctx->request_url.ReplaceComponents(replacements);
+
+    task_runner->PostTaskAndReply(
+        FROM_HERE,
+        base::BindOnce(&ShouldBlockRequestOnTaskRunner, ctx,
+                       base::make_optional<GURL>(canonical_url)),
+        base::BindOnce(&OnShouldBlockUncloakedRequestResult, next_callback,
+                       ctx));
+  } else {
+    next_callback.Run();
+  }
 }
 
 class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
@@ -114,8 +120,9 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
       const ResponseCallback& next_callback,
       scoped_refptr<base::SequencedTaskRunner> task_runner,
       std::shared_ptr<BraveRequestInfo> ctx) {
-    cb_ = base::BindOnce(&ShouldBlockAdWithOptionalCname, task_runner,
-                         std::move(next_callback), ctx);
+    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+    cb_ = base::BindOnce(&UseCnameResult, task_runner, std::move(next_callback),
+                         ctx);
 
     const auto network_isolation_key = ctx->network_isolation_key;
 
@@ -183,6 +190,42 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
   }
 };
 
+// Called after checking a request without any CNAME uncloaking.
+void OnShouldBlockRequestResult(
+    scoped_refptr<base::SequencedTaskRunner> task_runner,
+    const ResponseCallback& next_callback,
+    std::shared_ptr<BraveRequestInfo> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  if (ctx->blocked_by == kAdBlocked) {
+    brave_shields::DispatchBlockedEvent(
+        ctx->request_url, ctx->frame_tree_node_id, brave_shields::kAds);
+    next_callback.Run();
+  } else {
+    // If not blocked, the request still needs to be CNAME uncloaked.
+
+    // DoH or standard DNS queries won't be routed through Tor, so we need to
+    // skip it.
+    if (ctx->browser_context->IsTor() || ctx->did_match_important) {
+      next_callback.Run();
+    } else {
+      // This will be deleted by `AdblockCnameResolveHostClient::OnComplete`.
+      new AdblockCnameResolveHostClient(std::move(next_callback), task_runner,
+                                        ctx);
+    }
+  }
+}
+
+void ShouldBlockRequest(scoped_refptr<base::SequencedTaskRunner> task_runner,
+                        const ResponseCallback& next_callback,
+                        std::shared_ptr<BraveRequestInfo> ctx) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  task_runner->PostTaskAndReply(
+      FROM_HERE,
+      base::BindOnce(&ShouldBlockRequestOnTaskRunner, ctx, base::nullopt),
+      base::BindOnce(&OnShouldBlockRequestResult, task_runner, next_callback,
+                     ctx));
+}
+
 void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
                                  std::shared_ptr<BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -190,19 +233,12 @@ void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
   DCHECK(!ctx->request_url.is_empty());
   DCHECK(!ctx->initiator_url.is_empty());
 
+  DCHECK(g_brave_browser_process);
   scoped_refptr<base::SequencedTaskRunner> task_runner =
       g_brave_browser_process->ad_block_service()->GetTaskRunner();
 
   DCHECK(ctx->browser_context);
-  // DoH or standard DNS quries won't be routed through Tor, so we need to skip
-  // it.
-  if (ctx->browser_context->IsTor()) {
-    ShouldBlockAdWithOptionalCname(task_runner, std::move(next_callback), ctx,
-                                   base::nullopt);
-  } else {
-    new AdblockCnameResolveHostClient(std::move(next_callback), task_runner,
-                                      ctx);
-  }
+  ShouldBlockRequest(task_runner, std::move(next_callback), ctx);
 }
 
 int OnBeforeURLRequest_AdBlockTPPreWork(const ResponseCallback& next_callback,

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -99,6 +99,12 @@ struct BraveRequestInfo {
   GURL ipfs_gateway_url;
   bool ipfs_auto_fallback = false;
 
+  // Used to keep track of state between a primary adblock engine query and one
+  // after CNAME uncloaking the request.
+  bool did_match_rule = false;
+  bool did_match_exception = false;
+  bool did_match_important = false;
+
   bool ShouldMockRequest() const { return !mock_data_url.empty(); }
 
   net::NetworkIsolationKey network_isolation_key = net::NetworkIsolationKey();

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -99,12 +99,6 @@ struct BraveRequestInfo {
   GURL ipfs_gateway_url;
   bool ipfs_auto_fallback = false;
 
-  // Used to keep track of state between a primary adblock engine query and one
-  // after CNAME uncloaking the request.
-  bool did_match_rule = false;
-  bool did_match_exception = false;
-  bool did_match_important = false;
-
   bool ShouldMockRequest() const { return !mock_data_url.empty(); }
 
   net::NetworkIsolationKey network_isolation_key = net::NetworkIsolationKey();


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15302

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

We should verify that this doesn't regress any of the work from https://github.com/brave/brave-core/pull/7769 on all platforms (test steps copied directly here for convenience):

> ### DoH off 
> 1. Follow the section `Using the (Pre)-Master-Secret` to setup `SSLKEYLOGFILE`
> https://wiki.wireshark.org/TLS
> 2. After Wireshark is capturing traffic, use the `dns` filter
> 3. Launch Brave
> 4. Go to brave://settings/security and turn off `Use secure DNS`
> 5. Open Tor window
> 6. Navigate to https://tools.ietf.org/
> 7. After site loaded, stop Wireshark capturing
> 8. There shouldn't be any DNS query or DoH query for `tools.ietf.org`
> 
> ### DoH enabled
> 1. Follow the section `Using the (Pre)-Master-Secret` to setup `SSLKEYLOGFILE`
> https://wiki.wireshark.org/TLS
> 2. After Wireshark is capturing traffic, use the `dns` filter
> 3. Launch Brave
> 4. Go to brave://settings/security and make sure `Use secure DNS` is on and use custom Cloudflare resolver
> 5. Open Tor window
> 6. Navigate to https://tools.ietf.org/
> 7. After site loaded, stop Wireshark capturing
> 8. There shouldn't be any DNS query or DoH query for `tools.ietf.org`

Additionally, we should recreate the steps from https://github.com/brave/brave-browser/issues/14027#issuecomment-819782457:

> 1. Spin up wireshark, with TLS session recording
> 2. Visit https://www.macrumors.com/ while recording traffic, in a new profile
> 3. Look through the session's traffic and make sure none of the following occur:
>    - any requests to googletagmanager.com
>    - any DNS requests for googletagmanager.com
>    - any TLS preconnect steps to googletagmanager.com
