### PR TITLE
Update first-run dialog on macOS and Linux

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1313,7 +1313,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       </message>
       <!--First-run dialog messages -->
       <message name="IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE" desc="Default browser checkbox label">
-        Set Brave as your default browser
+        Set Brave as default browser
       </message>
       <message name="IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
         To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1316,11 +1316,14 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
           Help improve Brave by automatically sending crash reports
       </message>
       <message name="IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE" desc="Default browser checkbox label">
-        Set Brave as your default browser
+        Set Brave as default browser
       </message>
       <if expr="is_macosx">
-        <message name="IDS_FIRSTRUN_DLG_MAC_OPTIONS_SEND_USAGE_STATS_LABEL_BRAVE" desc="Label for checkbox to ask whether to send crash reports to brave">
-          Help improve <ph name="PRODUCT_NAME">$1<ex>Brave</ex></ph> by automatically sending crash reports
+        <message name="IDS_FIRSTRUN_DLG_MAC_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
+          To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.
+        </message>
+        <message name="IDS_FIRSTRUN_DLG_MAC_SET_DEFAULT_BROWSER_LABEL_BRAVE" desc="Label for checkbox that sets the default browser">
+          Set Brave as default browser
         </message>
       </if>
     </messages>

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1313,7 +1313,7 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       </message>
       <!--First-run dialog messages -->
       <message name="IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE" desc="Default browser checkbox label">
-        Set Brave as default browser
+        Set Brave as your default browser
       </message>
       <message name="IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
         To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1312,20 +1312,12 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
         Reset Brave Rewards data...
       </message>
       <!--First-run dialog messages -->
-      <message name="IDS_FR_ENABLE_LOGGING_BRAVE" desc="Label for checkbox to ask whether to send crash reports to brave">
-          Help improve Brave by automatically sending crash reports
-      </message>
       <message name="IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE" desc="Default browser checkbox label">
         Set Brave as default browser
       </message>
-      <if expr="is_macosx">
-        <message name="IDS_FIRSTRUN_DLG_MAC_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
-          To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.
-        </message>
-        <message name="IDS_FIRSTRUN_DLG_MAC_SET_DEFAULT_BROWSER_LABEL_BRAVE" desc="Label for checkbox that sets the default browser">
-          Set Brave as default browser
-        </message>
-      </if>
+      <message name="IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE" desc="Label at top of Dialog noting what's going to happen">
+        To ensure the best privacy online, consider setting Brave as the default browser on your computer. With Brave as default, any web link you click will open with Brave's privacy protections.
+      </message>
     </messages>
   </release>
 </grit>

--- a/chromium_src/chrome/browser/ui/cocoa/DEPS
+++ b/chromium_src/chrome/browser/ui/cocoa/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+third_party/google_toolbox_for_mac/src/AppKit",
+]

--- a/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
@@ -113,7 +113,7 @@ void CenterVertically(NSView* view) {
   // This string starts with the app name, which is strongly LTR, so force the
   // correct layout.
   std::u16string completeInstallationString = l10n_util::GetStringUTF16(
-      IDS_FIRSTRUN_DLG_MAC_COMPLETE_INSTALLATION_LABEL_BRAVE);
+      IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE);
   base::i18n::AdjustStringForLocaleDirection(&completeInstallationString);
   NSTextField* completionLabel = [TextFieldUtils
       labelWithString:base::SysUTF16ToNSString(completeInstallationString)];
@@ -121,7 +121,7 @@ void CenterVertically(NSView* view) {
 
   _defaultBrowserCheckbox = [ButtonUtils
       checkboxWithTitle:l10n_util::GetNSString(
-                            IDS_FIRSTRUN_DLG_MAC_SET_DEFAULT_BROWSER_LABEL_BRAVE)];
+                            IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE)];
   [_defaultBrowserCheckbox
       setFrame:NSMakeRect(45, 80, kDialogWidth - 2 * 45, 18)];
   [_defaultBrowserCheckbox setState:NSOnState];

--- a/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/first_run_dialog_controller.mm
@@ -3,15 +3,208 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/grit/brave_generated_resources.h"
-#include "chrome/grit/generated_resources.h"
+#include "chrome/browser/ui/cocoa/first_run_dialog_controller.h"
 
