### PR TITLE
Set proper DDG config as a default alternate SE except QWANT region in Tor (uplift to 1.28.x)

### DIFF
--- a/browser/search_engines/tor_window_search_engine_provider_service.cc
+++ b/browser/search_engines/tor_window_search_engine_provider_service.cc
@@ -9,6 +9,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "components/prefs/pref_service.h"
 #include "components/search_engines/search_engines_pref_names.h"
+#include "components/search_engines/template_url_data_util.h"
 #include "components/search_engines/template_url_prepopulate_data.h"
 #include "components/search_engines/template_url_service.h"
 
@@ -54,26 +55,14 @@ void TorWindowSearchEngineProviderService::OnTemplateURLServiceChanged() {
 std::unique_ptr<TemplateURLData>
 TorWindowSearchEngineProviderService::GetInitialSearchEngineProvider(
     PrefService* prefs) const {
-  std::unique_ptr<TemplateURLData> provider_data;
-
-  int initial_id = TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
-                       otr_profile_->GetPrefs())
-                       ->prepopulate_id;
-  switch (initial_id) {
-    case TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT:
-    case TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO:
-    case TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO_DE:
-    case TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO_AU_NZ_IE:
-      break;
-
-    default:
-      initial_id =
-          TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_DUCKDUCKGO;
-      break;
+  std::unique_ptr<TemplateURLData> provider_data =
+      TemplateURLPrepopulateData::GetPrepopulatedDefaultSearch(
+          otr_profile_->GetPrefs());
+  if (provider_data->prepopulate_id ==
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_QWANT) {
+    return provider_data;
   }
-  provider_data =
-      TemplateURLPrepopulateData::GetPrepopulatedEngine(prefs, initial_id);
 
-  DCHECK(provider_data);
-  return provider_data;
+  return TemplateURLDataFromPrepopulatedEngine(
+      TemplateURLPrepopulateData::duckduckgo);
 }


### PR DESCRIPTION
Uplift of #9486
fix https://github.com/brave/brave-browser/issues/16950

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.