### PR TITLE
'Start video call' -->  'Start call' on Brave Talk widget

### DIFF
--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -1017,7 +1017,7 @@
       <message name="IDS_REWARDS_WIDGET_START_USING" desc="">Start using Brave Rewards</message>
       <message name="IDS_TOGETHER_WIDGET_TITLE" desc="">Brave Talk</message>
       <message name="IDS_TOGETHER_WIDGET_WELCOME_TITLE" desc="">Start a private video call with your friends and colleagues.</message>
-      <message name="IDS_TOGETHER_WIDGET_START_BUTTON" desc="">Start video call</message>
+      <message name="IDS_TOGETHER_WIDGET_START_BUTTON" desc="">Start call</message>
       <message name="IDS_TOGETHER_WIDGET_ABOUT_DATA" desc="">About your data</message>
       <message name="IDS_BINANCE_WIDGET_BUY" desc="">Buy</message>
       <message name="IDS_BINANCE_WIDGET_BUY_CRYPTO" desc="">Buy Crypto</message>


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/17250