### PR TITLE
Enable gn check for //brave/common and solve missing dependencies

### DIFF
--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -101,8 +101,6 @@ source_set("common") {
     visibility += [ "//brave/components/ipfs/test:brave_ipfs_browser_tests" ]
   }
 
-  # Remove when https://github.com/brave/brave-browser/issues/10653 is resolved
-  check_includes = false
   deps = []
 
   sources = [
@@ -136,7 +134,11 @@ source_set("common") {
       "extensions/whitelist.h",
     ]
 
-    deps += [ "//extensions/common:common_constants" ]
+    deps += [
+      "//brave/components/brave_component_updater/browser",
+      "//brave/components/brave_wallet/common/buildflags",
+      "//extensions/common:common_constants",
+    ]
 
     public_deps = [ "extensions/api" ]
   }
@@ -148,6 +150,7 @@ source_set("common") {
     ":switches",
     "//base",
     "//brave/chromium_src:common",
+    "//components/version_info:channel",
     "//extensions/buildflags",
     "//services/service_manager",
     "//ui/base",
@@ -161,7 +164,9 @@ source_set("common") {
 
     deps += [
       "//brave/components/resources",
+      "//brave/components/resources:static_resources_grit",
       "//chrome/common",
+      "//chrome/common:channel_info",
       "//chrome/common:constants",
       "//components/resources",
       "//content/public/common",


### PR DESCRIPTION
With the fix from PR #9407 landed, we no longer have cycles since the
//chrome/common -> //brave/common dependency is now gone, and all that
remains is to remove the check_includes = false and add the missing
dependencies for the //brave/common target itself.

[1] https://github.com/brave/brave-core/pull/9407

Resolves https://github.com/brave/brave-browser/issues/10653

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A