### PR TITLE
Fixes estimated pending rewards does not reset to expected value when you have uncashed in tokens - follow up to #16678 - 1.26.x

### DIFF
--- a/components/brave_ads/browser/ads_service.cc
+++ b/components/brave_ads/browser/ads_service.cc
@@ -68,6 +68,8 @@ void AdsService::RegisterProfilePrefs(
                                "");
 
   registry->RegisterBooleanPref(ads::prefs::kHasMigratedConversionState, false);
+  registry->RegisterBooleanPref(ads::prefs::kHasMigratedEstimatedPendingRewards,
+                                false);
 }
 
 }  // namespace brave_ads

--- a/vendor/bat-native-ads/data/test/confirmations_issue_16744.json
+++ b/vendor/bat-native-ads/data/test/confirmations_issue_16744.json
@@ -1,0 +1,182 @@
+{
+  "ads_rewards": {
+    "payments": [
+      {
+        "balance": 0.28,
+        "month": "2021-05",
+        "transaction_count": "48"
+      },
+      {
+        "balance": 2.8025,
+        "month": "2021-04",
+        "transaction_count": "290"
+      },
+      {
+        "balance": 4.25,
+        "month": "2021-03",
+        "transaction_count": "342"
+      },
+      {
+        "balance": 6.73,
+        "month": "2021-02",
+        "transaction_count": "420"
+      },
+      {
+        "balance": 5.775,
+        "month": "2021-01",
+        "transaction_count": "432"
+      },
+      {
+        "balance": 5.475,
+        "month": "2020-12",
+        "transaction_count": "180"
+      },
+      {
+        "balance": 5.405,
+        "month": "2020-11",
+        "transaction_count": "151"
+      },
+      {
+        "balance": 0.825,
+        "month": "2020-10",
+        "transaction_count": "33"
+      },
+      {
+        "balance": 1.625,
+        "month": "2020-09",
+        "transaction_count": "80"
+      },
+      {
+        "balance": 6.45,
+        "month": "2020-08",
+        "transaction_count": "156"
+      },
+      {
+        "balance": 12.2,
+        "month": "2020-07",
+        "transaction_count": "241"
+      },
+      {
+        "balance": 11.79,
+        "month": "2020-06",
+        "transaction_count": "242"
+      },
+      {
+        "balance": 12.45,
+        "month": "2020-05",
+        "transaction_count": "238"
+      },
+      {
+        "balance": 15.55,
+        "month": "2020-04",
+        "transaction_count": "293"
+      },
+      {
+        "balance": 15.05,
+        "month": "2020-03",
+        "transaction_count": "284"
+      },
+      {
+        "balance": 7.65,
+        "month": "2020-02",
+        "transaction_count": "149"
+      },
+      {
+        "balance": 3.45,
+        "month": "2020-01",
+        "transaction_count": "65"
+      },
+      {
+        "balance": 5.5,
+        "month": "2019-12",
+        "transaction_count": "110"
+      },
+      {
+        "balance": 2.1,
+        "month": "2019-11",
+        "transaction_count": "42"
+      },
+      {
+        "balance": 6.2,
+        "month": "2019-10",
+        "transaction_count": "124"
+      },
+      {
+        "balance": 7.25,
+        "month": "2019-09",
+        "transaction_count": "115"
+      },
+      {
+        "balance": 13.65,
+        "month": "2019-08",
+        "transaction_count": "225"
+      },
+      {
+        "balance": 6.1,
+        "month": "2019-07",
+        "transaction_count": "114"
+      },
+      {
+        "balance": 12.65,
+        "month": "2019-06",
+        "transaction_count": "253"
+      }
+    ],
+    "unreconciled_estimated_pending_rewards": 2.8034999999999997,
+    "grants_balance": 169.68
+  },
+  "catalog_issuers": {
+  },
+  "confirmations": {
+    "failed_confirmations": []
+  },
+  "next_token_redemption_date_in_seconds": "4102444799",
+  "transaction_history": {
+    "transactions": [
+      {
+        "confirmation_type": "view",
+        "estimated_redemption_value": 0.01,
+        "timestamp_in_seconds": "1625096431"
+      },
+      {
+        "confirmation_type": "view",
+        "estimated_redemption_value": 0.01,
+        "timestamp_in_seconds": "1625142812"
+      },
+      {
+        "confirmation_type": "dismiss",
+        "estimated_redemption_value": 0,
+        "timestamp_in_seconds": "1625142813"
+      },
+      {
+        "confirmation_type": "view",
+        "estimated_redemption_value": 0.01,
+        "timestamp_in_seconds": "1625142861"
+      },
+      {
+        "confirmation_type": "view",
+        "estimated_redemption_value": 0.01,
+        "timestamp_in_seconds": "1625143649"
+      }
+    ]
+  },
+  "unblinded_payment_tokens": [
+    {
+      "public_key": "oOJO/xLaCXGW6yhpeIfM4K1X2ln7sgdjTCTCHe8BugE=",
+      "unblinded_token": "sd4NG8YF9jIzjqAapwO9Y+geBMh5YDdwn6jtD2PfBSye89L6s14SlMc/MLyJXb+oVwMI/ktpk7O3IlvYaxKZG4x+Rm/uDbXWjdqx8kQ7Ge1QVDvGkFdD2oAKsyiz4OYm"
+    },
+    {
+      "public_key": "uor3AzFj4OmdCxwetsYD1TxPXZSw40t3j/VOCUyC7Rs=",
+      "unblinded_token": "CtfIk2jtylneiONnhkBDv/H4MPgOLuVzuYEHpnGU94EZ4vy2RxJJu/NrQxmkGwBvNAUUit6KmvQvgVcLFvU5ynLwKUBSiZGsnykUYbCsYwDODzZPnIFN/RzV2UidiB0o"
+    },
+    {
+      "public_key": "oOJO/xLaCXGW6yhpeIfM4K1X2ln7sgdjTCTCHe8BugE=",
+      "unblinded_token": "I0PdV23mdq71MWCXhiIIgmrWDHR92S1gbXJRfOKtCFpuXY9+fiIlbr5Kk7iyaAP0Xkw7oLUcCQTS5g2lw0jvSKLiEuCeOMIYD8U1TF2J2r13hu7Nh1COoOEELhCnyeBe"
+    },
+    {
+      "public_key": "oOJO/xLaCXGW6yhpeIfM4K1X2ln7sgdjTCTCHe8BugE=",
+      "unblinded_token": "hlwvI/EELm+pEJt/KCL698hhg4iQpOygzbdIUk6num1+SLNFvkQsMlH1qfu5N3CkVG+U18o/SbINieAr2ghzopTVIP4C3ZgTx5WQKjq7Czmz7J0hTmsKDShayU2JGF1I"
+    }
+  ],
+  "unblinded_tokens": []
+}

