### PR TITLE
Disable CNAME uncloaking tests on macOS (uplift to 1.26.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -581,9 +581,23 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
+// These tests fail intermittently on macOS; see
+// https://github.com/brave/brave-browser/issues/15912
+#if defined(OS_MAC)
+#define MAYBE_CnameCloakedRequestsGetBlocked \
+  DISABLED_CnameCloakedRequestsGetBlocked
+#define MAYBE_CnameCloakedRequestsCanBeExcepted \
+  DISABLED_CnameCloakedRequestsCanBeExcepted
+#else
+#define MAYBE_CnameCloakedRequestsGetBlocked CnameCloakedRequestsGetBlocked
+#define MAYBE_CnameCloakedRequestsCanBeExcepted \
+  CnameCloakedRequestsCanBeExcepted
+#endif
+
 // Make sure that CNAME cloaked network requests get blocked correctly and
 // issue the correct number of DNS resolutions
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsGetBlocked) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
+                       MAYBE_CnameCloakedRequestsGetBlocked) {
   UpdateAdBlockInstanceWithRules("||cname-cloak-endpoint.tracking.com^");
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
   GURL tab_url = embedded_test_server()->GetURL("a.com", kAdBlockTestPage);
@@ -666,7 +680,8 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsGetBlocked) {
 
 // Make sure that an exception for a URL can apply to a blocking decision made
 // to its CNAME-uncloaked equivalent.
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsCanBeExcepted) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
+                       MAYBE_CnameCloakedRequestsCanBeExcepted) {
   UpdateAdBlockInstanceWithRules(
       "||cname-cloak-endpoint.tracking.com^\n"
       "@@||a.com/logo-unblock.png|");


### PR DESCRIPTION
Uplift of #8883
Resolves https://github.com/brave/brave-browser/issues/15912

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.