### PR TITLE
Fixed TabSearchButton's weird hover/pressed effect

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -363,6 +363,8 @@ source_set("ui") {
       "views/tabs/brave_alert_indicator.h",
       "views/tabs/brave_new_tab_button.cc",
       "views/tabs/brave_new_tab_button.h",
+      "views/tabs/brave_tab_search_button.cc",
+      "views/tabs/brave_tab_search_button.h",
       "views/toolbar/brave_toolbar_view.cc",
       "views/toolbar/brave_toolbar_view.h",
     ]

--- a/browser/ui/views/tabs/brave_tab_search_button.cc
+++ b/browser/ui/views/tabs/brave_tab_search_button.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
+
+#include <algorithm>
+
+#include "ui/gfx/geometry/size.h"
+
+BraveTabSearchButton::~BraveTabSearchButton() = default;
+
+int BraveTabSearchButton::GetCornerRadius() const {
+  // Copied from LayoutProvider::GetCornerRadiusMetric() for kMaximum.
+  // We override GetCornerRadiusMetric() by BraveLayoutProvider. However,
+  // TabSearchButton needs original radius value.
+  auto size = GetContentsBounds().size();
+  return std::min(size.width(), size.height()) / 2;
+}

--- a/browser/ui/views/tabs/brave_tab_search_button.h
+++ b/browser/ui/views/tabs/brave_tab_search_button.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
+#define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_
+
+#include "chrome/browser/ui/views/tabs/tab_search_button.h"
+
+class BraveTabSearchButton : public TabSearchButton {
+ public:
+  using TabSearchButton::TabSearchButton;
+  ~BraveTabSearchButton() override;
+  BraveTabSearchButton(const BraveTabSearchButton&) = delete;
+  BraveTabSearchButton& operator=(const BraveTabSearchButton&) = delete;
+
+  // TabSearchButton overrides:
+  int GetCornerRadius() const override;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_SEARCH_BUTTON_H_

--- a/chromium_src/chrome/browser/ui/views/frame/tab_strip_region_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/tab_strip_region_view.cc
@@ -4,7 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
+#include "brave/browser/ui/views/tabs/brave_tab_search_button.h"
 
 #define NewTabButton BraveNewTabButton
+#define TabSearchButton BraveTabSearchButton
 #include "../../../../../../../chrome/browser/ui/views/frame/tab_strip_region_view.cc"
+#undef TabSearchButton
 #undef NewTabButton

--- a/chromium_src/chrome/browser/ui/views/tabs/new_tab_button.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/new_tab_button.h
@@ -14,7 +14,9 @@
   // #define BRAVE_NEW_TAB_BUTTON_H_
 
 #define GetBorderPath virtual GetBorderPath
+#define GetCornerRadius virtual GetCornerRadius
 #include "../../../../../../../chrome/browser/ui/views/tabs/new_tab_button.h"
+#undef GetCornerRadius
 #undef GetBorderPath
 #undef BRAVE_NEW_TAB_BUTTON_H_
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15670

TabSearchButton needs original radius value from LayoutProvider.
However, we override it with BraveLayoutProvider. So, implemented in GetCornerRadius()
in subclass to give origin value.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

![image](https://user-images.githubusercontent.com/6786187/117411217-51d2a000-af4e-11eb-9a45-0dca2802a13d.png)


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

