### PR TITLE
Fixes brave://rewards ads per hour setting should not change to 0 after upgrade - 1.27.x

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -302,6 +302,7 @@ class AdsServiceImpl : public AdsService,
   void MigratePrefsVersion7To8();
   void MigratePrefsVersion8To9();
   void MigratePrefsVersion9To10();
+  void MigratePrefsVersion10To11();
 
   bool IsUpgradingFromPreBraveAdsBuild();
 

--- a/components/brave_ads/common/pref_names.cc
+++ b/components/brave_ads/common/pref_names.cc
@@ -39,7 +39,7 @@ const char kAdNotificationLastScreenPositionY[] =
 // Stores the preferences version number
 const char kVersion[] = "brave.brave_ads.prefs.version";
 
-const int kCurrentVersionNumber = 10;
+const int kCurrentVersionNumber = 11;
 
 }  // namespace prefs
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9555
Resolves https://github.com/brave/brave-browser/issues/17155

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.