### PR TITLE
Add flexible width support for permission dialog. (uplift to 1.26.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc
@@ -137,11 +137,11 @@ class PermissionLifetimeCombobox : public views::Combobox,
   std::vector<permissions::PermissionLifetimeOption> lifetime_options_;
 };
 
-void AddPermissionLifetimeComboboxIfNeeded(
+views::View* AddPermissionLifetimeComboboxIfNeeded(
     views::BubbleDialogDelegateView* dialog_delegate_view,
     permissions::PermissionPrompt::Delegate* delegate) {
   if (!ShouldShowLifetimeOptions(delegate)) {
-    return;
+    return nullptr;
   }
 
   // Create a single line container for a label and a combobox.
@@ -166,7 +166,7 @@ void AddPermissionLifetimeComboboxIfNeeded(
       ->SetFlexForView(combobox, 1);
 
   // Add the container to the view.
-  dialog_delegate_view->AddChildView(std::move(container));
+  return dialog_delegate_view->AddChildView(std::move(container));
 }
 
 void AddFootnoteViewIfNeeded(
@@ -217,8 +217,16 @@ void AddFootnoteViewIfNeeded(
 
 #define BRAVE_PERMISSION_PROMPT_BUBBLE_VIEW                               \
   AddAdditionalWidevineViewControlsIfNeeded(this, delegate_->Requests()); \
-  AddPermissionLifetimeComboboxIfNeeded(this, delegate_);                 \
-  AddFootnoteViewIfNeeded(this, browser_);
+  auto* permission_lifetime_view =                                        \
+      AddPermissionLifetimeComboboxIfNeeded(this, delegate_);             \
+  AddFootnoteViewIfNeeded(this, browser_);                                \
+  if (permission_lifetime_view) {                                         \
+    set_fixed_width(                                                      \
+        std::max(GetPreferredSize().width(),                              \
+                 permission_lifetime_view->GetPreferredSize().width()) +  \
+        margins().width());                                               \
+    set_should_ignore_snapping(true);                                     \
+  }
 
 #include "../../../../../../../chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc"
 #undef BRAVE_PERMISSION_PROMPT_BUBBLE_VIEW

--- a/chromium_src/ui/DEPS
+++ b/chromium_src/ui/DEPS
@@ -3,10 +3,10 @@ include_rules = [
   "+../../../../ui/native_theme",
   "+../../../../../ui/accessibility/platform",
   "+../../../../../ui/base/resource",
-  "+../../../../../ui/base/resource",
   "+../../../../../ui/base/webui",
   "+../../../../../ui/views/bubble",
   "+../../../../../ui/views/controls",
+  "+../../../../../ui/views/window",
   "+../../../../../../ui/views/controls/button",
   "+ui",
 ]

--- a/chromium_src/ui/views/bubble/bubble_frame_view.cc
+++ b/chromium_src/ui/views/bubble/bubble_frame_view.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ui/base/ui_base_types.h"
+
+#define DIALOG_BUTTON_NONE \
+  DIALOG_BUTTON_NONE && !dialog_delegate->should_ignore_snapping()
+
+#include "../../../../../ui/views/bubble/bubble_frame_view.cc"
+
+#undef DIALOG_BUTTON_NONE

--- a/chromium_src/ui/views/window/dialog_delegate.h
+++ b/chromium_src/ui/views/window/dialog_delegate.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_WINDOW_DIALOG_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_WINDOW_DIALOG_DELEGATE_H_
+
+#define set_use_custom_frame                                              \
+  set_should_ignore_snapping(bool should_ignore_snapping) {               \
+    should_ignore_snapping_ = should_ignore_snapping;                     \
+  }                                                                       \
+  bool should_ignore_snapping() const { return should_ignore_snapping_; } \
+                                                                          \
+ private:                                                                 \
+  bool should_ignore_snapping_ = false;                                   \
+                                                                          \
+ public:                                                                  \
+  void set_use_custom_frame
+
+#include "../../../../../ui/views/window/dialog_delegate.h"
+
+#undef set_use_custom_frame
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_WINDOW_DIALOG_DELEGATE_H_


### PR DESCRIPTION
Uplift of #9006
Resolves https://github.com/brave/brave-browser/issues/16219

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.