### PR TITLE
Fixes Brave ads are blocked forever after ads limits (per hour or per day) are reached - 1.25.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_events.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_events.cc
@@ -69,11 +69,9 @@ void RecordAdEvent(const AdEventInfo& ad_event) {
   const std::string confirmation_type_as_string =
       std::string(ad_event.confirmation_type);
 
-  const base::Time time = base::Time::Now();
-  const uint64_t timestamp = static_cast<uint64_t>(time.ToDoubleT());
-
   AdsClientHelper::Get()->RecordAdEvent(ad_type_as_string,
-                                        confirmation_type_as_string, timestamp);
+                                        confirmation_type_as_string,
+                                        ad_event.timestamp);
 }
 
 std::deque<uint64_t> GetAdEvents(const AdType& ad_type,


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/8801
Resolves https://github.com/brave/brave-browser/issues/15814

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.