### PR TITLE
Fix: Recovery Phrase Double Word Issue

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
@@ -14,25 +14,26 @@ import {
   ErrorContainer
 } from './style'
 import { NavButton } from '../../../extension'
+import { RecoveryObject } from '../../../../constants/types'
 import locale from '../../../../constants/locale'
 
 export interface Props {
   onSubmit: () => void
-  recoveryPhrase: string[]
-  sortedPhrase: string[]
-  selectWord: (word: string) => void
-  unSelectWord: (word: string) => void
+  recoveryPhrase: RecoveryObject[]
+  sortedPhrase: RecoveryObject[]
+  selectWord: (word: RecoveryObject) => void
+  unSelectWord: (word: RecoveryObject) => void
   hasVerifyError: boolean
 }
 
 function OnboardingVerify (props: Props) {
   const { onSubmit, recoveryPhrase, selectWord, unSelectWord, sortedPhrase, hasVerifyError } = props
 
-  const addWord = (word: string) => () => {
+  const addWord = (word: RecoveryObject) => () => {
     selectWord(word)
   }
 
-  const removeWord = (word: string) => () => {
+  const removeWord = (word: RecoveryObject) => () => {
     unSelectWord(word)
   }
 
@@ -41,12 +42,12 @@ function OnboardingVerify (props: Props) {
       <Title>{locale.verifyRecoveryTitle}</Title>
       <Description>{locale.verifyRecoveryDescription}</Description>
       <SelectedPhraseContainer error={hasVerifyError}>
-        {sortedPhrase.map((word) =>
+        {sortedPhrase.map((word, index) =>
           <SelectedBubble
-            key={word}
+            key={word.id}
             onClick={removeWord(word)}
           >
-            <SelectedBubbleText>{sortedPhrase.indexOf(word) + 1}. {word}</SelectedBubbleText>
+            <SelectedBubbleText>{index + 1}. {word.value}</SelectedBubbleText>
           </SelectedBubble>
         )}
         {hasVerifyError &&
@@ -58,12 +59,12 @@ function OnboardingVerify (props: Props) {
       <RecoveryPhraseContainer>
         {recoveryPhrase.map((word) =>
           <RecoveryBubble
-            key={word}
+            key={word.id}
             onClick={addWord(word)}
             disabled={sortedPhrase.includes(word)}
             isSelected={sortedPhrase.includes(word)}
           >
-            <RecoveryBubbleText isSelected={sortedPhrase.includes(word)}>{word}</RecoveryBubbleText>
+            <RecoveryBubbleText isSelected={sortedPhrase.includes(word)}>{word.value}</RecoveryBubbleText>
           </RecoveryBubble>
         )}
       </RecoveryPhraseContainer>

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -156,3 +156,8 @@ export interface WalletAPIHandler {
   lockWallet: () => Promise<void>
   unlockWallet: (password: string) => Promise<void>
 }
+
+export interface RecoveryObject {
+  value: string,
+  id: number
+}

--- a/components/brave_wallet_ui/stories/mock-data/user-accounts.ts
+++ b/components/brave_wallet_ui/stories/mock-data/user-accounts.ts
@@ -24,7 +24,7 @@ export const recoveryPhrase = [
   'velvet',
   'wishful',
   'span',
-  'celery',
+  'bowl',
   'atoms',
   'stone',
   'parent',

--- a/components/brave_wallet_ui/stories/screens/onboarding.tsx
+++ b/components/brave_wallet_ui/stories/screens/onboarding.tsx
@@ -7,7 +7,7 @@ import {
   OnboardingVerify,
   OnboardingCreatePassword
 } from '../../components/desktop'
-
+import { RecoveryObject } from '../../constants/types'
 import { BackButton } from '../../components/shared'
 
 export interface Props {
@@ -21,7 +21,7 @@ function Onboarding (props: Props) {
   const [onboardingStep, setOnboardingStep] = React.useState<number>(0)
   const [backupTerms, setBackupTerms] = React.useState<boolean>(false)
   const [backedUp, setBackedUp] = React.useState<boolean>(false)
-  const [sortedPhrase, setSortedPhrase] = React.useState<string[]>([])
+  const [sortedPhrase, setSortedPhrase] = React.useState<RecoveryObject[]>([])
   const [verifyError, setVerifyError] = React.useState<boolean>(false)
   const [password, setPassword] = React.useState<string>('')
   const [confirmedPassword, setConfirmedPassword] = React.useState<string>('')
@@ -59,13 +59,13 @@ function Onboarding (props: Props) {
     }
   }
 
-  const selectWord = (word: string) => {
+  const selectWord = (word: RecoveryObject) => {
     const newList = [...sortedPhrase, word]
     setSortedPhrase(newList)
     setVerifyError(false)
   }
 
-  const unSelectWord = (word: string) => {
+  const unSelectWord = (word: RecoveryObject) => {
     const newList = sortedPhrase.filter((key) => key !== word)
     setSortedPhrase(newList)
   }
@@ -78,7 +78,7 @@ function Onboarding (props: Props) {
       array[i] = array[j]
       array[j] = temp
     }
-    return array
+    return array.map((str, index) => ({ value: str, id: index + 1 }))
   }, [recoveryPhrase])
 
   const showError = () => {
@@ -87,7 +87,7 @@ function Onboarding (props: Props) {
   }
 
   const checkPhrase = () => {
-    if (sortedPhrase.length === recoveryPhrase.length && sortedPhrase.every((v, i) => v === recoveryPhrase[i])) {
+    if (sortedPhrase.length === recoveryPhrase.length && sortedPhrase.every((v, i) => v.value === recoveryPhrase[i])) {
       nextStep()
     } else {
       setSortedPhrase([])


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/16036>

The Bug - On the verify recovery phrase page, if the keyphrase contained 2 of the same words
and you selected one of them, it would disable both buttons not allowing you to select the second one.

The Fix - Mapped over the `Recovery Phrase` string[] and gave each string a unique `id` to check against while sorting.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. `npm run storybook`
2. Confirm that storybook shows the new component.
3. Check functionality of the new component.

https://user-images.githubusercontent.com/40611140/119192971-2b2c6300-ba3e-11eb-995e-ed594a1367e4.mov
