### PR TITLE
Remove Joe and I from the ads-client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,12 +36,12 @@ components/services/bat_ads/**/*.mm @brave/ads-client
 vendor/bat-native-ads/**/*.cc @brave/ads-client
 vendor/bat-native-ads/**/*.h @brave/ads-client
 vendor/bat-native-ads/**/*.mm @brave/ads-client
-vendor/bat-native-ads/src/bat/ads/internal/privacy/**/*.cc @brave/ads-client @fmarier
-vendor/bat-native-ads/src/bat/ads/internal/privacy/**/*.h @brave/ads-client @fmarier
-vendor/bat-native-ads/src/bat/ads/internal/privacy/**/*.mm @brave/ads-client @fmarier
-vendor/bat-native-ads/src/bat/ads/internal/security/**/*.cc @brave/ads-client @orspetol
-vendor/bat-native-ads/src/bat/ads/internal/security/**/*.h @brave/ads-client @orspetol
-vendor/bat-native-ads/src/bat/ads/internal/security/**/*.mm @brave/ads-client @orspetol
+vendor/bat-native-ads/src/bat/ads/internal/privacy/**/*.cc @brave/ads-client
+vendor/bat-native-ads/src/bat/ads/internal/privacy/**/*.h @brave/ads-client
+vendor/bat-native-ads/src/bat/ads/internal/privacy/**/*.mm @brave/ads-client
+vendor/bat-native-ads/src/bat/ads/internal/security/**/*.cc @brave/ads-client
+vendor/bat-native-ads/src/bat/ads/internal/security/**/*.h @brave/ads-client
+vendor/bat-native-ads/src/bat/ads/internal/security/**/*.mm @brave/ads-client
 
 # Network
 browser/net/ @iefremov


### PR DESCRIPTION
While this seemed like a good idea, in practice, this has mostly just meant an extra blocking codeowner review for each Chromium upgrade.

We're of course happy to review anything the ads team deems wortwhile, but we don't need to be codeowners for that.