### PR TITLE
Fixes unexpected error messages in logs - follow up to #16744

### DIFF
--- a/components/brave_ads/browser/ads_service.cc
+++ b/components/brave_ads/browser/ads_service.cc
@@ -68,6 +68,8 @@ void AdsService::RegisterProfilePrefs(
                                "");
 
   registry->RegisterBooleanPref(ads::prefs::kHasMigratedConversionState, false);
+  registry->RegisterBooleanPref(ads::prefs::kHasMigratedEstimatedPendingRewards,
+                                false);
 }
 
 }  // namespace brave_ads

--- a/vendor/bat-native-ads/include/bat/ads/pref_names.h
+++ b/vendor/bat-native-ads/include/bat/ads/pref_names.h
@@ -38,6 +38,7 @@ extern const char kEpsilonGreedyBanditArms[];
 extern const char kEpsilonGreedyBanditEligibleSegments[];
 
 extern const char kHasMigratedConversionState[];
+extern const char kHasMigratedEstimatedPendingRewards[];
 
 }  // namespace prefs
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
@@ -10,9 +10,11 @@
 #include "base/json/json_reader.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
+#include "bat/ads/internal/ads_client_helper.h"
 #include "bat/ads/internal/features/ad_rewards/ad_rewards_features.h"
 #include "bat/ads/internal/logging.h"
 #include "bat/ads/internal/number_util.h"
