### PR TITLE
Temporarily revert U2F sig check for Ledger U2F transport support (uplift to 1.26.x)

### DIFF
--- a/patches/device-fido-authenticator_get_assertion_response.cc.patch
+++ b/patches/device-fido-authenticator_get_assertion_response.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/device/fido/authenticator_get_assertion_response.cc b/device/fido/authenticator_get_assertion_response.cc
+index 833dbe83c042d035616a92f223e88f89c343dcec..55361ece642e244ae68134858d6ca72b24b0e7f9 100644
+--- a/device/fido/authenticator_get_assertion_response.cc
++++ b/device/fido/authenticator_get_assertion_response.cc
+@@ -54,7 +54,7 @@ AuthenticatorGetAssertionResponse::CreateFromU2fSignResponse(
+ 
+   bssl::UniquePtr<ECDSA_SIG> parsed_sig(
+       ECDSA_SIG_from_bytes(signature.data(), signature.size()));
+-  if (!parsed_sig) {
++  if (false && !parsed_sig) {
+     FIDO_LOG(ERROR)
+         << "Rejecting U2F assertion response with invalid signature";
+     return base::nullopt;

--- a/patches/device-fido-virtual_u2f_device.cc.patch
+++ b/patches/device-fido-virtual_u2f_device.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/device/fido/virtual_u2f_device.cc b/device/fido/virtual_u2f_device.cc
+index 789c81b88dbf4f505d8f39e4e3ace9fbe97bcd44..afd6ecb22ebae8ceed5427800933e2a6c77030d5 100644
+--- a/device/fido/virtual_u2f_device.cc
++++ b/device/fido/virtual_u2f_device.cc
+@@ -148,7 +148,7 @@ base::Optional<std::vector<uint8_t>> VirtualU2fDevice::DoRegister(
+ 
+   if (mutable_state()->u2f_invalid_public_key) {
+     // Flip a bit in the x-coordinate, which will push the point off the curve.
+-    x962[10] ^= 1;
++    // x962[10] ^= 1;
+   }
+ 
+   // Our key handles are simple hashes of the public key.
+@@ -253,7 +253,7 @@ base::Optional<std::vector<uint8_t>> VirtualU2fDevice::DoSign(
+   if (mutable_state()->u2f_invalid_signature) {
+     // Flip a bit in the ASN.1 header to make the signature structurally
+     // invalid.
+-    sig[0] ^= 1;
++    // sig[0] ^= 1;
+   }
+ 
+   // Add signature for full response.


### PR DESCRIPTION
Uplift of #8995
Resolves https://github.com/brave/brave-browser/issues/16204

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.