### PR TITLE
Fixes Brave News Inline ads are shown when User Activity threshold is not reached - 1.28.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/ad_notifications/ad_notification_serving.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/ad_notifications/ad_notification_serving.cc
@@ -99,7 +99,7 @@ void AdServing::StopServingAdsAtRegularIntervals() {
 }
 
 void AdServing::MaybeServeAd() {
-  ad_notifications::frequency_capping::PermissionRules permission_rules;
+  frequency_capping::PermissionRules permission_rules;
   if (!permission_rules.HasPermission()) {
     BLOG(1, "Ad notification not served: Not allowed due to permission rules");
     FailedToServeAd();

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/inline_content_ads/inline_content_ad_serving_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_serving/inline_content_ads/inline_content_ad_serving_test.cc
@@ -46,8 +46,6 @@ class BatAdsInlineContentAdServingTest : public UnitTestBase {
     MockUrlRequest(ads_client_mock_, endpoints);
 
     InitializeAds();
-
-    RecordUserActivityEvents();
   }
 
   void RecordUserActivityEvents() {
@@ -102,12 +100,12 @@ class BatAdsInlineContentAdServingTest : public UnitTestBase {
 
 TEST_F(BatAdsInlineContentAdServingTest, ServeAd) {
   // Arrange
-  CreativeInlineContentAdList creative_inline_content_ads;
+  RecordUserActivityEvents();
 
+  CreativeInlineContentAdList creative_inline_content_ads;
   CreativeInlineContentAdInfo creative_inline_content_ad =
       GetCreativeInlineContentAd();
   creative_inline_content_ads.push_back(creative_inline_content_ad);
-
   Save(creative_inline_content_ads);
 
   // Act
@@ -126,18 +124,37 @@ TEST_F(BatAdsInlineContentAdServingTest, ServeAd) {
 
 TEST_F(BatAdsInlineContentAdServingTest, DoNotServeAdForUnavailableDimensions) {
   // Arrange
-  CreativeInlineContentAdList creative_inline_content_ads;
+  RecordUserActivityEvents();
 
+  CreativeInlineContentAdList creative_inline_content_ads;
   CreativeInlineContentAdInfo creative_inline_content_ad =
       GetCreativeInlineContentAd();
   creative_inline_content_ads.push_back(creative_inline_content_ad);
-
   Save(creative_inline_content_ads);
 
   // Act
   ad_serving_->MaybeServeAd(
       "?x?", [](const bool success, const std::string& dimensions,
                 const InlineContentAdInfo& inline_content_ad) {
+        EXPECT_FALSE(success);
+      });
+
+  // Assert
+}
+
+TEST_F(BatAdsInlineContentAdServingTest,
+       DoNotServeAdIfNotAllowedDueToPermissionRules) {
+  // Arrange
+  CreativeInlineContentAdList creative_inline_content_ads;
+  CreativeInlineContentAdInfo creative_inline_content_ad =
+      GetCreativeInlineContentAd();
+  creative_inline_content_ads.push_back(creative_inline_content_ad);
+  Save(creative_inline_content_ads);
+
+  // Act
+  ad_serving_->MaybeServeAd(
+      "200x100", [](const bool success, const std::string& dimensions,
+                    const InlineContentAdInfo& inline_content_ad) {
         EXPECT_FALSE(success);
       });
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads/inline_content_ads/inline_content_ad.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads/inline_content_ads/inline_content_ad.cc
@@ -9,7 +9,6 @@
 #include "bat/ads/internal/ad_events/ad_event_util.h"
 #include "bat/ads/internal/ad_events/inline_content_ads/inline_content_ad_event_factory.h"
 #include "bat/ads/internal/ads/inline_content_ads/inline_content_ad_builder.h"
-#include "bat/ads/internal/ads/inline_content_ads/inline_content_ad_permission_rules.h"
 #include "bat/ads/internal/bundle/creative_inline_content_ad_info.h"
 #include "bat/ads/internal/database/tables/ad_events_database_table.h"
 #include "bat/ads/internal/database/tables/creative_inline_content_ads_database_table.h"
@@ -37,14 +36,6 @@ void InlineContentAd::FireEvent(const std::string& uuid,
   if (uuid.empty() || creative_instance_id.empty()) {
     BLOG(1, "Failed to fire inline content ad event due to invalid uuid "
                 << uuid << " or creative instance id " << creative_instance_id);
-    NotifyInlineContentAdEventFailed(uuid, creative_instance_id, event_type);
-    return;
-  }
-
-  inline_content_ads::frequency_capping::PermissionRules permission_rules;
-  if (event_type == InlineContentAdEventType::kViewed &&
-      !permission_rules.HasPermission()) {
-    BLOG(1, "Inline content ad: Not allowed due to permission rules");
     NotifyInlineContentAdEventFailed(uuid, creative_instance_id, event_type);
     return;
   }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9615
Resolves https://github.com/brave/brave-browser/issues/17303

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.