### PR TITLE
Changed sidebar mouse event detect area width for "On mousehover"

### DIFF
--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -102,9 +102,6 @@ void SidebarContainerView::SetSidebarShowOption(
     return;
   }
 
-  GetEventDetectWidget()->SetShowOnHover(show_option ==
-                                         ShowSidebarOption::kShowOnMouseOver);
-
   ShowSidebar(false, true);
 }
 
@@ -232,6 +229,11 @@ void SidebarContainerView::ShowOptionsEventDetectWidget(bool show) {
 
 void SidebarContainerView::ShowSidebar() {
   ShowSidebar(true, false);
+}
+
+bool SidebarContainerView::ShouldShowOnHover() {
+  const auto show_option = GetSidebarService(browser_)->GetSidebarShowOption();
+  return show_option == ShowSidebarOption::kShowOnMouseOver;
 }
 
 void SidebarContainerView::ShowSidebar(bool show_sidebar,

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -56,6 +56,7 @@ class SidebarContainerView
 
   // SidebarShowOptionsEventDetectWidget::Delegate overrides:
   void ShowSidebar() override;
+  bool ShouldShowOnHover() override;
 
   // sidebar::SidebarModel::Observer overrides:
   void OnActiveIndexChanged(int old_index, int new_index) override;

--- a/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.h
+++ b/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.h
@@ -23,6 +23,7 @@ class SidebarShowOptionsEventDetectWidget : public views::ViewObserver,
   class Delegate {
    public:
     virtual void ShowSidebar() = 0;
+    virtual bool ShouldShowOnHover() = 0;
 
    protected:
     virtual ~Delegate() {}
@@ -40,8 +41,6 @@ class SidebarShowOptionsEventDetectWidget : public views::ViewObserver,
   void Show();
   void Hide();
 
-  void SetShowOnHover(bool show_on_hover);
-
   // views::ViewObserver overrides:
   void OnViewBoundsChanged(views::View* observed_view) override;
 
@@ -53,6 +52,7 @@ class SidebarShowOptionsEventDetectWidget : public views::ViewObserver,
 
   BraveBrowserView* browser_view_ = nullptr;
   ContentsView* contents_view_ = nullptr;
+  Delegate* delegate_ = nullptr;
   std::unique_ptr<views::Widget> widget_;
   base::ScopedObservation<views::View, views::ViewObserver> observation_{this};
 };


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15913

Changed from 30px to 7px. With 30px, sidebar gets visible easily
when mouse is around the left side.
Widget width for "On click" option is not changed.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

