### PR TITLE
Reduce corner radius on location bar icon

### DIFF
--- a/chromium_src/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#define BRAVE_ICON_LABEL_BUBBLE_VIEW_GET_HIGHLIGHT_PATH                      \
+  if (!ShouldShowSeparator())                                                \
+    highlight_bounds.Inset(0, 0, 1, 0);                                      \
+  auto layout_radius =                                                       \
+      GetLayoutProvider()->GetCornerRadiusMetric(views::Emphasis::kMaximum); \
+  const SkRect new_rect = RectToSkRect(highlight_bounds);                    \
+  return SkPath().addRoundRect(new_rect, layout_radius, layout_radius);
+
+#include "../../../../../../../chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc"
+#undef BRAVE_ICON_LABEL_BUBBLE_VIEW_GET_HIGHLIGHT_PATH

--- a/patches/chrome-browser-ui-views-location_bar-icon_label_bubble_view.cc.patch
+++ b/patches/chrome-browser-ui-views-location_bar-icon_label_bubble_view.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc b/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc
+index f08cd04d815b30bfc089d5a94a4928c3d627fffd..b15046ab3c16f896384ed201db405db5649c688d 100644
+--- a/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc
++++ b/chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc
+@@ -568,6 +568,7 @@ SkPath IconLabelBubbleView::GetHighlightPath() const {
+   const float corner_radius = highlight_bounds.height() / 2.f;
+   const SkRect rect = RectToSkRect(highlight_bounds);
+ 
++  BRAVE_ICON_LABEL_BUBBLE_VIEW_GET_HIGHLIGHT_PATH
+   return SkPath().addRoundRect(rect, corner_radius, corner_radius);
+ }
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16290 - This fixes corner radius on the location bar to match with with the standard corner radius (4px). 

An advanced patch could not be done because the base class definition in chromium code performs a `static_cast` here: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/location_bar/icon_label_bubble_view.cc;l=131-133 - Overriding the method would still call the base class `GetHighlightPath`. [Here](https://replit.com/@petemill/CommonWastefulMigration#main.cpp) is a sample test.

![image](https://user-images.githubusercontent.com/8665427/124965459-02a0fe00-dfd7-11eb-9248-f94a486f710d.png)


Opted in for a basic patch instead.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

