### PR TITLE
Add flexible width support for permission dialog.

### DIFF
--- a/chromium_src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc
@@ -137,11 +137,11 @@ class PermissionLifetimeCombobox : public views::Combobox,
   std::vector<permissions::PermissionLifetimeOption> lifetime_options_;
 };
 
-void AddPermissionLifetimeComboboxIfNeeded(
+views::View* AddPermissionLifetimeComboboxIfNeeded(
     views::BubbleDialogDelegateView* dialog_delegate_view,
     permissions::PermissionPrompt::Delegate* delegate) {
   if (!ShouldShowLifetimeOptions(delegate)) {
-    return;
+    return nullptr;
   }
 
   // Create a single line container for a label and a combobox.
@@ -166,7 +166,7 @@ void AddPermissionLifetimeComboboxIfNeeded(
       ->SetFlexForView(combobox, 1);
 
   // Add the container to the view.
-  dialog_delegate_view->AddChildView(std::move(container));
+  return dialog_delegate_view->AddChildView(std::move(container));
 }
 
 void AddFootnoteViewIfNeeded(
@@ -217,8 +217,16 @@ void AddFootnoteViewIfNeeded(
 
 #define BRAVE_PERMISSION_PROMPT_BUBBLE_VIEW                               \
   AddAdditionalWidevineViewControlsIfNeeded(this, delegate_->Requests()); \
-  AddPermissionLifetimeComboboxIfNeeded(this, delegate_);                 \
-  AddFootnoteViewIfNeeded(this, browser_);
+  auto* permission_lifetime_view =                                        \
+      AddPermissionLifetimeComboboxIfNeeded(this, delegate_);             \
+  AddFootnoteViewIfNeeded(this, browser_);                                \
+  if (permission_lifetime_view) {                                         \
+    set_fixed_width(                                                      \
+        std::max(GetPreferredSize().width(),                              \
+                 permission_lifetime_view->GetPreferredSize().width()) +  \
+        margins().width());                                               \
+    set_should_ignore_snapping(true);                                     \
+  }
 
 #include "../../../../../../../chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc"
 #undef BRAVE_PERMISSION_PROMPT_BUBBLE_VIEW

--- a/chromium_src/ui/DEPS
+++ b/chromium_src/ui/DEPS
@@ -3,10 +3,10 @@ include_rules = [
   "+../../../../ui/native_theme",
   "+../../../../../ui/accessibility/platform",
   "+../../../../../ui/base/resource",
-  "+../../../../../ui/base/resource",
   "+../../../../../ui/base/webui",
   "+../../../../../ui/views/bubble",
   "+../../../../../ui/views/controls",
+  "+../../../../../ui/views/window",
   "+../../../../../../ui/views/controls/button",
   "+ui",
 ]

--- a/chromium_src/ui/views/bubble/bubble_frame_view.cc
+++ b/chromium_src/ui/views/bubble/bubble_frame_view.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ui/base/ui_base_types.h"
+
+#define DIALOG_BUTTON_NONE \
+  DIALOG_BUTTON_NONE && !dialog_delegate->should_ignore_snapping()
+
+#include "../../../../../ui/views/bubble/bubble_frame_view.cc"
+
+#undef DIALOG_BUTTON_NONE

--- a/chromium_src/ui/views/window/dialog_delegate.h
+++ b/chromium_src/ui/views/window/dialog_delegate.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_WINDOW_DIALOG_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_WINDOW_DIALOG_DELEGATE_H_
+
+#define set_use_custom_frame                                              \
+  set_should_ignore_snapping(bool should_ignore_snapping) {               \
+    should_ignore_snapping_ = should_ignore_snapping;                     \
+  }                                                                       \
+  bool should_ignore_snapping() const { return should_ignore_snapping_; } \
+                                                                          \
+ private:                                                                 \
+  bool should_ignore_snapping_ = false;                                   \
+                                                                          \
+ public:                                                                  \
+  void set_use_custom_frame
+
+#include "../../../../../ui/views/window/dialog_delegate.h"
+
+#undef set_use_custom_frame
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_WINDOW_DIALOG_DELEGATE_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Set dialog width using preferred permission lifetime combobox size.

Resolves https://github.com/brave/brave-browser/issues/16219

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

