### PR TITLE
Fixes system-notification ads don't auto-dismiss after click/landing, nor do they time-out - 1.26.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_notifications/ad_notification_event_clicked.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/ad_notifications/ad_notification_event_clicked.cc
@@ -9,6 +9,7 @@
 #include "bat/ads/confirmation_type.h"
 #include "bat/ads/internal/ad_events/ad_events.h"
 #include "bat/ads/internal/ads/ad_notifications/ad_notifications.h"
+#include "bat/ads/internal/ads_client_helper.h"
 #include "bat/ads/internal/ads_history/ads_history.h"
 #include "bat/ads/internal/logging.h"
 
@@ -25,6 +26,8 @@ void AdEventClicked::FireEvent(const AdNotificationInfo& ad) {
                                                << ad.creative_instance_id);
 
   AdNotifications::Get()->Remove(ad.uuid);
+
+  AdsClientHelper::Get()->CloseNotification(ad.uuid);
 
   LogAdEvent(ad, ConfirmationType::kClicked, [](const Result result) {
     if (result != Result::SUCCESS) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9160
Resolves https://github.com/brave/brave-browser/issues/16357

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.