### PR TITLE
Fix crash downloading large files due to the DownloadItemView

### DIFF
--- a/chromium_src/chrome/browser/ui/views/download/download_item_view.cc
+++ b/chromium_src/chrome/browser/ui/views/download/download_item_view.cc
@@ -5,22 +5,40 @@
 
 #include "chrome/browser/ui/views/download/download_item_view.h"
 
+// Include these headers from the original download_item_view.cc to prevent
+// unintentional redefinitions of Button into BraveDownloadItemViewButton.
+#include "ui/views/controls/button/image_button.h"
+#include "ui/views/controls/button/image_button_factory.h"
+#include "ui/views/controls/button/md_text_button.h"
+
 namespace views {
+
 namespace {
-class DownloadItemViewButton : public Button {
+
+// This class intercepts mouse/focus events on button and its associated view
+// and relays them to BraveDownloadItemView to make decisions on when to hide
+// the download item's URL (i.e. default) and when to show it (i.e. on hover).
+class BraveDownloadItemViewButton : public Button {
  public:
   using Button::Button;
 
+  // Button overrides.
   void OnMouseEntered(const ui::MouseEvent& event) override {
     parent()->OnMouseEntered(event);
+    Button::OnMouseEntered(event);
   }
+
   void OnMouseExited(const ui::MouseEvent& event) override {
     parent()->OnMouseExited(event);
+    Button::OnMouseExited(event);
   }
+
+  // ViewObserver overrides.
   void OnViewFocused(View* observed_view) override {
     auto* item = static_cast<DownloadItemView*>(parent());
     item->OnViewFocused(observed_view);
   }
+
   void OnViewBlurred(View* observed_view) override {
     auto* item = static_cast<DownloadItemView*>(parent());
     item->OnViewBlurred(observed_view);
@@ -31,7 +49,7 @@ class DownloadItemViewButton : public Button {
 
 }  // namespace views
 
-#define Button DownloadItemViewButton
+#define Button BraveDownloadItemViewButton
 #include "../../../../../../../chrome/browser/ui/views/download/download_item_view.cc"
 #undef Button
 


### PR DESCRIPTION
When downloading a large file the DownloadItemView is supposed to show
certain information about the item being downloaded, such as the name
and the current status. Additionally, it's also meant to show the URL
but, due to changes done recently in PR 9521 [1] (see issue in [2]),
Brave contains changes to only show the URL when hovering over the
download item view, to save space.

Turns out that these changes were causing a crash after a the change
below landed upstream and the reason seems to be that our chromium_src
override was wrongly redefining the Button symbol way beyond the scope
of download_item_view.cc, causing the crash.

This change includes the necessary headers from download_item_view.cc
to avoid this Button redefinition from propagating any further, and
also makes the most of the effort to fix some small things in the
override file, such as calling the parent methods of the overriden
methods from the Button class, or adding some extra documentation.

Last, this change also fixes 2 crashing browser tests:

  * BraveCheckClientDownloadRequestBaseBrowserTest.FilterRequest
  * SavePackageFinishedObserverBrowserTest.Success

[1] https://github.com/brave/brave-core/pull/9521
[2] https://github.com/brave/brave-browser/issues/1638

Chromium change:

https://source.chromium.org/chromium/chromium/src/+/03f006384e02fb387c177af07a3df9792e364e18

commit 03f006384e02fb387c177af07a3df9792e364e18
Author: Peter Kasting <pkasting@chromium.org>
Date:   Thu Jul 22 00:45:59 2021 +0000

    Clicking the download item context button should close any open menu.

    This is what other buttons in Chrome do: repeatedly clicking the button
    toggles it between open and closed, instead of flickering it closed and
    instantly reopening (the current behavior).

    Bug: 1031682

Resolves https://github.com/brave/brave-browser/issues/17386

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A