### PR TITLE
Fixed sidebar show option is not applied properly when it's changed

### DIFF
--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -175,12 +175,27 @@ bool SidebarContainerView::ShouldShowSidebar() const {
 }
 
 void SidebarContainerView::OnMouseEntered(const ui::MouseEvent& event) {
+  const auto show_option = GetSidebarService(browser_)->GetSidebarShowOption();
+  const bool autohide_sidebar =
+      show_option == ShowSidebarOption::kShowOnMouseOver ||
+      show_option == ShowSidebarOption::kShowOnClick;
+
+  // When user select to non-autohide option like "Never" option,
+  // hide timer is scheduled but this view can get mouse event when context
+  // menu is hidden. In this case, this should not be cancelled.
+  if (!autohide_sidebar)
+    return;
+
   // Cancel hide schedule when mouse entered again quickly.
-  if (sidebar_hide_timer_.IsRunning())
-    sidebar_hide_timer_.Stop();
+  sidebar_hide_timer_.Stop();
 }
 
 void SidebarContainerView::OnMouseExited(const ui::MouseEvent& event) {
+  // When context menu is shown, this view can get this exited callback.
+  // In that case, ignore this callback because mouse is still in this view.
+  if (IsMouseHovered())
+    return;
+
   const auto show_option = GetSidebarService(browser_)->GetSidebarShowOption();
   const bool autohide_sidebar =
       show_option == ShowSidebarOption::kShowOnMouseOver ||


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/15958
When sidebar show option context menu gets visible or hidden,
view's mouse entered/exited callback is called even if mouse is still
in the view. Because of this, newly changed option is not applied
well.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See STR in the issue