### PR TITLE
Expose Rewards verbose logging flag on Android (uplift to 1.25.x)

### DIFF
--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -176,7 +176,8 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      FEATURE_VALUE_TYPE(permissions::features::kPermissionLifetime)},       \
     {"brave-rewards-verbose-logging",                                       \
      flag_descriptions::kBraveRewardsVerboseLoggingName,                    \
-     flag_descriptions::kBraveRewardsVerboseLoggingDescription, kOsDesktop, \
+     flag_descriptions::kBraveRewardsVerboseLoggingDescription,             \
+     kOsDesktop | kOsAndroid,                                               \
      FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature)},  \
     {"brave-rewards-bitflyer",                                              \
      flag_descriptions::kBraveRewardsBitflyerName,                          \


### PR DESCRIPTION
Uplift of #8841
Resolves https://github.com/brave/brave-browser/issues/15924

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.