### PR TITLE
Only wait for OnRewardsInitialized if it didn't already fire (uplift to 1.25.x)

### DIFF
--- a/components/brave_ads/browser/ads_service_browsertest.cc
+++ b/components/brave_ads/browser/ads_service_browsertest.cc
@@ -102,17 +102,25 @@ class TestRewardsServiceObserver
   ~TestRewardsServiceObserver() override = default;
 
   void WaitForRewardsInitialization() {
+    if (rewards_initialized_) {
+      return;
+    }
+
     run_loop_ = std::make_unique<base::RunLoop>();
     run_loop_->Run();
   }
 
   // RewardsServiceObserver implementation
   void OnRewardsInitialized(brave_rewards::RewardsService* service) override {
-    run_loop_->Quit();
+    rewards_initialized_ = true;
+    if (run_loop_) {
+      run_loop_->Quit();
+    }
   }
 
  private:
   std::unique_ptr<base::RunLoop> run_loop_;
+  bool rewards_initialized_ = false;
 };
 
 class BraveAdsBrowserTest : public InProcessBrowserTest,


### PR DESCRIPTION
Uplift of #8845
Resolves https://github.com/brave/brave-browser/issues/15944

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.