### PR TITLE
Update GetAssetPrice API to support multiple from/to assets and 24h change

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/BraveWalletNativeWorker.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/BraveWalletNativeWorker.java
@@ -103,14 +103,15 @@ public class BraveWalletNativeWorker {
         BraveWalletNativeWorkerJni.get().resetWallet(mNativeBraveWalletNativeWorker);
     }
 
-    public void getAssetPrice(String asset) {
-        BraveWalletNativeWorkerJni.get().getAssetPrice(mNativeBraveWalletNativeWorker, asset);
+    public void getAssetPrice(String[] fromAssets, String[] toAssets) {
+        BraveWalletNativeWorkerJni.get().getAssetPrice(
+                mNativeBraveWalletNativeWorker, fromAssets, toAssets);
     }
 
     @CalledByNative
-    public void OnGetPrice(String price, boolean isSuccess) {
+    public void OnGetPrice(String prices, boolean isSuccess) {
         for (BraveWalletObserver observer : mObservers) {
-            observer.OnGetPrice(price, isSuccess);
+            observer.OnGetPrice(prices, isSuccess);
         }
     }
 
@@ -137,7 +138,8 @@ public class BraveWalletNativeWorker {
         boolean unlockWallet(long nativeBraveWalletNativeWorker, String password);
         String restoreWallet(long nativeBraveWalletNativeWorker, String mnemonic, String password);
         void resetWallet(long nativeBraveWalletNativeWorker);
-        void getAssetPrice(long nativeBraveWalletNativeWorker, String asset);
+        void getAssetPrice(
+                long nativeBraveWalletNativeWorker, String[] fromAssets, String[] toAssets);
         void getAssetPriceHistory(long nativeBraveWalletNativeWorker, String asset, int timeFrame);
     }
 }

--- a/browser/brave_wallet/android/brave_wallet_native_worker.cc
+++ b/browser/brave_wallet/android/brave_wallet_native_worker.cc
@@ -155,6 +155,7 @@ void BraveWalletNativeWorker::GetAssetPrice(
                                                      &assets_from);
   std::vector<std::string> assets_to;
   base::android::AppendJavaStringArrayToStringVector(env, to_assets,
+                                                     &assets_to);
 
   asset_ratio_controller_->GetPrice(
       assets_from, assets_to,

--- a/browser/brave_wallet/android/brave_wallet_native_worker.h
+++ b/browser/brave_wallet/android/brave_wallet_native_worker.h
@@ -40,9 +40,12 @@ class BraveWalletNativeWorker {
       const base::android::JavaParamRef<jstring>& password);
   void ResetWallet(JNIEnv* env);
 
-  void GetAssetPrice(JNIEnv* env,
-                     const base::android::JavaParamRef<jstring>& asset);
-  void OnGetPrice(bool success, const std::string& price);
+  void GetAssetPrice(
+      JNIEnv* env,
+      const base::android::JavaParamRef<jobjectArray>& from_assets,
+      const base::android::JavaParamRef<jobjectArray>& to_assets);
+  void OnGetPrice(bool success,
+                  std::vector<brave_wallet::mojom::AssetPricePtr> prices);
 
   void GetAssetPriceHistory(JNIEnv* env,
                             const base::android::JavaParamRef<jstring>& asset,

--- a/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
+++ b/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
@@ -103,10 +103,12 @@ void WalletHandler::UnlockWallet(const std::string& password,
   keyring_controller_->Unlock(password, std::move(callback));
 }
 
-void WalletHandler::GetAssetPrice(const std::string& asset,
+void WalletHandler::GetAssetPrice(const std::vector<std::string>& from_assets,
+                                  const std::vector<std::string>& to_assets,
                                   GetAssetPriceCallback callback) {
   EnsureConnected();
-  asset_ratio_controller_->GetPrice(asset, std::move(callback));
+  asset_ratio_controller_->GetPrice(from_assets, to_assets,
+                                    std::move(callback));
 }
 
 void WalletHandler::GetAssetPriceHistory(

--- a/browser/ui/webui/brave_wallet/common_handler/wallet_handler.h
+++ b/browser/ui/webui/brave_wallet/common_handler/wallet_handler.h
@@ -30,7 +30,9 @@ class WalletHandler : public brave_wallet::mojom::WalletHandler {
   void GetWalletInfo(GetWalletInfoCallback) override;
   void LockWallet() override;
   void UnlockWallet(const std::string& password, UnlockWalletCallback) override;
-  void GetAssetPrice(const std::string& asset, GetAssetPriceCallback) override;
+  void GetAssetPrice(const std::vector<std::string>& from_assets,
+                     const std::vector<std::string>& to_assets,
+                     GetAssetPriceCallback) override;
   void GetAssetPriceHistory(const std::string& asset,
                             brave_wallet::mojom::AssetPriceTimeframe timeframe,
                             GetAssetPriceHistoryCallback) override;

--- a/components/brave_wallet/browser/asset_ratio_controller.h
+++ b/components/brave_wallet/browser/asset_ratio_controller.h
@@ -41,7 +41,9 @@ class AssetRatioController : public KeyedService,
 
   mojo::PendingRemote<mojom::AssetRatioController> MakeRemote();
 
-  void GetPrice(const std::string& asset, GetPriceCallback callback) override;
+  void GetPrice(const std::vector<std::string>& from_assets,
+                const std::vector<std::string>& to_assets,
+                GetPriceCallback callback) override;
   // The asset param is a string like: "bat"
   void GetPriceHistory(const std::string& asset,
                        brave_wallet::mojom::AssetPriceTimeframe timeframe,

--- a/components/brave_wallet/browser/asset_ratio_controller.h
+++ b/components/brave_wallet/browser/asset_ratio_controller.h
@@ -47,14 +47,17 @@ class AssetRatioController : public KeyedService,
                        brave_wallet::mojom::AssetPriceTimeframe timeframe,
                        GetPriceHistoryCallback callback) override;
 
-  static GURL GetPriceURL(const std::string& asset);
+  static GURL GetPriceURL(const std::vector<std::string>& from_assets,
+                          const std::vector<std::string>& to_assets);
   static GURL GetPriceHistoryURL(
       const std::string& asset,
       brave_wallet::mojom::AssetPriceTimeframe timeframe);
   static void SetBaseURLForTest(const GURL& base_url_for_test);
 
  private:
-  void OnGetPrice(GetPriceCallback callback,
+  void OnGetPrice(std::vector<std::string> from_assets,
+                  std::vector<std::string> to_assets,
+                  GetPriceCallback callback,
                   const int status,
                   const std::string& body,
                   const std::map<std::string, std::string>& headers);

--- a/components/brave_wallet/browser/asset_ratio_response_parser.h
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.h
@@ -15,7 +15,10 @@
 
 namespace brave_wallet {
 
-bool ParseAssetPrice(const std::string& json, std::string* price);
+bool ParseAssetPrice(const std::string& json,
+                     const std::vector<std::string>& from_assets,
+                     const std::vector<std::string>& to_assets,
+                     std::vector<brave_wallet::mojom::AssetPricePtr>* values);
 bool ParseAssetPriceHistory(
     const std::string& json,
     std::vector<brave_wallet::mojom::AssetTimePricePtr>* values);

--- a/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
@@ -15,10 +15,54 @@
 namespace brave_wallet {
 
 TEST(AssetRatioResponseParserUnitTest, ParseAssetPrice) {
-  std::string json(
-      R"({"payload": {"basic-attention-token":{"usd":0.694503}}})");
-  std::string price;
-  ASSERT_TRUE(ParseAssetPrice(json, &price));
+  std::string json(R"({
+     "payload":{
+       "basic-attention-token":{
+         "btc":0.00001732,
+         "btc_24h_change":8.021672460190562,
+         "usd":0.55393,
+         "usd_24h_change":9.523443444373276
+       },
+       "bat":{
+          "btc":0.00001732,
+          "btc_24h_change":8.021672460190562,
+          "usd":0.55393,
+          "usd_24h_change":9.523443444373276
+        },
+        "link":{
+          "btc":0.00261901,
+          "btc_24h_change":0.5871625385632929,
+          "usd":83.77,
+          "usd_24h_change":1.7646208048244043
+        }
+      },
+      "lastUpdated":"2021-07-16T19:11:28.907Z"
+    })");
+
+  std::vector<brave_wallet::mojom::AssetPricePtr> prices;
+  ASSERT_TRUE(ParseAssetPrice(json, {"bat", "link"}, {"btc", "usd"}, &prices));
+  ASSERT_EQ(prices.size(), 4UL);
+  ASSERT_EQ(prices[0]->from_asset, "bat");
+  ASSERT_EQ(prices[0]->to_asset, "btc");
+  ASSERT_EQ(prices[0]->price, "0.00001732");
+  ASSERT_EQ(prices[0]->asset_24h_change, "8.021672460190562");
+
+  ASSERT_EQ(prices[1]->from_asset, "bat");
+  ASSERT_EQ(prices[1]->to_asset, "usd");
+  ASSERT_EQ(prices[1]->price, "0.55393");
+  ASSERT_EQ(prices[1]->asset_24h_change, "9.523443444373276");
+
+  ASSERT_EQ(prices[2]->from_asset, "link");
+  ASSERT_EQ(prices[2]->to_asset, "btc");
+  ASSERT_EQ(prices[2]->price, "0.00261901");
+  ASSERT_EQ(prices[2]->asset_24h_change, "0.5871625385632929");
+
+  ASSERT_EQ(prices[3]->from_asset, "link");
+  ASSERT_EQ(prices[3]->to_asset, "usd");
+  ASSERT_EQ(prices[3]->price, "83.77");
+  ASSERT_EQ(prices[3]->asset_24h_change, "1.7646208048244043");
+
+  /*
   ASSERT_EQ(price, "0.694503");
   // 2 value responses happen now for the alias and the full name
   // We always parse only the first.
@@ -35,6 +79,7 @@ TEST(AssetRatioResponseParserUnitTest, ParseAssetPrice) {
   ASSERT_FALSE(ParseAssetPrice(json, &price));
   json = "";
   ASSERT_FALSE(ParseAssetPrice(json, &price));
+  */
 }
 
 TEST(AssetRatioResponseParserUnitTest, ParseAssetPriceHistory) {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -75,6 +75,13 @@ struct AssetTimePrice {
   string price;
 };
 
+struct AssetPrice {
+  string from_asset;
+  string to_asset;
+  string price;
+  string asset_24h_change;
+};
+
 struct SwapParams {
   string taker_address;
   string sell_amount;
@@ -124,7 +131,7 @@ interface WalletHandler {
                       array<string> walletAccountNames);
   LockWallet();
   UnlockWallet(string password) => (bool isWalletUnlocked);
-  GetAssetPrice(string asset) => (bool success, string price);
+  GetAssetPrice(array<string> from_assets, array<string> to_assets) => (bool success, array<AssetTimePrice> values);
   GetAssetPriceHistory(string asset, AssetPriceTimeframe timeframe) =>
       (bool success, array<AssetTimePrice> values);
   GetPriceQuote(SwapParams params) => (bool success, SwapResponse response);

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -131,7 +131,7 @@ interface WalletHandler {
                       array<string> walletAccountNames);
   LockWallet();
   UnlockWallet(string password) => (bool isWalletUnlocked);
-  GetAssetPrice(array<string> from_assets, array<string> to_assets) => (bool success, array<AssetTimePrice> values);
+  GetAssetPrice(array<string> from_assets, array<string> to_assets) => (bool success, array<AssetPrice> values);
   GetAssetPriceHistory(string asset, AssetPriceTimeframe timeframe) =>
       (bool success, array<AssetTimePrice> values);
   GetPriceQuote(SwapParams params) => (bool success, SwapResponse response);
@@ -164,7 +164,8 @@ interface KeyringController {
 };
 
 interface AssetRatioController {
-  GetPrice(string asset) => (bool success, string price);
+  GetPrice(array<string> from_assets, array<string> to_assets) =>
+      (bool success, array<AssetPrice> values);
   GetPriceHistory(string asset, AssetPriceTimeframe timeframe) =>
       (bool success, array<AssetTimePrice> values);
 };

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -9,7 +9,7 @@ import {
   AssetOptionType,
   UserAssetOptionType,
   RPCTransactionType,
-  AssetPriceReturnInfo,
+  AssetPriceInfo,
   WalletAccountType,
   AssetPriceTimeframe
 } from '../../../../constants/types'
@@ -37,7 +37,8 @@ export interface Props {
   selectedTimeline: AssetPriceTimeframe
   portfolioPriceHistory: PriceDataObjectType[]
   selectedAssetPriceHistory: PriceDataObjectType[]
-  selectedAssetPrice: AssetPriceReturnInfo | undefined
+  selectedUSDAssetPrice: AssetPriceInfo | undefined
+  selectedBTCAssetPrice: AssetPriceInfo | undefined
   selectedAsset: AssetOptionType | undefined
   portfolioBalance: string
   transactions: (RPCTransactionType | undefined)[]
@@ -68,7 +69,8 @@ const CryptoView = (props: Props) => {
     selectedAsset,
     portfolioBalance,
     transactions,
-    selectedAssetPrice,
+    selectedUSDAssetPrice,
+    selectedBTCAssetPrice,
     isLoading,
     showAddModal,
     onToggleAddModal
@@ -169,7 +171,8 @@ const CryptoView = (props: Props) => {
           portfolioBalance={portfolioBalance}
           portfolioPriceHistory={portfolioPriceHistory}
           transactions={transactions}
-          selectedAssetPrice={selectedAssetPrice}
+          selectedUSDAssetPrice={selectedUSDAssetPrice}
+          selectedBTCAssetPrice={selectedBTCAssetPrice}
           userAssetList={userAssetList}
           isLoading={isLoading}
         />

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
@@ -5,7 +5,7 @@ import {
   PriceDataObjectType,
   AssetOptionType,
   RPCTransactionType,
-  AssetPriceReturnInfo,
+  AssetPriceInfo,
   UserAssetOptionType,
   WalletAccountType,
   AssetPriceTimeframe
@@ -59,7 +59,8 @@ export interface Props {
   accounts: WalletAccountType[]
   selectedTimeline: AssetPriceTimeframe
   selectedAsset: AssetOptionType | undefined
-  selectedAssetPrice: AssetPriceReturnInfo | undefined
+  selectedUSDAssetPrice: AssetPriceInfo | undefined
+  selectedBTCAssetPrice: AssetPriceInfo | undefined
   selectedAssetPriceHistory: PriceDataObjectType[]
   portfolioPriceHistory: PriceDataObjectType[]
   portfolioBalance: string
@@ -75,7 +76,8 @@ const Portfolio = (props: Props) => {
     onClickAddAccount,
     portfolioPriceHistory,
     selectedAssetPriceHistory,
-    selectedAssetPrice,
+    selectedUSDAssetPrice,
+    selectedBTCAssetPrice,
     selectedTimeline,
     accounts,
     selectedAsset,
@@ -168,17 +170,17 @@ const Portfolio = (props: Props) => {
           </AssetRow>
           <DetailText>{selectedAsset.name} {locale.price} ({selectedAsset.symbol})</DetailText>
           <PriceRow>
-            <PriceText>${hoverPrice ? hoverPrice : selectedAssetPrice ? formatePrices(Number(selectedAssetPrice.usd)) : 0.00}</PriceText>
-            <PercentBubble isDown={selectedAssetPrice ? selectedAssetPrice.change24Hour < 0 : false}>
-              <ArrowIcon isDown={selectedAssetPrice ? selectedAssetPrice.change24Hour < 0 : false} />
-              <PercentText>{selectedAssetPrice ? selectedAssetPrice.change24Hour : 0}%</PercentText>
+            <PriceText>${hoverPrice ? hoverPrice : selectedUSDAssetPrice ? formatePrices(Number(selectedUSDAssetPrice.price)) : 0.00}</PriceText>
+            <PercentBubble isDown={selectedUSDAssetPrice ? Number(selectedUSDAssetPrice.asset24hChange) < 0 : false}>
+              <ArrowIcon isDown={selectedUSDAssetPrice ? Number(selectedUSDAssetPrice.asset24hChange) < 0 : false} />
+              <PercentText>{selectedUSDAssetPrice ? Number(selectedUSDAssetPrice.asset24hChange).toFixed(2) : 0.00}%</PercentText>
             </PercentBubble>
           </PriceRow>
-          <DetailText>{selectedAssetPrice ? selectedAssetPrice.btc : 0} BTC</DetailText>
+          <DetailText>{selectedBTCAssetPrice ? selectedBTCAssetPrice.price : 0} BTC</DetailText>
         </InfoColumn>
       )}
       <LineChart
-        isDown={selectedAsset && selectedAssetPrice ? selectedAssetPrice.change24Hour < 0 : false}
+        isDown={selectedAsset && selectedUSDAssetPrice ? Number(selectedUSDAssetPrice.asset24hChange) < 0 : false}
         isAsset={!!selectedAsset}
         priceData={selectedAsset ? selectedAssetPriceHistory : portfolioPriceHistory}
         onUpdateBalance={onUpdateBalance}

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -248,12 +248,16 @@ export interface SwapResponseReturnInfo {
   response: SwapResponse
 }
 
-export interface GetAssetPriceReturnInfo {
-  success: boolean,
-  price: string
+export interface AssetPriceInfo {
   fromAsset: string
   toAsset: string
+  price: string
   asset24hChange: string
+}
+
+export interface GetAssetPriceReturnInfo {
+  success: boolean,
+  assetPrices: AssetPriceInfo[]
 }
 
 export interface GetAssetPriceHistoryReturnInfo {
@@ -279,7 +283,7 @@ export interface WalletAPIHandler {
   lockWallet: () => Promise<void>
   addAccountToWallet: () => Promise<AddAccountToWalletReturnInfo>
   unlockWallet: (password: string) => Promise<UnlockWalletReturnInfo>
-  getAssetPrice: (fromAssets: string[], toAssets: string[]) => Promise<GetAssetPriceReturnInfo[]>
+  getAssetPrice: (fromAssets: string[], toAssets: string[]) => Promise<GetAssetPriceReturnInfo>
   getAssetPriceHistory: (asset: string, timeframe: AssetPriceTimeframe) => Promise<GetAssetPriceHistoryReturnObjectInfo>
   addFavoriteApp: (appItem: AppObjectType) => Promise<void>
   removeFavoriteApp: (appItem: AppObjectType) => Promise<void>

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -251,9 +251,9 @@ export interface SwapResponseReturnInfo {
 export interface GetAssetPriceReturnInfo {
   success: boolean,
   price: string
-  from_asset: string
-  to_asset: string
-  asset_24h_change: string
+  fromAsset: string
+  toAsset: string
+  asset24hChange: string
 }
 
 export interface GetAssetPriceHistoryReturnInfo {
@@ -279,7 +279,7 @@ export interface WalletAPIHandler {
   lockWallet: () => Promise<void>
   addAccountToWallet: () => Promise<AddAccountToWalletReturnInfo>
   unlockWallet: (password: string) => Promise<UnlockWalletReturnInfo>
-  getAssetPrices: (assets: string[]) => Promise<GetAssetPriceReturnInfo[]>
+  getAssetPrice: (fromAssets: string[], toAssets: string[]) => Promise<GetAssetPriceReturnInfo[]>
   getAssetPriceHistory: (asset: string, timeframe: AssetPriceTimeframe) => Promise<GetAssetPriceHistoryReturnObjectInfo>
   addFavoriteApp: (appItem: AppObjectType) => Promise<void>
   removeFavoriteApp: (appItem: AppObjectType) => Promise<void>

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -252,7 +252,7 @@ export interface AssetPriceInfo {
 
 export interface GetAssetPriceReturnInfo {
   success: boolean,
-  assetPrices: AssetPriceInfo[]
+  values: AssetPriceInfo[]
 }
 
 export interface GetAssetPriceHistoryReturnInfo {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -98,12 +98,6 @@ export type ChartTimelineType =
   | '1Year'
   | 'AllTime'
 
-export interface AssetPriceReturnInfo {
-  usd: string
-  btc: number
-  change24Hour: number
-}
-
 export interface BuySendSwapObjectType {
   name: string
   id: BuySendSwapTypes
@@ -170,7 +164,8 @@ export interface PageState {
   invalidMnemonic: boolean
   selectedTimeline: AssetPriceTimeframe
   selectedAsset: AssetOptionType | undefined
-  selectedAssetPrice: AssetPriceReturnInfo | undefined
+  selectedBTCAssetPrice: AssetPriceInfo | undefined
+  selectedUSDAssetPrice: AssetPriceInfo | undefined
   selectedAssetPriceHistory: GetAssetPriceHistoryReturnInfo[]
   portfolioPriceHistory: PriceDataObjectType[]
   userAssets: string[]

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -251,10 +251,13 @@ export interface SwapResponseReturnInfo {
 export interface GetAssetPriceReturnInfo {
   success: boolean,
   price: string
+  from_asset: string
+  to_asset: string
+  asset_24h_change: string
 }
 
 export interface GetAssetPriceHistoryReturnInfo {
-  price: string,
+  price: string
   date: MojoTime
 }
 
@@ -276,7 +279,7 @@ export interface WalletAPIHandler {
   lockWallet: () => Promise<void>
   addAccountToWallet: () => Promise<AddAccountToWalletReturnInfo>
   unlockWallet: (password: string) => Promise<UnlockWalletReturnInfo>
-  getAssetPrice: (asset: string) => Promise<GetAssetPriceReturnInfo>
+  getAssetPrices: (assets: string[]) => Promise<GetAssetPriceReturnInfo[]>
   getAssetPriceHistory: (asset: string, timeframe: AssetPriceTimeframe) => Promise<GetAssetPriceHistoryReturnObjectInfo>
   addFavoriteApp: (appItem: AppObjectType) => Promise<void>
   removeFavoriteApp: (appItem: AppObjectType) => Promise<void>

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -74,17 +74,16 @@ handler.on(WalletPageActions.walletBackupComplete.getType(), async (store) => {
   await refreshWalletInfo(store)
 })
 
-// TODO: Spot Price will need to return btc: value and change24Hour: value in the future
 handler.on(WalletPageActions.selectAsset.getType(), async (store, payload: UpdateSelectedAssetType) => {
   store.dispatch(WalletPageActions.updateSelectedAsset(payload.asset))
   store.dispatch(WalletPageActions.setIsFetchingPriceHistory(true))
   const walletHandler = await getWalletHandler()
   if (payload.asset) {
-    const priceInfo = await walletHandler.getAssetPrice([payload.asset.symbol.toLowerCase()], ['usd'])
+    const priceInfo = await walletHandler.getAssetPrice([payload.asset.symbol.toLowerCase()], ['usd', 'btc'])
     const priceHistory = await walletHandler.getAssetPriceHistory(payload.asset.symbol.toLowerCase(), payload.timeFrame)
-    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, price: priceInfo.assetPrices[0].price, timeFrame: payload.timeFrame }))
+    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, usdPriceInfo: priceInfo.assetPrices[0], btcPriceInfo: priceInfo.assetPrices[1], timeFrame: payload.timeFrame }))
   } else {
-    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: undefined, price: '', timeFrame: payload.timeFrame }))
+    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: undefined, btcPriceInfo: undefined, usdPriceInfo: undefined, timeFrame: payload.timeFrame }))
   }
 })
 

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -80,9 +80,9 @@ handler.on(WalletPageActions.selectAsset.getType(), async (store, payload: Updat
   store.dispatch(WalletPageActions.setIsFetchingPriceHistory(true))
   const walletHandler = await getWalletHandler()
   if (payload.asset) {
-    const priceInfo = await walletHandler.getAssetPrices([payload.asset.symbol.toLowerCase()])
+    const priceInfo = await walletHandler.getAssetPrice([payload.asset.symbol.toLowerCase()], ['usd'])
     const priceHistory = await walletHandler.getAssetPriceHistory(payload.asset.symbol.toLowerCase(), payload.timeFrame)
-    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, price: priceInfo[0].price, timeFrame: payload.timeFrame }))
+    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, price: priceInfo.assetPrices[0].price, timeFrame: payload.timeFrame }))
   } else {
     store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: undefined, price: '', timeFrame: payload.timeFrame }))
   }

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -81,7 +81,7 @@ handler.on(WalletPageActions.selectAsset.getType(), async (store, payload: Updat
   if (payload.asset) {
     const priceInfo = await walletHandler.getAssetPrice([payload.asset.symbol.toLowerCase()], ['usd', 'btc'])
     const priceHistory = await walletHandler.getAssetPriceHistory(payload.asset.symbol.toLowerCase(), payload.timeFrame)
-    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, usdPriceInfo: priceInfo.assetPrices[0], btcPriceInfo: priceInfo.assetPrices[1], timeFrame: payload.timeFrame }))
+    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, usdPriceInfo: priceInfo.values[0], btcPriceInfo: priceInfo.values[1], timeFrame: payload.timeFrame }))
   } else {
     store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: undefined, btcPriceInfo: undefined, usdPriceInfo: undefined, timeFrame: payload.timeFrame }))
   }

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -80,9 +80,9 @@ handler.on(WalletPageActions.selectAsset.getType(), async (store, payload: Updat
   store.dispatch(WalletPageActions.setIsFetchingPriceHistory(true))
   const walletHandler = await getWalletHandler()
   if (payload.asset) {
-    const price = await walletHandler.getAssetPrice(payload.asset.symbol.toLowerCase())
+    const priceInfo = await walletHandler.getAssetPrices([payload.asset.symbol.toLowerCase()])
     const priceHistory = await walletHandler.getAssetPriceHistory(payload.asset.symbol.toLowerCase(), payload.timeFrame)
-    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, price: price.price, timeFrame: payload.timeFrame }))
+    store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, price: priceInfo[0].price, timeFrame: payload.timeFrame }))
   } else {
     store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: undefined, price: '', timeFrame: payload.timeFrame }))
   }

