### PR TITLE
[Android] fixes check permission crash (uplift to 1.27.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java
+++ b/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java
@@ -276,7 +276,10 @@ public class BraveStatsUtil {
     }
 
     public static boolean hasWritePermission(Activity activity) {
-        if (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        if (activity == null) {
+            return false;
+        }
+        if (activity.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 == PackageManager.PERMISSION_GRANTED) {
             return true;
         }


### PR DESCRIPTION
Uplift of #9233
Resolves https://github.com/brave/brave-browser/issues/16596

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.