### PR TITLE
[cr92 followup] Fixes blank settings page.

### DIFF
--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -23,8 +23,16 @@ function createMenuElement (title, href, iconName, pageVisibilitySection) {
 }
 
 function getMenuElement (templateContent, href) {
-  const menuEl = templateContent.querySelector(`a[href="${href}"]`)
+  let menuEl = templateContent.querySelector(`a[href="${href}"]`)
   if (!menuEl) {
+    // Search templates
+    const templates = templateContent.querySelectorAll('template')
+    for (const template of templates) {
+      menuEl = template.content.querySelector(`a[href="${href}"]`)
+      if (menuEl) {
+        return menuEl
+      }
+    }
     console.error(`[Brave Settings Overrides] Could not find menu item '${href}'`)
   }
   return menuEl


### PR DESCRIPTION
The page is blank because the /safetyCheck menu item cannot be found.
This happens because the menu item is no longer a direct child of the
menu, but instead is nested in a template.

Added code to search templates for menu items (perhpas there's a more
efficient way?).

Fixes brave/brave-browser#16708

Chromium change:

https://chromium.googlesource.com/chromium/src.git/+/49cea54a

commit 49cea54a094586e441513055fe0febedba4f377d
Author: dpapad <dpapad@chromium.org>
Date:   Fri May 14 08:53:26 2021 +0000

    Settings: Combine safetyCheck and privacy sections in re-design.

     - Hide the "Safety check" menu entry
     - Add a new |nest-under-section| attribute on <settings-section> and
       leverage it in main_page_behavior.js to show multiple
       <settings-section> instances at the same time.
     - Update tests.

    Bug: 1204457

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