-// Replaced string here instead of by running 'npm run chromium_rebase_l10n'
-// because string replacement failed with string that includes place holder like
-// <ph name="PRODUCT_NAME">$1<ex>Brave</ex></ph>. I assume this includes some
-// special characters.
-#undef IDS_FIRSTRUN_DLG_MAC_OPTIONS_SEND_USAGE_STATS_LABEL
-#define IDS_FIRSTRUN_DLG_MAC_OPTIONS_SEND_USAGE_STATS_LABEL \
-  IDS_FIRSTRUN_DLG_MAC_OPTIONS_SEND_USAGE_STATS_LABEL_BRAVE
-#include "../../../../../../chrome/browser/ui/cocoa/first_run_dialog_controller.mm"
-#undef IDS_FIRSTRUN_DLG_MAC_OPTIONS_SEND_USAGE_STATS_LABEL
+#include "base/i18n/rtl.h"
+#include "base/mac/scoped_nsobject.h"
+#include "base/strings/sys_string_conversions.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/ui/cocoa/key_equivalent_constants.h"
+#include "chrome/grit/chromium_strings.h"
+#include "chrome/grit/generated_resources.h"
+#import "third_party/google_toolbox_for_mac/src/AppKit/GTMUILocalizerAndLayoutTweaker.h"
+#include "ui/base/cocoa/controls/button_utils.h"
+#include "ui/base/cocoa/controls/textfield_utils.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/l10n/l10n_util_mac.h"
+
+namespace {
+
+// Return the internationalized message |message_id|, with the product name
+// substituted in for $1.
+NSString* NSStringWithProductName(int message_id) {
+  return l10n_util::GetNSStringF(message_id,
+                                 l10n_util::GetStringUTF16(IDS_PRODUCT_NAME));
+}
+
+// Reflows buttons. Requires them to be passed in vertical order, top down.
+CGFloat VerticallyReflowButtons(NSArray<NSButton*>* buttons) {
+  CGFloat localVerticalShift = 0;
+  for (NSButton* button in buttons) {
+    [GTMUILocalizerAndLayoutTweaker wrapButtonTitleForWidth:button];
+
+    NSRect oldFrame = button.frame;
+    [button sizeToFit];
+    NSRect newFrame = button.frame;
+    // -[NSControl sizeToFit], with no layout constraints, like here, will end
+    // up horizontally resizing and keeping the upper left corner in place.
+    // That wrecks RTL, and because all that's really needed is vertical
+    // resizing, reset the horizontal size.
+    newFrame.size.width = NSWidth(oldFrame);
+    button.frame = newFrame;
+
+    localVerticalShift += NSHeight(newFrame) - NSHeight(oldFrame);
+    if (localVerticalShift) {
+      NSPoint origin = button.frame.origin;
+      origin.y -= localVerticalShift;
+      [button setFrameOrigin:origin];
+    }
+  }
+  return localVerticalShift;
+}
+
+void MoveViewsVertically(NSArray* views, CGFloat distance) {
+  for (NSView* view : views) {
+    NSRect frame = view.frame;
+    frame.origin.y += distance;
+    [view setFrame:frame];
+  }
+}
+
+// Center |view| vertically within its own superview, so its horizontal
+// centerline is the same as its superview's horizontal centerline.
+void CenterVertically(NSView* view) {
+  NSView* superview = view.superview;
+  NSRect frame = view.frame;
+  NSRect superframe = superview.frame;
+  frame.origin.y = (NSHeight(superframe) - NSHeight(frame)) / 2.0;
+  [view setFrame:frame];
+}
+
+}  // namespace
+
+@implementation FirstRunDialogViewController {
+  // These are owned by the NSView hierarchy:
+  NSButton* _defaultBrowserCheckbox;
+}
+
+- (instancetype)initWithStatsCheckboxInitiallyChecked:(BOOL)checked
+                        defaultBrowserCheckboxVisible:(BOOL)visible {
+  // We always make default checkbox visible.
+  DCHECK(visible);
+  return [super init];
+}
+
+- (void)loadView {
+  const int kDialogWidth = 480;
+
+  BOOL isDarkMode = NO;
+  if (@available(macOS 10.14, *)) {
+    NSAppearanceName appearance =
+        [[NSApp effectiveAppearance] bestMatchFromAppearancesWithNames:@[
+          NSAppearanceNameAqua, NSAppearanceNameDarkAqua
+        ]];
+    isDarkMode = [appearance isEqual:NSAppearanceNameDarkAqua];
+  }
+  NSColor* topBoxColor = isDarkMode
+                             ? [NSColor colorWithCalibratedRed:0x32 / 255.0
+                                                         green:0x36 / 255.0
+                                                          blue:0x39 / 255.0
+                                                         alpha:1.0]
+                             : [NSColor whiteColor];
+
+  NSBox* topBox = [[[NSBox alloc]
+      initWithFrame:NSMakeRect(0, 110, kDialogWidth, 90)] autorelease];
+  [topBox setFillColor:topBoxColor];
+  [topBox setBoxType:NSBoxCustom];
+  [topBox setBorderType:NSNoBorder];
+  [topBox setContentViewMargins:NSZeroSize];
+
+  // This string starts with the app name, which is strongly LTR, so force the
+  // correct layout.
+  std::u16string completeInstallationString = l10n_util::GetStringUTF16(
+      IDS_FIRSTRUN_DLG_MAC_COMPLETE_INSTALLATION_LABEL_BRAVE);
+  base::i18n::AdjustStringForLocaleDirection(&completeInstallationString);
+  NSTextField* completionLabel = [TextFieldUtils
+      labelWithString:base::SysUTF16ToNSString(completeInstallationString)];
+  [completionLabel setFrame:NSMakeRect(13, 25, kDialogWidth - 2 * 13, 60)];
+
+  _defaultBrowserCheckbox = [ButtonUtils
+      checkboxWithTitle:l10n_util::GetNSString(
+                            IDS_FIRSTRUN_DLG_MAC_SET_DEFAULT_BROWSER_LABEL_BRAVE)];
+  [_defaultBrowserCheckbox
+      setFrame:NSMakeRect(45, 80, kDialogWidth - 2 * 45, 18)];
+  [_defaultBrowserCheckbox setState:NSOnState];
+
+  NSButton* startChromeButton =
+      [ButtonUtils buttonWithTitle:NSStringWithProductName(
+                                       IDS_FIRSTRUN_DLG_MAC_START_CHROME_BUTTON)
+                            action:@selector(ok:)
+                            target:self];
+  [startChromeButton setFrame:NSMakeRect(161, 12, 306, 32)];
+  [startChromeButton setKeyEquivalent:kKeyEquivalentReturn];
+
+  NSBox* topSeparator = [[[NSBox alloc]
+      initWithFrame:NSMakeRect(0, 109, kDialogWidth, 1)] autorelease];
+  [topSeparator setBoxType:NSBoxSeparator];
+
+  NSBox* bottomSeparator = [[[NSBox alloc]
+      initWithFrame:NSMakeRect(0, 55, kDialogWidth, 5)] autorelease];
+  [bottomSeparator setBoxType:NSBoxSeparator];
+
+  [topBox addSubview:completionLabel];
+  CenterVertically(completionLabel);
+
+  base::scoped_nsobject<NSView> content_view(
+      [[NSView alloc] initWithFrame:NSMakeRect(0, 0, kDialogWidth, 200)]);
+  self.view = content_view.get();
+  [self.view addSubview:topBox];
+  [self.view addSubview:topSeparator];
+  [self.view addSubview:_defaultBrowserCheckbox];
+  [self.view addSubview:bottomSeparator];
+  [self.view addSubview:startChromeButton];
+
+  // Now that the content view is constructed, fix the layout. The first step is
+  // to reflow the browser and stats checkbox texts, which can be quite lengthy
+  // in some locales. They may wrap onto additional lines, and in doing so cause
+  // the rest of the dialog to need to be rearranged.
+  {
+    CGFloat delta = VerticallyReflowButtons(@[ _defaultBrowserCheckbox ]);
+    if (delta) {
+      // If reflowing the checkboxes produced a height delta, move the
+      // checkboxes and the items above them in the content view upward, then
+      // grow the content view to match. This has the effect of moving
+      // everything visually-below the checkboxes downwards and expanding the
+      // window, leaving the vertical space the checkboxes need for their text.
+      MoveViewsVertically(@[ _defaultBrowserCheckbox, topSeparator, topBox ],
+                          delta);
+      NSRect frame = [self.view frame];
+      frame.size.height += delta;
+      [self.view setAutoresizesSubviews:NO];
+      [self.view setFrame:frame];
+      [self.view setAutoresizesSubviews:YES];
+    }
+  }
+
+  // The "Start Chrome" button needs to be sized to fit the localized string
+  // inside it, but it should still be at the right-most edge of the dialog, so
+  // any width added or subtracted by |sizeToFit| is added to its x coord, which
+  // keeps its right edge where it was.
+  CGFloat oldWidth = NSWidth([startChromeButton frame]);
+  [startChromeButton sizeToFit];
+  NSRect frame = [startChromeButton frame];
+  frame.origin.x += oldWidth - NSWidth([startChromeButton frame]);
+  if (base::i18n::IsRTL())
+    frame.origin.x = kDialogWidth - NSMaxX(frame);
+  [startChromeButton setFrame:frame];
+}
+
+- (NSString*)windowTitle {
+  return l10n_util::GetNSString(IDS_FIRST_RUN_DIALOG_WINDOW_TITLE);
+}
+
+- (BOOL)isStatsReportingEnabled {
+  // This dialog doesn't have stats reporting checkbox.
+  return false;
+}
+
+- (BOOL)isMakeDefaultBrowserEnabled {
+  return [_defaultBrowserCheckbox state] == NSOnState;
+}
+
+- (void)ok:(id)sender {
+  [[[self view] window] close];
+  [NSApp stopModal];
+}
+
+@end

