### PR TITLE
Fixes `landed` events are not triggered when Brave News is enabled and Brave ads are disabled - 1.28.x

### DIFF
--- a/browser/brave_ads/ads_tab_helper.cc
+++ b/browser/brave_ads/ads_tab_helper.cc
@@ -56,16 +56,8 @@ AdsTabHelper::~AdsTabHelper() {
 #endif
 }
 
-bool AdsTabHelper::IsAdsEnabled() const {
-  if (!ads_service_ || !ads_service_->IsEnabled()) {
-    return false;
-  }
-
-  return true;
-}
-
 void AdsTabHelper::TabUpdated() {
-  if (!IsAdsEnabled()) {
+  if (!ads_service_) {
     return;
   }
 
@@ -89,7 +81,9 @@ void AdsTabHelper::RunIsolatedJavaScript(
 }
 
 void AdsTabHelper::OnJavaScriptHtmlResult(base::Value value) {
-  DCHECK(ads_service_ && ads_service_->IsEnabled());
+  if (!ads_service_) {
+    return;
+  }
 
   if (!value.is_string()) {
     return;
@@ -101,7 +95,9 @@ void AdsTabHelper::OnJavaScriptHtmlResult(base::Value value) {
 }
 
 void AdsTabHelper::OnJavaScriptTextResult(base::Value value) {
-  DCHECK(ads_service_ && ads_service_->IsEnabled());
+  if (!ads_service_) {
+    return;
+  }
 
   if (!value.is_string()) {
     return;
@@ -116,7 +112,7 @@ void AdsTabHelper::DidFinishNavigation(
     content::NavigationHandle* navigation_handle) {
   DCHECK(navigation_handle);
 
-  if (!IsAdsEnabled() || !navigation_handle->IsInMainFrame() ||
+  if (!ads_service_ || !navigation_handle->IsInMainFrame() ||
       !navigation_handle->HasCommitted() || !tab_id_.is_valid()) {
     return;
   }
@@ -144,7 +140,7 @@ void AdsTabHelper::DidFinishNavigation(
 
 void AdsTabHelper::DocumentOnLoadCompletedInMainFrame(
     content::RenderFrameHost* render_frame_host) {
-  if (!IsAdsEnabled() || !should_process_) {
+  if (!should_process_) {
     return;
   }
 
@@ -168,7 +164,7 @@ void AdsTabHelper::DidFinishLoad(content::RenderFrameHost* render_frame_host,
 
 void AdsTabHelper::MediaStartedPlaying(const MediaPlayerInfo& video_type,
                                        const content::MediaPlayerId& id) {
-  if (!IsAdsEnabled()) {
+  if (!ads_service_) {
     return;
   }
 
@@ -179,7 +175,7 @@ void AdsTabHelper::MediaStoppedPlaying(
     const MediaPlayerInfo& video_type,
     const content::MediaPlayerId& id,
     WebContentsObserver::MediaStoppedReason reason) {
-  if (!IsAdsEnabled()) {
+  if (!ads_service_) {
     return;
   }
 
@@ -210,7 +206,7 @@ void AdsTabHelper::OnVisibilityChanged(content::Visibility visibility) {
 }
 
 void AdsTabHelper::WebContentsDestroyed() {
-  if (!IsAdsEnabled()) {
+  if (!ads_service_) {
     return;
   }
 

--- a/browser/brave_ads/ads_tab_helper.h
+++ b/browser/brave_ads/ads_tab_helper.h
@@ -55,8 +55,6 @@ class AdsTabHelper : public content::WebContentsObserver,
  private:
   friend class content::WebContentsUserData<AdsTabHelper>;
 
-  bool IsAdsEnabled() const;
-
   void TabUpdated();
 
   void RunIsolatedJavaScript(content::RenderFrameHost* render_frame_host);

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -397,7 +397,6 @@ void AdsServiceImpl::OnWalletUpdated() {
 
 void AdsServiceImpl::OnGetBraveWallet(ledger::type::BraveWalletPtr wallet) {
   if (!wallet) {
-    VLOG(0) << "Failed to get wallet";
     return;
   }
 
@@ -1141,10 +1140,6 @@ void AdsServiceImpl::NotificationTimedOut(const std::string& uuid) {
 
 void AdsServiceImpl::RegisterResourceComponentsForLocale(
     const std::string& locale) {
-  if (!IsEnabled()) {
-    return;
-  }
-
   g_brave_browser_process->resource_component()->RegisterComponentsForLocale(
       locale);
 }

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/account.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/account.cc
@@ -60,7 +60,7 @@ bool Account::SetWallet(const std::string& id, const std::string& seed) {
   const WalletInfo last_wallet = wallet_->Get();
 
   if (!wallet_->Set(id, seed)) {
-    BLOG(0, "Invalid wallet");
+    NotifyWalletInvalid();
     return false;
   }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/ad_targeting_segment_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/ad_targeting_segment_util_unittest.cc
@@ -8,14 +8,22 @@
 #include <string>
 
 #include "bat/ads/internal/client/client.h"
-#include "testing/gtest/include/gtest/gtest.h"
+#include "bat/ads/internal/unittest_base.h"
+#include "bat/ads/internal/unittest_util.h"
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 
 namespace ads {
 namespace ad_targeting {
 
-TEST(BatAdsAdTargetingSegmentUtilTest, SplitParentChildSegment) {
+class BatAdsAdTargetingSegmentUtilTest : public UnitTestBase {
+ protected:
+  BatAdsAdTargetingSegmentUtilTest() = default;
+
+  ~BatAdsAdTargetingSegmentUtilTest() override = default;
+};
+
+TEST_F(BatAdsAdTargetingSegmentUtilTest, SplitParentChildSegment) {
   // Arrange
   const std::string segment = "parent-child";
 
@@ -28,7 +36,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, SplitParentChildSegment) {
   EXPECT_EQ(expected_segments, segments);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, SplitParentSegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, SplitParentSegment) {
   // Arrange
   const std::string segment = "parent";
 
@@ -41,7 +49,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, SplitParentSegment) {
   EXPECT_EQ(expected_segments, segments);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, SplitEmptySegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, SplitEmptySegment) {
   // Arrange
   const std::string segment = "";
 
@@ -54,7 +62,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, SplitEmptySegment) {
   EXPECT_EQ(expected_segments, segments);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, GetParentSegment) {
   // Arrange
   const std::string segment = "technology & computing-software";
 
@@ -67,7 +75,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegment) {
   EXPECT_EQ(expected_parent_segment, parent_segment);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentFromParentSegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentFromParentSegment) {
   // Arrange
   const std::string segment = "technology & computing";
 
@@ -80,7 +88,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentFromParentSegment) {
   EXPECT_EQ(expected_parent_segment, parent_segment);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentFromEmptyString) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentFromEmptyString) {
   // Arrange
   const std::string segment = "";
 
@@ -93,7 +101,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentFromEmptyString) {
   EXPECT_EQ(expected_parent_segment, parent_segment);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegments) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, GetParentSegments) {
   // Arrange
   const SegmentList segments = {"technology & computing-software",
                                 "personal finance-personal finance",
@@ -109,7 +117,7 @@ TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegments) {
   EXPECT_EQ(expected_parent_segments, parent_segments);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentsForEmptyList) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentsForEmptyList) {
   // Arrange
   const SegmentList segments;
 
@@ -122,10 +130,8 @@ TEST(BatAdsAdTargetingSegmentUtilTest, GetParentSegmentsForEmptyList) {
   EXPECT_EQ(expected_parent_segments, parent_segments);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, ShouldFilterParentChildSegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, ShouldFilterParentChildSegment) {
   // Arrange
-  Client client;
-
   Client::Get()->ToggleAdOptOutAction("parent-child",
                                       CategoryContentInfo::OptAction::kNone);
 
@@ -136,24 +142,8 @@ TEST(BatAdsAdTargetingSegmentUtilTest, ShouldFilterParentChildSegment) {
   EXPECT_TRUE(should_filter_segment);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, ShouldFilterParentSegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, ShouldNotFilterParentChildSegment) {
   // Arrange
-  Client client;
-
-  Client::Get()->ToggleAdOptOutAction("parent",
-                                      CategoryContentInfo::OptAction::kNone);
-
-  // Act
-  const bool should_filter_segment = ShouldFilterSegment("parent");
-
-  // Assert
-  EXPECT_TRUE(should_filter_segment);
-}
-
-TEST(BatAdsAdTargetingSegmentUtilTest, ShouldNotFilterParentChildSegment) {
-  // Arrange
-  Client client;
-
   Client::Get()->ToggleAdOptOutAction("parent-child",
                                       CategoryContentInfo::OptAction::kNone);
 
@@ -164,10 +154,20 @@ TEST(BatAdsAdTargetingSegmentUtilTest, ShouldNotFilterParentChildSegment) {
   EXPECT_FALSE(should_filter_segment);
 }
 
-TEST(BatAdsAdTargetingSegmentUtilTest, ShouldNotFilterParentSegment) {
+TEST_F(BatAdsAdTargetingSegmentUtilTest, ShouldFilterParentSegment) {
   // Arrange
-  Client client;
+  Client::Get()->ToggleAdOptOutAction("parent",
+                                      CategoryContentInfo::OptAction::kNone);
 
+  // Act
+  const bool should_filter_segment = ShouldFilterSegment("parent");
+
+  // Assert
+  EXPECT_TRUE(should_filter_segment);
+}
+
+TEST_F(BatAdsAdTargetingSegmentUtilTest, ShouldNotFilterParentSegment) {
+  // Arrange
   Client::Get()->ToggleAdOptOutAction("parent",
                                       CategoryContentInfo::OptAction::kNone);
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
@@ -111,7 +111,7 @@ class AdsImpl : public Ads,
 
   void set_for_testing(privacy::TokenGeneratorInterface* token_generator);
 
-  bool IsInitialized();
+  bool IsInitialized() const;
 
   // Ads implementation
   void Initialize(InitializeCallback callback) override;
@@ -263,9 +263,15 @@ class AdsImpl : public Ads,
   void MaybeUpdateCatalog();
 
   void MaybeServeAdNotification();
+
+  bool ShouldServeAdNotificationsAtRegularIntervals() const;
   void MaybeServeAdNotificationsAtRegularIntervals();
 
+  void MaybeTopUpUnblindedTokens();
+
   // AccountObserver implementation
+  void OnWalletChanged(const WalletInfo& wallet) override;
+  void OnWalletInvalid() override;
   void OnAdRewardsChanged() override;
   void OnTransactionsChanged() override;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/client/client.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client/client.cc
@@ -77,14 +77,20 @@ bool Client::HasInstance() {
 }
 
 FilteredAdList Client::get_filtered_ads() const {
+  DCHECK(is_initialized_);
+
   return client_->ad_preferences.filtered_ads;
 }
 
 FilteredCategoryList Client::get_filtered_categories() const {
+  DCHECK(is_initialized_);
+
   return client_->ad_preferences.filtered_categories;
 }
 
 FlaggedAdList Client::get_flagged_ads() const {
+  DCHECK(is_initialized_);
+
   return client_->ad_preferences.flagged_ads;
 }
 
@@ -95,6 +101,8 @@ void Client::Initialize(InitializeCallback callback) {
 }
 
 void Client::AppendAdHistoryToAdsHistory(const AdHistoryInfo& ad_history) {
+  DCHECK(is_initialized_);
+
   client_->ads_shown_history.push_front(ad_history);
 
   const uint64_t timestamp = static_cast<uint64_t>(
@@ -113,12 +121,16 @@ void Client::AppendAdHistoryToAdsHistory(const AdHistoryInfo& ad_history) {
 }
 
 const std::deque<AdHistoryInfo>& Client::GetAdsHistory() const {
+  DCHECK(is_initialized_);
+
   return client_->ads_shown_history;
 }
 
 void Client::AppendToPurchaseIntentSignalHistoryForSegment(
     const std::string& segment,
     const PurchaseIntentSignalHistoryInfo& history) {
+  DCHECK(is_initialized_);
+
   if (client_->purchase_intent_signal_history.find(segment) ==
       client_->purchase_intent_signal_history.end()) {
     client_->purchase_intent_signal_history.insert({segment, {}});
@@ -136,6 +148,8 @@ void Client::AppendToPurchaseIntentSignalHistoryForSegment(
 
 const PurchaseIntentSignalHistoryMap& Client::GetPurchaseIntentSignalHistory()
     const {
+  DCHECK(is_initialized_);
+
   return client_->purchase_intent_signal_history;
 }
 
@@ -143,6 +157,8 @@ AdContentInfo::LikeAction Client::ToggleAdThumbUp(
     const std::string& creative_instance_id,
     const std::string& creative_set_id,
     const AdContentInfo::LikeAction action) {
+  DCHECK(is_initialized_);
+
   AdContentInfo::LikeAction like_action;
   if (action == AdContentInfo::LikeAction::kThumbsUp) {
     like_action = AdContentInfo::LikeAction::kNeutral;
@@ -173,6 +189,8 @@ AdContentInfo::LikeAction Client::ToggleAdThumbDown(
     const std::string& creative_instance_id,
     const std::string& creative_set_id,
     const AdContentInfo::LikeAction action) {
+  DCHECK(is_initialized_);
+
   AdContentInfo::LikeAction like_action;
   if (action == AdContentInfo::LikeAction::kThumbsDown) {
     like_action = AdContentInfo::LikeAction::kNeutral;
@@ -211,6 +229,8 @@ AdContentInfo::LikeAction Client::ToggleAdThumbDown(
 CategoryContentInfo::OptAction Client::ToggleAdOptInAction(
     const std::string& category,
     const CategoryContentInfo::OptAction action) {
+  DCHECK(is_initialized_);
+
   CategoryContentInfo::OptAction opt_action;
   if (action == CategoryContentInfo::OptAction::kOptIn) {
     opt_action = CategoryContentInfo::OptAction::kNone;
@@ -240,6 +260,8 @@ CategoryContentInfo::OptAction Client::ToggleAdOptInAction(
 CategoryContentInfo::OptAction Client::ToggleAdOptOutAction(
     const std::string& category,
     const CategoryContentInfo::OptAction action) {
+  DCHECK(is_initialized_);
+
   CategoryContentInfo::OptAction opt_action;
   if (action == CategoryContentInfo::OptAction::kOptOut) {
     opt_action = CategoryContentInfo::OptAction::kNone;
@@ -277,6 +299,8 @@ CategoryContentInfo::OptAction Client::ToggleAdOptOutAction(
 bool Client::ToggleSaveAd(const std::string& creative_instance_id,
                           const std::string& creative_set_id,
                           const bool saved) {
+  DCHECK(is_initialized_);
+
   const bool saved_ad = !saved;
 
   // Update this ad in the saved ads list
@@ -315,6 +339,8 @@ bool Client::ToggleSaveAd(const std::string& creative_instance_id,
 bool Client::ToggleFlagAd(const std::string& creative_instance_id,
                           const std::string& creative_set_id,
                           const bool flagged) {
+  DCHECK(is_initialized_);
+
   const bool flagged_ad = !flagged;
 
   // Update this ad in the flagged ads list
@@ -351,6 +377,8 @@ bool Client::ToggleFlagAd(const std::string& creative_instance_id,
 }
 
 void Client::UpdateSeenAd(const AdInfo& ad) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(ad.type);
   client_->seen_ads[type_as_string][ad.creative_instance_id] = true;
   client_->seen_advertisers[type_as_string][ad.advertiser_id] = true;
@@ -359,12 +387,16 @@ void Client::UpdateSeenAd(const AdInfo& ad) {
 
 const std::map<std::string, bool>& Client::GetSeenAdsForType(
     const AdType& type) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(type);
   return client_->seen_ads[type_as_string];
 }
 
 void Client::ResetSeenAdsForType(const CreativeAdList& ads,
                                  const AdType& type) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(type);
 
   BLOG(1, "Resetting seen " << type_as_string << "s");
@@ -381,6 +413,8 @@ void Client::ResetSeenAdsForType(const CreativeAdList& ads,
 }
 
 void Client::ResetAllSeenAdsForType(const AdType& type) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(type);
   BLOG(1, "Resetting seen " << type_as_string << "s");
   client_->seen_ads[type_as_string] = {};
@@ -389,12 +423,16 @@ void Client::ResetAllSeenAdsForType(const AdType& type) {
 
 const std::map<std::string, bool>& Client::GetSeenAdvertisersForType(
     const AdType& type) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(type);
   return client_->seen_advertisers[type_as_string];
 }
 
 void Client::ResetSeenAdvertisersForType(const CreativeAdList& ads,
                                          const AdType& type) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(type);
 
   BLOG(1, "Resetting seen " << type_as_string << " advertisers");
@@ -411,6 +449,8 @@ void Client::ResetSeenAdvertisersForType(const CreativeAdList& ads,
 }
 
 void Client::ResetAllSeenAdvertisersForType(const AdType& type) {
+  DCHECK(is_initialized_);
+
   const std::string type_as_string = std::string(type);
   BLOG(1, "Resetting seen " << type_as_string << " advertisers");
   client_->seen_advertisers[type_as_string] = {};
@@ -419,6 +459,8 @@ void Client::ResetAllSeenAdvertisersForType(const AdType& type) {
 
 void Client::SetNextAdServingInterval(
     const base::Time& next_check_serve_ad_date) {
+  DCHECK(is_initialized_);
+
   client_->next_ad_serving_interval_timestamp =
       static_cast<uint64_t>(next_check_serve_ad_date.ToDoubleT());
 
@@ -426,11 +468,15 @@ void Client::SetNextAdServingInterval(
 }
 
 base::Time Client::GetNextAdServingInterval() {
+  DCHECK(is_initialized_);
+
   return base::Time::FromDoubleT(client_->next_ad_serving_interval_timestamp);
 }
 
 void Client::AppendTextClassificationProbabilitiesToHistory(
     const TextClassificationProbabilitiesMap& probabilities) {
+  DCHECK(is_initialized_);
+
   client_->text_classification_probabilities.push_front(probabilities);
 
   const size_t maximum_entries =
@@ -444,10 +490,14 @@ void Client::AppendTextClassificationProbabilitiesToHistory(
 
 const TextClassificationProbabilitiesList&
 Client::GetTextClassificationProbabilitiesHistory() {
+  DCHECK(is_initialized_);
+
   return client_->text_classification_probabilities;
 }
 
 void Client::RemoveAllHistory() {
+  DCHECK(is_initialized_);
+
   BLOG(1, "Successfully reset client state");
 
   client_.reset(new ClientInfo());
@@ -456,10 +506,14 @@ void Client::RemoveAllHistory() {
 }
 
 std::string Client::GetVersionCode() const {
+  DCHECK(is_initialized_);
+
   return client_->version_code;
 }
 
 void Client::SetVersionCode(const std::string& value) {
+  DCHECK(is_initialized_);
+
   client_->version_code = value;
 
   Save();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9638
Resolves https://github.com/brave/brave-browser/issues/17330

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.