### PR TITLE
Not proceed with ads service init if new Start() call initiated.

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -13,6 +13,7 @@
 #include "base/bind.h"
 #include "base/command_line.h"
 #include "base/containers/flat_map.h"
+#include "base/debug/dump_without_crashing.h"
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -885,6 +886,13 @@ void AdsServiceImpl::OnEnsureBaseDirectoryExists(uint32_t number_of_start,
 
   g_brave_browser_process->resource_component()->AddObserver(this);
 
+  if (database_) {
+    NOTREACHED() << "Ads service shutdown was not initiated prior to start";
+    base::debug::DumpWithoutCrashing();
+    const bool success =
+        file_task_runner_->DeleteSoon(FROM_HERE, database_.release());
+    VLOG_IF(1, !success) << "Failed to release database";
+  }
   database_ = std::make_unique<ads::Database>(
       base_path_.AppendASCII("database.sqlite"));
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -208,19 +208,19 @@ class AdsServiceImpl : public AdsService,
   bool StartService();
 
   void MaybeStart(const bool should_restart);
-  void Start(uint32_t number_of_start);
+  void Start(const uint32_t number_of_start);
   void Stop();
 
   void ResetState();
   void OnShutdownAndResetBatAds(const bool success);
   void OnResetAllState(const bool success);
 
-  void DetectUncertainFuture(uint32_t number_of_start);
-  void OnDetectUncertainFuture(uint32_t number_of_start,
+  void DetectUncertainFuture(const uint32_t number_of_start);
+  void OnDetectUncertainFuture(const uint32_t number_of_start,
                                const bool is_uncertain_future);
 
-  void EnsureBaseDirectoryExists(uint32_t number_of_start);
-  void OnEnsureBaseDirectoryExists(uint32_t number_of_start,
+  void EnsureBaseDirectoryExists(const uint32_t number_of_start);
+  void OnEnsureBaseDirectoryExists(const uint32_t number_of_start,
                                    const bool success);
 
   void SetEnvironment();

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -208,18 +208,20 @@ class AdsServiceImpl : public AdsService,
   bool StartService();
 
   void MaybeStart(const bool should_restart);
-  void Start();
+  void Start(uint32_t number_of_start);
   void Stop();
 
   void ResetState();
   void OnShutdownAndResetBatAds(const bool success);
   void OnResetAllState(const bool success);
 
-  void DetectUncertainFuture();
-  void OnDetectUncertainFuture(const bool is_uncertain_future);
+  void DetectUncertainFuture(uint32_t number_of_start);
+  void OnDetectUncertainFuture(uint32_t number_of_start,
+                               const bool is_uncertain_future);
 
-  void EnsureBaseDirectoryExists();
-  void OnEnsureBaseDirectoryExists(const bool success);
+  void EnsureBaseDirectoryExists(uint32_t number_of_start);
+  void OnEnsureBaseDirectoryExists(uint32_t number_of_start,
+                                   const bool success);
 
   void SetEnvironment();
 
@@ -444,6 +446,10 @@ class AdsServiceImpl : public AdsService,
   bool is_initialized_ = false;
 
   bool is_upgrading_from_pre_brave_ads_build_;
+
+  // This is needed to check if current ads service init become stale as
+  // another ads service start is in progress
+  uint32_t total_number_of_starts_ = 0;
 
   const scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
 


### PR DESCRIPTION
There is a possibility of AdsServiceImpl::Start() method is called when
previous ad service init is not finished. One possible situation is when
bat ads process is crashed twice in a short period of time, so
MaybeStart(true) would be called twice. It can lead to a race condition
when two Shutdown() calls runs before two Start() calls.

This PR adds a number to each ads service start and counts total number of
starts. During init we can check if current start become stale and should
be declined as there was another Start() call happen.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/15783

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Start browser
- Check that there is `Successfully initialized ads` message in Logs
- Turn off then turn on Ads from settings
- Check that another `Successfully initialized ads` appeared in Logs