--- a/vendor/bat-native-ads/data/test/confirmations_with_unblinded_tokens.json
+++ b/vendor/bat-native-ads/data/test/confirmations_with_unblinded_tokens.json
@@ -1,0 +1,83 @@
+{
+  "ads_rewards": {
+    "grants_balance": 4.21,
+    "payments": [
+      {
+        "balance": 48.0,
+        "month": "2021-04",
+        "transaction_count": "16"
+      }
+    ],
+    "unreconciled_estimated_pending_rewards": 0
+  },
+  "catalog_issuers": {
+    "issuers": [
+      {
+        "name": "0.05BAT",
+        "public_key": "mmXlFlskcF+LjQmJTPQUmoDMV8Co2r+0eNqSyzCywmk="
+      }
+    ],
+    "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34="
+  },
+  "confirmations": {
+    "failed_confirmations": []
+  },
+  "next_token_redemption_date_in_seconds": "4102444799",
+  "transaction_history": {
+    "transactions": [
+      {
+        "confirmation_type": "view",
+        "estimated_redemption_value": 0.01,
+        "timestamp_in_seconds": "1625096431"
+      }
+    ]
+  },
+  "unblinded_payment_tokens": [
+    {
+      "public_key": "mmXlFlskcF+LjQmJTPQUmoDMV8Co2r+0eNqSyzCywmk=",
+      "unblinded_token": "sBHEriHjOcSJBLi65AuZwqvPm7U+kgloDIZZrJ1G6t7l3Q0nSvag+EXj4xc+ObeL6xou0XCryeJSusoZrLZuXUguYj9trXz/q/WS+OXxehg91iXvOToywZOYTBnSCR1t"
+    }
+  ],
+  "unblinded_tokens": [
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "atubfO/tAwnsRB+5VnuaxTGzU0CL4aDKgGHPXfN/EpWDR+KjGwt3ovsMOK92Tm5LKxClzF/Z3H3tIcma7IIYMXroU9f0hoNbAuPSP8i5YbwaGvh4c5o4QVpHo7XRGC9D"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "yhaUOcMud72qEb6baX4UzbN44pQaQtZtkKwe0s0X0N0jKvEyjej3QHAEgSzCkVrjGtbW1+C9yfIp/Edw5LEj2lZ9b7bG7/QU3+UEmhAKOYfLDKKpUpgDB0OsI09PfnYe"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "ew4Ef177oDvCpRVf17j6iEKO7qbO0gRL546Cb1j+gt9XvmnZ3ql8EPNTC2prHhY4VmyGoTSm+AwwSknWlllwI4Rg8hN3yDSJhXrct2Sv9ZP8+QM6B3ehU6h53RtYExx9"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "Xjseuo+ytWWyacB+XM9pCo4firipS1zP49sIHnm+I+/Uywh93lTmtKdbmHfOIbUHYwBKi0mZIYzMoeQva2dKEOyB4KsVMNdP+10ZbkDJb7lFr1xkzztc4Ak922VUHXdC"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "KQjDymeGzhR6n+4e1Fn5toWVk5dYseGrgYYPQiRbXeRtIHzzCOBJnziKS+4KFK92UItoVs5K36DZGw0ZSLIA5XKovk6Khx1rVBRoMB6KtDdd9lUsR0ZZv/cv99FB1Rse"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "C31OH2zWMsgj0x9MSg3ZvU40r2ej+xH2BWjSf3cCVYvzynugc0Gnykltg1hlSuaFjZXS92IZ+BjYXGqyCnKOk6rkfiU+kq2OIKVS/jicHmCku8f8N2Dke/GqBafelRo7"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "Ammp3zDZQMTBOwDpToE5Qignncf8nBVmIgH2o5/x+ss9ImM6iRQbVVZi7WXz3Rv8l9xyZjyBrPUe5JYa7OR27hi9trSfjPFGevmcw7dYJd3XhSTENLW109AOm+KLLSht"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "q1d0crpq8UoGHbZ/p3nB5tr07OOmBZb+kG3MVEjei+0GBAfHsQhD259zDwGbSP3SiFqie6t3ChzpLo9dclfJnYR0YQQmt99Rk05xy/vMRz5CK+AoYT1nOXPdjzNvNw4w"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "XzRNuxKYtLmYvB829SduKpiZkOVrnLF/FRkHzREsW9tq1AuTG3gvk5VPrMEQa2xjwwOsHV3HuWjDDo+ylaXqDSbfDGVglzLwnZbU8ETCy26paFBUaZKs8+TGLrJObU1u"
+    },
+    {
+      "public_key": "qi1Vl8YrPEZliN5wmBgLTuGkbk8K505QwlXLTZjUd34=",
+      "unblinded_token": "DcWpe7XPtc85TKz0UlStWZ/v8eo14kQraJ2XXFw5g/AS5bmNu3ltSxokCLvFeJucz2WbCjrnKL/39r79sbe+bd6XkriIoQ2AJ1Xr5C/T0+68Y3PhIWBX2Yk4uVdzgxUD"
+    }
+  ]
+}

