### PR TITLE
Collapse HTML elements with blocked image/iframe requests

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -1047,12 +1047,15 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CollapseBlockedImage) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
 
-  ASSERT_EQ(true, EvalJs(contents,
+  EXPECT_EQ(true, EvalJs(contents,
                          "setExpectations(0, 1, 0, 0);"
                          "addImage('ad_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 
-  ASSERT_EQ(true, EvalJs(contents,
+  // There is no way for JS to directly tell if an element has been collapsed,
+  // but the clientHeight property is zero for collapsed elements and nonzero
+  // otherwise.
+  EXPECT_EQ(true, EvalJs(contents,
                          "let i = document.getElementsByClassName('adImage');"
                          "i[0].clientHeight === 0"));
 }
@@ -1067,10 +1070,13 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CollapseBlockedIframe) {
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
 
-  ASSERT_EQ(true, EvalJs(contents, "addFrame('ad_banner.png')"));
+  EXPECT_EQ(true, EvalJs(contents, "addFrame('ad_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 
-  ASSERT_EQ(true, EvalJs(contents,
+  // There is no way for JS to directly tell if an element has been collapsed,
+  // but the clientHeight property is zero for collapsed elements and nonzero
+  // otherwise.
+  EXPECT_EQ(true, EvalJs(contents,
                          "let i = document.getElementsByClassName('adFrame');"
                          "i[0].clientHeight === 0"));
 }
@@ -1096,12 +1102,15 @@ IN_PROC_BROWSER_TEST_F(CollapseBlockedElementsFlagDisabledTest,
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
 
-  ASSERT_EQ(true, EvalJs(contents,
+  EXPECT_EQ(true, EvalJs(contents,
                          "setExpectations(0, 1, 0, 0);"
                          "addImage('ad_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 
-  ASSERT_EQ(true, EvalJs(contents,
+  // There is no way for JS to directly tell if an element has been collapsed,
+  // but the clientHeight property is zero for collapsed elements and nonzero
+  // otherwise.
+  EXPECT_EQ(true, EvalJs(contents,
                          "let i = document.getElementsByClassName('adImage');"
                          "i[0].clientHeight !== 0"));
 }
@@ -1117,10 +1126,13 @@ IN_PROC_BROWSER_TEST_F(CollapseBlockedElementsFlagDisabledTest,
   content::WebContents* contents =
       browser()->tab_strip_model()->GetActiveWebContents();
 
-  ASSERT_EQ(true, EvalJs(contents, "addFrame('ad_banner.png')"));
+  EXPECT_EQ(true, EvalJs(contents, "addFrame('ad_banner.png')"));
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 
-  ASSERT_EQ(true, EvalJs(contents,
+  // There is no way for JS to directly tell if an element has been collapsed,
+  // but the clientHeight property is zero for collapsed elements and nonzero
+  // otherwise.
+  EXPECT_EQ(true, EvalJs(contents,
                          "let i = document.getElementsByClassName('adFrame');"
                          "i[0].clientHeight !== 0"));
 }

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -69,6 +69,7 @@ const char kRegionalAdBlockComponentTest64PublicKey[] =
     "LwIDAQAB";
 
 using brave_shields::features::kBraveAdblockCnameUncloaking;
+using brave_shields::features::kBraveAdblockCollapseBlockedElements;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using content::BrowserThread;
 
@@ -1034,6 +1035,94 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, TagPrefsControlTags) {
   AssertTagExists(brave_shields::kFacebookEmbeds, true);
   AssertTagExists(brave_shields::kTwitterEmbeds, true);
   AssertTagExists(brave_shields::kLinkedInEmbeds, false);
+}
+
+// Load a page with a blocked image, and make sure it is collapsed.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CollapseBlockedImage) {
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  ASSERT_EQ(true, EvalJs(contents,
+                         "setExpectations(0, 1, 0, 0);"
+                         "addImage('ad_banner.png')"));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+
+  ASSERT_EQ(true, EvalJs(contents,
+                         "let i = document.getElementsByClassName('adImage');"
+                         "i[0].clientHeight === 0"));
+}
+
+// Load a page with a blocked iframe, and make sure it is collapsed.
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CollapseBlockedIframe) {
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  ASSERT_EQ(true, EvalJs(contents, "addFrame('ad_banner.png')"));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+
+  ASSERT_EQ(true, EvalJs(contents,
+                         "let i = document.getElementsByClassName('adFrame');"
+                         "i[0].clientHeight === 0"));
+}
+
+class CollapseBlockedElementsFlagDisabledTest : public AdBlockServiceTest {
+ public:
+  CollapseBlockedElementsFlagDisabledTest() {
+    feature_list_.InitAndDisableFeature(kBraveAdblockCollapseBlockedElements);
+  }
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+};
+
+// Load a page with a blocked image, and make sure it is not collapsed.
+IN_PROC_BROWSER_TEST_F(CollapseBlockedElementsFlagDisabledTest,
+                       DontCollapseBlockedImage) {
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  ASSERT_EQ(true, EvalJs(contents,
+                         "setExpectations(0, 1, 0, 0);"
+                         "addImage('ad_banner.png')"));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+
+  ASSERT_EQ(true, EvalJs(contents,
+                         "let i = document.getElementsByClassName('adImage');"
+                         "i[0].clientHeight !== 0"));
+}
+
+// Load a page with a blocked iframe, and make sure it is not collapsed.
+IN_PROC_BROWSER_TEST_F(CollapseBlockedElementsFlagDisabledTest,
+                       DontCollapseBlockedIframe) {
+  ASSERT_TRUE(InstallDefaultAdBlockExtension());
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
+
+  GURL url = embedded_test_server()->GetURL(kAdBlockTestPage);
+  ui_test_utils::NavigateToURL(browser(), url);
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+
+  ASSERT_EQ(true, EvalJs(contents, "addFrame('ad_banner.png')"));
+  EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
+
+  ASSERT_EQ(true, EvalJs(contents,
+                         "let i = document.getElementsByClassName('adFrame');"
+                         "i[0].clientHeight !== 0"));
 }
 
 // Load a page with a script which uses a redirect data URL.

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -610,7 +610,15 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::
 void BraveProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
     const network::URLLoaderCompletionStatus& status) {
   if (!request_completed_) {
-    target_client_->OnComplete(status);
+    // Make a non-const copy of status so that |should_collapse_initiator| can
+    // be modified
+    network::URLLoaderCompletionStatus collapse_status(status);
+
+    if (ctx_->blocked_by == brave::kAdBlocked) {
+      collapse_status.should_collapse_initiator = true;
+    }
+
+    target_client_->OnComplete(collapse_status);
   }
 
   // Deletes |this|.

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -14,6 +14,7 @@
 #include "base/task/post_task.h"
 #include "brave/browser/net/brave_request_handler.h"
 #include "brave/components/brave_shields/browser/adblock_stub_response.h"
+#include "brave/components/brave_shields/common/features.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -614,7 +615,9 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
     // be modified
     network::URLLoaderCompletionStatus collapse_status(status);
 
-    if (ctx_->blocked_by == brave::kAdBlocked) {
+    if (base::FeatureList::IsEnabled(
+            ::brave_shields::features::kBraveAdblockCollapseBlockedElements) &&
+        ctx_->blocked_by == brave::kAdBlocked) {
       collapse_status.should_collapse_initiator = true;
     }
 

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -25,6 +25,7 @@
 #include "net/base/features.h"
 
 using brave_shields::features::kBraveAdblockCnameUncloaking;
+using brave_shields::features::kBraveAdblockCollapseBlockedElements;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockCosmeticFilteringNative;
 using brave_shields::features::kBraveAdblockCspRules;
@@ -135,6 +136,10 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      flag_descriptions::kBraveAdblockCnameUncloakingName,                   \
      flag_descriptions::kBraveAdblockCnameUncloakingDescription, kOsAll,    \
      FEATURE_VALUE_TYPE(kBraveAdblockCnameUncloaking)},                     \
+    {"brave-adblock-collapse-blocked-elements",                             \
+     flag_descriptions::kBraveAdblockCollapseBlockedElementsName,           \
+     flag_descriptions::kBraveAdblockCollapseBlockedElementsDescription,    \
+     kOsAll, FEATURE_VALUE_TYPE(kBraveAdblockCollapseBlockedElements)},     \
     {"brave-adblock-cosmetic-filtering",                                    \
      flag_descriptions::kBraveAdblockCosmeticFilteringName,                 \
      flag_descriptions::kBraveAdblockCosmeticFilteringDescription, kOsAll,  \

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -25,6 +25,11 @@ const char kBraveAdblockCnameUncloakingName[] = "Enable CNAME uncloaking";
 const char kBraveAdblockCnameUncloakingDescription[] =
     "Take DNS CNAME records into account when making network request blocking "
     "decisions.";
+const char kBraveAdblockCollapseBlockedElementsName[] =
+    "Collapse HTML elements with blocked source attributes";
+const char kBraveAdblockCollapseBlockedElementsDescription[] =
+    "Cause iframe and img elements to be collapsed if the URL of their src "
+    "attribute is blocked";
 const char kBraveAdblockCosmeticFilteringName[] = "Enable cosmetic filtering";
 const char kBraveAdblockCosmeticFilteringDescription[] =
     "Enable support for cosmetic filtering";

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -17,6 +17,8 @@ extern const char kBraveNTPBrandedWallpaperDemoName[];
 extern const char kBraveNTPBrandedWallpaperDemoDescription[];
 extern const char kBraveAdblockCnameUncloakingName[];
 extern const char kBraveAdblockCnameUncloakingDescription[];
+extern const char kBraveAdblockCollapseBlockedElementsName[];
+extern const char kBraveAdblockCollapseBlockedElementsDescription[];
 extern const char kBraveAdblockCosmeticFilteringName[];
 extern const char kBraveAdblockCosmeticFilteringNativeName[];
 extern const char kBraveAdblockCosmeticFilteringDescription[];

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -15,6 +15,8 @@ namespace features {
 // substituted for any canonical name found.
 const base::Feature kBraveAdblockCnameUncloaking{
     "BraveAdblockCnameUncloaking", base::FEATURE_ENABLED_BY_DEFAULT};
+// When enabled, Brave will apply HTML element collapsing to all images and
+// iframes that initiate a blocked network request.
 const base::Feature kBraveAdblockCollapseBlockedElements{
     "BraveAdblockCollapseBlockedElements", base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveAdblockCosmeticFiltering{

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -15,6 +15,8 @@ namespace features {
 // substituted for any canonical name found.
 const base::Feature kBraveAdblockCnameUncloaking{
     "BraveAdblockCnameUncloaking", base::FEATURE_ENABLED_BY_DEFAULT};
+const base::Feature kBraveAdblockCollapseBlockedElements{
+    "BraveAdblockCollapseBlockedElements", base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveAdblockCosmeticFiltering{
     "BraveAdblockCosmeticFiltering",
     base::FEATURE_ENABLED_BY_DEFAULT};

--- a/components/brave_shields/common/features.h
+++ b/components/brave_shields/common/features.h
@@ -13,6 +13,7 @@ struct Feature;
 namespace brave_shields {
 namespace features {
 extern const base::Feature kBraveAdblockCnameUncloaking;
+extern const base::Feature kBraveAdblockCollapseBlockedElements;
 extern const base::Feature kBraveAdblockCosmeticFiltering;
 extern const base::Feature kBraveAdblockCosmeticFilteringNative;
 extern const base::Feature kBraveAdblockCspRules;

--- a/test/data/blocking.html
+++ b/test/data/blocking.html
@@ -67,6 +67,23 @@ function addImage(src) {
   });
 }
 
+// Adds an iframe to the DOM with the specified src
+function addFrame(src) {
+  return new Promise(resolve => {
+    const frame = document.createElement('iframe')
+    frame.src = src
+    frame.className = 'adFrame'
+
+    frame.addEventListener('load', () => {
+      resolve(onLoad())
+    })
+    frame.addEventListener('error', () => {
+      resolve(onLoad())
+    })
+    document.body.appendChild(frame)
+  });
+}
+
 function installBlockingServiceWorker() {
   return new Promise(resolve => {
     navigator.serviceWorker.addEventListener('message', msg => {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/14825
Resolves https://github.com/brave/brave-browser/issues/14960

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Fix for https://github.com/brave/brave-browser/issues/14825

Load the following HTML page from an HTTP or HTTPS source (i.e. `http://` or `https://`, not a `file://` URL):

```html
<html>
    <body>
        <iframe src="https://1-1ads.com"></iframe>
        <iframe src="https://123freeavatars.com"></iframe>
        <iframe src="https://example.com"></iframe>
    </body>
</html>
```

With default Shields settings, only one frame (`example.com`) should be visible. The other two frames should be hidden.

With "Allow all trackers & ads" selected in the Shields panel, or with Shields disabled altogether, all three frames should be visible. Contents should load in the second frame (`123freeavatars.com`) and the third frame (`example.com`).

With default Shields settings, but with `#brave-adblock-collapse-blocked-elements` disabled in `brave://flags`, all three frames should be visible but only the last one (`example.com`) should actually load.

### Fix for https://github.com/brave/brave-browser/issues/14960

Visit https://www.twitch.tv/directory and observe profile and video thumbnail images loading correctly.

Add `||*^$image,domain=twitch.tv` to the "Custom filters" section of `brave://adblock` and reload the Twitch page.

Observe that the profile and video thumbnail images are missing from the page, and that no "broken image" placeholders appear on the page.

Finally, disable `#brave-adblock-collapse-blocked-elements` in `brave://flags` and relaunch the browser. The missing images on the Twitch page should now have visible "broken image" placeholders like below:

![broken image placeholder example](https://user-images.githubusercontent.com/44932435/112532379-5e1fe680-8d6e-11eb-90e7-4eecf3145b10.png).

