### PR TITLE
speedreader: Completely separate states

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -165,9 +165,6 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
 #if BUILDFLAG(BRAVE_ADS_ENABLED) || BUILDFLAG(ENABLE_SPEEDREADER)
   command_line.AppendSwitch(switches::kEnableDomDistiller);
 #endif  // BUILDFLAG(BRAVE_ADS_ENABLED) || BUILDFLAG(ENABLE_SPEEDREADER)
-#if BUILDFLAG(ENABLE_SPEEDREADER)
-  command_line.AppendSwitch(switches::kEnableDistillabilityService);
-#endif  // BUILDFLAG(ENABLE_SPEEDREADER)
   command_line.AppendSwitch(switches::kDisableDomainReliability);
   command_line.AppendSwitch(switches::kNoPings);
 

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -460,19 +460,21 @@ BraveContentBrowserClient::CreateURLLoaderThrottles(
   }
   auto* tab_helper =
       speedreader::SpeedreaderTabHelper::FromWebContents(contents);
-  if (tab_helper && tab_helper->IsActiveForMainFrame() &&
-      request.resource_type ==
-          static_cast<int>(blink::mojom::ResourceType::kMainFrame)) {
+  if (tab_helper) {
     const auto state = tab_helper->PageDistillState();
-    std::unique_ptr<speedreader::SpeedReaderThrottle> throttle =
-        speedreader::SpeedReaderThrottle::MaybeCreateThrottleFor(
-            g_brave_browser_process->speedreader_rewriter_service(),
-            HostContentSettingsMapFactory::GetForProfile(
-                Profile::FromBrowserContext(browser_context)),
-            request.url, state == DistillState::kSpeedreaderMode,
-            base::ThreadTaskRunnerHandle::Get());
-    if (throttle)
-      result.push_back(std::move(throttle));
+    if (speedreader::SpeedreaderTabHelper::PageStateIsDistilled(state) &&
+        request.resource_type ==
+            static_cast<int>(blink::mojom::ResourceType::kMainFrame)) {
+      std::unique_ptr<speedreader::SpeedReaderThrottle> throttle =
+          speedreader::SpeedReaderThrottle::MaybeCreateThrottleFor(
+              g_brave_browser_process->speedreader_rewriter_service(),
+              HostContentSettingsMapFactory::GetForProfile(
+                  Profile::FromBrowserContext(browser_context)),
+              request.url, state == DistillState::kSpeedreaderMode,
+              base::ThreadTaskRunnerHandle::Get());
+      if (throttle)
+        result.push_back(std::move(throttle));
+    }
   }
 #endif  // ENABLE_SPEEDREADER
   return result;

--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -69,10 +69,9 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
     return browser()->tab_strip_model()->GetActiveWebContents();
   }
 