--- a/chromium_src/chrome/browser/ui/views/DEPS
+++ b/chromium_src/chrome/browser/ui/views/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+components/crash/core/app",
+]

--- a/chromium_src/chrome/browser/ui/views/first_run_dialog.cc
+++ b/chromium_src/chrome/browser/ui/views/first_run_dialog.cc
@@ -3,18 +3,127 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "chrome/browser/ui/views/first_run_dialog.h"
+
+#include <string>
+
+#include "base/bind.h"
+#include "base/run_loop.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "build/build_config.h"
+#include "chrome/browser/first_run/first_run.h"
+#include "chrome/browser/first_run/first_run_dialog.h"
+#include "chrome/browser/metrics/metrics_reporting_state.h"
+#include "chrome/browser/platform_util.h"
+#include "chrome/browser/shell_integration.h"
+#include "chrome/browser/ui/browser_dialogs.h"
+#include "chrome/browser/ui/ui_features.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/common/url_constants.h"
 #include "chrome/grit/chromium_strings.h"
 #include "chrome/grit/generated_resources.h"
+#include "components/crash/core/app/breakpad_linux.h"
+#include "components/crash/core/app/crashpad.h"
+#include "components/strings/grit/components_strings.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/views/border.h"
+#include "ui/views/controls/button/checkbox.h"
+#include "ui/views/controls/link.h"
+#include "ui/views/layout/box_layout.h"
+#include "ui/views/layout/grid_layout.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/window/dialog_delegate.h"
 
