### PR TITLE
Fixed sidebar gets hidden when item reordering or bubble is visible

### DIFF
--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -18,8 +18,12 @@
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "content/public/browser/browser_context.h"
 #include "ui/base/theme_provider.h"
+#include "ui/events/event_observer.h"
+#include "ui/events/types/event_type.h"
+#include "ui/gfx/geometry/point.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/webview/webview.h"
+#include "ui/views/event_monitor.h"
 #include "ui/views/widget/widget.h"
 #include "url/gurl.h"
 
@@ -33,8 +37,43 @@ sidebar::SidebarService* GetSidebarService(BraveBrowser* browser) {
 
 }  // namespace
 
+class SidebarContainerView::BrowserWindowEventObserver
+    : public ui::EventObserver {
+ public:
+  explicit BrowserWindowEventObserver(SidebarContainerView* host)
+      : host_(host) {}
+  ~BrowserWindowEventObserver() override = default;
+  BrowserWindowEventObserver(const BrowserWindowEventObserver&) = delete;
+  BrowserWindowEventObserver& operator=(const BrowserWindowEventObserver&) =
+      delete;
+
+  void OnEvent(const ui::Event& event) override {
+    DCHECK(event.IsMouseEvent());
+    const auto* mouse_event = event.AsMouseEvent();
+
+    gfx::Point window_event_position = mouse_event->location();
+    // Convert window position to sidebar view's coordinate and check whether
+    // it's included in sidebar ui or not.
+    // If it's not included and sidebar could be hidden, stop monitoring and
+    // hide UI.
+    views::View::ConvertPointFromWidget(host_->sidebar_control_view_,
+                                        &window_event_position);
+    if (!host_->sidebar_control_view_->GetLocalBounds().Contains(
+            window_event_position) &&
+        !host_->ShouldShowSidebar()) {
+      host_->StopBrowserWindowEventMonitoring();
+      host_->ShowSidebar(false, true);
+    }
+  }
+
+ private:
+  SidebarContainerView* host_ = nullptr;
+};
+
 SidebarContainerView::SidebarContainerView(BraveBrowser* browser)
