### PR TITLE
Fixes ad notifications should not be served on mobile if a user is opted-in to Brave News and has Brave Ads disabled - 1.27.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/ad_notifications/ad_notification_serving.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/ad_notifications/ad_notification_serving.cc
@@ -59,6 +59,8 @@ void AdServing::StartServingAdsAtRegularIntervals() {
     return;
   }
 
+  BLOG(1, "Start serving ads at regular intervals");
+
   base::TimeDelta delay;
 
   if (Client::Get()->GetNextAdServingInterval().is_null()) {
@@ -81,6 +83,12 @@ void AdServing::StartServingAdsAtRegularIntervals() {
 }
 
 void AdServing::StopServingAdsAtRegularIntervals() {
+  if (!timer_.IsRunning()) {
+    return;
+  }
+
+  BLOG(1, "Stop serving ads at regular intervals");
+
   timer_.Stop();
 }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -139,7 +139,9 @@ void AdsImpl::ChangeLocale(const std::string& locale) {
 }
 
 void AdsImpl::OnPrefChanged(const std::string& path) {
-  if (path == prefs::kAdsPerHour) {
+  if (path == prefs::kEnabled) {
+    MaybeServeAdNotificationsAtRegularIntervals();
+  } else if (path == prefs::kAdsPerHour) {
     ad_notification_serving_->OnAdsPerHourChanged();
   } else if (path == prefs::kAdsSubdivisionTargetingCode) {
     subdivision_targeting_->MaybeFetchForCurrentLocale();
@@ -655,7 +657,8 @@ void AdsImpl::MaybeServeAdNotificationsAtRegularIntervals() {
     return;
   }
 
-  if ((BrowserManager::Get()->IsActive() ||
+  if (IsInitialized() &&
+      (BrowserManager::Get()->IsActive() ||
        AdsClientHelper::Get()->CanShowBackgroundNotifications()) &&
       settings::GetAdsPerHour() > 0) {
     ad_notification_serving_->StartServingAdsAtRegularIntervals();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9317
Resolves https://github.com/brave/brave-browser/issues/16739

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