-// Replaced string here instead of by running 'npm run chromium_rebase_l10n'
-// because same string is used from other IDS_XXX..
-#undef IDS_FR_ENABLE_LOGGING
-#undef IDS_FR_CUSTOMIZE_DEFAULT_BROWSER
-#define IDS_FR_ENABLE_LOGGING IDS_FR_ENABLE_LOGGING_BRAVE
-#define IDS_FR_CUSTOMIZE_DEFAULT_BROWSER IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE
+namespace first_run {
 
-#include "../../../../../../chrome/browser/ui/views/first_run_dialog.cc"
+void ShowFirstRunDialog(Profile* profile) {
+#if defined(OS_MAC)
+  if (base::FeatureList::IsEnabled(features::kViewsFirstRunDialog))
+    ShowFirstRunDialogViews(profile);
+  else
+    ShowFirstRunDialogCocoa(profile);
+#else
+  ShowFirstRunDialogViews(profile);
+#endif
+}
 
-#undef IDS_FR_ENABLE_LOGGING
-#undef IDS_FR_CUSTOMIZE_DEFAULT_BROWSER
+void ShowFirstRunDialogViews(Profile* profile) {
+  FirstRunDialog::Show(profile);
+}
+
+}  // namespace first_run
+
+// static
+void FirstRunDialog::Show(Profile* profile) {
+  FirstRunDialog* dialog = new FirstRunDialog(profile);
+  views::DialogDelegate::CreateDialogWidget(dialog, NULL, NULL)->Show();
+
+  base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
+  dialog->quit_runloop_ = run_loop.QuitClosure();
+  run_loop.Run();
+}
+
+FirstRunDialog::FirstRunDialog(Profile* profile) {
+  ALLOW_UNUSED_LOCAL(report_crashes_);
+
+  SetTitle(l10n_util::GetStringUTF16(IDS_FIRST_RUN_DIALOG_WINDOW_TITLE));
+  SetButtons(ui::DIALOG_BUTTON_OK);
+  SetExtraView(
+      std::make_unique<views::Link>(l10n_util::GetStringUTF16(IDS_LEARN_MORE)))
+      ->SetCallback(base::BindRepeating(&platform_util::OpenExternal,
+                                        base::Unretained(profile),
+                                        GURL(chrome::kLearnMoreReportingURL)));
+
+  constexpr int kChildSpacing = 16;
+  constexpr int kPadding = 24;
+
+  SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kVertical,
+      gfx::Insets(kPadding, kPadding, kPadding, kPadding), kChildSpacing));
+
+  constexpr int kFontSize = 15;
+  int size_diff = kFontSize - views::Label::GetDefaultFontList().GetFontSize();
+  views::Label::CustomFont contents_font = {
+      views::Label::GetDefaultFontList()
+          .DeriveWithSizeDelta(size_diff)
+          .DeriveWithWeight(gfx::Font::Weight::NORMAL)};
+  auto* contents_label = AddChildView(std::make_unique<views::Label>(
+      l10n_util::GetStringUTF16(
+          IDS_FIRSTRUN_DLG_COMPLETE_INSTALLATION_LABEL_BRAVE),
+      contents_font));
+  contents_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+  contents_label->SetMultiLine(true);
+  contents_label->SetMaximumWidth(450);
+
+  make_default_ = AddChildView(std::make_unique<views::Checkbox>(
+      l10n_util::GetStringUTF16(IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE)));
+  make_default_->SetChecked(true);
+
+  chrome::RecordDialogCreation(chrome::DialogIdentifier::FIRST_RUN_DIALOG);
+}
+
+FirstRunDialog::~FirstRunDialog() = default;
+
+void FirstRunDialog::Done() {
+  CHECK(!quit_runloop_.is_null());
+  quit_runloop_.Run();
+}
+
+bool FirstRunDialog::Accept() {
+  GetWidget()->Hide();
+
+  if (make_default_->GetChecked())
+    shell_integration::SetAsDefaultBrowser();
+
+  Done();
+  return true;
+}
+
+void FirstRunDialog::WindowClosing() {
+  first_run::SetShouldShowWelcomePage();
+  Done();
+}
+
+BEGIN_METADATA(FirstRunDialog, views::DialogDelegateView)
+END_METADATA

--- a/chromium_src/chrome/browser/ui/views/first_run_dialog.cc
+++ b/chromium_src/chrome/browser/ui/views/first_run_dialog.cc
@@ -94,7 +94,8 @@ FirstRunDialog::FirstRunDialog(Profile* profile) {
       contents_font));
   contents_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
   contents_label->SetMultiLine(true);
-  contents_label->SetMaximumWidth(450);
+  constexpr int kMaxWidth = 450;
+  contents_label->SetMaximumWidth(kMaxWidth);
 
   make_default_ = AddChildView(std::make_unique<views::Checkbox>(
       l10n_util::GetStringUTF16(IDS_FR_CUSTOMIZE_DEFAULT_BROWSER_BRAVE)));


### PR DESCRIPTION
Each dialog class' public api is reused and implementation is replaced by file overriding.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16820

macOS:
<img width="497" alt="Screen Shot 2021-07-15 at 22 45 21" src="https://user-images.githubusercontent.com/6786187/126017983-4d6867d4-eece-4c3a-8c5b-f7f63de111a1.png">

linux:
![image](https://user-images.githubusercontent.com/6786187/126017923-7cc5061d-ee24-48b6-9537-978b9064fcaa.png)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Delete existing user data dir
2. Launch browser and check first-run dialog