### PR TITLE
Check for invalid iterator during leave sync chain (uplift to 1.28.x)

### DIFF
--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.h
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.h
@@ -16,6 +16,10 @@
   GetAllBraveDeviceInfo() const override;                                    \
   void ForcePulseForTest
 
+#define RefreshLocalDeviceInfoIfNeeded                                     \
+  RefreshLocalDeviceInfoIfNeeded_ChromiumImpl(base::OnceClosure callback); \
+  void RefreshLocalDeviceInfoIfNeeded
+
 // private:
 #define StoreSpecifics                              \
   OnDeviceInfoDeleted(const std::string& client_id, \
@@ -24,6 +28,7 @@
 
 #include "../../../../components/sync_device_info/device_info_sync_bridge.h"
 
+#undef RefreshLocalDeviceInfoIfNeeded
 #undef ForcePulseForTest
 #undef StoreSpecifics
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_SYNC_BRIDGE_H_


### PR DESCRIPTION
Uplift of #9610
Resolves https://github.com/brave/brave-browser/issues/17221

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.