### PR TITLE
settings: Add option to toggle speedreader pref

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -270,6 +270,9 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <message name="IDS_SETTINGS_BRAVE_MRU_CYCLING_LABEL" desc="The label to activate MRU cycling with Ctrl-tab">
         Cycle through the most recently used tabs with Ctrl-Tab
       </message>
+      <message name="IDS_SETTINGS_SPEEDREADER_LABEL" desc="The label to activate Speedreader">
+        Automatically distill readable pages with Speedreader
+      </message>
       <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_AUTOCOMPLETE_IN_ADDRESS_BAR" desc="The label for settings switch controlling the showing of autocomplete in address bar">
         Show autocomplete in address bar
       </message>

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -271,7 +271,10 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         Cycle through the most recently used tabs with Ctrl-Tab
       </message>
       <message name="IDS_SETTINGS_SPEEDREADER_LABEL" desc="The label to activate Speedreader">
-        Automatically distill readable pages with Speedreader
+        Speedreader
+      </message>
+      <message name="IDS_SETTINGS_SPEEDREADER_SUB_LABEL" desc="The sub-label describing Speedreader">
+        Articles automatically load in reader mode, saving you time
       </message>
       <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_SHOW_AUTOCOMPLETE_IN_ADDRESS_BAR" desc="The label for settings switch controlling the showing of autocomplete in address bar">
         Show autocomplete in address bar

--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -11,6 +11,7 @@ import("//brave/components/ftx/browser/buildflags/buildflags.gni")
 import("//brave/components/gemini/browser/buildflags/buildflags.gni")
 import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//brave/components/sidebar/buildflags/buildflags.gni")
+import("//brave/components/speedreader/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//build/config/features.gni")
 import("//components/gcm_driver/config.gni")
@@ -70,6 +71,7 @@ source_set("extensions") {
     "//brave/components/decentralized_dns/buildflags",
     "//brave/components/ipfs/buildflags",
     "//brave/components/sidebar/buildflags",
+    "//brave/components/speedreader",
     "//brave/components/tor/buildflags",
     "//chrome/browser/extensions",
     "//chrome/common",

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -17,6 +17,7 @@
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/sidebar/buildflags/buildflags.h"
+#include "brave/components/speedreader/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/extensions/api/settings_private/prefs_util.h"
 #include "chrome/common/extensions/api/settings_private.h"
@@ -47,6 +48,10 @@
 
 #if BUILDFLAG(ENABLE_SIDEBAR)
 #include "brave/components/sidebar/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+#include "brave/components/speedreader/speedreader_pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
@@ -123,6 +128,10 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
 #if BUILDFLAG(ENABLE_SIDEBAR)
   (*s_brave_allowlist)[sidebar::kSidebarShowOption] =
       settings_api::PrefType::PREF_TYPE_NUMBER;
+#endif
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+  (*s_brave_allowlist)[speedreader::kSpeedreaderPrefEnabled] =
+      settings_api::PrefType::PREF_TYPE_BOOLEAN;
 #endif
   // new tab prefs
   (*s_brave_allowlist)[kNewTabPageShowSponsoredImagesBackgroundImage] =

--- a/browser/resources/settings/brave_overrides/appearance_page.js
+++ b/browser/resources/settings/brave_overrides/appearance_page.js
@@ -69,6 +69,13 @@ RegisterPolymerTemplateModifications({
           label="${I18nBehavior.i18n('mruCyclingSettingLabel')}">
         </settings-toggle-button>
       `)
+      zoomLevel.parentNode.insertAdjacentHTML('afterend', `
+      <settings-toggle-button
+        class="hr"
+        pref="{{prefs.brave.speedreader.enabled}}"
+        label="${I18nBehavior.i18n('speedreaderSettingLabel')}">
+      </settings-toggle-button>
+    `)
     }
     // Super referral themes prefs
     const pages = templateContent.getElementById('pages')

--- a/browser/resources/settings/brave_overrides/appearance_page.js
+++ b/browser/resources/settings/brave_overrides/appearance_page.js
@@ -69,13 +69,18 @@ RegisterPolymerTemplateModifications({
           label="${I18nBehavior.i18n('mruCyclingSettingLabel')}">
         </settings-toggle-button>
       `)
-      zoomLevel.parentNode.insertAdjacentHTML('afterend', `
-      <settings-toggle-button
-        class="hr"
-        pref="{{prefs.brave.speedreader.enabled}}"
-        label="${I18nBehavior.i18n('speedreaderSettingLabel')}">
-      </settings-toggle-button>
-    `)
+      const isSpeedreaderEnabled = loadTimeData.getBoolean('isSpeedreaderFeatureEnabled')
+      if (isSpeedreaderEnabled) {
+        zoomLevel.parentNode.insertAdjacentHTML('afterend', `
+          <settings-toggle-button
+            class="hr"
+            pref="{{prefs.brave.speedreader.enabled}}"
+            label="${I18nBehavior.i18n('speedreaderSettingLabel')}"
+            sub-label="${I18nBehavior.i18n('speedreaderSettingSubLabel')}"
+            learn-more-url="${I18nBehavior.i18n('speedreaderLearnMoreURL')}">
+          </settings-toggle-button>
+      `)
+      }
     }
     // Super referral themes prefs
     const pages = templateContent.getElementById('pages')

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/feature_list.h"
 #include "brave/browser/ntp_background_images/view_counter_service_factory.h"
 #include "brave/browser/resources/settings/grit/brave_settings_resources.h"
 #include "brave/browser/resources/settings/grit/brave_settings_resources_map.h"
@@ -20,6 +21,7 @@
 #include "brave/components/brave_sync/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "brave/components/sidebar/buildflags/buildflags.h"
+#include "brave/components/speedreader/buildflags.h"
 #include "brave/components/version_info/version_info.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
@@ -35,6 +37,10 @@
 
 #if BUILDFLAG(ENABLE_SIDEBAR)
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
+#endif
+
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+#include "brave/components/speedreader/features.h"
 #endif
 
 using ntp_background_images::ViewCounterServiceFactory;
@@ -82,5 +88,11 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
   // channels.
   html_source->AddBoolean("isSidebarFeatureEnabled",
                           sidebar::CanUseSidebar(profile));
+#endif
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+  // TODO(keur): Remove this when Speedreader feature enabled by default.
+  html_source->AddBoolean(
+      "isSpeedreaderFeatureEnabled",
+      base::FeatureList::IsEnabled(speedreader::kSpeedreaderFeature));
 #endif
 }

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
@@ -8,6 +8,7 @@
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
+#include "brave/common/url_constants.h"
 #include "brave/components/ipfs/ipfs_constants.h"
 #include "brave/components/ipfs/pref_names.h"
 #include "brave/components/sidebar/buildflags/buildflags.h"
