### PR TITLE
Fixes ads resources are not loaded after browser restart - 1.27.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -866,6 +866,9 @@ void AdsServiceImpl::OnEnsureBaseDirectoryExists(const bool success) {
       bat_ads_.BindNewEndpointAndPassReceiver(),
       base::BindOnce(&AdsServiceImpl::OnCreate, AsWeakPtr()));
 
+  const std::string locale = GetLocale();
+  RegisterResourceComponentsForLocale(locale);
+
   OnWalletUpdated();
 
   MaybeShowMyFirstAdNotification();
@@ -1742,9 +1745,6 @@ void AdsServiceImpl::OnPrefsChanged(const std::string& pref) {
       if (!IsEnabled()) {
         SuspendP2AHistograms();
         VLOG(1) << "P2A histograms suspended";
-      } else {
-        const std::string locale = GetLocale();
-        RegisterResourceComponentsForLocale(locale);
       }
 
       brave_rewards::p3a::UpdateAdsStateOnPreferenceChange(profile_->GetPrefs(),


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9410
Resolves https://github.com/brave/brave-browser/issues/16918

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.