### PR TITLE
Tor disabled cleanup

### DIFF
--- a/browser/tor/tor_profile_service_factory.cc
+++ b/browser/tor/tor_profile_service_factory.cc
@@ -7,12 +7,10 @@
 
 #include <memory>
 
-#include "base/path_service.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/tor/pref_names.h"
 #include "brave/components/tor/tor_profile_service_impl.h"
 #include "chrome/browser/browser_process.h"
-#include "chrome/common/chrome_paths.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_context.h"
@@ -60,16 +58,11 @@ TorProfileServiceFactory::~TorProfileServiceFactory() {}
 
 KeyedService* TorProfileServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  base::FilePath user_data_dir;
-  base::PathService::Get(chrome::DIR_USER_DATA, &user_data_dir);
-  DCHECK(!user_data_dir.empty());
   std::unique_ptr<tor::TorProfileService> tor_profile_service(
       new tor::TorProfileServiceImpl(
-          context,
-          g_brave_browser_process
-              ? g_brave_browser_process->tor_client_updater()
-              : nullptr,
-          user_data_dir));
+          context, g_brave_browser_process
+                       ? g_brave_browser_process->tor_client_updater()
+                       : nullptr));
 
   return tor_profile_service.release();
 }

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -239,6 +239,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "torStatusConnected", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_CONNECTED },         // NOLINT
         { "torStatusDisconnected", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_DISCONNECTED },   // NOLINT
         { "torStatusInitializing", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_INITIALIZING },   // NOLINT
+        { "torTip", IDS_BRAVE_PRIVATE_NEW_TAB_TOR_TIP},
 
         // Together prompt
         { "togetherPromptTitle", IDS_BRAVE_TOGETHER_PROMPT_TITLE },

--- a/components/brave_new_tab_ui/containers/privateTab/torTab.tsx
+++ b/components/brave_new_tab_ui/containers/privateTab/torTab.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../components/private'
 
 // Helpers
-import { getLocale } from '../../../common/locale'
+import { getLocale, getLocaleWithTag } from '../../../common/locale'
 
 // Assets
 const privateWindowImg = require('../../../img/newtab/private-window-tor.svg')
@@ -47,6 +47,25 @@ export default class TorTab extends React.PureComponent<Props, {}> {
     }
     return getLocale('torStatusDisconnected')
   }
