### PR TITLE
Fixes shields extension showing disabled in background tabs. (uplift to 1.25.x)

### DIFF
--- a/patches/chrome-browser-extensions-api-tabs-tabs_api.cc.patch
+++ b/patches/chrome-browser-extensions-api-tabs-tabs_api.cc.patch
@@ -1,0 +1,29 @@
+diff --git a/chrome/browser/extensions/api/tabs/tabs_api.cc b/chrome/browser/extensions/api/tabs/tabs_api.cc
+index 64daa1117fdecd3d7bfe9e58fe1d953d75002da3..f42d13754d0ced8494bae157b5f37c23f1e30d81 100644
+--- a/chrome/browser/extensions/api/tabs/tabs_api.cc
++++ b/chrome/browser/extensions/api/tabs/tabs_api.cc
+@@ -1052,12 +1052,8 @@ ExtensionFunction::ResponseAction TabsQueryFunction::Run() {
+       continue;
+     }
+ 
+-    // Bug fix for crbug.com/1197888. Disable query during any tab drag to
+-    // ensure that the result matches the eventual state of the tab strip.
+-    TabStripModel* tab_strip =
+-        ExtensionTabUtil::GetEditableTabStripModel(browser);
+-    if (!tab_strip)
+-      return RespondNow(Error(tabs_constants::kTabStripNotEditableQueryError));
++    TabStripModel* tab_strip = browser->tab_strip_model();
++    DCHECK(tab_strip);
+     for (int i = 0; i < tab_strip->count(); ++i) {
+       WebContents* web_contents = tab_strip->GetWebContentsAt(i);
+ 
+@@ -1244,9 +1240,6 @@ ExtensionFunction::ResponseAction TabsGetFunction::Run() {
+     return RespondNow(Error(std::move(error)));
+   }
+ 
+-  if (!ExtensionTabUtil::IsTabStripEditable())
+-    return RespondNow(Error(tabs_constants::kTabStripNotEditableError));
+-
+   return RespondNow(ArgumentList(tabs::Get::Results::Create(
+       *CreateTabObjectHelper(contents, extension(), source_context_type(),
+                              tab_strip, tab_index))));


### PR DESCRIPTION
Fixes brave/brave-browser#16362
Uplift of #9105

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.