### PR TITLE
Show add item bubble when mouse hovered or tap gesture

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -310,6 +310,8 @@ source_set("ui") {
       "views/sidebar/sidebar_container_view.h",
       "views/sidebar/sidebar_control_view.cc",
       "views/sidebar/sidebar_control_view.h",
+      "views/sidebar/sidebar_item_add_button.cc",
+      "views/sidebar/sidebar_item_add_button.h",
       "views/sidebar/sidebar_item_added_feedback_bubble.cc",
       "views/sidebar/sidebar_item_added_feedback_bubble.h",
       "views/sidebar/sidebar_item_drag_context.cc",

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -11,8 +11,8 @@
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
-#include "brave/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
+#include "brave/browser/ui/views/sidebar/sidebar_item_add_button.h"
 #include "brave/browser/ui/views/sidebar/sidebar_items_scroll_view.h"
 #include "brave/components/sidebar/sidebar_service.h"
 #include "brave/grit/brave_generated_resources.h"
@@ -183,11 +183,8 @@ void SidebarControlView::AddChildViews() {
       AddChildView(std::make_unique<SidebarItemsScrollView>(browser_));
 
   sidebar_item_add_view_ =
-      AddChildView(std::make_unique<SidebarButtonView>(nullptr));
+      AddChildView(std::make_unique<SidebarItemAddButton>(browser_));
   sidebar_item_add_view_->set_context_menu_controller(this);
-  sidebar_item_add_view_->SetCallback(
-      base::BindRepeating(&SidebarControlView::OnButtonPressed,
-                          base::Unretained(this), sidebar_item_add_view_));
 
   sidebar_settings_view_ =
       AddChildView(std::make_unique<SidebarButtonView>(nullptr));
@@ -197,13 +194,6 @@ void SidebarControlView::AddChildViews() {
 }
 
 void SidebarControlView::OnButtonPressed(views::View* view) {
-  if (view == sidebar_item_add_view_) {
-    auto* bubble = views::BubbleDialogDelegateView::CreateBubble(
-        new SidebarAddItemBubbleDelegateView(browser_, view));
-    bubble->Show();
-    return;
-  }
-
   if (view == sidebar_settings_view_) {
     browser_->sidebar_controller()->LoadAtTab(
         GURL(chrome::kChromeUISettingsURL));

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -1,0 +1,38 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/sidebar/sidebar_item_add_button.h"
+
+#include "brave/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h"
+
+SidebarItemAddButton::SidebarItemAddButton(BraveBrowser* browser)
+    : SidebarButtonView(nullptr), browser_(browser) {}
+
+SidebarItemAddButton::~SidebarItemAddButton() = default;
+
+void SidebarItemAddButton::OnMouseEntered(const ui::MouseEvent& event) {
+  SidebarButtonView::OnMouseEntered(event);
+  ShowBubble();
+}
+
+void SidebarItemAddButton::OnGestureEvent(ui::GestureEvent* event) {
+  SidebarButtonView::OnGestureEvent(event);
+  if (event->type() == ui::ET_GESTURE_TAP)
+    ShowBubble();
+}
+
+void SidebarItemAddButton::OnWidgetDestroying(views::Widget* widget) {
+  observation_.Reset();
+}
+
+void SidebarItemAddButton::ShowBubble() {
+  if (observation_.IsObserving())
+    return;
+
+  auto* bubble = views::BubbleDialogDelegateView::CreateBubble(
+      new SidebarAddItemBubbleDelegateView(browser_, this));
+  observation_.Observe(bubble);
+  bubble->Show();
+}

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/sidebar/sidebar_item_add_button.h"
 
+#include "base/time/time.h"
 #include "brave/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.h"
 
 SidebarItemAddButton::SidebarItemAddButton(BraveBrowser* browser)
@@ -14,23 +15,41 @@ SidebarItemAddButton::~SidebarItemAddButton() = default;
 
 void SidebarItemAddButton::OnMouseEntered(const ui::MouseEvent& event) {
   SidebarButtonView::OnMouseEntered(event);
-  ShowBubble();
+  ShowBubbleWithDelay();
+}
+
+void SidebarItemAddButton::OnMouseExited(const ui::MouseEvent& event) {
+  SidebarButtonView::OnMouseEntered(event);
+  // Don't show bubble if user goes outo from add item quickly.
+  timer_.Stop();
 }
 
 void SidebarItemAddButton::OnGestureEvent(ui::GestureEvent* event) {
   SidebarButtonView::OnGestureEvent(event);
-  if (event->type() == ui::ET_GESTURE_TAP)
-    ShowBubble();
+  if (event->type() == ui::ET_GESTURE_TAP) {
+    // Show bubble immediately after tapping.
+    DoShowBubble();
+  }
 }
 
 void SidebarItemAddButton::OnWidgetDestroying(views::Widget* widget) {
   observation_.Reset();
 }
 
-void SidebarItemAddButton::ShowBubble() {
+void SidebarItemAddButton::ShowBubbleWithDelay() {
   if (observation_.IsObserving())
     return;
 
+  if (timer_.IsRunning())
+    timer_.Stop();
+
+  constexpr int kBubbleLaunchDelayInMS = 200;
+  timer_.Start(FROM_HERE,
+               base::TimeDelta::FromMilliseconds(kBubbleLaunchDelayInMS), this,
+               &SidebarItemAddButton::DoShowBubble);
+}
+
+void SidebarItemAddButton::DoShowBubble() {
   auto* bubble = views::BubbleDialogDelegateView::CreateBubble(
       new SidebarAddItemBubbleDelegateView(browser_, this));
   observation_.Observe(bubble);

--- a/browser/ui/views/sidebar/sidebar_item_add_button.h
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_ITEM_ADD_BUTTON_H_
 
 #include "base/scoped_observation.h"
+#include "base/timer/timer.h"
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/widget/widget_observer.h"
@@ -24,15 +25,18 @@ class SidebarItemAddButton : public SidebarButtonView,
 
   // SidebarButtonView overrides:
   void OnMouseEntered(const ui::MouseEvent& event) override;
+  void OnMouseExited(const ui::MouseEvent& event) override;
   void OnGestureEvent(ui::GestureEvent* event) override;
 
   // views::WidgetObserver overrides:
   void OnWidgetDestroying(views::Widget* widget) override;
 
  private:
-  void ShowBubble();
+  void ShowBubbleWithDelay();
+  void DoShowBubble();
 
   BraveBrowser* browser_;
+  base::OneShotTimer timer_;
   base::ScopedObservation<views::Widget, views::WidgetObserver> observation_{
       this};
 };

--- a/browser/ui/views/sidebar/sidebar_item_add_button.h
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_ITEM_ADD_BUTTON_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_ITEM_ADD_BUTTON_H_
+
+#include "base/scoped_observation.h"
+#include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_observer.h"
+
+class BraveBrowser;
+
+class SidebarItemAddButton : public SidebarButtonView,
+                             public views::WidgetObserver {
+ public:
+  explicit SidebarItemAddButton(BraveBrowser* browser);
+  ~SidebarItemAddButton() override;
+
+  SidebarItemAddButton(const SidebarItemAddButton&) = delete;
+  SidebarItemAddButton& operator=(const SidebarItemAddButton&) = delete;
+
+  // SidebarButtonView overrides:
+  void OnMouseEntered(const ui::MouseEvent& event) override;
+  void OnGestureEvent(ui::GestureEvent* event) override;
+
+  // views::WidgetObserver overrides:
+  void OnWidgetDestroying(views::Widget* widget) override;
+
+ private:
+  void ShowBubble();
+
+  BraveBrowser* browser_;
+  base::ScopedObservation<views::Widget, views::WidgetObserver> observation_{
+      this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_ITEM_ADD_BUTTON_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15713
fix https://github.com/brave/brave-browser/issues/15428

Show add item bubble when mouse hovered instead of click.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave with clean profile
2. Enable sidebar flag and relaunch
3. Load www.brave.com
4. Mouse hover over the item add button
5. Check item add bubble is shown