### PR TITLE
Implement custom ad notification field trials

### DIFF
--- a/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsNotificationDialog.java
+++ b/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsNotificationDialog.java
@@ -44,6 +44,8 @@ public class BraveAdsNotificationDialog {
         }
         AlertDialog.Builder b = new AlertDialog.Builder(context);
 
+        mNotificationId = notificationId;
+
         LayoutInflater inflater = LayoutInflater.from(context);
         b.setView(inflater.inflate(R.layout.brave_ads_custom_notification, null));
         mAdsDialog = b.create();
@@ -75,7 +77,6 @@ public class BraveAdsNotificationDialog {
         ((TextView) mAdsDialog.findViewById(R.id.brave_ads_custom_notification_header)).setText(title);
         ((TextView) mAdsDialog.findViewById(R.id.brave_ads_custom_notification_body)).setText(body);
 
-        mNotificationId = notificationId;
         closeButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/browser/ui/brave_ads/BUILD.gn
+++ b/browser/ui/brave_ads/BUILD.gn
@@ -21,6 +21,7 @@ source_set("brave_ads") {
       "//brave/app:brave_generated_resources_grit",
       "//brave/app/vector_icons",
       "//brave/browser/profiles:util",
+      "//brave/components/brave_ads/browser",
       "//brave/components/brave_ads/common",
       "//components/prefs",
       "//skia",

--- a/browser/ui/brave_ads/ad_notification_header_view.cc
+++ b/browser/ui/brave_ads/ad_notification_header_view.cc
@@ -54,9 +54,9 @@ constexpr SkColor kDarkModeTitleColor = SkColorSetRGB(0xe3, 0xe6, 0xec);
 const gfx::HorizontalAlignment kTitleHorizontalAlignment = gfx::ALIGN_LEFT;
 const gfx::VerticalAlignment kTitleVerticalAlignment = gfx::ALIGN_BOTTOM;
 
-constexpr gfx::Insets kTitleBorderInsets(/* top */ 10,
-                                         /* left */ 6,
-                                         /* bottom */ 6,
+constexpr gfx::Insets kTitleBorderInsets(/* top */ 11,
+                                         /* left */ 10,
+                                         /* bottom */ 3,
                                          /* right */ 0);
 
 }  // namespace

--- a/browser/ui/brave_ads/ad_notification_popup.h
+++ b/browser/ui/brave_ads/ad_notification_popup.h
@@ -107,11 +107,11 @@ class AdNotificationPopup : public views::WidgetDelegateView,
   AdNotification ad_notification_;
   AdNotification GetAdNotification() const;
 
-  gfx::Point GetDefaultOriginForSize(const gfx::Size& size) const;
-  gfx::Point GetOriginForSize(const gfx::Size& size) const;
+  gfx::Point GetDefaultOriginForSize(const gfx::Size& size);
+  gfx::Point GetOriginForSize(const gfx::Size& size);
   void SaveOrigin(const gfx::Point& origin) const;
 
-  gfx::Rect CalculateBounds() const;
+  gfx::Rect CalculateBounds();
 
   void RecomputeAlignment();
 

--- a/browser/ui/brave_ads/padded_image_button.cc
+++ b/browser/ui/brave_ads/padded_image_button.cc
@@ -21,9 +21,17 @@
 namespace brave_ads {
 
 namespace {
+
 constexpr SkColor kBackgroundColor = SK_ColorTRANSPARENT;
-constexpr gfx::Insets kBorderInset(6);
+
+constexpr gfx::Insets kBorderInset(
+    /* top */ 4,
+    /* left */ 4,
+    /* bottom */ 0,
+    /* right */ 4);
+
 const float kVisibleOpacity = 0.12f;
+
 }  // namespace
 
 PaddedImageButton::PaddedImageButton(PressedCallback callback)

--- a/browser/ui/brave_ads/padded_image_view.cc
+++ b/browser/ui/brave_ads/padded_image_view.cc
@@ -18,9 +18,9 @@ namespace {
 constexpr SkColor kBackgroundColor = SK_ColorTRANSPARENT;
 
 constexpr gfx::Insets kBorderInset(
-    /* top */ 4,
+    /* top */ 2,
     /* left */ 6,
-    /* bottom */ 6,
+    /* bottom */ 0,
     /* right */ 6);
 
 }  // namespace

--- a/browser/ui/brave_ads/text_ad_notification_view.cc
+++ b/browser/ui/brave_ads/text_ad_notification_view.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/brave_ads/ad_notification_control_buttons_view.h"
 #include "brave/browser/ui/brave_ads/ad_notification_header_view.h"
 #include "brave/browser/ui/brave_ads/insets_util.h"
+#include "build/build_config.h"
 #include "ui/gfx/color_palette.h"
 #include "ui/gfx/font.h"
 #include "ui/gfx/font_list.h"
@@ -30,11 +31,11 @@ namespace brave_ads {
 namespace {
 
 const int kNotificationWidth = 350;
-const int kNotificationHeight = 104;
+const int kNotificationHeight = 100;
 
 constexpr gfx::Insets kContainerViewInsideBorderInsets(
     /* top */ 0,
-    /* left */ 16,
+    /* left */ 20,
     /* bottom */ 10,
     /* right */ 10);
 
@@ -50,7 +51,14 @@ constexpr SkColor kLightModeBodyColor = SkColorSetRGB(0x45, 0x49, 0x55);
 constexpr SkColor kDarkModeBodyColor = SkColorSetRGB(0xd7, 0xdb, 0xe2);
 
 const int kBodyMaximumLines = 2;
-const int kBodyLineSpacing = 3;
+
+#if defined(OS_WIN)
+const int kBodyLineSpacing = 0;
+#elif defined(OS_MAC)
+const int kBodyLineSpacing = 2;
+#elif defined(OS_LINUX)
+const int kBodyLineSpacing = 2;
+#endif
 
 const gfx::HorizontalAlignment kBodyHorizontalAlignment = gfx::ALIGN_LEFT;
 const gfx::VerticalAlignment kBodyVerticalAlignment = gfx::ALIGN_TOP;
@@ -176,7 +184,8 @@ views::Label* TextAdNotificationView::CreateBodyLabel(
   AdjustInsetsForFontList(&border_insets, font_list);
   label->SetBorder(views::CreateEmptyBorder(border_insets));
 
-  const int width = View::width() - GetInsets().width();
+  const int width = View::width() - kContainerViewInsideBorderInsets.width() -
+                    border_insets.width();
   label->SizeToFit(width);
 
   label->SetHandlesTooltips(false);

--- a/common/brave_channel_info.cc
+++ b/common/brave_channel_info.cc
@@ -24,13 +24,4 @@ std::string GetChannelName() {
 #endif  // !OFFICIAL_BUILD
 }
 
-bool IsNightlyOrDeveloperBuild() {
-#if defined(OFFICIAL_BUILD)
-  return chrome::GetChannel() == version_info::Channel::CANARY ||
-      chrome::GetChannel() == version_info::Channel::UNKNOWN;
-#else  // OFFICIAL_BUILD
-  return true;
-#endif  // !OFFICIAL_BUILD
-}
-
 }  // namespace brave

--- a/common/brave_channel_info.h
+++ b/common/brave_channel_info.h
@@ -9,10 +9,7 @@
 #include <string>
 
 namespace brave {
-
 std::string GetChannelName();
-bool IsNightlyOrDeveloperBuild();
-
 }
 
 #endif  // BRAVE_COMMON_BRAVE_CHANNEL_INFO_H_

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -53,6 +53,8 @@ source_set("browser") {
       "component_updater/resource_component.h",
       "component_updater/resource_component_observer.h",
       "component_updater/resource_info.h",
+      "features.cc",
+      "features.h",
       "frequency_capping_helper.cc",
       "frequency_capping_helper.h",
       "notification_helper.cc",

--- a/components/brave_ads/browser/features.cc
+++ b/components/brave_ads/browser/features.cc
@@ -1,0 +1,148 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/features.h"
+
+#include "base/feature_list.h"
+
+namespace brave_ads {
+namespace features {
+
+const base::Feature kAdNotifications{"AdNotifications",
+                                     base::FEATURE_ENABLED_BY_DEFAULT};
+
+namespace {
+
+// Set to true to show custom ad notifications or false to show system
+// notifications
+const char kFieldTrialParameterShouldShowCustomAdNotifications[] =
+    "should_show_custom_notifications";
+const bool kDefaultShouldShowCustomAdNotifications = true;
+
+// Ad notification timeout in seconds. Set to 0 to never time out
+const char kFieldTrialParameterAdNotificationTimeout[] =
+    "ad_notification_timeout";
+#if !defined(OS_ANDROID)
+const int kDefaultAdNotificationTimeout = 120;
+#else
+const int kDefaultAdNotificationTimeout = 30;
+#endif
+
+#if !defined(OS_ANDROID)
+
+// Ad notification fade animation duration in milliseconds
+const char kFieldTrialParameterAdNotificationFadeDuration[] =
+    "ad_notification_fade_duration";
+const int kDefaultAdNotificationFadeDuration = 200;
+
+// Ad notification normalized display coordinate for the x component should be
+// between 0.0 and 1.0; coordinates outside this range will be adjusted to fit
+// the work area. Set to 0.0 for left, 0.5 for center or 1.0 for right
+const char kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateX[] =
+    "ad_notification_normalized_display_coordinate_x";
+#if defined(OS_WIN)
+const double kDefaultAdNotificationNormalizedDisplayCoordinateX = 1.0;
+#elif defined(OS_MAC)
+const double kDefaultAdNotificationNormalizedDisplayCoordinateX = 1.0;
+#elif defined(OS_LINUX)
+const double kDefaultAdNotificationNormalizedDisplayCoordinateX = 1.0;
+#endif
+
+// Ad notification x inset within the display's work area specified in screen
+// coordinates
+const char kFieldTrialParameterAdNotificationInsetX[] =
+    "ad_notification_inset_x";
+#if defined(OS_WIN)
+const int kDefaultAdNotificationInsetX = -13;
+#elif defined(OS_MAC)
+const int kSystemNotificationWidth = 360;
+const int kDefaultAdNotificationInsetX = -(10 + kSystemNotificationWidth);
+#elif defined(OS_LINUX)
+const int kDefaultAdNotificationInsetX = -13;
+#endif
+
+// Ad notification normalized display coordinate for the y component should be
+// between 0.0 and 1.0; coordinates outside this range will be adjusted to fit
+// the work area. Set to 0.0 for top, 0.5 for middle or 1.0 for bottom
+const char kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateY[] =
+    "ad_notification_normalized_display_coordinate_y";
+#if defined(OS_WIN)
+const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 0.0;
+#elif defined(OS_MAC)
+const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 0.0;
+#elif defined(OS_LINUX)
+const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 0.0;
+#endif
+
+// Ad notification y inset within the display's work area specified in screen
+// coordinates
+const char kFieldTrialParameterAdNotificationInsetY[] =
+    "ad_notification_inset_y";
+#if defined(OS_WIN)
+const int kDefaultAdNotificationInsetY = 18;
+#elif defined(OS_MAC)
+const int kDefaultAdNotificationInsetY = 11;
+#elif defined(OS_LINUX)
+const int kDefaultAdNotificationInsetY = 18;
+#endif
+
+#endif  // !defined(OS_ANDROID)
+
+}  // namespace
+
+bool IsAdNotificationsEnabled() {
+  return base::FeatureList::IsEnabled(kAdNotifications);
+}
+
+bool ShouldShowCustomAdNotifications() {
+  return GetFieldTrialParamByFeatureAsBool(
+      kAdNotifications, kFieldTrialParameterShouldShowCustomAdNotifications,
+      kDefaultShouldShowCustomAdNotifications);
+}
+
+int AdNotificationTimeout() {
+  return GetFieldTrialParamByFeatureAsInt(
+      kAdNotifications, kFieldTrialParameterAdNotificationTimeout,
+      kDefaultAdNotificationTimeout);
+}
+
+#if !defined(OS_ANDROID)
+
+int AdNotificationFadeDuration() {
+  return GetFieldTrialParamByFeatureAsInt(
+      kAdNotifications, kFieldTrialParameterAdNotificationFadeDuration,
+      kDefaultAdNotificationFadeDuration);
+}
+
+double AdNotificationNormalizedDisplayCoordinateX() {
+  return GetFieldTrialParamByFeatureAsDouble(
+      kAdNotifications,
+      kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateX,
+      kDefaultAdNotificationNormalizedDisplayCoordinateX);
+}
+
+int AdNotificationInsetX() {
+  return GetFieldTrialParamByFeatureAsInt(
+      kAdNotifications, kFieldTrialParameterAdNotificationInsetX,
+      kDefaultAdNotificationInsetX);
+}
+
+double AdNotificationNormalizedDisplayCoordinateY() {
+  return GetFieldTrialParamByFeatureAsDouble(
+      kAdNotifications,
+      kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateY,
+      kDefaultAdNotificationNormalizedDisplayCoordinateY);
+}
+
+int AdNotificationInsetY() {
+  return GetFieldTrialParamByFeatureAsInt(
+      kAdNotifications, kFieldTrialParameterAdNotificationInsetY,
+      kDefaultAdNotificationInsetY);
+}
+
+#endif  // !defined(OS_ANDROID)
+
+}  // namespace features
+}  // namespace brave_ads

--- a/components/brave_ads/browser/features.h
+++ b/components/brave_ads/browser/features.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_FEATURES_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_FEATURES_H_
+
+#include "build/build_config.h"
+
+namespace base {
+struct Feature;
+}  // namespace base
+
+namespace brave_ads {
+namespace features {
+
+extern const base::Feature kAdNotifications;
+
+bool IsAdNotificationsEnabled();
+
+bool ShouldShowCustomAdNotifications();
+
+int AdNotificationTimeout();
+
+#if !defined(OS_ANDROID)
+
+int AdNotificationFadeDuration();
+
+double AdNotificationNormalizedDisplayCoordinateX();
+int AdNotificationInsetX();
+double AdNotificationNormalizedDisplayCoordinateY();
+int AdNotificationInsetY();
+
+#endif  // !defined(OS_ANDROID)
+
+}  // namespace features
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_FEATURES_H_

--- a/components/brave_ads/browser/notification_helper_android.cc
+++ b/components/brave_ads/browser/notification_helper_android.cc
@@ -13,8 +13,8 @@
 #include "brave/browser/brave_ads/android/jni_headers/BraveAdsSignupDialog_jni.h"
 #include "brave/browser/brave_ads/android/jni_headers/BraveAds_jni.h"
 #include "brave/build/android/jni_headers/BraveNotificationSettingsBridge_jni.h"
-#include "brave/common/brave_channel_info.h"
 #include "brave/components/brave_ads/browser/background_helper.h"
+#include "brave/components/brave_ads/browser/features.h"
 #include "chrome/android/chrome_jni_headers/NotificationSystemStatusUtil_jni.h"
 #include "chrome/browser/notifications/notification_channels_provider_android.h"
 
@@ -34,7 +34,7 @@ NotificationHelperAndroid::NotificationHelperAndroid() = default;
 NotificationHelperAndroid::~NotificationHelperAndroid() = default;
 
 bool NotificationHelperAndroid::ShouldShowNotifications() {
-  if (brave::IsNightlyOrDeveloperBuild()) {
+  if (features::ShouldShowCustomAdNotifications()) {
     return true;
   }
 
@@ -59,17 +59,18 @@ bool NotificationHelperAndroid::ShowMyFirstAdNotification() {
     return false;
   }
 
-  const bool use_custom_notifications = brave::IsNightlyOrDeveloperBuild();
+  const bool should_show_custom_notifications =
+      features::ShouldShowCustomAdNotifications();
 
   JNIEnv* env = base::android::AttachCurrentThread();
   Java_BraveAdsSignupDialog_enqueueOnboardingNotificationNative(
-      env, use_custom_notifications);
+      env, should_show_custom_notifications);
 
   return true;
 }
 
 bool NotificationHelperAndroid::CanShowBackgroundNotifications() const {
-  if (brave::IsNightlyOrDeveloperBuild()) {
+  if (features::ShouldShowCustomAdNotifications()) {
     return true;
   }
 

--- a/components/brave_ads/browser/notification_helper_linux.cc
+++ b/components/brave_ads/browser/notification_helper_linux.cc
@@ -5,8 +5,7 @@
 
 #include "brave/components/brave_ads/browser/notification_helper_linux.h"
 
-#include "base/logging.h"
-#include "brave/common/brave_channel_info.h"
+#include "brave/components/brave_ads/browser/features.h"
 
 namespace brave_ads {
 
@@ -15,7 +14,7 @@ NotificationHelperLinux::NotificationHelperLinux() = default;
 NotificationHelperLinux::~NotificationHelperLinux() = default;
 
 bool NotificationHelperLinux::ShouldShowNotifications() {
-  if (brave::IsNightlyOrDeveloperBuild()) {
+  if (features::ShouldShowCustomAdNotifications()) {
     return true;
   }
 

--- a/components/brave_ads/browser/notification_helper_mac.mm
+++ b/components/brave_ads/browser/notification_helper_mac.mm
@@ -13,7 +13,7 @@
 #include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/mac/mac_util.h"
-#include "brave/common/brave_channel_info.h"
+#include "brave/components/brave_ads/browser/features.h"
 #include "brave/components/brave_ads/browser/notification_helper_mac.h"
 #include "chrome/common/chrome_features.h"
 
@@ -24,7 +24,7 @@ NotificationHelperMac::NotificationHelperMac() = default;
 NotificationHelperMac::~NotificationHelperMac() = default;
 
 bool NotificationHelperMac::ShouldShowNotifications() {
-  if (brave::IsNightlyOrDeveloperBuild()) {
+  if (features::ShouldShowCustomAdNotifications()) {
     return true;
   }
 
@@ -34,7 +34,7 @@ bool NotificationHelperMac::ShouldShowNotifications() {
     return true;
   }
 
-  if (!base::FeatureList::IsEnabled(features::kNativeNotifications)) {
+  if (!base::FeatureList::IsEnabled(::features::kNativeNotifications)) {
     LOG(WARNING) << "Native notification feature is disabled so falling back to"
                     " Message Center";
     return true;

--- a/components/brave_ads/browser/notification_helper_win.cc
+++ b/components/brave_ads/browser/notification_helper_win.cc
@@ -12,7 +12,7 @@
 #include "base/win/core_winrt_util.h"
 #include "base/win/scoped_hstring.h"
 #include "base/win/windows_version.h"
-#include "brave/common/brave_channel_info.h"
+#include "brave/components/brave_ads/browser/features.h"
 #include "chrome/common/chrome_features.h"
 #include "chrome/install_static/install_util.h"
 #include "chrome/installer/util/install_util.h"
@@ -65,7 +65,7 @@ NotificationHelperWin::NotificationHelperWin() = default;
 NotificationHelperWin::~NotificationHelperWin() = default;
 
 bool NotificationHelperWin::ShouldShowNotifications() {
-  if (brave::IsNightlyOrDeveloperBuild()) {
+  if (features::ShouldShowCustomAdNotifications()) {
     return true;
   }
 
@@ -81,7 +81,7 @@ bool NotificationHelperWin::ShouldShowNotifications() {
     return true;
   }
 
-  if (!base::FeatureList::IsEnabled(features::kNativeNotifications)) {
+  if (!base::FeatureList::IsEnabled(::features::kNativeNotifications)) {
     LOG(WARNING) << "Native notification feature is disabled so falling back to"
                     " Message Center";
     return true;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_notifications/ad_notifications.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/ad_notifications/ad_notifications.cc
@@ -21,7 +21,6 @@
 #include "bat/ads/internal/logging.h"
 #include "bat/ads/pref_names.h"
 #include "bat/ads/result.h"
-#include "brave/common/brave_channel_info.h"
 
 #if defined(OS_ANDROID)
 #include "base/android/build_info.h"
@@ -182,10 +181,6 @@ uint64_t AdNotifications::Count() const {
 
 #if defined(OS_ANDROID)
 void AdNotifications::RemoveAllAfterReboot() {
-  if (brave::IsNightlyOrDeveloperBuild()) {
-    return;
-  }
-
   database::table::AdEvents database_table;
   database_table.GetAll([=](const Result result, const AdEventList& ad_events) {
     if (result != Result::SUCCESS) {
@@ -209,10 +204,6 @@ void AdNotifications::RemoveAllAfterReboot() {
 }
 
 void AdNotifications::RemoveAllAfterUpdate() {
-  if (brave::IsNightlyOrDeveloperBuild()) {
-    return;
-  }
-
   const std::string current_version_code =
       base::android::BuildInfo::GetInstance()->package_version_code();
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15624

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm the default position of custom ad notifications on macOS are positioned top-right to the left of system notifications
- Confirm the default ad notification timeout for custom ad notifications on macOS is 120 seconds
- Confirm the default position of custom ad notifications on Windows are positioned top-right
- Confirm the default ad notification timeout for custom ad notifications on Windows is 120 seconds
- Confirm the default position of custom ad notifications on Linux are positioned top-right
- Confirm the default ad notification timeout for custom ad notifications on Linux is 120 seconds
- Confirm the default ad notification timeout for custom ad notifications on Android is 30 seconds
- Confirm the default ad notification fade in/out animation duration for custom ad notifications is 200 milliseconds
- Confirm the default ad notification fade in/out animation duration for custom ad notifications is 200 milliseconds

Variations seed.json can be tested later as each change will need to go through the privacy team