### PR TITLE
Do not overwrite Rewards wallet data on read error

### DIFF
--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -351,12 +351,6 @@ class RewardsService : public KeyedService {
 
   virtual void GetEventLogs(GetEventLogsCallback callback) = 0;
 
-  virtual std::string GetEncryptedStringState(const std::string& key) = 0;
-
-  virtual bool SetEncryptedStringState(
-      const std::string& key,
-      const std::string& value) = 0;
-
   virtual void GetBraveWallet(GetBraveWalletCallback callback) = 0;
 
   virtual void StartProcess(base::OnceClosure callback) = 0;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -3315,44 +3315,22 @@ void RewardsServiceImpl::OnGetEventLogs(
   std::move(callback).Run(std::move(logs));
 }
 
-bool RewardsServiceImpl::SetEncryptedStringState(
-      const std::string& name,
-      const std::string& value) {
-  std::string encrypted_value;
-  if (!OSCrypt::EncryptString(value, &encrypted_value)) {
-    BLOG(0, "Couldn't encrypt value for " + name);
-    return false;
-  }
+absl::optional<std::string> RewardsServiceImpl::EncryptString(
+    const std::string& value) {
+  std::string encrypted;
+  if (OSCrypt::EncryptString(value, &encrypted))
+    return encrypted;
 
-  std::string encoded_value;
-  base::Base64Encode(encrypted_value, &encoded_value);
-
-  profile_->GetPrefs()->SetString(GetPrefPath(name), encoded_value);
-  return true;
+  return {};
 }
 
-std::string RewardsServiceImpl::GetEncryptedStringState(
-    const std::string& name) {
-  const std::string encoded_value =
-      profile_->GetPrefs()->GetString(GetPrefPath(name));
+absl::optional<std::string> RewardsServiceImpl::DecryptString(
+    const std::string& value) {
+  std::string decrypted;
+  if (OSCrypt::DecryptString(value, &decrypted))
+    return decrypted;
 
-  std::string encrypted_value;
-  if (!base::Base64Decode(encoded_value, &encrypted_value)) {
-    BLOG(0, "base64 decode failed for " + name);
-    return "";
-  }
-
-  if (encrypted_value.empty()) {
-    return "";
-  }
-
-  std::string value;
-  if (!OSCrypt::DecryptString(encrypted_value, &value)) {
-    BLOG(0, "Decrypting failed for " + name);
-    return "";
-  }
-
-  return value;
+  return {};
 }
 
 void RewardsServiceImpl::GetBraveWallet(GetBraveWalletCallback callback) {

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -332,11 +332,9 @@ class RewardsServiceImpl : public RewardsService,
 
   void StopLedger(StopLedgerCallback callback);
 
-  std::string GetEncryptedStringState(const std::string& name) override;
+  absl::optional<std::string> EncryptString(const std::string& value) override;
 
-  bool SetEncryptedStringState(
-      const std::string& name,
-      const std::string& value) override;
+  absl::optional<std::string> DecryptString(const std::string& value) override;
 
   void GetBraveWallet(GetBraveWalletCallback callback) override;
 

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.cc
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.cc
@@ -9,6 +9,7 @@
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_context_helper.h"
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_context_util.h"
 #include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.h"
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
 #include "brave/components/brave_rewards/common/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/common/features.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
@@ -476,7 +477,11 @@ void RewardsBrowserTestContribution::SetUpGeminiWallet(
 
   std::string json;
   base::JSONWriter::Write(wallet, &json);
-  rewards_service->SetEncryptedStringState("wallets.gemini", json);
+  auto encrypted =
+      rewards_browsertest_util::EncryptPrefString(rewards_service_, json);
+  ASSERT_TRUE(encrypted);
+  browser_->profile()->GetPrefs()->SetString(
+      brave_rewards::prefs::kWalletGemini, *encrypted);
 }
 #endif
 
@@ -506,7 +511,12 @@ void RewardsBrowserTestContribution::SetUpUpholdWallet(
 
   std::string json;
   base::JSONWriter::Write(wallet, &json);
-  rewards_service->SetEncryptedStringState("wallets.uphold", json);
+  auto encrypted =
+      rewards_browsertest_util::EncryptPrefString(rewards_service_, json);
+  ASSERT_TRUE(encrypted);
+
+  browser_->profile()->GetPrefs()->SetString(
+      brave_rewards::prefs::kWalletUphold, *encrypted);
 }
 
 double RewardsBrowserTestContribution::GetReconcileTipTotal() {

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_util.cc
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_util.cc
@@ -3,8 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
+
 #include <utility>
 
+#include "base/base64.h"
 #include "base/files/file_util.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
@@ -12,7 +15,6 @@
 #include "base/test/bind.h"
 #include "bat/ledger/mojom_structs.h"
 #include "brave/common/brave_paths.h"
-#include "brave/components/brave_rewards/browser/test/common/rewards_browsertest_util.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/test/base/ui_test_utils.h"
@@ -123,6 +125,29 @@ void SetOnboardingBypassed(Browser* browser, bool bypassed) {
   // Rewards onboarding will be skipped if the rewards enabled flag is set
   PrefService* prefs = browser->profile()->GetPrefs();
   prefs->SetBoolean(brave_rewards::prefs::kEnabled, bypassed);
+}
+
+absl::optional<std::string> EncryptPrefString(
+    brave_rewards::RewardsServiceImpl* rewards_service,
+    const std::string& value) {
+  DCHECK(rewards_service);
+  auto encrypted = rewards_service->EncryptString(value);
+  if (!encrypted)
+    return {};
+  std::string encoded;
+  base::Base64Encode(*encrypted, &encoded);
+  return encoded;
+}
+
+absl::optional<std::string> DecryptPrefString(
+    brave_rewards::RewardsServiceImpl* rewards_service,
+    const std::string& value) {
+  DCHECK(rewards_service);
+  std::string decoded;
+  if (!base::Base64Decode(value, &decoded))
+    return {};
+
+  return rewards_service->DecryptString(decoded);
 }
 
 }  // namespace rewards_browsertest_util

--- a/components/brave_rewards/browser/test/common/rewards_browsertest_util.h
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_util.h
@@ -54,6 +54,16 @@ void CreateWallet(brave_rewards::RewardsServiceImpl* rewards_service);
 
 void SetOnboardingBypassed(Browser* browser, bool bypassed = true);
 
+// TODO(zenparsing): Remove these functions when browser tests that read or
+// write encrypted "state" are migrated to the bat ledger library.
+absl::optional<std::string> EncryptPrefString(
+    brave_rewards::RewardsServiceImpl* rewards_service,
+    const std::string& value);
+
+absl::optional<std::string> DecryptPrefString(
+    brave_rewards::RewardsServiceImpl* rewards_service,
+    const std::string& value);
+
 }  // namespace rewards_browsertest_util
 
 #endif  // BRAVE_COMPONENTS_BRAVE_REWARDS_BROWSER_TEST_COMMON_REWARDS_BROWSERTEST_UTIL_H_

--- a/components/services/bat_ledger/bat_ledger_client_mojo_bridge.cc
+++ b/components/services/bat_ledger/bat_ledger_client_mojo_bridge.cc
@@ -370,19 +370,18 @@ void BatLedgerClientMojoBridge::DeleteLog(
       base::BindOnce(&OnDeleteLog, std::move(callback)));
 }
 
-bool BatLedgerClientMojoBridge::SetEncryptedStringState(
-    const std::string& name,
+absl::optional<std::string> BatLedgerClientMojoBridge::EncryptString(
     const std::string& value) {
-  bool success;
-  bat_ledger_client_->SetEncryptedStringState(name, value, &success);
-  return success;
+  absl::optional<std::string> result;
+  bat_ledger_client_->EncryptString(value, &result);
+  return result;
 }
 
-std::string BatLedgerClientMojoBridge::GetEncryptedStringState(
-    const std::string& name) {
-  std::string value;
-  bat_ledger_client_->GetEncryptedStringState(name, &value);
-  return value;
+absl::optional<std::string> BatLedgerClientMojoBridge::DecryptString(
+    const std::string& value) {
+  absl::optional<std::string> result;
+  bat_ledger_client_->DecryptString(value, &result);
+  return result;
 }
 
 }  // namespace bat_ledger

--- a/components/services/bat_ledger/bat_ledger_client_mojo_bridge.h
+++ b/components/services/bat_ledger/bat_ledger_client_mojo_bridge.h
@@ -118,11 +118,9 @@ class BatLedgerClientMojoBridge :
 
   void DeleteLog(ledger::client::ResultCallback callback) override;
 
-  bool SetEncryptedStringState(
-      const std::string& name,
-      const std::string& value) override;
+  absl::optional<std::string> EncryptString(const std::string& name) override;
 
-  std::string GetEncryptedStringState(const std::string& name) override;
+  absl::optional<std::string> DecryptString(const std::string& name) override;
 
  private:
   bool Connected() const;

--- a/components/services/bat_ledger/public/cpp/ledger_client_mojo_bridge.cc
+++ b/components/services/bat_ledger/public/cpp/ledger_client_mojo_bridge.cc
@@ -376,17 +376,14 @@ void LedgerClientMojoBridge::DeleteLog(DeleteLogCallback callback) {
                 _1));
 }
 
-void LedgerClientMojoBridge::SetEncryptedStringState(
-    const std::string& name,
-    const std::string& value,
-    SetEncryptedStringStateCallback callback) {
-  std::move(callback).Run(ledger_client_->SetEncryptedStringState(name, value));
+void LedgerClientMojoBridge::EncryptString(const std::string& value,
+                                           EncryptStringCallback callback) {
+  std::move(callback).Run(ledger_client_->EncryptString(value));
 }
 
-void LedgerClientMojoBridge::GetEncryptedStringState(
-    const std::string& name,
-    GetEncryptedStringStateCallback callback) {
-  std::move(callback).Run(ledger_client_->GetEncryptedStringState(name));
+void LedgerClientMojoBridge::DecryptString(const std::string& value,
+                                           DecryptStringCallback callback) {
+  std::move(callback).Run(ledger_client_->DecryptString(value));
 }
 
 }  // namespace bat_ledger

--- a/components/services/bat_ledger/public/cpp/ledger_client_mojo_bridge.h
+++ b/components/services/bat_ledger/public/cpp/ledger_client_mojo_bridge.h
@@ -133,14 +133,11 @@ class LedgerClientMojoBridge :
 
   void DeleteLog(DeleteLogCallback callback) override;
 
-  void SetEncryptedStringState(
-      const std::string& name,
-      const std::string& value,
-      SetEncryptedStringStateCallback callback) override;
+  void EncryptString(const std::string& value,
+                     EncryptStringCallback callback) override;
 
-  void GetEncryptedStringState(
-      const std::string& name,
-      GetEncryptedStringStateCallback callback) override;
+  void DecryptString(const std::string& value,
+                     DecryptStringCallback callback) override;
 
  private:
   // workaround to pass base::OnceCallback into std::bind

--- a/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
+++ b/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
@@ -242,8 +242,8 @@ interface BatLedgerClient {
   DeleteLog() => (ledger.mojom.Result result);
 
   [Sync]
-  SetEncryptedStringState(string name, string value) => (bool success);
+  EncryptString(string value) => (string? encrypted);
 
   [Sync]
-  GetEncryptedStringState(string name) => (string value);
+  DecryptString(string value) => (string? decrypted);
 };

--- a/ios/browser/api/ledger/ledger_client_bridge.h
+++ b/ios/browser/api/ledger/ledger_client_bridge.h
@@ -68,9 +68,8 @@
 - (void)clearAllNotifications;
 - (void)walletDisconnected:(const std::string&)wallet_type;
 - (void)deleteLog:(ledger::client::ResultCallback)callback;
-- (bool)setEncryptedStringState:(const std::string&)key
-                          value:(const std::string&)value;
-- (std::string)getEncryptedStringState:(const std::string&)key;
+- (absl::optional<std::string>)encryptString:(const std::string&)value;
+- (absl::optional<std::string>)decryptString:(const std::string&)value;
 
 @end
 

--- a/ios/browser/api/ledger/ledger_client_ios.h
+++ b/ios/browser/api/ledger/ledger_client_ios.h
@@ -80,9 +80,8 @@ class LedgerClientIOS : public ledger::LedgerClient {
   void ClearAllNotifications() override;
   void WalletDisconnected(const std::string& wallet_type) override;
   void DeleteLog(ledger::client::ResultCallback callback) override;
-  bool SetEncryptedStringState(const std::string& key,
-                               const std::string& value) override;
-  std::string GetEncryptedStringState(const std::string& key) override;
+  absl::optional<std::string> EncryptString(const std::string& value) override;
+  absl::optional<std::string> DecryptString(const std::string& value) override;
 };
 
 #endif  // BRAVE_IOS_BROWSER_API_LEDGER_LEDGER_CLIENT_IOS_H_

--- a/ios/browser/api/ledger/ledger_client_ios.mm
+++ b/ios/browser/api/ledger/ledger_client_ios.mm
@@ -165,10 +165,11 @@ void LedgerClientIOS::WalletDisconnected(const std::string& wallet_type) {
 void LedgerClientIOS::DeleteLog(ledger::client::ResultCallback callback) {
   [bridge_ deleteLog:callback];
 }
-bool LedgerClientIOS::SetEncryptedStringState(const std::string& key,
-                                              const std::string& value) {
-  return [bridge_ setEncryptedStringState:key value:value];
+absl::optional<std::string> LedgerClientIOS::EncryptString(
+    const std::string& value) {
+  return [bridge_ encryptString:value];
 }
-std::string LedgerClientIOS::GetEncryptedStringState(const std::string& key) {
-  return [bridge_ getEncryptedStringState:key];
+absl::optional<std::string> LedgerClientIOS::DecryptString(
+    const std::string& value) {
+  return [bridge_ decryptString:value];
 }

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger_client.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger_client.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BAT_LEDGER_LEDGER_CLIENT_H_
-#define BAT_LEDGER_LEDGER_CLIENT_H_
+#ifndef BRAVE_VENDOR_BAT_NATIVE_LEDGER_INCLUDE_BAT_LEDGER_LEDGER_CLIENT_H_
+#define BRAVE_VENDOR_BAT_NATIVE_LEDGER_INCLUDE_BAT_LEDGER_LEDGER_CLIENT_H_
 
 #include <functional>
 #include <memory>
@@ -12,8 +12,9 @@
 #include <string>
 #include <map>
 
-#include "bat/ledger/mojom_structs.h"
 #include "bat/ledger/export.h"
+#include "bat/ledger/mojom_structs.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace ledger {
 namespace client {
@@ -153,13 +154,13 @@ class LEDGER_EXPORT LedgerClient {
 
   virtual void DeleteLog(client::ResultCallback callback) = 0;
 
-  virtual bool SetEncryptedStringState(
-      const std::string& name,
+  virtual absl::optional<std::string> EncryptString(
       const std::string& value) = 0;
 
-  virtual std::string GetEncryptedStringState(const std::string& name) = 0;
+  virtual absl::optional<std::string> DecryptString(
+      const std::string& value) = 0;
 };
 
 }  // namespace ledger
 
-#endif  // BAT_LEDGER_LEDGER_CLIENT_H_
+#endif  // BRAVE_VENDOR_BAT_NATIVE_LEDGER_INCLUDE_BAT_LEDGER_LEDGER_CLIENT_H_

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/bitflyer/bitflyer_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/bitflyer/bitflyer_util_unittest.cc
@@ -133,12 +133,12 @@ TEST_F(BitflyerUtilTest, GetWithdrawUrl) {
 
 TEST_F(BitflyerUtilTest, GetWallet) {
   // no wallet
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBitflyer))
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBitflyer))
       .WillByDefault(testing::Return(""));
   auto result = mock_ledger_impl_.get()->bitflyer()->GetWallet();
   ASSERT_TRUE(!result);
 
-  const std::string wallet = R"({
+  const std::string wallet = FakeEncryption::Base64EncryptString(R"({
     "account_url": "https://bitflyer.com/ex/Home?login=1",
     "add_url": "",
     "address": "2323dff2ba-d0d1-4dfw-8e56-a2605bcaf4af",
@@ -151,9 +151,9 @@ TEST_F(BitflyerUtilTest, GetWallet) {
     "user_name": "test",
     "verify_url": "https://sandbox.bitflyer.com/authorize/4c2b665ca060d",
     "withdraw_url": ""
-  })";
+  })");
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBitflyer))
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBitflyer))
       .WillByDefault(testing::Return(wallet));
 
   // Bitflyer wallet

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/core/bat_ledger_test.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/core/bat_ledger_test.cc
@@ -9,6 +9,10 @@
 
 namespace ledger {
 
+BATLedgerTest::BATLedgerTest() = default;
+
+BATLedgerTest::~BATLedgerTest() = default;
+
 void BATLedgerTest::AddNetworkResultForTesting(const std::string& url,
                                                mojom::UrlMethod method,
                                                mojom::UrlResponsePtr response) {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/core/bat_ledger_test.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/core/bat_ledger_test.h
@@ -12,6 +12,7 @@
 #include "base/test/task_environment.h"
 #include "bat/ledger/internal/core/bat_ledger_context.h"
 #include "bat/ledger/internal/core/test_ledger_client.h"
+#include "bat/ledger/internal/ledger_impl.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace ledger {
@@ -19,6 +20,10 @@ namespace ledger {
 // Base class for unit tests. |BATLedgerTest| provides a task environment,
 // access to a |BATLedgerContext|, and an test implementation of |LedgerClient|.
 class BATLedgerTest : public testing::Test {
+ public:
+  BATLedgerTest();
+  ~BATLedgerTest() override;
+
  protected:
   // Returns the |TaskEnvironment| for this test.
   base::test::TaskEnvironment* task_environment() { return &task_environment_; }
@@ -28,6 +33,9 @@ class BATLedgerTest : public testing::Test {
 
   // Returns the |TestLedgerClient| instance for this test.
   TestLedgerClient* GetTestLedgerClient() { return &client_; }
+
+  // Returns the |LedgerImpl| instance for this test.
+  LedgerImpl* GetLedgerImpl() { return &ledger_; }
 
   // Adds a mock network response for the specified URL and HTTP method.
   void AddNetworkResultForTesting(const std::string& url,
@@ -40,7 +48,8 @@ class BATLedgerTest : public testing::Test {
  private:
   base::test::TaskEnvironment task_environment_;
   TestLedgerClient client_;
-  BATLedgerContext context_{&client_};
+  LedgerImpl ledger_{&client_};
+  BATLedgerContext context_{&ledger_};
 };
 
 }  // namespace ledger

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/core/test_ledger_client.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/core/test_ledger_client.h
@@ -21,6 +21,15 @@
 
 namespace ledger {
 
+struct FakeEncryption {
+  static std::string EncryptString(const std::string& value);
+  static absl::optional<std::string> DecryptString(const std::string& value);
+
+  static std::string Base64EncryptString(const std::string& value);
+  static absl::optional<std::string> Base64DecryptString(
+      const std::string& value);
+};
+
 struct TestNetworkResult {
   TestNetworkResult(const std::string& url,
                     mojom::UrlMethod method,
@@ -144,10 +153,9 @@ class TestLedgerClient : public LedgerClient {
 
   void DeleteLog(client::ResultCallback callback) override;
 
-  bool SetEncryptedStringState(const std::string& name,
-                               const std::string& value) override;
+  absl::optional<std::string> EncryptString(const std::string& value) override;
 
-  std::string GetEncryptedStringState(const std::string& name) override;
+  absl::optional<std::string> DecryptString(const std::string& value) override;
 
   // Test environment setup methods:
 
@@ -172,7 +180,6 @@ class TestLedgerClient : public LedgerClient {
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   std::unique_ptr<LedgerDatabaseImpl> ledger_database_;
   base::Value state_store_;
-  base::Value encrypted_state_store_;
   base::Value option_store_;
   std::list<TestNetworkResult> network_results_;
   LogCallback log_callback_;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_transaction_anon/post_transaction_anon_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/payment/post_transaction_anon/post_transaction_anon_unittest.cc
@@ -44,12 +44,12 @@ class PostTransactionAnonTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(wallet));
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+        .WillByDefault(testing::Return(wallet));
   }
 };
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/delete_claim/delete_claim_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/delete_claim/delete_claim_unittest.cc
@@ -42,11 +42,11 @@ class DeleteClaimTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
         .WillByDefault(testing::Return(wallet));
   }
 };

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_bat_loss/post_bat_loss_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_bat_loss/post_bat_loss_unittest.cc
@@ -42,12 +42,12 @@ class PostBatLossTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(wallet));
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+        .WillByDefault(testing::Return(wallet));
   }
 };
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_bitflyer/post_claim_bitflyer_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_bitflyer/post_claim_bitflyer_unittest.cc
@@ -43,11 +43,11 @@ class PostClaimBitflyerTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
         .WillByDefault(testing::Return(wallet));
   }
 };

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_brave/post_claim_brave_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_brave/post_claim_brave_unittest.cc
@@ -42,12 +42,12 @@ class PostClaimBraveTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(wallet));
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+        .WillByDefault(testing::Return(wallet));
   }
 };
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_gemini/post_claim_gemini_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_claim_gemini/post_claim_gemini_unittest.cc
@@ -42,11 +42,11 @@ class PostClaimGeminiTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
         .WillByDefault(testing::Return(wallet));
   }
 };

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_creds/post_creds_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_creds/post_creds_unittest.cc
@@ -43,12 +43,12 @@ class PostCredsTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(wallet));
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+        .WillByDefault(testing::Return(wallet));
   }
 };
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions_claim/post_suggestions_claim_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_suggestions_claim/post_suggestions_claim_unittest.cc
@@ -58,11 +58,11 @@ class PostSuggestionsClaimTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
         .WillByDefault(testing::Return(wallet));
   }
 };

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_wallet_brave/post_wallet_brave_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/promotion/post_wallet_brave/post_wallet_brave_unittest.cc
@@ -42,12 +42,12 @@ class PostWalletBraveTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(wallet));
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+        .WillByDefault(testing::Return(wallet));
   }
 };
 

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_util_unittest.cc
@@ -136,12 +136,12 @@ TEST_F(GeminiUtilTest, GetWithdrawUrl) {
 
 TEST_F(GeminiUtilTest, GetWallet) {
   // no wallet
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletGemini))
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletGemini))
       .WillByDefault(testing::Return(""));
   auto result = mock_ledger_impl_.get()->gemini()->GetWallet();
   ASSERT_TRUE(!result);
 
