### PR TITLE
Fixes ad rewards not updated at brave://rewards due to loss of precision - 1.24.x

### DIFF
--- a/vendor/bat-native-ads/data/test/confirmations_issue_15801.json
+++ b/vendor/bat-native-ads/data/test/confirmations_issue_15801.json
@@ -1,0 +1,64 @@
+{
+  "ads_rewards": {
+    "grants_balance": 40.355,
+    "payments": [
+      {
+        "balance": 0.6075,
+        "month": "2021-05",
+        "transaction_count": "108"
+      },
+      {
+        "balance": 2.6895,
+        "month": "2021-04",
+        "transaction_count": "275"
+      },
+      {
+        "balance": 6.015,
+        "month": "2021-03",
+        "transaction_count": "498"
+      },
+      {
+        "balance": 6.235,
+        "month": "2021-02",
+        "transaction_count": "430"
+      },
+      {
+        "balance": 3.1,
+        "month": "2021-01",
+        "transaction_count": "273"
+      },
+      {
+        "balance": 10.66,
+        "month": "2020-12",
+        "transaction_count": "390"
+      },
+      {
+        "balance": 5.795,
+        "month": "2020-11",
+        "transaction_count": "198"
+      },
+      {
+        "balance": 6.8,
+        "month": "2020-10",
+        "transaction_count": "228"
+      },
+      {
+        "balance": 2.05,
+        "month": "2020-09",
+        "transaction_count": "93"
+      }
+    ],
+    "unreconciled_estimated_pending_rewards": 0.41750000000000015
+  },
+  "catalog_issuers": {
+  },
+  "confirmations": {
+    "failed_confirmations": []
+  },
+  "next_token_redemption_date_in_seconds": "4102444799",
+  "transaction_history": {
+    "transactions": []
+  },
+  "unblinded_payment_tokens": [],
+  "unblinded_tokens": []
+}

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
@@ -12,6 +12,7 @@
 #include "base/strings/stringprintf.h"
 #include "bat/ads/internal/features/ad_rewards/ad_rewards_features.h"
 #include "bat/ads/internal/logging.h"
