### PR TITLE
Fixes Brave News ads should not send confirmations for conversions if users have not opted-in to Brave Ads - 1.27.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -791,6 +791,10 @@ void AdsImpl::OnAdTransfer(const AdInfo& ad) {
 
 void AdsImpl::OnConversion(
     const ConversionQueueItemInfo& conversion_queue_item) {
+  if (!ShouldRewardUser()) {
+    return;
+  }
+
   account_->Deposit(conversion_queue_item.creative_instance_id,
                     ConfirmationType::kConversion);
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9221
Resolves https://github.com/brave/brave-browser/issues/16575

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
