### PR TITLE
Add Japan-specific welcome tab (uplift to 1.25.x)

### DIFF
--- a/browser/ui/webui/brave_welcome_ui.cc
+++ b/browser/ui/webui/brave_welcome_ui.cc
@@ -21,6 +21,7 @@
 #include "chrome/browser/ui/webui/settings/search_engines_handler.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/common/webui_url_constants.h"
+#include "components/country_codes/country_codes.h"
 #include "components/grit/brave_components_resources.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
@@ -29,6 +30,18 @@
 using content::WebUIMessageHandler;
 
 namespace {
+
+void OpenJapanWelcomePage(Profile* profile) {
+  DCHECK(profile);
+  Browser* browser = chrome::FindBrowserWithProfile(profile);
+  if (browser) {
+    content::OpenURLParams open_params(
+        GURL("https://brave.com/ja/users-bitflyer/"), content::Referrer(),
+        WindowOpenDisposition::NEW_BACKGROUND_TAB,
+        ui::PAGE_TRANSITION_AUTO_TOPLEVEL, false);
+    browser->OpenURL(open_params);
+  }
+}
 
 void RecordP3AHistogram(int screen_number, bool finished) {
   int answer = 0;
@@ -117,6 +130,16 @@ BraveWelcomeUI::BraveWelcomeUI(content::WebUI* web_ui, const std::string& name)
   // added to allow front end to read/modify default search engine
   web_ui->AddMessageHandler(
       std::make_unique<settings::SearchEnginesHandler>(profile));
+
+  // Open additional page in Japanese region
+  if (!profile->GetPrefs()->GetBoolean(prefs::kHasSeenWelcomePage)) {
+    int country_id = country_codes::GetCountryIDFromPrefs(profile->GetPrefs());
+    if (country_id == country_codes::CountryStringToCountryID("JP")) {
+      base::ThreadTaskRunnerHandle::Get()->PostDelayedTask(
+          FROM_HERE, base::BindOnce(&OpenJapanWelcomePage, profile),
+          base::TimeDelta::FromSeconds(3));
+    }
+  }
 
   profile->GetPrefs()->SetBoolean(prefs::kHasSeenWelcomePage, true);
 }


### PR DESCRIPTION
Uplift of #8686
Resolves https://github.com/brave/brave-browser/issues/15526

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.