### PR TITLE
Revert "Fixes confirmations should only be sent for New Tab Page sponsored images if a user has signed up to Brave Ads"

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -722,19 +722,11 @@ void AdsImpl::OnAdNotificationEventFailed(
 }
 
 void AdsImpl::OnNewTabPageAdViewed(const NewTabPageAdInfo& ad) {
-  if (!ShouldRewardUser()) {
-    return;
-  }
-
   account_->Deposit(ad.creative_instance_id, ConfirmationType::kViewed);
 }
 
 void AdsImpl::OnNewTabPageAdClicked(const NewTabPageAdInfo& ad) {
   ad_transfer_->SetLastClickedAd(ad);
-
-  if (!ShouldRewardUser()) {
-    return;
-  }
 
   account_->Deposit(ad.creative_instance_id, ConfirmationType::kClicked);
 }


### PR DESCRIPTION
Reverts brave/brave-core#9115