### PR TITLE
Fixes still shows 7-day Ads History in popup linked from 30-day Ads History on brave://rewards - 1.28.x

### DIFF
--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -312,7 +312,7 @@ class RewardsDOMHandler : public WebUIMessageHandler,
 
 namespace {
 
-const int kDaysOfAdsHistory = 7;
+const int kDaysOfAdsHistory = 30;
 
 const char kShouldAllowAdsSubdivisionTargeting[] =
     "shouldAllowAdsSubdivisionTargeting";

--- a/components/brave_rewards/resources/page/components/adsBox.tsx
+++ b/components/brave_rewards/resources/page/components/adsBox.tsx
@@ -484,7 +484,7 @@ class AdsBox extends React.Component<Props, State> {
               adsPerHour={adsPerHour}
               rows={rows}
               hasSavedEntries={this.hasSavedEntries(rows)}
-              totalDays={7}
+              totalDays={30}
           />
           : null
         }

--- a/components/brave_rewards/resources/ui/stories/modal.tsx
+++ b/components/brave_rewards/resources/ui/stories/modal.tsx
@@ -505,7 +505,7 @@ storiesOf('Rewards/Modal', module)
         rows={rows}
         adsPerHour={adsPerHour}
         hasSavedEntries={true}
-        totalDays={7}
+        totalDays={30}
       />
     )
   })


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9513
Resolves https://github.com/brave/brave-browser/issues/17063

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