+#include "bat/ads/pref_names.h"
 #include "third_party/re2/src/re2/re2.h"
 
 namespace ads {
@@ -118,11 +120,23 @@ double Payments::GetBalance() const {
 bool Payments::DidReconcileBalance(
     const double last_balance,
     const double unreconciled_estimated_pending_rewards) const {
+  const double balance = GetBalance();
+
+  if (!AdsClientHelper::Get()->GetBooleanPref(
+          prefs::kHasMigratedEstimatedPendingRewards)) {
+    AdsClientHelper::Get()->SetBooleanPref(
+        prefs::kHasMigratedEstimatedPendingRewards, true);
+
+    if (balance > last_balance) {
+      return true;
+    }
+  }
+
   if (unreconciled_estimated_pending_rewards == 0.0) {
     return true;
   }
 
-  const double delta = GetBalance() - last_balance;
+  const double delta = balance - last_balance;
   if (DoubleIsGreaterEqual(delta, unreconciled_estimated_pending_rewards)) {
     return true;
   }

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
@@ -676,50 +676,17 @@ bool ConfirmationsState::ParseAdRewardsFromDictionary(
     return false;
   }
 
-  // Migration path for https://github.com/brave/brave-browser/issues/16678 and
-  // https://github.com/brave/brave-browser/issues/16744
-  const double value = GetUnreconciledEstimatedPendingRewards(dictionary);
-  ad_rewards_dictionary->SetDoubleKey("unreconciled_estimated_pending_rewards",
-                                      value);
+  const base::Value* unblinded_tokens =
+      dictionary->FindListKey("unblinded_payment_tokens");
+  if (unblinded_tokens && unblinded_tokens->GetList().empty()) {
+    // Migration path for https://github.com/brave/brave-browser/issues/16678
+    ad_rewards_dictionary->SetDoubleKey(
+        "unreconciled_estimated_pending_rewards", 0.0);
+  }
 
   ad_rewards_->SetFromDictionary(ad_rewards_dictionary);
 
   return true;
-}
-
-double ConfirmationsState::GetUnreconciledEstimatedPendingRewards(
-    base::DictionaryValue* dictionary) {
-  DCHECK(dictionary);
-
-  const base::Value* unblinded_payment_tokens =
-      dictionary->FindListKey("unblinded_payment_tokens");
-  if (!unblinded_payment_tokens) {
-    return 0.0;
-  }
-
-  size_t count = unblinded_payment_tokens->GetList().size();
-  if (count == 0) {
-    // There are no uncleared unblinded payment tokens to redeem
-    return 0.0;
-  }
-
-  // Uncleared transactions are always at the end of the transaction history
-  if (transactions_.size() < count) {
-    // There are fewer transactions than unblinded payment tokens which is
-    // likely due to manually editing transactions in confirmations.json
-    NOTREACHED();
-    count = transactions_.size();
-  }
-
-  const TransactionList transactions(transactions_.end() - count,
-                                     transactions_.end());
-
-  double value = 0.0;
-  for (const auto& transaction : transactions) {
-    value += transaction.estimated_redemption_value;
-  }
-
-  return value;
 }
 
 bool ConfirmationsState::ParseUnblindedTokensFromDictionary(

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.h
@@ -90,9 +90,6 @@ class ConfirmationsState {
 
   bool ParseAdRewardsFromDictionary(base::DictionaryValue* dictionary);
 
-  double GetUnreconciledEstimatedPendingRewards(
-      base::DictionaryValue* dictionary);
-
   std::unique_ptr<privacy::UnblindedTokens> unblinded_tokens_;
   bool ParseUnblindedTokensFromDictionary(base::DictionaryValue* dictionary);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/unittest_util.cc
@@ -398,7 +398,8 @@ void MockDefaultPrefs(const std::unique_ptr<AdsClientMock>& mock) {
   mock->SetInt64Pref(prefs::kCatalogPing, 7200000);
   mock->SetInt64Pref(prefs::kCatalogLastUpdated, DistantPastAsTimestamp());
 
-  mock->SetBooleanPref(prefs::kHasMigratedConversionState, true);
+  mock->SetBooleanPref(prefs::kHasMigratedConversionState, false);
+  mock->SetBooleanPref(prefs::kHasMigratedEstimatedPendingRewards, false);
 }
 
 }  // namespace

--- a/vendor/bat-native-ads/src/bat/ads/pref_names.cc
+++ b/vendor/bat-native-ads/src/bat/ads/pref_names.cc
@@ -57,6 +57,8 @@ const char kEpsilonGreedyBanditEligibleSegments[] =
 // Stores migration status
 const char kHasMigratedConversionState[] =
     "brave.brave_ads.migrated.conversion_state";
+const char kHasMigratedEstimatedPendingRewards[] =
+    "brave.brave_ads.migrated.estimated_pending_rewards";
 
 }  // namespace prefs
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16810

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Install a version before the fixes
- Enable ads
- Wait for ads to initialize (see the console log)
- Quit the browser
- Use Charles Proxy to rewrite the `GetPayments` `/v1/confirmation/payment/{payment_id}` endpoint to return
```
[
  {
    "month": "2021-07",
    "transactionCount": "5",
    "balance": "0.05"
  },
  {
    "month": "2021-06",
    "transactionCount": "234",
    "balance": "1.9475"
  },
  {
    "month": "2021-05",
    "transactionCount": "170",
    "balance": "1.0385"
  },
  {
    "month": "2021-04",
    "transactionCount": "290",
    "balance": "2.8025"
  },
  {
    "month": "2021-03",
    "transactionCount": "342",
    "balance": "4.25"
  },
  {
    "month": "2021-02",
    "transactionCount": "420",
    "balance": "6.73"
  },
  {
    "month": "2021-01",
    "transactionCount": "432",
    "balance": "5.775"
  },
  {
    "month": "2020-12",
    "transactionCount": "180",
    "balance": "5.475"
  },
  {
    "month": "2020-11",
    "transactionCount": "151",
    "balance": "5.405"
  },
  {
    "month": "2020-10",
    "transactionCount": "33",
    "balance": "0.825"
  },
  {
    "month": "2020-09",
    "transactionCount": "80",
    "balance": "1.625"
  },
  {
    "month": "2020-08",
    "transactionCount": "156",
    "balance": "6.45"
  },
  {
    "month": "2020-07",
    "transactionCount": "241",
    "balance": "12.2"
  },
  {
    "month": "2020-06",
    "transactionCount": "242",
    "balance": "11.79"
  },
  {
    "month": "2020-05",
    "transactionCount": "238",
    "balance": "12.45"
  },
  {
    "month": "2020-04",
    "transactionCount": "293",
    "balance": "15.55"
  },
  {
    "month": "2020-03",
    "transactionCount": "284",
    "balance": "15.05"
  },
  {
    "month": "2020-02",
    "transactionCount": "149",
    "balance": "7.65"
  },
  {
    "month": "2020-01",
    "transactionCount": "65",
    "balance": "3.45"
  },
  {
    "month": "2019-12",
    "transactionCount": "110",
    "balance": "5.5"
  },
  {
    "month": "2019-11",
    "transactionCount": "42",
    "balance": "2.1"
  },
  {
    "month": "2019-10",
    "transactionCount": "124",
    "balance": "6.2"
  },
  {
    "month": "2019-09",
    "transactionCount": "115",
    "balance": "7.25"
  },
  {
    "month": "2019-08",
    "transactionCount": "225",
    "balance": "13.65"
  },
  {
    "month": "2019-07",
    "transactionCount": "114",
    "balance": "6.1"
  },
  {
    "month": "2019-06",
    "transactionCount": "253",
    "balance": "12.65"
  }
]
```
- Use Charles Proxy to rewrite the `GetPayments` `/v1/promotions/ads/grants/summary?paymentId={payment_id}` endpoint to return
```
{
  "type": "ads",
  "amount": "169.68",
  "lastClaim": "2021-05-06T20:55:56Z"
}
```
- Replace the `ad_rewards` node in the `confirmations.json` file with:
```
  "ads_rewards": {
    "payments": [
      {
        "balance": 0.28,
        "month": "2021-05",
        "transaction_count": "48"
      },
      {
        "balance": 2.8025,
        "month": "2021-04",
        "transaction_count": "290"
      },
      {
        "balance": 4.25,
        "month": "2021-03",
        "transaction_count": "342"
      },
      {
        "balance": 6.73,
        "month": "2021-02",
        "transaction_count": "420"
      },
      {
        "balance": 5.775,
        "month": "2021-01",
        "transaction_count": "432"
      },
      {
        "balance": 5.475,
        "month": "2020-12",
        "transaction_count": "180"
      },
      {
        "balance": 5.405,
        "month": "2020-11",
        "transaction_count": "151"
      },
      {
        "balance": 0.825,
        "month": "2020-10",
        "transaction_count": "33"
      },
      {
        "balance": 1.625,
        "month": "2020-09",
        "transaction_count": "80"
      },
      {
        "balance": 6.45,
        "month": "2020-08",
        "transaction_count": "156"
      },
      {
        "balance": 12.2,
        "month": "2020-07",
        "transaction_count": "241"
      },
      {
        "balance": 11.79,
        "month": "2020-06",
        "transaction_count": "242"
      },
      {
        "balance": 12.45,
        "month": "2020-05",
        "transaction_count": "238"
      },
      {
        "balance": 15.55,
        "month": "2020-04",
        "transaction_count": "293"
      },
      {
        "balance": 15.05,
        "month": "2020-03",
        "transaction_count": "284"
      },
      {
        "balance": 7.65,
        "month": "2020-02",
        "transaction_count": "149"
      },
      {
        "balance": 3.45,
        "month": "2020-01",
        "transaction_count": "65"
      },
      {
        "balance": 5.5,
        "month": "2019-12",
        "transaction_count": "110"
      },
      {
        "balance": 2.1,
        "month": "2019-11",
        "transaction_count": "42"
      },
      {
        "balance": 6.2,
        "month": "2019-10",
        "transaction_count": "124"
      },
      {
        "balance": 7.25,
        "month": "2019-09",
        "transaction_count": "115"
      },
      {
        "balance": 13.65,
        "month": "2019-08",
        "transaction_count": "225"
      },
      {
        "balance": 6.1,
        "month": "2019-07",
        "transaction_count": "114"
      },
      {
        "balance": 12.65,
        "month": "2019-06",
        "transaction_count": "253"
      }
    ],
    "unreconciled_estimated_pending_rewards": 2.8034999999999997,
    "grants_balance": 169.68
  },
```
- Replace the `transaction_history` node in the `confirmations.json` file with:
```
  "transaction_history": {
    "transactions": [
      {
        "confirmation_type": "view",
        "estimated_redemption_value": 0.01,
        "timestamp_in_seconds": "1625142812"
      },
      {
        "confirmation_type": "dismiss",
        "estimated_redemption_value": 0,
        "timestamp_in_seconds": "1625142813"
      },
      {
        "confirmation_type": "view",
        "estimated_redemption_value": 0.01,
        "timestamp_in_seconds": "1625142861"
      },
      {
        "confirmation_type": "view",
        "estimated_redemption_value": 0.01,
        "timestamp_in_seconds": "1625143649"
      },
      {
        "confirmation_type": "view",
        "estimated_redemption_value": 0.01,
        "timestamp_in_seconds": "1625669358"
      }
    ]
  },
```
- Replace the `unblinded_payment_tokens` node in the `confirmations.json` file with:
```
  "unblinded_payment_tokens": [
    {
      "public_key": "oOJO/xLaCXGW6yhpeIfM4K1X2ln7sgdjTCTCHe8BugE=",
      "unblinded_token": "sd4NG8YF9jIzjqAapwO9Y+geBMh5YDdwn6jtD2PfBSye89L6s14SlMc/MLyJXb+oVwMI/ktpk7O3IlvYaxKZG4x+Rm/uDbXWjdqx8kQ7Ge1QVDvGkFdD2oAKsyiz4OYm"
    },
    {
      "public_key": "uor3AzFj4OmdCxwetsYD1TxPXZSw40t3j/VOCUyC7Rs=",
      "unblinded_token": "CtfIk2jtylneiONnhkBDv/H4MPgOLuVzuYEHpnGU94EZ4vy2RxJJu/NrQxmkGwBvNAUUit6KmvQvgVcLFvU5ynLwKUBSiZGsnykUYbCsYwDODzZPnIFN/RzV2UidiB0o"
    },
    {
      "public_key": "oOJO/xLaCXGW6yhpeIfM4K1X2ln7sgdjTCTCHe8BugE=",
      "unblinded_token": "I0PdV23mdq71MWCXhiIIgmrWDHR92S1gbXJRfOKtCFpuXY9+fiIlbr5Kk7iyaAP0Xkw7oLUcCQTS5g2lw0jvSKLiEuCeOMIYD8U1TF2J2r13hu7Nh1COoOEELhCnyeBe"
    },
    {
      "public_key": "oOJO/xLaCXGW6yhpeIfM4K1X2ln7sgdjTCTCHe8BugE=",
      "unblinded_token": "hlwvI/EELm+pEJt/KCL698hhg4iQpOygzbdIUk6num1+SLNFvkQsMlH1qfu5N3CkVG+U18o/SbINieAr2ghzopTVIP4C3ZgTx5WQKjq7Czmz7J0hTmsKDShayU2JGF1I"
    },
    {
      "public_key": "JiwFR2EU/Adf1lgox+xqOVPuc6a/rxdy/LguFG5eaXg=",
      "unblinded_token": "ReEeAEMTqLvS8fG9GiLbhawi4EykfgwHPkkS46G7ZqsVoDXuJY/O0JQHxGDIKF8ZYWSuhU00pjeLYOPuAGd/m5hdXNkKvJ/cRLHN/WbR9RayXBATnRMt1u9KMubrYoUu"
    }
  ],
```
- Launch the browser
- Navigate to brave://rewards

EXPECTED RESULT:
    `Current earnings this month (estimated): 0.08` (1.27.x or 1.28.x) or `Estimated pending rewards: 4.3135` (1.26.x)

- View another ad and confirm the earnings are incremented
- Relaunch the browser and confirm the values are correct

---------------------------------

We should no longer see the following in the logs:
```
[10741:775:0629/112116.477230:INFO:ad_rewards.cc(280)] Payment balance is not ready
[10741:775:0629/112116.477303:VERBOSE1:ad_rewards.cc(355)] Failed to reconcile ad rewards
```
