### PR TITLE
Update locales for Gemini promo card (uplift to 1.29.x)

### DIFF
--- a/components/brave_rewards/resources/page/promos/index.tsx
+++ b/components/brave_rewards/resources/page/promos/index.tsx
@@ -69,7 +69,12 @@ export const getPromo = (type: PromoType, rewardsData: Rewards.State) => {
             {getLocale('geminiPromoInfo')}
           </StyledInfo>
         ),
-        supportedLocales: ['US'],
+        supportedLocales: [
+          'AR', 'AT', 'AU', 'BE', 'BG', 'BM', 'BR', 'BS', 'BT', 'CA', 'CH', 'CL', 'CY', 'CZ', 'DK', 'EE', 'EG', 'ES',
+          'FI', 'GB', 'GG', 'GI', 'GR', 'HK', 'HR', 'HU', 'IL', 'IN', 'IS', 'IT', 'JE', 'KR', 'KY', 'LI', 'LT', 'LU',
+          'LV', 'MM', 'MT', 'NG', 'NL', 'NO', 'NZ', 'PE', 'PH', 'PL', 'PT', 'RO', 'SE', 'SG', 'SI', 'SK', 'TR', 'TW',
+          'US', 'UY', 'VC', 'VG', 'VN', 'ZA'
+        ],
         title: getLocale('geminiPromoTitle'),
         disclaimer: getLocale('geminiPromoDisclaimer')
       }


### PR DESCRIPTION
Uplift of #9684
Resolves https://github.com/brave/brave-browser/issues/17383

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.