### PR TITLE
Fixes follow up of #13038 - swiping up ad notification doesn't trigger the dismiss event type - 1.26.x

### DIFF
--- a/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsNotificationDialog.java
+++ b/browser/brave_ads/android/java/org/chromium/chrome/browser/dialogs/BraveAdsNotificationDialog.java
@@ -116,7 +116,7 @@ public class BraveAdsNotificationDialog {
                                     mAdsDialog = null;
                                     BraveAdsNativeHelper.nativeOnCloseAdNotification(
                                             Profile.getLastUsedRegularProfile(), mNotificationId,
-                                            false);
+                                            true);
                                     mNotificationId = null;
                                 } else if (deltaYDp <= MAX_DISTANCE_FOR_TAP
                                         && deltaYDp >= (-1 * MAX_DISTANCE_FOR_TAP)) {
@@ -170,9 +170,9 @@ public class BraveAdsNotificationDialog {
         try {
             if (mNotificationId != null && mNotificationId.equals(notificationId) && mAdsDialog != null) {
                 mAdsDialog.dismiss();
+                mAdsDialog = null;
                 BraveAdsNativeHelper.nativeOnCloseAdNotification(
                         Profile.getLastUsedRegularProfile(), mNotificationId, false);
-                mAdsDialog = null;
             }
         } catch (IllegalArgumentException e) {
             mAdsDialog = null;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9099
Resolves https://github.com/brave/brave-browser/issues/16361

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.