### PR TITLE
Avoid CNAME uncloaking if a proxy is configured

### DIFF
--- a/browser/net/BUILD.gn
+++ b/browser/net/BUILD.gn
@@ -63,6 +63,7 @@ source_set("net") {
     "//brave/extensions:common",
     "//components/content_settings/core/browser",
     "//components/prefs",
+    "//components/proxy_config",
     "//components/user_prefs",
     "//content/public/browser",
     "//content/public/common",

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -258,20 +258,24 @@ bool ProxySettingsAllowUncloaking(content::BrowserContext* browser_context) {
 
   if (availability ==
       net::ProxyConfigService::ConfigAvailability::CONFIG_VALID) {
+    LOG(ERROR) << "CONFIG_VALID";
     // PROXY_LIST corresponds to SingleProxy mode.
     if (config.value().proxy_rules().type ==
         net::ProxyConfig::ProxyRules::Type::PROXY_LIST) {
+      LOG(ERROR) << "PROXY_LIST";
       can_uncloak = false;
     }
   } else if (availability ==
              net::ProxyConfigService::ConfigAvailability::CONFIG_PENDING) {
     // Fallback to not CNAME uncloaking if the proxy configuration cannot be
     // determined.
+    LOG(ERROR) << "CONFIG_PENDING";
     can_uncloak = false;
   }
 
   config_tracker->DetachFromPrefService();
 
+  LOG(ERROR) << can_uncloak;
   return can_uncloak;
 }
 
@@ -293,6 +297,8 @@ void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
           brave_shields::features::kBraveAdblockCnameUncloaking) &&
       ctx->browser_context && !ctx->browser_context->IsTor() &&
       ProxySettingsAllowUncloaking(ctx->browser_context);
+
+  LOG(ERROR) << "should_check_uncloaked: " << should_check_uncloaked;
 
   task_runner->PostTaskAndReplyWithResult(
       FROM_HERE,

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -258,24 +258,15 @@ bool ProxySettingsAllowUncloaking(content::BrowserContext* browser_context) {
 
   if (availability ==
       net::ProxyConfigService::ConfigAvailability::CONFIG_VALID) {
-    LOG(ERROR) << "CONFIG_VALID";
     // PROXY_LIST corresponds to SingleProxy mode.
     if (config.value().proxy_rules().type ==
         net::ProxyConfig::ProxyRules::Type::PROXY_LIST) {
-      LOG(ERROR) << "PROXY_LIST";
       can_uncloak = false;
     }
-  } else if (availability ==
-             net::ProxyConfigService::ConfigAvailability::CONFIG_PENDING) {
-    // Fallback to not CNAME uncloaking if the proxy configuration cannot be
-    // determined.
-    LOG(ERROR) << "CONFIG_PENDING";
-    can_uncloak = false;
   }
 
   config_tracker->DetachFromPrefService();
 
-  LOG(ERROR) << can_uncloak;
   return can_uncloak;
 }
 
@@ -297,8 +288,6 @@ void OnBeforeURLRequestAdBlockTP(const ResponseCallback& next_callback,
           brave_shields::features::kBraveAdblockCnameUncloaking) &&
       ctx->browser_context && !ctx->browser_context->IsTor() &&
       ProxySettingsAllowUncloaking(ctx->browser_context);
-
-  LOG(ERROR) << "should_check_uncloaked: " << should_check_uncloaked;
 
   task_runner->PostTaskAndReplyWithResult(
       FROM_HERE,


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16011

<details><summary>Caveats about the previous implementation (since updated)</summary>
<p>
Disclaimer: this doesn't seem like the right solution, but I'm opening this now to get discussion going on how it should best be done, and possibly to get it merged as a short-term fix. In particular:
</p>
<ul>
<li>The semantics of <code>ProxyConfigDictionary</code> are not quite what we're looking for. It'd be preferable to learn whether or not the proxy is in <code>SingleProxy</code> mode, but that's a private part of <code>UrlRequestContext</code> which I don't even see how to get here.</li>
<li>This is difficult to test appropriately. I've only been able to test it so far by manually adding <code>LOG</code> statements and checking whether or not the correct if-branch is selected when the NordVPN extension is installed (on Linux).</li>
</ul>
</details>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Install the [NordVPN extension](https://chrome.google.com/webstore/detail/nordvpn-%E2%80%94-1-vpn-chrome-ex/fjoaledfpmneenckfbpdfhkmimnjocfa/related).
- Sign in to the extension via the menu in the plugin area at the top-right of the browser (NordVPN credentials are available in 1Password).
- In the extension UI, connect to the VPN. Use a location that is distinctly different from your actual location.
- Visit http://browserleaks.com/dns and begin the test.
- Once the test is complete, verify that the "Your DNS Servers" section does not show your actual location.