### PR TITLE
Fix child process monitor crash

### DIFF
--- a/components/child_process_monitor/child_process_monitor.cc
+++ b/components/child_process_monitor/child_process_monitor.cc
@@ -93,6 +93,7 @@ void TearDownPipeHack() {
 void MonitorChild(base::ProcessHandle p_handle,
                   base::OnceCallback<void(base::ProcessId)> callback) {
   DCHECK(callback);
+  base::ProcessId child_pid = base::GetProcId(p_handle);
 #if defined(OS_POSIX)
   char buf[PIPE_BUF];
 
@@ -101,7 +102,7 @@ void MonitorChild(base::ProcessHandle p_handle,
       pid_t pid;
       int status;
 
-      if ((pid = waitpid(base::GetProcId(p_handle), &status, WNOHANG)) != -1) {
+      if ((pid = waitpid(child_pid, &status, WNOHANG)) != -1) {
         if (WIFSIGNALED(status)) {
           VLOG(0) << "child(" << pid << ") got terminated by signal "
                   << WTERMSIG(status);
@@ -121,7 +122,7 @@ void MonitorChild(base::ProcessHandle p_handle,
   }
 #elif defined(OS_WIN)
   WaitForSingleObject(p_handle, INFINITE);
-  std::move(callback).Run(base::GetProcId(p_handle));
+  std::move(callback).Run(child_pid);
 #else
 #error unsupported platforms
 #endif

--- a/components/services/tor/tor_launcher_impl.cc
+++ b/components/services/tor/tor_launcher_impl.cc
@@ -29,6 +29,8 @@ void TorLauncherImpl::Cleanup() {
     return;
   in_shutdown_ = true;
 
+  // Delete watch folder every time that Tor is terminated
+  base::DeletePathRecursively(tor_watch_path_);
   child_monitor_.reset();
 }
 
@@ -67,20 +69,20 @@ void TorLauncherImpl::Launch(mojom::TorConfigPtr config,
   }
   args.AppendArg("--__OwningControllerProcess");
   args.AppendArg(base::NumberToString(base::Process::Current().Pid()));
-  base::FilePath tor_watch_path = config->tor_watch_path;
-  if (!tor_watch_path.empty()) {
-    if (!base::DirectoryExists(tor_watch_path))
-      base::CreateDirectory(tor_watch_path);
+  tor_watch_path_ = config->tor_watch_path;
+  if (!tor_watch_path_.empty()) {
+    if (!base::DirectoryExists(tor_watch_path_))
+      base::CreateDirectory(tor_watch_path_);
     args.AppendArg("--pidfile");
-    args.AppendArgPath(tor_watch_path.AppendASCII("tor.pid"));
+    args.AppendArgPath(tor_watch_path_.AppendASCII("tor.pid"));
     args.AppendArg("--controlport");
     args.AppendArg("auto");
     args.AppendArg("--controlportwritetofile");
-    args.AppendArgPath(tor_watch_path.AppendASCII("controlport"));
+    args.AppendArgPath(tor_watch_path_.AppendASCII("controlport"));
     args.AppendArg("--cookieauthentication");
     args.AppendArg("1");
     args.AppendArg("--cookieauthfile");
-    args.AppendArgPath(tor_watch_path.AppendASCII("control_auth_cookie"));
+    args.AppendArgPath(tor_watch_path_.AppendASCII("control_auth_cookie"));
   }
 
   base::LaunchOptions launchopts;

--- a/components/services/tor/tor_launcher_impl.h
+++ b/components/services/tor/tor_launcher_impl.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/files/file_path.h"
 #include "base/memory/weak_ptr.h"
 #include "base/process/process.h"
 #include "base/sequence_checker.h"
@@ -39,6 +40,7 @@ class TorLauncherImpl : public tor::mojom::TorLauncher {
   std::unique_ptr<brave::ChildProcessMonitor> child_monitor_;
   mojo::Receiver<tor::mojom::TorLauncher> receiver_;
   bool in_shutdown_ = false;
+  base::FilePath tor_watch_path_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16068
Resolves https://github.com/brave/brave-browser/issues/16924

This PR 
1. Fixes crash of getting pid from invalid process handle on Windows
2. Prevents redundant relaunch when Tor process is killed (it should only be one relaunch)
3. Delete tor watch folder when Tor process is no longer alive to gives next launch a fresh state
3.1. before this fix, users often get stuck into disconnected state, caused by tor state (Tor data dir) or cookie auth failed (Wrong cookie in Tor watch dir)
3.2 This is meant to fix the later

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Launch Brave and open Tor window
2. Kill tor process `tor-[VERSION]-[PLATFORM]-brave-0`
3. A new tor process should be relaunch once
4. Wait for Tor window connected to Tor network
5. Visit https://check.torproject.org/ in Tor window and we should be on Tor network
6. Visit `about:crashes` on regular window, there should be no new crash report
7. Close Tor window
8. Go to `[User Data Dir]/tor`, `watch` folder should be deleted when there is no Tor process running
