### PR TITLE
Fix ads upgrade-related browser tests (uplift to 1.24.x)

### DIFF
--- a/components/brave_ads/browser/ads_service_browsertest.cc
+++ b/components/brave_ads/browser/ads_service_browsertest.cc
@@ -26,7 +26,9 @@
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service_impl.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service_observer.h"
+#include "brave/components/brave_rewards/browser/rewards_service.h"
 #include "brave/components/brave_rewards/browser/rewards_service_impl.h"
+#include "brave/components/brave_rewards/browser/rewards_service_observer.h"
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/l10n/browser/locale_helper_mock.h"
@@ -93,6 +95,26 @@ std::unique_ptr<net::test_server::HttpResponse> HandleRequest(
 
 }  // namespace
 
+class TestRewardsServiceObserver
+    : public brave_rewards::RewardsServiceObserver {
+ public:
+  TestRewardsServiceObserver() = default;
+  ~TestRewardsServiceObserver() override = default;
+
+  void WaitForRewardsInitialization() {
+    run_loop_ = std::make_unique<base::RunLoop>();
+    run_loop_->Run();
+  }
+
+  // RewardsServiceObserver implementation
+  void OnRewardsInitialized(brave_rewards::RewardsService* service) override {
+    run_loop_->Quit();
+  }
+
+ private:
+  std::unique_ptr<base::RunLoop> run_loop_;
+};
+
 class BraveAdsBrowserTest : public InProcessBrowserTest,
                             public base::SupportsWeakPtr<BraveAdsBrowserTest> {
  public:
@@ -114,7 +136,7 @@ class BraveAdsBrowserTest : public InProcessBrowserTest,
 
     host_resolver()->AddRule("*", "127.0.0.1");
 
-    // Setup up embedded test server for HTTPS requests
+    // Setup embedded test server for HTTPS requests
     https_server_.reset(new net::EmbeddedTestServer(
         net::test_server::EmbeddedTestServer::TYPE_HTTPS));
     https_server_->SetSSLConfig(net::EmbeddedTestServer::CERT_OK);
@@ -128,6 +150,8 @@ class BraveAdsBrowserTest : public InProcessBrowserTest,
 
     rewards_service_ = static_cast<brave_rewards::RewardsServiceImpl*>(
         brave_rewards::RewardsServiceFactory::GetForProfile(browser_profile));
+    rewards_service_->AddObserver(&rewards_service_observer_);
+
     rewards_service_->ForTestingSetTestResponseCallback(base::BindRepeating(
         &BraveAdsBrowserTest::GetTestResponse, base::Unretained(this)));
 
@@ -137,11 +161,12 @@ class BraveAdsBrowserTest : public InProcessBrowserTest,
     rewards_service_->SetLedgerEnvForTesting();
   }
 
-  void TearDown() override {
+  void TearDownOnMainThread() override {
     // Code here will be called immediately after each test (right before the
     // destructor)
+    rewards_service_->RemoveObserver(&rewards_service_observer_);
 
-    InProcessBrowserTest::TearDown();
+    InProcessBrowserTest::TearDownOnMainThread();
   }
 
   void GetTestDataDir(base::FilePath* test_data_dir) {
@@ -366,6 +391,8 @@ class BraveAdsBrowserTest : public InProcessBrowserTest,
   brave_rewards::RewardsServiceImpl* rewards_service_;
 
   brave_ads::AdsServiceImpl* ads_service_;
+
+  TestRewardsServiceObserver rewards_service_observer_;
 
   std::unique_ptr<brave_l10n::LocaleHelperMock> locale_helper_mock_;
   const std::string newly_supported_locale_ = "en_830";
@@ -999,6 +1026,19 @@ const BraveAdsUpgradePathParamInfo kTests[] = {
 
 IN_PROC_BROWSER_TEST_P(BraveAdsUpgradeBrowserTest, PRE_UpgradePath) {
   // Handled in |MaybeMockLocaleHelperForBraveAdsUpgradePath|
+
+  const ::testing::TestInfo* const test_info =
+      ::testing::UnitTest::GetInstance()->current_test_info();
+  ASSERT_NE(nullptr, test_info);
+  const std::string test_name = test_info->name();
+
+  // Wait for Brave Rewards to be initialized before proceeding with
+  // tests that rely on Rewards
+  if ((test_name.find("WithRewardsEnabled_") != std::string::npos ||
+       test_name.find("WithRewardsAndAdsEnabled_") != std::string::npos) &&
+      !rewards_service_->IsInitialized()) {
+    rewards_service_observer_.WaitForRewardsInitialization();
+  }
 }
 
 IN_PROC_BROWSER_TEST_P(BraveAdsUpgradeBrowserTest, UpgradePath) {

--- a/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsAndAdsDisabled
+++ b/test/data/rewards-data/migration/PreferencesForVersion12WithRewardsAndAdsDisabled
@@ -13,7 +13,7 @@
   "brave": {
     "brave_ads": {
       "ads_per_hour": "2",
-      "enabled": true,
+      "enabled": false,
       "prefs": {
         "version": 6
       },


### PR DESCRIPTION
Uplift of #8676
Resolves https://github.com/brave/brave-browser/issues/15335

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.