### PR TITLE
Fixed dark hover color (uplift to 1.27.x)

### DIFF
--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -83,6 +83,9 @@ RegisterStyleOverride(
         a[href].iron-selected iron-icon {
           color: var(--settings-nav-item-color) !important;
         }
+        a:hover, iron-icon:hover {
+          color: #737ADE !important;
+        }
       }
 
       a[href],


### PR DESCRIPTION
Uplift of #9356
Resolves https://github.com/brave/brave-browser/issues/16802

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.