### PR TITLE
Fixes brave://rewards ads per hour setting should not change to 0 after upgrade - 1.28.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1444,7 +1444,8 @@ bool AdsServiceImpl::MigratePrefs(const int source_version,
       {{6, 7}, &AdsServiceImpl::MigratePrefsVersion6To7},
       {{7, 8}, &AdsServiceImpl::MigratePrefsVersion7To8},
       {{8, 9}, &AdsServiceImpl::MigratePrefsVersion8To9},
-      {{9, 10}, &AdsServiceImpl::MigratePrefsVersion9To10}};
+      {{9, 10}, &AdsServiceImpl::MigratePrefsVersion9To10},
+      {{10, 11}, &AdsServiceImpl::MigratePrefsVersion10To11}};
 
   // Cycle through migration paths, i.e. if upgrading from version 2 to 5 we
   // should migrate version 2 to 3, then 3 to 4 and finally version 4 to 5
@@ -1653,18 +1654,30 @@ void AdsServiceImpl::MigratePrefsVersion8To9() {
 }
 
 void AdsServiceImpl::MigratePrefsVersion9To10() {
+  if (!PrefExists(ads::prefs::kAdsPerHour)) {
+    return;
+  }
+
   const int64_t ads_per_hour = GetInt64Pref(ads::prefs::kAdsPerHour);
-  if (ads_per_hour == -1) {
-    // Default value
+  if (ads_per_hour == -1 || ads_per_hour == 2) {
+    // The user did not change the ads per hour setting from the legacy default
+    // value of 2 so we should clear the preference to transition to
+    // |kDefaultAdNotificationsPerHour|
+    profile_->GetPrefs()->ClearPref(ads::prefs::kAdsPerHour);
+  }
+}
+
+void AdsServiceImpl::MigratePrefsVersion10To11() {
+  if (!PrefExists(ads::prefs::kAdsPerHour)) {
     return;
   }
 
-  if (ads_per_hour != 2) {
-    // User changed ads per day from the legacy default value
-    return;
+  const int64_t ads_per_hour = GetInt64Pref(ads::prefs::kAdsPerHour);
+  if (ads_per_hour == 0 || ads_per_hour == -1) {
+    // Clear the ads per hour preference to transition to
+    // |kDefaultAdNotificationsPerHour|
+    profile_->GetPrefs()->ClearPref(ads::prefs::kAdsPerHour);
   }
-
-  SetInt64Pref(ads::prefs::kAdsPerHour, -1);
 }
 
 bool AdsServiceImpl::IsUpgradingFromPreBraveAdsBuild() {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -306,6 +306,7 @@ class AdsServiceImpl : public AdsService,
   void MigratePrefsVersion7To8();
   void MigratePrefsVersion8To9();
   void MigratePrefsVersion9To10();
+  void MigratePrefsVersion10To11();
 
   bool IsUpgradingFromPreBraveAdsBuild();
 

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -39,7 +39,7 @@ const char kAdNotificationLastScreenPositionY[] =
 // Stores the preferences version number
 const char kVersion[] = "brave.brave_ads.prefs.version";
 
-const int kCurrentVersionNumber = 10;
+const int kCurrentVersionNumber = 11;
 
 }  // namespace prefs
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9555
Resolves https://github.com/brave/brave-browser/issues/17155

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.