### PR TITLE
Fix#5775 - About page now shows Brave URLs instead of Chrome

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/DEPS
+++ b/chromium_src/chrome/browser/ui/webui/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+third_party/re2",
+]

--- a/chromium_src/chrome/browser/ui/webui/about_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/about_ui.cc
@@ -1,19 +1,26 @@
-/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/re2/src/re2/re2.h"
+
 #define CHROME_INTERNAL_URLS_TO_BRAVE                                 \
-  const std::string CHROME = "Chrome";                                \
-  const std::string BRAVE = "Brave";                                  \
-  const std::string TAG_CHROME_PROTOCOL = ">chrome:";                 \
-  const std::string TAG_BRAVE_PROTOCOL = ">brave:";                   \
-  const std::string SPACE_CHROME_PROTOCOL = " chrome:";               \
-  const std::string SPACE_BRAVE_PROTOCOL = " brave:";                 \
-  RE2::GlobalReplace(&html, CHROME, BRAVE);                           \
-  RE2::GlobalReplace(&html, TAG_CHROME_PROTOCOL, TAG_BRAVE_PROTOCOL); \
-  RE2::GlobalReplace(&html, SPACE_CHROME_PROTOCOL, SPACE_BRAVE_PROTOCOL);
+  const std::string chrome_header = "Chrome URLs";                    \
+  const std::string brave_header = "Brave URLs";                      \
+  const std::string chrome_pages_header = "List of Chrome URLs";      \
+  const std::string brave_pages_header = "List of Brave URLs";        \
+  const std::string chrome_internal_pages_header =                    \
+      "List of chrome://internals pages";                             \
+  const std::string brave_internal_pages_header =                     \
+      "List of brave://internals pages";                              \
+  const std::string chrome_url_list = ">chrome://";                   \
+  const std::string brave_url_list = ">brave://";                     \
+  RE2::GlobalReplace(&html, chrome_header, brave_header);             \
+  RE2::GlobalReplace(&html, chrome_pages_header, brave_pages_header); \
+  RE2::GlobalReplace(&html, chrome_internal_pages_header,             \
+                     brave_internal_pages_header);                    \
+  RE2::GlobalReplace(&html, chrome_url_list, brave_url_list);
 
 #include "../../../../../../chrome/browser/ui/webui/about_ui.cc"
 #undef CHROME_INTERNAL_URLS_TO_BRAVE

--- a/chromium_src/chrome/browser/ui/webui/about_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/about_ui.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/re2/src/re2/re2.h"
+#define CHROME_INTERNAL_URLS_TO_BRAVE                                 \
+  const std::string CHROME = "Chrome";                                \
+  const std::string BRAVE = "Brave";                                  \
+  const std::string TAG_CHROME_PROTOCOL = ">chrome:";                 \
+  const std::string TAG_BRAVE_PROTOCOL = ">brave:";                   \
+  const std::string SPACE_CHROME_PROTOCOL = " chrome:";               \
+  const std::string SPACE_BRAVE_PROTOCOL = " brave:";                 \
+  RE2::GlobalReplace(&html, CHROME, BRAVE);                           \
+  RE2::GlobalReplace(&html, TAG_CHROME_PROTOCOL, TAG_BRAVE_PROTOCOL); \
+  RE2::GlobalReplace(&html, SPACE_CHROME_PROTOCOL, SPACE_BRAVE_PROTOCOL);
+
+#include "../../../../../../chrome/browser/ui/webui/about_ui.cc"
+#undef CHROME_INTERNAL_URLS_TO_BRAVE

--- a/patches/chrome-browser-ui-webui-about_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-about_ui.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/webui/about_ui.cc b/chrome/browser/ui/webui/about_ui.cc
+index ea75f9808fc903ec030f38d49970099ffbbe760c..6fb3ea330fb244273c81e0c8eec924876c186b70 100644
+--- a/chrome/browser/ui/webui/about_ui.cc
++++ b/chrome/browser/ui/webui/about_ui.cc
+@@ -577,6 +577,7 @@ std::string ChromeURLs() {
+   html += "</ul>\n";
+ 
+   AppendFooter(&html);
++  CHROME_INTERNAL_URLS_TO_BRAVE 
+   return html;
+ }
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#5775.

Currently chromium generates the entire static html page and returns it as a single string. So replacing all instances of "chrome" with "brave" before returning the final string should be sufficient.

![image](https://user-images.githubusercontent.com/28645536/120096896-83a0e600-c14b-11eb-9384-b943f279c421.png)
![image](https://user-images.githubusercontent.com/28645536/120096918-92879880-c14b-11eb-8c69-4e5277de2889.png)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