--- a/components/brave_wallet_ui/page/constants/action_types.ts
+++ b/components/brave_wallet_ui/page/constants/action_types.ts
@@ -2,7 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
-import { GetAssetPriceHistoryReturnObjectInfo, AssetOptionType, AssetPriceTimeframe } from '../../constants/types'
+import { GetAssetPriceHistoryReturnObjectInfo, AssetOptionType, AssetPriceInfo, AssetPriceTimeframe } from '../../constants/types'
 
 export type CreateWalletPayloadType = {
   password: string
@@ -32,6 +32,7 @@ export type UpdateSelectedAssetType = {
 
 export type SelectAssetPayloadType = {
   priceHistory: GetAssetPriceHistoryReturnObjectInfo | undefined,
-  price: string
+  usdPriceInfo: AssetPriceInfo | undefined,
+  btcPriceInfo: AssetPriceInfo | undefined,
   timeFrame: AssetPriceTimeframe
 }

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -74,7 +74,8 @@ function Container (props: Props) {
     mnemonic,
     selectedTimeline,
     selectedAsset,
-    selectedAssetPrice,
+    selectedUSDAssetPrice,
+    selectedBTCAssetPrice,
     selectedAssetPriceHistory,
     portfolioPriceHistory,
     userAssets,
@@ -373,7 +374,8 @@ function Container (props: Props) {
                   onSelectAsset={onSelectAsset}
                   portfolioBalance={fullPortfolioBalance}
                   selectedAsset={selectedAsset}
-                  selectedAssetPrice={selectedAssetPrice}
+                  selectedUSDAssetPrice={selectedUSDAssetPrice}
+                  selectedBTCAssetPrice={selectedBTCAssetPrice}
                   selectedAssetPriceHistory={formatedPriceHistory}
                   portfolioPriceHistory={portfolioPriceHistory}
                   selectedTimeline={selectedTimeline}

--- a/components/brave_wallet_ui/page/reducers/page_reducer.ts
+++ b/components/brave_wallet_ui/page/reducers/page_reducer.ts
@@ -15,7 +15,8 @@ const defaultState: PageState = {
   invalidMnemonic: false,
   selectedTimeline: AssetPriceTimeframe.OneDay,
   selectedAsset: undefined,
-  selectedAssetPrice: undefined,
+  selectedUSDAssetPrice: undefined,
+  selectedBTCAssetPrice: undefined,
   selectedAssetPriceHistory: [],
   portfolioPriceHistory: [],
   userAssets: ['1', '2'],
@@ -78,11 +79,8 @@ reducer.on(Actions.updatePriceInfo, (state: PageState, payload: SelectAssetPaylo
   const history = payload.priceHistory ? payload.priceHistory.values : []
   return {
     ...state,
-    selectedAssetPrice: payload.priceHistory ? {
-      usd: payload.price,
-      btc: 0,
-      change24Hour: 0
-    } : undefined,
+    selectedUSDAssetPrice: payload.usdPriceInfo,
+    selectedBTCAssetPrice: payload.btcPriceInfo,
     selectedAssetPriceHistory: history,
     selectedTimeline: payload.timeFrame,
     isFetchingPriceHistory: false

--- a/components/brave_wallet_ui/stories/mock-data/current-price-data.ts
+++ b/components/brave_wallet_ui/stories/mock-data/current-price-data.ts
@@ -2,30 +2,34 @@ export const CurrentPriceMockData = [
   {
     name: 'Bitcoin',
     symbol: 'BTC',
-    usd: 56806.36,
-    btc: 1,
-    change24Hour: 2.3
+    usd: '56806.36',
+    btc: '1',
+    usd24hChange: '2.3',
+    btc24hChange: '-0.1'
 
   },
   {
     name: 'Binance Coin',
     symbol: 'BNB',
-    usd: 502.24,
-    btc: 0.0098,
-    change24Hour: -4.6
+    usd: '502.24',
+    btc: '0.0098',
+    usd24hChange: '-4.6',
+    btc24hChange: '-4.8'
   },
   {
     name: 'Ethereum',
     symbol: 'ETH',
-    usd: 2156.20,
-    btc: 0.042,
-    change24Hour: 0.2
+    usd: '2156.20',
+    btc: '0.042',
+    usd24hChange: '0.2',
+    btc24hChange: '0.3'
   },
   {
     name: 'Basic Attention Token',
     symbol: 'BAT',
-    usd: 1.34,
-    btc: 0.000022,
-    change24Hour: 20
+    usd: '1.34',
+    btc: '0.000022',
+    usd24hChange: '2',
+    btc24hChange: '2.1'
   }
 ]

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -12,7 +12,7 @@ import {
   AssetPriceTimeframe,
   PriceDataObjectType,
   AssetOptionType,
-  AssetPriceReturnInfo,
+  AssetPriceInfo,
   RPCResponseType,
   NetworkOptionsType,
   OrderTypes,
@@ -127,16 +127,32 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     }
   }
 
-  const selectedAssetPrice = React.useMemo(() => {
+  const selectedUSDAssetPrice = React.useMemo(() => {
     if (selectedAsset) {
       const data = CurrentPriceMockData.find((coin) => coin.symbol === selectedAsset.symbol)
-      const usdValue = data ? data.usd : 0
-      const btcValue = data ? data.btc : 0
-      const change24Hour = data ? data.change24Hour : 0
-      const response: AssetPriceReturnInfo = {
-        usd: formatePrices(usdValue),
-        btc: btcValue,
-        change24Hour: change24Hour
+      const usdValue = data ? data.usd : '0'
+      const usd24hChange = data ? data.usd24hChange : '0'
+      const response: AssetPriceInfo = {
+        price: usdValue,
+        asset24hChange: usd24hChange,
+        fromAsset: '',
+        toAsset: ''
+      }
+      return response
+    }
+    return undefined
+  }, [selectedAsset])
+
+  const selectedBTCAssetPrice = React.useMemo(() => {
+    if (selectedAsset) {
+      const data = CurrentPriceMockData.find((coin) => coin.symbol === selectedAsset.symbol)
+      const btcValue = data ? data.btc : '0'
+      const btc24hChange = data ? data.btc24hChange : '0'
+      const response: AssetPriceInfo = {
+        price: btcValue,
+        asset24hChange: btc24hChange,
+        fromAsset: '',
+        toAsset: ''
       }
       return response
     }
@@ -152,7 +168,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   const singleAccountFiatBalance = (account: RPCResponseType) => {
     const asset = assetInfo(account)
     const data = CurrentPriceMockData.find((coin) => coin.symbol === asset?.symbol)
-    const value = data ? asset ? asset.balance * data.usd : 0 : 0
+    const value = data ? asset ? Number(asset.balance) * Number(data.usd) : 0 : 0
     return formatePrices(value)
   }
 
@@ -215,7 +231,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   // This will scrape all of the user's accounts and combine the fiat value for a single asset
   const scrapedFullAssetFiatBalance = (asset: AssetOptionType) => {
     const fullBallance = scrapedFullAssetBalance(asset)
-    const price = CurrentPriceMockData.find((coin) => coin.symbol === asset?.symbol)?.usd
+    const price = Number(CurrentPriceMockData.find((coin) => coin.symbol === asset?.symbol)?.usd)
     const value = price ? price * fullBallance : 0
     return value
   }
@@ -433,7 +449,8 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
                           portfolioPriceHistory={selectedAssetPriceHistory}
                           portfolioBalance={scrapedFullPortfolioBalance()}
                           transactions={transactions}
-                          selectedAssetPrice={selectedAssetPrice}
+                          selectedUSDAssetPrice={selectedUSDAssetPrice}
+                          selectedBTCAssetPrice={selectedBTCAssetPrice}
                           userAssetList={userAssetList}
                           onConnectHardwareWallet={onConnectHardwareWallet}
                           onCreateAccount={onCreateAccount}


### PR DESCRIPTION
The endpoint for getting asset prices changed.
It now supports multiple from and to assets, as well as showing the 24h change. 

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17050

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