--- a/vendor/bat-native-ads/include/bat/ads/pref_names.h
+++ b/vendor/bat-native-ads/include/bat/ads/pref_names.h
@@ -38,6 +38,7 @@ extern const char kEpsilonGreedyBanditArms[];
 extern const char kEpsilonGreedyBanditEligibleSegments[];
 
 extern const char kHasMigratedConversionState[];
+extern const char kHasMigratedEstimatedPendingRewards[];
 
 }  // namespace prefs
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc
@@ -288,11 +288,256 @@ TEST_F(
         // payment balances
         expected_statement.estimated_pending_rewards = 4.1235;
 
-        // Calculated from the above payment balance for May
+        // Calculated from the above payment balance for June
         expected_statement.earnings_this_month = 1.8375;
 
-        // Calculated from the above payment balance for April
+        // Calculated from the above payment balance for May
         expected_statement.earnings_last_month = 1.0385;
+
+        EXPECT_EQ(expected_statement, statement);
+      });
+
+  // Assert
+}
+
+TEST_F(
+    BatAdsAdRewardsIntegrationTest,
+    FailedToUpdateAdRewardsDueToNotZeroingUnreconciledEstimatedPendingRewardsIssue16744) {  // NOLINT
+  // Arrange
+  const URLEndpoints endpoints = {
+      {"/v1/confirmation/payment/c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_OK,
+         R"([
+              {
+                "month": "2021-07",
+                "transactionCount": "5",
+                "balance": "0.05"
+              },
+              {
+                "month": "2021-06",
+                "transactionCount": "234",
+                "balance": "1.9475"
+              },
+              {
+                "month": "2021-05",
+                "transactionCount": "170",
+                "balance": "1.0385"
+              },
+              {
+                "month": "2021-04",
+                "transactionCount": "290",
+                "balance": "2.8025"
+              },
+              {
+                "month": "2021-03",
+                "transactionCount": "342",
+                "balance": "4.25"
+              },
+              {
+                "month": "2021-02",
+                "transactionCount": "420",
+                "balance": "6.73"
+              },
+              {
+                "month": "2021-01",
+                "transactionCount": "432",
+                "balance": "5.775"
+              },
+              {
+                "month": "2020-12",
+                "transactionCount": "180",
+                "balance": "5.475"
+              },
+              {
+                "month": "2020-11",
+                "transactionCount": "151",
+                "balance": "5.405"
+              },
+              {
+                "month": "2020-10",
+                "transactionCount": "33",
+                "balance": "0.825"
+              },
+              {
+                "month": "2020-09",
+                "transactionCount": "80",
+                "balance": "1.625"
+              },
+              {
+                "month": "2020-08",
+                "transactionCount": "156",
+                "balance": "6.45"
+              },
+              {
+                "month": "2020-07",
+                "transactionCount": "241",
+                "balance": "12.2"
+              },
+              {
+                "month": "2020-06",
+                "transactionCount": "242",
+                "balance": "11.79"
+              },
+              {
+                "month": "2020-05",
+                "transactionCount": "238",
+                "balance": "12.45"
+              },
+              {
+                "month": "2020-04",
+                "transactionCount": "293",
+                "balance": "15.55"
+              },
+              {
+                "month": "2020-03",
+                "transactionCount": "284",
+                "balance": "15.05"
+              },
+              {
+                "month": "2020-02",
+                "transactionCount": "149",
+                "balance": "7.65"
+              },
+              {
+                "month": "2020-01",
+                "transactionCount": "65",
+                "balance": "3.45"
+              },
+              {
+                "month": "2019-12",
+                "transactionCount": "110",
+                "balance": "5.5"
+              },
+              {
+                "month": "2019-11",
+                "transactionCount": "42",
+                "balance": "2.1"
+              },
+              {
+                "month": "2019-10",
+                "transactionCount": "124",
+                "balance": "6.2"
+              },
+              {
+                "month": "2019-09",
+                "transactionCount": "115",
+                "balance": "7.25"
+              },
+              {
+                "month": "2019-08",
+                "transactionCount": "225",
+                "balance": "13.65"
+              },
+              {
+                "month": "2019-07",
+                "transactionCount": "114",
+                "balance": "6.1"
+              },
+              {
+                "month": "2019-06",
+                "transactionCount": "253",
+                "balance": "12.65"
+              }
+            ])"}}},
+      {"/v1/promotions/ads/grants/"
+       "summary?paymentId=c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_OK,
+         R"({
+              "type" : "ads",
+              "amount" : "169.68",
+              "lastClaim" : "2021-05-06T20:55:56Z"
+            })"}}}};
+
+  MockUrlRequest(ads_client_mock_, endpoints);
+
+  MockLoad(ads_client_mock_, "confirmations.json",
+           "confirmations_issue_16744.json");
+
+  InitializeAds();
+
+  AdvanceClock(TimeFromDateString("4 July 2021"));
+
+  // Act
+  GetAds()->GetAccountStatement(
+      [](const bool success, const StatementInfo& statement) {
+        ASSERT_TRUE(success);
+
+        StatementInfo expected_statement;
+        expected_statement.next_payment_date =
+            TimestampFromDateString("5 July 2021");
+
+        // Calculated by subtracting the ad grant balance from the accumulated
+        // payment balances
+        expected_statement.estimated_pending_rewards = 4.3135;
+
+        // Calculated from the above payment balance for June
+        expected_statement.earnings_this_month = 0.08;
+
+        // Calculated from the above payment balance for May
+        expected_statement.earnings_last_month = 1.9475;
+
+        // Calculated from ads received during July
+        expected_statement.ads_received_this_month = 3;
+
+        // Transactions
+        TransactionInfo transaction_1;  // June 30, 2021 11:40:31 PM
+        transaction_1.timestamp = 1625096431;
+        transaction_1.estimated_redemption_value = 0.01;
+        transaction_1.confirmation_type = "view";
+        expected_statement.transactions.push_back(transaction_1);
+
+        TransactionInfo transaction_2;  //  July 1, 2021 12:33:32 PM
+        transaction_2.timestamp = 1625142812;
+        transaction_2.estimated_redemption_value = 0.01;
+        transaction_2.confirmation_type = "view";
+        expected_statement.transactions.push_back(transaction_2);
+
+        TransactionInfo transaction_3;  //  July 1, 2021 12:33:33 PM
+        transaction_3.timestamp = 1625142813;
+        transaction_3.estimated_redemption_value = 0.0;
+        transaction_3.confirmation_type = "dismiss";
+        expected_statement.transactions.push_back(transaction_3);
+
+        TransactionInfo transaction_4;  //  July 1, 2021 12:34:21 PM
+        transaction_4.timestamp = 1625142861;
+        transaction_4.estimated_redemption_value = 0.01;
+        transaction_4.confirmation_type = "view";
+        expected_statement.transactions.push_back(transaction_4);
+
+        TransactionInfo transaction_5;  // July 1, 2021 12:47:29 PM
+        transaction_5.timestamp = 1625143649;
+        transaction_5.estimated_redemption_value = 0.01;
+        transaction_5.confirmation_type = "view";
+        expected_statement.transactions.push_back(transaction_5);
+
+        // Uncleared transactions
+        TransactionInfo uncleared_transaction_1;  // July 1, 2021 12:33:32 PM
+        uncleared_transaction_1.timestamp = 1625142812;
+        uncleared_transaction_1.estimated_redemption_value = 0.01;
+        uncleared_transaction_1.confirmation_type = "view";
+        expected_statement.uncleared_transactions.push_back(
+            uncleared_transaction_1);
+
+        TransactionInfo uncleared_transaction_2;  // July 1, 2021 12:33:33 PM
+        uncleared_transaction_2.timestamp = 1625142813;
+        uncleared_transaction_2.estimated_redemption_value = 0.0;
+        uncleared_transaction_2.confirmation_type = "dismiss";
+        expected_statement.uncleared_transactions.push_back(
+            uncleared_transaction_2);
+
+        TransactionInfo uncleared_transaction_3;  // July 1, 2021 12:34:21 PM
+        uncleared_transaction_3.timestamp = 1625142861;
+        uncleared_transaction_3.estimated_redemption_value = 0.01;
+        uncleared_transaction_3.confirmation_type = "view";
+        expected_statement.uncleared_transactions.push_back(
+            uncleared_transaction_3);
+
+        TransactionInfo uncleared_transaction_4;  // July 1, 2021 12:47:29 PM
+        uncleared_transaction_4.timestamp = 1625143649;
+        uncleared_transaction_4.estimated_redemption_value = 0.01;
+        uncleared_transaction_4.confirmation_type = "view";
+        expected_statement.uncleared_transactions.push_back(
+            uncleared_transaction_4);
 
         EXPECT_EQ(expected_statement, statement);
       });

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
@@ -10,9 +10,11 @@
 #include "base/json/json_reader.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
