### PR TITLE
[do not merge] print rust version in CI before installing cargo audit

### DIFF
--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -142,6 +142,7 @@ def rustup_version(version):
     rustup_tool_path = os.path.join(rustup_bin_path, "rustup" if sys.platform != "win32" else "rustup.exe")
     print(subprocess.check_call([rustup_tool_path, "toolchain", "install", version], env=env))
     print(subprocess.check_call([rustup_tool_path, "default", version], env=env))
+    print(subprocess.check_call([rustup_tool_path, "target", "list"], env=env))
     print(subprocess.check_call([rustup_tool_path, "target", "add", "x86_64-apple-ios", "aarch64-apple-ios"], env=env))
     print(subprocess.check_call([rustup_tool_path, "target", "list"], env=env))
 
@@ -185,7 +186,7 @@ def main():
     if args.platform == 'android':
         make_standalone_toolchain_for_android()
             
-    rustup_version("1.53.0")
+    rustup_version("1.51.0")
 
     tools = [
         {

--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -133,6 +133,17 @@ def parse_args():
     return args
 
 
+def rustup_version(version):
+    env = os.environ.copy()
+    env['RUSTUP_HOME'] = RUSTUP_HOME
+    env['CARGO_HOME'] = RUSTUP_HOME
+    
+    rustup_bin_path = os.path.abspath(os.path.join(RUSTUP_HOME, 'bin'))
+    rustup_tool_path = os.path.join(rustup_bin_path, "rustup" if sys.platform != "win32" else "rustup.exe")
+    print(subprocess.check_call([rustup_tool_path, "toolchain", "install", version], env=env))
+    print(subprocess.check_call([rustup_tool_path, "default", version], env=env))
+    
+
 def cargo_install(tool):
     # Set environment variables for rustup
     env = os.environ.copy()
@@ -142,7 +153,7 @@ def cargo_install(tool):
     rustup_bin = os.path.abspath(os.path.join(RUSTUP_HOME, 'bin'))
     cargo_bin = os.path.join(rustup_bin, "cargo" if sys.platform != "win32" else "cargo.exe")
 
-    print(subprocess.check_call([cargo_bin, "--version"], env=env))
+    print(subprocess.check_call([cargo_bin, "--version"], env=env)) 
     # Install the tool
     cargo_args = []
     cargo_args.append(cargo_bin)
@@ -172,6 +183,8 @@ def main():
 
     if args.platform == 'android':
         make_standalone_toolchain_for_android()
+            
+    rustup_version("1.53.0")
 
     tools = [
         {

--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -142,6 +142,7 @@ def cargo_install(tool):
     rustup_bin = os.path.abspath(os.path.join(RUSTUP_HOME, 'bin'))
     cargo_bin = os.path.join(rustup_bin, "cargo" if sys.platform != "win32" else "cargo.exe")
 
+    print(subprocess.check_call([cargo_bin, "--version"], env=env))
     # Install the tool
     cargo_args = []
     cargo_args.append(cargo_bin)

--- a/script/download_rust_deps.py
+++ b/script/download_rust_deps.py
@@ -142,7 +142,8 @@ def rustup_version(version):
     rustup_tool_path = os.path.join(rustup_bin_path, "rustup" if sys.platform != "win32" else "rustup.exe")
     print(subprocess.check_call([rustup_tool_path, "toolchain", "install", version], env=env))
     print(subprocess.check_call([rustup_tool_path, "default", version], env=env))
-    
+    print(subprocess.check_call([rustup_tool_path, "target", "add", "x86_64-apple-ios", "aarch64-apple-ios"], env=env))
+    print(subprocess.check_call([rustup_tool_path, "target", "list"], env=env))
 
 def cargo_install(tool):
     # Set environment variables for rustup

--- a/script/rust_deps_config.py
+++ b/script/rust_deps_config.py
@@ -6,4 +6,4 @@
 # Version number and URL for pre-configured rust dependency package
 # e.g. rust_deps_mac_0.1.0.gz
 RUST_DEPS_PACKAGES_URL = "https://rust-pkg-brave-core.s3.brave.com"
-RUST_DEPS_PACKAGE_VERSION = "0.1.6"
+RUST_DEPS_PACKAGE_VERSION = "0.1.7"


### PR DESCRIPTION
Just adding a print statement for `cargo --version` to check what we're running on CI.