-  const std::string wallet = R"({
+  const std::string wallet = FakeEncryption::Base64EncryptString(R"({
     "account_url": "https://exchange.sandbox.gemini.com",
     "add_url": "",
     "address": "2323dff2ba-d0d1-4dfw-8e56-a2605bcaf4af",
@@ -153,9 +153,9 @@ TEST_F(GeminiUtilTest, GetWallet) {
     "user_name": "test",
     "verify_url": "https://exchange.sandbox.gemini.com/auth/token",
     "withdraw_url": ""
-  })";
+  })");
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletGemini))
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletGemini))
       .WillByDefault(testing::Return(wallet));
 
   // Gemini wallet

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_client_mock.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_client_mock.cc
@@ -11,4 +11,14 @@ MockLedgerClient::MockLedgerClient() = default;
 
 MockLedgerClient::~MockLedgerClient() = default;
 
+absl::optional<std::string> MockLedgerClient::EncryptString(
+    const std::string& value) {
+  return FakeEncryption::EncryptString(value);
+}
+
+absl::optional<std::string> MockLedgerClient::DecryptString(
+    const std::string& value) {
+  return FakeEncryption::DecryptString(value);
+}
+
 }  // namespace ledger

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_client_mock.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/ledger_client_mock.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BAT_LEDGER_LEDGER_CLIENT_MOCK_H_
-#define BAT_LEDGER_LEDGER_CLIENT_MOCK_H_
+#ifndef BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_LEDGER_CLIENT_MOCK_H_
+#define BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_LEDGER_CLIENT_MOCK_H_
 
 #include <stdint.h>
 
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "bat/ledger/internal/core/test_ledger_client.h"
 #include "bat/ledger/ledger_client.h"
 
 #include "testing/gmock/include/gmock/gmock.h"