+#include "bat/ads/internal/ads_client_helper.h"
 #include "bat/ads/internal/features/ad_rewards/ad_rewards_features.h"
 #include "bat/ads/internal/logging.h"
 #include "bat/ads/internal/number_util.h"
+#include "bat/ads/pref_names.h"
 #include "third_party/re2/src/re2/re2.h"
 
 namespace ads {
@@ -118,11 +120,23 @@ double Payments::GetBalance() const {
 bool Payments::DidReconcileBalance(
     const double last_balance,
     const double unreconciled_estimated_pending_rewards) const {
+  const double balance = GetBalance();
+
+  if (!AdsClientHelper::Get()->GetBooleanPref(
+          prefs::kHasMigratedEstimatedPendingRewards)) {
+    AdsClientHelper::Get()->SetBooleanPref(
+        prefs::kHasMigratedEstimatedPendingRewards, true);
+
+    if (DoubleIsGreaterEqual(balance, last_balance)) {
+      return true;
+    }
+  }
+
   if (unreconciled_estimated_pending_rewards == 0.0) {
     return true;
   }
 
-  const double delta = GetBalance() - last_balance;
+  const double delta = balance - last_balance;
   if (DoubleIsGreaterEqual(delta, unreconciled_estimated_pending_rewards)) {
     return true;
   }

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments_unittest.cc
@@ -165,12 +165,38 @@ TEST_F(BatAdsPaymentsTest,
 }
 
 TEST_F(BatAdsPaymentsTest,
+    DidReconcileBalanceGreaterThanOrEqualToUnreconciledEstimatedPendingRewards) {  // NOLINT
+  // Arrange
+  const std::string json = R"(
+    [
+      {
+        "balance" : "0.5",
+        "month" : "2019-06",
+        "transactionCount" : "10"
+      }
+    ]
+  )";
+
+  payments_->SetFromJson(json);
+
+  const double last_balance = 0.3;
+  const double unreconciled_estimated_pending_rewards = 0.2;
+
+  // Act
+  const bool did_reconcile = payments_->DidReconcileBalance(last_balance,
+      unreconciled_estimated_pending_rewards);
+
+  // Assert
+  EXPECT_TRUE(did_reconcile);
+}
+
+TEST_F(BatAdsPaymentsTest,
     DidNotReconcileBalanceLessThanUnreconciledEstimatedPendingRewards) {
   // Arrange
   const std::string json = R"(
     [
       {
-        "balance" : "0.3",
+        "balance" : "0.2",
         "month" : "2019-06",
         "transactionCount" : "5"
       }

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
@@ -256,12 +256,12 @@ bool ConfirmationsState::FromJson(const std::string& json) {
     BLOG(1, "Failed to parse failed confirmations");
   }
 
-  if (!ParseAdRewardsFromDictionary(dictionary)) {
-    BLOG(1, "Failed to parse ad rewards");
-  }
-
   if (!ParseTransactionsFromDictionary(dictionary)) {
     BLOG(1, "Failed to parse transactions");
+  }
+
+  if (!ParseAdRewardsFromDictionary(dictionary)) {
+    BLOG(1, "Failed to parse ad rewards");
   }
 
   if (!ParseUnblindedTokensFromDictionary(dictionary)) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
@@ -398,7 +398,8 @@ void MockDefaultPrefs(const std::unique_ptr<AdsClientMock>& mock) {
   mock->SetInt64Pref(prefs::kCatalogPing, 7200000);
   mock->SetInt64Pref(prefs::kCatalogLastUpdated, DistantPastAsTimestamp());
 
-  mock->SetBooleanPref(prefs::kHasMigratedConversionState, true);
+  mock->SetBooleanPref(prefs::kHasMigratedConversionState, false);
+  mock->SetBooleanPref(prefs::kHasMigratedEstimatedPendingRewards, false);
 }
 
 }  // namespace

--- a/vendor/bat-native-ads/src/bat/ads/pref_names.cc
+++ b/vendor/bat-native-ads/src/bat/ads/pref_names.cc
@@ -57,6 +57,8 @@ const char kEpsilonGreedyBanditEligibleSegments[] =
 // Stores migration status
 const char kHasMigratedConversionState[] =
     "brave.brave_ads.migrated.conversion_state";
+const char kHasMigratedEstimatedPendingRewards[] =
+    "brave.brave_ads.migrated.fix_estimated_pending_rewards";
 
 }  // namespace prefs
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9309
Uplift of https://github.com/brave/brave-core/pull/9354
Uplift of https://github.com/brave/brave-core/pull/9370
Resolves https://github.com/brave/brave-browser/issues/16744

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
