### PR TITLE
Update sidebar's builtin items property

### DIFF
--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -87,7 +87,8 @@ void SidebarController::AddItemWithCurrentTab() {
   const GURL url = active_contents->GetVisibleURL();
   const std::u16string title = active_contents->GetTitle();
   GetSidebarService(browser_)->AddItem(
-      SidebarItem::Create(url, title, SidebarItem::Type::kTypeWeb, false));
+      SidebarItem::Create(url, title, SidebarItem::Type::kTypeWeb,
+                          SidebarItem::BuiltInItemType::kNone, false));
 }
 
 void SidebarController::SetSidebar(Sidebar* sidebar) {

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -352,13 +352,13 @@ void SidebarItemsContentsView::UpdateItemViewStateAt(int index, bool active) {
     item_view->set_draw_highlight(active);
 
   if (sidebar::IsBuiltInType(item)) {
-    const GURL& url = item.url;
-    item_view->SetImage(views::Button::STATE_NORMAL,
-                        GetImageForBuiltInItems(url, active));
+    item_view->SetImage(
+        views::Button::STATE_NORMAL,
+        GetImageForBuiltInItems(item.built_in_item_type, active));
     item_view->SetImage(views::Button::STATE_HOVERED,
-                        GetImageForBuiltInItems(url, true));
+                        GetImageForBuiltInItems(item.built_in_item_type, true));
     item_view->SetImage(views::Button::STATE_PRESSED,
-                        GetImageForBuiltInItems(url, true));
+                        GetImageForBuiltInItems(item.built_in_item_type, true));
   }
 }
 
