### PR TITLE
Temporarily revert U2F sig check for Ledger U2F transport support

### DIFF
--- a/patches/device-fido-authenticator_get_assertion_response.cc.patch
+++ b/patches/device-fido-authenticator_get_assertion_response.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/device/fido/authenticator_get_assertion_response.cc b/device/fido/authenticator_get_assertion_response.cc
+index 833dbe83c042d035616a92f223e88f89c343dcec..55361ece642e244ae68134858d6ca72b24b0e7f9 100644
+--- a/device/fido/authenticator_get_assertion_response.cc
++++ b/device/fido/authenticator_get_assertion_response.cc
+@@ -54,7 +54,7 @@ AuthenticatorGetAssertionResponse::CreateFromU2fSignResponse(
+ 
+   bssl::UniquePtr<ECDSA_SIG> parsed_sig(
+       ECDSA_SIG_from_bytes(signature.data(), signature.size()));
+-  if (!parsed_sig) {
++  if (false && !parsed_sig) {
+     FIDO_LOG(ERROR)
+         << "Rejecting U2F assertion response with invalid signature";
+     return base::nullopt;

--- a/patches/device-fido-virtual_u2f_device.cc.patch
+++ b/patches/device-fido-virtual_u2f_device.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/device/fido/virtual_u2f_device.cc b/device/fido/virtual_u2f_device.cc
+index 789c81b88dbf4f505d8f39e4e3ace9fbe97bcd44..afd6ecb22ebae8ceed5427800933e2a6c77030d5 100644
+--- a/device/fido/virtual_u2f_device.cc
++++ b/device/fido/virtual_u2f_device.cc
+@@ -148,7 +148,7 @@ base::Optional<std::vector<uint8_t>> VirtualU2fDevice::DoRegister(
+ 
+   if (mutable_state()->u2f_invalid_public_key) {
+     // Flip a bit in the x-coordinate, which will push the point off the curve.
+-    x962[10] ^= 1;
++    // x962[10] ^= 1;
+   }
+ 
+   // Our key handles are simple hashes of the public key.
+@@ -253,7 +253,7 @@ base::Optional<std::vector<uint8_t>> VirtualU2fDevice::DoSign(
+   if (mutable_state()->u2f_invalid_signature) {
+     // Flip a bit in the ASN.1 header to make the signature structurally
+     // invalid.
+-    sig[0] ^= 1;
++    // sig[0] ^= 1;
+   }
+ 
+   // Add signature for full response.


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16204

This is tracking a partial revert of this patch https://github.com/chromium/chromium/commit/07ef8d73c7b010a549c9bb960c6f7c73f1346fe5
which makes the U2F transport more strict. It breaks Ledger support. 
We're going to move our ledger compatibility to webhid instead, but this will buy us time to do that.
See the above Slack links for an internal discussion on this.

Issue to revert the revert here:
https://github.com/brave/brave-browser/issues/16205

Issue to implement webhid for our wallet here:
https://github.com/brave/brave-browser/issues/16206


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
https://bravesoftware.slack.com/archives/CBP2ZKC0H/p1622651391047000?thread_ts=1622102662.023400&cid=CBP2ZKC0H

https://bravesoftware.slack.com/archives/CBP2ZKC0H/p1622653482048200?thread_ts=1622102662.023400&cid=CBP2ZKC0H

- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

