### PR TITLE
Fix version shown in auto-update popup on Mac (uplift to 1.26.x)

### DIFF
--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -57,6 +57,12 @@ def _OverrideVersionKey(plist, brave_version):
     adjusted_minor = int(version_values[1]) + (100 * int(version_values[0]))
     plist['CFBundleVersion'] = str(adjusted_minor) + '.' + version_values[2]
 
+  # The "short" version is only used for display purposes. Chromium uses four
+  # numbers w.x.y.z while Brave uses only three. So override the entry with our
+  # value. This is in particular displayed in Brave's (/Sparkle's) update
+  # notification popup: "Version X is available. You have version Y."
+  plist['CFBundleShortVersionString'] = brave_version
+
 
 def Main(argv):
   parser = optparse.OptionParser('%prog [options]')


### PR DESCRIPTION
Uplift of #8642

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.