### PR TITLE
Decrease download shelf height and show origin url on hover

### DIFF
--- a/browser/ui/views/download/brave_download_item_view.cc
+++ b/browser/ui/views/download/brave_download_item_view.cc
@@ -43,10 +43,10 @@ constexpr int kProgressTextPadding = 8;
 constexpr int kProgressIndicatorSize = 25;
 
 // The minimum vertical padding above and below contents of the download item.
-constexpr int kMinimumVerticalPadding = 6;
+constexpr int kMinimumVerticalPadding = 2;
 
 // The normal height of the item which may be exceeded if text is large.
-constexpr int kDefaultHeight = 65;
+constexpr int kDefaultHeight = 48;
 
 // Lock icon color.
 constexpr SkColor kDownloadUnlockIconColor = SkColorSetRGB(0xC6, 0x36, 0x26);
@@ -62,7 +62,8 @@ BraveDownloadItemView::BraveDownloadItemView(
     views::View* accessible_alert)
     : DownloadItemView(std::move(download), parent, accessible_alert),
       brave_model_(model_.get()),
-      is_origin_url_secure_(false) {
+      is_origin_url_secure_(false),
+      is_origin_url_visible_(false) {
   // Prepare origin url font.
   ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
   origin_url_font_list_ =
@@ -75,11 +76,6 @@ BraveDownloadItemView::~BraveDownloadItemView() {}
 
 void BraveDownloadItemView::Layout() {
   DownloadItemView::Layout();
-  // Adjust the position of the status text label.
-  if (!IsShowingWarningDialog()) {
-    file_name_label_->SetY(GetYForFilenameText());
-    status_label_->SetY(GetYForStatusText());
-  }
 }
 
 gfx::Size BraveDownloadItemView::CalculatePreferredSize() const {
@@ -101,7 +97,9 @@ gfx::Size BraveDownloadItemView::CalculatePreferredSize() const {
 
 void BraveDownloadItemView::OnPaint(gfx::Canvas* canvas) {
   DownloadItemView::OnPaint(canvas);
-  DrawOriginURL(canvas);
+  if (is_origin_url_visible_)
+    DrawOriginURL(canvas);
+  file_name_label_->SetVisible(!is_origin_url_visible_);
 }
 
 // download::DownloadItem::Observer overrides.
@@ -163,7 +161,7 @@ int BraveDownloadItemView::GetYForFilenameText() const {
 
 int BraveDownloadItemView::GetYForOriginURLText() const {
   int y = GetYForFilenameText();
-  y += (file_name_label_->GetLineHeight() + kBraveVerticalTextPadding);
+  y = file_name_label_->y() + kBraveVerticalTextPadding;
   return y;
 }
 
@@ -236,4 +234,20 @@ void BraveDownloadItemView::SetMode(download::DownloadItemMode mode) {
     extra += char16_t(' ') + origin_url_text_;
     accessible_name_ += extra;
   }
+}
+
+void BraveDownloadItemView::OnMouseEntered(const ui::MouseEvent& event) {
+  is_origin_url_visible_ = true;
+}
+
+void BraveDownloadItemView::OnMouseExited(const ui::MouseEvent& event) {
+  is_origin_url_visible_ = false;
+}
+
+void BraveDownloadItemView::OnViewFocused(View* observed_view) {
+  is_origin_url_visible_ = true;
+}
+
+void BraveDownloadItemView::OnViewBlurred(View* observed_view) {
+  is_origin_url_visible_ = false;
 }

--- a/browser/ui/views/download/brave_download_item_view.h
+++ b/browser/ui/views/download/brave_download_item_view.h
@@ -34,7 +34,7 @@ class BraveDownloadItemView : public DownloadItemView {
   static constexpr int kOriginURLIconRightPadding = 2;
 
   // Vertical padding between text lines.
-  static constexpr int kBraveVerticalTextPadding = 3;
+  static constexpr int kBraveVerticalTextPadding = 2;
 
   // These functions calculate the vertical coordinates for each text line.
   int GetYForFilenameText() const;
@@ -50,6 +50,10 @@ class BraveDownloadItemView : public DownloadItemView {
 
   // Overrides the accessible name construction to reflect the origin URL.
   void SetMode(download::DownloadItemMode mode) override;
+  void OnMouseEntered(const ui::MouseEvent& event) override;
+  void OnMouseExited(const ui::MouseEvent& event) override;
+  void OnViewFocused(View* observed_view) override;
+  void OnViewBlurred(View* observed_view) override;
 
   // Brave download item model.
   BraveDownloadItemModel brave_model_;
@@ -60,6 +64,7 @@ class BraveDownloadItemView : public DownloadItemView {
   // Origin url text.
   std::u16string origin_url_text_;
   bool is_origin_url_secure_;
+  bool is_origin_url_visible_;
 
   DISALLOW_COPY_AND_ASSIGN(BraveDownloadItemView);
 };

--- a/chromium_src/chrome/browser/ui/views/download/download_item_view.cc
+++ b/chromium_src/chrome/browser/ui/views/download/download_item_view.cc
@@ -3,7 +3,37 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "chrome/browser/ui/views/download/download_item_view.h"
+
+namespace views {
+namespace {
+class DownloadItemViewButton : public Button {
+ public:
+  using Button::Button;
+
+  void OnMouseEntered(const ui::MouseEvent& event) override {
+    parent()->OnMouseEntered(event);
+  }
+  void OnMouseExited(const ui::MouseEvent& event) override {
+    parent()->OnMouseExited(event);
+  }
+  void OnViewFocused(View* observed_view) override {
+    auto* item = static_cast<DownloadItemView*>(parent());
+    item->OnViewFocused(observed_view);
+  }
+  void OnViewBlurred(View* observed_view) override {
+    auto* item = static_cast<DownloadItemView*>(parent());
+    item->OnViewBlurred(observed_view);
+  }
+};
+
+}  // namespace
+
+}  // namespace views
+
+#define Button DownloadItemViewButton
 #include "../../../../../../../chrome/browser/ui/views/download/download_item_view.cc"
+#undef Button
 
 bool DownloadItemView::IsShowingWarningDialog() const {
   return has_warning_label(mode_);


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
This decreases the whole download shelf height and hides the origin url by default. The origin url is only visible on hover and on tab focus.

`TransparentButton` is overlaid on top of DownloadItemView and the static cast is needed to access specific events such as: `OnViewFocused` and `OnViewBlurred` which isn't part of `parent()`View itself. It's part of ViewObserver class.

Here is the definition of TransparentButton: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/download/download_item_view.cc;l=146

Resolves https://github.com/brave/brave-browser/issues/1638

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