@@ -376,7 +376,7 @@ void SidebarItemsContentsView::OnItemPressed(const views::View* item) {
 }
 
 gfx::ImageSkia SidebarItemsContentsView::GetImageForBuiltInItems(
-    const GURL& item_url,
+    sidebar::SidebarItem::BuiltInItemType type,
     bool focused) const {
   SkColor base_button_color = SK_ColorWHITE;
   if (const ui::ThemeProvider* theme_provider = GetThemeProvider()) {
@@ -384,25 +384,25 @@ gfx::ImageSkia SidebarItemsContentsView::GetImageForBuiltInItems(
         BraveThemeProperties::COLOR_SIDEBAR_BUTTON_BASE);
   }
   auto& bundle = ui::ResourceBundle::GetSharedInstance();
-  if (item_url == GURL("chrome://wallet/")) {
+  if (type == sidebar::SidebarItem::BuiltInItemType::kWallet) {
     if (focused)
       return *bundle.GetImageSkiaNamed(IDR_SIDEBAR_CRYPTO_WALLET_FOCUSED);
     return gfx::CreateVectorIcon(kSidebarCryptoWalletIcon, base_button_color);
   }
 
-  if (item_url == GURL("https://together.brave.com/")) {
+  if (type == sidebar::SidebarItem::BuiltInItemType::kBraveTalk) {
     if (focused)
       return *bundle.GetImageSkiaNamed(IDR_SIDEBAR_BRAVE_TOGETHER_FOCUSED);
     return gfx::CreateVectorIcon(kSidebarBraveTogetherIcon, base_button_color);
   }
 
-  if (item_url == GURL("chrome://bookmarks/")) {
+  if (type == sidebar::SidebarItem::BuiltInItemType::kBookmarks) {
     if (focused)
       return *bundle.GetImageSkiaNamed(IDR_SIDEBAR_BOOKMARKS_FOCUSED);
     return gfx::CreateVectorIcon(kSidebarBookmarksIcon, base_button_color);
   }
 
-  if (item_url == GURL("chrome://history/")) {
+  if (type == sidebar::SidebarItem::BuiltInItemType::kHistory) {
     if (focused)
       return *bundle.GetImageSkiaNamed(IDR_SIDEBAR_HISTORY_FOCUSED);
     return gfx::CreateVectorIcon(kSidebarHistoryIcon, base_button_color);

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.h
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.h
@@ -93,8 +93,9 @@ class SidebarItemsContentsView : public views::View,
 
   void OnContextMenuClosed();
 
-  gfx::ImageSkia GetImageForBuiltInItems(const GURL& item_url,
-                                         bool focus) const;
+  gfx::ImageSkia GetImageForBuiltInItems(
+      sidebar::SidebarItem::BuiltInItemType type,
+      bool focus) const;
   void UpdateAllBuiltInItemsViewState();
   void ShowItemAddedFeedbackBubble(views::View* anchor_view);
 

--- a/components/sidebar/BUILD.gn
+++ b/components/sidebar/BUILD.gn
@@ -7,6 +7,7 @@ import("//brave/components/sidebar/buildflags/buildflags.gni")
 
 static_library("sidebar") {
   sources = [
+    "constants.h",
     "features.cc",
     "features.h",
     "pref_names.h",

--- a/components/sidebar/constants.h
+++ b/components/sidebar/constants.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SIDEBAR_CONSTANTS_H_
+#define BRAVE_COMPONENTS_SIDEBAR_CONSTANTS_H_
+
+namespace sidebar {
+
+constexpr char kSidebarItemURLKey[] = "url";
+constexpr char kSidebarItemTypeKey[] = "type";
+constexpr char kSidebarItemBuiltInItemTypeKey[] = "built_in_item_type";
+constexpr char kSidebarItemTitleKey[] = "title";
+constexpr char kSidebarItemOpenInPanelKey[] = "open_in_panel";
+
+}  // namespace sidebar
+
+#endif  // BRAVE_COMPONENTS_SIDEBAR_CONSTANTS_H_

--- a/components/sidebar/sidebar_item.cc
+++ b/components/sidebar/sidebar_item.cc
@@ -11,11 +11,13 @@ namespace sidebar {
 SidebarItem SidebarItem::Create(const GURL& url,
                                 const std::u16string& title,
                                 Type type,
+                                BuiltInItemType built_in_item_type,
                                 bool open_in_panel) {
   SidebarItem item;
   item.url = url;
   item.title = title;
   item.type = type;
+  item.built_in_item_type = built_in_item_type;
   item.open_in_panel = open_in_panel;
   return item;
 }

--- a/components/sidebar/sidebar_item.h
+++ b/components/sidebar/sidebar_item.h
@@ -16,9 +16,18 @@ struct SidebarItem {
     kTypeWeb,
   };
 
+  enum class BuiltInItemType {
+    kNone = 0,
+    kBraveTalk,
+    kWallet,
+    kBookmarks,
+    kHistory,
+  };
+
   static SidebarItem Create(const GURL& url,
                             const std::u16string& title,
                             Type type,
+                            BuiltInItemType built_in_item_type,
                             bool open_in_panel);
 
   SidebarItem();
@@ -26,6 +35,7 @@ struct SidebarItem {
 
   GURL url;
   Type type;
+  BuiltInItemType built_in_item_type;
   std::u16string title;
   // Set false to open this item in new tab.
   bool open_in_panel;

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -29,7 +29,7 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
   switch (type) {
     case SidebarItem::BuiltInItemType::kBraveTalk:
       return SidebarItem::Create(
-          GURL("https://together.brave.com/"),
+          GURL("https://talk.brave.com/"),
           l10n_util::GetStringUTF16(IDS_SIDEBAR_BRAVE_TALK_ITEM_TITLE),
           SidebarItem::Type::kTypeBuiltIn,
           SidebarItem::BuiltInItemType::kBraveTalk, true);
@@ -61,7 +61,7 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
 }
 
 SidebarItem::BuiltInItemType GetBuiltInItemTypeForURL(const std::string& url) {
-  if (url == "https://together.brave.com/")
+  if (url == "https://together.brave.com/" || url == "https://talk.brave.com/")
     return SidebarItem::BuiltInItemType::kBraveTalk;
 
   if (url == "chrome://wallet/")

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -11,6 +11,7 @@
 #include "base/feature_list.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
+#include "brave/components/sidebar/constants.h"
 #include "brave/components/sidebar/features.h"
 #include "brave/components/sidebar/pref_names.h"
 #include "components/grit/brave_components_strings.h"
@@ -24,30 +25,71 @@ namespace sidebar {
 
 namespace {
 
-constexpr char kSidebarItemURLKey[] = "url";
-constexpr char kSidebarItemTypeKey[] = "type";
-constexpr char kSidebarItemTitleKey[] = "title";
-constexpr char kSidebarItemOpenInPanelKey[] = "open_in_panel";
+SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
+  switch (type) {
+    case SidebarItem::BuiltInItemType::kBraveTalk:
+      return SidebarItem::Create(
+          GURL("https://together.brave.com/"),
+          l10n_util::GetStringUTF16(IDS_SIDEBAR_BRAVE_TALK_ITEM_TITLE),
+          SidebarItem::Type::kTypeBuiltIn,
+          SidebarItem::BuiltInItemType::kBraveTalk, true);
+    case SidebarItem::BuiltInItemType::kWallet:
+      return SidebarItem::Create(
+          GURL("chrome://wallet/"),
+          l10n_util::GetStringUTF16(IDS_SIDEBAR_WALLET_ITEM_TITLE),
+          SidebarItem::Type::kTypeBuiltIn,
+          SidebarItem::BuiltInItemType::kWallet, false);
+      break;
+    case SidebarItem::BuiltInItemType::kBookmarks:
+      return SidebarItem::Create(
+          GURL("chrome://bookmarks/"),
+          l10n_util::GetStringUTF16(IDS_SIDEBAR_BOOKMARKS_ITEM_TITLE),
+          SidebarItem::Type::kTypeBuiltIn,
+          SidebarItem::BuiltInItemType::kBookmarks, true);
+      break;
+    case SidebarItem::BuiltInItemType::kHistory:
+      return SidebarItem::Create(
+          GURL("chrome://history/"),
+          l10n_util::GetStringUTF16(IDS_SIDEBAR_HISTORY_ITEM_TITLE),
+          SidebarItem::Type::kTypeBuiltIn,
+          SidebarItem::BuiltInItemType::kHistory, true);
+      break;
+    default:
+      NOTREACHED();
+  }
+  return SidebarItem();
+}
+
+SidebarItem::BuiltInItemType GetBuiltInItemTypeForURL(const std::string& url) {
+  if (url == "https://together.brave.com/")
+    return SidebarItem::BuiltInItemType::kBraveTalk;
+
+  if (url == "chrome://wallet/")
+    return SidebarItem::BuiltInItemType::kWallet;
+
+  if (url == "chrome://bookmarks/")
+    return SidebarItem::BuiltInItemType::kBookmarks;
+
+  if (url == "chrome://history/")
+    return SidebarItem::BuiltInItemType::kHistory;
+
+  NOTREACHED();
+  return SidebarItem::BuiltInItemType::kNone;
+}
+
+SidebarItem GetBuiltInItemForURL(const std::string& url) {
+  return GetBuiltInItemForType(GetBuiltInItemTypeForURL(url));
+}
 
 std::vector<SidebarItem> GetDefaultSidebarItems() {
-  // TODO(simonhong): Get titles by observing webcontents.
   std::vector<SidebarItem> items;
-  items.push_back(SidebarItem::Create(
-      GURL("https://together.brave.com/"),
-      l10n_util::GetStringUTF16(IDS_SIDEBAR_BRAVE_TALK_ITEM_TITLE),
-      SidebarItem::Type::kTypeBuiltIn, true));
-  items.push_back(SidebarItem::Create(
-      GURL("chrome://wallet/"),
-      l10n_util::GetStringUTF16(IDS_SIDEBAR_WALLET_ITEM_TITLE),
-      SidebarItem::Type::kTypeBuiltIn, false));
-  items.push_back(SidebarItem::Create(
-      GURL("chrome://bookmarks/"),
-      l10n_util::GetStringUTF16(IDS_SIDEBAR_BOOKMARKS_ITEM_TITLE),
-      SidebarItem::Type::kTypeBuiltIn, true));
-  items.push_back(SidebarItem::Create(
-      GURL("chrome://history/"),
-      l10n_util::GetStringUTF16(IDS_SIDEBAR_HISTORY_ITEM_TITLE),
-      SidebarItem::Type::kTypeBuiltIn, true));
+  items.push_back(
+      GetBuiltInItemForType(SidebarItem::BuiltInItemType::kBraveTalk));
+  items.push_back(GetBuiltInItemForType(SidebarItem::BuiltInItemType::kWallet));
+  items.push_back(
+      GetBuiltInItemForType(SidebarItem::BuiltInItemType::kBookmarks));
+  items.push_back(
+      GetBuiltInItemForType(SidebarItem::BuiltInItemType::kHistory));
   return items;
 }
 
@@ -127,6 +169,8 @@ void SidebarService::UpdateSidebarItemsToPrefStore() {
     dict.SetStringKey(kSidebarItemURLKey, item.url.spec());
     dict.SetStringKey(kSidebarItemTitleKey, base::UTF16ToUTF8(item.title));
     dict.SetIntKey(kSidebarItemTypeKey, static_cast<int>(item.type));
+    dict.SetIntKey(kSidebarItemBuiltInItemTypeKey,
+                   static_cast<int>(item.built_in_item_type));
     dict.SetBoolKey(kSidebarItemOpenInPanelKey, item.open_in_panel);
     update->Append(std::move(dict));
   }
@@ -147,7 +191,8 @@ std::vector<SidebarItem> SidebarService::GetNotAddedDefaultSidebarItems()
   for (const auto& added_item : added_default_items) {
     auto iter = std::find_if(default_items.begin(), default_items.end(),
                              [added_item](const auto& default_item) {
-                               return default_item.url == added_item.url;
+                               return default_item.built_in_item_type ==
+                                      added_item.built_in_item_type;
                              });
     default_items.erase(iter);
   }
@@ -179,6 +224,13 @@ void SidebarService::LoadSidebarItems() {
 
   const auto& items = preference->GetValue()->GetList();
   for (const auto& item : items) {
+    SidebarItem::Type type;
+    if (const auto value = item.FindIntKey(kSidebarItemTypeKey)) {
+      type = static_cast<SidebarItem::Type>(*value);
+    } else {
+      continue;
+    }
+
     std::string url;
     if (const auto* value = item.FindStringKey(kSidebarItemURLKey)) {
       url = *value;
@@ -186,10 +238,17 @@ void SidebarService::LoadSidebarItems() {
       continue;
     }
 
-    SidebarItem::Type type;
-    if (const auto value = item.FindIntKey(kSidebarItemTypeKey)) {
-      type = static_cast<SidebarItem::Type>(*value);
-    } else {
+    // Always use latest properties for built-in type item.
+    if (type == SidebarItem::Type::kTypeBuiltIn) {
+      SidebarItem built_in_item;
+      if (const auto value = item.FindIntKey(kSidebarItemBuiltInItemTypeKey)) {
+        built_in_item = GetBuiltInItemForType(
+            static_cast<SidebarItem::BuiltInItemType>(*value));
+      } else {
+        // Fallback when built-in item type key is not existed.
+        built_in_item = GetBuiltInItemForURL(url);
+      }
+      items_.push_back(built_in_item);
       continue;
     }
 
@@ -206,8 +265,10 @@ void SidebarService::LoadSidebarItems() {
       title = *value;
     }
 
-    items_.push_back(SidebarItem::Create(GURL(url), base::UTF8ToUTF16(title),
-                                         type, open_in_panel));
+    DCHECK(type != SidebarItem::Type::kTypeBuiltIn);
+    items_.push_back(SidebarItem::Create(
+        GURL(url), base::UTF8ToUTF16(title), type,
+        SidebarItem::BuiltInItemType::kNone, open_in_panel));
   }
 }
 

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -175,7 +175,7 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Check service has updated built-in item. Previously url was deprecated.xxx.
   EXPECT_EQ(1UL, service_->items().size());
-  EXPECT_EQ("https://together.brave.com/", service_->items()[0].url);
+  EXPECT_EQ("https://talk.brave.com/", service_->items()[0].url);
 
   // Simulate re-launch and check service has still updated items.
   service_->RemoveObserver(this);
@@ -185,7 +185,7 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Check service has updated built-in item. Previously url was deprecated.xxx.
   EXPECT_EQ(1UL, service_->items().size());
-  EXPECT_EQ("https://together.brave.com/", service_->items()[0].url);
+  EXPECT_EQ("https://talk.brave.com/", service_->items()[0].url);
 }
 
 TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithoutBuiltInItemTypeKey) {

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -4,11 +4,15 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <memory>
+#include <utility>
 
 #include "base/feature_list.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/components/sidebar/constants.h"
 #include "brave/components/sidebar/features.h"
+#include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 #include "components/prefs/testing_pref_service.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -27,11 +31,14 @@ class SidebarServiceTest : public testing::Test,
 
     scoped_feature_list_.InitAndEnableFeature(kSidebarFeature);
     SidebarService::RegisterProfilePrefs(prefs_.registry());
-    service_.reset(new SidebarService(&prefs_));
-    service_->AddObserver(this);
   }
 
   void TearDown() override { service_->RemoveObserver(this); }
+
+  void InitService() {
+    service_.reset(new SidebarService(&prefs_));
+    service_->AddObserver(this);
+  }
 
   // SidebarServiceObserver overrides:
   void OnItemAdded(const SidebarItem& item, int index) override {
@@ -75,6 +82,8 @@ class SidebarServiceTest : public testing::Test,
 };
 
 TEST_F(SidebarServiceTest, AddRemoveItems) {
+  InitService();
+
   // Check the default items count.
   EXPECT_EQ(4UL, service_->items().size());
   EXPECT_EQ(0UL, service_->GetNotAddedDefaultSidebarItems().size());
@@ -105,9 +114,9 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
   EXPECT_TRUE(on_item_added_called_);
   ClearState();
 
-  const SidebarItem item2 =
-      SidebarItem::Create(GURL("https://www.brave.com/"), std::u16string(),
-                          SidebarItem::Type::kTypeWeb, true);
+  const SidebarItem item2 = SidebarItem::Create(
+      GURL("https://www.brave.com/"), std::u16string(),
+      SidebarItem::Type::kTypeWeb, SidebarItem::BuiltInItemType::kNone, true);
   EXPECT_TRUE(IsWebType(item2));
   service_->AddItem(item2);
   EXPECT_EQ(4, item_index_on_called_);
@@ -117,6 +126,8 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
 }
 
 TEST_F(SidebarServiceTest, MoveItem) {
+  InitService();
+
   EXPECT_EQ(4UL, service_->items().size());
 
   // Move item at 0 to index 2.
@@ -139,6 +150,67 @@ TEST_F(SidebarServiceTest, MoveItem) {
   item = service_->items()[2];
   service_->MoveItem(2, 1);
   EXPECT_EQ(item.url, service_->items()[1].url);
+}
+
+TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
+  // Make prefs already have builtin items before service initialization.
+  // And it has old url.
+  {
+    ListPrefUpdate update(&prefs_, sidebar::kSidebarItems);
+    update->ClearList();
+
+    base::Value dict(base::Value::Type::DICTIONARY);
+    dict.SetStringKey(sidebar::kSidebarItemURLKey,
+                      "https://deprecated.brave.com/");
+    dict.SetStringKey(sidebar::kSidebarItemTitleKey, "Brave together");
+    dict.SetIntKey(sidebar::kSidebarItemTypeKey,
+                   static_cast<int>(SidebarItem::Type::kTypeBuiltIn));
+    dict.SetIntKey(sidebar::kSidebarItemBuiltInItemTypeKey,
+                   static_cast<int>(SidebarItem::BuiltInItemType::kBraveTalk));
+    dict.SetBoolKey(sidebar::kSidebarItemOpenInPanelKey, true);
+    update->Append(std::move(dict));
+  }
+
+  InitService();
+
+  // Check service has updated built-in item. Previously url was deprecated.xxx.
+  EXPECT_EQ(1UL, service_->items().size());
+  EXPECT_EQ("https://together.brave.com/", service_->items()[0].url);
+
+  // Simulate re-launch and check service has still updated items.
+  service_->RemoveObserver(this);
+  service_.reset();
+
+  InitService();
+
+  // Check service has updated built-in item. Previously url was deprecated.xxx.
+  EXPECT_EQ(1UL, service_->items().size());
+  EXPECT_EQ("https://together.brave.com/", service_->items()[0].url);
+}
+
+TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithoutBuiltInItemTypeKey) {
+  // Prepare built-in item in prefs w/o setting BuiltInItemType.
+  // If not stored, service uses url to get proper latest properties.
+  {
+    ListPrefUpdate update(&prefs_, sidebar::kSidebarItems);
+    update->ClearList();
+
+    base::Value dict(base::Value::Type::DICTIONARY);
+    dict.SetStringKey(sidebar::kSidebarItemURLKey,
+                      "https://together.brave.com/");
+    dict.SetStringKey(sidebar::kSidebarItemTitleKey, "Brave together");
+    dict.SetIntKey(sidebar::kSidebarItemTypeKey,
+                   static_cast<int>(SidebarItem::Type::kTypeBuiltIn));
+    dict.SetBoolKey(sidebar::kSidebarItemOpenInPanelKey, true);
+    update->Append(std::move(dict));
+  }
+
+  InitService();
+
+  // Check item type is set properly.
+  EXPECT_EQ(1UL, service_->items().size());
+  EXPECT_EQ(SidebarItem::BuiltInItemType::kBraveTalk,
+            service_->items()[0].built_in_item_type);
 }
 
 }  // namespace sidebar


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16709

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_unit_tests -- --filter=*Sidebar*`

1. Launch previous version that uses together.brave.com url
2. Enable sidebar feature from brave://flags and relaunch
3. Update sidebar item such as adding new items or reordering to save items list into prefs
4. Relaunch browser and check together.brave.com is saved in prefs from brave://prefs-internals/
5. Close browser and launch latest version that uses talks.brave.com url
6. Close and re-launch and check talks.brave.com is save in prefs from brave://prefs-insternals/