### PR TITLE
Store last wallet unlocked YMD in preferences

### DIFF
--- a/browser/extensions/api/brave_wallet_api.cc
+++ b/browser/extensions/api/brave_wallet_api.cc
@@ -104,6 +104,17 @@ BraveWalletReadyFunction::Run() {
   return RespondNow(NoArguments());
 }
 
+ExtensionFunction::ResponseAction BraveWalletNotifyWalletUnlockFunction::Run() {
+  if (browser_context()->IsTor()) {
+    return RespondNow(Error("Not available in Tor context"));
+  }
+
+  Profile* profile = Profile::FromBrowserContext(browser_context());
+  ::brave_wallet::UpdateLastUnlockPref(profile->GetPrefs());
+
+  return RespondNow(NoArguments());
+}
+
 ExtensionFunction::ResponseAction
 BraveWalletLoadUIFunction::Run() {
   auto* service = GetEthereumRemoteClientService(browser_context());

--- a/browser/extensions/api/brave_wallet_api.h
+++ b/browser/extensions/api/brave_wallet_api.h
@@ -35,6 +35,15 @@ class BraveWalletReadyFunction :
   ResponseAction Run() override;
 };
 
+class BraveWalletNotifyWalletUnlockFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("braveWallet.notifyWalletUnlock", UNKNOWN)
+
+ protected:
+  ~BraveWalletNotifyWalletUnlockFunction() override {}
+  ResponseAction Run() override;
+};
+
 class BraveWalletShouldCheckForDappsFunction : public ExtensionFunction {
  public:
   DECLARE_EXTENSION_FUNCTION("braveWallet.shouldCheckForDapps", UNKNOWN)

--- a/common/extensions/api/brave_wallet.json
+++ b/common/extensions/api/brave_wallet.json
@@ -60,6 +60,11 @@
           }
         ]
       }, {
+        "name": "notifyWalletUnlock",
+        "type": "function",
+        "description": "Called to notify Brave that the wallet was unlocked",
+        "parameters": []
+      }, {
         "name": "getWalletSeed",
         "type": "function",
         "description": "Called when website detects a Dapp",

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -40,6 +40,7 @@ void BraveWalletService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(kBraveWalletDefaultKeyringAccountNum, 0);
   registry->RegisterBooleanPref(kShowWalletIconOnToolbar, true);
   registry->RegisterBooleanPref(kBraveWalletBackupComplete, false);
+  registry->RegisterTimePref(kBraveWalletLastUnlockTime, base::Time());
 }
 
 brave_wallet::EthJsonRpcController* BraveWalletService::rpc_controller() const {

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -15,10 +15,12 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
-#include "base/strings/stringprintf.h"
+#include "base/time/time.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/third_party/ethash/src/include/ethash/keccak.h"
 #include "brave/vendor/bip39wally-core-native/include/wally_bip39.h"
+#include "components/prefs/pref_service.h"
 #include "crypto/random.h"
 #include "third_party/boringssl/src/include/openssl/evp.h"
 
@@ -373,6 +375,14 @@ void SecureZeroData(void* data, size_t size) {
   for (size_t i = 0; i < size; i++)
     d[i] = 0;
 #endif
+}
+
+// Updates preferences for when the wallet is unlocked.
+// This is done in a utils function instead of in the KeyringController
+// because we call it both from the old extension and the new wallet when
+// it unlocks.
+void UpdateLastUnlockPref(PrefService* prefs) {
+  prefs->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -12,6 +12,8 @@
 
 #include "brave/components/brave_wallet/browser/brave_wallet_types.h"
 
+class PrefService;
+
 namespace brave_wallet {
 
 bool IsNativeWalletEnabled();
@@ -73,6 +75,12 @@ std::string Namehash(const std::string& name);
 // for security reason, compiler optimizer can remove such call.
 // So we use our own function for this purpose.
 void SecureZeroData(void* data, size_t size);
+
+// Updates preferences for when the wallet is unlocked.
+// This is done in a utils function instead of in the KeyringController
+// because we call it both from the old extension and the new wallet when
+// it unlocks.
+void UpdateLastUnlockPref(PrefService* prefs);
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/browser/keyring_controller.cc
+++ b/components/brave_wallet/browser/keyring_controller.cc
@@ -130,6 +130,7 @@ bool KeyringController::Unlock(const std::string& password) {
     return false;
   }
 
+  UpdateLastUnlockPref(prefs_);
   return true;
 }
 
@@ -205,6 +206,7 @@ bool KeyringController::CreateDefaultKeyringInternal(
     return false;
   default_keyring_ = std::make_unique<HDKeyring>();
   default_keyring_->ConstructRootHDKey(*seed, "m/44'/60'/0'/0");
+  UpdateLastUnlockPref(prefs_);
 
   return true;
 }

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -16,3 +16,5 @@ const char kBraveWalletDefaultKeyringAccountNum[] =
 const char kShowWalletIconOnToolbar[] =
     "brave.wallet.show_wallet_icon_on_toolbar";
 const char kBraveWalletBackupComplete[] = "brave.wallet.wallet_backup_complete";
+const char kBraveWalletLastUnlockTime[] =
+    "brave.wallet.wallet_last_unlock_time";

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -13,5 +13,6 @@ extern const char kBraveWalletEncryptedMnemonic[];
 extern const char kBraveWalletDefaultKeyringAccountNum[];
 extern const char kShowWalletIconOnToolbar[];
 extern const char kBraveWalletBackupComplete[];
+extern const char kBraveWalletLastUnlockTime[];
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_PREF_NAMES_H_

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -351,6 +351,7 @@ declare namespace chrome.braveWallet {
   const shouldPromptForSetup: (callback: (dappDetection: boolean) => void) => void
   const loadUI: (callback: () => void) => void
   const isNativeWalletEnabled: (callback: (enabled: boolean) => void) => void
+  const notifyWalletUnlock: () => void
 }
 
 declare namespace chrome.ipfs {

--- a/test/data/extensions/api_test/braveWallet/background.js
+++ b/test/data/extensions/api_test/braveWallet/background.js
@@ -152,6 +152,7 @@ function testBasics() {
     function braveWalletExtensionHasAccess() {
       if (chrome.braveWallet &&
           chrome.braveWallet.shouldPromptForSetup &&
+          chrome.braveWallet.notifyWalletUnlock &&
           chrome.braveWallet.loadUI &&
           chrome.braveWallet.promptToEnableWallet) {
         chrome.test.succeed();


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16174
Related PR: https://github.com/brave/ethereum-remote-client/pull/246

This stores the last wallet unlock year-month-day (YMD) for both the Crypto Wallets extension and the new wallet. It does not differentiate between the two.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
  - This work is just for the local preference that is stored on the user's machine, so no security/privacy review needed for it.
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

