### PR TITLE
Expose sending ETH transactions over mojo

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -11,6 +11,8 @@ source_set("brave_wallet") {
     "asset_ratio_controller_factory.h",
     "brave_wallet_context_utils.cc",
     "brave_wallet_context_utils.h",
+    "eth_tx_controller_factory.cc",
+    "eth_tx_controller_factory.h",
     "keyring_controller_factory.cc",
     "keyring_controller_factory.h",
     "rpc_controller_factory.cc",

--- a/browser/brave_wallet/eth_tx_controller_factory.cc
+++ b/browser/brave_wallet/eth_tx_controller_factory.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_wallet/eth_tx_controller_factory.h"
+
+#include <memory>
+#include <utility>
+
+#include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
+#include "brave/browser/brave_wallet/keyring_controller_factory.h"
+#include "brave/browser/brave_wallet/rpc_controller_factory.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
+#include "brave/components/brave_wallet/browser/eth_tx_controller.h"
+#include "chrome/browser/profiles/incognito_helpers.h"
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/storage_partition.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+namespace brave_wallet {
+
+// static
+EthTxControllerFactory* EthTxControllerFactory::GetInstance() {
+  return base::Singleton<EthTxControllerFactory>::get();
+}
+
+// static
+mojo::PendingRemote<mojom::EthTxController>
+EthTxControllerFactory::GetForContext(content::BrowserContext* context) {
+  if (!IsAllowedForContext(context)) {
+    return mojo::PendingRemote<mojom::EthTxController>();
+  }
+
+  return static_cast<EthTxController*>(
+             GetInstance()->GetServiceForBrowserContext(context, true))
+      ->MakeRemote();
+}
+
+// static
+EthTxController* EthTxControllerFactory::GetControllerForContext(
+    content::BrowserContext* context) {
+  if (!IsAllowedForContext(context)) {
+    return nullptr;
+  }
+  return static_cast<EthTxController*>(
+      GetInstance()->GetServiceForBrowserContext(context, true));
+}
+
+EthTxControllerFactory::EthTxControllerFactory()
+    : BrowserContextKeyedServiceFactory(
+          "EthTxController",
+          BrowserContextDependencyManager::GetInstance()) {
+  DependsOn(brave_wallet::RpcControllerFactory::GetInstance());
+  DependsOn(brave_wallet::KeyringControllerFactory::GetInstance());
+}
+
+EthTxControllerFactory::~EthTxControllerFactory() {}
+
+KeyedService* EthTxControllerFactory::BuildServiceInstanceFor(
+    content::BrowserContext* context) const {
+  auto tx_state_manager = std::make_unique<EthTxStateManager>(
+      user_prefs::UserPrefs::Get(context),
+      RpcControllerFactory::GetForContext(context));
+  auto eth_nonce_tracker = std::make_unique<EthNonceTracker>(
+      tx_state_manager.get(),
+      RpcControllerFactory::GetControllerForContext(context));
+  auto eth_pending_tx_tracker = std::make_unique<EthPendingTxTracker>(
+      tx_state_manager.get(),
+      RpcControllerFactory::GetControllerForContext(context),
+      eth_nonce_tracker.get());
+  return new EthTxController(
+      RpcControllerFactory::GetControllerForContext(context),
+      KeyringControllerFactory::GetControllerForContext(context),
+      std::move(tx_state_manager), std::move(eth_nonce_tracker),
+      std::move(eth_pending_tx_tracker), user_prefs::UserPrefs::Get(context));
+}
+
+content::BrowserContext* EthTxControllerFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  return chrome::GetBrowserContextRedirectedInIncognito(context);
+}
+
+}  // namespace brave_wallet

--- a/browser/brave_wallet/eth_tx_controller_factory.h
+++ b/browser/brave_wallet/eth_tx_controller_factory.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_WALLET_ETH_TX_CONTROLLER_FACTORY_H_
+#define BRAVE_BROWSER_BRAVE_WALLET_ETH_TX_CONTROLLER_FACTORY_H_
+
+#include "base/memory/singleton.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "content/public/browser/browser_context.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+namespace brave_wallet {
+
+class EthTxController;
+
+class EthTxControllerFactory : public BrowserContextKeyedServiceFactory {
+ public:
+  static mojo::PendingRemote<mojom::EthTxController> GetForContext(
+      content::BrowserContext* context);
+  static EthTxController* GetControllerForContext(
+      content::BrowserContext* context);
+  static EthTxControllerFactory* GetInstance();
+
+ private:
+  friend struct base::DefaultSingletonTraits<EthTxControllerFactory>;
+
+  EthTxControllerFactory();
+  ~EthTxControllerFactory() override;
+
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* context) const override;
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
+
+  DISALLOW_COPY_AND_ASSIGN(EthTxControllerFactory);
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_BROWSER_BRAVE_WALLET_ETH_TX_CONTROLLER_FACTORY_H_

--- a/browser/browser_context_keyed_service_factories.cc
+++ b/browser/browser_context_keyed_service_factories.cc
@@ -31,6 +31,7 @@
 
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
 #include "brave/browser/brave_wallet/asset_ratio_controller_factory.h"
+#include "brave/browser/brave_wallet/eth_tx_controller_factory.h"
 #include "brave/browser/brave_wallet/keyring_controller_factory.h"
 #include "brave/browser/brave_wallet/rpc_controller_factory.h"
 #include "brave/browser/brave_wallet/swap_controller_factory.h"
@@ -76,6 +77,7 @@ void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
   brave_wallet::KeyringControllerFactory::GetInstance();
   brave_wallet::RpcControllerFactory::GetInstance();
   brave_wallet::SwapControllerFactory::GetInstance();
+  brave_wallet::EthTxControllerFactory::GetInstance();
 #endif
 
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED)

--- a/browser/ui/webui/brave_wallet/wallet_page_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_page_ui.cc
@@ -36,6 +36,9 @@
 
 #include "brave/components/brave_wallet/browser/erc_token_registry.h"
 
+#include "brave/browser/brave_wallet/eth_tx_controller_factory.h"
+#include "brave/components/brave_wallet/browser/eth_tx_controller.h"
+
 WalletPageUI::WalletPageUI(content::WebUI* web_ui)
     : ui::MojoWebUIController(web_ui,
                               true /* Needed for webui browser tests */) {
@@ -82,7 +85,9 @@ void WalletPageUI::CreatePageHandler(
     mojo::PendingReceiver<brave_wallet::mojom::KeyringController>
         keyring_controller_receiver,
     mojo::PendingReceiver<brave_wallet::mojom::ERCTokenRegistry>
-        erc_token_registry_receiver) {
+        erc_token_registry_receiver,
+    mojo::PendingReceiver<brave_wallet::mojom::EthTxController>
+        eth_tx_controller_receiver) {
   DCHECK(page);
   auto* profile = Profile::FromWebUI(web_ui());
   DCHECK(profile);
@@ -120,5 +125,11 @@ void WalletPageUI::CreatePageHandler(
   auto* erc_token_registry = brave_wallet::ERCTokenRegistry::GetInstance();
   if (erc_token_registry) {
     erc_token_registry->Bind(std::move(erc_token_registry_receiver));
+  }
+
+  auto* eth_tx_controller =
+      brave_wallet::EthTxControllerFactory::GetControllerForContext(profile);
+  if (eth_tx_controller) {
+    eth_tx_controller->Bind(std::move(eth_tx_controller_receiver));
   }
 }

--- a/browser/ui/webui/brave_wallet/wallet_page_ui.h
+++ b/browser/ui/webui/brave_wallet/wallet_page_ui.h
@@ -49,7 +49,9 @@ class WalletPageUI : public ui::MojoWebUIController,
       mojo::PendingReceiver<brave_wallet::mojom::KeyringController>
           keyring_controller,
       mojo::PendingReceiver<brave_wallet::mojom::ERCTokenRegistry>
-          erc_token_registry) override;
+          erc_token_registry,
+      mojo::PendingReceiver<brave_wallet::mojom::EthTxController>
+          eth_tx_controller) override;
 
   std::unique_ptr<WalletPageHandler> page_handler_;
   std::unique_ptr<WalletHandler> wallet_handler_;

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
@@ -40,6 +40,9 @@
 
 #include "brave/components/brave_wallet/browser/erc_token_registry.h"
 
