### PR TITLE
Move chromium version ref to brave-core/package.json

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -632,7 +632,7 @@ const util = {
     return needsUpdate
   },
 
-  gclientSync: (forceReset = false, cleanup = false, braveCoreRef = null, options = {}) => {
+  gclientSync: (forceReset = false, cleanup = false, braveCoreRef = null, shouldCheckChromiumVersion = true, options = {}) => {
     let reset = forceReset
 
     // base args
@@ -674,7 +674,12 @@ const util = {
       reset = true
     }
 
-    if (forceReset || util.shouldUpdateChromium()) {
+    if (!shouldCheckChromiumVersion) {
+      const chromiumNeedsUpdate = util.shouldUpdateChromium()
+      if (chromiumNeedsUpdate) {
+        console.warn(chalk.yellow.bold('Chromium needed update but received the flag to skip performing the update. Working directory may not compile correctly.'))
+      }
+    } else if (forceReset || util.shouldUpdateChromium()) {
       args = [...args, ...chromiumArgs]
       reset = true
       didUpdateChromium = true

--- a/build/commands/scripts/sync.js
+++ b/build/commands/scripts/sync.js
@@ -23,6 +23,7 @@ program
   .option('--init', 'initialize all dependencies')
   .option('--all', 'This flag is deprecated and no longer has any effect')
   .option('--force', 'force reset all projects to origin/ref')
+  .option('--ignore_chromium', 'do not update chromium version even if it is stale')
 
 const installDepotTools = (options = config.defaultOptions) => {
   options.cwd = config.braveCoreDir
@@ -86,7 +87,7 @@ async function RunCommand () {
   }
 
   Log.progress('Running gclient sync...')
-  const result = util.gclientSync(program.init || program.force, program.init, braveCoreRef)
+  const result = util.gclientSync(program.init || program.force, program.init, braveCoreRef, !program.ignore_chromium)
   const postSyncBraveCoreRef = util.getGitReadableLocalRef(config.braveCoreDir)
   Log.status(`Brave Core is now at ${postSyncBraveCoreRef || '[unknown]'}`)
   if (result.didUpdateChromium) {

--- a/package.json
+++ b/package.json
@@ -245,6 +245,17 @@
     "url": "https://github.com/brave/brave-browser/issues"
   },
   "homepage": "https:/github.com/brave/brave-core#readme",
+  "config": {
+    "projects": {
+      "chrome": {
+        "dir": "src",
+        "tag": "96.0.4664.27",
+        "repository": {
+          "url": "https://github.com/chromium/chromium"
+        }
+      }
+    }
+  },
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@dump247/storybook-state": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "96.0.4664.27",
+        "tag": "96.0.4664.35",
         "repository": {
           "url": "https://github.com/chromium/chromium"
         }


### PR DESCRIPTION
Related PR https://github.com/brave/brave-browser/pull/16558
Fixes https://github.com/brave/brave-browser/issues/16419

Since developers will need an alternate way to perform a `npm run sync` without updating chromium, we introduce the following flag:

```
npm run sync -- --ignore_chromium
```

![image](https://user-images.githubusercontent.com/741836/134593546-b906a09e-71ad-48bc-ba68-92e73e97d419.png)
