### PR TITLE
[Android] fixes lint minimum API error for request permission (uplift to 1.27.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java
+++ b/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java
@@ -276,19 +276,21 @@ public class BraveStatsUtil {
     }
 
     public static boolean hasWritePermission(Activity activity) {
-        if (activity == null) {
-            return false;
-        }
-        if (activity.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                == PackageManager.PERMISSION_GRANTED) {
-            return true;
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            activity.requestPermissions(new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                    SHARE_STATS_WRITE_EXTERNAL_STORAGE_PERM);
+            if (activity == null) {
+                return false;
+            }
+            if (activity.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    == PackageManager.PERMISSION_GRANTED) {
+                return true;
+            } else {
+                activity.requestPermissions(
+                        new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                        SHARE_STATS_WRITE_EXTERNAL_STORAGE_PERM);
+                return false;
+            }
         }
-
-        return false;
+        return true;
     }
 
     public static void shareStats(int layout) {


### PR DESCRIPTION
Uplift of #9249
Resolves https://github.com/brave/brave-browser/issues/16623

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.