### PR TITLE
Fixed the crash from tab context menu

### DIFF
--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -67,9 +67,12 @@ bool BraveTabContextMenuContents::GetAcceleratorForCommandId(
     return false;
 
   int browser_cmd;
+  views::Widget* widget =
+      BrowserView::GetBrowserViewForBrowser(controller_->browser())
+          ->GetWidget();
   return TabStripModel::ContextMenuCommandToBrowserCommand(command_id,
-                                                           &browser_cmd) ?
-      tab_->GetWidget()->GetAccelerator(browser_cmd, accelerator) : false;
+                                                           &browser_cmd) &&
+         widget->GetAccelerator(browser_cmd, accelerator);
 }
 
 void BraveTabContextMenuContents::ExecuteCommand(int command_id,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15894

Not 100% sure tab_ is the cause of this crash but it's the only difference with upstream.
We fetched widget via tab_ pointer but upstream fetches it via tabstrip_->GetWidget().
In this PR, BrowserView is used to get widget pointer because can't access
controller_->tabstrip_.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Can't repro though..