### PR TITLE
Return granted accounts for ethereum.enable API

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_provider_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_delegate.h
@@ -15,7 +15,8 @@ namespace brave_wallet {
 
 class BraveWalletProviderDelegate {
  public:
-  using RequestEthereumPermissionsCallback = base::OnceCallback<void(bool)>;
+  using RequestEthereumPermissionsCallback =
+      base::OnceCallback<void(const std::vector<std::string>&)>;
 
   BraveWalletProviderDelegate() = default;
   BraveWalletProviderDelegate(const BraveWalletProviderDelegate&) = delete;

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -43,8 +43,10 @@ void BraveWalletProviderImpl::Enable(EnableCallback callback) {
                      weak_factory_.GetWeakPtr(), std::move(callback)));
 }
 
-void BraveWalletProviderImpl::OnEnable(EnableCallback callback, bool success) {
-  std::move(callback).Run(success);
+void BraveWalletProviderImpl::OnEnable(
+    EnableCallback callback,
+    const std::vector<std::string>& accounts) {
+  std::move(callback).Run(accounts);
 }
 
 void BraveWalletProviderImpl::GetChainId(GetChainIdCallback callback) {

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -37,7 +37,8 @@ class BraveWalletProviderImpl final
                bool auto_retry_on_network_change,
                RequestCallback callback) override;
   void Enable(EnableCallback callback) override;
-  void OnEnable(EnableCallback callback, bool success);
+  void OnEnable(EnableCallback callback,
+                const std::vector<std::string>& accounts);
   void GetChainId(GetChainIdCallback callback) override;
   void Init(
       mojo::PendingRemote<mojom::EventsListener> events_listener) override;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -16,7 +16,7 @@ interface EventsListener {
 interface BraveWalletProvider {
   Init(pending_remote<EventsListener> events_listener);
   Request(string json_payload, bool auto_retry_on_network_change) => (int32 http_code, string response, map<string, string> headers);
-  Enable() => (bool success);
+  Enable() => (array<string> accounts);
   GetChainId() => (string chain_id);
 };
 

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "base/containers/flat_map.h"
 #include "base/memory/weak_ptr.h"
@@ -73,7 +74,7 @@ class BraveWalletJSHandler : public mojom::EventsListener {
   void OnEnable(v8::Global<v8::Promise::Resolver> promise_resolver,
                 v8::Isolate* isolate,
                 v8::Global<v8::Context> context_old,
-                bool success);
+                const std::vector<std::string>& accounts);
 
   content::RenderFrame* render_frame_;
   mojo::Remote<mojom::BraveWalletProvider> brave_wallet_provider_;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17269

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable wallet flag & unlock wallet, create at least two addresses.
2. Visit brave://settings/content/ethereum to remove existing entries of test sites if needed.
3. Visit instagram.com & open devtool
4. Run `window.ethereum.enable().then(value => {console.log(value)})` in devtool
5. Select one account and connect in the prompt.
6. Should see the selected account in devtool when promise is resolved
7. Visit facebook.com & open devtool
8. Run `window.ethereum.enable().then(value => {console.log(value)})` in devtool
9. Select two accounts and connect in the prompt.
10. Should see both selected accounts in devtool when promise is resolved