### PR TITLE
Fixed Line Chart Label Padding

### DIFF
--- a/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
@@ -86,9 +86,14 @@ function LineChart (props: Props) {
     if (value.active && value.payload && value.payload.length) {
       setPosition(value.coordinate.x)
       onUpdateBalance(value.payload[0].value)
-      const labelPosition = Math.trunc(value.coordinate.x) === 8 ? 'start' : Math.trunc(value.coordinate.x) - Math.trunc(value.viewBox.width) === 8 ? 'end' : 'middle'
+      const xLeftCoordinate = Math.trunc(value.coordinate.x)
+      const viewBoxWidth = Math.trunc(value.viewBox.width)
+      const xRightCoordinate = xLeftCoordinate - viewBoxWidth
+      const isEndOrMiddle = xRightCoordinate >= -46 ? 'end' : 'middle'
+      const labelPosition = xLeftCoordinate <= 62 ? 'start' : isEndOrMiddle
+      const middleEndTranslate = xRightCoordinate >= 8 ? 0 : Math.abs(xRightCoordinate) + 8
       return (
-        <LabelWrapper labelPosition={labelPosition}>
+        <LabelWrapper labelTranslate={labelPosition === 'start' ? xLeftCoordinate : middleEndTranslate} labelPosition={labelPosition}>
           <ChartLabel>{parseDate(value.label)}</ChartLabel>
         </LabelWrapper>
       )

--- a/components/brave_wallet_ui/components/desktop/line-chart/style.ts
+++ b/components/brave_wallet_ui/components/desktop/line-chart/style.ts
@@ -3,6 +3,7 @@ import { LoaderIcon } from 'brave-ui/components/icons'
 
 interface StyleProps {
   labelPosition: 'start' | 'middle' | 'end'
+  labelTranslate: number
   isLoading: boolean
 }
 
@@ -15,12 +16,15 @@ export const StyledWrapper = styled.div`
 `
 
 export const LabelWrapper = styled.div<Partial<StyleProps>>`
+  --label-start-translate: translateX(calc(-${(p) => p.labelTranslate}px + 4px));
+  --label-end-translate: translateX(calc(-100% + ${(p) => p.labelTranslate}px));
+  --label-middle-end-condition: ${(p) => p.labelPosition === 'end' ? 'var(--label-end-translate)' : 'translateX(-50%)'};
   display: flex;
   align-items: center;
   justify-content: center;
   position: absolute;
   top: -16px;
-  transform: ${(p) => p.labelPosition === 'start' ? 'translateX(0%)' : p.labelPosition === 'end' ? 'translateX(-100%)' : 'translateX(-50%)'};
+  transform: ${(p) => p.labelPosition === 'start' ? 'var(--label-start-translate)' : 'var(--label-middle-end-condition)'};
   white-space: nowrap
 `
 


### PR DESCRIPTION
## Description 

Fixed the `Line Chart` component's `Custom Label` so it doesn't overlap onto the rest of the page on the left and right sides of the `Line Chart` view box.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/16984>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/126015031-0cc0a685-cab2-4e16-852a-05f3755fd248.mov
