### PR TITLE
Fix formatting for python subprocess errors in brave build tasks, e.g. web-ui webpack compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pep8": "pycodestyle --max-line-length 120 -r script",
     "pylint": "node ./build/commands/scripts/commands.js pylint",
     "web-ui-gen-grd": "node components/webpack/gen-webpack-grd",
-    "web-ui": "webpack --config components/webpack/webpack.config.js --progress --colors",
+    "web-ui": "webpack --config components/webpack/webpack.config.js --colors",
     "build-storybook": "build-storybook -c .storybook -o .storybook-out",
     "storybook": "start-storybook",
     "test-unit": "jest -t",

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -170,13 +170,23 @@ def execute(argv, env=os.environ):
     if is_verbose_mode():
         print(' '.join(argv))
     try:
-        output = subprocess.check_output(argv, stderr=subprocess.STDOUT,
-                                         env=env)
+        process = subprocess.Popen(
+          argv, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+          universal_newlines=True)
+        stdout, stderr = process.communicate()
         if is_verbose_mode():
-            print(output)
-        return output
+            print(stdout)
+        elif process.returncode != 0:
+            # Print the output instead of raising it, so that we get pretty output.
+            # Most useful erroroutput from typescript / webpack is in stdout
+            # and not stderr.
+            print(stdout)
+            raise RuntimeError('Command \'%s\' failed' % (' '.join(argv)), stderr)
+        return stdout
     except subprocess.CalledProcessError as e:
-        print(e.output)
+        print('Error in subprocess:')
+        print(' '.join(argv))
+        print(e.stderr)
         raise e
 
 


### PR DESCRIPTION
**This is apparently only compatible with Python 3.5+ and not backwards compatible.**

Fix https://github.com/brave/brave-browser/issues/17047

## Test plan:
- Make an error in JS, i.e. just write `testerror` on a new line in `brave_new_tab.tsx`.
- (optional) Run this, replacing all your paths
  - cd to out/Component directory (or your current build target)
```
python3 ../../brave/script/transpile-web-ui.py --output_path=gen/brave/web-ui-brave_new_tab --root_gen_dir=/Users/petemill/Development/Brave/brave-browser-c93/src/out/Component/gen --grd_name=brave_new_tab.grd --resource_name=brave_new_tab --depfile_path=/Users/petemill/Development/Brave/brave-browser-c93/src/out/Component/gen/brave/components/brave_new_tab_ui/brave_new_tab_ui.d --entry=brave_new_tab=/Users/petemill/Development/Brave/brave-browser-c93/src/brave/components/brave_new_tab_ui/brave_new_tab.tsx
```
- (or) Perform a build as normal
- --> Error should be printed and formatted nicely with colors and newlines.