### PR TITLE
NTP: correct string for together button tooltip

### DIFF
--- a/components/brave_new_tab_ui/components/default/footer/footer.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/footer.tsx
@@ -44,7 +44,7 @@ function TogetherItem (props: Props) {
   if (!props.togetherPromptDismissed) {
     return (
       <TogetherTooltip onClose={props.onDismissTogetherPrompt}>
-        <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+        <IconLink title={getLocale('togetherPromptTitle')} href='https://together.brave.com/widget'>
           <TogetherIcon />
         </IconLink>
       </TogetherTooltip>
@@ -52,7 +52,7 @@ function TogetherItem (props: Props) {
   }
 
   return (
-    <IconLink title={getLocale('togetherPageTitle')} href='https://together.brave.com/widget'>
+    <IconLink title={getLocale('togetherPromptTitle')} href='https://together.brave.com/widget'>
       <TogetherIcon />
     </IconLink>
   )

--- a/components/brave_together/buildflags/buildflags.gni
+++ b/components/brave_together/buildflags/buildflags.gni
@@ -1,5 +1,6 @@
 import("//brave/build/config.gni")
 
 declare_args() {
-  brave_together_enabled = brave_channel == "nightly"
+  brave_together_enabled =
+      brave_channel == "nightly" || brave_channel == "development"
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16740

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- NTP renders without throwing error