@@ -104,6 +105,7 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
 #endif
     {"mruCyclingSettingLabel", IDS_SETTINGS_BRAVE_MRU_CYCLING_LABEL},
     {"speedreaderSettingLabel", IDS_SETTINGS_SPEEDREADER_LABEL},
+    {"speedreaderSettingSubLabel", IDS_SETTINGS_SPEEDREADER_SUB_LABEL},
     {"braveShieldsTitle", IDS_SETTINGS_BRAVE_SHIELDS_TITLE},
     {"braveShieldsDefaultsSectionTitle",
      IDS_SETTINGS_BRAVE_SHIELDS_DEFAULTS_TITLE},
@@ -302,6 +304,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
                          base::ASCIIToUTF16(kGoogleLoginLearnMoreURL));
   html_source->AddString("ipfsDNSLinkLearnMoreURL",
                          base::UTF8ToUTF16(kDNSLinkLearnMoreURL));
+  html_source->AddString("speedreaderLearnMoreURL",
+                         base::UTF8ToUTF16(kSpeedreaderLearnMoreUrl));
   html_source->AddString(
       "getMoreExtensionsUrl",
       base::ASCIIToUTF16(

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
@@ -103,6 +103,7 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
      IDS_SETTINGS_APPEARANCE_SETTINGS_SIDEBAR_DISABLED_DESC},
 #endif
     {"mruCyclingSettingLabel", IDS_SETTINGS_BRAVE_MRU_CYCLING_LABEL},
+    {"speedreaderSettingLabel", IDS_SETTINGS_SPEEDREADER_LABEL},
     {"braveShieldsTitle", IDS_SETTINGS_BRAVE_SHIELDS_TITLE},
     {"braveShieldsDefaultsSectionTitle",
      IDS_SETTINGS_BRAVE_SHIELDS_DEFAULTS_TITLE},


### PR DESCRIPTION
We need this setting since the speedreader bubble has a link to the
settings page.

Resolves https://github.com/brave/brave-browser/issues/16238

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

