### PR TITLE
add flag for first-party blocking in standard blocking mode

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -180,7 +180,7 @@ EngineFlags ShouldBlockRequestOnTaskRunner(
 
   SCOPED_UMA_HISTOGRAM_TIMER("Brave.Adblock.ShouldBlockRequest");
   g_brave_browser_process->ad_block_service()->ShouldStartRequest(
-      url_to_check, ctx->resource_type, source_host,
+      url_to_check, ctx->resource_type, source_host, ctx->aggressive_blocking,
       &previous_result.did_match_rule, &previous_result.did_match_exception,
       &previous_result.did_match_important, &ctx->mock_data_url);
 

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -138,6 +138,9 @@ std::shared_ptr<brave::BraveRequestInfo> BraveRequestInfo::MakeCTX(
       brave_shields::GetBraveShieldsEnabled(map, ctx->tab_origin);
   ctx->allow_ads = brave_shields::GetAdControlType(map, ctx->tab_origin) ==
                    brave_shields::ControlType::ALLOW;
+  ctx->aggressive_blocking =
+      brave_shields::GetCosmeticFilteringControlType(map, ctx->tab_origin) ==
+      brave_shields::ControlType::BLOCK;
   ctx->allow_http_upgradable_resource =
       !brave_shields::GetHTTPSEverywhereEnabled(map, ctx->tab_origin);
 

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -138,6 +138,8 @@ std::shared_ptr<brave::BraveRequestInfo> BraveRequestInfo::MakeCTX(
       brave_shields::GetBraveShieldsEnabled(map, ctx->tab_origin);
   ctx->allow_ads = brave_shields::GetAdControlType(map, ctx->tab_origin) ==
                    brave_shields::ControlType::ALLOW;
+  // Currently, "aggressive" mode is registered as a cosmetic filtering control
+  // type, even though it can also affect network blocking.
   ctx->aggressive_blocking =
       brave_shields::GetCosmeticFilteringControlType(map, ctx->tab_origin) ==
       brave_shields::ControlType::BLOCK;

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -76,6 +76,8 @@ struct BraveRequestInfo {
   // TODO(iefremov): rename to shields_up.
   bool allow_brave_shields = true;
   bool allow_ads = false;
+  // Whether or not Shields "aggressive" mode was enabled where the request was
+  // initiated.
   bool aggressive_blocking = false;
   bool allow_http_upgradable_resource = false;
   bool allow_referrers = false;

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -76,6 +76,7 @@ struct BraveRequestInfo {
   // TODO(iefremov): rename to shields_up.
   bool allow_brave_shields = true;
   bool allow_ads = false;
+  bool aggressive_blocking = false;
   bool allow_http_upgradable_resource = false;
   bool allow_referrers = false;
   bool is_webtorrent_disabled = false;

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -61,6 +61,7 @@ using brave_shields::features::kBraveAdblockCollapseBlockedElements;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockCosmeticFilteringNative;
 using brave_shields::features::kBraveAdblockCspRules;
+using brave_shields::features::kBraveAdblockDefault1pBlocking;
 using brave_shields::features::kBraveDarkModeBlock;
 using brave_shields::features::kBraveDomainBlock;
 using brave_shields::features::kBraveExtensionNetworkBlocking;
@@ -195,6 +196,10 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      flag_descriptions::kBraveAdblockCspRulesName,                          \
      flag_descriptions::kBraveAdblockCspRulesDescription, kOsAll,           \
      FEATURE_VALUE_TYPE(kBraveAdblockCspRules)},                            \
+    {"brave-adblock-default-1p-blocking",                                   \
+     flag_descriptions::kBraveAdblockDefault1pBlockingName,                 \
+     flag_descriptions::kBraveAdblockDefault1pBlockingDescription, kOsAll,  \
+     FEATURE_VALUE_TYPE(kBraveAdblockDefault1pBlocking)},                   \
     {"brave-domain-block",                                                  \
      flag_descriptions::kBraveDomainBlockName,                              \
      flag_descriptions::kBraveDomainBlockDescription, kOsAll,               \

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -21,6 +21,11 @@ const char kBraveNTPBrandedWallpaperDemoDescription[] =
     "Force dummy data for the Branded Wallpaper New Tab Page Experience. "
     "View rate and user opt-in conditionals will still be followed to decide "
     "when to display the Branded Wallpaper.";
+const char kBraveAdblockDefault1pBlockingName[] =
+    "Shields first-party network blocking";
+const char kBraveAdblockDefault1pBlockingDescription[] =
+    "Allow Brave Shields to block first-party network requests in Standard "
+    "blocking mode";
 const char kBraveAdblockCnameUncloakingName[] = "Enable CNAME uncloaking";
 const char kBraveAdblockCnameUncloakingDescription[] =
     "Take DNS CNAME records into account when making network request blocking "

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -17,6 +17,8 @@ extern const char kBraveNTPBrandedWallpaperName[];
 extern const char kBraveNTPBrandedWallpaperDescription[];
 extern const char kBraveNTPBrandedWallpaperDemoName[];
 extern const char kBraveNTPBrandedWallpaperDemoDescription[];
+extern const char kBraveAdblockDefault1pBlockingName[];
+extern const char kBraveAdblockDefault1pBlockingDescription[];
 extern const char kBraveAdblockCnameUncloakingName[];
 extern const char kBraveAdblockCnameUncloakingDescription[];
 extern const char kBraveAdblockCollapseBlockedElementsName[];

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -116,6 +116,7 @@ void AdBlockBaseService::ShouldStartRequest(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
     const std::string& tab_host,
+    bool aggressive_blocking,
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,

--- a/components/brave_shields/browser/ad_block_base_service.h
+++ b/components/brave_shields/browser/ad_block_base_service.h
@@ -44,6 +44,7 @@ class AdBlockBaseService : public BaseBraveShieldsService {
   void ShouldStartRequest(const GURL& url,
                           blink::mojom::ResourceType resource_type,
                           const std::string& tab_host,
+                          bool aggressive_blocking,
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -119,6 +119,7 @@ void AdBlockRegionalServiceManager::ShouldStartRequest(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
     const std::string& tab_host,
+    bool aggressive_blocking,
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
@@ -127,8 +128,8 @@ void AdBlockRegionalServiceManager::ShouldStartRequest(
 
   for (const auto& regional_service : regional_services_) {
     regional_service.second->ShouldStartRequest(
-        url, resource_type, tab_host, did_match_rule, did_match_exception,
-        did_match_important, mock_data_url);
+        url, resource_type, tab_host, aggressive_blocking, did_match_rule,
+        did_match_exception, did_match_important, mock_data_url);
     if (did_match_important && *did_match_important) {
       return;
     }

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -50,6 +50,7 @@ class AdBlockRegionalServiceManager {
   void ShouldStartRequest(const GURL& url,
                           blink::mojom::ResourceType resource_type,
                           const std::string& tab_host,
+                          bool aggressive_blocking,
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -75,8 +75,7 @@ void AdBlockService::ShouldStartRequest(
       base::FeatureList::IsEnabled(
           brave_shields::features::kBraveAdblockDefault1pBlocking) ||
       !SameDomainOrHost(
-          url,
-          url::Origin::CreateFromNormalizedTuple("https", tab_host.c_str(), 80),
+          url, url::Origin::CreateFromNormalizedTuple("https", tab_host, 80),
           net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES)) {
     AdBlockBaseService::ShouldStartRequest(
         url, resource_type, tab_host, aggressive_blocking, did_match_rule,

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -29,6 +29,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
+#include "url/origin.h"
 
 #define DAT_FILE "rs-ABPFilterParserData.dat"
 #define REGIONAL_CATALOG "regional_catalog.json"
@@ -44,8 +45,7 @@ void AdBlockServiceDomainResolver(const char* host,
                                   uint32_t* end) {
   const auto host_str = std::string(host);
   const auto domain = net::registry_controlled_domains::GetDomainAndRegistry(
-      host_str,
-      net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
+      host_str, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
   const size_t match = host_str.rfind(domain);
   if (match != std::string::npos) {
     *start = match;
@@ -66,27 +66,36 @@ void AdBlockService::ShouldStartRequest(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
     const std::string& tab_host,
+    bool aggressive_blocking,
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
     std::string* mock_data_url) {
-  AdBlockBaseService::ShouldStartRequest(
-      url, resource_type, tab_host, did_match_rule, did_match_exception,
-      did_match_important, mock_data_url);
-  if (did_match_important && *did_match_important) {
-    return;
+  if (aggressive_blocking ||
+      base::FeatureList::IsEnabled(
+          brave_shields::features::kBraveAdblockDefault1pBlocking) ||
+      !SameDomainOrHost(
+          url,
+          url::Origin::CreateFromNormalizedTuple("https", tab_host.c_str(), 80),
+          net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES)) {
+    AdBlockBaseService::ShouldStartRequest(
+        url, resource_type, tab_host, aggressive_blocking, did_match_rule,
+        did_match_exception, did_match_important, mock_data_url);
+    if (did_match_important && *did_match_important) {
+      return;
+    }
   }
 
   regional_service_manager()->ShouldStartRequest(
-      url, resource_type, tab_host, did_match_rule, did_match_exception,
-      did_match_important, mock_data_url);
+      url, resource_type, tab_host, aggressive_blocking, did_match_rule,
+      did_match_exception, did_match_important, mock_data_url);
   if (did_match_important && *did_match_important) {
     return;
   }
 
   custom_filters_service()->ShouldStartRequest(
-      url, resource_type, tab_host, did_match_rule, did_match_exception,
-      did_match_important, mock_data_url);
+      url, resource_type, tab_host, aggressive_blocking, did_match_rule,
+      did_match_exception, did_match_important, mock_data_url);
 }
 
 absl::optional<std::string> AdBlockService::GetCspDirectives(

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -52,6 +52,7 @@ class AdBlockService : public AdBlockBaseService {
   void ShouldStartRequest(const GURL& url,
                           blink::mojom::ResourceType resource_type,
                           const std::string& tab_host,
+                          bool aggressive_blocking,
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,

--- a/components/brave_shields/browser/base_brave_shields_service.cc
+++ b/components/brave_shields/browser/base_brave_shields_service.cc
@@ -53,6 +53,7 @@ void BaseBraveShieldsService::ShouldStartRequest(
     const GURL& url,
     blink::mojom::ResourceType resource_type,
     const std::string& tab_host,
+    bool aggressive_blocking,
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,

--- a/components/brave_shields/browser/base_brave_shields_service.cc
+++ b/components/brave_shields/browser/base_brave_shields_service.cc
@@ -57,7 +57,6 @@ void BaseBraveShieldsService::ShouldStartRequest(
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
-    std::string* mock_data_url) {
-}
+    std::string* mock_data_url) {}
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/base_brave_shields_service.h
+++ b/components/brave_shields/browser/base_brave_shields_service.h
@@ -34,6 +34,7 @@ class BaseBraveShieldsService : public BraveComponent {
   virtual void ShouldStartRequest(const GURL& url,
                                   blink::mojom::ResourceType resource_type,
                                   const std::string& tab_host,
+                                  bool aggressive_blocking,
                                   bool* did_match_rule,
                                   bool* did_match_exception,
                                   bool* did_match_important,

--- a/components/brave_shields/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/browser/domain_block_navigation_throttle.cc
@@ -40,9 +40,14 @@ bool ShouldBlockDomainOnTaskRunner(
   bool did_match_rule = false;
   bool did_match_important = false;
   std::string mock_data_url;
+  // force aggressive blocking to `true` for domain blocking - these requests
+  // are all "first-party", but the throttle is already only called when
+  // necessary.
+  bool aggressive_blocking = true;
   ad_block_service->ShouldStartRequest(
-      url, blink::mojom::ResourceType::kMainFrame, url.host(), &did_match_rule,
-      &did_match_exception, &did_match_important, &mock_data_url);
+      url, blink::mojom::ResourceType::kMainFrame, url.host(),
+      aggressive_blocking, &did_match_rule, &did_match_exception,
+      &did_match_important, &mock_data_url);
   return (did_match_important || (did_match_rule && !did_match_exception));
 }
 

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -10,6 +10,10 @@
 namespace brave_shields {
 namespace features {
 
+// When disabled, Brave will allow first-party requests in "standard" blocking
+// mode regardless of whether or not they appear in a filter list.
+const base::Feature kBraveAdblockDefault1pBlocking{
+    "BraveAdblockDefault1pBlocking", base::FEATURE_ENABLED_BY_DEFAULT};
 // When enabled, Brave will issue DNS queries for requests that the adblock
 // engine has not blocked, then check them again with the original hostname
 // substituted for any canonical name found.

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -10,8 +10,10 @@
 namespace brave_shields {
 namespace features {
 
-// When disabled, Brave will allow first-party requests in "standard" blocking
-// mode regardless of whether or not they appear in a filter list.
+// When enabled, Brave will block first-party requests that appear in a filter
+// list when Shields is in "standard" blocking mode. When disabled, Brave will
+// allow first-party requests in "standard" blocking mode regardless of whether
+// or not they appear in a filter list.
 const base::Feature kBraveAdblockDefault1pBlocking{
     "BraveAdblockDefault1pBlocking", base::FEATURE_ENABLED_BY_DEFAULT};
 // When enabled, Brave will issue DNS queries for requests that the adblock

--- a/components/brave_shields/common/features.h
+++ b/components/brave_shields/common/features.h
@@ -12,6 +12,7 @@ struct Feature;
 
 namespace brave_shields {
 namespace features {
+extern const base::Feature kBraveAdblockDefault1pBlocking;
 extern const base::Feature kBraveAdblockCnameUncloaking;
 extern const base::Feature kBraveAdblockCollapseBlockedElements;
 extern const base::Feature kBraveAdblockCosmeticFiltering;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17366

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Disable the new `#brave-adblock-default-1p-blocking` flag, then visit https://dev-pages.bravesoftware.com/filtering/network-requests.html and follow the directions,  ensuring that the images are shown as described.