+#include "brave/browser/brave_wallet/eth_tx_controller_factory.h"
+#include "brave/components/brave_wallet/browser/eth_tx_controller.h"
+
 namespace {
 
 content::WebContents* GetWebContentsFromTabId(int32_t tab_id) {
@@ -103,7 +106,9 @@ void WalletPanelUI::CreatePanelHandler(
     mojo::PendingReceiver<brave_wallet::mojom::KeyringController>
         keyring_controller_receiver,
     mojo::PendingReceiver<brave_wallet::mojom::ERCTokenRegistry>
-        erc_token_registry_receiver) {
+        erc_token_registry_receiver,
+    mojo::PendingReceiver<brave_wallet::mojom::EthTxController>
+        eth_tx_controller_receiver) {
   DCHECK(page);
   auto* profile = Profile::FromWebUI(web_ui());
   DCHECK(profile);
@@ -142,5 +147,11 @@ void WalletPanelUI::CreatePanelHandler(
   auto* erc_token_registry = brave_wallet::ERCTokenRegistry::GetInstance();
   if (erc_token_registry) {
     erc_token_registry->Bind(std::move(erc_token_registry_receiver));
+  }
+
+  auto* eth_tx_controller =
+      brave_wallet::EthTxControllerFactory::GetControllerForContext(profile);
+  if (eth_tx_controller) {
+    eth_tx_controller->Bind(std::move(eth_tx_controller_receiver));
   }
 }

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui.h
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui.h
@@ -49,7 +49,9 @@ class WalletPanelUI : public ui::MojoBubbleWebUIController,
       mojo::PendingReceiver<brave_wallet::mojom::KeyringController>
           keyring_controller,
       mojo::PendingReceiver<brave_wallet::mojom::ERCTokenRegistry>
-          erc_token_registry) override;
+          erc_token_registry,
+      mojo::PendingReceiver<brave_wallet::mojom::EthTxController>
+          eth_tx_controller) override;
 
   std::unique_ptr<WalletPanelHandler> panel_handler_;
   std::unique_ptr<WalletHandler> wallet_handler_;

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -76,8 +76,8 @@ std::vector<uint8_t> KeccakHash(const std::vector<uint8_t>& input) {
 }
 
 std::string GetFunctionHash(const std::string& input) {
-  auto result = KeccakHash(input);
-  return result.substr(0, std::min(static_cast<size_t>(10), input.length()));
+  std::string result = KeccakHash(input);
+  return result.substr(0, std::min(static_cast<size_t>(10), result.length()));
 }
 
 // Pads a hex encoded parameter to 32-bytes

--- a/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
@@ -39,6 +39,7 @@ TEST(BraveWalletUtilsUnitTest, KeccakHash) {
 }
 
 TEST(BraveWalletUtilsUnitTest, GetFunctionHash) {
+  ASSERT_EQ(GetFunctionHash("transfer(address,uint256)"), "0xa9059cbb");
   ASSERT_EQ(GetFunctionHash("approve(address,uint256)"), "0x095ea7b3");
   ASSERT_EQ(GetFunctionHash("balanceOf(address)"), "0x70a08231");
 }

--- a/components/brave_wallet/browser/eip1559_transaction.cc
+++ b/components/brave_wallet/browser/eip1559_transaction.cc
@@ -14,12 +14,26 @@
 
 namespace brave_wallet {
 
-Eip1559Transaction::Eip1559Transaction() = default;
-Eip1559Transaction::Eip1559Transaction(const TxData& tx_data,
-                                       uint64_t chain_id,
+Eip1559Transaction::Eip1559Transaction() {
+  type_ = 2;
+}
+
+Eip1559Transaction::Eip1559Transaction(uint256_t nonce,
+                                       uint256_t gas_price,
+                                       uint256_t gas_limit,
+                                       const EthAddress& to,
+                                       uint256_t value,
+                                       const std::vector<uint8_t>& data,
+                                       uint256_t chain_id,
                                        uint256_t max_priority_fee_per_gas,
                                        uint256_t max_fee_per_gas)
-    : Eip2930Transaction(tx_data, chain_id),
+    : Eip2930Transaction(nonce,
+                         gas_price,
+                         gas_limit,
+                         to,
+                         value,
+                         data,
+                         chain_id),
       max_priority_fee_per_gas_(max_priority_fee_per_gas),
       max_fee_per_gas_(max_fee_per_gas) {
   type_ = 2;
@@ -34,14 +48,39 @@ bool Eip1559Transaction::operator==(const Eip1559Transaction& tx) const {
 }
 
 // static
+absl::optional<Eip1559Transaction> Eip1559Transaction::FromTxData(
+    const mojom::TxData1559Ptr& tx_data1559) {
+  uint256_t chain_id;
+  if (!HexValueToUint256(tx_data1559->chain_id, &chain_id))
+    return absl::nullopt;
+
+  absl::optional<Eip2930Transaction> tx_2930 =
+      Eip2930Transaction::FromTxData(tx_data1559->base_data, chain_id);
+  if (!tx_2930)
+    return absl::nullopt;
+
+  uint256_t max_priority_fee_per_gas;
+  if (!HexValueToUint256(tx_data1559->max_priority_fee_per_gas,
+                         &max_priority_fee_per_gas))
+    return absl::nullopt;
+  uint256_t max_fee_per_gas;
+  if (!HexValueToUint256(tx_data1559->max_fee_per_gas, &max_fee_per_gas))
+    return absl::nullopt;
+
+  Eip1559Transaction tx(tx_2930->nonce(), tx_2930->gas_price(),
+                        tx_2930->gas_limit(), tx_2930->to(), tx_2930->value(),
+                        tx_2930->data(), tx_2930->chain_id(),
+                        max_priority_fee_per_gas, max_fee_per_gas);
+  return tx;
+}
+
+// static
 absl::optional<Eip1559Transaction> Eip1559Transaction::FromValue(
     const base::Value& value) {
   absl::optional<Eip2930Transaction> tx_2930 =
       Eip2930Transaction::FromValue(value);
   if (!tx_2930)
     return absl::nullopt;
-  TxData tx_data(tx_2930->nonce(), tx_2930->gas_price(), tx_2930->gas_limit(),
-                 tx_2930->to(), tx_2930->value(), tx_2930->data());
 
   const std::string* tx_max_priority_fee_per_gas =
       value.FindStringKey("max_priority_fee_per_gas");
@@ -60,8 +99,10 @@ absl::optional<Eip1559Transaction> Eip1559Transaction::FromValue(
   if (!HexValueToUint256(*tx_max_fee_per_gas, &max_fee_per_gas))
     return absl::nullopt;
 
-  Eip1559Transaction tx(tx_data, tx_2930->chain_id(), max_priority_fee_per_gas,
-                        max_fee_per_gas);
+  Eip1559Transaction tx(tx_2930->nonce(), tx_2930->gas_price(),
+                        tx_2930->gas_limit(), tx_2930->to(), tx_2930->value(),
+                        tx_2930->data(), tx_2930->chain_id(),
+                        max_priority_fee_per_gas, max_fee_per_gas);
   tx.v_ = tx_2930->v();
   tx.r_ = tx_2930->r();
   tx.s_ = tx_2930->s();
@@ -70,7 +111,7 @@ absl::optional<Eip1559Transaction> Eip1559Transaction::FromValue(
 }
 
 std::vector<uint8_t> Eip1559Transaction::GetMessageToSign(
-    uint64_t chain_id) const {
+    uint256_t chain_id) const {
   std::vector<uint8_t> result;
   result.push_back(type_);
 

--- a/components/brave_wallet/browser/eip1559_transaction.cc
+++ b/components/brave_wallet/browser/eip1559_transaction.cc
@@ -148,7 +148,7 @@ std::string Eip1559Transaction::GetSignedTransaction() const {
   list.Append(RLPUint256ToBlobValue(value_));
   list.Append(base::Value(data_));
   list.Append(base::Value(AccessListToValue(access_list_)));
-  list.Append(base::Value(v_));
+  list.Append(RLPUint256ToBlobValue(v_));
   list.Append(base::Value(r_));
   list.Append(base::Value(s_));
 

--- a/components/brave_wallet/browser/eip1559_transaction.h
+++ b/components/brave_wallet/browser/eip1559_transaction.h
@@ -16,14 +16,21 @@ namespace brave_wallet {
 class Eip1559Transaction : public Eip2930Transaction {
  public:
   Eip1559Transaction();
-  Eip1559Transaction(const TxData&,
-                     uint64_t chain_id,
+  Eip1559Transaction(uint256_t nonce,
+                     uint256_t gas_price,
+                     uint256_t gas_limit,
+                     const EthAddress& to,
+                     uint256_t value,
+                     const std::vector<uint8_t>& data,
+                     uint256_t chain_id,
                      uint256_t max_priority_fee_per_gas,
                      uint256_t max_fee_per_gas);
   Eip1559Transaction(const Eip1559Transaction&);
   ~Eip1559Transaction() override;
   bool operator==(const Eip1559Transaction&) const;
 
+  static absl::optional<Eip1559Transaction> FromTxData(
+      const mojom::TxData1559Ptr& tx_data);
   static absl::optional<Eip1559Transaction> FromValue(const base::Value& value);
 
   uint256_t max_priority_fee_per_gas() const {
@@ -33,7 +40,7 @@ class Eip1559Transaction : public Eip2930Transaction {
 
   // keccak256(0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas,
   // gasLimit, destination, value, data, access_list]))
-  std::vector<uint8_t> GetMessageToSign(uint64_t chain_id = 0) const override;
+  std::vector<uint8_t> GetMessageToSign(uint256_t chain_id = 0) const override;
 
   // 0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit,
   // destination, value, data, accessList, signatureYParity, signatureR,

--- a/components/brave_wallet/browser/eip1559_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eip1559_transaction_unittest.cc
@@ -15,11 +15,10 @@ namespace brave_wallet {
 TEST(Eip1559TransactionUnitTest, GetMessageToSign) {
   std::vector<uint8_t> data;
   EXPECT_TRUE(base::HexStringToBytes("010200", &data));
-  EthTransaction::TxData tx_data(
+  Eip1559Transaction tx(
       0x00, 0x00, 0x00,
       EthAddress::FromHex("0x0101010101010101010101010101010101010101"), 0x00,
-      data);
-  Eip1559Transaction tx(tx_data, 0x04, 0, 0);
+      data, 0x04, 0, 0);
   ASSERT_EQ(tx.type(), 2);
   auto* access_list = tx.access_list();
   Eip2930Transaction::AccessListItem item;
@@ -103,11 +102,11 @@ TEST(Eip1559TransactionUnitTest, GetSignedTransaction) {
     HDKey key;
     key.SetPrivateKey(private_key);
     Eip1559Transaction tx(
-        EthTransaction::TxData(
-            cases[i].nonce, 0x00, cases[i].gas_limit,
-            EthAddress::FromHex("0x000000000000000000000000000000000000aaaa"),
-            cases[i].value, std::vector<uint8_t>()),
-        0x04, cases[i].max_priority_fee_per_gas, cases[i].max_fee_per_gas);
+        cases[i].nonce, 0x00, cases[i].gas_limit,
+        EthAddress::FromHex("0x000000000000000000000000000000000000aaaa"),
+        cases[i].value, std::vector<uint8_t>(), 0x04,
+        cases[i].max_priority_fee_per_gas, cases[i].max_fee_per_gas);
+
     int recid;
     const std::vector<uint8_t> signature =
         key.Sign(tx.GetMessageToSign(), &recid);
@@ -118,11 +117,9 @@ TEST(Eip1559TransactionUnitTest, GetSignedTransaction) {
 
 TEST(Eip1559TransactionUnitTest, GetUpfrontCost) {
   Eip1559Transaction tx(
-      EthTransaction::TxData(
-          0x00, 0x00, 100,
-          EthAddress::FromHex("0x0101010101010101010101010101010101010101"),
-          0x06, std::vector<uint8_t>()),
-      0x04, 8, 10);
+      0x00, 0x00, 100,
+      EthAddress::FromHex("0x0101010101010101010101010101010101010101"), 0x06,
+      std::vector<uint8_t>(), 0x04, 8, 10);
   EXPECT_EQ(tx.GetUpfrontCost(), uint256_t(806));
   EXPECT_EQ(tx.GetUpfrontCost(0), uint256_t(806));
   EXPECT_EQ(tx.GetUpfrontCost(4), uint256_t(1006));
@@ -130,11 +127,9 @@ TEST(Eip1559TransactionUnitTest, GetUpfrontCost) {
 
 TEST(Eip1559TransactionUnitTest, Serialization) {
   Eip1559Transaction tx(
-      EthTransaction::TxData(
-          0x09, 0x4a817c800, 0x5208,
-          EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
-          0x0de0b6b3a7640000, std::vector<uint8_t>()),
-      5566, 123, 456);
+      0x09, 0x4a817c800, 0x5208,
+      EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
+      0xde0b6b3a7640000, std::vector<uint8_t>(), 5566, 123, 456);
   auto* access_list = tx.access_list();
   Eip2930Transaction::AccessListItem item_a;
   item_a.address.fill(0x0a);

--- a/components/brave_wallet/browser/eip2930_transaction.cc
+++ b/components/brave_wallet/browser/eip2930_transaction.cc
@@ -43,12 +43,21 @@ bool Eip2930Transaction::AccessListItem::operator!=(
   return !operator==(item);
 }
 
-Eip2930Transaction::Eip2930Transaction() = default;
-Eip2930Transaction::Eip2930Transaction(const TxData& tx_data, uint64_t chain_id)
-    : EthTransaction(tx_data), chain_id_(chain_id) {
+Eip2930Transaction::Eip2930Transaction(const Eip2930Transaction&) = default;
+Eip2930Transaction::Eip2930Transaction(uint256_t nonce,
+                                       uint256_t gas_price,
+                                       uint256_t gas_limit,
+                                       const EthAddress& to,
+                                       uint256_t value,
+                                       const std::vector<uint8_t>& data,
+                                       uint256_t chain_id)
+    : EthTransaction(nonce, gas_price, gas_limit, to, value, data),
+      chain_id_(chain_id) {
   type_ = 1;
 }
-Eip2930Transaction::Eip2930Transaction(const Eip2930Transaction&) = default;
+Eip2930Transaction::Eip2930Transaction() {
+  type_ = 1;
+}
 Eip2930Transaction::~Eip2930Transaction() = default;
 
 bool Eip2930Transaction::operator==(const Eip2930Transaction& tx) const {
@@ -58,15 +67,24 @@ bool Eip2930Transaction::operator==(const Eip2930Transaction& tx) const {
 }
 
 // static
+absl::optional<Eip2930Transaction> Eip2930Transaction::FromTxData(
+    const mojom::TxDataPtr& tx_data,
+    uint256_t chain_id) {
+  absl::optional<EthTransaction> legacy_tx =
+      EthTransaction::FromTxData(tx_data);
+  if (!legacy_tx)
+    return absl::nullopt;
+  return Eip2930Transaction(legacy_tx->nonce(), legacy_tx->gas_price(),
+                            legacy_tx->gas_limit(), legacy_tx->to(),
+                            legacy_tx->value(), legacy_tx->data(), chain_id);
+}
+
+// static
 absl::optional<Eip2930Transaction> Eip2930Transaction::FromValue(
     const base::Value& value) {
   absl::optional<EthTransaction> legacy_tx = EthTransaction::FromValue(value);
   if (!legacy_tx)
     return absl::nullopt;
-  TxData tx_data(legacy_tx->nonce(), legacy_tx->gas_price(),
-                 legacy_tx->gas_limit(), legacy_tx->to(), legacy_tx->value(),
-                 legacy_tx->data());
-
   const std::string* tx_chain_id = value.FindStringKey("chain_id");
   if (!tx_chain_id)
     return absl::nullopt;
@@ -74,7 +92,9 @@ absl::optional<Eip2930Transaction> Eip2930Transaction::FromValue(
   if (!HexValueToUint256(*tx_chain_id, &chain_id))
     return absl::nullopt;
 
-  Eip2930Transaction tx(tx_data, static_cast<uint64_t>(chain_id));
+  Eip2930Transaction tx(legacy_tx->nonce(), legacy_tx->gas_price(),
+                        legacy_tx->gas_limit(), legacy_tx->to(),
+                        legacy_tx->value(), legacy_tx->data(), chain_id);
   tx.v_ = legacy_tx->v();
   tx.r_ = legacy_tx->r();
   tx.s_ = legacy_tx->s();
@@ -130,7 +150,7 @@ Eip2930Transaction::ValueToAccessList(const base::Value& value) {
 }
 
 std::vector<uint8_t> Eip2930Transaction::GetMessageToSign(
-    uint64_t chain_id) const {
+    uint256_t chain_id) const {
   std::vector<uint8_t> result;
   result.push_back(type_);
 
@@ -180,7 +200,7 @@ std::string Eip2930Transaction::GetSignedTransaction() const {
 
 void Eip2930Transaction::ProcessSignature(const std::vector<uint8_t> signature,
                                           int recid,
-                                          uint64_t chain_id) {
+                                          uint256_t chain_id) {
   EthTransaction::ProcessSignature(signature, recid, chain_id_);
   v_ = recid;
 }

--- a/components/brave_wallet/browser/eip2930_transaction.cc
+++ b/components/brave_wallet/browser/eip2930_transaction.cc
@@ -185,7 +185,7 @@ std::string Eip2930Transaction::GetSignedTransaction() const {
   list.Append(RLPUint256ToBlobValue(value_));
   list.Append(base::Value(data_));
   list.Append(base::Value(AccessListToValue(access_list_)));
-  list.Append(base::Value(v_));
+  list.Append(RLPUint256ToBlobValue(v_));
   list.Append(base::Value(r_));
   list.Append(base::Value(s_));
 

--- a/components/brave_wallet/browser/eip2930_transaction.h
+++ b/components/brave_wallet/browser/eip2930_transaction.h
@@ -33,23 +33,31 @@ class Eip2930Transaction : public EthTransaction {
   typedef std::vector<AccessListItem> AccessList;
 
   Eip2930Transaction();
-  Eip2930Transaction(const TxData&, uint64_t chain_id);
+  Eip2930Transaction(uint256_t nonce,
+                     uint256_t gas_price,
+                     uint256_t gas_limit,
+                     const EthAddress& to,
+                     uint256_t value,
+                     const std::vector<uint8_t>& data,
+                     uint256_t chain_id);
   Eip2930Transaction(const Eip2930Transaction&);
   ~Eip2930Transaction() override;
   bool operator==(const Eip2930Transaction&) const;
 
+  static absl::optional<Eip2930Transaction> FromTxData(const mojom::TxDataPtr&,
+                                                       uint256_t chain_id);
   static absl::optional<Eip2930Transaction> FromValue(const base::Value& value);
 
   static std::vector<base::Value> AccessListToValue(const AccessList&);
   static absl::optional<AccessList> ValueToAccessList(const base::Value&);
 
-  uint64_t chain_id() const { return chain_id_; }
+  uint256_t chain_id() const { return chain_id_; }
   const AccessList* access_list() const { return &access_list_; }
   AccessList* access_list() { return &access_list_; }
 
   // keccak256(0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data,
   // accessList]))
-  std::vector<uint8_t> GetMessageToSign(uint64_t chain_id = 0) const override;
+  std::vector<uint8_t> GetMessageToSign(uint256_t chain_id = 0) const override;
 
   // 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data,
   // accessList, signatureYParity, signatureR, signatureS])
@@ -57,7 +65,7 @@ class Eip2930Transaction : public EthTransaction {
 
   void ProcessSignature(const std::vector<uint8_t> signature,
                         int recid,
-                        uint64_t chain_id = 0) override;
+                        uint256_t chain_id = 0) override;
 
   bool IsSigned() const override;
 
@@ -66,7 +74,7 @@ class Eip2930Transaction : public EthTransaction {
   uint256_t GetDataFee() const override;
 
  protected:
-  uint64_t chain_id_;
+  uint256_t chain_id_;
   AccessList access_list_;
 };
 

--- a/components/brave_wallet/browser/eip2930_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eip2930_transaction_unittest.cc
@@ -134,7 +134,7 @@ TEST(Eip2930TransactionUnitTest, GetSignedTransaction) {
       "77b35057971e6b4b06dfdf55a6fbed819133a6c1d31e187f1bca938da00be950468ba1c2"
       "5a5cb50e9f6d8aa13c8cd21f24ba909402775b262ac76d374d");
 
-  EXPECT_EQ(tx.v_, 0u);
+  EXPECT_EQ(tx.v_, (uint256_t)0);
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx.r_)),
             "294ac94077b35057971e6b4b06dfdf55a6fbed819133a6c1d31e187f1bca938d");
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx.s_)),

--- a/components/brave_wallet/browser/eip2930_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eip2930_transaction_unittest.cc
@@ -74,11 +74,10 @@ TEST(Eip2930TransactionUnitTest, AccessListAndValue) {
 TEST(Eip2930TransactionUnitTest, GetMessageToSign) {
   std::vector<uint8_t> data;
   EXPECT_TRUE(base::HexStringToBytes("010200", &data));
-  EthTransaction::TxData tx_data(
+  Eip2930Transaction tx(
       0x00, 0x00, 0x00,
       EthAddress::FromHex("0x0101010101010101010101010101010101010101"), 0x00,
-      data);
-  Eip2930Transaction tx(tx_data, 0x01);
+      data, 0x01);
   ASSERT_EQ(tx.type(), 1);
   auto* access_list = tx.access_list();
   Eip2930Transaction::AccessListItem item;
@@ -95,11 +94,10 @@ TEST(Eip2930TransactionUnitTest, GetMessageToSign) {
 }
 
 TEST(Eip2930TransactionUnitTest, GetSignedTransaction) {
-  EthTransaction::TxData tx_data(
+  Eip2930Transaction tx(
       0x00, 0x3b9aca00, 0x62d4,
       EthAddress::FromHex("0xdf0a88b2b68c673713a8ec826003676f272e3573"), 0x01,
-      std::vector<uint8_t>());
-  Eip2930Transaction tx(tx_data, 0x796f6c6f763378);
+      std::vector<uint8_t>(), 0x796f6c6f763378);
   ASSERT_EQ(tx.type(), 1);
   auto* access_list = tx.access_list();
   Eip2930Transaction::AccessListItem item;
@@ -145,11 +143,9 @@ TEST(Eip2930TransactionUnitTest, GetSignedTransaction) {
 
 TEST(Eip2930TransactionUnitTest, Serialization) {
   Eip2930Transaction tx(
-      EthTransaction::TxData(
-          0x09, 0x4a817c800, 0x5208,
-          EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
-          0x0de0b6b3a7640000, std::vector<uint8_t>()),
-      5566);
+      0x09, 0x4a817c800, 0x5208,
+      EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
+      0x0de0b6b3a7640000, std::vector<uint8_t>(), 5566);
   auto* access_list = tx.access_list();
   Eip2930Transaction::AccessListItem item_a;
   item_a.address.fill(0x0a);
@@ -168,11 +164,9 @@ TEST(Eip2930TransactionUnitTest, GetBaseFee) {
   std::vector<uint8_t> data;
   ASSERT_TRUE(base::HexStringToBytes("010200", &data));
   Eip2930Transaction tx(
-      EthTransaction::TxData(
-          0, 0, 0,
-          EthAddress::FromHex("0x3535353535353535353535353535353535353535"), 0,
-          data),
-      5566);
+      0, 0, 0,
+      EthAddress::FromHex("0x3535353535353535353535353535353535353535"), 0,
+      data, 5566);
 
   auto* access_list = tx.access_list();
   Eip2930Transaction::AccessListItem item_a;
@@ -187,8 +181,7 @@ TEST(Eip2930TransactionUnitTest, GetBaseFee) {
   const uint256_t fee = 21000 + 2 * 16 + 4 + 2400 + 1900;
   EXPECT_EQ(tx.GetBaseFee(), fee);
 
-  Eip2930Transaction tx2(EthTransaction::TxData(0, 0, 0, EthAddress(), 0, data),
-                         5566);
+  Eip2930Transaction tx2(0, 0, 0, EthAddress(), 0, data, 5566);
   *tx2.access_list() = *tx.access_list();
   // Plus contract creation
   const uint256_t fee2 = fee + uint256_t(32000);
@@ -196,11 +189,9 @@ TEST(Eip2930TransactionUnitTest, GetBaseFee) {
 
   // Duplicate items in Access list
   Eip2930Transaction tx3(
-      EthTransaction::TxData(
-          0, 0, 0,
-          EthAddress::FromHex("0x3535353535353535353535353535353535353535"), 0,
-          std::vector<uint8_t>()),
-      5566);
+      0, 0, 0,
+      EthAddress::FromHex("0x3535353535353535353535353535353535353535"), 0,
+      std::vector<uint8_t>(), 5566);
 
   auto* access_list3 = tx3.access_list();
   access_list3->push_back(item_a);

--- a/components/brave_wallet/browser/eth_call_data_builder.cc
+++ b/components/brave_wallet/browser/eth_call_data_builder.cc
@@ -5,11 +5,30 @@
 
 #include "brave/components/brave_wallet/browser/eth_call_data_builder.h"
 
+#include "base/logging.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 
 namespace brave_wallet {
 
 namespace erc20 {
+
+bool Transfer(const std::string& to_address,
+              uint256_t amount,
+              std::string* data) {
+  const std::string function_hash =
+      GetFunctionHash("transfer(address,uint256)");
+  std::string padded_address;
+  if (!brave_wallet::PadHexEncodedParameter(to_address, &padded_address)) {
+    return false;
+  }
+  std::string padded_amount;
+  if (!PadHexEncodedParameter(Uint256ValueToHex(amount), &padded_amount)) {
+    return false;
+  }
+  std::vector<std::string> hex_strings = {function_hash, padded_address,
+                                          padded_amount};
+  return ConcatHexStrings(hex_strings, data);
+}
 
 bool BalanceOf(const std::string& address, std::string* data) {
   const std::string function_hash = GetFunctionHash("balanceOf(address)");

--- a/components/brave_wallet/browser/eth_call_data_builder.h
+++ b/components/brave_wallet/browser/eth_call_data_builder.h
@@ -9,11 +9,16 @@
 #include <string>
 #include <vector>
 #include "base/values.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_types.h"
 
 namespace brave_wallet {
 
 namespace erc20 {
 
+// Allows transferring ERC20 tokens
+bool Transfer(const std::string& to_address,
+              uint256_t amount,
+              std::string* data);
 // Returns the balance of an  address
 bool BalanceOf(const std::string& address, std::string* data);
 

--- a/components/brave_wallet/browser/eth_call_data_builder_unittest.cc
+++ b/components/brave_wallet/browser/eth_call_data_builder_unittest.cc
@@ -11,6 +11,16 @@ namespace brave_wallet {
 
 namespace erc20 {
 
+TEST(EthCallDataBuilderTest, Transfer) {
+  std::string data;
+  Transfer("0xBFb30a082f650C2A15D0632f0e87bE4F8e64460f", 0xde0b6b3a7640000,
+           &data);
+  ASSERT_EQ(
+      data,
+      "0xa9059cbb000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e6446"
+      "0f0000000000000000000000000000000000000000000000000de0b6b3a7640000");
+}
+
 TEST(EthCallDataBuilderTest, BalanceOf) {
   std::string data;
   BalanceOf("0x4e02f254184E904300e0775E4b8eeCB1", &data);

--- a/components/brave_wallet/browser/eth_json_rpc_controller.cc
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.cc
@@ -144,9 +144,13 @@ void EthJsonRpcController::FireNetworkChanged() {
   }
 }
 
+std::string EthJsonRpcController::GetChainId() const {
+  return GetChainIdFromNetwork(network_);
+}
+
 void EthJsonRpcController::GetChainId(
     mojom::EthJsonRpcController::GetChainIdCallback callback) {
-  std::move(callback).Run(GetChainIdFromNetwork(network_));
+  std::move(callback).Run(GetChainId());
 }
 
 void EthJsonRpcController::GetBlockTrackerUrl(
@@ -464,6 +468,7 @@ std::string EthJsonRpcController::GetChainIdFromNetwork(
       chain_id = "0x2a";
       break;
     case brave_wallet::mojom::Network::Localhost:
+      chain_id = "0x539";  // 1337
       break;
     case brave_wallet::mojom::Network::Custom:
       break;

--- a/components/brave_wallet/browser/eth_json_rpc_controller.h
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.h
@@ -94,6 +94,7 @@ class EthJsonRpcController : public KeyedService,
   void GetNetwork(
       mojom::EthJsonRpcController::GetNetworkCallback callback) override;
   void SetNetwork(mojom::Network network) override;
+  std::string GetChainId() const;
   void GetChainId(
       mojom::EthJsonRpcController::GetChainIdCallback callback) override;
   void GetBlockTrackerUrl(

--- a/components/brave_wallet/browser/eth_nonce_tracker.cc
+++ b/components/brave_wallet/browser/eth_nonce_tracker.cc
@@ -23,9 +23,9 @@ uint256_t GetHighestLocallyConfirmed(
     const std::vector<std::unique_ptr<EthTxStateManager::TxMeta>>& metas) {
   uint256_t highest = 0;
   for (auto& meta : metas) {
-    highest = std::max(highest, meta->tx->nonce());
+    highest = std::max(highest, meta->tx->nonce() + (uint256_t)1);
   }
-  return ++highest;
+  return highest;
 }
 
 uint256_t GetHighestContinuousFrom(

--- a/components/brave_wallet/browser/eth_pending_tx_tracker.cc
+++ b/components/brave_wallet/browser/eth_pending_tx_tracker.cc
@@ -77,7 +77,7 @@ void EthPendingTxTracker::OnGetTxReceipt(std::string id,
     nonce_lock->Release();
     return;
   }
-  if (receipt.status == true) {
+  if (receipt.status) {
     meta->tx_receipt = receipt;
     meta->status = EthTxStateManager::TransactionStatus::CONFIRMED;
     meta->confirmed_time = base::Time::Now();

--- a/components/brave_wallet/browser/eth_transaction.cc
+++ b/components/brave_wallet/browser/eth_transaction.cc
@@ -23,31 +23,20 @@ constexpr uint256_t kTxDataZeroCostPerByte = 4;
 constexpr uint256_t kTxDataCostPerByte = 16;
 }  // namespace
 
-EthTransaction::TxData::TxData() = default;
-EthTransaction::TxData::~TxData() = default;
-EthTransaction::TxData::TxData(const uint256_t& nonce_in,
-                               const uint256_t& gas_price_in,
-                               const uint256_t& gas_limit_in,
-                               const EthAddress& to_in,
-                               const uint256_t& value_in,
-                               const std::vector<uint8_t>& data_in)
-    : nonce(nonce_in),
-      gas_price(gas_price_in),
-      gas_limit(gas_limit_in),
-      to(to_in),
-      value(value_in),
-      data(data_in) {}
-
 EthTransaction::EthTransaction() = default;
-EthTransaction::EthTransaction(const TxData& tx_data)
-    : nonce_(tx_data.nonce),
-      gas_price_(tx_data.gas_price),
-      gas_limit_(tx_data.gas_limit),
-      to_(tx_data.to),
-      value_(tx_data.value),
-      data_(tx_data.data) {}
-
 EthTransaction::EthTransaction(const EthTransaction&) = default;
+EthTransaction::EthTransaction(uint256_t nonce,
+                               uint256_t gas_price,
+                               uint256_t gas_limit,
+                               const EthAddress& to,
+                               uint256_t value,
+                               const std::vector<uint8_t>& data)
+    : nonce_(nonce),
+      gas_price_(gas_price),
+      gas_limit_(gas_limit),
+      to_(to),
+      value_(value),
+      data_(data) {}
 EthTransaction::~EthTransaction() = default;
 
 bool EthTransaction::operator==(const EthTransaction& tx) const {
@@ -56,6 +45,23 @@ bool EthTransaction::operator==(const EthTransaction& tx) const {
          std::equal(data_.begin(), data_.end(), tx.data_.begin()) &&
          v_ == tx.v_ && std::equal(r_.begin(), r_.end(), tx.r_.begin()) &&
          std::equal(s_.begin(), s_.end(), tx.s_.begin()) && type_ == tx.type_;
+}
+
+// static
+absl::optional<EthTransaction> EthTransaction::FromTxData(
+    const mojom::TxDataPtr& tx_data) {
+  EthTransaction tx;
+  if (!HexValueToUint256(tx_data->nonce, &tx.nonce_))
+    return absl::nullopt;
+  if (!HexValueToUint256(tx_data->gas_price, &tx.gas_price_))
+    return absl::nullopt;
+  if (!HexValueToUint256(tx_data->gas_limit, &tx.gas_limit_))
+    return absl::nullopt;
+  tx.to_ = EthAddress::FromHex(tx_data->to);
+  if (!HexValueToUint256(tx_data->value, &tx.value_))
+    return absl::nullopt;
+  tx.data_ = tx_data->data;
+  return tx;
 }
 
 // static
@@ -128,7 +134,8 @@ absl::optional<EthTransaction> EthTransaction::FromValue(
   return tx;
 }
 
-std::vector<uint8_t> EthTransaction::GetMessageToSign(uint64_t chain_id) const {
+std::vector<uint8_t> EthTransaction::GetMessageToSign(
+    uint256_t chain_id) const {
   base::ListValue list;
   list.Append(RLPUint256ToBlobValue(nonce_));
   list.Append(RLPUint256ToBlobValue(gas_price_));
@@ -164,7 +171,7 @@ std::string EthTransaction::GetSignedTransaction() const {
 // signature and recid will be used to produce v, r, s
 void EthTransaction::ProcessSignature(const std::vector<uint8_t> signature,
                                       int recid,
-                                      uint64_t chain_id) {
+                                      uint256_t chain_id) {
   if (signature.size() != 64) {
     LOG(ERROR) << __func__ << ": signature length should be 64 bytes";
     return;
@@ -177,7 +184,10 @@ void EthTransaction::ProcessSignature(const std::vector<uint8_t> signature,
                             signature.begin() + signature.size() / 2);
   s_ = std::vector<uint8_t>(signature.begin() + signature.size() / 2,
                             signature.end());
-  v_ = chain_id ? recid + (chain_id * 2 + 35) : recid + 27;
+  v_ = chain_id ? static_cast<uint256_t>(recid) +
+                      (chain_id * static_cast<uint256_t>(2) +
+                       static_cast<uint256_t>(35))
+                : static_cast<uint256_t>(recid) + static_cast<uint256_t>(27);
 }
 
 bool EthTransaction::IsSigned() const {

--- a/components/brave_wallet/browser/eth_transaction.cc
+++ b/components/brave_wallet/browser/eth_transaction.cc
@@ -161,7 +161,7 @@ std::string EthTransaction::GetSignedTransaction() const {
   list.Append(base::Value(to_.bytes()));
   list.Append(RLPUint256ToBlobValue(value_));
   list.Append(base::Value(data_));
-  list.Append(base::Value(v_));
+  list.Append(RLPUint256ToBlobValue(v_));
   list.Append(base::Value(r_));
   list.Append(base::Value(s_));
 
@@ -191,7 +191,7 @@ void EthTransaction::ProcessSignature(const std::vector<uint8_t> signature,
 }
 
 bool EthTransaction::IsSigned() const {
-  return v_ != 0 && r_.size() != 0 && s_.size() != 0;
+  return v_ != (uint256_t)0 && r_.size() != 0 && s_.size() != 0;
 }
 
 base::Value EthTransaction::ToValue() const {

--- a/components/brave_wallet/browser/eth_transaction.h
+++ b/components/brave_wallet/browser/eth_transaction.h
@@ -49,7 +49,7 @@ class EthTransaction {
   EthAddress to() const { return to_; }
   uint256_t value() const { return value_; }
   std::vector<uint8_t> data() const { return data_; }
-  uint8_t v() const { return v_; }
+  uint256_t v() const { return v_; }
   std::vector<uint8_t> r() const { return r_; }
   std::vector<uint8_t> s() const { return s_; }
 
@@ -96,7 +96,7 @@ class EthTransaction {
   uint256_t value_;
   std::vector<uint8_t> data_;
 
-  uint8_t v_ = 0;
+  uint256_t v_ = 0;
   std::vector<uint8_t> r_;
   std::vector<uint8_t> s_;
 

--- a/components/brave_wallet/browser/eth_transaction.h
+++ b/components/brave_wallet/browser/eth_transaction.h
@@ -12,6 +12,7 @@
 #include "base/gtest_prod_util.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_types.h"
 #include "brave/components/brave_wallet/browser/eth_address.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace base {
@@ -25,29 +26,19 @@ FORWARD_DECLARE_TEST(Eip2930TransactionUnitTest, GetSignedTransaction);
 
 class EthTransaction {
  public:
-  struct TxData {
-    TxData();
-    TxData(const uint256_t& nonce_in,
-           const uint256_t& gas_price_in,
-           const uint256_t& gas_limit_in,
-           const EthAddress& to_in,
-           const uint256_t& value_in,
-           const std::vector<uint8_t>& data_in);
-    ~TxData();
-
-    uint256_t nonce;
-    uint256_t gas_price;
-    uint256_t gas_limit;
-    EthAddress to;
-    uint256_t value;
-    std::vector<uint8_t> data;
-  };
   EthTransaction();
-  explicit EthTransaction(const TxData&);
+  EthTransaction(uint256_t nonce,
+                 uint256_t gas_price,
+                 uint256_t gas_limit,
+                 const EthAddress& to,
+                 uint256_t value,
+                 const std::vector<uint8_t>& data);
   EthTransaction(const EthTransaction&);
   virtual ~EthTransaction();
   bool operator==(const EthTransaction&) const;
 
+  static absl::optional<EthTransaction> FromTxData(
+      const mojom::TxDataPtr& tx_data);
   static absl::optional<EthTransaction> FromValue(const base::Value& value);
 
   uint8_t type() const { return type_; }
@@ -71,7 +62,7 @@ class EthTransaction {
   // return
   // keccack(rlp([nonce, gasPrice, gasLimit, to, value, data, chainID, 0, 0])
   // Support EIP-155 chain id
-  virtual std::vector<uint8_t> GetMessageToSign(uint64_t chain_id = 0) const;
+  virtual std::vector<uint8_t> GetMessageToSign(uint256_t chain_id = 0) const;
 
   // return rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
   virtual std::string GetSignedTransaction() const;
@@ -80,7 +71,7 @@ class EthTransaction {
   // Support EIP-155 chain id
   virtual void ProcessSignature(const std::vector<uint8_t> signature,
                                 int recid,
-                                uint64_t chain_id = 0);
+                                uint256_t chain_id = 0);
 
   virtual bool IsSigned() const;
 

--- a/components/brave_wallet/browser/eth_transaction.h
+++ b/components/brave_wallet/browser/eth_transaction.h
@@ -62,7 +62,7 @@ class EthTransaction {
   // return
   // keccack(rlp([nonce, gasPrice, gasLimit, to, value, data, chainID, 0, 0])
   // Support EIP-155 chain id
-  virtual std::vector<uint8_t> GetMessageToSign(uint256_t chain_id = 0) const;
+  virtual std::vector<uint8_t> GetMessageToSign(uint256_t chain_id) const;
 
   // return rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
   virtual std::string GetSignedTransaction() const;
@@ -71,7 +71,7 @@ class EthTransaction {
   // Support EIP-155 chain id
   virtual void ProcessSignature(const std::vector<uint8_t> signature,
                                 int recid,
-                                uint256_t chain_id = 0);
+                                uint256_t chain_id);
 
   virtual bool IsSigned() const;
 

--- a/components/brave_wallet/browser/eth_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eth_transaction_unittest.cc
@@ -31,19 +31,19 @@ TEST(EthTransactionUnitTest, GetMessageToSign) {
       "00000000000000000000000a00000000000000000000000000000000000000000000"
       "0000000000000000000d",
       &data));
-  EthTransaction tx1(EthTransaction::TxData(
+  EthTransaction tx1(
       0x06, 0x09184e72a000, 0x0974,
       EthAddress::FromHex("0xbe862ad9abfe6f22bcb087716c7d89a26051f74c"),
-      0x016345785d8a0000, data));
+      0x016345785d8a0000, data);
 
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx1.GetMessageToSign())),
             "61e1ec33764304dddb55348e7883d4437426f44ab3ef65e6da1e025734c03ff0");
 
   data.clear();
-  EthTransaction tx2(EthTransaction::TxData(
+  EthTransaction tx2(
       0x0b, 0x051f4d5c00, 0x5208,
       EthAddress::FromHex("0x656e929d6fc0cac52d3d9526d288fe02dcd56fbd"),
-      0x2386f26fc10000, data));
+      0x2386f26fc10000, data);
 
   // with chain id (mainnet)
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx2.GetMessageToSign(1))),
@@ -91,10 +91,9 @@ TEST(EthTransactionUnitTest, GetMessageToSign) {
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-    EthTransaction tx(EthTransaction::TxData(
-        cases[i].nonce, cases[i].gas_price, cases[i].gas_limit,
-        EthAddress::FromHex(cases[i].to), cases[i].value,
-        std::vector<uint8_t>()));
+    EthTransaction tx(cases[i].nonce, cases[i].gas_price, cases[i].gas_limit,
+                      EthAddress::FromHex(cases[i].to), cases[i].value,
+                      std::vector<uint8_t>());
     // with chain id (mainnet)
     EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx.GetMessageToSign(1))),
               cases[i].hash);
@@ -109,10 +108,11 @@ TEST(EthTransactionUnitTest, GetSignedTransaction) {
 
   HDKey key;
   key.SetPrivateKey(private_key);
-  EthTransaction tx(EthTransaction::TxData(
+  EthTransaction tx(
       0x09, 0x4a817c800, 0x5208,
       EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
-      0x0de0b6b3a7640000, std::vector<uint8_t>()));
+      0x0de0b6b3a7640000, std::vector<uint8_t>());
+
   const std::vector<uint8_t> message = tx.GetMessageToSign(1);
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(message)),
             "daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53");
@@ -151,10 +151,10 @@ TEST(EthTransactionUnitTest, GetSignedTransaction) {
 }
 
 TEST(EthTransactionUnitTest, TransactionAndValue) {
-  EthTransaction tx(EthTransaction::TxData(
+  EthTransaction tx(
       0x09, 0x4a817c800, 0x5208,
       EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
-      0x0de0b6b3a7640000, std::vector<uint8_t>()));
+      0x0de0b6b3a7640000, std::vector<uint8_t>());
   base::Value tx_value = tx.ToValue();
   auto tx_from_value = EthTransaction::FromValue(tx_value);
   ASSERT_NE(tx_from_value, absl::nullopt);
@@ -184,18 +184,18 @@ TEST(EthTransactionUnitTest, GetDataFee) {
       "0000000000000000000000000000000000000000000000000000000a0000000000000000"
       "00000000000000000000000000000000000000000000000d",
       &data));
-  EthTransaction tx2(EthTransaction::TxData(
+  EthTransaction tx2(
       0x06, 0x09184e72a000, 0x0974,
       EthAddress::FromHex("0xbe862ad9abfe6f22bcb087716c7d89a26051f74c"),
-      0x016345785d8a0000, data));
+      0x016345785d8a0000, data);
   EXPECT_EQ(tx2.GetDataFee(), uint256_t(1716));
 }
 
 TEST(EthTransactionUnitTest, GetUpFrontCost) {
-  EthTransaction tx(EthTransaction::TxData(
+  EthTransaction tx(
       0x00, 1000, 10000000,
       EthAddress::FromHex("0x3535353535353535353535353535353535353535"), 42,
-      std::vector<uint8_t>()));
+      std::vector<uint8_t>());
   EXPECT_EQ(tx.GetUpfrontCost(), uint256_t(10000000042));
 }
 

--- a/components/brave_wallet/browser/eth_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eth_transaction_unittest.cc
@@ -36,8 +36,11 @@ TEST(EthTransactionUnitTest, GetMessageToSign) {
       EthAddress::FromHex("0xbe862ad9abfe6f22bcb087716c7d89a26051f74c"),
       0x016345785d8a0000, data);
 
-  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx1.GetMessageToSign())),
+  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx1.GetMessageToSign(0))),
             "61e1ec33764304dddb55348e7883d4437426f44ab3ef65e6da1e025734c03ff0");
+
+  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(tx1.GetMessageToSign(1337))),
+            "9ad82175b6921c5525fc52ebc08b97118cc9709952a16b2249a3f42d44614721");
 
   data.clear();
   EthTransaction tx2(
@@ -122,7 +125,7 @@ TEST(EthTransactionUnitTest, GetSignedTransaction) {
 
   // invalid
   tx.ProcessSignature(std::vector<uint8_t>(63), recid, 1);
-  EXPECT_EQ(tx.v_, 0);
+  EXPECT_EQ(tx.v_, (uint256_t)0);
   EXPECT_TRUE(tx.r_.empty());
   EXPECT_TRUE(tx.s_.empty());
   EXPECT_FALSE(tx.IsSigned());
@@ -141,13 +144,32 @@ TEST(EthTransactionUnitTest, GetSignedTransaction) {
             "dc64214b297fb1966a3b6d83");
 
   EXPECT_TRUE(tx.IsSigned());
-  EXPECT_EQ(tx.v_, 37);
+  EXPECT_EQ(tx.v_, (uint256_t)37);
   // 18515461264373351373200002665853028612451056578545711640558177340181847433846
   EXPECT_EQ(base::HexEncode(tx.r_),
             "28EF61340BD939BC2195FE537567866003E1A15D3C71FF63E1590620AA636276");
   // 46948507304638947509940763649030358759909902576025900602547168820602576006531
   EXPECT_EQ(base::HexEncode(tx.s_),
             "67CBE9D8997F761AECB703304B3800CCF555C9F3DC64214B297FB1966A3B6D83");
+
+  // Bigger chain_id
+  const std::vector<uint8_t> message1337 = tx.GetMessageToSign(1337);
+  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(message1337)),
+            "9df81edc908cd622cbbab86525a4588fdcbaf6c88757f39b42b1f8f58fd617c2");
+  recid = 0;
+  const std::vector<uint8_t> signature1337 = key.Sign(message1337, &recid);
+  tx.ProcessSignature(signature1337, recid, 1337);
+  EXPECT_EQ(tx.GetSignedTransaction(),
+            "0xf86e098504a817c8008252089435353535353535353535353535353535353535"
+            "35880de0b6b3a764000080820a96a011d1f0b9de554ad9e690bb8355507007731b"
+            "741e232ecb0dc183154c10c77875a03a4b32607c8c2287e82ae8c2a334d8412baf"
+            "15e52ee25c531762dc34252a1365");
+  EXPECT_TRUE(tx.IsSigned());
+  EXPECT_EQ(tx.v_, (uint256_t)2710);
+  EXPECT_EQ(base::HexEncode(tx.r_),
+            "11D1F0B9DE554AD9E690BB8355507007731B741E232ECB0DC183154C10C77875");
+  EXPECT_EQ(base::HexEncode(tx.s_),
+            "3A4B32607C8C2287E82AE8C2A334D8412BAF15E52EE25C531762DC34252A1365");
 }
 
 TEST(EthTransactionUnitTest, TransactionAndValue) {

--- a/components/brave_wallet/browser/eth_tx_controller.cc
+++ b/components/brave_wallet/browser/eth_tx_controller.cc
@@ -5,38 +5,48 @@
 
 #include "brave/components/brave_wallet/browser/eth_tx_controller.h"
 
+#include <memory>
 #include <utility>
 
 #include "base/bind.h"
 #include "base/logging.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
+#include "brave/components/brave_wallet/browser/eip1559_transaction.h"
 #include "brave/components/brave_wallet/browser/eth_address.h"
 #include "brave/components/brave_wallet/browser/eth_json_rpc_controller.h"
 #include "brave/components/brave_wallet/browser/keyring_controller.h"
 
 namespace brave_wallet {
 
-EthTxController::EthTxController(EthJsonRpcController* rpc_controller,
-                                 KeyringController* keyring_controller,
-                                 PrefService* prefs)
+EthTxController::EthTxController(
+    EthJsonRpcController* rpc_controller,
+    KeyringController* keyring_controller,
+    std::unique_ptr<EthTxStateManager> tx_state_manager,
+    std::unique_ptr<EthNonceTracker> nonce_tracker,
+    std::unique_ptr<EthPendingTxTracker> pending_tx_tracker,
+    PrefService* prefs)
     : rpc_controller_(rpc_controller),
       keyring_controller_(keyring_controller),
-      // TODO(darkdh): make TxStateManagerFactory after
-      // https://github.com/brave/brave-core/pull/9671
-      tx_state_manager_(
-          std::make_unique<EthTxStateManager>(prefs,
-                                              rpc_controller_->MakeRemote())),
-      nonce_tracker_(std::make_unique<EthNonceTracker>(tx_state_manager_.get(),
-                                                       rpc_controller_)),
-      pending_tx_tracker_(
-          std::make_unique<EthPendingTxTracker>(tx_state_manager_.get(),
-                                                rpc_controller_,
-                                                nonce_tracker_.get())),
+      tx_state_manager_(std::move(tx_state_manager)),
+      nonce_tracker_(std::move(nonce_tracker)),
+      pending_tx_tracker_(std::move(pending_tx_tracker)),
       weak_factory_(this) {
   DCHECK(rpc_controller_);
   DCHECK(keyring_controller_);
 }
 
 EthTxController::~EthTxController() = default;
+
+mojo::PendingRemote<mojom::EthTxController> EthTxController::MakeRemote() {
+  mojo::PendingRemote<mojom::EthTxController> remote;
+  receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
+  return remote;
+}
+
+void EthTxController::Bind(
+    mojo::PendingReceiver<mojom::EthTxController> receiver) {
+  receivers_.Add(this, std::move(receiver));
+}
 
 void EthTxController::AddObserver(Observer* observer) {
   observers_.AddObserver(observer);
@@ -47,28 +57,57 @@ void EthTxController::RemoveObserver(Observer* observer) {
 }
 
 void EthTxController::AddUnapprovedTransaction(
-    std::unique_ptr<EthTransaction> tx,
-    const EthAddress& from) {
-  EthTxStateManager::TxMeta meta(std::move(tx));
+    mojom::TxDataPtr tx_data,
+    const std::string& from,
+    AddUnapprovedTransactionCallback callback) {
+  auto tx = EthTransaction::FromTxData(tx_data);
+  if (!tx) {
+    std::move(callback).Run(false, "");
+    return;
+  }
+  EthTxStateManager::TxMeta meta(std::make_unique<EthTransaction>(*tx));
   meta.id = EthTxStateManager::GenerateMetaID();
-  // TODO(darkdh): estimate gas price and limit
-  meta.tx->set_gas_price(20);
-  meta.tx->set_gas_limit(21000);
-  meta.from = from;
+  meta.from = EthAddress::FromHex(from);
   meta.created_time = base::Time::Now();
   meta.status = EthTxStateManager::TransactionStatus::UNAPPROVED;
   tx_state_manager_->AddOrUpdateTx(meta);
 
   for (Observer& observer : observers_)
     observer.OnNewUnapprovedTx(meta);
+
+  std::move(callback).Run(true, meta.id);
 }
 
-bool EthTxController::ApproveTransaction(const std::string& tx_meta_id) {
+void EthTxController::AddUnapproved1559Transaction(
+    mojom::TxData1559Ptr tx_data,
+    const std::string& from,
+    AddUnapproved1559TransactionCallback callback) {
+  auto tx = Eip1559Transaction::FromTxData(tx_data);
+  if (!tx) {
+    std::move(callback).Run(false, "");
+    return;
+  }
+  EthTxStateManager::TxMeta meta(std::make_unique<Eip1559Transaction>(*tx));
+  meta.id = EthTxStateManager::GenerateMetaID();
+  meta.from = EthAddress::FromHex(from);
+  meta.created_time = base::Time::Now();
+  meta.status = EthTxStateManager::TransactionStatus::UNAPPROVED;
+  tx_state_manager_->AddOrUpdateTx(meta);
+
+  for (Observer& observer : observers_)
+    observer.OnNewUnapprovedTx(meta);
+
+  std::move(callback).Run(true, meta.id);
+}
+
+void EthTxController::ApproveTransaction(const std::string& tx_meta_id,
+                                         ApproveTransactionCallback callback) {
   std::unique_ptr<EthTxStateManager::TxMeta> meta =
       tx_state_manager_->GetTx(tx_meta_id);
   if (!meta) {
     LOG(ERROR) << "No transaction found";
-    return false;
+    std::move(callback).Run(false);
+    return;
   }
   if (!meta->last_gas_price) {
     nonce_tracker_->GetNextNonce(
@@ -80,18 +119,21 @@ bool EthTxController::ApproveTransaction(const std::string& tx_meta_id) {
     OnGetNextNonce(std::move(meta), true, nonce);
   }
 
-  return true;
+  std::move(callback).Run(true);
 }
 
-void EthTxController::RejectTransaction(const std::string& tx_meta_id) {
+void EthTxController::RejectTransaction(const std::string& tx_meta_id,
+                                        RejectTransactionCallback callback) {
   std::unique_ptr<EthTxStateManager::TxMeta> meta =
       tx_state_manager_->GetTx(tx_meta_id);
   if (!meta) {
     LOG(ERROR) << "No transaction found";
+    std::move(callback).Run(false);
     return;
   }
   meta->status = EthTxStateManager::TransactionStatus::REJECTED;
   tx_state_manager_->AddOrUpdateTx(*meta);
+  std::move(callback).Run(true);
 }
 
 void EthTxController::OnGetNextNonce(
@@ -103,26 +145,26 @@ void EthTxController::OnGetNextNonce(
     LOG(ERROR) << "GetNextNonce failed";
     return;
   }
+  if (!meta->tx->IsSigned()) {
+    LOG(ERROR) << "Transaction must be signed first";
+    return;
+  }
   meta->tx->set_nonce(nonce);
   DCHECK(!keyring_controller_->IsLocked());
   keyring_controller_->SignTransactionByDefaultKeyring(
       meta->from.ToChecksumAddress(), meta->tx.get());
   meta->status = EthTxStateManager::TransactionStatus::APPROVED;
   tx_state_manager_->AddOrUpdateTx(*meta);
-  PublishTransaction(*meta->tx, meta->id);
+  PublishTransaction(meta->id, meta->tx->GetSignedTransaction());
 }
 
-void EthTxController::PublishTransaction(const EthTransaction& tx,
-                                         const std::string& tx_meta_id) {
-  if (!tx.IsSigned()) {
-    LOG(ERROR) << "Transaction must be signed first";
-    return;
-  }
-
+void EthTxController::PublishTransaction(
+    const std::string& tx_meta_id,
+    const std::string& signed_transaction) {
   rpc_controller_->SendRawTransaction(
-      tx.GetSignedTransaction(),
+      signed_transaction,
       base::BindOnce(&EthTxController::OnPublishTransaction,
-                     weak_factory_.GetWeakPtr(), std::string(tx_meta_id)));
+                     weak_factory_.GetWeakPtr(), tx_meta_id));
 }
 
 void EthTxController::OnPublishTransaction(std::string tx_meta_id,

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -67,6 +67,9 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
                           ApproveTransactionCallback) override;
   void RejectTransaction(const std::string& tx_meta_id,
                          RejectTransactionCallback) override;
+  void MakeERC20TransferData(const std::string& to_address,
+                             const std::string& amount,
+                             MakeERC20TransferDataCallback) override;
 
  private:
   void OnConnectionError();

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -71,6 +71,7 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
  private:
   void OnConnectionError();
   void OnGetNextNonce(std::unique_ptr<EthTxStateManager::TxMeta> meta,
+                      uint256_t chain_id,
                       bool success,
                       uint256_t nonce);
   void PublishTransaction(const std::string& tx_meta_id,

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -14,6 +14,10 @@
 #include "brave/components/brave_wallet/browser/eth_pending_tx_tracker.h"
 #include "brave/components/brave_wallet/browser/eth_transaction.h"
 #include "brave/components/brave_wallet/browser/eth_tx_state_manager.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
 
 class PrefService;
 
@@ -26,7 +30,7 @@ namespace brave_wallet {
 class EthJsonRpcController;
 class KeyringController;
 
-class EthTxController {
+class EthTxController : public KeyedService, public mojom::EthTxController {
  public:
   class Observer : public base::CheckedObserver {
    public:
@@ -35,27 +39,42 @@ class EthTxController {
    protected:
     ~Observer() override = default;
   };
-  explicit EthTxController(EthJsonRpcController* rpc_controller,
-                           KeyringController* keyring_controller,
-                           PrefService* prefs);
-  ~EthTxController();
+  explicit EthTxController(
+      EthJsonRpcController* eth_json_rpc_controller,
+      KeyringController* keyring_controller,
+      std::unique_ptr<EthTxStateManager> tx_state_manager,
+      std::unique_ptr<EthNonceTracker> nonce_tracker,
+      std::unique_ptr<EthPendingTxTracker> pending_tx_tracker,
+      PrefService* prefs);
+  ~EthTxController() override;
   EthTxController(const EthTxController&) = delete;
   EthTxController operator=(const EthTxController&) = delete;
+
+  mojo::PendingRemote<mojom::EthTxController> MakeRemote();
+  void Bind(mojo::PendingReceiver<mojom::EthTxController> receiver);
 
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
-  void AddUnapprovedTransaction(std::unique_ptr<EthTransaction> tx,
-                                const EthAddress& from);
-  bool ApproveTransaction(const std::string& tx_meta_id);
-  void RejectTransaction(const std::string& tx_meta_id);
+  void AddUnapprovedTransaction(mojom::TxDataPtr tx_data,
+                                const std::string& from,
+                                AddUnapprovedTransactionCallback) override;
+  void AddUnapproved1559Transaction(
+      mojom::TxData1559Ptr tx_data,
+      const std::string& from,
+      AddUnapproved1559TransactionCallback) override;
+  void ApproveTransaction(const std::string& tx_meta_id,
+                          ApproveTransactionCallback) override;
+  void RejectTransaction(const std::string& tx_meta_id,
+                         RejectTransactionCallback) override;
 
  private:
+  void OnConnectionError();
   void OnGetNextNonce(std::unique_ptr<EthTxStateManager::TxMeta> meta,
                       bool success,
                       uint256_t nonce);
-  void PublishTransaction(const EthTransaction& tx,
-                          const std::string& tx_meta_id);
+  void PublishTransaction(const std::string& tx_meta_id,
+                          const std::string& signed_transaction);
   void OnPublishTransaction(std::string tx_meta_id,
                             bool status,
                             const std::string& tx_hash);
@@ -67,6 +86,7 @@ class EthTxController {
   std::unique_ptr<EthPendingTxTracker> pending_tx_tracker_;
 
   base::ObserverList<Observer> observers_;
+  mojo::ReceiverSet<mojom::EthTxController> receivers_;
 
   base::WeakPtrFactory<EthTxController> weak_factory_;
 };

--- a/components/brave_wallet/browser/eth_tx_state_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_state_manager_unittest.cc
@@ -62,13 +62,11 @@ TEST_F(EthTxStateManagerUnitTest, GenerateMetaID) {
 }
 
 TEST_F(EthTxStateManagerUnitTest, TxMetaAndValue) {
-  EthTransaction::TxData tx_data(
+  // type 0
+  std::unique_ptr<EthTransaction> tx = std::make_unique<EthTransaction>(
       0x09, 0x4a817c800, 0x5208,
       EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
       0x0de0b6b3a7640000, std::vector<uint8_t>());
-  // type 0
-  std::unique_ptr<EthTransaction> tx =
-      std::make_unique<EthTransaction>(tx_data);
   EthTxStateManager::TxMeta meta(std::move(tx));
   meta.id = EthTxStateManager::GenerateMetaID();
   meta.status = EthTxStateManager::TransactionStatus::SUBMITTED;
@@ -113,7 +111,10 @@ TEST_F(EthTxStateManagerUnitTest, TxMetaAndValue) {
 
   // type 1
   std::unique_ptr<Eip2930Transaction> tx1 =
-      std::make_unique<Eip2930Transaction>(tx_data, 3);
+      std::make_unique<Eip2930Transaction>(
+          0x09, 0x4a817c800, 0x5208,
+          EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
+          0x0de0b6b3a7640000, std::vector<uint8_t>(), 3);
   auto* access_list = tx1->access_list();
   Eip2930Transaction::AccessListItem item_a;
   item_a.address.fill(0x0a);
@@ -133,7 +134,10 @@ TEST_F(EthTxStateManagerUnitTest, TxMetaAndValue) {
 
   // type2
   std::unique_ptr<Eip1559Transaction> tx2 =
-      std::make_unique<Eip1559Transaction>(tx_data, 3, 30, 50);
+      std::make_unique<Eip1559Transaction>(
+          0x09, 0x4a817c800, 0x5208,
+          EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
+          0x0de0b6b3a7640000, std::vector<uint8_t>(), 3, 30, 50);
   EthTxStateManager::TxMeta meta2(std::move(tx2));
   base::Value value2 = EthTxStateManager::TxMetaToValue(meta2);
   auto meta_from_value2 = EthTxStateManager::ValueToTxMeta(value2);

--- a/components/brave_wallet/browser/hd_keyring.cc
+++ b/components/brave_wallet/browser/hd_keyring.cc
@@ -64,21 +64,21 @@ std::string HDKeyring::GetAddress(size_t index) {
                                               public_key.end());
   EthAddress addr = EthAddress::FromPublicKey(pubkey_no_header);
 
-  // TODO(darkdh): chain id
+  // TODO(darkdh): chain id op code
   return addr.ToChecksumAddress();
 }
 
 void HDKeyring::SignTransaction(const std::string& address,
-                                EthTransaction* tx) {
+                                EthTransaction* tx,
+                                uint256_t chain_id) {
   HDKey* hd_key = GetHDKeyFromAddress(address);
   if (!hd_key || !tx)
     return;
 
-  // TODO(darkdh): chain id
-  const std::vector<uint8_t> message = tx->GetMessageToSign();
+  const std::vector<uint8_t> message = tx->GetMessageToSign(chain_id);
   int recid;
   const std::vector<uint8_t> signature = hd_key->Sign(message, &recid);
-  tx->ProcessSignature(signature, recid);
+  tx->ProcessSignature(signature, recid, chain_id);
 }
 
 std::vector<uint8_t> HDKeyring::SignMessage(

--- a/components/brave_wallet/browser/hd_keyring.h
+++ b/components/brave_wallet/browser/hd_keyring.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "base/gtest_prod_util.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_types.h"
 
 namespace brave_wallet {
 
@@ -43,7 +44,9 @@ class HDKeyring {
 
   // TODO(darkdh): Abstract Transacation class
   // eth_signTransaction
-  virtual void SignTransaction(const std::string& address, EthTransaction* tx);
+  virtual void SignTransaction(const std::string& address,
+                               EthTransaction* tx,
+                               uint256_t chain_id);
   // eth_sign
   virtual std::vector<uint8_t> SignMessage(const std::string& address,
                                            const std::vector<uint8_t>& message);

--- a/components/brave_wallet/browser/hd_keyring_unittest.cc
+++ b/components/brave_wallet/browser/hd_keyring_unittest.cc
@@ -82,7 +82,7 @@ TEST(HDKeyringUnitTest, SignTransaction) {
       0x09, 0x4a817c800, 0x5208,
       EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
       0x0de0b6b3a7640000, std::vector<uint8_t>());
-  keyring.SignTransaction("0xDEADBEEFdeadbeefdeadbeefdeadbeefDEADBEEF", &tx);
+  keyring.SignTransaction("0xDEADBEEFdeadbeefdeadbeefdeadbeefDEADBEEF", &tx, 0);
   EXPECT_FALSE(tx.IsSigned());
 
   std::vector<uint8_t> seed;
@@ -92,7 +92,7 @@ TEST(HDKeyringUnitTest, SignTransaction) {
       &seed));
   keyring.ConstructRootHDKey(seed, "m/44'/60'/0'/0");
   keyring.AddAccounts();
-  keyring.SignTransaction(keyring.GetAddress(0), &tx);
+  keyring.SignTransaction(keyring.GetAddress(0), &tx, 0);
   EXPECT_TRUE(tx.IsSigned());
 }
 

--- a/components/brave_wallet/browser/hd_keyring_unittest.cc
+++ b/components/brave_wallet/browser/hd_keyring_unittest.cc
@@ -78,10 +78,10 @@ TEST(HDKeyringUnitTest, Accounts) {
 TEST(HDKeyringUnitTest, SignTransaction) {
   // Specific signature check is in eth_transaction_unittest.cc
   HDKeyring keyring;
-  EthTransaction tx(EthTransaction::TxData(
+  EthTransaction tx(
       0x09, 0x4a817c800, 0x5208,
       EthAddress::FromHex("0x3535353535353535353535353535353535353535"),
-      0x0de0b6b3a7640000, std::vector<uint8_t>()));
+      0x0de0b6b3a7640000, std::vector<uint8_t>());
   keyring.SignTransaction("0xDEADBEEFdeadbeefdeadbeefdeadbeefDEADBEEF", &tx);
   EXPECT_FALSE(tx.IsSigned());
 

--- a/components/brave_wallet/browser/keyring_controller.cc
+++ b/components/brave_wallet/browser/keyring_controller.cc
@@ -427,10 +427,11 @@ std::vector<mojom::AccountInfoPtr> KeyringController::GetAccountInfosForKeyring(
 
 void KeyringController::SignTransactionByDefaultKeyring(
     const std::string& address,
-    EthTransaction* tx) {
+    EthTransaction* tx,
+    uint256_t chain_id) {
   if (!default_keyring_)
     return;
-  default_keyring_->SignTransaction(address, tx);
+  default_keyring_->SignTransaction(address, tx, chain_id);
 }
 
 bool KeyringController::IsLocked() const {

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -12,6 +12,7 @@
 
 #include "base/gtest_prod_util.h"
 #include "base/values.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_types.h"
 #include "brave/components/brave_wallet/browser/password_encryptor.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -92,7 +93,8 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   bool IsDefaultKeyringCreated();
 
   void SignTransactionByDefaultKeyring(const std::string& address,
-                                       EthTransaction* tx);
+                                       EthTransaction* tx,
+                                       uint256_t chain_id);
 
   bool IsLocked() const;
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -257,4 +257,5 @@ interface EthTxController {
   AddUnapproved1559Transaction(TxData1559 tx_data, string from) => (bool success, string tx_meta_id);
   ApproveTransaction(string tx_meta_id) => (bool status);
   RejectTransaction(string tx_meta_id) => (bool status);
+  MakeERC20TransferData(string to_address, string amount) => (bool success, array<uint8> data);
 };

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -31,7 +31,8 @@ interface PanelHandlerFactory {
                      pending_receiver<SwapController> swap_controller,
                      pending_receiver<AssetRatioController> asset_ratio_controller,
                      pending_receiver<KeyringController> keyring_controller,
-                     pending_receiver<ERCTokenRegistry> erc_token_registry);
+                     pending_receiver<ERCTokenRegistry> erc_token_registry,
+                     pending_receiver<EthTxController> eth_tx_controller);
 };
 
 interface PageHandlerFactory {
@@ -43,7 +44,8 @@ interface PageHandlerFactory {
                     pending_receiver<SwapController> swap_controller,
                     pending_receiver<AssetRatioController> asset_ratio_controller,
                     pending_receiver<KeyringController> keyring_controller,
-                    pending_receiver<ERCTokenRegistry> erc_token_registry);
+                    pending_receiver<ERCTokenRegistry> erc_token_registry,
+                     pending_receiver<EthTxController> eth_tx_controller);
 
 };
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -218,6 +218,22 @@ interface EthJsonRpcControllerObserver {
   ChainChangedEvent(string chain_id);
 };
 
+struct TxData {
+  string nonce;
+  string gas_price;
+  string gas_limit;
+  string to;
+  string value;
+  array<uint8> data;
+};
+
+struct TxData1559 {
+  TxData base_data;
+  string chain_id;
+  string max_priority_fee_per_gas;
+  string max_fee_per_gas;
+};
+
 interface EthJsonRpcController {
   SetNetwork(Network network);
   GetNetwork() => (Network network);
@@ -232,4 +248,11 @@ interface EthJsonRpcController {
   Request(string json_payload, bool auto_retry_on_network_change) => (int32 http_code, string response, map<string, string> headers);
   AddObserver(pending_remote<EthJsonRpcControllerObserver> observer);
   SetCustomNetwork(url.mojom.Url provider_url);
+};
+
+interface EthTxController {
+  AddUnapprovedTransaction(TxData tx_data, string from) => (bool success, string tx_meta_id);
+  AddUnapproved1559Transaction(TxData1559 tx_data, string from) => (bool success, string tx_meta_id);
+  ApproveTransaction(string tx_meta_id) => (bool status);
+  RejectTransaction(string tx_meta_id) => (bool status);
 };

--- a/components/brave_wallet_ui/common/async/wallet_async_handler.ts
+++ b/components/brave_wallet_ui/common/async/wallet_async_handler.ts
@@ -200,3 +200,14 @@ handler.on(WalletActions.selectPortfolioTimeline.getType(), async (store, payloa
 })
 
 export default handler.middleware
+
+// TOOD(bbondy): Remove after we have this hooked up
+// This is for Ganache seedwords of: garage erosion rapid salmon make wine dragon great away drift jewel evoke
+// Don't use this seed with actual funds!
+//   const apiProxy = await getAPIProxy()
+//  const txData = apiProxy.makeTxData('0x1', '0x14', '0x5208', '0xBFb30a082f650C2A15D0632f0e87bE4F8e64460f', '0xde0b6b3a7640000')
+//  const addResult = await apiProxy.ethTxController.addUnapprovedTransaction(txData, '0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7')
+//  console.log('addResult: ', addResult)
+//  const approveResult = await apiProxy.ethTxController.approveTransaction(addResult.txMetaId)
+//  console.log('approveResult: ', approveResult)
+//

--- a/components/brave_wallet_ui/common/async/wallet_async_handler.ts
+++ b/components/brave_wallet_ui/common/async/wallet_async_handler.ts
@@ -204,10 +204,23 @@ export default handler.middleware
 // TOOD(bbondy): Remove after we have this hooked up
 // This is for Ganache seedwords of: garage erosion rapid salmon make wine dragon great away drift jewel evoke
 // Don't use this seed with actual funds!
-//   const apiProxy = await getAPIProxy()
-//  const txData = apiProxy.makeTxData('0x1', '0x14', '0x5208', '0xBFb30a082f650C2A15D0632f0e87bE4F8e64460f', '0xde0b6b3a7640000')
+// Sending ETH:
+//  const apiProxy = await getAPIProxy()
+//  const txData = apiProxy.makeTxData('0x1', '0x20000000000', '0x5208', '0xBFb30a082f650C2A15D0632f0e87bE4F8e64460f', '0xde0b6b3a7640000', [])
 //  const addResult = await apiProxy.ethTxController.addUnapprovedTransaction(txData, '0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7')
 //  console.log('addResult: ', addResult)
 //  const approveResult = await apiProxy.ethTxController.approveTransaction(addResult.txMetaId)
 //  console.log('approveResult: ', approveResult)
 //
+// Sending ERC20 tokens:
+//  const apiProxy = await getAPIProxy()
+//  const transferDataResult = await await apiProxy.ethTxController.makeERC20TransferData('0xBFb30a082f650C2A15D0632f0e87bE4F8e64460f', '0x0de0b6b3a7640000')
+//  console.log('data field result: ', transferDataResult)
+//  //const dataArray = Array.from(hexStringToUint8Array(transferDataResult.data))
+//  console.log('data array is: ', transferDataResult.data)
+//  // Deployed ERC20 contract is 0x774171b92Ba6e1d57ac08D6b77AbDD0B51660310
+//  const txData = apiProxy.makeTxData('0x1', '0x20000000000', '0xFDE8', '0x774171b92Ba6e1d57ac08D6b77AbDD0B51660310', '0x0', transferDataResult.data)
+//  const addResult = await apiProxy.ethTxController.addUnapprovedTransaction(txData, '0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7')
+//  console.log('addResult: ', addResult)
+//  const approveResult = await apiProxy.ethTxController.approveTransaction(addResult.txMetaId)
+//  console.log('approveResult: ', approveResult)

--- a/components/brave_wallet_ui/common/wallet_api_proxy.js
+++ b/components/brave_wallet_ui/common/wallet_api_proxy.js
@@ -38,6 +38,17 @@ export default class WalletApiProxy {
     this.ethJsonRpcController.addObserver(ethJsonRpcControllerObserverReceiver.$.bindNewPipeAndPassRemote());
   }
 
+  makeTxData(nonce, gasPrice, gasLimit, to, value) {
+    const txData = new braveWallet.mojom.TxData()
+    txData.nonce = nonce
+    txData.gasPrice = gasPrice
+    txData.gasLimit = gasLimit
+    txData.to = to
+    txData.value = value
+    txData.data = []
+    return txData
+  }
+
   addKeyringControllerObserver(store) {
     const keyringControllerObserverReceiver = new braveWallet.mojom.KeyringControllerObserverReceiver({
       keyringCreated: function (chainId) {

--- a/components/brave_wallet_ui/common/wallet_api_proxy.js
+++ b/components/brave_wallet_ui/common/wallet_api_proxy.js
@@ -38,14 +38,14 @@ export default class WalletApiProxy {
     this.ethJsonRpcController.addObserver(ethJsonRpcControllerObserverReceiver.$.bindNewPipeAndPassRemote());
   }
 
-  makeTxData(nonce, gasPrice, gasLimit, to, value) {
+  makeTxData(nonce, gasPrice, gasLimit, to, value, data) {
     const txData = new braveWallet.mojom.TxData()
     txData.nonce = nonce
     txData.gasPrice = gasPrice
     txData.gasLimit = gasLimit
     txData.to = to
     txData.value = value
-    txData.data = []
+    txData.data = data
     return txData
   }
 

--- a/components/brave_wallet_ui/common/wallet_api_proxy.js
+++ b/components/brave_wallet_ui/common/wallet_api_proxy.js
@@ -23,9 +23,10 @@ export default class WalletApiProxy {
     this.assetRatioController = new braveWallet.mojom.AssetRatioControllerRemote();
     /** @type {!braveWallet.mojom.KeyringControllerRemote} */
     this.keyringController = new braveWallet.mojom.KeyringControllerRemote();
-
     /** @type {!braveWallet.mojom.KeyringControllerRemote} */
     this.ercTokenRegistry = new braveWallet.mojom.ERCTokenRegistryRemote();
+    /** @type {!braveWallet.mojom.EthTxControllerRemote} */
+    this.ethTxController = new braveWallet.mojom.EthTxControllerRemote();
   }
 
   addEthJsonRpcControllerObserver(store) {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -419,11 +419,17 @@ export interface RejectTransactionReturnInfo {
   status: boolean
 }
 
+export interface MakeERC20TransferDataReturnInfo {
+  success: boolean
+  data: number[]
+}
+
 export interface EthTxController {
   addUnapprovedTransaction: (txData: TxData, from: string) => Promise<AddUnapprovedTransactionReturnInfo>
   addUnapproved1559Transaction: (txData: TxData1559, from: string) => (AddUnapproved1559TransactionReturnInfo)
   approveTransaction: (txMetaId: string) => Promise<ApproveTransactionReturnInfo>
   rejectTransaction: (txMetaId: string) => Promise<RejectTransactionReturnInfo>
+  makeERC20TransferData: (toAddress: string, amount: string) => Promise<MakeERC20TransferDataReturnInfo>
 }
 
 export interface EthJsonRpcController {
@@ -518,7 +524,7 @@ export interface APIProxyControllers {
   keyringController: KeyringController
   ercTokenRegistry: ERCTokenRegistry
   ethTxController: EthTxController
-  makeTxData: (nonce: string, gasPrice: string, gasLimit: string, to: string, value: string) => any
+  makeTxData: (nonce: string, gasPrice: string, gasLimit: string, to: string, value: string, data: number[]) => any
 }
 
 export type AllowSpendReturnPayload = {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -518,6 +518,7 @@ export interface APIProxyControllers {
   keyringController: KeyringController
   ercTokenRegistry: ERCTokenRegistry
   ethTxController: EthTxController
+  makeTxData: (nonce: string, gasPrice: string, gasLimit: string, to: string, value: string) => any
 }
 
 export type AllowSpendReturnPayload = {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -385,6 +385,47 @@ export interface ERCTokenRegistry {
   getAllTokens: () => Promise<GetAllTokensReturnInfo>
 }
 
+export class TxData {
+  nonce: string
+  gasPrice: string
+  gasLimit: string
+  to: string
+  value: string
+  data: Uint8Array
+}
+
+export class TxData1559 {
+  baseData: TxData
+  chainId: string
+  maxPriorityFeePerGas: string
+  maxFeePerGas: string
+}
+
+export interface AddUnapprovedTransactionReturnInfo {
+  success: boolean
+  txMetaId: string
+}
+
+export interface AddUnapproved1559TransactionReturnInfo {
+  success: boolean
+  txMetaId: string
+}
+
+export interface ApproveTransactionReturnInfo {
+  status: boolean
+}
+
+export interface RejectTransactionReturnInfo {
+  status: boolean
+}
+
+export interface EthTxController {
+  addUnapprovedTransaction: (txData: TxData, from: string) => Promise<AddUnapprovedTransactionReturnInfo>
+  addUnapproved1559Transaction: (txData: TxData1559, from: string) => (AddUnapproved1559TransactionReturnInfo)
+  approveTransaction: (txMetaId: string) => Promise<ApproveTransactionReturnInfo>
+  rejectTransaction: (txMetaId: string) => Promise<RejectTransactionReturnInfo>
+}
+
 export interface EthJsonRpcController {
   getNetwork: () => Promise<GetNetworkReturnInfo>
   setNetwork: (netowrk: Network) => Promise<void>
@@ -476,6 +517,7 @@ export interface APIProxyControllers {
   assetRatioController: AssetRatioController
   keyringController: KeyringController
   ercTokenRegistry: ERCTokenRegistry
+  ethTxController: EthTxController
 }
 
 export type AllowSpendReturnPayload = {

--- a/components/brave_wallet_ui/page/wallet_page_api_proxy.d.ts
+++ b/components/brave_wallet_ui/page/wallet_page_api_proxy.d.ts
@@ -16,4 +16,5 @@ export default class APIProxy {
   ethTxController: EthTxController
   addEthJsonRpcControllerObserver: (store: any) => void
   addKeyringControllerObserver: (store: any) => void
+  makeTxData: (nonce: string, gasPrice: string, gasLimit: string, to: string, value: string) => any
 }

--- a/components/brave_wallet_ui/page/wallet_page_api_proxy.d.ts
+++ b/components/brave_wallet_ui/page/wallet_page_api_proxy.d.ts
@@ -13,6 +13,7 @@ export default class APIProxy {
   assetRatioController: AssetRatioController
   ercTokenRegistry: ERCTokenRegistry
   keyringController: KeyringController
+  ethTxController: EthTxController
   addEthJsonRpcControllerObserver: (store: any) => void
   addKeyringControllerObserver: (store: any) => void
 }

--- a/components/brave_wallet_ui/page/wallet_page_api_proxy.js
+++ b/components/brave_wallet_ui/page/wallet_page_api_proxy.js
@@ -27,7 +27,8 @@ export default class WalletPageApiProxyImpl extends WalletApiProxy {
       this.swapController.$.bindNewPipeAndPassReceiver(),
       this.assetRatioController.$.bindNewPipeAndPassReceiver(),
       this.keyringController.$.bindNewPipeAndPassReceiver(),
-      this.ercTokenRegistry.$.bindNewPipeAndPassReceiver());
+      this.ercTokenRegistry.$.bindNewPipeAndPassReceiver(),
+      this.ethTxController.$.bindNewPipeAndPassReceiver());
   }
 }
 

--- a/components/brave_wallet_ui/panel/wallet_panel_api_proxy.d.ts
+++ b/components/brave_wallet_ui/panel/wallet_panel_api_proxy.d.ts
@@ -17,6 +17,7 @@ export default class APIProxy implements APIProxyControllers {
   assetRatioController: AssetRatioController
   ercTokenRegistry: ERCTokenRegistry
   keyringController: KeyringController
+  ethTxController: EthTxController
   addEthJsonRpcControllerObserver: (store: any) => void
   addKeyringControllerObserver: (store: any) => void
 }

--- a/components/brave_wallet_ui/panel/wallet_panel_api_proxy.d.ts
+++ b/components/brave_wallet_ui/panel/wallet_panel_api_proxy.d.ts
@@ -20,4 +20,5 @@ export default class APIProxy implements APIProxyControllers {
   ethTxController: EthTxController
   addEthJsonRpcControllerObserver: (store: any) => void
   addKeyringControllerObserver: (store: any) => void
+  makeTxData: (nonce: string, gasPrice: string, gasLimit: string, to: string, value: string) => any
 }

--- a/components/brave_wallet_ui/panel/wallet_panel_api_proxy.js
+++ b/components/brave_wallet_ui/panel/wallet_panel_api_proxy.js
@@ -33,7 +33,8 @@ export default class WalletPanelApiProxyImpl extends WalletApiProxy {
         this.swapController.$.bindNewPipeAndPassReceiver(),
         this.assetRatioController.$.bindNewPipeAndPassReceiver(),
         this.keyringController.$.bindNewPipeAndPassReceiver(),
-        this.ercTokenRegistry.$.bindNewPipeAndPassReceiver());
+        this.ercTokenRegistry.$.bindNewPipeAndPassReceiver(),
+        this.ethTxController.$.bindNewPipeAndPassReceiver());
   }
 
   /** @override */


### PR DESCRIPTION
- Adds an `EthTxController` factory (`EthTxControllerFactory`)
- Exposes `EthTxController`'s `AddUnapprovedTransaction`, `AddUnapprovedTransaction1559` (new), `ApproveTransaction`, and `RejectTransaction` to mojo
- `TxData` now defined in mojo instead (as well as the new `TxData1559`)
- Exposes `EthTxController` to JS and add example usage
- Fixes chain_id to be `uint256_t` everywhere
- Fixes `v_` calculation to be `uint256_t` and not `uint8_t` (It was not calculating this value correctly due to overflow when using more than 8-bit chain-ids. 
- Generating erc20 transfer transaction data
- Example JS usage for sending an ERC20 token


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17642

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

