### PR TITLE
Fixes Brave Ads dom_distiller::RunIsolatedJavaScript throws DCHECK exception - 1.26.x

### DIFF
--- a/browser/brave_ads/ads_tab_helper.cc
+++ b/browser/brave_ads/ads_tab_helper.cc
@@ -91,7 +91,9 @@ void AdsTabHelper::RunIsolatedJavaScript(
 void AdsTabHelper::OnJavaScriptHtmlResult(base::Value value) {
   DCHECK(ads_service_ && ads_service_->IsEnabled());
 
-  DCHECK(value.is_string());
+  if (!value.is_string()) {
+    return;
+  }
   std::string html;
   value.GetAsString(&html);
 
@@ -101,7 +103,9 @@ void AdsTabHelper::OnJavaScriptHtmlResult(base::Value value) {
 void AdsTabHelper::OnJavaScriptTextResult(base::Value value) {
   DCHECK(ads_service_ && ads_service_->IsEnabled());
 
-  DCHECK(value.is_string());
+  if (!value.is_string()) {
+    return;
+  }
   std::string text;
   value.GetAsString(&text);
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9123
Resolves https://github.com/brave/brave-browser/issues/16410

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.