+#include "bat/ads/internal/number_util.h"
 #include "third_party/re2/src/re2/re2.h"
 
 namespace ads {
@@ -122,7 +123,7 @@ bool Payments::DidReconcileBalance(
   }
 
   const double delta = GetBalance() - last_balance;
-  if (delta >= unreconciled_estimated_pending_rewards) {
+  if (DoubleIsGreaterEqual(delta, unreconciled_estimated_pending_rewards)) {
     return true;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/number_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/number_util.cc
@@ -10,13 +10,41 @@
 namespace ads {
 
 namespace {
-const double kEpsilon = .0001;
+
+const double kEpsilon = .00001;
+const int kDecimalPlaces = 4;
+
+double RoundDoubleNPlaces(const double value, const int n_places) {
+  const double pow_10 = pow(10.0f, static_cast<double>(n_places));
+  return round(value * pow_10) / pow_10;
+}
+
 }  // namespace
 
-bool DoubleEquals(const double a, const double b) {
+bool DoubleEquals(const double lhs, const double rhs) {
   // Choice of epsilon for double comparison allows for proper comparison, we
   // want it to be relatively high to avoid false negative comparison results
-  return std::abs(a - b) < kEpsilon;
+  return std::abs(lhs - rhs) <= kEpsilon;
+}
+
+bool DoubleIsGreaterEqual(const double lhs, const double rhs) {
+  return RoundDoubleNPlaces(lhs, kDecimalPlaces) >=
+         RoundDoubleNPlaces(rhs, kDecimalPlaces);
+}
+
+bool DoubleIsGreater(const double lhs, const double rhs) {
+  return RoundDoubleNPlaces(lhs, kDecimalPlaces) >
+         RoundDoubleNPlaces(rhs, kDecimalPlaces);
+}
+
+bool DoubleIsLessEqual(const double lhs, const double rhs) {
+  return RoundDoubleNPlaces(lhs, kDecimalPlaces) <=
+         RoundDoubleNPlaces(rhs, kDecimalPlaces);
+}
+
+bool DoubleIsLess(const double lhs, const double rhs) {
+  return RoundDoubleNPlaces(lhs, kDecimalPlaces) <
+         RoundDoubleNPlaces(rhs, kDecimalPlaces);
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/number_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/number_util.h
@@ -8,7 +8,11 @@
 
 namespace ads {
 
-bool DoubleEquals(const double a, const double b);
+bool DoubleEquals(const double lhs, const double rhs);
+bool DoubleIsGreaterEqual(const double lhs, const double rhs);
+bool DoubleIsGreater(const double lhs, const double rhs);
+bool DoubleIsLessEqual(const double lhs, const double rhs);
+bool DoubleIsLess(const double lhs, const double rhs);
 
 }  // namespace ads
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/number_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/number_util_unittest.cc
@@ -15,10 +15,10 @@ namespace ads {
 
 TEST(BatAdsNumberUtilTest, DoubleEquals) {
   // Arrange
-  const double value = 1.0;
+  const double value = 1.00001;
 
   // Act
-  const bool does_equal = DoubleEquals(value, 1.0);
+  const bool does_equal = DoubleEquals(value, 1.00002);
 
   // Assert
   EXPECT_TRUE(does_equal);
@@ -26,24 +26,109 @@ TEST(BatAdsNumberUtilTest, DoubleEquals) {
 
 TEST(BatAdsNumberUtilTest, DoubleNotEquals) {
   // Arrange
-  const double value = 1.0;
+  const double value = 1.0001;
 
   // Act
-  const bool does_equal = DoubleEquals(value, 0.9);
+  const bool does_equal = DoubleEquals(value, 1.0002);
 
   // Assert
   EXPECT_FALSE(does_equal);
 }
 
-TEST(BatAdsNumberUtilTest, DoubleEqualsBelowEpsilon) {
+TEST(BatAdsNumberUtilTest, DoubleIsGreaterEqual) {
   // Arrange
-  const double value = 0.9999;
+  const double value = 0.41749999999999687361196265555918216705322265625000;
 
   // Act
-  const bool does_equal = DoubleEquals(value, 1.0);
+  const bool is_greater_equal = DoubleIsGreaterEqual(
+      value, 0.41750000000000014876988529977097641676664352416992);
 
   // Assert
-  EXPECT_TRUE(does_equal);
+  EXPECT_TRUE(is_greater_equal);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsNotGreaterEqual) {
+  // Arrange
+  const double value = 0.41744999999999687361196265555918216705322265625000;
+
+  // Act
+  const bool is_greater_equal = DoubleIsGreaterEqual(
+      value, 0.41750000000000014876988529977097641676664352416992);
+
+  // Assert
+  EXPECT_FALSE(is_greater_equal);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsGreater) {
+  // Arrange
+  const double value = 0.41759999999999687361196265555918216705322265625000;
+
+  // Act
+  const bool is_greater = DoubleIsGreater(
+      value, 0.41750000000000014876988529977097641676664352416992);
+
+  // Assert
+  EXPECT_TRUE(is_greater);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsNotGreater) {
+  // Arrange
+  const double value = 0.41749999999999687361196265555918216705322265625000;
+
+  // Act
+  const bool is_greater = DoubleIsGreater(
+      value, 0.41750000000000014876988529977097641676664352416992);
+
+  // Assert
+  EXPECT_FALSE(is_greater);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsLessEqual) {
+  // Arrange
+  const double value = 0.41750000000000014876988529977097641676664352416992;
+
+  // Act
+  const bool is_less_equal = DoubleIsLessEqual(
+      value, 0.41749999999999687361196265555918216705322265625000);
+
+  // Assert
+  EXPECT_TRUE(is_less_equal);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsNotLessEqual) {
+  // Arrange
+  const double value = 0.41750000000000014876988529977097641676664352416992;
+
+  // Act
+  const bool is_less_equal = DoubleIsLessEqual(
+      value, 0.41744999999999687361196265555918216705322265625000);
+
+  // Assert
+  EXPECT_FALSE(is_less_equal);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsLess) {
+  // Arrange
+  const double value = 0.41750000000000014876988529977097641676664352416992;
+
+  // Act
+  const bool is_less =
+      DoubleIsLess(value, 0.41759999999999687361196265555918216705322265625000);
+
+  // Assert
+  EXPECT_TRUE(is_less);
+}
+
+TEST(BatAdsNumberUtilTest, DoubleIsNotLess) {
+  // Arrange
+  const double value = 0.41750000000000014876988529977097641676664352416992;
+
+  // Act
+  const bool is_less =
+      DoubleIsLess(value, 0.41749999999999687361196265555918216705322265625000);
+
+  // Assert
+  EXPECT_FALSE(is_less);
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
@@ -575,6 +575,25 @@ void MockLoad(const std::unique_ptr<AdsClientMock>& mock) {
       }));
 }
 
+void MockLoad(const std::unique_ptr<AdsClientMock>& mock,
+              const std::string& filename,
+              const std::string& filename_override) {
+  ON_CALL(*mock, Load(filename, _))
+      .WillByDefault(
+          Invoke([=](const std::string& name, LoadCallback callback) {
+            base::FilePath path = GetTestPath();
+            path = path.AppendASCII(filename_override);
+
+            std::string value;
+            if (!base::ReadFileToString(path, &value)) {
+              callback(FAILED, value);
+              return;
+            }
+
+            callback(SUCCESS, value);
+          }));
+}
+
 void MockLoadUserModelForId(const std::unique_ptr<AdsClientMock>& mock) {
   ON_CALL(*mock, LoadUserModelForId(_, _))
       .WillByDefault(Invoke([](const std::string& id, LoadCallback callback) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.h
@@ -118,6 +118,9 @@ void MockCloseNotification(const std::unique_ptr<AdsClientMock>& mock);
 void MockSave(const std::unique_ptr<AdsClientMock>& mock);
 
 void MockLoad(const std::unique_ptr<AdsClientMock>& mock);
+void MockLoad(const std::unique_ptr<AdsClientMock>& mock,
+              const std::string& name,
+              const std::string& filename);
 
 void MockLoadUserModelForId(const std::unique_ptr<AdsClientMock>& mock);
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/8786
Resolves https://github.com/brave/brave-browser/issues/15801

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
