### PR TITLE
Moved alert indicator area on the browser tab next to favicon

### DIFF
--- a/browser/ui/views/tabs/brave_alert_indicator.cc
+++ b/browser/ui/views/tabs/brave_alert_indicator.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/tabs/tab_types.h"
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -62,12 +63,15 @@ BraveAlertIndicator::BraveAlertIndicator(Tab* parent_tab)
 }
 
 SkColor BraveAlertIndicator::GetBackgroundColor() const {
-  TabStyle::TabColors colors = parent_tab_->tab_style()->CalculateColors();
+  SkColor fill_color = parent_tab_->controller()->GetTabBackgroundColor(
+      parent_tab_->IsActive() ? TabActive::kInactive : TabActive::kActive,
+      BrowserFrameActiveState::kUseCurrent);
+
   if (!IsTabAudioToggleable() || !IsMouseHovered())
-    return colors.background_color;
+    return fill_color;
 
   // Approximating the InkDrop behavior of the close button.
-  return color_utils::BlendTowardMaxContrast(colors.background_color,
+  return color_utils::BlendTowardMaxContrast(fill_color,
                                              mouse_pressed_ ? 72 : 36);
 }
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.cc
@@ -5,6 +5,18 @@
 
 #include "brave/browser/ui/views/tabs/brave_alert_indicator.h"
 
+// Set alert indicator's pos to start of the title and
+// move title after the alert indicator.
+// Title right should respect close btn's space
+
+#define BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION    \
+  alert_indicator_->SetX(title_left - after_title_padding); \
+  title_right = close_x - after_title_padding;              \
+  if (showing_close_button_)                                \
+    title_right = close_x - after_title_padding;            \
+  title_left =                                              \
+      alert_indicator_->x() + alert_indicator_->width() + after_title_padding;
 #define AlertIndicator BraveAlertIndicator
 #include "../../../../../../../chrome/browser/ui/views/tabs/tab.cc"  // NOLINT
 #undef AlertIndicator
+#undef BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION

--- a/chromium_src/chrome/browser/ui/views/tabs/tab.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab.h
@@ -1,0 +1,13 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_H_
+#define kMinimumContentsWidthForCloseButtons \
+  kMinimumContentsWidthForCloseButtons = 55; \
+  static constexpr int kMinimumContentsWidthForCloseButtons_UnUsed
+#include "../../../../../../../chrome/browser/ui/views/tabs/tab.h"
+#undef kMinimumContentsWidthForCloseButtons
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_TAB_H_

--- a/patches/chrome-browser-ui-views-tabs-tab.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/tabs/tab.cc b/chrome/browser/ui/views/tabs/tab.cc
+index e5c02320a7520f9cc92b614c9429b9d0e5b231b0..576abcf95d3fecd46bdb398d757f1ef12ce359cf 100644
+--- a/chrome/browser/ui/views/tabs/tab.cc
++++ b/chrome/browser/ui/views/tabs/tab.cc
+@@ -384,6 +384,7 @@ void Tab::Layout() {
+     int title_right = contents_rect.right();
+     if (showing_alert_indicator_) {
+       title_right = alert_indicator_->x() - after_title_padding;
++      BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION
+     } else if (showing_close_button_) {
+       // Allow the title to overlay the close button's empty border padding.
+       title_right = close_x - after_title_padding;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
This PR resolves https://github.com/brave/brave-browser/issues/16860 and https://github.com/brave/brave-browser/issues/13946

This fix does basic patch overriding for moving the position of the alert indicator because of too many conditions in-between. The logic for layout is also very long to just copy over.

The default color fill for the audio indicator on active tab inherits from in-active tab bg and on in-active tabs it inherits from the active tab bg. This ensures adaptability on various color schemes even user-defined ones.

![image](https://user-images.githubusercontent.com/8665427/125719502-f7225f37-322f-4114-85eb-7024bb2d8ef8.png)
![image](https://user-images.githubusercontent.com/8665427/125719507-56d9dc66-ba1a-4fef-8c15-caaf664fe88b.png)

~In-order to grab diff state of colors we need tab strip's `GetTabBackgroundColor` function. This requires a static cast. The linkage to `parent_tab` is as follows:~

```
PARENT_TAB ---> CONTROLLER (TAB STRIP) ---> TAB_STRIP ---> GetTabBackgroundColor
```

TabStrip: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/tabs/tab_strip.h;bpv=0;bpt=1
Tab:
https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/tabs/tab.cc;bpv=0;bpt=1


Min content width has been modified to an optimal value:

![image](https://user-images.githubusercontent.com/8665427/125726513-29361054-62b2-49fc-a9e8-75dba7de5370.png)



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open multiple tabs
2. Choose a tab and play a random video on Youtube - audio indicator state should show next to the favicon
3. Choose another tab and play https://online-voice-recorder.com/ - recording state should show next to the favicon
 