### PR TITLE
Remove duplicated menu separator after remove translate menu item

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -161,6 +161,13 @@ source_set("ui") {
       "views/toolbar/bookmark_button.h",
     ]
 
+    if (use_aura) {
+      sources += [
+        "views/renderer_context_menu/brave_render_view_context_menu_views.cc",
+        "views/renderer_context_menu/brave_render_view_context_menu_views.h",
+      ]
+    }
+
     if (enable_sparkle) {
       sources += [
         "views/update_recommended_message_box_mac.h",

--- a/browser/ui/views/renderer_context_menu/brave_render_view_context_menu_views.cc
+++ b/browser/ui/views/renderer_context_menu/brave_render_view_context_menu_views.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/renderer_context_menu/brave_render_view_context_menu_views.h"
+
+BraveRenderViewContextMenuViews::BraveRenderViewContextMenuViews(
+    content::RenderFrameHost* render_frame_host,
+    const content::ContextMenuParams& params)
+    : RenderViewContextMenuViews(render_frame_host, params) {}
+
+BraveRenderViewContextMenuViews::~BraveRenderViewContextMenuViews() = default;
+
+// static
+RenderViewContextMenuViews* BraveRenderViewContextMenuViews::Create(
+    content::RenderFrameHost* render_frame_host,
+    const content::ContextMenuParams& params) {
+  return new BraveRenderViewContextMenuViews(render_frame_host, params);
+}
+
+void BraveRenderViewContextMenuViews::Show() {
+  // Removes duplicated separator if any. The duplicated separator may appear
+  // in |BraveRenderViewContextMenu::InitMenu| after remove the translate menu
+  // item.
+  RemoveAdjacentSeparators();
+  RenderViewContextMenuViews::Show();
+}

--- a/browser/ui/views/renderer_context_menu/brave_render_view_context_menu_views.h
+++ b/browser/ui/views/renderer_context_menu/brave_render_view_context_menu_views.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_RENDERER_CONTEXT_MENU_BRAVE_RENDER_VIEW_CONTEXT_MENU_VIEWS_H_
+#define BRAVE_BROWSER_UI_VIEWS_RENDERER_CONTEXT_MENU_BRAVE_RENDER_VIEW_CONTEXT_MENU_VIEWS_H_
+
+#include "chrome/browser/ui/views/renderer_context_menu/render_view_context_menu_views.h"
+
+class BraveRenderViewContextMenuViews : public RenderViewContextMenuViews {
+ public:
+  ~BraveRenderViewContextMenuViews() override;
+  BraveRenderViewContextMenuViews(const BraveRenderViewContextMenuViews&) =
+      delete;
+  BraveRenderViewContextMenuViews& operator=(
+      const BraveRenderViewContextMenuViews&) = delete;
+
+  // Factory function to create an instance.
+  static RenderViewContextMenuViews* Create(
+      content::RenderFrameHost* render_frame_host,
+      const content::ContextMenuParams& params);
+
+  void Show() override;
+
+ protected:
+  BraveRenderViewContextMenuViews(content::RenderFrameHost* render_frame_host,
+                                  const content::ContextMenuParams& params);
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_RENDERER_CONTEXT_MENU_BRAVE_RENDER_VIEW_CONTEXT_MENU_VIEWS_H_

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -321,6 +321,8 @@ void BraveRenderViewContextMenu::InitMenu() {
 #endif
 
   // Only show the translate item when go-translate is enabled.
+  // This removes menu item, but keeps the duplicated separator. The duplicated
+  // separator is removed in |BraveRenderViewContextMenuViews::Show|
 #if !BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
   index = menu_model_.GetIndexOfCommandId(IDC_CONTENT_CONTEXT_TRANSLATE);
   if (index != -1)

--- a/chromium_src/chrome/browser/ui/views/tab_contents/DEPS
+++ b/chromium_src/chrome/browser/ui/views/tab_contents/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+../../../../../../../chrome/browser/ui/views/tab_contents",
+]

--- a/chromium_src/chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views.cc
+++ b/chromium_src/chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views.cc
@@ -1,0 +1,10 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/renderer_context_menu/brave_render_view_context_menu_views.h"
+
+#define RenderViewContextMenuViews BraveRenderViewContextMenuViews
+#include "../../../../../../../chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views.cc"
+#undef RenderViewContextMenuViews


### PR DESCRIPTION

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15714

Sometimes after removing the Translate menu item, separator item is duplicated.
This PR removes the duplicated separator, if required.

Not related to the sync options on Nightly `1.27.4` at least.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open the website of other language than your system has
2. Invoke the context menu
3. Ensure there are no double separators one by one, as on https://github.com/brave/brave-browser/issues/15714 screenshots.