### PR TITLE
Get context from frame_tree_node_id in AdblockCnameResolveHostClient (uplift to 1.26.x)

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -91,9 +91,17 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
     if (secure_dns_config.mode() == net::SecureDnsMode::kSecure)
       optional_parameters->source = net::HostResolverSource::DNS;
 
+    auto* web_contents =
+        content::WebContents::FromFrameTreeNodeId(ctx->frame_tree_node_id);
+    if (!web_contents) {
+      start_time_ = base::TimeTicks::Now();
+      this->OnComplete(net::ERR_FAILED, net::ResolveErrorInfo(), base::nullopt);
+      return;
+    }
+
     network::mojom::NetworkContext* network_context =
         content::BrowserContext::GetDefaultStoragePartition(
-            ctx->browser_context)
+            web_contents->GetBrowserContext())
             ->GetNetworkContext();
 
     start_time_ = base::TimeTicks::Now();


### PR DESCRIPTION
Uplift of #8921
Resolves https://github.com/brave/brave-browser/issues/16062

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.