### PR TITLE
Add stub brave vpn button to toolbar

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1319,6 +1319,10 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
           Bookmark All Tabs...
         </message>
       </if>
+      <!-- Brave VPN -->
+      <message name="IDS_BRAVE_VPN_TOOLBAR_BUTTON_TEXT" desc="Text for vpn button in toolbar.">
+        VPN
+      </message>
       <message name="IDS_BRAVE_BOOKMARK_MANAGER_EMPTY_LIST" desc="">
         To add a bookmark, click the bookmark button next to the address bar
       </message>

--- a/app/vector_icons/BUILD.gn
+++ b/app/vector_icons/BUILD.gn
@@ -18,6 +18,7 @@ aggregate_vector_icons("brave_vector_icons") {
     "download_unlock.icon",
     "open_in_ipfs.icon",
     "open_in_tor.icon",
+    "vpn_indicator.icon",
   ]
 
   if (enable_sidebar) {

--- a/app/vector_icons/vpn_indicator.icon
+++ b/app/vector_icons/vpn_indicator.icon
@@ -1,0 +1,8 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+CANVAS_DIMENSIONS, 6,
+NEW_PATH,
+CIRCLE, 3, 3, 3

--- a/browser/themes/BUILD.gn
+++ b/browser/themes/BUILD.gn
@@ -30,6 +30,7 @@ source_set("themes") {
     }
 
     deps += [
+      "//brave/components/brave_vpn/buildflags",
       "//brave/components/sidebar/buildflags",
       "//brave/components/speedreader:buildflags",
       "//chrome/browser:theme_properties",

--- a/browser/themes/theme_properties.cc
+++ b/browser/themes/theme_properties.cc
@@ -88,6 +88,14 @@ absl::optional<SkColor> MaybeGetDefaultColorForBraveLightUi(int id) {
     case BraveThemeProperties::COLOR_SPEEDREADER_TOGGLE_TRACK:
       return SkColorSetRGB(0xE1, 0xE2, 0xF6);
 #endif
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+    case BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_BORDER:
+      return SkColorSetRGB(0xE1, 0xE1, 0xE1);
+    case BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_TEXT_CONNECTED:
+      return SkColorSetRGB(0x21, 0x25, 0x29);
+    case BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_TEXT_DISCONNECTED:
+      return SkColorSetRGB(0x86, 0x8E, 0x96);
+#endif
     case BraveThemeProperties::COLOR_FOR_TEST:
       return BraveThemeProperties::kLightColorForTest;
     default:
@@ -174,6 +182,13 @@ absl::optional<SkColor> MaybeGetDefaultColorForBraveDarkUi(int id) {
       return SkColorSetRGB(0x44, 0x36, 0xE1);
     case BraveThemeProperties::COLOR_SPEEDREADER_TOGGLE_TRACK:
       return SkColorSetRGB(0x76, 0x79, 0xB1);
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+    case BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_BORDER:
+      return SkColorSetRGB(0x5E, 0x61, 0x75);
+    case BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_TEXT_CONNECTED:
+    case BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_TEXT_DISCONNECTED:
+      return SkColorSetRGB(0xF0, 0xF2, 0xFF);
 #endif
     case BraveThemeProperties::COLOR_FOR_TEST:
       return BraveThemeProperties::kDarkColorForTest;

--- a/browser/themes/theme_properties.h
+++ b/browser/themes/theme_properties.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_THEMES_THEME_PROPERTIES_H_
 
 #include "brave/browser/themes/brave_dark_mode_utils.h"
+#include "brave/components/brave_vpn/buildflags/buildflags.h"
 #include "brave/components/sidebar/buildflags/buildflags.h"
 #include "brave/components/speedreader/buildflags.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -48,6 +49,11 @@ enum ThemeProperties {
   COLOR_SPEEDREADER_ICON,
   COLOR_SPEEDREADER_TOGGLE_TRACK,
   COLOR_SPEEDREADER_TOGGLE_THUMB,
+#endif
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  COLOR_BRAVE_VPN_BUTTON_BORDER,
+  COLOR_BRAVE_VPN_BUTTON_TEXT_CONNECTED,
+  COLOR_BRAVE_VPN_BUTTON_TEXT_DISCONNECTED,
 #endif
   BRAVE_THEME_PROPERTIES_LAST = COLOR_SIDEBAR_SEPARATOR,
 };

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1,6 +1,7 @@
 import("//brave/browser/ethereum_remote_client/buildflags/buildflags.gni")
 import("//brave/browser/translate/buildflags/buildflags.gni")
 import("//brave/build/config.gni")
+import("//brave/components/brave_vpn/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/decentralized_dns/buildflags/buildflags.gni")
@@ -253,6 +254,7 @@ source_set("ui") {
     "//brave/components/brave_rewards/resources:page_generated_resources",
     "//brave/components/brave_rewards/resources:tip_generated_resources",
     "//brave/components/brave_shields/browser",
+    "//brave/components/brave_vpn/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/brave_wayback_machine:buildflags",
     "//brave/components/cosmetic_filters/resources/data:generated_resources",
@@ -466,6 +468,14 @@ source_set("ui") {
       "//extensions/common:common_constants",
       "//ui/base/dragdrop:types",
     ]
+  }
+
+  if (enable_brave_vpn && toolkit_views) {
+    sources += [
+      "views/toolbar/brave_vpn_button.cc",
+      "views/toolbar/brave_vpn_button.h",
+    ]
+    deps += [ "//brave/components/brave_vpn" ]
   }
 
   if (is_win && is_official_build) {

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -13,6 +13,7 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/common/pref_names.h"
+#include "brave/components/brave_vpn/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/browser_process.h"
@@ -31,6 +32,11 @@
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
 #include "brave/browser/ui/views/toolbar/wallet_button.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#include "brave/browser/ui/views/toolbar/brave_vpn_button.h"
+#include "brave/components/brave_vpn/brave_vpn_utils.h"
 #endif
 
 namespace {
@@ -159,6 +165,13 @@ void BraveToolbarView::Init() {
   if (wallet_) {
     AddChildViewAt(wallet_, GetIndexOf(GetAppMenuButton()) - 1);
     wallet_->UpdateImageAndText();
+  }
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  if (brave_vpn::IsBraveVPNEnabled()) {
+    AddChildViewAt(std::make_unique<BraveVPNButton>(),
+                   GetIndexOf(GetAppMenuButton()) - 1);
   }
 #endif
 

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -1,0 +1,121 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/toolbar/brave_vpn_button.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/notreached.h"
+#include "brave/app/vector_icons/vector_icons.h"
+#include "brave/browser/themes/theme_properties.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_ink_drop_util.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/gfx/paint_vector_icon.h"
+#include "ui/gfx/rrect_f.h"
+#include "ui/gfx/skia_util.h"
+#include "ui/views/background.h"
+#include "ui/views/border.h"
+#include "ui/views/controls/highlight_path_generator.h"
+
+namespace {
+
+constexpr int kButtonRadius = 47;
+
+class BraveVPNButtonHighlightPathGenerator
+    : public views::HighlightPathGenerator {
+ public:
+  explicit BraveVPNButtonHighlightPathGenerator(const gfx::Insets& insets)
+      : HighlightPathGenerator(insets) {}
+
+  BraveVPNButtonHighlightPathGenerator(
+      const BraveVPNButtonHighlightPathGenerator&) = delete;
+  BraveVPNButtonHighlightPathGenerator& operator=(
+      const BraveVPNButtonHighlightPathGenerator&) = delete;
+
+  // views::HighlightPathGenerator overrides:
+  absl::optional<gfx::RRectF> GetRoundRect(const gfx::RectF& rect) override {
+    return gfx::RRectF(rect, kButtonRadius);
+  }
+};
+
+}  // namespace
+
+BraveVPNButton::BraveVPNButton()
+    : ToolbarButton(base::BindRepeating(&BraveVPNButton::OnButtonPressed,
+                                        base::Unretained(this))) {
+  // Replace ToolbarButton's highlight path generator.
+  views::HighlightPathGenerator::Install(
+      this, std::make_unique<BraveVPNButtonHighlightPathGenerator>(
+                GetToolbarInkDropInsets(this)));
+
+  label()->SetText(
+      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_TOOLBAR_BUTTON_TEXT));
+  gfx::FontList font_list = views::Label::GetDefaultFontList();
+  constexpr int kFontSize = 12;
+  label()->SetFontList(
+      font_list.DeriveWithSizeDelta(kFontSize - font_list.GetFontSize()));
+
+  // Set image positions first. then label.
+  SetHorizontalAlignment(gfx::ALIGN_LEFT);
+
+  UpdateButtonState();
+}
+
+void BraveVPNButton::UpdateColorsAndInsets() {
+  if (const auto* tp = GetThemeProvider()) {
+    const gfx::Insets paint_insets =
+        gfx::Insets((height() - GetLayoutConstant(LOCATION_BAR_HEIGHT)) / 2);
+    SetBackground(views::CreateBackgroundFromPainter(
+        views::Painter::CreateSolidRoundRectPainter(
+            tp->GetColor(ThemeProperties::COLOR_TOOLBAR), kButtonRadius,
+            paint_insets)));
+
+    SetEnabledTextColors(tp->GetColor(
+        IsConnected()
+            ? BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_TEXT_CONNECTED
+            : BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_TEXT_DISCONNECTED));
+
+    std::unique_ptr<views::Border> border = views::CreateRoundedRectBorder(
+        1, kButtonRadius, gfx::Insets(),
+        tp->GetColor(BraveThemeProperties::COLOR_BRAVE_VPN_BUTTON_BORDER));
+    constexpr gfx::Insets kTargetInsets{4, 6};
+    const gfx::Insets extra_insets = kTargetInsets - border->GetInsets();
+    SetBorder(views::CreatePaddedBorder(std::move(border), extra_insets));
+  }
+
+  constexpr int kBraveAvatarImageLabelSpacing = 4;
+  SetImageLabelSpacing(kBraveAvatarImageLabelSpacing);
+}
+
+void BraveVPNButton::UpdateButtonState() {
+  constexpr SkColor kColorConnected = SkColorSetRGB(0x51, 0xCF, 0x66);
+  constexpr SkColor kColorDisconnected = SkColorSetRGB(0xAE, 0xB1, 0xC2);
+  SetImage(views::Button::STATE_NORMAL,
+           gfx::CreateVectorIcon(kVpnIndicatorIcon, IsConnected()
+                                                        ? kColorConnected
+                                                        : kColorDisconnected));
+}
+
+bool BraveVPNButton::IsConnected() {
+  // TODO(simonhong): Get connection status when service is ready to use.
+  NOTIMPLEMENTED();
+  return true;
+}
+
+void BraveVPNButton::OnButtonPressed(const ui::Event& event) {
+  ShowBraveVPNPanel();
+}
+
+void BraveVPNButton::ShowBraveVPNPanel() {
+  NOTIMPLEMENTED();
+}
+
+BEGIN_METADATA(BraveVPNButton, LabelButton)
+END_METADATA

--- a/browser/ui/views/toolbar/brave_vpn_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_button.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_
+#define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_
+
+#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+
+class BraveVPNButton : public ToolbarButton {
+ public:
+  METADATA_HEADER(BraveVPNButton);
+
+  BraveVPNButton();
+  ~BraveVPNButton() override = default;
+
+  BraveVPNButton(const BraveVPNButton&) = delete;
+  BraveVPNButton& operator=(const BraveVPNButton&) = delete;
+
+ private:
+  void UpdateColorsAndInsets() override;
+
+  // Update button based on connection state.
+  void UpdateButtonState();
+  bool IsConnected();
+
+  void OnButtonPressed(const ui::Event& event);
+  void ShowBraveVPNPanel();
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_

--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -13,6 +13,8 @@ static_library("brave_vpn") {
     "brave_vpn_connection_manager.h",
     "brave_vpn_service.cc",
     "brave_vpn_service.h",
+    "brave_vpn_utils.cc",
+    "brave_vpn_utils.h",
     "features.cc",
     "features.h",
   ]

--- a/components/brave_vpn/brave_vpn_utils.cc
+++ b/components/brave_vpn/brave_vpn_utils.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/brave_vpn_utils.h"
+
+#include "base/feature_list.h"
+#include "brave/components/brave_vpn/features.h"
+
+namespace brave_vpn {
+
+bool IsBraveVPNEnabled() {
+  return base::FeatureList::IsEnabled(brave_vpn::kBraveVPNFeature);
+}
+
+}  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_utils.h
+++ b/components/brave_vpn/brave_vpn_utils.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_UTILS_H_
+
+namespace brave_vpn {
+
+bool IsBraveVPNEnabled();
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_UTILS_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
fix brave/brave-browser#17235

Note: BraveVPN feature is disabled by default.
To enable, pass `--enable-features=BraveVPN` command line options.

![Screenshot 2021-08-03 110025](https://user-images.githubusercontent.com/6786187/127946212-4a91efb1-6c12-40b4-8c9f-4f0913f26b40.png)
![Screenshot 2021-08-03 110051](https://user-images.githubusercontent.com/6786187/127946213-2e95331a-212c-4c5e-8e41-834dac13257e.png)
![Screenshot 2021-08-04 010159](https://user-images.githubusercontent.com/6786187/128105341-f6291e94-fc61-4cd2-98bf-4231fff897ae.png)
![Screenshot 2021-08-03 234147](https://user-images.githubusercontent.com/6786187/128099997-1b610cd4-6cf4-4fc3-920f-6b5dc8f94e57.png)

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
