### PR TITLE
speedreader: Fix icon onclick in reader mode state

### DIFF
--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -98,7 +98,8 @@ void MaybeDistillAndShowSpeedreaderBubble(Browser* browser) {
         tab_helper->ShowSpeedreaderBubble();
         break;
       case DistillState::kReaderMode:
-        tab_helper->ShowReaderModeBubble();
+        // Refresh the page (toggles off Speedreader)
+        contents->GetController().Reload(content::ReloadType::NORMAL, false);
         break;
       case DistillState::kPageProbablyReadable:
         tab_helper->SingleShotSpeedreader();


### PR DESCRIPTION
Clicking the pill should refresh the page (thus toggling the
distillation off). The promo bubble is only shown automatically, the
first 3 times that Speedreader is used. This was brought up in
Friday's design review

Resolves https://github.com/brave/brave-browser/issues/16888