### PR TITLE
Disable Brave ads custom ad notifications by default - 1.26.x

### DIFF
--- a/components/brave_ads/browser/features.cc
+++ b/components/brave_ads/browser/features.cc
@@ -19,7 +19,7 @@ namespace {
 // notifications
 const char kFieldTrialParameterShouldShowCustomAdNotifications[] =
     "should_show_custom_notifications";
-const bool kDefaultShouldShowCustomAdNotifications = true;
+const bool kDefaultShouldShowCustomAdNotifications = false;
 
 // Ad notification timeout in seconds. Set to 0 to never time out
 const char kFieldTrialParameterAdNotificationTimeout[] =


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/8900
Resolves https://github.com/brave/brave-browser/issues/16024

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