-  speedreader::SpeedreaderTabHelper* tab_helper() {
-    auto* contents = browser()->tab_strip_model()->GetActiveWebContents();
-    speedreader::SpeedreaderTabHelper::CreateForWebContents(contents);
-    return speedreader::SpeedreaderTabHelper::FromWebContents(contents);
+  speedreader::SpeedreaderService* speedreader_service() {
+    return speedreader::SpeedreaderServiceFactory::GetForProfile(
+        browser()->profile());
   }
 
   void ToggleSpeedreader() {
@@ -121,6 +120,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, P3ATest) {
   ui_test_utils::NavigateToURL(browser(), url);
 
   // SpeedReader never enabled
+  DCHECK(!speedreader_service()->IsEnabled());
   tester.ExpectBucketCount(kSpeedreaderEnabledUMAHistogramName, 0, 1);
   tester.ExpectBucketCount(kSpeedreaderToggleUMAHistogramName, 0, 1);
 

--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -120,7 +120,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, P3ATest) {
   ui_test_utils::NavigateToURL(browser(), url);
 
   // SpeedReader never enabled
-  DCHECK(!speedreader_service()->IsEnabled());
+  EXPECT_FALSE(speedreader_service()->IsEnabled());
   tester.ExpectBucketCount(kSpeedreaderEnabledUMAHistogramName, 0, 1);
   tester.ExpectBucketCount(kSpeedreaderToggleUMAHistogramName, 0, 1);
 

--- a/browser/speedreader/speedreader_tab_helper.cc
+++ b/browser/speedreader/speedreader_tab_helper.cc
@@ -18,6 +18,7 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/web_contents.h"
 
 namespace speedreader {
 
@@ -36,14 +37,17 @@ bool SpeedreaderTabHelper::IsSpeedreaderEnabled() const {
 }
 
 bool SpeedreaderTabHelper::IsEnabledForSite() {
+  return IsEnabledForSite(web_contents()->GetLastCommittedURL());
+}
+
+bool SpeedreaderTabHelper::IsEnabledForSite(const GURL& url) {
   if (!IsSpeedreaderEnabled())
     return false;
 
   Profile* profile =
       Profile::FromBrowserContext(web_contents()->GetBrowserContext());
   auto* content_rules = HostContentSettingsMapFactory::GetForProfile(profile);
-  return speedreader::IsEnabledForSite(content_rules,
-                                       web_contents()->GetLastCommittedURL());
+  return speedreader::IsEnabledForSite(content_rules, url);
 }
 
 void SpeedreaderTabHelper::MaybeToggleEnabledForSite(bool on) {
@@ -101,7 +105,7 @@ void SpeedreaderTabHelper::UpdateActiveState(
               << "URL passed speedreader heuristic: " << handle->GetURL();
       if (!IsSpeedreaderEnabled()) {
         SetNextRequestState(DistillState::kPageProbablyReadable);
-      } else if (!IsEnabledForSite()) {
+      } else if (!IsEnabledForSite(handle->GetURL())) {
         SetNextRequestState(DistillState::kSpeedreaderOnDisabledPage);
       } else {
         SetNextRequestState(DistillState::kSpeedreaderMode);

--- a/browser/speedreader/speedreader_tab_helper.cc
+++ b/browser/speedreader/speedreader_tab_helper.cc
@@ -64,9 +64,21 @@ void SpeedreaderTabHelper::MaybeToggleEnabledForSite(bool on) {
 
 void SpeedreaderTabHelper::SingleShotSpeedreader() {
   single_shot_next_request_ = true;
+
+  // Refresh the page so it runs through the speedreader throttle
   auto* contents = web_contents();
   if (contents)
     contents->GetController().Reload(content::ReloadType::NORMAL, false);
+
+  // Determine if bubble should be shown automatically
+  Profile* profile =
+      Profile::FromBrowserContext(web_contents()->GetBrowserContext());
+  DCHECK(profile);
+  auto* speedreader_service = SpeedreaderServiceFactory::GetForProfile(profile);
+  if (speedreader_service->ShouldPromptUserToEnable()) {
+    ShowReaderModeBubble();
+    speedreader_service->IncrementPromptCount();
+  }
 }
 
 void SpeedreaderTabHelper::UpdateActiveState(

--- a/browser/speedreader/speedreader_tab_helper.h
+++ b/browser/speedreader/speedreader_tab_helper.h
@@ -63,7 +63,6 @@ class SpeedreaderTabHelper
   // Returns |true| if the user has enabled Speedreader but the domain in the
   // active web contents is blacklisted.
   bool IsEnabledForSite();
-  bool IsEnabledForSite(const GURL& url);
 
   DistillState PageDistillState() const { return distill_state_; }
 
@@ -98,6 +97,11 @@ class SpeedreaderTabHelper
   // |is_bubble_speedreader| will show a bubble for pages in Speedreader if set
   // to true, otherwise pages in reader mode.
   void ShowBubble(bool is_bubble_speedreader);
+
+  // Returns |true| if the user has enabled Speedreader but the URL is
+  // blacklisted. This method is used when the URL we want to check has not been
+  // committed to the WebContents.
+  bool IsEnabledForSite(const GURL& url);
 
   void UpdateActiveState(content::NavigationHandle* handle);
   void SetNextRequestState(DistillState state);

--- a/browser/speedreader/speedreader_tab_helper.h
+++ b/browser/speedreader/speedreader_tab_helper.h
@@ -63,6 +63,7 @@ class SpeedreaderTabHelper
   // Returns |true| if the user has enabled Speedreader but the domain in the
   // active web contents is blacklisted.
   bool IsEnabledForSite();
+  bool IsEnabledForSite(const GURL& url);
 
   DistillState PageDistillState() const { return distill_state_; }
 

--- a/browser/speedreader/speedreader_tab_helper.h
+++ b/browser/speedreader/speedreader_tab_helper.h
@@ -24,32 +24,38 @@ class SpeedreaderTabHelper
       public content::WebContentsUserData<SpeedreaderTabHelper> {
  public:
   enum class DistillState {
-    // The web contents is not distilled by either
+    // The web contents is not distilled
     kNone,
-    // kReaderMode is the manual reader mode state. It uses Speedreader to mimic
-    // how reader modes in other browsers behave. This state can be reached two
-    // ways:
-    //   (1) Speedreader is disabled. The Speedreader icon will pop up in the
-    //       address bar, and the user clicks it. It runs Speedreader is "Single
-    //       Shot Mode". The Speedreader throttle is created for the following
-    //       request, then deactivated.
-    //   (2) Speedreader is enabled, but the page was blacklisted by the user.
-    //       they are still able to come back and manually distill the page. It
-    //       uses the same mechanism as (1).
+
+    // Reader mode state that can only be reached when Speedreader is disabled
+    // The Speedreader icon will pop up in the address bar, and the user clicks
+    // it. It runs Speedreader is "Single Shot Mode".  The Speedreader throttle
+    // is created for the following request, then deactivated.
     //
     // The first time a user activates reader mode on a page, a bubble drops
     // down asking them to enable the Speedreader feature for automatic
     // distillation.
     kReaderMode,
+
     // Speedreader is enabled and the page was automatically distilled.
     kSpeedreaderMode,
+
+    // Speedreader is enabled, but the page was blacklisted by the user.
+    kSpeedreaderOnDisabledPage,
+
+    // Speedreader is disabled, the URL passes the heuristic.
+    kPageProbablyReadable,
   };
+
+  static bool PageStateIsDistilled(DistillState state) {
+    return state == DistillState::kReaderMode ||
+           state == DistillState::kSpeedreaderMode;
+  }
+
   ~SpeedreaderTabHelper() override;
 
   SpeedreaderTabHelper(const SpeedreaderTabHelper&) = delete;
   SpeedreaderTabHelper& operator=(SpeedreaderTabHelper&) = delete;
-
-  bool IsActiveForMainFrame() const;
 
   // Returns |true| if Speedreader is turned on for all sites.
   bool IsSpeedreaderEnabled() const;

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -298,10 +298,7 @@ source_set("ui") {
   }
 
   if (enable_speedreader) {
-    deps += [
-      "//brave/components/speedreader",
-      "//components/dom_distiller/content/browser",
-    ]
+    deps += [ "//brave/components/speedreader" ]
 
     sources += [
       "speedreader/speedreader_bubble_view.h",

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -100,17 +100,9 @@ void MaybeDistillAndShowSpeedreaderBubble(Browser* browser) {
       case DistillState::kReaderMode:
         tab_helper->ShowReaderModeBubble();
         break;
-      case DistillState::kPageProbablyReadable: {
-        auto* speedreader_service =
-            speedreader::SpeedreaderServiceFactory::GetForProfile(
-                browser->profile());
+      case DistillState::kPageProbablyReadable:
         tab_helper->SingleShotSpeedreader();
-        if (speedreader_service->ShouldPromptUserToEnable()) {
-          tab_helper->ShowReaderModeBubble();
-          speedreader_service->IncrementPromptCount();
-        }
         break;
-      }
       default:
         NOTREACHED();
     }

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -84,50 +84,28 @@ void OpenGuestProfile() {
 void MaybeDistillAndShowSpeedreaderBubble(Browser* browser) {
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   using DistillState = speedreader::SpeedreaderTabHelper::DistillState;
-  speedreader::SpeedreaderService* service =
-      speedreader::SpeedreaderServiceFactory::GetForProfile(browser->profile());
-  if (service) {
-    WebContents* contents = browser->tab_strip_model()->GetActiveWebContents();
-    if (contents) {
-      auto* tab_helper =
-          speedreader::SpeedreaderTabHelper::FromWebContents(contents);
-      if (!tab_helper)
-        return;
+  WebContents* contents = browser->tab_strip_model()->GetActiveWebContents();
+  if (contents) {
+    auto* tab_helper =
+        speedreader::SpeedreaderTabHelper::FromWebContents(contents);
+    if (!tab_helper)
+      return;
 
-      const bool speedreader_enabled = tab_helper->IsSpeedreaderEnabled();
-      const DistillState state = tab_helper->PageDistillState();
-
-      if (state == DistillState::kSpeedreaderMode) {
-        // The page was distilled by Speedreader and the user clicked the icon.
-        // Show per-domain blacklists.
+    const DistillState state = tab_helper->PageDistillState();
+    switch (state) {
+      case DistillState::kSpeedreaderMode:
+      case DistillState::kSpeedreaderOnDisabledPage:
         tab_helper->ShowSpeedreaderBubble();
-      } else if (state == DistillState::kReaderMode) {
-        // The page was distilled manually and the user clicked the icon.
-        // Three things can happen:
-        //   (1) Speedreader is not enabled, so show the bubble about enabling
-        //       the feature globally.
-        //   (2) Speedreader is enabled and the domain is blacklisted. Show the
-        //       Speedreader bubble to let the user remove from the list.
-        //   (3) Speedreader is enabled and the domain doesn't match the url
-        //       heuristic. Don't show any bubble.
-        if (speedreader_enabled) {
-          if (!tab_helper->IsEnabledForSite())
-            tab_helper->ShowSpeedreaderBubble();
-        } else {
-          tab_helper->ShowReaderModeBubble();
-        }
-      } else {
-        // The user clicked the reader mode icon to distill a page. If
-        // Speedreader is not enabled then automatically show the bubble
-        // prompting the user to turn on the feature.
-        //
-        // TODO(keur): Maybe register a pref to only automatically drop the
-        // reader mode bubble once. The user can always get to it manually
-        // later.
+        break;
+      case DistillState::kReaderMode:
+        tab_helper->ShowReaderModeBubble();
+        break;
+      case DistillState::kPageProbablyReadable:
         tab_helper->SingleShotSpeedreader();
-        if (!speedreader_enabled)
-          tab_helper->ShowReaderModeBubble();
-      }
+        tab_helper->ShowReaderModeBubble();
+        break;
+      default:
+        NOTREACHED();
     }
   }
 #endif  // BUILDFLAG(ENABLE_SPEEDREADER)

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -100,10 +100,17 @@ void MaybeDistillAndShowSpeedreaderBubble(Browser* browser) {
       case DistillState::kReaderMode:
         tab_helper->ShowReaderModeBubble();
         break;
-      case DistillState::kPageProbablyReadable:
+      case DistillState::kPageProbablyReadable: {
+        auto* speedreader_service =
+            speedreader::SpeedreaderServiceFactory::GetForProfile(
+                browser->profile());
         tab_helper->SingleShotSpeedreader();
-        tab_helper->ShowReaderModeBubble();
+        if (speedreader_service->ShouldPromptUserToEnable()) {
+          tab_helper->ShowReaderModeBubble();
+          speedreader_service->IncrementPromptCount();
+        }
         break;
+      }
       default:
         NOTREACHED();
     }

--- a/browser/ui/views/speedreader/speedreader_icon_view.h
+++ b/browser/ui/views/speedreader/speedreader_icon_view.h
@@ -7,7 +7,6 @@
 #define BRAVE_BROWSER_UI_VIEWS_SPEEDREADER_SPEEDREADER_ICON_VIEW_H_
 
 #include "chrome/browser/ui/views/page_action/page_action_icon_view.h"
-#include "components/dom_distiller/content/browser/distillable_page_utils.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
@@ -19,7 +18,6 @@ class PrefService;
 
 class SpeedreaderIconView : public PageActionIconView,
                             public IconLabelBubbleView::Delegate,
-                            public dom_distiller::DistillabilityObserver,
                             public content::WebContentsObserver {
  public:
   METADATA_HEADER(SpeedreaderIconView);
@@ -44,10 +42,9 @@ class SpeedreaderIconView : public PageActionIconView,
   SkColor GetIconLabelBubbleInkDropColor() const override;
   SkColor GetIconLabelBubbleBackgroundColor() const override;
 
-  // dom_distiller::DistillabilityObserver:
-  void OnResult(const dom_distiller::DistillabilityResult& result) override;
-
  private:
+  SkColor GetLabelColorOr(SkColor fallback) const;
+
   IconLabelBubbleView::Delegate* icon_label_bubble_delegate_ = nullptr;
 };
 

--- a/components/speedreader/speedreader_pref_names.h
+++ b/components/speedreader/speedreader_pref_names.h
@@ -17,7 +17,7 @@ constexpr char kSpeedreaderPrefEverEnabled[] = "brave.speedreader.ever_enabled";
 // Number of times the user has toggled Speedreader
 constexpr char kSpeedreaderPrefToggleCount[] = "brave.speedreader.toggle_count";
 
-// Number of times the "Enable Speedreader" button was show automatically
+// Number of times the "Enable Speedreader" button was shown automatically
 constexpr char kSpeedreaderPrefPromptCount[] = "brave.speedreader.prompt_count";
 
 }  // namespace speedreader

--- a/components/speedreader/speedreader_pref_names.h
+++ b/components/speedreader/speedreader_pref_names.h
@@ -8,9 +8,17 @@
 
 namespace speedreader {
 
+// Is Speedreader currently enabled
 constexpr char kSpeedreaderPrefEnabled[] = "brave.speedreader.enabled";
+
+// Set if Speedreader was enabled at least once
 constexpr char kSpeedreaderPrefEverEnabled[] = "brave.speedreader.ever_enabled";
+
+// Number of times the user has toggled Speedreader
 constexpr char kSpeedreaderPrefToggleCount[] = "brave.speedreader.toggle_count";
+
+// Number of times the "Enable Speedreader" button was show automatically
+constexpr char kSpeedreaderPrefPromptCount[] = "brave.speedreader.prompt_count";
 
 }  // namespace speedreader
 

--- a/components/speedreader/speedreader_service.cc
+++ b/components/speedreader/speedreader_service.cc
@@ -83,6 +83,7 @@ void SpeedreaderService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kSpeedreaderPrefEnabled, false);
   registry->RegisterBooleanPref(kSpeedreaderPrefEverEnabled, false);
   registry->RegisterListPref(kSpeedreaderPrefToggleCount);
+  registry->RegisterIntegerPref(kSpeedreaderPrefPromptCount, 0);
 }
 
 void SpeedreaderService::ToggleSpeedreader() {
@@ -102,6 +103,20 @@ bool SpeedreaderService::IsEnabled() {
   const bool enabled = prefs_->GetBoolean(kSpeedreaderPrefEnabled);
   RecordHistograms(prefs_, false, enabled);
   return enabled;
+}
+
+bool SpeedreaderService::ShouldPromptUserToEnable() const {
+  constexpr int max_speedreader_prompts = 2;
+
+  if (prefs_->GetBoolean(kSpeedreaderPrefEverEnabled) ||
+      prefs_->GetInteger(kSpeedreaderPrefPromptCount) > max_speedreader_prompts)
+    return false;
+  return true;
+}
+
+void SpeedreaderService::IncrementPromptCount() {
+  int count = prefs_->GetInteger(kSpeedreaderPrefPromptCount);
+  prefs_->SetInteger(kSpeedreaderPrefPromptCount, count + 1);
 }
 
 }  // namespace speedreader

--- a/components/speedreader/speedreader_service.h
+++ b/components/speedreader/speedreader_service.h
@@ -24,6 +24,8 @@ class SpeedreaderService : public KeyedService {
 
   void ToggleSpeedreader();
   bool IsEnabled();
+  bool ShouldPromptUserToEnable() const;
+  void IncrementPromptCount();
 
   SpeedreaderService(const SpeedreaderService&) = delete;
   SpeedreaderService& operator=(const SpeedreaderService&) = delete;


### PR DESCRIPTION
  * Do not conflate Reader Mode state and Speedreader state. This leads
    to confusion.
  * Due to removing the conflation, delete the dependency on the
    Chromium distillability observer. We now use our own URL heuristic.
  * Have SpeedreaderTabHelper::UpdateActiveState() manage all
    Speedreader state for a stage. The bubbles and icons will just check
    that variable. Vastly simplifies logic.
  * Demarcate label and icon colors when Speedreader is enabled or
    disabled for a page.

As a bonus, the code should be much easier to understand now.

Resolves https://github.com/brave/brave-browser/issues/16663

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

