### PR TITLE
Hide favicon for NTP in tab UI

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -543,3 +543,19 @@ source_set("ui") {
     }
   }
 }
+
+source_set("browser_tests") {
+  if (!is_android) {
+    testonly = true
+    defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+    sources = [ "brave_browser_browsertest.cc" ]
+
+    deps = [
+      "//brave/browser/ui",
+      "//chrome/browser/ui",
+      "//chrome/test:test_support_ui",
+      "//content/test:test_support",
+    ]
+  }
+}

--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -4,6 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/brave_browser.h"
+#include "chrome/browser/search/search.h"
+#include "chrome/common/webui_url_constants.h"
+#include "content/public/common/url_constants.h"
+#include "url/gurl.h"
 
 #if BUILDFLAG(ENABLE_SIDEBAR)
 #include "brave/browser/ui/brave_browser_window.h"
@@ -47,6 +51,29 @@ void BraveBrowser::ScheduleUIUpdate(content::WebContents* source,
     }
   }
 #endif
+}
+
+bool BraveBrowser::ShouldDisplayFavicon(
+    content::WebContents* web_contents) const {
+  // Override to not show favicon for NTP in tab.
+
+  // Suppress the icon for the new-tab page, even if a navigation to it is
+  // not committed yet. Note that we're looking at the visible URL, so
+  // navigations from NTP generally don't hit this case and still show an icon.
+  GURL url = web_contents->GetVisibleURL();
+  if (url.SchemeIs(content::kChromeUIScheme) &&
+      url.host_piece() == chrome::kChromeUINewTabHost) {
+    return false;
+  }
+
+  // Also suppress instant-NTP. This does not use search::IsInstantNTP since
+  // it looks at the last-committed entry and we need to show icons for pending
+  // navigations away from it.
+  if (search::IsInstantNTPURL(url, profile())) {
+    return false;
+  }
+
+  return Browser::ShouldDisplayFavicon(web_contents);
 }
 
 void BraveBrowser::OnTabStripModelChanged(

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -19,6 +19,10 @@ class SidebarController;
 class BraveBrowserWindow;
 #endif
 
+namespace content {
+class WebContents;
+}  // namespace content
+
 class BraveBrowser : public Browser {
  public:
   explicit BraveBrowser(const CreateParams& params);
@@ -30,6 +34,7 @@ class BraveBrowser : public Browser {
   // Browser overrides:
   void ScheduleUIUpdate(content::WebContents* source,
                         unsigned changed_flags) override;
+  bool ShouldDisplayFavicon(content::WebContents* web_contents) const override;
   void OnTabStripModelChanged(
       TabStripModel* tab_strip_model,
       const TabStripModelChange& change,

--- a/browser/ui/brave_browser_browsertest.cc
+++ b/browser/ui/brave_browser_browsertest.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+
+using BraveBrowserBrowserTest = InProcessBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserBrowserTest, NTPFaviconTest) {
+  ui_test_utils::NavigateToURL(browser(), GURL("brave://newtab/"));
+
+  auto* tab_model = browser()->tab_strip_model();
+  EXPECT_FALSE(
+      browser()->ShouldDisplayFavicon(tab_model->GetActiveWebContents()));
+}

--- a/chromium_src/chrome/browser/ui/browser.h
+++ b/chromium_src/chrome/browser/ui/browser.h
@@ -7,6 +7,7 @@
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_
 
 #define ScheduleUIUpdate virtual ScheduleUIUpdate
+#define ShouldDisplayFavicon virtual ShouldDisplayFavicon
 #define BRAVE_BROWSER_H              \
  private:                            \
   friend class BookmarkPrefsService; \
@@ -16,5 +17,6 @@
 
 #undef BRAVE_BROWSER_H
 #undef ScheduleUIUpdate
+#undef ShouldDisplayFavicon
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_BROWSER_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -669,6 +669,7 @@ if (!is_android) {
       "//brave/browser/farbling:browser_tests",
       "//brave/browser/permissions:browser_tests",
       "//brave/browser/tor:browser_tests",
+      "//brave/browser/ui:browser_tests",
       "//brave/browser/ui/sidebar:browser_tests",
       "//brave/browser/ui/tabs/test:browser_tests",
       "//brave/browser/widevine:browser_tests",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/16773

<img width="405" alt="Screen Shot 2021-07-06 at 11 09 27 AM" src="https://user-images.githubusercontent.com/6786187/124532039-b0cb6d00-de4a-11eb-8575-f5d95be14de3.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=*BraveBrowserBrowserTest*`

1. Launch browser
2. Open NTP and check NTP doesn't have favicon in tab UI
3. Repeat step 2 with private/tor/guest window NTP