@@ -23,6 +24,10 @@ class MockLedgerClient : public LedgerClient {
  public:
   MockLedgerClient();
   ~MockLedgerClient() override;
+
+  absl::optional<std::string> EncryptString(const std::string& value) override;
+
+  absl::optional<std::string> DecryptString(const std::string& value) override;
 
   MOCK_METHOD2(OnReconcileComplete, void(
       type::Result result,
@@ -156,14 +161,8 @@ class MockLedgerClient : public LedgerClient {
   MOCK_METHOD1(DeleteLog, void(const client::ResultCallback callback));
 
   MOCK_METHOD0(GetLegacyWallet, std::string());
-
-  MOCK_METHOD2(
-      SetEncryptedStringState,
-      bool(const std::string&, const std::string&));
-
-  MOCK_METHOD1(GetEncryptedStringState, std::string(const std::string&));
 };
 
 }  // namespace ledger
 
-#endif  // BAT_LEDGER_LEDGER_CLIENT_MOCK_H_
+#endif  // BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_LEDGER_CLIENT_MOCK_H_

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/promotion/promotion_unittest.cc
@@ -73,12 +73,12 @@ class PromotionTest : public testing::Test {
   }
 
   void SetUp() override {
-    const std::string wallet = R"({
+    const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "payment_id":"fa5dea51-6af4-44ca-801b-07b6df3dcfe4",
       "recovery_seed":"AN6DLuI2iZzzDxpzywf+IKmK1nzFRarNswbaIDI3pQg="
-    })";
-    ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(wallet));
+    })");
+    ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+        .WillByDefault(testing::Return(wallet));
 
     ON_CALL(*mock_ledger_impl_, database())
       .WillByDefault(testing::Return(mock_database_.get()));

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/state/state.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/state/state.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
 namespace ledger {
 class LedgerImpl;
 
@@ -108,6 +110,10 @@ class State {
   void ResetWalletType();
 
   uint64_t GetPromotionLastFetchStamp();
+
+  absl::optional<std::string> GetEncryptedString(const std::string& key);
+
+  bool SetEncryptedString(const std::string& key, const std::string& value);
 
  private:
   LedgerImpl* ledger_;  // NOT OWNED

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/state/state_migration_v7.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/state/state_migration_v7.cc
@@ -21,20 +21,16 @@ StateMigrationV7::~StateMigrationV7() = default;
 void StateMigrationV7::Migrate(ledger::ResultCallback callback) {
   const std::string brave =
       ledger_->ledger_client()->GetStringState(kWalletBrave);
-  bool success =
-      ledger_->ledger_client()->SetEncryptedStringState(kWalletBrave, brave);
 
-  if (!success) {
+  if (!ledger_->state()->SetEncryptedString(kWalletBrave, brave)) {
     callback(type::Result::LEDGER_ERROR);
     return;
   }
 
   const std::string uphold =
       ledger_->ledger_client()->GetStringState(kWalletUphold);
-  success =
-      ledger_->ledger_client()->SetEncryptedStringState(kWalletUphold, uphold);
 
-  if (!success) {
+  if (!ledger_->state()->SetEncryptedString(kWalletUphold, uphold)) {
     callback(type::Result::LEDGER_ERROR);
     return;
   }

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_unittest.cc
@@ -57,12 +57,12 @@ class UpholdTest : public Test {
 };
 
 TEST_F(UpholdTest, FetchBalanceConnectedWallet) {
-  const std::string wallet = R"({
+  const std::string wallet = FakeEncryption::Base64EncryptString(R"({
       "token":"token",
       "address":"address"
       "status":1
-    })";
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
+    })");
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
       .WillByDefault(Return(wallet));
   EXPECT_CALL(*mock_ledger_client_, LoadURL(_, _)).Times(0);
 
@@ -344,25 +344,20 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(Authorize, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto& input_args = std::get<2>(params);
   const auto& uphold_oauth_response = std::get<3>(params);
   const auto expected_result = std::get<4>(params);
   const auto& expected_args = std::get<5>(params);
   const auto expected_status = std::get<6>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
@@ -429,22 +424,17 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(Generate, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto expected_result = std::get<2>(params);
   const auto expected_status = std::get<3>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
@@ -654,23 +644,18 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(GetUser, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto& uphold_get_user_response = std::get<2>(params);
   const auto expected_result = std::get<3>(params);
   const auto expected_status = std::get<4>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
@@ -895,7 +880,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(GetCardID, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto& uphold_get_user_response = std::get<2>(params);
   const auto& uphold_list_cards_response = std::get<3>(params);
   const auto& uphold_create_card_response = std::get<4>(params);
@@ -903,18 +888,13 @@ TEST_P(GetCardID, Paths) {
   const auto expected_result = std::get<6>(params);
   const auto expected_status = std::get<7>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
@@ -1026,7 +1006,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(GetAnonFunds, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto& uphold_get_user_response = std::get<2>(params);
   const auto& uphold_list_cards_response = std::get<3>(params);
   const auto fetch_old_balance = std::get<4>(params);
@@ -1036,18 +1016,13 @@ TEST_P(GetAnonFunds, Paths) {
   const auto expected_result = std::get<7>(params);
   const auto expected_status = std::get<8>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
@@ -1067,10 +1042,11 @@ TEST_P(GetAnonFunds, Paths) {
       .WillByDefault(Return(mock_database_.get()));
 
   ON_CALL(*mock_ledger_client_, GetBooleanState(state::kFetchOldBalance))
-      .WillByDefault(testing::Return(fetch_old_balance));
+      .WillByDefault(Return(fetch_old_balance));
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(input_rewards_wallet));
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+      .WillByDefault(
+          Return(FakeEncryption::Base64EncryptString(input_rewards_wallet)));
 
   uphold_->GenerateWallet([&](type::Result result) {
     ASSERT_EQ(result, expected_result);
@@ -1197,7 +1173,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(LinkWallet, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto& uphold_get_user_response = std::get<2>(params);
   const auto& uphold_list_cards_response = std::get<3>(params);
   const auto fetch_old_balance = std::get<4>(params);
@@ -1206,18 +1182,13 @@ TEST_P(LinkWallet, Paths) {
   const auto expected_result = std::get<7>(params);
   const auto expected_status = std::get<8>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
@@ -1237,10 +1208,11 @@ TEST_P(LinkWallet, Paths) {
       .WillByDefault(Return(mock_database_.get()));
 
   ON_CALL(*mock_ledger_client_, GetBooleanState(state::kFetchOldBalance))
-      .WillByDefault(testing::Return(fetch_old_balance));
+      .WillByDefault(Return(fetch_old_balance));
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(input_rewards_wallet));
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+      .WillByDefault(
+          Return(FakeEncryption::Base64EncryptString(input_rewards_wallet)));
 
   uphold_->GenerateWallet(
       [&](type::Result result) { ASSERT_EQ(result, expected_result); });
@@ -1397,29 +1369,25 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(DisconnectWallet, Paths) {
   const auto& params = GetParam();
-  const auto& input_uphold_wallet = std::get<1>(params);
+  std::string uphold_wallet = std::get<1>(params);
   const auto& input_rewards_wallet = std::get<2>(params);
   const auto& rewards_unlink_wallet_response = std::get<3>(params);
   const auto expected_result = std::get<4>(params);
   const auto expected_status = std::get<5>(params);
 
-  std::string uphold_wallet = "";
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
+      .WillByDefault(
+          [&] { return FakeEncryption::Base64EncryptString(uphold_wallet); });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
-      .WillByDefault([&] {
-        return uphold_wallet.empty() ? uphold_wallet = input_uphold_wallet
-                                     : uphold_wallet;
-      });
-
-  ON_CALL(*mock_ledger_client_,
-          SetEncryptedStringState(state::kWalletUphold, _))
+  ON_CALL(*mock_ledger_client_, SetStringState(state::kWalletUphold, _))
       .WillByDefault([&](const std::string&, const std::string& value) {
-        uphold_wallet = value;
+        uphold_wallet = *FakeEncryption::Base64DecryptString(value);
         return true;
       });
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletBrave))
-      .WillByDefault(testing::Return(input_rewards_wallet));
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletBrave))
+      .WillByDefault(
+          Return(FakeEncryption::Base64EncryptString(input_rewards_wallet)));
 
   ON_CALL(*mock_ledger_client_, LoadURL(_, _))
       .WillByDefault(

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc
@@ -179,12 +179,12 @@ TEST_F(UpholdUtilTest, GetSecondStepVerify) {
 
 TEST_F(UpholdUtilTest, GetWallet) {
   // no wallet
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
       .WillByDefault(testing::Return(""));
   auto result = mock_ledger_impl_.get()->uphold()->GetWallet();
   ASSERT_TRUE(!result);
 
-  const std::string wallet = R"({
+  const std::string wallet = FakeEncryption::Base64EncryptString(R"({
     "account_url":"https://wallet-sandbox.uphold.com/dashboard",
     "add_url":"https://wallet-sandbox.uphold.com/dashboard/cards/asadasdasd/add",
     "address":"2323dff2ba-d0d1-4dfw-8e56-a2605bcaf4af",
@@ -197,9 +197,9 @@ TEST_F(UpholdUtilTest, GetWallet) {
     "verify_url":"",
     "withdraw_url":
       "https://wallet-sandbox.uphold.com/dashboard/cards/asadasdasd/use"
-  })";
+  })");
 
-  ON_CALL(*mock_ledger_client_, GetEncryptedStringState(state::kWalletUphold))
+  ON_CALL(*mock_ledger_client_, GetStringState(state::kWalletUphold))
       .WillByDefault(testing::Return(wallet));
 
   // uphold wallet

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet.h
@@ -49,7 +49,7 @@ class Wallet {
 
   void DisconnectAllWallets(ledger::ResultCallback callback);
 
-  type::BraveWalletPtr GetWallet();
+  type::BraveWalletPtr GetWallet(bool create = false);
 
   bool SetWallet(type::BraveWalletPtr wallet);
 
@@ -70,4 +70,5 @@ class Wallet {
 
 }  // namespace wallet
 }  // namespace ledger
+
 #endif  // BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_WALLET_WALLET_H_

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_unittest.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ledger/internal/wallet/wallet.h"
+
+#include <vector>
+
+#include "bat/ledger/internal/core/bat_ledger_test.h"
+#include "bat/ledger/internal/ledger_impl.h"
+#include "bat/ledger/internal/state/state_keys.h"
+
+namespace ledger {
+
+class WalletTest : public BATLedgerTest {};
+
+TEST_F(WalletTest, GetWallet) {
+  auto* ledger = GetLedgerImpl();
+
+  // A wallet is created if none exists
+  ledger->state()->SetEncryptedString(state::kWalletBrave, "");
+  auto wallet = ledger->wallet()->GetWallet(true);
+  ASSERT_TRUE(wallet);
+  EXPECT_TRUE(wallet->payment_id.empty());
+  EXPECT_TRUE(!wallet->recovery_seed.empty());
+
+  // The created wallet is saved
+  std::vector<uint8_t> recovery_seed = wallet->recovery_seed;
+  wallet = ledger->wallet()->GetWallet(true);
+  ASSERT_TRUE(wallet);
+  EXPECT_EQ(wallet->recovery_seed, recovery_seed);
+
+  // Corrupted wallet data is not overwritten
+  ledger->state()->SetEncryptedString(state::kWalletBrave, "BAD-DATA");
+  wallet = ledger->wallet()->GetWallet(true);
+  ASSERT_FALSE(wallet);
+}
+
+TEST_F(WalletTest, CreateWallet) {
+  auto* ledger = GetLedgerImpl();
+
+  ledger->state()->SetEncryptedString(state::kWalletBrave, "BAD-DATA");
+
+  mojom::Result result;
+  ledger->wallet()->CreateWalletIfNecessary(
+      [&result](mojom::Result r) mutable { result = r; });
+
+  // Corrupted wallet data is not overwritten with a new wallet
+  EXPECT_EQ(result, mojom::Result::LEDGER_ERROR);
+  EXPECT_EQ(ledger->state()->GetEncryptedString(state::kWalletBrave),
+            "BAD-DATA");
+}
+
+}  // namespace ledger

--- a/vendor/bat-native-ledger/test/BUILD.gn
+++ b/vendor/bat-native-ledger/test/BUILD.gn
@@ -111,6 +111,7 @@ source_set("bat_native_ledger_tests") {
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/publisher/publisher_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/uphold/uphold_util_unittest.cc",
+    "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/wallet/wallet_utils_unittest.cc",
   ]
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16373

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Scenario: App loses access to system password store

- Given that the user has opted in to Rewards and created a rewards wallet
- When the app loses access to the operating system's "keychain"
- Then the existing wallet data is not overwritten
- And an error indicating decryption failure is written to the Rewards error log.

### Scenario: Rewards wallet data is corrupted

- Given that the user has opted in to Rewards and created a rewards wallet
- When the `brave.rewards.wallets.brave` preferences is corrupted
- Then the existing wallet data is not overwritten
- And an error indicating the read failure is written to the Rewards error log

#### Possible test steps:

- Open the browser with a clean profile on staging.
- Open the rewards panel and click "Start using Brave Rewards" to generate a rewards wallet.
- Accept the UGP grant.
- Close the browser.
- Remove the browser's access to the system password store.
  - On MacOS, this can be accomplished by opening the "Keychain Access" app and removing the app from the access list for "Brave Safe Storage".
- Start the browser and deny the app's request to access the system password store.
- Navigate to `brave://rewards`
- Attempt to toggle the Ads enabled setting (previously, this would generate a new rewards wallet).
- Navigate to `brave://rewards-internals` and view the logs.
  - Verify that a "Decryption failed" message has been logged.
- Restart the browser, and grant access to the system password store.
  - Verify that Rewards functionality works (i.e. that the user can tip).