### PR TITLE
Fix EthNonceTrackerUnitTest.* unit tests on Linux Component builds

### DIFF
--- a/components/brave_wallet/browser/eth_nonce_tracker_unittest.cc
+++ b/components/brave_wallet/browser/eth_nonce_tracker_unittest.cc
@@ -52,9 +52,11 @@ class EthNonceTrackerUnitTest : public testing::Test {
   void SetTransactionCount(uint256_t count) {
     transaction_count_ = count;
     url_loader_factory_.ClearResponses();
-    url_loader_factory_.AddResponse(
-        "https://mainnet-infura.brave.com/f7106c838853428280fa0c585acc9485",
-        GetResultString());
+
+    // See EthJsonRpcController::SetNetwork() to better understand where the
+    // http://localhost:8545 URL used below is coming from.
+    url_loader_factory_.AddResponse("http://localhost:8545/",
+                                    GetResultString());
   }
 
  private:
@@ -72,7 +74,7 @@ class EthNonceTrackerUnitTest : public testing::Test {
 };
 
 TEST_F(EthNonceTrackerUnitTest, GetNonce) {
-  EthJsonRpcController controller(Network::kMainnet,
+  EthJsonRpcController controller(Network::kLocalhost,
                                   shared_url_loader_factory());
   EthTxStateManager tx_state_manager(GetPrefs());
   EthNonceTracker nonce_tracker(&tx_state_manager, &controller);
@@ -157,7 +159,7 @@ TEST_F(EthNonceTrackerUnitTest, GetNonce) {
 }
 
 TEST_F(EthNonceTrackerUnitTest, NonceLock) {
-  EthJsonRpcController controller(Network::kMainnet,
+  EthJsonRpcController controller(Network::kLocalhost,
                                   shared_url_loader_factory());
   EthTxStateManager tx_state_manager(GetPrefs());
   EthNonceTracker nonce_tracker(&tx_state_manager, &controller);


### PR DESCRIPTION
Despite of these tests passing on CI without any issues, they are
consistenly failing at least on Linux Component builds and the issue
seems to be related to the ethereum blockchain network used in the
tests: if Mainnet is used and a full valid URL is specified by
including the PATH part in the URL (e.g. [1]), the tests fail.

Removing the PATH part from the URL and simply using something such
as https://mainnet-infura.brave.com/ would get the tests passing,
but probably the right fix is something like what we did in PR 9388
and switch to using the "localhost network" for tests instead, which
is what this CL implements.

[1] https://mainnet-infura.brave.com/f7106c838853428280fa0c585acc9485
[2] https://github.com/brave/brave-core/pull/9388

Resolves https://github.com/brave/brave-browser/issues/16992

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A (just running the unit tests covers this)