### PR TITLE
Check local_device_info to avoid crash on reset (uplift to 1.26.x)

### DIFF
--- a/components/brave_sync/profile_sync_service_helper.cc
+++ b/components/brave_sync/profile_sync_service_helper.cc
@@ -30,6 +30,13 @@ void ResetSync(syncer::BraveProfileSyncService* sync_service,
   const syncer::DeviceInfo* local_device_info =
       device_info_service->GetLocalDeviceInfoProvider()->GetLocalDeviceInfo();
 
+  // Remove DCHECK when will be found the reason of the issue
+  // https://github.com/brave/brave-browser/issues/16066 .
+  DCHECK(local_device_info);
+  if (!local_device_info) {
+    return;
+  }
+
   sync_service->SuspendDeviceObserverForOwnReset();
 
   tracker->DeleteDeviceInfo(


### PR DESCRIPTION
Uplift of #8929
Resolves https://github.com/brave/brave-browser/issues/16066

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.