### PR TITLE
Bugfix: dark mode broken for settings when strict fingerprinting (uplift to 1.27.x)

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -691,12 +691,14 @@ bool BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation(
           web_contents, prefs);
   Profile* profile =
       Profile::FromBrowserContext(web_contents->GetBrowserContext());
+  const GURL url = web_contents->GetLastCommittedURL();
+  const bool shields_up = brave_shields::GetBraveShieldsEnabled(
+      HostContentSettingsMapFactory::GetForProfile(profile), url);
   auto fingerprinting_type = brave_shields::GetFingerprintingControlType(
-      HostContentSettingsMapFactory::GetForProfile(profile),
-      web_contents->GetLastCommittedURL());
+      HostContentSettingsMapFactory::GetForProfile(profile), url);
   // https://github.com/brave/brave-browser/issues/15265
   // Always use color scheme Light if fingerprinting mode strict
-  if (fingerprinting_type == ControlType::BLOCK) {
+  if (shields_up && fingerprinting_type == ControlType::BLOCK) {
     prefs->preferred_color_scheme = blink::mojom::PreferredColorScheme::kLight;
     changed = true;
   }

--- a/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
+++ b/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
@@ -27,6 +27,9 @@
 using brave_shields::ControlType;
 
 const char kEmbeddedTestServerDirectory[] = "dark_mode_block";
+const char kMatchDarkMode[] =
+    "window.domAutomationController.send(window.matchMedia('(prefers-color-"
+    "scheme: dark)').matches)";
 
 class BraveDarkModeFingerprintProtection : public InProcessBrowserTest {
  public:
@@ -142,4 +145,15 @@ IN_PROC_BROWSER_TEST_F(BraveDarkModeFingerprintProtection, RegressionCheck) {
   NavigateToURLUntilLoadStop(dark_mode_url());
   ASSERT_TRUE(ui_test_utils::GetCurrentTabTitle(browser(), &tab_title));
   EXPECT_EQ(base::ASCIIToUTF16("light"), tab_title);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveDarkModeFingerprintProtection, SettingsPagesCheck) {
+  // On settings page should get dark mode with fingerprinting strict
+  test_theme_.SetDarkMode(true);
+  BlockFingerprinting();
+  NavigateToURLUntilLoadStop(GURL("brave://settings"));
+  bool result;
+  ASSERT_TRUE(content::ExecuteScriptAndExtractBool(contents(), kMatchDarkMode,
+                                                   &result));
+  EXPECT_TRUE(result);
 }


### PR DESCRIPTION
Uplift of #9215

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.