-    : browser_(browser) {
+    : browser_(browser),
+      browser_window_event_observer_(
+          std::make_unique<BrowserWindowEventObserver>(this)) {
   SetNotifyEnterExitOnChild(true);
 }
 
@@ -128,23 +167,25 @@ void SidebarContainerView::OnThemeChanged() {
   UpdateBackgroundAndBorder();
 }
 
-bool SidebarContainerView::ShouldHideSidebar() const {
+bool SidebarContainerView::ShouldShowSidebar() const {
   return sidebar_panel_view_->GetVisible() ||
          sidebar_control_view_->IsItemReorderingInProgress() ||
          sidebar_control_view_->IsBubbleWidgetVisible();
 }
 
 void SidebarContainerView::OnMouseExited(const ui::MouseEvent& event) {
-  if (ShouldHideSidebar())
-    return;
-
   const auto show_option = GetSidebarService(browser_)->GetSidebarShowOption();
-  const bool show_options_widget =
+  const bool autohide_sidebar =
       show_option == ShowSidebarOption::kShowOnMouseOver ||
       show_option == ShowSidebarOption::kShowOnClick;
 
-  if (!show_options_widget)
+  if (!autohide_sidebar)
     return;
+
+  if (ShouldShowSidebar()) {
+    StartBrowserWindowEventMonitoring();
+    return;
+  }
 
   ShowSidebar(false, true);
 }
@@ -191,4 +232,17 @@ void SidebarContainerView::ShowSidebar(bool show_sidebar,
   sidebar_control_view_->SetVisible(show_sidebar);
   ShowOptionsEventDetectWidget(show_event_detect_widget);
   InvalidateLayout();
+}
+
+void SidebarContainerView::StartBrowserWindowEventMonitoring() {
+  if (browser_window_event_monitor_)
+    return;
+
+  browser_window_event_monitor_ = views::EventMonitor::CreateWindowMonitor(
+      browser_window_event_observer_.get(), GetWidget()->GetNativeWindow(),
+      {ui::ET_MOUSE_MOVED});
+}
+
+void SidebarContainerView::StopBrowserWindowEventMonitoring() {
+  browser_window_event_monitor_.reset();
 }

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -128,8 +128,14 @@ void SidebarContainerView::OnThemeChanged() {
   UpdateBackgroundAndBorder();
 }
 
+bool SidebarContainerView::ShouldHideSidebar() const {
+  return sidebar_panel_view_->GetVisible() ||
+         sidebar_control_view_->IsItemReorderingInProgress() ||
+         sidebar_control_view_->IsBubbleWidgetVisible();
+}
+
 void SidebarContainerView::OnMouseExited(const ui::MouseEvent& event) {
-  if (sidebar_panel_view_->GetVisible())
+  if (ShouldHideSidebar())
     return;
 
   const auto show_option = GetSidebarService(browser_)->GetSidebarShowOption();

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -64,6 +64,7 @@ class SidebarContainerView
   void ShowOptionsEventDetectWidget(bool show);
   void ShowSidebar(bool show_sidebar, bool show_event_detect_widget);
   SidebarShowOptionsEventDetectWidget* GetEventDetectWidget();
+  bool ShouldHideSidebar() const;
 
   BraveBrowser* browser_ = nullptr;
   sidebar::SidebarModel* sidebar_model_ = nullptr;

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -13,14 +13,15 @@
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "ui/events/event_observer.h"
 #include "ui/views/view.h"
 
 namespace views {
+class EventMonitor;
 class WebView;
 }  // namespace views
 
 class BraveBrowser;
-
 class SidebarControlView;
 
 // This view is the parent view of all sidebar ui.
@@ -58,19 +59,37 @@ class SidebarContainerView
   void OnActiveIndexChanged(int old_index, int new_index) override;
 
  private:
+  class BrowserWindowEventObserver;
+
   void AddChildViews();
   void UpdateBackgroundAndBorder();
   void UpdateChildViewVisibility();
   void ShowOptionsEventDetectWidget(bool show);
   void ShowSidebar(bool show_sidebar, bool show_event_detect_widget);
   SidebarShowOptionsEventDetectWidget* GetEventDetectWidget();
-  bool ShouldHideSidebar() const;
+  bool ShouldShowSidebar() const;
+
+  // On some condition(ex, add item bubble is visible),
+  // sidebar should not be hidden even if mouse goes out from sidebar ui.
+  // If it's hidden, only bubble ui is visible. Then, weird situation happens.
+  // (Sidear UI is hidden and bubble is only visible)
+  // With this handling, sidebar ui is still visible after this bubble ui is
+  // disappeared. To make sidebar ui hidden, this widget's
+  // event is monitored. |BrowserWindowEventObserver| will get widget's
+  // mouse event when mouse is exited from sidebar ui but sidebar ui is shown.
+  // |BrowserWindowEventObserver| will ask to stop monitoring and ask to hide
+  // sidebar ui when those conditions are cleared and current mouse is outside
+  // of sidebar ui.
+  void StartBrowserWindowEventMonitoring();
+  void StopBrowserWindowEventMonitoring();
 
   BraveBrowser* browser_ = nullptr;
   sidebar::SidebarModel* sidebar_model_ = nullptr;
   views::WebView* sidebar_panel_view_ = nullptr;
   SidebarControlView* sidebar_control_view_ = nullptr;
   bool initialized_ = false;
+  std::unique_ptr<BrowserWindowEventObserver> browser_window_event_observer_;
+  std::unique_ptr<views::EventMonitor> browser_window_event_monitor_;
   std::unique_ptr<SidebarShowOptionsEventDetectWidget> show_options_widget_;
   ScopedObserver<sidebar::SidebarModel, sidebar::SidebarModel::Observer>
       observed_{this};

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -265,3 +265,20 @@ void SidebarControlView::UpdateSettingsButtonState() {
         bundle.GetImageSkiaNamed(IDR_SIDEBAR_SETTINGS_FOCUSED));
   }
 }
+
+bool SidebarControlView::IsItemReorderingInProgress() const {
+  return sidebar_items_view_->IsItemReorderingInProgress();
+}
+
+bool SidebarControlView::IsBubbleWidgetVisible() const {
+  if (context_menu_runner_ && context_menu_runner_->IsRunning())
+    return true;
+
+  if (sidebar_item_add_view_->IsBubbleVisible())
+    return true;
+
+  if (sidebar_items_view_->IsBubbleVisible())
+    return true;
+
+  return false;
+}

--- a/browser/ui/views/sidebar/sidebar_control_view.h
+++ b/browser/ui/views/sidebar/sidebar_control_view.h
@@ -16,6 +16,7 @@
 
 class BraveBrowser;
 class SidebarButtonView;
+class SidebarItemAddButton;
 class SidebarItemsScrollView;
 class SidebarContainerView;
 
@@ -62,6 +63,9 @@ class SidebarControlView : public views::View,
 
   void Update();
 
+  bool IsItemReorderingInProgress() const;
+  bool IsBubbleWidgetVisible() const;
+
  private:
   void AddChildViews();
 
@@ -74,7 +78,7 @@ class SidebarControlView : public views::View,
 
   BraveBrowser* browser_ = nullptr;
   SidebarItemsScrollView* sidebar_items_view_ = nullptr;
-  SidebarButtonView* sidebar_item_add_view_ = nullptr;
+  SidebarItemAddButton* sidebar_item_add_view_ = nullptr;
   SidebarButtonView* sidebar_settings_view_ = nullptr;
   std::unique_ptr<ui::SimpleMenuModel> context_menu_model_;
   std::unique_ptr<views::MenuRunner> context_menu_runner_;

--- a/browser/ui/views/sidebar/sidebar_item_add_button.cc
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.cc
@@ -37,7 +37,7 @@ void SidebarItemAddButton::OnWidgetDestroying(views::Widget* widget) {
 }
 
 void SidebarItemAddButton::ShowBubbleWithDelay() {
-  if (observation_.IsObserving())
+  if (IsBubbleVisible())
     return;
 
   if (timer_.IsRunning())
@@ -54,4 +54,8 @@ void SidebarItemAddButton::DoShowBubble() {
       new SidebarAddItemBubbleDelegateView(browser_, this));
   observation_.Observe(bubble);
   bubble->Show();
+}
+
+bool SidebarItemAddButton::IsBubbleVisible() const {
+  return observation_.IsObserving();
 }

--- a/browser/ui/views/sidebar/sidebar_item_add_button.h
+++ b/browser/ui/views/sidebar/sidebar_item_add_button.h
@@ -31,6 +31,8 @@ class SidebarItemAddButton : public SidebarButtonView,
   // views::WidgetObserver overrides:
   void OnWidgetDestroying(views::Widget* widget) override;
 
+  bool IsBubbleVisible() const;
+
  private:
   void ShowBubbleWithDelay();
   void DoShowBubble();

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -242,9 +242,11 @@ void SidebarItemsContentsView::ShowItemAddedFeedbackBubble(
     views::View* anchor_view) {
   // Only launch feedback bubble for active browser window.
   DCHECK_EQ(browser_, BrowserList::GetInstance()->GetLastActive());
+  DCHECK(!observation_.IsObserving());
 
   auto* bubble = views::BubbleDialogDelegateView::CreateBubble(
       new SidebarItemAddedFeedbackBubble(anchor_view, this));
+  observation_.Observe(bubble);
   bubble->Show();
 }
 
@@ -395,4 +397,18 @@ gfx::ImageSkia SidebarItemsContentsView::GetImageForBuiltInItems(
 
   NOTREACHED();
   return gfx::ImageSkia();
+}
+
+void SidebarItemsContentsView::OnWidgetDestroying(views::Widget* widget) {
+  observation_.Reset();
+}
+
+bool SidebarItemsContentsView::IsBubbleVisible() const {
+  if (context_menu_runner_ && context_menu_runner_->IsRunning())
+    return true;
+
+  if (observation_.IsObserving())
+    return true;
+
+  return false;
 }

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -8,12 +8,15 @@
 
 #include <memory>
 
+#include "base/scoped_observation.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
 #include "brave/components/sidebar/sidebar_item.h"
 #include "ui/base/models/simple_menu_model.h"
 #include "ui/views/context_menu_controller.h"
 #include "ui/views/view.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_observer.h"
 
 namespace views {
 class MenuRunner;
@@ -25,6 +28,7 @@ class SidebarItemView;
 class SidebarItemsContentsView : public views::View,
                                  public SidebarButtonView::Delegate,
                                  public views::ContextMenuController,
+                                 public views::WidgetObserver,
                                  public ui::SimpleMenuModel::Delegate {
  public:
   SidebarItemsContentsView(BraveBrowser* browser,
@@ -46,6 +50,9 @@ class SidebarItemsContentsView : public views::View,
                                   const gfx::Point& point,
                                   ui::MenuSourceType source_type) override;
 
+  // views::WidgetObserver overrides:
+  void OnWidgetDestroying(views::Widget* widget) override;
+
   // ui::SimpleMenuModel::Delegate overrides:
   void ExecuteCommand(int command_id, int event_flags) override;
 
@@ -66,6 +73,8 @@ class SidebarItemsContentsView : public views::View,
   // Returns drag indicator index.
   int DrawDragIndicator(views::View* source, const gfx::Point& position);
   void ClearDragIndicator();
+
+  bool IsBubbleVisible() const;
 
  private:
   enum ContextMenuIDs {
@@ -102,6 +111,9 @@ class SidebarItemsContentsView : public views::View,
   sidebar::SidebarModel* sidebar_model_ = nullptr;
   std::unique_ptr<ui::SimpleMenuModel> context_menu_model_;
   std::unique_ptr<views::MenuRunner> context_menu_runner_;
+  // Observe to know whether item added feedback bubble is visible or not.
+  base::ScopedObservation<views::Widget, views::WidgetObserver> observation_{
+      this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_ITEMS_CONTENTS_VIEW_H_

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -451,3 +451,11 @@ bool SidebarItemsScrollView::CanStartDragForView(views::View* sender,
 
   return false;
 }
+
+bool SidebarItemsScrollView::IsItemReorderingInProgress() const {
+  return drag_context_->source_index() != -1;
+}
+
+bool SidebarItemsScrollView::IsBubbleVisible() const {
+  return contents_view_->IsBubbleVisible();
+}

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -77,6 +77,9 @@ class SidebarItemsScrollView : public views::View,
   void OnFaviconUpdatedForItem(const sidebar::SidebarItem& item,
                                const gfx::ImageSkia& image) override;
 
+  bool IsItemReorderingInProgress() const;
+  bool IsBubbleVisible() const;
+
  private:
   void UpdateArrowViewsTheme();
   void UpdateArrowViewsEnabledState();


### PR DESCRIPTION
First commit is for not hiding sidebar ui when sidebar item reordering is in-progress or sidebar bubble is shown.
With first commit, sidebar ui is not hidden when in some situation such as sidebar add item bubble is shown.
However,  another side effect is added. When that bubble gets hidden, sidebar ui is still visible and only it gets hidden after mouse enters into it and exits again.
Second commit is for hiding sidebar ui after sidebar bubble is disappeared by window's event monitoring.
When mouse moves outside of sidebar ui and sidebar bubble is hidden, sidebar ui will be hidden.

fix https://github.com/brave/brave-browser/issues/15766
fix https://github.com/brave/brave-browser/issues/15765

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable sidebar flag and re-launch
2. Select `On mousehover` sidebar show option 
3. Re-order any item and sidebar UI is not hidden
4. Load www.brave.com
5. Mouse hover over to sidebar add item
6. Mouse goes out from sidebar ui after add item menu bubble is shown
7. Check sidebar ui is not hidden
8. Hide add item menu bubble by clicking any point in webpage
9. Check sidebar ui is hidden after add item menu bubble is hidden