### PR TITLE
Fixes shields extension showing disabled in background tabs.

### DIFF
--- a/patches/chrome-browser-extensions-api-tabs-tabs_api.cc.patch
+++ b/patches/chrome-browser-extensions-api-tabs-tabs_api.cc.patch
@@ -1,0 +1,29 @@
+diff --git a/chrome/browser/extensions/api/tabs/tabs_api.cc b/chrome/browser/extensions/api/tabs/tabs_api.cc
+index 64daa1117fdecd3d7bfe9e58fe1d953d75002da3..f42d13754d0ced8494bae157b5f37c23f1e30d81 100644
+--- a/chrome/browser/extensions/api/tabs/tabs_api.cc
++++ b/chrome/browser/extensions/api/tabs/tabs_api.cc
+@@ -1052,12 +1052,8 @@ ExtensionFunction::ResponseAction TabsQueryFunction::Run() {
+       continue;
+     }
+ 
+-    // Bug fix for crbug.com/1197888. Disable query during any tab drag to
+-    // ensure that the result matches the eventual state of the tab strip.
+-    TabStripModel* tab_strip =
+-        ExtensionTabUtil::GetEditableTabStripModel(browser);
+-    if (!tab_strip)
+-      return RespondNow(Error(tabs_constants::kTabStripNotEditableQueryError));
++    TabStripModel* tab_strip = browser->tab_strip_model();
++    DCHECK(tab_strip);
+     for (int i = 0; i < tab_strip->count(); ++i) {
+       WebContents* web_contents = tab_strip->GetWebContentsAt(i);
+ 
+@@ -1244,9 +1240,6 @@ ExtensionFunction::ResponseAction TabsGetFunction::Run() {
+     return RespondNow(Error(std::move(error)));
+   }
+ 
+-  if (!ExtensionTabUtil::IsTabStripEditable())
+-    return RespondNow(Error(tabs_constants::kTabStripNotEditableError));
+-
+   return RespondNow(ArgumentList(tabs::Get::Results::Create(
+       *CreateTabObjectHelper(contents, extension(), source_context_type(),
+                              tab_strip, tab_index))));


### PR DESCRIPTION
Fixes brave/brave-browser#16362

This is an upstream bug, see: crbug.com/1213925

The fix has been merged to upstream main and cr92, but not cr91.
This is the upstream patch applied to cr91.

Chromium changes:

https://chromium.googlesource.com/chromium/src/+/d9c16df2c22fd827e760f0ee20a1f977c717c849
https://chromium.googlesource.com/chromium/src/+/19555526c6fa4520598ccce63b031ffa91a5ad1c

commit d9c16df2c22fd827e760f0ee20a1f977c717c849
Author: Solomon Kinard <solomonkinard@chromium.org>
Date:   Thu Jun 3 17:08:55 2021 +0000

    [Extensions][Tabs] Allow tabs.query and tabs.get while drag in progress

    TapStripModel acquisition was restricted in crrev.com/c/2891080.
    Obtaining TapStripModel for read only purposes while drag in progress
    should be ok. This CL aims to restore that behavior to undo the
    regression.

    Bug: 1213925

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

