### PR TITLE
build/macOS: Use "hermetic" Xcode toolchain

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -53,6 +53,12 @@ hooks = [
     'action': ['vpython3', 'script/download_rust_deps.py'],
   },
   {
+    'name': 'hermetic_xcode',
+    'pattern': '.',
+    'condition': 'checkout_mac',
+    'action': ['vpython3', 'script/hermetic_xcode.py'],
+  },
+  {
     'name': 'generate_licenses',
     'pattern': '.',
     'action': ['python', 'script/generate_licenses.py'],

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -255,8 +255,11 @@ Config.prototype.buildArgs = function () {
     sparkle_dsa_private_key_file: this.sparkleDSAPrivateKeyFile,
     sparkle_eddsa_private_key: this.sparkleEdDSAPrivateKey,
     sparkle_eddsa_public_key: this.sparkleEdDSAPublicKey,
-    use_system_xcode: process.platform === 'darwin',
     ...this.extraGnArgs,
+  }
+  
+  if (process.platform === 'darwin') {
+    args.use_system_xcode = false;
   }
 
   if (this.shouldSign()) {
@@ -401,7 +404,8 @@ Config.prototype.buildArgs = function () {
     args.ios_enable_credential_provider_extension = false
     args.ios_enable_widget_kit_extension = false
 
-    args.use_system_xcode = false
+    // TODO(yannic): Use hermetic Xcode for iOS builds.
+    args.use_system_xcode = true
 
     delete args.safebrowsing_api_endpoint
     delete args.updater_prod_endpoint

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -255,6 +255,7 @@ Config.prototype.buildArgs = function () {
     sparkle_dsa_private_key_file: this.sparkleDSAPrivateKeyFile,
     sparkle_eddsa_private_key: this.sparkleEdDSAPrivateKey,
     sparkle_eddsa_public_key: this.sparkleEdDSAPublicKey,
+    use_system_xcode: process.platform === 'darwin',
     ...this.extraGnArgs,
   }
 
@@ -399,6 +400,8 @@ Config.prototype.buildArgs = function () {
     args.ios_enable_share_extension = false
     args.ios_enable_credential_provider_extension = false
     args.ios_enable_widget_kit_extension = false
+
+    args.use_system_xcode = false
 
     delete args.safebrowsing_api_endpoint
     delete args.updater_prod_endpoint

--- a/script/hermetic_xcode.py
+++ b/script/hermetic_xcode.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Script to put a hermetic Xcode toolchain into the source tree."""
+
+import os
+import subprocess
+import sys
+
+
+BRAVE_CORE_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir))
+
+CHROMIUM_SRC_ROOT = os.path.abspath(
+    os.path.join(BRAVE_CORE_ROOT, os.pardir))
+
+MAC_FILES = os.path.join(CHROMIUM_SRC_ROOT, 'build', 'mac_files')
+
+
+def _run(*args, workdir=None, extra_env={}):
+    # Set environment variables for subprocess
+    env = os.environ.copy()
+    env.update(extra_env)
+
+    try:
+        result = subprocess.run(
+            args,
+            cwd=workdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True)
+        return result.stdout, result.stderr
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        raise e
+
+
+def _normalize_xcode_version(version):
+    parts = version.split('.')
+    while len(parts) < 3:
+        parts.append('0')
+    return '.'.join(parts)
+
+
+def _get_xcode_version():
+    # stdout should be of format
+    #   Xcode x.y.z
+    #   Build version abc
+    stdout, _ = _run('xcodebuild', '-version')
+
+    version = []
+    for line in stdout.split(b'\n'):
+        if line.startswith(b'Xcode '):
+            xcode = _normalize_xcode_version(
+                str(line[len(b'Xcode '):], 'utf8'))
+            version.append(xcode)
+        elif line.startswith(b'Build version '):
+            build = str(line[len(b'Build version '):], 'utf8')
+            version.append(build)
+    
+    return '.'.join(version)
+
+
+def _get_install_path():
+    xcode_version = _get_xcode_version()
+
+    # TODO(yannic): Use xcode-locator to ensure it's the right version?
+    stdout, _ = _run('xcode-select', '--print-path')
+
+    developer_dir = str(stdout, 'utf8')
+    return {
+        'version': xcode_version,
+        'path': os.path.abspath(
+            os.path.join(developer_dir, os.pardir, os.pardir))        
+    }
+
+
+def main():
+    if os.path.exists(MAC_FILES):
+        _run('rm', '-rf', MAC_FILES)
+    _run('mkdir', '-p', MAC_FILES)
+
+    xcode = _get_install_path()
+    _run('ln', '-s', xcode['path'], 'xcode_binaries', workdir=MAC_FILES)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This change adds a step to the checkout on macOS that symlinks the
system-installed Xcode into the source tree to emulate a hermetic Xcode
toolchain like Google uses. This is required for Goma on macOS to work.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

