### PR TITLE
Bugfix: dark mode broken for settings when strict fingerprinting 

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -691,12 +691,14 @@ bool BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation(
           web_contents, prefs);
   Profile* profile =
       Profile::FromBrowserContext(web_contents->GetBrowserContext());
+  const GURL url = web_contents->GetLastCommittedURL();
+  const bool shields_up = brave_shields::GetBraveShieldsEnabled(
+      HostContentSettingsMapFactory::GetForProfile(profile), url);
   auto fingerprinting_type = brave_shields::GetFingerprintingControlType(
-      HostContentSettingsMapFactory::GetForProfile(profile),
-      web_contents->GetLastCommittedURL());
+      HostContentSettingsMapFactory::GetForProfile(profile), url);
   // https://github.com/brave/brave-browser/issues/15265
   // Always use color scheme Light if fingerprinting mode strict
-  if (fingerprinting_type == ControlType::BLOCK) {
+  if (shields_up && fingerprinting_type == ControlType::BLOCK) {
     prefs->preferred_color_scheme = blink::mojom::PreferredColorScheme::kLight;
     changed = true;
   }

--- a/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
+++ b/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
@@ -27,6 +27,9 @@
 using brave_shields::ControlType;
 
 const char kEmbeddedTestServerDirectory[] = "dark_mode_block";
+const char kMatchDarkMode[] =
+    "window.domAutomationController.send(window.matchMedia('(prefers-color-"
+    "scheme: dark)').matches)";
 
 class BraveDarkModeFingerprintProtection : public InProcessBrowserTest {
  public:
@@ -142,4 +145,15 @@ IN_PROC_BROWSER_TEST_F(BraveDarkModeFingerprintProtection, RegressionCheck) {
   NavigateToURLUntilLoadStop(dark_mode_url());
   ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
   EXPECT_EQ(base::ASCIIToUTF16("light"), tab_title);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveDarkModeFingerprintProtection, SettingsPagesCheck) {
+  // On settings page should get dark mode with fingerprinting strict
+  test_theme_.SetDarkMode(true);
+  BlockFingerprinting();
+  NavigateToURLUntilLoadStop(GURL("brave://settings"));
+  bool result;
+  ASSERT_TRUE(content::ExecuteScriptAndExtractBool(contents(), kMatchDarkMode,
+                                                   &result));
+  EXPECT_TRUE(result);
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves  https://github.com/brave/brave-browser/issues/16496. Needed to add an explicit check to make sure shields are up. 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Added automated test for the breakage
- Check against https://dev-pages.brave.software/fingerprinting/strict-mode.html as detailed in [original PR](https://github.com/brave/brave-browser/issues/15265#issuecomment-861071038)
- Should also check for dark mode detection on Settings pages 
