### PR TITLE
Fixed follow up of #14813 - The size of the custom ad notification popup is enlarged after reposition - 1.27.x

### DIFF
--- a/browser/ui/brave_ads/ad_notification_popup.cc
+++ b/browser/ui/brave_ads/ad_notification_popup.cc
@@ -164,6 +164,17 @@ void AdNotificationPopup::OnClick(const std::string& notification_id) {
   popup->FadeOut();
 }
 
+// static
+gfx::Rect AdNotificationPopup::GetBounds(const std::string& notification_id) {
+  DCHECK(!notification_id.empty());
+
+  DCHECK(g_ad_notification_popups[notification_id]);
+  AdNotificationPopup* popup = g_ad_notification_popups[notification_id];
+  DCHECK(popup);
+
+  return popup->CalculateBounds();
+}
+
 void AdNotificationPopup::OnDisplayRemoved(
     const display::Display& old_display) {
   // Called when |old_display| has been removed
@@ -197,7 +208,7 @@ void AdNotificationPopup::OnWorkAreaChanged() {
 void AdNotificationPopup::OnPaintBackground(gfx::Canvas* canvas) {
   DCHECK(canvas);
 
-  gfx::RectF bounds(GetWidget()->GetLayer()->bounds());
+  gfx::Rect bounds(GetWidget()->GetLayer()->bounds());
   bounds.Inset(-GetShadowMargin());
 
   const bool should_use_dark_colors = GetNativeTheme()->ShouldUseDarkColors();
@@ -391,7 +402,6 @@ void AdNotificationPopup::RecomputeAlignment() {
   gfx::Rect bounds = GetWidget()->GetWindowBoundsInScreen();
   const gfx::NativeView native_view = GetWidget()->GetNativeView();
   AdjustBoundsToFitWorkAreaForNativeView(&bounds, native_view);
-
   GetWidget()->SetBounds(bounds);
 }
 

--- a/browser/ui/brave_ads/ad_notification_popup.h
+++ b/browser/ui/brave_ads/ad_notification_popup.h
@@ -65,6 +65,9 @@ class AdNotificationPopup : public views::WidgetDelegateView,
   // User clicked the notification popup view for the given |notification_id|
   static void OnClick(const std::string& notification_id);
 
+  // Return the bounds for the given |notification_id|
+  static gfx::Rect GetBounds(const std::string& notification_id);
+
   // display::DisplayObserver:
   void OnDisplayRemoved(const display::Display& old_display) override;
   void OnDisplayMetricsChanged(const display::Display& display,

--- a/browser/ui/brave_ads/ad_notification_view.cc
+++ b/browser/ui/brave_ads/ad_notification_view.cc
@@ -78,8 +78,8 @@ bool AdNotificationView::OnMouseDragged(const ui::MouseEvent& event) {
     return false;
   }
 
-  gfx::Rect bounds =
-      GetWidget()->GetContentsView()->GetBoundsInScreen() + movement;
+  const std::string id = ad_notification_.id();
+  gfx::Rect bounds = AdNotificationPopup::GetBounds(id) + movement;
   const gfx::NativeView native_view = GetWidget()->GetNativeView();
   AdjustBoundsToFitWorkAreaForNativeView(&bounds, native_view);
   GetWidget()->SetBounds(bounds);
@@ -101,6 +101,13 @@ void AdNotificationView::OnMouseReleased(const ui::MouseEvent& event) {
   AdNotificationPopup::OnClick(id);
 
   View::OnMouseReleased(event);
+}
+
+void AdNotificationView::OnDeviceScaleFactorChanged(
+    float old_device_scale_factor,
+    float new_device_scale_factor) {
+  GetWidget()->DeviceScaleFactorChanged(old_device_scale_factor,
+                                        new_device_scale_factor);
 }
 
 void AdNotificationView::OnThemeChanged() {

--- a/browser/ui/brave_ads/ad_notification_view.h
+++ b/browser/ui/brave_ads/ad_notification_view.h
@@ -34,6 +34,8 @@ class AdNotificationView : public views::InkDropHostView {
   bool OnMousePressed(const ui::MouseEvent& event) override;
   bool OnMouseDragged(const ui::MouseEvent& event) override;
   void OnMouseReleased(const ui::MouseEvent& event) override;
+  void OnDeviceScaleFactorChanged(float old_device_scale_factor,
+                                  float new_device_scale_factor) override;
   void OnThemeChanged() override;
 
  private:


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9224
Resolves brave/brave-browser#16241

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
