### PR TITLE
A possible crash for custom ad notifications when Activity is not in a good state (uplift to 1.26.x)

### DIFF
--- a/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsNotificationDialog.java
+++ b/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsNotificationDialog.java
@@ -22,7 +22,8 @@ import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import org.chromium.base.ContextUtils;
+import org.chromium.base.ActivityState;
+import org.chromium.base.ApplicationStatus;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveAdsNativeHelper;
@@ -149,10 +150,19 @@ public class BraveAdsNotificationDialog {
     }
 
     @CalledByNative
-    public static void showAdNotification(final String notificationId, final String origin,
-            final String title, final String body) {
-        BraveAdsNotificationDialog.showAdNotification(
-                BraveActivity.getBraveActivity(), notificationId, origin, title, body);
+    public static void showAdNotification(final String notificationId,
+            final String origin, final String title, final String body) {
+        Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
+        assert activity != null;
+        // We want to show ads only when activity is in started or resumed
+        // state
+        int state = ApplicationStatus.getStateForActivity(activity);
+        if (activity == null || (state != ActivityState.STARTED &&
+                    state != ActivityState.RESUMED))
+            return;
+
+        BraveAdsNotificationDialog.showAdNotification(activity, notificationId,
+            origin, title, body);
     }
 
     @CalledByNative


### PR DESCRIPTION
Uplift of #8944
Resolves https://github.com/brave/brave-browser/issues/16100

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.