### PR TITLE
Fix #17362 - Show configuration error in panel if the user and publisher custodians don't match (uplift to 1.29.x)

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
+++ b/components/brave_rewards/resources/extension/brave_rewards/components/panel.tsx
@@ -669,6 +669,8 @@ export class Panel extends React.Component<Props, State> {
         return walletType !== 'uphold'
       case 3: // BITFLYER_VERIFIED
         return walletType !== 'bitflyer'
+      case 4: // GEMINI_VERIFIED
+        return walletType !== 'gemini'
       default:
         return false
     }


### PR DESCRIPTION
Uplift of #9679
Resolves https://github.com/brave/brave-browser/issues/17362

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.