### PR TITLE
Adat to deprecation of base::ScopedObserver

### DIFF
--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -130,8 +130,8 @@ void BraveSyncWorker::RequestSync(JNIEnv* env) {
   syncer::SyncService* service =
       ProfileSyncServiceFactory::GetForProfile(profile_);
 
-  if (service && !sync_service_observer_.IsObserving(service)) {
-    sync_service_observer_.Add(service);
+  if (service && !sync_service_observer_.IsObservingSource(service)) {
+    sync_service_observer_.AddObservation(service);
   }
 
   // Mark Sync as requested by the user. It might already be requested, but
@@ -212,8 +212,8 @@ void BraveSyncWorker::SetSyncV2MigrateNoticeDismissed(
 void BraveSyncWorker::OnResetDone() {
   syncer::SyncService* sync_service = GetSyncService();
   if (sync_service) {
-    if (sync_service_observer_.IsObserving(sync_service)) {
-      sync_service_observer_.Remove(sync_service);
+    if (sync_service_observer_.IsObservingSource(sync_service)) {
+      sync_service_observer_.RemoveObservation(sync_service);
     }
   }
 }

--- a/browser/android/brave_sync_worker.h
+++ b/browser/android/brave_sync_worker.h
@@ -10,7 +10,7 @@
 #include <string>
 
 #include "base/android/jni_weak_ref.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_multi_source_observation.h"
 #include "components/sync/driver/sync_service.h"
 #include "components/sync/driver/sync_service_observer.h"
 
@@ -69,7 +69,8 @@ class BraveSyncWorker : public syncer::SyncServiceObserver {
 
   std::string passphrase_;
 
-  ScopedObserver<syncer::SyncService, syncer::SyncServiceObserver>
+  base::ScopedMultiSourceObservation<syncer::SyncService,
+                                     syncer::SyncServiceObserver>
       sync_service_observer_{this};
   base::WeakPtrFactory<BraveSyncWorker> weak_ptr_factory_{this};
 

--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -48,13 +48,11 @@ const char BraveDrmTabHelper::kWidevineComponentId[] =
     "oimompecagnajdejgnnjijobebaeigek";
 
 BraveDrmTabHelper::BraveDrmTabHelper(content::WebContents* contents)
-    : WebContentsObserver(contents),
-      receivers_(contents, this),
-      observer_(this) {
+    : WebContentsObserver(contents), receivers_(contents, this) {
   auto* updater = g_browser_process->component_updater();
   // We don't need to observe if widevine is already registered.
   if (!IsAlreadyRegistered(updater))
-    observer_.Add(updater);
+    observer_.Observe(updater);
 }
 
 BraveDrmTabHelper::~BraveDrmTabHelper() {}
@@ -105,7 +103,7 @@ void BraveDrmTabHelper::OnEvent(Events event, const std::string& id) {
       ReloadIfActive(web_contents());
 #endif
     // Stop observing component update event.
-    observer_.RemoveAll();
+    observer_.Reset();
   }
 }
 

--- a/browser/brave_drm_tab_helper.h
+++ b/browser/brave_drm_tab_helper.h
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "brave/components/brave_drm/brave_drm.mojom.h"
 #include "components/component_updater/component_updater_service.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -54,8 +54,9 @@ class BraveDrmTabHelper final
   // True if we are notified that a page requested widevine availability.
   bool is_widevine_requested_ = false;
 
-  ScopedObserver<component_updater::ComponentUpdateService,
-                 component_updater::ComponentUpdateService::Observer> observer_;
+  base::ScopedObservation<component_updater::ComponentUpdateService,
+                          component_updater::ComponentUpdateService::Observer>
+      observer_{this};
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_DRM_TAB_HELPER_H_

--- a/browser/browsing_data/brave_clear_browsing_data.cc
+++ b/browser/browsing_data/brave_clear_browsing_data.cc
@@ -9,7 +9,7 @@
 
 #include "base/logging.h"
 #include "base/run_loop.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_multi_source_observation.h"
 #include "base/trace_event/trace_event.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/browsing_data/chrome_browsing_data_remover_constants.h"
@@ -30,7 +30,7 @@ using content::BraveClearBrowsingData;
 class BrowsingDataRemovalWatcher
     : public content::BrowsingDataRemover::Observer {
  public:
-  BrowsingDataRemovalWatcher() : observer_(this) {}
+  BrowsingDataRemovalWatcher() {}
 
   void ClearBrowsingDataForLoadedProfiles(
       BraveClearBrowsingData::OnExitTestingCallback* testing_callback);
@@ -47,11 +47,11 @@ class BrowsingDataRemovalWatcher
   int num_profiles_to_clear_ = 0;
   base::RunLoop run_loop_;
   // Keep track of the set of BrowsingDataRemover instances this object has
-  // attached itself to as an observer. When ScopedObserver is destroyed it
-  // removes this object as an observer from all those instances.
-  ScopedObserver<content::BrowsingDataRemover,
-                 content::BrowsingDataRemover::Observer>
-      observer_;
+  // attached itself to as an observer. When ScopedMultiSourceObservation is
+  // destroyed it removes this object as an observer from all those instances.
+  base::ScopedMultiSourceObservation<content::BrowsingDataRemover,
+                                     content::BrowsingDataRemover::Observer>
+      observer_{this};
 };
 
 // See ClearBrowsingDataHandler::HandleClearBrowsingData which constructs the
@@ -137,7 +137,7 @@ void BrowsingDataRemovalWatcher::ClearBrowsingDataForLoadedProfiles(
     ++num_profiles_to_clear_;
     content::BrowsingDataRemover* remover =
         content::BrowserContext::GetBrowsingDataRemover(profile);
-    observer_.Add(remover);
+    observer_.AddObservation(remover);
     if (testing_callback)
       testing_callback->BeforeClearOnExitRemoveData(remover, remove_mask,
                                                     origin_mask);

--- a/browser/ethereum_remote_client/ethereum_remote_client_service.cc
+++ b/browser/ethereum_remote_client/ethereum_remote_client_service.cc
@@ -47,9 +47,6 @@ EthereumRemoteClientService::EthereumRemoteClientService(
     : context_(context),
       ethereum_remote_client_delegate_(
           std::move(ethereum_remote_client_delegate)),
-#if BUILDFLAG(ENABLE_EXTENSIONS)
-      extension_registry_observer_(this),
-#endif
       file_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
           {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})) {
@@ -63,7 +60,8 @@ EthereumRemoteClientService::EthereumRemoteClientService(
   // this point.
   RemoveUnusedWeb3ProviderContentScripts();
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-  extension_registry_observer_.Add(extensions::ExtensionRegistry::Get(context));
+  extension_registry_observer_.Observe(
+      extensions::ExtensionRegistry::Get(context));
 #endif
 }
 

--- a/browser/ethereum_remote_client/ethereum_remote_client_service.h
+++ b/browser/ethereum_remote_client/ethereum_remote_client_service.h
@@ -19,7 +19,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "base/values.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "extensions/buildflags/buildflags.h"
@@ -113,8 +113,8 @@ class EthereumRemoteClientService
   std::unique_ptr<EthereumRemoteClientDelegate>
       ethereum_remote_client_delegate_;
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-  ScopedObserver<extensions::ExtensionRegistry,
-                 extensions::ExtensionRegistryObserver>
+  base::ScopedObservation<extensions::ExtensionRegistry,
+                          extensions::ExtensionRegistryObserver>
       extension_registry_observer_{this};
 #endif
   scoped_refptr<base::SequencedTaskRunner> file_task_runner_;

--- a/browser/extensions/api/brave_wallet_api_browsertest.cc
+++ b/browser/extensions/api/brave_wallet_api_browsertest.cc
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/path_service.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_multi_source_observation.h"
 #include "brave/browser/ethereum_remote_client/ethereum_remote_client_constants.h"
 #include "brave/browser/infobars/crypto_wallets_infobar_delegate.h"
 #include "brave/common/brave_paths.h"
@@ -35,9 +35,7 @@ namespace extensions {
 class BraveWalletAPIBrowserTest : public InProcessBrowserTest,
     public InfoBarManager::Observer {
  public:
-  BraveWalletAPIBrowserTest() : infobar_observer_(this),
-      infobar_added_(false) {
-  }
+  BraveWalletAPIBrowserTest() : infobar_added_(false) {}
 
   void WaitForBraveExtensionAdded() {
     // Brave extension must be loaded, otherwise dapp detection events
@@ -105,11 +103,11 @@ class BraveWalletAPIBrowserTest : public InProcessBrowserTest,
   }
 
   void AddInfoBarObserver(InfoBarService* infobar_service) {
-    infobar_observer_.Add(infobar_service);
+    infobar_observer_.AddObservation(infobar_service);
   }
 
   void RemoveInfoBarObserver(InfoBarService* infobar_service) {
-    infobar_observer_.Remove(infobar_service);
+    infobar_observer_.AddObservation(infobar_service);
   }
 
   content::WebContents* active_contents() {
@@ -160,8 +158,8 @@ class BraveWalletAPIBrowserTest : public InProcessBrowserTest,
 
  private:
   scoped_refptr<const extensions::Extension> extension_;
-  ScopedObserver<InfoBarManager, InfoBarManager::Observer>
-      infobar_observer_;
+  base::ScopedMultiSourceObservation<InfoBarManager, InfoBarManager::Observer>
+      infobar_observer_{this};
   bool infobar_added_;
   std::unique_ptr<base::RunLoop> infobar_added_run_loop_;
 

--- a/browser/extensions/brave_extension_management.cc
+++ b/browser/extensions/brave_extension_management.cc
@@ -42,8 +42,8 @@
 namespace extensions {
 
 BraveExtensionManagement::BraveExtensionManagement(Profile* profile)
-    : ExtensionManagement(profile), extension_registry_observer_(this) {
-  extension_registry_observer_.Add(
+    : ExtensionManagement(profile) {
+  extension_registry_observer_.Observe(
       ExtensionRegistry::Get(static_cast<content::BrowserContext*>(profile)));
   providers_.push_back(std::make_unique<BraveExtensionProvider>());
   local_state_pref_change_registrar_.Init(g_browser_process->local_state());

--- a/browser/extensions/brave_extension_management.h
+++ b/browser/extensions/brave_extension_management.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_BROWSER_EXTENSIONS_BRAVE_EXTENSION_MANAGEMENT_H_
 #define BRAVE_BROWSER_EXTENSIONS_BRAVE_EXTENSION_MANAGEMENT_H_
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "chrome/browser/extensions/extension_management.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "extensions/browser/extension_registry.h"
@@ -35,8 +35,8 @@ class BraveExtensionManagement : public ExtensionManagement,
 
   PrefChangeRegistrar local_state_pref_change_registrar_;
 
-  ScopedObserver<ExtensionRegistry, ExtensionRegistryObserver>
-    extension_registry_observer_;
+  base::ScopedObservation<ExtensionRegistry, ExtensionRegistryObserver>
+      extension_registry_observer_{this};
 
   DISALLOW_COPY_AND_ASSIGN(BraveExtensionManagement);
 };

--- a/browser/extensions/brave_theme_event_router.cc
+++ b/browser/extensions/brave_theme_event_router.cc
@@ -18,16 +18,15 @@
 namespace extensions {
 
 BraveThemeEventRouter::BraveThemeEventRouter(Profile* profile)
-    : profile_(profile),
-      observer_(this) {
-  observer_.Add(ui::NativeTheme::GetInstanceForNativeUi());
+    : profile_(profile) {
+  observer_.Observe(ui::NativeTheme::GetInstanceForNativeUi());
 }
 
 BraveThemeEventRouter::~BraveThemeEventRouter() {}
 
 void BraveThemeEventRouter::OnNativeThemeUpdated(
     ui::NativeTheme* observed_theme) {
-  DCHECK(observer_.IsObserving(observed_theme));
+  DCHECK(observer_.IsObservingSource(observed_theme));
   Notify();
 }
 

--- a/browser/extensions/brave_theme_event_router.h
+++ b/browser/extensions/brave_theme_event_router.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_BROWSER_EXTENSIONS_BRAVE_THEME_EVENT_ROUTER_H_
 #define BRAVE_BROWSER_EXTENSIONS_BRAVE_THEME_EVENT_ROUTER_H_
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "ui/native_theme/native_theme.h"
 #include "ui/native_theme/native_theme_observer.h"
 
@@ -30,7 +30,8 @@ class BraveThemeEventRouter : public ui::NativeThemeObserver {
 
   ui::NativeTheme* current_native_theme_for_testing_ = nullptr;
   Profile* profile_;
-  ScopedObserver<ui::NativeTheme, ui::NativeThemeObserver> observer_;
+  base::ScopedObservation<ui::NativeTheme, ui::NativeThemeObserver> observer_{
+      this};
 
   DISALLOW_COPY_AND_ASSIGN(BraveThemeEventRouter);
 };

--- a/browser/greaselion/greaselion_browsertest.cc
+++ b/browser/greaselion/greaselion_browsertest.cc
@@ -6,6 +6,7 @@
 #include "base/containers/flat_map.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
+#include "base/scoped_observation.h"
 #include "base/task/post_task.h"
 #include "base/test/thread_test_helper.h"
 #include "brave/browser/brave_browser_process.h"
@@ -41,8 +42,8 @@ class GreaselionDownloadServiceWaiter
  public:
   explicit GreaselionDownloadServiceWaiter(
       GreaselionDownloadService* download_service)
-      : download_service_(download_service), scoped_observer_(this) {
-    scoped_observer_.Add(download_service_);
+      : download_service_(download_service) {
+    scoped_observer_.Observe(download_service_);
   }
   ~GreaselionDownloadServiceWaiter() override = default;
 
@@ -56,8 +57,9 @@ class GreaselionDownloadServiceWaiter
 
   GreaselionDownloadService* const download_service_;
   base::RunLoop run_loop_;
-  ScopedObserver<GreaselionDownloadService, GreaselionDownloadService::Observer>
-      scoped_observer_;
+  base::ScopedObservation<GreaselionDownloadService,
+                          GreaselionDownloadService::Observer>
+      scoped_observer_{this};
 
   DISALLOW_COPY_AND_ASSIGN(GreaselionDownloadServiceWaiter);
 };
@@ -65,8 +67,8 @@ class GreaselionDownloadServiceWaiter
 class GreaselionServiceWaiter : public GreaselionService::Observer {
  public:
   explicit GreaselionServiceWaiter(GreaselionService* greaselion_service)
-      : greaselion_service_(greaselion_service), scoped_observer_(this) {
-    scoped_observer_.Add(greaselion_service_);
+      : greaselion_service_(greaselion_service) {
+    scoped_observer_.Observe(greaselion_service_);
   }
   ~GreaselionServiceWaiter() override = default;
 
@@ -85,8 +87,8 @@ class GreaselionServiceWaiter : public GreaselionService::Observer {
 
   GreaselionService* const greaselion_service_;
   base::RunLoop run_loop_;
-  ScopedObserver<GreaselionService, GreaselionService::Observer>
-      scoped_observer_;
+  base::ScopedObservation<GreaselionService, GreaselionService::Observer>
+      scoped_observer_{this};
 
   DISALLOW_COPY_AND_ASSIGN(GreaselionServiceWaiter);
 };

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -173,7 +173,7 @@ void BraveProfileManager::MigrateProfileNames() {
 void BraveProfileManager::OnProfileAdded(Profile* profile) {
   // Observe new profiles for creation of OTR profiles so that we can add our
   // shared resources to them.
-  observed_profiles_.Add(profile);
+  observed_profiles_.AddObservation(profile);
   AddBraveSharedResourcesDataSourceToProfile(profile);
 }
 
@@ -184,7 +184,7 @@ void BraveProfileManager::OnOffTheRecordProfileCreated(
 
 void BraveProfileManager::OnProfileWillBeDestroyed(Profile* profile) {
   if (!profile->IsOffTheRecord()) {
-    observed_profiles_.Remove(profile);
+    observed_profiles_.RemoveObservation(profile);
   }
 }
 

--- a/browser/profiles/brave_profile_manager.h
+++ b/browser/profiles/brave_profile_manager.h
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_multi_source_observation.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
 #include "chrome/browser/profiles/profile_observer.h"
@@ -40,7 +40,8 @@ class BraveProfileManager : public ProfileManager,
 
  private:
   void MigrateProfileNames();
-  ScopedObserver<Profile, ProfileObserver> observed_profiles_{this};
+  base::ScopedMultiSourceObservation<Profile, ProfileObserver>
+      observed_profiles_{this};
 
   DISALLOW_COPY_AND_ASSIGN(BraveProfileManager);
 };

--- a/browser/search_engines/search_engine_tracker.cc
+++ b/browser/search_engines/search_engine_tracker.cc
@@ -74,7 +74,7 @@ bool SearchEngineTrackerFactory::ServiceIsCreatedWithBrowserContext() const {
 SearchEngineTracker::SearchEngineTracker(
     TemplateURLService* template_url_service)
     : template_url_service_(template_url_service) {
-  observer_.Add(template_url_service_);
+  observer_.Observe(template_url_service_);
   const TemplateURL* template_url =
       template_url_service_->GetDefaultSearchProvider();
 

--- a/browser/search_engines/search_engine_tracker.h
+++ b/browser/search_engines/search_engine_tracker.h
@@ -7,7 +7,7 @@
 #define BRAVE_BROWSER_SEARCH_ENGINES_SEARCH_ENGINE_TRACKER_H_
 
 #include "base/memory/singleton.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_member.h"
@@ -65,8 +65,8 @@ class SearchEngineTracker : public KeyedService,
   // TemplateURLServiceObserver overrides:
   void OnTemplateURLServiceChanged() override;
 
-  ScopedObserver<TemplateURLService, TemplateURLServiceObserver> observer_{
-      this};
+  base::ScopedObservation<TemplateURLService, TemplateURLServiceObserver>
+      observer_{this};
 
   // Keeping this to check for changes in |OnTemplateURLServiceChanged|.
   GURL default_search_url_;

--- a/browser/sync/brave_profile_sync_service_delegate.cc
+++ b/browser/sync/brave_profile_sync_service_delegate.cc
@@ -28,7 +28,7 @@ BraveProfileSyncServiceDelegate::BraveProfileSyncServiceDelegate(
   device_info_tracker_ = device_info_sync_service_->GetDeviceInfoTracker();
   DCHECK(device_info_tracker_);
 
-  device_info_observer_.Add(device_info_tracker_);
+  device_info_observer_.Observe(device_info_tracker_);
 }
 
 BraveProfileSyncServiceDelegate::~BraveProfileSyncServiceDelegate() {}
@@ -66,14 +66,12 @@ void BraveProfileSyncServiceDelegate::OnSelfDeviceInfoDeleted() {
 }
 
 void BraveProfileSyncServiceDelegate::SuspendDeviceObserverForOwnReset() {
-  if (device_info_observer_.IsObserving(device_info_tracker_)) {
-    device_info_observer_.Remove(device_info_tracker_);
-  }
+  device_info_observer_.Reset();
 }
 
 void BraveProfileSyncServiceDelegate::ResumeDeviceObserver() {
-  if (!device_info_observer_.IsObserving(device_info_tracker_)) {
-    device_info_observer_.Add(device_info_tracker_);
+  if (!device_info_observer_.IsObserving()) {
+    device_info_observer_.Observe(device_info_tracker_);
   }
 }
 

--- a/browser/sync/brave_profile_sync_service_delegate.h
+++ b/browser/sync/brave_profile_sync_service_delegate.h
@@ -9,7 +9,7 @@
 #include "brave/components/sync/driver/profile_sync_service_delegate.h"
 
 #include "base/memory/weak_ptr.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "components/sync/driver/profile_sync_service.h"
 #include "components/sync_device_info/device_info_tracker.h"
 
@@ -42,7 +42,8 @@ class BraveProfileSyncServiceDelegate
 
   syncer::DeviceInfoTracker* device_info_tracker_;
   syncer::LocalDeviceInfoProvider* local_device_info_provider_;
-  ScopedObserver<syncer::DeviceInfoTracker, syncer::DeviceInfoTracker::Observer>
+  base::ScopedObservation<syncer::DeviceInfoTracker,
+                          syncer::DeviceInfoTracker::Observer>
       device_info_observer_{this};
 
   DeviceInfoSyncService* device_info_sync_service_;

--- a/browser/sync/brave_sync_devices_android.cc
+++ b/browser/sync/brave_sync_devices_android.cc
@@ -43,12 +43,12 @@ BraveSyncDevicesAndroid::BraveSyncDevicesAndroid(
        ->GetDeviceInfoTracker();
   DCHECK(tracker);
   if (tracker) {
-    device_info_tracker_observer_.Add(tracker);
+    device_info_tracker_observer_.Observe(tracker);
   }
 }
 
 BraveSyncDevicesAndroid::~BraveSyncDevicesAndroid() {
-  // Observer will be removed by ScopedObserver
+  // Observer will be removed by ScopedObservation
 }
 
 void BraveSyncDevicesAndroid::Destroy(JNIEnv* env) {

--- a/browser/sync/brave_sync_devices_android.h
+++ b/browser/sync/brave_sync_devices_android.h
@@ -9,7 +9,7 @@
 #include <jni.h>
 
 #include "base/android/jni_weak_ref.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "base/values.h"
 #include "chrome/browser/sync/profile_sync_service_android.h"
 #include "components/sync_device_info/device_info_tracker.h"
@@ -42,7 +42,8 @@ class BraveSyncDevicesAndroid : public syncer::DeviceInfoTracker::Observer {
 
   syncer::BraveProfileSyncService* GetSyncService() const;
 
-  ScopedObserver<syncer::DeviceInfoTracker, syncer::DeviceInfoTracker::Observer>
+  base::ScopedObservation<syncer::DeviceInfoTracker,
+                          syncer::DeviceInfoTracker::Observer>
       device_info_tracker_observer_{this};
 
   JavaObjectWeakGlobalRef weak_java_brave_sync_worker_;

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -31,7 +31,7 @@ SidebarService* GetSidebarService(Browser* browser) {
 
 SidebarController::SidebarController(BraveBrowser* browser, Profile* profile)
     : browser_(browser), sidebar_model_(new SidebarModel(profile)) {
-  sidebar_service_observed_.Add(GetSidebarService(browser_));
+  sidebar_service_observed_.Observe(GetSidebarService(browser_));
 }
 
 SidebarController::~SidebarController() = default;

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "brave/components/sidebar/sidebar_service.h"
 
 class BraveBrowser;
@@ -63,7 +63,7 @@ class SidebarController : public SidebarService::Observer {
   Sidebar* sidebar_ = nullptr;
 
   std::unique_ptr<SidebarModel> sidebar_model_;
-  ScopedObserver<SidebarService, SidebarService::Observer>
+  base::ScopedObservation<SidebarService, SidebarService::Observer>
       sidebar_service_observed_{this};
 };
 

--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -66,10 +66,10 @@ void SidebarModel::Init(history::HistoryService* history_service) {
   for (const auto& item : GetAllSidebarItems())
     AddItem(item, -1, false);
 
-  sidebar_observed_.Add(GetSidebarService(profile_));
+  sidebar_observed_.Observe(GetSidebarService(profile_));
   // Can be null in test.
   if (history_service)
-    history_observed_.Add(history_service);
+    history_observed_.Observe(history_service);
 }
 
 void SidebarModel::AddObserver(Observer* observer) {

--- a/browser/ui/sidebar/sidebar_model.h
+++ b/browser/ui/sidebar/sidebar_model.h
@@ -12,7 +12,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/optional.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "brave/browser/ui/sidebar/sidebar_model_data.h"
 #include "brave/components/sidebar/sidebar_service.h"
 #include "components/history/core/browser/history_service.h"
@@ -134,9 +134,9 @@ class SidebarModel : public SidebarService::Observer,
   std::unique_ptr<base::CancelableTaskTracker> task_tracker_;
   base::ObserverList<Observer> observers_;
   std::vector<std::unique_ptr<SidebarModelData>> data_;
-  ScopedObserver<SidebarService, SidebarService::Observer> sidebar_observed_{
-      this};
-  ScopedObserver<history::HistoryService, HistoryServiceObserver>
+  base::ScopedObservation<SidebarService, SidebarService::Observer>
+      sidebar_observed_{this};
+  base::ScopedObservation<history::HistoryService, HistoryServiceObserver>
       history_observed_{this};
   base::WeakPtrFactory<SidebarModel> weak_ptr_factory_{this};
 };

--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -116,9 +116,6 @@ BraveActionsContainer::BraveActionsContainer(Browser* browser, Profile* profile)
       extension_action_manager_(
           extensions::ExtensionActionManager::Get(profile)),
       brave_action_api_(extensions::BraveActionAPI::Get(browser)),
-      extension_registry_observer_(this),
-      extension_action_observer_(this),
-      brave_action_observer_(this),
       empty_extensions_container_(new EmptyExtensionsContainer),
       rewards_service_(
           brave_rewards::RewardsServiceFactory::GetForProfile(profile)),
@@ -392,9 +389,9 @@ void BraveActionsContainer::OnRewardsStubButtonClicked() {
 
 void BraveActionsContainer::OnExtensionSystemReady() {
   // observe changes in extension system
-  extension_registry_observer_.Add(extension_registry_);
-  extension_action_observer_.Add(extension_action_api_);
-  brave_action_observer_.Add(brave_action_api_);
+  extension_registry_observer_.Observe(extension_registry_);
+  extension_action_observer_.Observe(extension_action_api_);
+  brave_action_observer_.Observe(brave_action_api_);
   // Check if extensions already loaded
   AddAction(brave_extension_id);
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)

--- a/browser/ui/views/brave_actions/brave_actions_container.h
+++ b/browser/ui/views/brave_actions/brave_actions_container.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "base/scoped_observation.h"
 #include "brave/browser/extensions/api/brave_action_api.h"
 #include "brave/components/brave_rewards/browser/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/browser/rewards_service.h"
@@ -167,19 +168,19 @@ class BraveActionsContainer : public views::View,
   extensions::BraveActionAPI* brave_action_api_;
 
   // Listen to extension load, unloaded notifications.
-  ScopedObserver<extensions::ExtensionRegistry,
-                 extensions::ExtensionRegistryObserver>
-      extension_registry_observer_;
+  base::ScopedObservation<extensions::ExtensionRegistry,
+                          extensions::ExtensionRegistryObserver>
+      extension_registry_observer_{this};
 
   // Listen to when the action is updated
-  ScopedObserver<extensions::ExtensionActionAPI,
-                 extensions::ExtensionActionAPI::Observer>
-      extension_action_observer_;
+  base::ScopedObservation<extensions::ExtensionActionAPI,
+                          extensions::ExtensionActionAPI::Observer>
+      extension_action_observer_{this};
 
   // Listen to when we need to open a popup
-  ScopedObserver<extensions::BraveActionAPI,
-                 extensions::BraveActionAPI::Observer>
-      brave_action_observer_;
+  base::ScopedObservation<extensions::BraveActionAPI,
+                          extensions::BraveActionAPI::Observer>
+      brave_action_observer_{this};
 
   // Listen for Brave Rewards preferences changes.
   BooleanPrefMember brave_rewards_enabled_;

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -84,7 +84,7 @@ void SidebarContainerView::Init() {
   initialized_ = true;
 
   sidebar_model_ = browser_->sidebar_controller()->model();
-  observed_.Add(sidebar_model_);
+  observed_.Observe(sidebar_model_);
 
   AddChildViews();
   UpdateChildViewVisibility();

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "base/timer/timer.h"
 #include "brave/browser/ui/sidebar/sidebar.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
@@ -97,7 +97,8 @@ class SidebarContainerView
   std::unique_ptr<BrowserWindowEventObserver> browser_window_event_observer_;
   std::unique_ptr<views::EventMonitor> browser_window_event_monitor_;
   std::unique_ptr<SidebarShowOptionsEventDetectWidget> show_options_widget_;
-  ScopedObserver<sidebar::SidebarModel, sidebar::SidebarModel::Observer>
+  base::ScopedObservation<sidebar::SidebarModel,
+                          sidebar::SidebarModel::Observer>
       observed_{this};
 };
 

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -57,7 +57,7 @@ SidebarControlView::SidebarControlView(BraveBrowser* browser)
   UpdateItemAddButtonState();
   UpdateSettingsButtonState();
 
-  sidebar_model_observed_.Add(browser_->sidebar_controller()->model());
+  sidebar_model_observed_.Observe(browser_->sidebar_controller()->model());
 }
 
 void SidebarControlView::Layout() {

--- a/browser/ui/views/sidebar/sidebar_control_view.h
+++ b/browser/ui/views/sidebar/sidebar_control_view.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
 #include "ui/base/models/simple_menu_model.h"
@@ -83,7 +83,8 @@ class SidebarControlView : public views::View,
   SidebarButtonView* sidebar_settings_view_ = nullptr;
   std::unique_ptr<ui::SimpleMenuModel> context_menu_model_;
   std::unique_ptr<views::MenuRunner> context_menu_runner_;
-  ScopedObserver<sidebar::SidebarModel, sidebar::SidebarModel::Observer>
+  base::ScopedObservation<sidebar::SidebarModel,
+                          sidebar::SidebarModel::Observer>
       sidebar_model_observed_{this};
 };
 

--- a/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.cc
+++ b/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.cc
@@ -42,7 +42,7 @@ SidebarItemAddedFeedbackBubble::SidebarItemAddedFeedbackBubble(
   SetButtons(ui::DIALOG_BUTTON_NONE);
 
   AddChildViews();
-  observed_.Add(items_contents_view);
+  observed_.Observe(items_contents_view);
 }
 
 SidebarItemAddedFeedbackBubble::~SidebarItemAddedFeedbackBubble() = default;

--- a/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h
+++ b/browser/ui/views/sidebar/sidebar_item_added_feedback_bubble.h
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "base/timer/timer.h"
 #include "ui/gfx/animation/animation_delegate.h"
 #include "ui/gfx/animation/linear_animation.h"
@@ -53,7 +53,7 @@ class SidebarItemAddedFeedbackBubble : public views::BubbleDialogDelegateView,
   base::OneShotTimer fade_timer_;
   gfx::LinearAnimation animation_;
 
-  ScopedObserver<views::View, views::ViewObserver> observed_{this};
+  base::ScopedObservation<views::View, views::ViewObserver> observed_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_ITEM_ADDED_FEEDBACK_BUBBLE_H_

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -83,9 +83,9 @@ SidebarItemsScrollView::SidebarItemsScrollView(BraveBrowser* browser)
           std::make_unique<views::BoundsAnimator>(this)),
       scroll_animator_for_smooth_(
           std::make_unique<views::BoundsAnimator>(this)) {
-  model_observed_.Add(browser->sidebar_controller()->model());
-  bounds_animator_observed_.Add(scroll_animator_for_new_item_.get());
-  bounds_animator_observed_.Add(scroll_animator_for_smooth_.get());
+  model_observed_.Observe(browser->sidebar_controller()->model());
+  bounds_animator_observed_.AddObservation(scroll_animator_for_new_item_.get());
+  bounds_animator_observed_.AddObservation(scroll_animator_for_smooth_.get());
   contents_view_ =
       AddChildView(std::make_unique<SidebarItemsContentsView>(browser_, this));
   up_arrow_ = AddChildView(std::make_unique<SidebarItemsArrowView>());

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <set>
 
+#include "base/scoped_multi_source_observation.h"
+#include "base/scoped_observation.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "ui/base/clipboard/clipboard.h"
 #include "ui/views/animation/bounds_animator.h"
@@ -102,9 +104,11 @@ class SidebarItemsScrollView : public views::View,
   std::unique_ptr<SidebarItemDragContext> drag_context_;
   std::unique_ptr<views::BoundsAnimator> scroll_animator_for_new_item_;
   std::unique_ptr<views::BoundsAnimator> scroll_animator_for_smooth_;
-  ScopedObserver<sidebar::SidebarModel, sidebar::SidebarModel::Observer>
+  base::ScopedObservation<sidebar::SidebarModel,
+                          sidebar::SidebarModel::Observer>
       model_observed_{this};
-  ScopedObserver<views::BoundsAnimator, views::BoundsAnimatorObserver>
+  base::ScopedMultiSourceObservation<views::BoundsAnimator,
+                                     views::BoundsAnimatorObserver>
       bounds_animator_observed_{this};
 };
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -112,7 +112,7 @@ bool IsAvatarButtonHideable(Profile* profile) {
 }  // namespace
 
 BraveToolbarView::BraveToolbarView(Browser* browser, BrowserView* browser_view)
-    : ToolbarView(browser, browser_view), profile_observer_(this) {}
+    : ToolbarView(browser, browser_view) {}
 
 BraveToolbarView::~BraveToolbarView() {}
 
@@ -129,7 +129,7 @@ void BraveToolbarView::Init() {
 
   // Track changes in profile count
   if (IsAvatarButtonHideable(profile)) {
-    profile_observer_.Add(
+    profile_observer_.Observe(
         &g_browser_process->profile_manager()->GetProfileAttributesStorage());
   }
   // track changes in bookmarks enabled setting

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -6,7 +6,7 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "chrome/browser/profiles/profile_attributes_storage.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "components/prefs/pref_member.h"
@@ -55,8 +55,9 @@ class BraveToolbarView : public ToolbarView,
   // Whether this toolbar has been initialized.
   bool brave_initialized_ = false;
   // Tracks profile count to determine whether profile switcher should be shown.
-  ScopedObserver<ProfileAttributesStorage, ProfileAttributesStorage::Observer>
-      profile_observer_;
+  base::ScopedObservation<ProfileAttributesStorage,
+                          ProfileAttributesStorage::Observer>
+      profile_observer_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_

--- a/browser/ui/webui/settings/brave_sync_handler.cc
+++ b/browser/ui/webui/settings/brave_sync_handler.cc
@@ -60,12 +60,14 @@ void BraveSyncHandler::RegisterMessages() {
 void BraveSyncHandler::OnJavascriptAllowed() {
   syncer::DeviceInfoTracker* tracker = GetDeviceInfoTracker();
   DCHECK(tracker);
-  if (tracker)
-    device_info_tracker_observer_.Add(tracker);
+  if (tracker) {
+    device_info_tracker_observer_.Reset();
+    device_info_tracker_observer_.Observe(tracker);
+  }
 }
 
 void BraveSyncHandler::OnJavascriptDisallowed() {
-  device_info_tracker_observer_.RemoveAll();
+  device_info_tracker_observer_.Reset();
 }
 
 void BraveSyncHandler::OnDeviceInfoChange() {

--- a/browser/ui/webui/settings/brave_sync_handler.h
+++ b/browser/ui/webui/settings/brave_sync_handler.h
@@ -7,7 +7,7 @@
 #define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_SYNC_HANDLER_H_
 
 #include "base/memory/weak_ptr.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "base/values.h"
 #include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
 #include "chrome/services/qrcode_generator/public/cpp/qrcode_generator_service.h"
@@ -62,7 +62,8 @@ class BraveSyncHandler : public settings::SettingsPageUIHandler,
   Profile* profile_ = nullptr;
 
   // Manages observer lifetimes.
-  ScopedObserver<syncer::DeviceInfoTracker, syncer::DeviceInfoTracker::Observer>
+  base::ScopedObservation<syncer::DeviceInfoTracker,
+                          syncer::DeviceInfoTracker::Observer>
       device_info_tracker_observer_{this};
 
   base::WeakPtrFactory<BraveSyncHandler> weak_ptr_factory_;

--- a/components/brave_component_updater/browser/local_data_files_observer.cc
+++ b/components/brave_component_updater/browser/local_data_files_observer.cc
@@ -11,15 +11,14 @@ namespace brave_component_updater {
 
 LocalDataFilesObserver::LocalDataFilesObserver(
     LocalDataFilesService* local_data_files_service)
-    : local_data_files_service_(local_data_files_service),
-      local_data_files_observer_(this) {
-  local_data_files_observer_.Add(local_data_files_service);
+    : local_data_files_service_(local_data_files_service) {
+  local_data_files_observer_.Observe(local_data_files_service);
 }
 
 LocalDataFilesObserver::~LocalDataFilesObserver() {}
 
 void LocalDataFilesObserver::OnLocalDataFilesServiceDestroyed() {
-  local_data_files_observer_.RemoveAll();
+  local_data_files_observer_.Reset();
   local_data_files_service_ = nullptr;
 }
 

--- a/components/brave_component_updater/browser/local_data_files_observer.h
+++ b/components/brave_component_updater/browser/local_data_files_observer.h
@@ -9,7 +9,7 @@
 #include <string>
 
 #include "base/files/file_path.h"
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_service.h"
 
 namespace brave_component_updater {
@@ -30,8 +30,8 @@ class LocalDataFilesObserver {
 
  protected:
   LocalDataFilesService* local_data_files_service_;  // NOT OWNED
-  ScopedObserver<LocalDataFilesService, LocalDataFilesObserver>
-      local_data_files_observer_;
+  base::ScopedObservation<LocalDataFilesService, LocalDataFilesObserver>
+      local_data_files_observer_{this};
 };
 
 }  // namespace brave_component_updater

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -41,11 +41,11 @@ BraveSyncDeviceTracker::BraveSyncDeviceTracker(
     std::function<void()> on_device_info_changed_callback)
     : on_device_info_changed_callback_(on_device_info_changed_callback) {
   DCHECK(device_info_tracker);
-  device_info_tracker_observer_.Add(device_info_tracker);
+  device_info_tracker_observer_.Observe(device_info_tracker);
 }
 
 BraveSyncDeviceTracker::~BraveSyncDeviceTracker() {
-  // Observer will be removed by ScopedObserver
+  // Observer will be removed by ScopedObservation
 }
 
 void BraveSyncDeviceTracker::OnDeviceInfoChange() {
@@ -59,11 +59,11 @@ BraveSyncServiceTracker::BraveSyncServiceTracker(
     std::function<void()> on_state_changed_callback)
     : on_state_changed_callback_(on_state_changed_callback) {
   DCHECK(profile_sync_service);
-  sync_service_observer_.Add(profile_sync_service);
+  sync_service_observer_.Observe(profile_sync_service);
 }
 
 BraveSyncServiceTracker::~BraveSyncServiceTracker() {
-  // Observer will be removed by ScopedObserver
+  // Observer will be removed by ScopedObservation
 }
 
 void BraveSyncServiceTracker::OnStateChanged(syncer::SyncService* sync) {
@@ -78,7 +78,7 @@ BraveSyncWorker::BraveSyncWorker(ChromeBrowserState* browser_state)
 }
 
 BraveSyncWorker::~BraveSyncWorker() {
-  // Observer will be removed by ScopedObserver
+  // Observer will be removed by ScopedObservation
 }
 
 bool BraveSyncWorker::SetSyncEnabled(bool enabled) {
@@ -92,8 +92,8 @@ bool BraveSyncWorker::SetSyncEnabled(bool enabled) {
     return false;
   }
 
-  if (!sync_service_observer_.IsObserving(sync_service)) {
-    sync_service_observer_.Add(sync_service);
+  if (!sync_service_observer_.IsObserving()) {
+    sync_service_observer_.Observe(sync_service);
   }
 
   setup_service->SetSyncEnabled(enabled);
@@ -297,17 +297,17 @@ void BraveSyncWorker::OnStateChanged(syncer::SyncService* service) {
 }
 
 void BraveSyncWorker::OnSyncShutdown(syncer::SyncService* service) {
-  if (sync_service_observer_.IsObserving(service)) {
-    sync_service_observer_.Remove(service);
+  if (sync_service_observer_.IsObserving()) {
+    DCHECK(sync_service_observer_.IsObservingSource(service));
+    sync_service_observer_.Reset();
   }
 }
 
 void BraveSyncWorker::OnResetDone() {
   syncer::SyncService* sync_service = GetSyncService();
-  if (sync_service) {
-    if (sync_service_observer_.IsObserving(sync_service)) {
-      sync_service_observer_.Remove(sync_service);
-    }
+  if (sync_service && sync_service_observer_.IsObserving()) {
+    DCHECK(sync_service_observer_.IsObservingSource(sync_service));
+    sync_service_observer_.Reset();
   }
 }
 

--- a/ios/browser/api/sync/brave_sync_worker.h
+++ b/ios/browser/api/sync/brave_sync_worker.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include "base/scoped_observer.h"
+#include "base/scoped_observation.h"
 #include "components/sync/driver/sync_service.h"
 #include "components/sync/driver/sync_service_observer.h"
 #include "components/sync_device_info/device_info_sync_service.h"
@@ -37,7 +37,8 @@ class BraveSyncDeviceTracker : public syncer::DeviceInfoTracker::Observer {
 
   std::function<void()> on_device_info_changed_callback_;
 
-  ScopedObserver<syncer::DeviceInfoTracker, syncer::DeviceInfoTracker::Observer>
+  base::ScopedObservation<syncer::DeviceInfoTracker,
+                          syncer::DeviceInfoTracker::Observer>
       device_info_tracker_observer_{this};
 };
 
@@ -52,7 +53,7 @@ class BraveSyncServiceTracker : public syncer::SyncServiceObserver {
 
   std::function<void()> on_state_changed_callback_;
 
-  ScopedObserver<syncer::SyncService, syncer::SyncServiceObserver>
+  base::ScopedObservation<syncer::SyncService, syncer::SyncServiceObserver>
       sync_service_observer_{this};
 };
 
@@ -89,7 +90,7 @@ class BraveSyncWorker : public syncer::SyncServiceObserver {
   std::string passphrase_;
 
   ChromeBrowserState* browser_state_;  // NOT OWNED
-  ScopedObserver<syncer::SyncService, syncer::SyncServiceObserver>
+  base::ScopedObservation<syncer::SyncService, syncer::SyncServiceObserver>
       sync_service_observer_{this};
   base::WeakPtrFactory<BraveSyncWorker> weak_ptr_factory_{this};
 


### PR DESCRIPTION
base::ScopedObserver is being deprecated on Chromium 93, so we need
to migrate to either ScopedObservation or ScopedMultiSourceObservation
depending on whether one or multiple sources are being observed.

Chromium change:

https://chromium.googlesource.com/chromium/src/+/3a35c513e236f28ba817b6667c9c973163241ebd

commit 3a35c513e236f28ba817b6667c9c973163241ebd
Author: Sigurdur Asgeirsson <siggi@chromium.org>
Date:   Thu Jun 3 16:34:54 2021 +0000

    Remove redundant base/scoped_observer.h includes.

    ScopedObserver is being deprecated in favor of two new classes:
    - base::ScopedObservation for observers that only ever observe
      a single source.
    - base::ScopedMultiSourceObservation for observers that do or may
      observe more than a single source.

    Bug: 1145565

Resolves https://github.com/brave/brave-browser/issues/16371

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A