### PR TITLE
Tie CSP rule injection to Shields ads/tracker setting

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -223,6 +223,12 @@ void AdBlockServiceTest::WaitForBraveExtensionShieldsDataReady() {
   ASSERT_TRUE(extension_listener.WaitUntilSatisfied());
 }
 
+void AdBlockServiceTest::ShieldsDown(const GURL& url) {
+  brave_shields::SetBraveShieldsEnabled(content_settings(),
+                                        false,
+                                        url);
+}
+
 // Load a page with an ad image, and make sure it is blocked.
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, AdsGetBlockedByDefaultBlocker) {
   ASSERT_TRUE(InstallDefaultAdBlockExtension());
@@ -1085,6 +1091,32 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CspRuleMerging) {
   ASSERT_EQ(false, EvalJs(contents, "!!window.loadedDataImage"));
 
   // Violations of injected CSP directives do not increment the Shields counter
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+}
+
+// Verify that scripts violating a Content Security Policy from a `$csp` rule
+// are not loaded.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CspRuleShieldsDown) {
+  UpdateAdBlockInstanceWithRules(
+      "||example.com^$csp=script-src 'nonce-abcdef' 'unsafe-eval' 'self'");
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  const GURL url =
+      embedded_test_server()->GetURL("example.com", "/csp_rules.html");
+  ShieldsDown(url);
+
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  auto res = EvalJs(contents, "await window.allLoaded");
+  ASSERT_EQ(true, EvalJs(contents, "!!window.loadedNonceScript"));
+  ASSERT_EQ(true, EvalJs(contents, "!!window.loadedEvalScript"));
+  ASSERT_EQ(true, EvalJs(contents, "!!window.loadedSamePartyScript"));
+  ASSERT_EQ(true, EvalJs(contents, "!!window.loadedThirdPartyScript"));
+  ASSERT_EQ(true, EvalJs(contents, "!!window.loadedUnsafeInlineScript"));
+  ASSERT_EQ(true, EvalJs(contents, "!!window.loadedDataImage"));
+
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
 

--- a/browser/brave_shields/ad_block_service_browsertest.h
+++ b/browser/brave_shields/ad_block_service_browsertest.h
@@ -37,6 +37,7 @@ class AdBlockServiceTest : public extensions::ExtensionBrowserTest {
   bool StartAdBlockRegionalServices();
   void WaitForAdBlockServiceThreads();
   void WaitForBraveExtensionShieldsDataReady();
+  void ShieldsDown(const GURL& url);
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_SHIELDS_AD_BLOCK_SERVICE_BROWSERTEST_H_

--- a/browser/net/brave_ad_block_csp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_csp_network_delegate_helper.cc
@@ -62,7 +62,7 @@ int OnHeadersReceived_AdBlockCspWork(
     std::shared_ptr<brave::BraveRequestInfo> ctx) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  if (!response_headers) {
+  if (!response_headers || !ctx->allow_brave_shields || ctx->allow_ads) {
     return net::OK;
   }
 

--- a/test/data/adbanner.js.mock-http-headers
+++ b/test/data/adbanner.js.mock-http-headers
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Content-Type: application/javascript
+Access-Control-Allow-Origin: *

--- a/test/data/csp_rules.html
+++ b/test/data/csp_rules.html
@@ -20,7 +20,7 @@
 
     const thirdPartyScriptPromise = new Promise(resolve => {
         const thirdPartyScript = document.createElement('script');
-        thirdPartyScript.src = 'https://thirdparty.com/adbanner.js';
+        thirdPartyScript.src = '/cross-site/thirdparty.com/adbanner.js';
         thirdPartyScript.onload = (r) => {
             window.loadedThirdPartyScript = true;
             resolve();


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16283

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Note the test plan from https://github.com/brave/brave-core/pull/8281:

> Visit http://pirateiro.com/. Refresh the page while the developer console is open, and check in the console to verify that the browser refused to load scripts violating the policy `script-src 'self' 'unsafe-inline' https://hcaptcha.com *.hcaptcha.com`.

> On Android, it will be sufficient to observe 0 blocked items in the Shields panel rather than 5 (the requests are still blocked, but will not increment the counter).

This behavior should hold when Shields are up and ads/trackers blocked setting is either standard or aggressive mode. When Shields are down, or ads/trackers are allowed, the above should no longer be observed.