### PR TITLE
move security and privacy settings out of additional menu

### DIFF
--- a/browser/resources/settings/brave_overrides/basic_page.js
+++ b/browser/resources/settings/brave_overrides/basic_page.js
@@ -103,12 +103,11 @@ RegisterPolymerTemplateModifications({
     } else if (!isGuest) {
       console.error('[Brave Settings Overrides] Could not move autofill route to advanced route', r)
     }
-    // Privacy route is moved to advanced.
-    if (r.PRIVACY && r.ADVANCED) {
-      r.PRIVACY.parent = r.ADVANCED
-      r.CLEAR_BROWSER_DATA.parent = r.ADVANCED
+    // Safety check route is moved to advanced.
+    if (r.SAFETY_CHECK && r.ADVANCED) {
+      r.SAFETY_CHECK.parent = r.ADVANCED
     } else if (!isGuest) {
-      console.error('[Brave Settings Overrides] Could not move privacy route to advanced route', r)
+      console.error('[Brave Settings Overrides] Could not move safety check route to advanced route', r)
     }
     // Add 'Getting Started' section
     // Entire content is wrapped in another conditional template
@@ -236,15 +235,18 @@ RegisterPolymerTemplateModifications({
       sectionGetStarted.insertAdjacentElement('afterend', sectionAppearance)
       // Insert New Tab
       sectionAppearance.insertAdjacentElement('afterend', sectionNewTab)
-      // Insert sync
-      sectionNewTab.insertAdjacentElement('afterend', sectionSync)
       // Insert shields
-      sectionSync.insertAdjacentElement('afterend', sectionShields)
+      sectionNewTab.insertAdjacentElement('afterend', sectionShields)
       // Insert Social Blocking
       sectionShields.insertAdjacentElement('afterend', sectionSocialBlocking)
+      // Move privacy section to after social blocking
+      const sectionPrivacy = getSectionElement(actualTemplate.content, 'privacy')
+      sectionSocialBlocking.insertAdjacentElement('afterend', sectionPrivacy)
+      // Insert sync
+      sectionPrivacy.insertAdjacentElement('afterend', sectionSync)
       // Move search
       const sectionSearch = getSectionElement(actualTemplate.content, 'search')
-      sectionSocialBlocking.insertAdjacentElement('afterend', sectionSearch)
+      sectionSync.insertAdjacentElement('afterend', sectionSearch)
       // Insert extensions
       sectionSearch.insertAdjacentElement('afterend', sectionExtensions)
       // Insert Wallet
@@ -273,12 +275,12 @@ RegisterPolymerTemplateModifications({
       const sectionAutofill = getSectionElement(actualTemplate.content, 'autofill')
       const sectionLanguages = getSectionElement(advancedSubSectionsTemplate.content, 'languages')
       sectionLanguages.insertAdjacentElement('beforebegin', sectionAutofill)
-      // Move privacy to before autofill
-      const sectionPrivacy = getSectionElement(actualTemplate.content, 'privacy')
-      sectionAutofill.insertAdjacentElement('beforebegin', sectionPrivacy)
-      // Move help tips after downloads
+      // Move safety check after downloads
       const sectionDownloads = getSectionElement(advancedSubSectionsTemplate.content, 'downloads')
-      sectionDownloads.insertAdjacentElement('afterend', sectionHelpTips)
+      const sectionSafetyCheck = getSectionElement(actualTemplate.content, 'safetyCheck')
+      sectionDownloads.insertAdjacentElement('afterend', sectionSafetyCheck)
+      // Move help tips after safety check
+      sectionSafetyCheck.insertAdjacentElement('afterend', sectionHelpTips)
     }
   }
 })

--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -175,21 +175,6 @@ RegisterPolymerTemplateModifications({
       'newTab'
     )
     appearanceBrowserEl.insertAdjacentElement('afterend', newTabEl)
-    // Add Sync and Help Tips item
-    const helpTipsEl = createMenuElement(
-      loadTimeData.getString('braveHelpTips'),
-      '/braveHelpTips',
-      'brave_settings:help',
-      'braveHelpTips',
-    )
-    const syncEl = createMenuElement(
-      loadTimeData.getString('braveSync'),
-      '/braveSync',
-      'brave_settings:sync',
-      'braveSync',
-    )
-    newTabEl.insertAdjacentElement('afterend', syncEl)
-    syncEl.insertAdjacentElement('afterend', helpTipsEl)
     // Add Shields item
     const shieldsEl = createMenuElement(
       loadTimeData.getString('braveShieldsTitle'),
@@ -197,7 +182,7 @@ RegisterPolymerTemplateModifications({
       'brave_settings:shields',
       'shields',
     )
-    helpTipsEl.insertAdjacentElement('afterend', shieldsEl)
+    newTabEl.insertAdjacentElement('afterend', shieldsEl)
     // Add Embed Blocking item
     const embedEl = createMenuElement(
       loadTimeData.getString('socialBlocking'),
@@ -206,9 +191,20 @@ RegisterPolymerTemplateModifications({
       'socialBlocking',
     )
     shieldsEl.insertAdjacentElement('afterend', embedEl)
+    // Add privacy
+    const privacyEl = getMenuElement(templateContent, '/privacy')
+    embedEl.insertAdjacentElement('afterend', privacyEl)
+    // Add Sync item
+    const syncEl = createMenuElement(
+      loadTimeData.getString('braveSync'),
+      '/braveSync',
+      'brave_settings:sync',
+      'braveSync',
+    )
+    privacyEl.insertAdjacentElement('afterend', syncEl)
     // Move search item
     const searchEl = getMenuElement(templateContent, '/search')
-    embedEl.insertAdjacentElement('afterend', searchEl)
+    syncEl.insertAdjacentElement('afterend', searchEl)
     // Add Extensions item
     const extensionEl = createMenuElement(
       loadTimeData.getString('braveDefaultExtensions'),
@@ -238,12 +234,18 @@ RegisterPolymerTemplateModifications({
     const autofillEl = getMenuElement(templateContent, '/autofill')
     const languagesEl = getMenuElement(templateContent, '/languages')
     languagesEl.insertAdjacentElement('beforebegin', autofillEl)
-    // Move privacy to advanced
-    const privacyEl = getMenuElement(templateContent, '/privacy')
-    autofillEl.insertAdjacentElement('beforebegin', privacyEl)
-    // Move helptips to advanced
+    // Move safety check after downloads
     const downloadsEl = getMenuElement(templateContent, '/downloads')
-    downloadsEl.insertAdjacentElement('afterend', helpTipsEl)
+    const safetyEl = getMenuElement(templateContent, '/safetyCheck')
+    downloadsEl.insertAdjacentElement('afterend', safetyEl)
+    // Move help tips after safety check
+    const helpTipsEl = createMenuElement(
+      loadTimeData.getString('braveHelpTips'),
+      '/braveHelpTips',
+      'brave_settings:help',
+      'braveHelpTips',
+    )
+    safetyEl.insertAdjacentElement('afterend', helpTipsEl)
     // Allow Accessibility to be removed :-(
     const a11yEl = getMenuElement(templateContent, '/accessibility')
     a11yEl.setAttribute('hidden', '[[!pageVisibility.a11y]')


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/16470



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

all brave://settings items should still be present and functional, but they should be re-ordered to this:

<img width="240" alt="Screen Shot 2021-06-24 at 10 50 59 PM" src="https://user-images.githubusercontent.com/549654/123376504-6b03d000-d53f-11eb-8004-cffaeb7e4bb0.png">
<img width="240" alt="Screen Shot 2021-06-24 at 10 51 16 PM" src="https://user-images.githubusercontent.com/549654/123376509-6e975700-d53f-11eb-9733-dca497d6a9d4.png">

note: i noticed a crash when clicking additional settings, but it seems unrelated to this PR. https://bravesoftware.slack.com/archives/C7VLGSR55/p1624599889002200