### PR TITLE
Update Japanese l10n for 1.26.x release. (uplift to 1.27.x)

### DIFF
--- a/app/resources/brave_generated_resources_ja.xtb
+++ b/app/resources/brave_generated_resources_ja.xtb
@@ -305,7 +305,7 @@
 <translation id="9089090017461255038">Speedreaderをオンにする</translation>
 <translation id="312393675740711187">記事が自動的にリーダーモードで読み込まれるため、時間を節約できます。</translation>
 <translation id="3234744217174488546">このウェブサイトでのみリーダーモードをオン/オフにします。ブラウザのプロファイル全体でSpeedreaderをオフにするには、次へ移動します:</translation>
-<translation id="7839742507462737706">: Speedreaderオン</translation>
+<translation id="7839742507462737706">Speedreaderが有効化されています</translation>
 <translation id="1872784258300710671">Braveは完全に匿名の製品分析を使い、特定の機能が全体でどの程度使われているか予測します</translation>
 <translation id="8712637175834984815">閉じる</translation>
 <translation id="4394049700291259645">無効にする</translation>

--- a/browser/ui/android/strings/translations/android_brave_strings_ja.xtb
+++ b/browser/ui/android/strings/translations/android_brave_strings_ja.xtb
@@ -36,7 +36,7 @@
 <translation id="2448893613530489637">トラッカーや広告の読み込みやウェブページでの表示を防ぎます</translation>
 <translation id="1680858055899097121">セッション間でタブを保持しない</translation>
 <translation id="7142548388914389999">プライバシーを保護したプロダクト分析 (P3A) を許可する</translation>
-<translation id="5469408008145872264">この完全に匿名の情報は、Braveで特定の機能の全体的な使用状況を予測し、ユーザーエクスペリエンスを向上するために役立ちます。</translation>
+<translation id="5469408008145872264">この完全に匿名化された情報は、Braveが特定の機能の全体的な使用状況を推定し、ユーザーエクスペリエンスを向上するために役立ちます。</translation>
 <translation id="7977176350719484850">節約できた\n通信量 (推定)</translation>
 <translation id="9008534313521214777">節約できた\n時間(推定)</translation>
 <translation id="6572660632052512096">デスクトップモード</translation>
@@ -154,7 +154,7 @@
 <translation id="7510166204621526816">Brave Rewardsサーバーが応答しません。可能な限り早く回復いたします。</translation>
 <translation id="683765328936486920">YouTubeで</translation>
 <translation id="8969049974285901797">Twitchで</translation>
-<translation id="3692362746128814480">あなたは、寄付を受け取るためにまだサインアップしていないクリエイターに対して<ph name="BAT_VALUE"/>BATを指定しました。あなたのブラウザーは、クリエイターたちが確認するまで、または90日が経過するまで寄付の実行を試み続けます。</translation>
+<translation id="3692362746128814480">あなたは、寄付を受け取るためにまだサインアップしていないクリエイターに対して<ph name="BAT_VALUE"/>BATを指定しました。あなたのブラウザーは、クリエイターたちが認証するまで、または90日が経過するまで寄付の実行を試み続けます。</translation>
 <translation id="3101693828171454453"><ph name="TOKEN"/>足りません</translation>
 <translation id="6940273954212603510">お願いします</translation>
 <translation id="1036277985068412734">資金を追加する</translation>
@@ -329,6 +329,7 @@
 <translation id="5617673581653540121">これで、あなたの接続が暗号化されました。</translation>
 <translation id="4055107796760496928">可能な場合、Braveは自動的に安全な接続にアップブレード致します。</translation>
 <translation id="8869714780588464835">ニュースをシェア</translation>
+<translation id="7427391215172269363">BraveでWebを閲覧して毎日データ通信量を節約しています。</translation>
 <translation id="5372054974373489308">1,000件のトラッカーと広告がブロックされました！</translation>
 <translation id="2338952568654182692">5,000件のトラッカーと広告がブロックされました！</translation>
 <translation id="5289711064670408815">10,000件のトラッカーと広告がブロックされました！</translation>

--- a/components/brave_extension/extension/brave_extension/_locales/ja/messages.json
+++ b/components/brave_extension/extension/brave_extension/_locales/ja/messages.json
@@ -176,7 +176,7 @@
     "description": "Message for context menu that opens a page for adding, editing, and removing custom cosmetic filters"
   },
   "elementPickerMode": {
-    "message": "Block element",
+    "message": "要素を指定してブロック",
     "description": "Message for context menu that enables the element picker UI to apply cosmetic filter rules to the page."
   },
   "advancedView": {


### PR DESCRIPTION
Fixes brave/brave-browser#16555
Uplift of #9211

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.