### PR TITLE
Move sources from //chrome/browser to //brave/browser/component_updater

### DIFF
--- a/browser/component_updater/BUILD.gn
+++ b/browser/component_updater/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+source_set("component_updater") {
+  sources = [
+    "brave_component_installer.cc",
+    "brave_component_installer.h",
+    "brave_component_updater_delegate.cc",
+    "brave_component_updater_delegate.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/components/brave_component_updater/browser",
+    "//chrome/browser:browser_process",
+    "//components/component_updater",
+    "//components/crx_file",
+    "//components/update_client",
+    "//crypto",
+  ]
+}

--- a/browser/component_updater/sources.gni
+++ b/browser/component_updater/sources.gni
@@ -4,20 +4,14 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 brave_browser_component_updater_sources = [
-  "//brave/browser/component_updater/brave_component_installer.cc",
-  "//brave/browser/component_updater/brave_component_installer.h",
   "//brave/browser/component_updater/brave_component_updater_configurator.cc",
   "//brave/browser/component_updater/brave_component_updater_configurator.h",
-  "//brave/browser/component_updater/brave_component_updater_delegate.cc",
-  "//brave/browser/component_updater/brave_component_updater_delegate.h",
 ]
 
 brave_browser_component_updater_deps = [
   "//base",
   "//brave/common:switches",
-  "//brave/components/brave_component_updater/browser",
   "//chrome/browser:browser_process",
-  "//chrome/common:constants",
   "//components/component_updater",
   "//components/crx_file",
   "//components/prefs",
@@ -28,6 +22,5 @@ brave_browser_component_updater_deps = [
   "//components/update_client:patch_impl",
   "//components/update_client:unzip_impl",
   "//content/public/browser",
-  "//crypto",
   "//services/network/public/cpp",
 ]

--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -55,6 +55,7 @@ source_set("extensions") {
     ":resources",
     "//base",
     "//brave/app:brave_generated_resources_grit",
+    "//brave/browser/component_updater",
     "//brave/browser/profiles",
     "//brave/browser/webcompat_reporter",
     "//brave/common",

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -90,6 +90,7 @@ brave_chrome_browser_deps = [
   "//brave/browser/brave_ads/notifications",
   "//brave/browser/brave_stats:stats_updater",
   "//brave/browser/browsing_data",
+  "//brave/browser/component_updater",
   "//brave/browser/content_settings",
   "//brave/browser/ephemeral_storage",
   "//brave/browser/gcm_driver",


### PR DESCRIPTION
Currently, all the sources from brave/browser/component_updater are
part of the //chrome/browser GN target:

  brave_browser_component_updater_sources = [
    "//brave/browser/component_updater/brave_component_installer.cc",
    "//brave/browser/component_updater/brave_component_installer.h",
    "//brave/browser/component_updater/brave_component_updater_configurator.cc",
    "//brave/browser/component_updater/brave_component_updater_configurator.h",
    "//brave/browser/component_updater/brave_component_updater_delegate.cc",
    "//brave/browser/component_updater/brave_component_updater_delegate.h",
  ]

However, only brave_component_updater_configurator.{h,cc} depends
really on //chrome/browser (due to SystemNetworkContextManager), meaning
that we could move the other bits back to their own GN target, without
violating any GN dependency, so let's do that to reduce the size of the
monolithic //chrome/browser target.

Resolves https://github.com/brave/brave-browser/issues/16176

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A