### PR TITLE
don't use cached storage areas for ephemeral local storage (uplift to 1.25.x)

### DIFF
--- a/chromium_src/third_party/blink/renderer/modules/storage/dom_window_storage.cc
+++ b/chromium_src/third_party/blink/renderer/modules/storage/dom_window_storage.cc
@@ -222,8 +222,11 @@ StorageArea* BraveDOMWindowStorage::ephemeralLocalStorage() {
   if (!namespaces)
     return nullptr;
 
-  auto storage_area =
-      namespaces->local_storage()->GetCachedArea(window->GetSecurityOrigin());
+  auto* controller = StorageController::GetInstance();
+  controller->ClearAreasIfNeeded();
+  auto storage_area = base::MakeRefCounted<CachedStorageArea>(
+      CachedStorageArea::AreaType::kSessionStorage, window->GetSecurityOrigin(),
+      controller->TaskRunner(), namespaces->local_storage());
 
   // Ephemeral localStorage never persists stored data, which is also how
   // sessionStorage works. Due to this, when opening up a new ephemeral


### PR DESCRIPTION
Uplift of #8804
Resolves https://github.com/brave/brave-browser/issues/15646

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.