### PR TITLE
Remove EAFF custom header (fixes brave/brave-browser#16961)

### DIFF
--- a/browser/net/brave_referrals_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_referrals_network_delegate_helper_unittest.cc
@@ -20,8 +20,7 @@
 using brave::ResponseCallback;
 
 TEST(BraveReferralsNetworkDelegateHelperTest, ReplaceHeadersForMatchingDomain) {
-  const std::array<std::tuple<GURL, std::string>, 3> test_cases = {
-      std::make_tuple<>(GURL("https://eaff.com"), "eaff"),
+  const std::array<std::tuple<GURL, std::string>, 2> test_cases = {
       std::make_tuple<>(GURL("https://api-sandbox.uphold.com"), "uphold"),
       std::make_tuple<>(GURL("http://grammarly.com"), "grammarly"),
   };

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -144,12 +144,9 @@ BraveReferralsHeaders::BraveReferralsHeaders() {
   // https://github.com/brave/brave-browser/wiki/Custom-Headers for more
   // information. Custom headers are deprecated and new partners use the
   // navigator.brave.isBrave() JavaScript API.
-  constexpr char kPartnerEaffName[] = "eaff";
   constexpr char kPartnerUpholdName[] = "uphold";
   constexpr char kPartnerGrammarlyName[] = "grammarly";
 
-  referral_headers_.push_back(
-      CreateReferralHeader(kPartnerEaffName, {"eaff.com", "stg.eaff.com"}));
   referral_headers_.push_back(CreateReferralHeader(
       kPartnerUpholdName, {"sandbox.uphold.com", "api-sandbox.uphold.com",
                            "uphold.com", "api.uphold.com"}));


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16961

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [x] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit <https://eaff.com/> with the Network tab of the devtools open.
2. Click on the main request (the document).
3. Look for the `X-Brave-Partner` header in the **Request** headers.
![Screenshot from 2021-07-14 17-13-59](https://user-images.githubusercontent.com/167821/125708823-d4fe23d3-5dac-49ab-a6ff-6577f93c0b43.png)
4. Confirm that the header is **not present**.