### PR TITLE
Fixing `nullptr` dereference in `RewardsDOMHandler`. (uplift to 1.29.x)

### DIFF
--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -617,11 +617,11 @@ void RewardsDOMHandler::SetExternalWalletType(const base::ListValue* args) {
 }
 
 void RewardsDOMHandler::OnExternalWalletTypeUpdated(
-    const ledger::type::Result result,
+    ledger::type::Result,
     ledger::type::ExternalWalletPtr wallet) {
   if (IsJavascriptAllowed()) {
     CallJavascriptFunction("brave_rewards.externalWalletLogin",
-                           base::Value(wallet->login_url));
+                           base::Value(wallet ? wallet->login_url : ""));
   }
 }
 


### PR DESCRIPTION
Uplift of #9622
Resolves https://github.com/brave/brave-browser/issues/17259

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.