### PR TITLE
speedreader: Fix InvokeUi test on bubble (Uplift to 1.27.x)

### DIFF
--- a/browser/ui/speedreader/speedreader_bubble_browsertest.cc
+++ b/browser/ui/speedreader/speedreader_bubble_browsertest.cc
@@ -42,24 +42,22 @@ class SpeedreaderBubbleBrowserTest : public DialogBrowserTest {
         ActiveWebContents());
   }
 
-  void ToggleSpeedreader() {
-    auto* speedreader_service =
-        speedreader::SpeedreaderServiceFactory::GetForProfile(
-            browser()->profile());
-    speedreader_service->ToggleSpeedreader();
+  speedreader::SpeedreaderService* speedreader_service() {
+    return speedreader::SpeedreaderServiceFactory::GetForProfile(
+        browser()->profile());
   }
 };
 
 IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
                        InvokeUi_reader_mode_bubble_basic) {
-  EXPECT_FALSE(tab_helper()->IsSpeedreaderEnabled());
+  EXPECT_FALSE(speedreader_service()->IsEnabled());
   ShowAndVerifyUi();
 }
 
 IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
                        InvokeUi_speedreader_mode_bubble_basic) {
-  ToggleSpeedreader();
-  EXPECT_TRUE(tab_helper()->IsSpeedreaderEnabled());
+  speedreader_service()->ToggleSpeedreader();
+  EXPECT_TRUE(speedreader_service()->IsEnabled());
   // We need to navigate somewhere so the host is non-empty. For tests the new
   // tab page is fine.
   NavigateToNewTab();


### PR DESCRIPTION
Use the service and not the tab helper. This is due to inconsistent
behavior with the webcontents in the test.

Resolves https://github.com/brave/brave-browser/issues/16903

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

