### PR TITLE
Check for invalid iterator during leave sync chain

### DIFF
--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.h
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.h
@@ -16,6 +16,10 @@
   GetAllBraveDeviceInfo() const override;                                    \
   void ForcePulseForTest
 
+#define RefreshLocalDeviceInfoIfNeeded                                     \
+  RefreshLocalDeviceInfoIfNeeded_ChromiumImpl(base::OnceClosure callback); \
+  void RefreshLocalDeviceInfoIfNeeded
+
 // private:
 #define StoreSpecifics                              \
   OnDeviceInfoDeleted(const std::string& client_id, \
@@ -24,6 +28,7 @@
 
 #include "../../../../components/sync_device_info/device_info_sync_bridge.h"
 
+#undef RefreshLocalDeviceInfoIfNeeded
 #undef ForcePulseForTest
 #undef StoreSpecifics
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_SYNC_BRIDGE_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17221

Details of the crash are at https://github.com/brave/brave-browser/issues/17221#issuecomment-891142032 .

This PR introduces a check on iterator before invoke the code where crash may happened.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`

(1 test failed:
    AdNotificationPopupBrowserTest.CheckThemeChanged (../../brave/browser/ui/brave_ads/ad_notfication_popup_browsertest.cc:89)
)

- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Use the one from https://github.com/brave/brave-browser/issues/17221#issuecomment-891142032 