+  renderTorTip () {
+    const { beforeTag, duringTag, afterTag } = getLocaleWithTag('torTip')
+    if (this.props.newTabData && !this.props.newTabData.torCircuitEstablished) {
+      return (
+        <Text>
+          {beforeTag}
+            <Link
+              href='chrome://settings/extensions'
+              style={{ margin: 0 }}
+            >
+            {duringTag}
+            </Link>
+          {afterTag}
+        </Text>
+      )
+    }
+    return ''
+  }
+
   render () {
     return (
       <Grid>
@@ -95,6 +114,7 @@ export default class TorTab extends React.PureComponent<Props, {}> {
         <Box>
           <Title>{getLocale('torStatus')}</Title>
           <Text>{this.torStatus}</Text>
+          {this.renderTorTip()}
         </Box>
       </Grid>
     )

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -334,6 +334,7 @@
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_CONNECTED" desc="">Connected</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_DISCONNECTED" desc="">Disconnected</message>
       <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_STATUS_INITIALIZING" desc="">Initializing [[percentage]]%</message>
+      <message name="IDS_BRAVE_PRIVATE_NEW_TAB_TOR_TIP" desc="">Having problems with Tor? Try <ph name="BEGIN_LINK">$1</ph>disabling private window with Tor<ph name="END_LINK">$2</ph> and turning it back on again.</message>
 
       <!-- WebUI adblock resources -->
       <message name="IDS_ADBLOCK_ADDITIONAL_FILTERS_TITLE" desc="Title for additional filters section">Additional Filters</message>

--- a/components/tor/brave_tor_client_updater.cc
+++ b/components/tor/brave_tor_client_updater.cc
@@ -150,6 +150,10 @@ void BraveTorClientUpdater::Cleanup() {
       user_data_dir_.AppendASCII(kTorClientComponentId);
   task_runner_->PostTask(FROM_HERE,
                          base::BindOnce(&DeleteDir, tor_component_dir));
+  task_runner_->PostTask(FROM_HERE,
+                         base::BindOnce(&DeleteDir, GetTorDataPath()));
+  task_runner_->PostTask(FROM_HERE,
+                         base::BindOnce(&DeleteDir, GetTorWatchPath()));
 }
 
 void BraveTorClientUpdater::SetExecutablePath(const base::FilePath& path) {
@@ -160,6 +164,18 @@ void BraveTorClientUpdater::SetExecutablePath(const base::FilePath& path) {
 
 base::FilePath BraveTorClientUpdater::GetExecutablePath() const {
   return executable_path_;
+}
+
+base::FilePath BraveTorClientUpdater::GetTorDataPath() const {
+  DCHECK(!user_data_dir_.empty());
+  return user_data_dir_.Append(FILE_PATH_LITERAL("tor"))
+      .Append(FILE_PATH_LITERAL("data"));
+}
+
+base::FilePath BraveTorClientUpdater::GetTorWatchPath() const {
+  DCHECK(!user_data_dir_.empty());
+  return user_data_dir_.Append(FILE_PATH_LITERAL("tor"))
+      .Append(FILE_PATH_LITERAL("watch"));
 }
 
 void BraveTorClientUpdater::OnComponentReady(

--- a/components/tor/brave_tor_client_updater.h
+++ b/components/tor/brave_tor_client_updater.h
@@ -54,6 +54,8 @@ class BraveTorClientUpdater : public BraveComponent {
   void Unregister();
   void Cleanup();
   base::FilePath GetExecutablePath() const;
+  base::FilePath GetTorDataPath() const;
+  base::FilePath GetTorWatchPath() const;
   scoped_refptr<base::SequencedTaskRunner> GetTaskRunner() {
     return task_runner_;
   }

--- a/components/tor/tor_profile_service_impl.h
+++ b/components/tor/tor_profile_service_impl.h
@@ -36,8 +36,7 @@ class TorProfileServiceImpl : public TorProfileService,
                               public TorLauncherObserver {
  public:
   TorProfileServiceImpl(content::BrowserContext* context,
-                        BraveTorClientUpdater* tor_client_updater,
-                        const base::FilePath& user_data_dir);
+                        BraveTorClientUpdater* tor_client_updater);
   ~TorProfileServiceImpl() override;
 
   // TorProfileService:
@@ -55,16 +54,15 @@ class TorProfileServiceImpl : public TorProfileService,
  private:
   void LaunchTor();
 
-  base::FilePath GetTorExecutablePath();
-  base::FilePath GetTorDataPath();
-  base::FilePath GetTorWatchPath();
+  base::FilePath GetTorExecutablePath() const;
+  base::FilePath GetTorDataPath() const;
+  base::FilePath GetTorWatchPath() const;
 
   // BraveTorClientUpdater::Observer
   void OnExecutableReady(const base::FilePath& path) override;
 
   content::BrowserContext* context_ = nullptr;
   BraveTorClientUpdater* tor_client_updater_ = nullptr;
-  base::FilePath user_data_dir_;
   TorLauncherFactory* tor_launcher_factory_;  // Singleton
   net::ProxyConfigServiceTor* proxy_config_service_;  // NOT OWNED
   base::WeakPtrFactory<TorProfileServiceImpl> weak_ptr_factory_;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14518

This PR cleans up tor/data and tor/watch used by Tor when Tor is disabled. Also prompt users to do disable and then re-enabled when Tor status stays disconnected

<img width="500" alt="Screen Shot 2021-05-05 at 10 06 12" src="https://user-images.githubusercontent.com/11330831/117181020-a7118480-ad89-11eb-8975-230cb21443f1.png">


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Initialization stuck
1. @fmarier can share with QA a user-supplied broken profile for Mac that reproduces this problem without having to disable one's Internet connection.
2. Copy the `tor/data` from step 1 to `user_data_dir` to replace the original one
3. Open Tor window should experience initialization stuck at some point and also see the tip message
4. Close Tor window and go to `brave://settings/extensions` and disable Tor and re-enable it again
5.  Open Tor window
6. Tor status should be connected after initiating complete

### Prompt
1. Turn off internet access (for simulating constant disconnected state of Tor)
2. Open Tor window
3. We will see Tor status is disconnected and there is a tip prompting users to disable and re-enable Tor
4. Click on the link
5. It should lead us to brave://settings/extensions
6. Turn internet back on and go back to Tor window
7. When the status is connected, the tip should go away

### Disable Tor
1. Open a Tor window and make sure `user_data_dir` has a `tor/data` and `tor/watch`
2. Go to `brave://settings/extensions` and disable Tor
3. `tor` folder in `user_data_dir` should be empty