### PR TITLE
Ignore redirect-cc in compile database generator.

### DIFF
--- a/patches/tools-clang-pylib-clang-compile_db.py.patch
+++ b/patches/tools-clang-pylib-clang-compile_db.py.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/clang/pylib/clang/compile_db.py b/tools/clang/pylib/clang/compile_db.py
+index 8b019f70d8baff26e5aecc108443dfe9a13474e0..134cde87cb45c7de6df79fb6ca4ba8ec5dcbafe4 100755
+--- a/tools/clang/pylib/clang/compile_db.py
++++ b/tools/clang/pylib/clang/compile_db.py
+@@ -14,7 +14,7 @@ import shutil
+ 
+ _RSP_RE = re.compile(r' (@(.+?\.rsp)) ')
+ _CMD_LINE_RE = re.compile(
+-    r'^(?P<gomacc>.*gomacc(\.exe)?"?\s+)?(?P<clang>\S*clang\S*)\s+(?P<args>.*)$'
++    r'^(?P<gomacc>.*(gomacc|redirect-cc)(\.exe|\.py)?"?\s+)?(?P<clang>\S*clang\S*)\s+(?P<args>.*)$'
+ )
+ _debugging = False
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Clangd is a very powerful tool, but currently it cannot properly parse the compile database on Windows. This is because of ```redirect-cc.exe``` as a first argument. This change allows the generator to remove ```redirect-cc.exe/py``` from the generated file.

To generate compile database:
```
python ${workspaceFolder}/tools/clang/scripts/generate_compdb.py -p out/Component -o ${workspaceFolder}/compile_commands.json
```

Command to build before:
```
"command": "D:\\brave\\4\\src\\brave\\buildtools\\win\\redirect-cc\\bin\\redirect-cc.exe ..\\..\\third_party\\llvm-build\\Release+Asserts\\bin\\clang-cl.exe /showIncludes:user ...
```
Command to build after:
```
"command": "..\\..\\third_party\\llvm-build\\Release+Asserts\\bin\\clang-cl.exe --driver-mode=cl /showIncludes:user ...
```

Resolves https://github.com/brave/brave-browser/issues/16756

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

