### PR TITLE
Fixed follow up of #14813 - The size of the custom ad notification popup is enlarged after reposition

### DIFF
--- a/browser/ui/brave_ads/ad_notification_popup.cc
+++ b/browser/ui/brave_ads/ad_notification_popup.cc
@@ -164,6 +164,17 @@ void AdNotificationPopup::OnClick(const std::string& notification_id) {
   popup->FadeOut();
 }
 
+// static
+gfx::Rect AdNotificationPopup::GetBounds(const std::string& notification_id) {
+  DCHECK(!notification_id.empty());
+
+  DCHECK(g_ad_notification_popups[notification_id]);
+  AdNotificationPopup* popup = g_ad_notification_popups[notification_id];
+  DCHECK(popup);
+
+  return popup->CalculateBounds();
+}
+
 void AdNotificationPopup::OnDisplayRemoved(
     const display::Display& old_display) {
   // Called when |old_display| has been removed
@@ -197,7 +208,7 @@ void AdNotificationPopup::OnWorkAreaChanged() {
 void AdNotificationPopup::OnPaintBackground(gfx::Canvas* canvas) {
   DCHECK(canvas);
 
-  gfx::RectF bounds(GetWidget()->GetLayer()->bounds());
+  gfx::Rect bounds(GetWidget()->GetLayer()->bounds());
   bounds.Inset(-GetShadowMargin());
 
   const bool should_use_dark_colors = GetNativeTheme()->ShouldUseDarkColors();
@@ -391,7 +402,6 @@ void AdNotificationPopup::RecomputeAlignment() {
   gfx::Rect bounds = GetWidget()->GetWindowBoundsInScreen();
   const gfx::NativeView native_view = GetWidget()->GetNativeView();
   AdjustBoundsToFitWorkAreaForNativeView(&bounds, native_view);
-
   GetWidget()->SetBounds(bounds);
 }
 

--- a/browser/ui/brave_ads/ad_notification_popup.h
+++ b/browser/ui/brave_ads/ad_notification_popup.h
@@ -65,6 +65,9 @@ class AdNotificationPopup : public views::WidgetDelegateView,
   // User clicked the notification popup view for the given |notification_id|
   static void OnClick(const std::string& notification_id);
 
+  // Return the bounds for the given |notification_id|
+  static gfx::Rect GetBounds(const std::string& notification_id);
+
   // display::DisplayObserver:
   void OnDisplayRemoved(const display::Display& old_display) override;
   void OnDisplayMetricsChanged(const display::Display& display,

--- a/browser/ui/brave_ads/ad_notification_view.cc
+++ b/browser/ui/brave_ads/ad_notification_view.cc
@@ -78,8 +78,8 @@ bool AdNotificationView::OnMouseDragged(const ui::MouseEvent& event) {
     return false;
   }
 
-  gfx::Rect bounds =
-      GetWidget()->GetContentsView()->GetBoundsInScreen() + movement;
+  const std::string id = ad_notification_.id();
+  gfx::Rect bounds = AdNotificationPopup::GetBounds(id) + movement;
   const gfx::NativeView native_view = GetWidget()->GetNativeView();
   AdjustBoundsToFitWorkAreaForNativeView(&bounds, native_view);
   GetWidget()->SetBounds(bounds);
@@ -101,6 +101,13 @@ void AdNotificationView::OnMouseReleased(const ui::MouseEvent& event) {
   AdNotificationPopup::OnClick(id);
 
   View::OnMouseReleased(event);
+}
+
+void AdNotificationView::OnDeviceScaleFactorChanged(
+    float old_device_scale_factor,
+    float new_device_scale_factor) {
+  GetWidget()->DeviceScaleFactorChanged(old_device_scale_factor,
+                                        new_device_scale_factor);
 }
 
 void AdNotificationView::OnThemeChanged() {

--- a/browser/ui/brave_ads/ad_notification_view.h
+++ b/browser/ui/brave_ads/ad_notification_view.h
@@ -34,6 +34,8 @@ class AdNotificationView : public views::InkDropHostView {
   bool OnMousePressed(const ui::MouseEvent& event) override;
   bool OnMouseDragged(const ui::MouseEvent& event) override;
   void OnMouseReleased(const ui::MouseEvent& event) override;
+  void OnDeviceScaleFactorChanged(float old_device_scale_factor,
+                                  float new_device_scale_factor) override;
   void OnThemeChanged() override;
 
  private:


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16241

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See https://github.com/brave/brave-browser/issues/16241 and also test that when changing the displays scale factor that notifications scale accordingly.