### PR TITLE
New Tab Page: Brave Talk prompt show and hide spec

### DIFF
--- a/browser/ui/webui/new_tab_page/BUILD.gn
+++ b/browser/ui/webui/new_tab_page/BUILD.gn
@@ -7,10 +7,16 @@ source_set("unit_tests") {
   testonly = true
 
   if (!is_android) {
-    sources = [ "brave_new_tab_ui_unittest.cc" ]
+    sources = [
+      "brave_new_tab_message_handler_unittest.cc",
+      "brave_new_tab_ui_unittest.cc",
+    ]
 
     deps = [
+      "//base",
+      "//base/test:test_support",
       "//brave/browser/ui",
+      "//chrome/browser",
       "//components/history/core/browser",
       "//components/ntp_tiles",
       "//testing/gtest",

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h
@@ -15,6 +15,11 @@
 #include "content/public/browser/web_ui_message_handler.h"
 
 class Profile;
+
+namespace base {
+class Time;
+}  //  namespace base
+
 namespace content {
 class WebUIDataSource;
 }
@@ -35,6 +40,8 @@ class BraveNewTabMessageHandler : public content::WebUIMessageHandler,
 
   static void RegisterLocalStatePrefs(PrefRegistrySimple* local_state);
   static void RecordInitialP3AValues(PrefService* local_state);
+  static bool CanPromptBraveTalk();
+  static bool CanPromptBraveTalk(base::Time now);
   static BraveNewTabMessageHandler* Create(
       content::WebUIDataSource* html_source,
       Profile* profile);

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler_unittest.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler_unittest.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h"
+
+#include "base/test/simple_test_clock.h"
+#include "base/time/time.h"
+#include "chrome/browser/first_run/first_run.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(BraveNewTabMessageHandlerTest, TalkPrompt) {
+  auto* clock = new base::SimpleTestClock();
+  clock->SetNow(first_run::GetFirstRunSentinelCreationTime());
+  EXPECT_EQ(BraveNewTabMessageHandler::CanPromptBraveTalk(clock->Now()), false);
+  clock->Advance(base::TimeDelta::FromDays(2));
+  EXPECT_EQ(BraveNewTabMessageHandler::CanPromptBraveTalk(clock->Now()), false);
+  clock->Advance(base::TimeDelta::FromDays(1));
+  EXPECT_EQ(BraveNewTabMessageHandler::CanPromptBraveTalk(clock->Now()), true);
+}

--- a/components/brave_new_tab_ui/actions/new_tab_actions.ts
+++ b/components/brave_new_tab_ui/actions/new_tab_actions.ts
@@ -20,7 +20,10 @@ export const statsUpdated = (stats: Stats) =>
 
 export const init = createAction<void>('page init')
 
-export const dismissBraveTalkPrompt = createAction('dismiss brave talk prompt')
+export type DismissBraveTalkPromptPayload = {
+  isAutomatic: boolean
+}
+export const dismissBraveTalkPrompt = createAction<DismissBraveTalkPromptPayload>('dismiss brave talk prompt')
 
 export const privateTabDataUpdated = (data: PrivateTabData) =>
   action(types.NEW_TAB_PRIVATE_TAB_DATA_UPDATED, data)

--- a/components/brave_new_tab_ui/components/default/braveTalk/index.tsx
+++ b/components/brave_new_tab_ui/components/default/braveTalk/index.tsx
@@ -88,7 +88,7 @@ class BraveTalk extends React.PureComponent<Props, {}> {
                 <PrivacyLink
                   rel={'noopener'}
                   target={'_blank'}
-                  href={'https://brave.com/privacy/#brave-together-learn'}
+                  href={'https://brave.com/privacy/browser/#brave-talk-learn'}
                 >
                   {getLocale('braveTalkWidgetAboutData')}
                 </PrivacyLink>

--- a/components/brave_new_tab_ui/components/default/footer/braveTalkItem.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/braveTalkItem.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { getLocale } from '../../../../common/locale'
+import VisibilityTimer from '../../../helpers/visibilityTimer'
+import { IconLink } from '..'
+import BraveTalkTooltip from './braveTalkTooltip'
+import BraveTalkIcon from './braveTalkTooltip/braveTalkIcon'
+import { OnDismissBraveTalkPrompt, Props } from './footer'
+
+function BraveTalkTooltipItem (props: Props) {
+  const tooltipRef = React.useRef<HTMLDivElement>(null)
+  // Make callback a ref so that timer callback has access to latest value
+  const handleDismissPromptRef = React.useRef<null | OnDismissBraveTalkPrompt>(null)
+  React.useEffect(() => {
+    handleDismissPromptRef.current = props.onDismissBraveTalkPrompt
+  }, [props.onDismissBraveTalkPrompt])
+  // Set up timer to auto dismiss
+  React.useEffect(() => {
+    if (!tooltipRef.current) {
+      return
+    }
+    const timer = new VisibilityTimer(() => {
+      // Sanity check
+      if (!handleDismissPromptRef.current) {
+        return
+      }
+      handleDismissPromptRef.current({ isAutomatic: true })
+    }, 4000, tooltipRef.current)
+    timer.startTracking()
+    return () => timer.stopTracking()
+  }, [tooltipRef.current])
+  // Regular 'close' handler
+  const handleClose = () => {
+    props.onDismissBraveTalkPrompt({ isAutomatic: false })
+  }
+  return (
+    <BraveTalkTooltip ref={tooltipRef} onClose={handleClose}>
+      <IconLink title={getLocale('braveTalkPromptTitle')} href='https://talk.brave.com/widget'>
+        <BraveTalkIcon />
+      </IconLink>
+    </BraveTalkTooltip>
+  )
+}
+
+export default function BraveTalkItem (props: Props) {
+  if (props.showBraveTalkPrompt) {
+    return <BraveTalkTooltipItem {...props} />
+  }
+  return (
+    <IconLink title={getLocale('braveTalkPromptTitle')} href='https://talk.brave.com/widget'>
+      <BraveTalkIcon />
+    </IconLink>
+  )
+}

--- a/components/brave_new_tab_ui/components/default/footer/braveTalkTooltip/index.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/braveTalkTooltip/index.tsx
@@ -11,13 +11,13 @@ import { LinkButton } from '../../../outlineButton'
 import * as S from './style'
 import { braveTalkWidgetUrl } from '../../../../constants/new_tab_ui'
 
-type Props = {
+type Props = React.PropsWithChildren<{
   onClose: () => any
-}
+}>
 
-const BraveTalkTooltip: React.FunctionComponent<Props> = function (props) {
+const BraveTalkTooltip = React.forwardRef<HTMLDivElement, Props>(function BraveTalkTooltip (props, ref) {
   return (
-    <S.Anchor>
+    <S.Anchor ref={ref}>
       <S.Tooltip>
         <S.Title>
           <S.TitleIcon><BraveTalkIcon /></S.TitleIcon>
@@ -39,6 +39,6 @@ const BraveTalkTooltip: React.FunctionComponent<Props> = function (props) {
       {props.children}
     </S.Anchor>
   )
-}
+})
 
 export default BraveTalkTooltip

--- a/components/brave_new_tab_ui/components/default/footer/braveTalkTooltip/index.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/braveTalkTooltip/index.tsx
@@ -26,7 +26,7 @@ const BraveTalkTooltip: React.FunctionComponent<Props> = function (props) {
         <S.Body>
           {getLocale('braveTalkPromptDescription')}
         </S.Body>
-        <LinkButton href={braveTalkWidgetUrl}>
+        <LinkButton href={braveTalkWidgetUrl} onClick={props.onClose}>
           {getLocale('braveTalkPromptAction')}
         </LinkButton>
         <S.CloseButton

--- a/components/brave_new_tab_ui/components/default/footer/footer.tsx
+++ b/components/brave_new_tab_ui/components/default/footer/footer.tsx
@@ -24,38 +24,21 @@ import {
   BookmarkBook,
   HistoryIcon
 } from 'brave-ui/components/icons'
-import BraveTalkTooltip from './braveTalkTooltip'
-import BraveTalkIcon from './braveTalkTooltip/braveTalkIcon'
+import BraveTalkItem from './braveTalkItem'
 
 // Helpers
 import { getLocale } from '../../../../common/locale'
+import { DismissBraveTalkPromptPayload } from '../../../actions/new_tab_actions'
 
-interface Props {
+export type OnDismissBraveTalkPrompt = (payload: DismissBraveTalkPromptPayload) => unknown
+export interface Props {
   textDirection: string
   supportsBraveTalk: boolean
-  braveTalkPromptDismissed: boolean
+  showBraveTalkPrompt: boolean
   backgroundImageInfo: any
   showPhotoInfo: boolean
   onClickSettings: () => any
-  onDismissBraveTalkPrompt: () => any
-}
-
-function BraveTalkItem (props: Props) {
-  if (!props.braveTalkPromptDismissed) {
-    return (
-      <BraveTalkTooltip onClose={props.onDismissBraveTalkPrompt}>
-        <IconLink title={getLocale('braveTalkPromptTitle')} href='https://talk.brave.com/widget'>
-          <BraveTalkIcon />
-        </IconLink>
-      </BraveTalkTooltip>
-    )
-  }
-
-  return (
-    <IconLink title={getLocale('braveTalkPromptTitle')} href='https://talk.brave.com/widget'>
-      <BraveTalkIcon />
-    </IconLink>
-  )
+  onDismissBraveTalkPrompt: OnDismissBraveTalkPrompt
 }
 
 export default class FooterInfo extends React.PureComponent<Props, {}> {

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -1142,7 +1142,7 @@ class NewTabPage extends React.Component<Props, State> {
             <FooterInfo
               textDirection={newTabData.textDirection}
               supportsBraveTalk={newTabData.braveTalkSupported}
-              braveTalkPromptDismissed={newTabData.braveTalkPromptDismissed}
+              showBraveTalkPrompt={!newTabData.braveTalkPromptDismissed}
               backgroundImageInfo={newTabData.backgroundImage}
               showPhotoInfo={!isShowingBrandedWallpaper && newTabData.showBackgroundImage}
               onClickSettings={this.openSettings}

--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -1142,7 +1142,7 @@ class NewTabPage extends React.Component<Props, State> {
             <FooterInfo
               textDirection={newTabData.textDirection}
               supportsBraveTalk={newTabData.braveTalkSupported}
-              showBraveTalkPrompt={!newTabData.braveTalkPromptDismissed}
+              showBraveTalkPrompt={newTabData.braveTalkPromptAllowed && !newTabData.braveTalkPromptDismissed}
               backgroundImageInfo={newTabData.backgroundImage}
               showPhotoInfo={!isShowingBrandedWallpaper && newTabData.showBackgroundImage}
               onClickSettings={this.openSettings}

--- a/components/brave_new_tab_ui/reducers/new_tab_reducer.ts
+++ b/components/brave_new_tab_ui/reducers/new_tab_reducer.ts
@@ -49,7 +49,11 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
         geminiSupported: initialDataPayload.geminiSupported,
         cryptoDotComSupported: initialDataPayload.cryptoDotComSupported,
         ftxSupported: initialDataPayload.ftxSupported,
-        binanceSupported: initialDataPayload.binanceSupported
+        binanceSupported: initialDataPayload.binanceSupported,
+        // Auto-dismiss of together prompt only
+        // takes effect on the next page view and not the
+        // page view that the action occured on.
+        braveTalkPromptDismissed: state.braveTalkPromptDismissed || state.braveTalkPromptAutoDismissed
       }
       if (state.brandedWallpaperData && !state.brandedWallpaperData.isSponsored) {
         // Update feature flag if this is super referral wallpaper.
@@ -190,9 +194,13 @@ export const newTabReducer: Reducer<NewTab.State | undefined> = (state: NewTab.S
     }
 
     case Actions.dismissBraveTalkPrompt.getType(): {
+      const actionPayload = payload as Actions.DismissBraveTalkPromptPayload
+      const stateChange: Partial<NewTab.State> = actionPayload.isAutomatic
+        ? { braveTalkPromptAutoDismissed: true }
+        : { braveTalkPromptDismissed: true }
       state = {
         ...state,
-        braveTalkPromptDismissed: true
+        ...stateChange
       }
       break
     }

--- a/components/brave_new_tab_ui/storage/new_tab_storage.ts
+++ b/components/brave_new_tab_ui/storage/new_tab_storage.ts
@@ -53,6 +53,7 @@ export const defaultState: NewTab.State = {
     fingerprintingBlockedStat: 0
   },
   braveTalkPromptDismissed: false,
+  braveTalkPromptAutoDismissed: false,
   rewardsState: {
     adsAccountStatement: {
       nextPaymentDate: 0,
@@ -280,9 +281,13 @@ export const load = (): NewTab.State => {
 
 export const debouncedSave = debounce<NewTab.State>((data: NewTab.State) => {
   if (data) {
+    // TODO(petemill): This should be of type NewTab.PersistantState, and first
+    // fix errors related to properties which shouldn't be defined as persistant
+    // (or are obsolete).
     const dataToSave = {
       braveTalkSupported: data.braveTalkSupported,
       braveTalkPromptDismissed: data.braveTalkPromptDismissed,
+      braveTalkPromptAutoDismissed: data.braveTalkPromptAutoDismissed,
       binanceSupported: data.binanceSupported,
       geminiSupported: data.geminiSupported,
       bitcoinDotComSupported: data.bitcoinDotComSupported,

--- a/components/brave_new_tab_ui/storage/new_tab_storage.ts
+++ b/components/brave_new_tab_ui/storage/new_tab_storage.ts
@@ -54,6 +54,7 @@ export const defaultState: NewTab.State = {
   },
   braveTalkPromptDismissed: false,
   braveTalkPromptAutoDismissed: false,
+  braveTalkPromptAllowed: loadTimeData.getBoolean('braveTalkPromptAllowed'),
   rewardsState: {
     adsAccountStatement: {
       nextPaymentDate: 0,

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -79,6 +79,7 @@ declare namespace NewTab {
   export interface PersistentState {
     braveTalkPromptDismissed: boolean
     braveTalkSupported: boolean
+    braveTalkPromptAutoDismissed: boolean
     geminiSupported: boolean
     binanceSupported: boolean
     bitcoinDotComSupported: boolean

--- a/components/definitions/newTab.d.ts
+++ b/components/definitions/newTab.d.ts
@@ -133,6 +133,7 @@ declare namespace NewTab {
     showBitcoinDotCom: boolean
     showFTX: boolean,
     stats: Stats,
+    braveTalkPromptAllowed: boolean
     brandedWallpaperData?: BrandedWallpaper
   }
 


### PR DESCRIPTION
- Hides Brave Talk prompt when the main action is clicked (fix https://github.com/brave/brave-browser/issues/13492)
- Hides Brave Talk prompt after 4 seconds of being viewed (only on future NTP opens)
- Shows Brave Talk prompt only after 3 days since the browser was first run (fix https://github.com/brave/brave-browser/issues/16312)

## Test Plan:

### Only shows after 3 days
0. Run fresh profile
1. Open NTP
2. Observe no prompt for Brave Talk
3. Close browser
4. Forward OS clock 3 days
5. Run same profile
6. Open NTP
7. Observer there is a prompt for Brave Talk

### Auto dismisses after 4 seconds
0. Run profile which is showing prompt for Brave Talk
1. Have window with NTP open active for > 4 seconds
2. Observe prompt for Brave Talk is not hidden in current Tab.
3. Open a new NTP tab (or refresh)
4. Observe prompt for Brave Talk is hidden in the new Tab.

### Closes prompt when performing main action
0. Run profile which is showing prompt for Brave Talk
1. Click on main action button (not the close button)
2. Observe that main action happens (opens Brave Talk)
3. Open a new NTP
4. Observe prompt for Brave Talk is hidden in the new Tab.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A
