### PR TITLE
Always return light mode in fingerprinting strict mode

### DIFF
--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -28,6 +28,9 @@ class RenderProcessHost;
 namespace blink {
 class AssociatedInterfaceRegistry;
 }  // namespace blink
+namespace web_pref {
+struct WebPreferences;
+}  // namespace web_pref
 
 class BraveContentBrowserClient : public ChromeContentBrowserClient {
  public:
@@ -115,6 +118,10 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
       service_manager::BinderRegistry* registry,
       blink::AssociatedInterfaceRegistry* associated_registry,
       content::RenderProcessHost* render_process_host) override;
+
+  bool OverrideWebPreferencesAfterNavigation(
+      content::WebContents* web_contents,
+      blink::web_pref::WebPreferences* prefs) override;
 
  private:
   uint64_t session_token_;

--- a/browser/farbling/BUILD.gn
+++ b/browser/farbling/BUILD.gn
@@ -10,6 +10,7 @@ if (!is_android) {
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
     sources = [
+      "brave_dark_mode_fingerprint_protection_browsertest.cc",
       "brave_enumeratedevices_farbling_browsertest.cc",
       "brave_navigator_devicememory_farbling_browsertest.cc",
       "brave_navigator_hardwareconcurrency_farbling_browsertest.cc",
@@ -21,17 +22,22 @@ if (!is_android) {
     ]
 
     deps = [
+      "//base",
       "//brave/browser",
       "//brave/common:pref_names",
       "//brave/components/brave_component_updater/browser:browser",
       "//brave/components/brave_shields/browser:browser",
       "//chrome/browser",
       "//chrome/browser/ui",
+      "//chrome/common",
       "//chrome/test:test_support",
       "//chrome/test:test_support_ui",
       "//components/embedder_support:browser_util",
       "//components/permissions:permissions",
+      "//components/prefs",
+      "//content/public/browser",
       "//content/test:test_support",
+      "//ui/native_theme:test_support",
     ]
   }
 }

--- a/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
+++ b/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
@@ -1,0 +1,145 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "base/strings/stringprintf.h"
+#include "base/task/post_task.h"
+#include "base/test/thread_test_helper.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/browser/extensions/brave_base_local_data_files_browsertest.h"
+#include "brave/common/brave_paths.h"
+#include "brave/common/pref_names.h"
+#include "brave/components/brave_component_updater/browser/local_data_files_service.h"
+#include "brave/components/brave_shields/browser/brave_shields_util.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "ui/native_theme/test_native_theme.h"
+
+using brave_shields::ControlType;
+
+const char kEmbeddedTestServerDirectory[] = "dark_mode_block";
+
+class BraveDarkModeFingerprintProtection : public InProcessBrowserTest {
+ public:
+  class BraveContentBrowserClientWithWebTheme
+      : public BraveContentBrowserClient {
+   public:
+    explicit BraveContentBrowserClientWithWebTheme(const ui::NativeTheme* theme)
+        : theme_(theme) {}
+
+   protected:
+    const ui::NativeTheme* GetWebTheme() const override { return theme_; }
+
+   private:
+    const ui::NativeTheme* const theme_;
+  };
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    content::SetBrowserClientForTesting(
+        new BraveContentBrowserClientWithWebTheme(&test_theme_));
+
+    host_resolver()->AddRule("*", "127.0.0.1");
+    content::SetupCrossSiteRedirector(embedded_test_server());
+
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    test_data_dir = test_data_dir.AppendASCII(kEmbeddedTestServerDirectory);
+    embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+    ASSERT_TRUE(embedded_test_server()->Start());
+
+    top_level_page_url_ = embedded_test_server()->GetURL("a.com", "/");
+    dark_mode_url_ =
+        embedded_test_server()->GetURL("a.com", "/dark_mode_fingerprint.html");
+  }
+
+  const GURL& dark_mode_url() { return dark_mode_url_; }
+
+  HostContentSettingsMap* content_settings() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  void AllowFingerprinting() {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::ALLOW, top_level_page_url_);
+  }
+
+  void BlockFingerprinting() {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::BLOCK, top_level_page_url_);
+  }
+
+  void SetFingerprintingDefault() {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::DEFAULT, top_level_page_url_);
+  }
+
+  content::WebContents* contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  void NavigateToURLUntilLoadStop(const GURL& url) {
+    ui_test_utils::NavigateToURL(browser(), url);
+    ASSERT_TRUE(WaitForLoadStop(contents()));
+  }
+
+ protected:
+  ui::TestNativeTheme test_theme_;
+
+ private:
+  GURL top_level_page_url_;
+  GURL dark_mode_url_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveDarkModeFingerprintProtection, DarkModeCheck) {
+  test_theme_.SetDarkMode(true);
+  // On fingerprinting off, should return dark mode
+  AllowFingerprinting();
+  NavigateToURLUntilLoadStop(dark_mode_url());
+  std::u16string tab_title;
+  ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
+  EXPECT_EQ(base::ASCIIToUTF16("dark"), tab_title);
+  // On fingerprinting default, should return dark mode
+  SetFingerprintingDefault();
+  NavigateToURLUntilLoadStop(dark_mode_url());
+  ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
+  EXPECT_EQ(base::ASCIIToUTF16("dark"), tab_title);
+  // On fingerprinting block, should return light
+  BlockFingerprinting();
+  NavigateToURLUntilLoadStop(dark_mode_url());
+  ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
+  EXPECT_EQ(base::ASCIIToUTF16("light"), tab_title);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveDarkModeFingerprintProtection, RegressionCheck) {
+  test_theme_.SetDarkMode(false);
+  // On all modes, should return light
+  // Fingerprinting off
+  AllowFingerprinting();
+  NavigateToURLUntilLoadStop(dark_mode_url());
+  std::u16string tab_title;
+  ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
+  EXPECT_EQ(base::ASCIIToUTF16("light"), tab_title);
+  // Fingerprinting default
+  SetFingerprintingDefault();
+  NavigateToURLUntilLoadStop(dark_mode_url());
+  ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
+  EXPECT_EQ(base::ASCIIToUTF16("light"), tab_title);
+  // Fingerprinting strict/block
+  BlockFingerprinting();
+  NavigateToURLUntilLoadStop(dark_mode_url());
+  ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
+  EXPECT_EQ(base::ASCIIToUTF16("light"), tab_title);
+}

--- a/test/data/dark_mode_block/dark_mode_fingerprint.html
+++ b/test/data/dark_mode_block/dark_mode_fingerprint.html
@@ -1,0 +1,12 @@
+<html>
+<title>FAIL</title>
+<script>
+  if (window.matchMedia("(prefers-color-scheme: light)").matches) {
+    document.title = "light";
+  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    document.title = "dark";
+  } else if (window.matchMedia("(prefers-color-scheme: no-preference)").matches) {
+    document.title = "no-preference";
+  }
+</script>
+</html>


### PR DESCRIPTION
<del>
This PR adds a patch to `blink/renderer/core/css/media_values.cc` that always returns `mojom::PreferredColorScheme::kLight` if fingerprinting mode is strict. 
Note that a page's override media feature will still be respected.    
</del>

On @bridiver's recommendation, overriding `BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation` to return light mode if fingerprinting mode = strict instead of patching `blink/renderer/core/css/media_values.cc`. 
Resolves https://github.com/brave/brave-browser/issues/15265.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

