### PR TITLE
FTX New Tab Page: Fix timing issue with first authenticated data fetch

### DIFF
--- a/components/brave_new_tab_ui/widgets/ftx/ftx_reducer.ts
+++ b/components/brave_new_tab_ui/widgets/ftx/ftx_reducer.ts
@@ -72,8 +72,6 @@ function stateWithBalancesAndMarkets (state: FTXState, incomingMarketData: chrom
 }
 
 reducer.on(Actions.initialized, (state, payload) => {
-  console.log('ftx initialized', payload)
-
   return {
     ...stateWithBalancesAndMarkets(state, payload.marketData, payload.balances),
     hasInitialized: true,


### PR DESCRIPTION
Resolves a timing issue where widget UI initial data is fetched before auth token response is received.

Since the widget knows it's meant to be connected from being on a page with url query `?ftxAuthSuccess`, it can retry initial data fetch until data with authenticated information is retrieved.

It would be great to have an observable and fire events that all frontends could respond to by showing updated data, but this is a good short-term solution for non-permanently-shown UI.

Resolves https://github.com/brave/brave-browser/issues/16122

## Test Plan
- Slow down your internet connection by using a proxy that can be configured for high latency.
- Run the browser with a fresh profile
- Open 1 NTP
- Connect to FTX
- Ensure when the auth flow completes and you are back on the NTP that FTX is showing the "connected" state and not the "disconnected" state.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A


