### PR TITLE
Migrate tor log from disk to memory

### DIFF
--- a/browser/ui/webui/tor_internals_ui.cc
+++ b/browser/ui/webui/tor_internals_ui.cc
@@ -77,6 +77,11 @@ void TorInternalsDOMHandler::OnTorControlEvent(const std::string& event) {
                                          base::Value(event));
 }
 
+void TorInternalsDOMHandler::OnTorLogUpdated() {
+  tor_launcher_factory_->GetTorLog(base::BindOnce(
+      &TorInternalsDOMHandler::OnGetTorLog, weak_ptr_factory_.GetWeakPtr()));
+}
+
 void TorInternalsDOMHandler::OnTorInitializing(const std::string& percentage) {
   web_ui()->CallJavascriptFunctionUnsafe("tor_internals.onGetTorInitPercentage",
                                          base::Value(percentage));

--- a/browser/ui/webui/tor_internals_ui.h
+++ b/browser/ui/webui/tor_internals_ui.h
@@ -35,6 +35,7 @@ class TorInternalsDOMHandler : public content::WebUIMessageHandler,
   void OnTorCircuitEstablished(bool result) override;
   void OnTorInitializing(const std::string& percentage) override;
   void OnTorControlEvent(const std::string& event) override;
+  void OnTorLogUpdated() override;
 
   TorLauncherFactory* tor_launcher_factory_ = nullptr;
 

--- a/components/services/tor/tor_launcher_impl.cc
+++ b/components/services/tor/tor_launcher_impl.cc
@@ -58,19 +58,12 @@ void TorLauncherImpl::Launch(mojom::TorConfigPtr config,
   args.AppendArg("/nonexistent");
   args.AppendArg("--SocksPort");
   args.AppendArg("auto");
-  args.AppendArg("--TruncateLogFile");
-  args.AppendArg("1");
   base::FilePath tor_data_path = config->tor_data_path;
   if (!tor_data_path.empty()) {
     if (!base::DirectoryExists(tor_data_path))
       base::CreateDirectory(tor_data_path);
     args.AppendArg("--DataDirectory");
     args.AppendArgPath(tor_data_path);
-    args.AppendArg("--Log");
-    base::CommandLine::StringType log_file;
-    log_file += FILE_PATH_LITERAL("notice file ");
-    args.AppendArgNative(log_file +
-                         tor_data_path.AppendASCII("tor.log").value());
   }
   args.AppendArg("--__OwningControllerProcess");
   args.AppendArg(base::NumberToString(base::Process::Current().Pid()));

--- a/components/tor/brave_tor_client_updater.h
+++ b/components/tor/brave_tor_client_updater.h
@@ -72,6 +72,8 @@ class BraveTorClientUpdater : public BraveComponent {
  private:
   friend class ::BraveTorClientUpdaterTest;
 
+  void RemoveObsoleteFiles();
+
   static std::string g_tor_client_component_name_;
   static std::string g_tor_client_component_id_;
   static std::string g_tor_client_component_base64_public_key_;

--- a/components/tor/tor_launcher_factory.cc
+++ b/components/tor/tor_launcher_factory.cc
@@ -355,6 +355,8 @@ void TorLauncherFactory::OnTorEvent(
              event == tor::TorControlEvent::WARN ||
              event == tor::TorControlEvent::ERR) {
     tor_log_ += raw_event + '\n';
+    for (auto& observer : observers_)
+      observer.OnTorLogUpdated();
   }
 }
 

--- a/components/tor/tor_launcher_factory.cc
+++ b/components/tor/tor_launcher_factory.cc
@@ -9,10 +9,6 @@
 
 #include "base/bind.h"
 #include "base/bind_post_task.h"
-#include "base/files/file_util.h"
-#include "base/sequenced_task_runner.h"
-#include "base/task/post_task.h"
-#include "base/task/thread_pool.h"
 #include "base/threading/sequenced_task_runner_handle.h"
 #include "brave/components/tor/service_sandbox_type.h"
 #include "brave/components/tor/tor_file_watcher.h"
@@ -22,8 +18,6 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/service_process_host.h"
 
-using content::BrowserThread;
-
 namespace {
 constexpr char kTorProxyScheme[] = "socks5://";
 // tor::TorControlEvent::STATUS_CLIENT response
@@ -31,18 +25,6 @@ constexpr char kStatusClientBootstrap[] = "BOOTSTRAP";
 constexpr char kStatusClientBootstrapProgress[] = "PROGRESS=";
 constexpr char kStatusClientCircuitEstablished[] = "CIRCUIT_ESTABLISHED";
 constexpr char kStatusClientCircuitNotEstablished[] = "CIRCUIT_NOT_ESTABLISHED";
-
-std::pair<bool, std::string> LoadTorLogOnFileTaskRunner(
-    const base::FilePath& path) {
-  std::string data;
-  bool success = base::ReadFileToString(path, &data);
-  std::pair<bool, std::string> result;
-  result.first = success;
-  if (success) {
-    result.second = data;
-  }
-  return result;
-}
 }  // namespace
 
 // static
@@ -111,13 +93,6 @@ void TorLauncherFactory::LaunchTorProcess(const tor::mojom::TorConfig& config) {
   LaunchTorInternal();
 }
 
-void TorLauncherFactory::OnTorLogLoaded(
-    GetLogCallback callback,
-    const std::pair<bool, std::string>& result) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  std::move(callback).Run(result.first, result.second);
-}
-
 void TorLauncherFactory::LaunchTorInternal() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
@@ -138,7 +113,9 @@ void TorLauncherFactory::KillTorProcess() {
   control_->Stop();
   tor_launcher_.reset();
   tor_pid_ = -1;
+  is_starting_ = false;
   is_connected_ = false;
+  tor_log_.clear();
 }
 
 int64_t TorLauncherFactory::GetTorPid() const {
@@ -163,16 +140,7 @@ std::string TorLauncherFactory::GetTorVersion() const {
 
 void TorLauncherFactory::GetTorLog(GetLogCallback callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  base::FilePath tor_log_path = config_.tor_data_path.AppendASCII("tor.log");
-  scoped_refptr<base::SequencedTaskRunner> file_task_runner(
-      base::ThreadPool::CreateSequencedTaskRunner(
-          {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
-           base::TaskShutdownBehavior::BLOCK_SHUTDOWN}));
-  base::PostTaskAndReplyWithResult(
-      file_task_runner.get(), FROM_HERE,
-      base::BindOnce(&LoadTorLogOnFileTaskRunner, tor_log_path),
-      base::BindOnce(&TorLauncherFactory::OnTorLogLoaded,
-                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+  std::move(callback).Run(true, std::string(tor_log_));
 }
 
 void TorLauncherFactory::AddObserver(TorLauncherObserver* observer) {
@@ -250,6 +218,11 @@ void TorLauncherFactory::OnTorControlReady() {
                       base::DoNothing::Once<bool>());
   control_->Subscribe(tor::TorControlEvent::STREAM,
                       base::DoNothing::Once<bool>());
+  control_->Subscribe(tor::TorControlEvent::NOTICE,
+                      base::DoNothing::Once<bool>());
+  control_->Subscribe(tor::TorControlEvent::WARN,
+                      base::DoNothing::Once<bool>());
+  control_->Subscribe(tor::TorControlEvent::ERR, base::DoNothing::Once<bool>());
 }
 
 void TorLauncherFactory::GotVersion(bool error, const std::string& version) {
@@ -378,6 +351,10 @@ void TorLauncherFactory::OnTorEvent(
       for (auto& observer : observers_)
         observer.OnTorCircuitEstablished(false);
     }
+  } else if (event == tor::TorControlEvent::NOTICE ||
+             event == tor::TorControlEvent::WARN ||
+             event == tor::TorControlEvent::ERR) {
+    tor_log_ += raw_event + '\n';
   }
 }
 

--- a/components/tor/tor_launcher_factory.h
+++ b/components/tor/tor_launcher_factory.h
@@ -65,8 +65,6 @@ class TorLauncherFactory : public tor::TorControl::Delegate {
   TorLauncherFactory();
   ~TorLauncherFactory() override;
 
-  void OnTorLogLoaded(GetLogCallback, const std::pair<bool, std::string>&);
-
   void OnTorControlPrerequisitesReady(int64_t pid,
                                       bool ready,
                                       std::vector<uint8_t> cookie,
@@ -91,6 +89,8 @@ class TorLauncherFactory : public tor::TorControl::Delegate {
 
   std::string tor_proxy_uri_;
   std::string tor_version_;
+
+  std::string tor_log_;
 
   int64_t tor_pid_;
 

--- a/components/tor/tor_launcher_observer.h
+++ b/components/tor/tor_launcher_observer.h
@@ -21,6 +21,7 @@ class TorLauncherObserver : public base::CheckedObserver {
   virtual void OnTorCircuitEstablished(bool result) {}
   virtual void OnTorInitializing(const std::string& percentage) {}
   virtual void OnTorControlEvent(const std::string& event) {}
+  virtual void OnTorLogUpdated() {}
 };
 
 #endif  // BRAVE_COMPONENTS_TOR_TOR_LAUNCHER_OBSERVER_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16747

This PR cache tor log from control channel in memory and purge it whenever the corresponding Tor process is killed.
It also removed tor.log previously written on disk.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Tor log check
1. Launch brave with fresh profile
2. Open brave://tor-internals/ and go to `Logs` tab on a regular window
3. Open a private window with Tor
4. Visit https://brave5t5rjjg3s6k.onion/ in Tor window
5. We should be able to see initialization process on `NOTICE` level and onion address v2 warning on `WARN` level without timestamp like this
<img width="1491" alt="Screen Shot 2021-07-06 at 16 29 32" src="https://user-images.githubusercontent.com/11330831/124678457-62809300-de77-11eb-9593-aa284a0c3db2.png">

6.  Check `[User Data Dir]/Tor/data`, there should be no `tor.log` store on disk

### Tor log migration
1. Launch older version of Brave
2. Open a private window with Tor
3. Quit Brave
4. Launch Brave with the fix
5. Open a private window with Tor
6. `tor.log` in `[User Data Dir]/Tor/data` should be removed
