### PR TITLE
Fix double dep path substitution.

### DIFF
--- a/patches/chrome-browser-resources-tools-optimize_webui.py.patch
+++ b/patches/chrome-browser-resources-tools-optimize_webui.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/resources/tools/optimize_webui.py b/chrome/browser/resources/tools/optimize_webui.py
-index f41a89bf816fe8cdba73d3700399ce55e94a7e99..8381a1b5be429ef32861c2e9ea36655fd0e114c7 100755
+index f41a89bf816fe8cdba73d3700399ce55e94a7e99..6ee5dee93a04bf1bb7a26346d47b3cf8a9c9ba40 100755
 --- a/chrome/browser/resources/tools/optimize_webui.py
 +++ b/chrome/browser/resources/tools/optimize_webui.py
 @@ -26,6 +26,7 @@ import node_modules
@@ -10,11 +10,12 @@ index f41a89bf816fe8cdba73d3700399ce55e94a7e99..8381a1b5be429ef32861c2e9ea36655f
  for excluded_file in [
    'resources/polymer/v1_0/web-animations-js/web-animations-next-lite.min.js',
    'resources/css/roboto.css',
-@@ -70,6 +71,7 @@ def _update_dep_file(in_folder, args, manifest):
-   # that we can map it to the correct source file path below.
-   request_list = map(lambda dep: _get_dep_path(dep, args.host_url, in_path),
-                      request_list)
-+  for (redirect_url, file_path) in [ ('chrome://brave-resources/', _BR_RESOURCES_PATH), ('//brave-resources/', _BR_RESOURCES_PATH) ]: request_list = map(lambda dep: _get_dep_path(dep, redirect_url, file_path), request_list)
+@@ -50,6 +51,8 @@ def _request_list_path(out_path, host_url):
+   return os.path.join(out_path, host + '_requestlist.txt')
  
-   deps = map(os.path.normpath, request_list)
- 
+ def _get_dep_path(dep, host_url, in_path):
++  for brave_host_url in ['chrome://brave-resources/', '//brave-resources/']:
++    if dep.startswith(brave_host_url): return dep.replace(brave_host_url, os.path.relpath(_BR_RESOURCES_PATH, _CWD))
+   if dep.startswith(host_url):
+     return dep.replace(host_url, os.path.relpath(in_path, _CWD))
+   elif not (dep.startswith('chrome://') or dep.startswith('//')):


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Fix optimize_webui.py logic to not generate wrong paths for dep files.
First, chromium code do `_get_dep_path` call and then we do same thing on already processed paths. I moved our processing code to `_get_dep_path` to handle our specific paths and return our fixed paths.

Resolves https://github.com/brave/brave-browser/issues/16224

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

