### PR TITLE
Fix Android Debug x86_64 build failures while linking

### DIFF
--- a/browser/ephemeral_storage/BUILD.gn
+++ b/browser/ephemeral_storage/BUILD.gn
@@ -24,6 +24,7 @@ if (!is_android) {
     deps = [
       ":ephemeral_storage",
       "//base",
+      "//brave/common",
       "//brave/components/brave_shields/browser:browser",
       "//brave/components/brave_shields/common:common",
       "//chrome/browser",

--- a/browser/ipfs/test/BUILD.gn
+++ b/browser/ipfs/test/BUILD.gn
@@ -23,6 +23,7 @@ source_set("unittests") {
     "//brave/browser",
     "//brave/browser/net:net",
     "//brave/browser/tor",
+    "//brave/common",
     "//brave/components/decentralized_dns/buildflags",
     "//brave/components/ipfs",
     "//brave/components/tor/buildflags",

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -161,6 +161,7 @@ source_set("common") {
 
     deps += [
       "//brave/components/resources",
+      "//chrome/common",
       "//chrome/common:constants",
       "//components/resources",
       "//content/public/common",

--- a/patches/chrome-common-BUILD.gn.patch
+++ b/patches/chrome-common-BUILD.gn.patch
@@ -1,24 +1,16 @@
 diff --git a/chrome/common/BUILD.gn b/chrome/common/BUILD.gn
-index 195f082ff6d37c19e37d18170909126c0a8fc47b..845994e88564e1ed8ad5ceda57f17e3a2944cc94 100644
+index 195f082ff6d37c19e37d18170909126c0a8fc47b..4003c4e1ada82097969f7a78eaefc36ed826f06a 100644
 --- a/chrome/common/BUILD.gn
 +++ b/chrome/common/BUILD.gn
-@@ -66,6 +66,7 @@ source_set("channel_info") {
-     "//build:branding_buildflags",
-     "//build:chromeos_buildflags",
-   ]
-+  deps += [ "//brave/common:channel_info" ]
-   public_deps = [
-     "//base",
-     "//components/version_info",
-@@ -152,6 +153,7 @@ static_library("common") {
-   ]
+@@ -85,6 +85,7 @@ source_set("channel_info") {
+   } else if (is_posix) {
+     sources += [ "channel_info_posix.cc" ]
+   }
++  public_deps += [ "//brave/common:channel_info" ]
+ }
  
-   public_deps = [
-+    "//brave/common",
-     ":available_offline_content_mojom",
-     ":buildflags",
-     ":channel_info",
-@@ -545,6 +547,7 @@ static_library("non_code_constants") {
+ source_set("ini_parser") {
+@@ -545,6 +546,7 @@ static_library("non_code_constants") {
      "//printing/buildflags",
      "//ui/base:buildflags",
    ]

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -67,6 +67,7 @@ static_library("brave_test_support_unit") {
   deps = [
     ":test_support",
     "//brave/browser/profiles",
+    "//brave/common",
     "//brave/common:pref_names",
     "//components/gcm_driver",
     "//components/gcm_driver:gcm_buildflags",
@@ -673,6 +674,7 @@ if (!is_android) {
       "//brave/browser/ui/tabs/test:browser_tests",
       "//brave/browser/widevine:browser_tests",
       "//brave/chromium_src/third_party/blink/renderer/modules:browser_tests",
+      "//brave/common",
       "//brave/components/brave_rewards/common:features",
       "//brave/components/brave_rewards/common/buildflags:buildflags",
       "//brave/components/brave_search/browser",


### PR DESCRIPTION
Android Debug build for x86_64 [1] is currently failing with these kind
of errors while linking:
```
  [51/503] SOLINK ./libmonochrome.cr.so
  FAILED: libmonochrome.cr.so libmonochrome.cr.so.TOC lib.unstripped/libmonochrome.cr.so
  python "../../build/toolchain/gcc_solink_wrapper.py"
    --readelf="../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-readelf"
    --nm="../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-nm"
    --strip=../.>
  ld.lld: error: undefined symbol: ChromeContentClient::ChromeContentClient()
```
The problem is a missing //brave/common->//chrome/common dependency,
but we can't simply add it or we'll get a dependency cycle.

Fortunately, the only cases that include files from //brave/common are
chromium_src sources overriding files not included in //chrome/common:

  * chrome/common/channel_info_posix.cc, from //chrome/common:channel_info
  * chrome/common/chrome_paths_linux.cc, from //chrome/common:constants

The first case already depends on //brave/common:channel_info, so all
we have to do is to add that dependency in //chrome/common:constants
as well so we can drop the //chrome/common->//brave/common dependency,
and fix both the Android build and this potential deps cycle in one go.

Last, this PR is precursor to be able to fix https://github.com/brave/brave-browser/issues/10653.

[1] npm run build -- Debug --target_os=android --target_arch=x64

Resolves: https://github.com/brave/brave-browser/issues/11909

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A