### PR TITLE
Always open brave://sync page in normal window instead of private

### DIFF
--- a/browser/brave_scheme_load_browsertest.cc
+++ b/browser/brave_scheme_load_browsertest.cc
@@ -235,3 +235,8 @@ IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
                        WalletPageIsNotAllowedInPrivateWindow) {
   TestURLIsNotLoadedInPrivateWindow("brave://wallet");
 }
+
+IN_PROC_BROWSER_TEST_F(BraveSchemeLoadBrowserTest,
+                       BraveSyncPageIsNotAllowedInPrivateWindow) {
+  TestURLIsNotLoadedInPrivateWindow("brave://sync");
+}

--- a/chromium_src/chrome/browser/ui/browser_navigator.cc
+++ b/chromium_src/chrome/browser/ui/browser_navigator.cc
@@ -55,9 +55,9 @@ void MaybeHandleInParent(NavigateParams* params, bool allow_in_incognito) {
 }
 
 bool IsHostAllowedInIncognitoBraveImpl(const base::StringPiece& host) {
-  if (host == kWalletHost ||
-      host == kRewardsPageHost ||
-      host == chrome::kChromeUISyncInternalsHost) {
+  if (host == kWalletHost || host == kRewardsPageHost ||
+      host == chrome::kChromeUISyncInternalsHost ||
+      host == chrome::kChromeUISyncHost) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15717


Crash happens in `PeopleHandler::GetSyncStatusDictionary` after call
```
auto* identity_manager = IdentityManagerFactory::GetForProfile(profile_);
```
`identity_manager` is null.

This happens because of code 
```
content::BrowserContext*
BrowserContextKeyedServiceFactory::GetBrowserContextToUse(
    content::BrowserContext* context) const {
  // Safe default for Incognito mode: no service.
  if (context->IsOffTheRecord())
    return nullptr;

  return context;
}
```

For the private window or TOR Window profile is off the record.

brave://sync is equivalent for brave://sync-internals: `chrome/browser/browser_about_handler.cc`
```
...
  } else if (host == chrome::kChromeUISyncHost) {
    // Replace chrome://sync with chrome://sync-internals (for legacy reasons).
    host = chrome::kChromeUISyncInternalsHost;
  }
...
```

`IsHostAllowedInIncognitoBraveImpl` had check for `kChromeUISyncHost` before, but was reverted in https://github.com/brave/brave-core/commit/7ab37ec50888a01b8c5480e583145933e27b5295#diff-c2e627ca7460532e3bff1d6c52e459ed07119802deeb5b9be25d874e334b1645 , for sync v1 brave://sync was used as a main settings page.

This PR makes brave://sync to be opened in normal profile window.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
```
warnings on `npm run tslint`
some failed on browser test:
1 test failed:
    RewardsContributionBrowserTest.ProcessPendingContributions (../../brave/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc:385)
``` 
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Use test plan from  https://github.com/brave/brave-browser/issues/15717 