### PR TITLE
Only request a payment ID when the user opens the QR code modal (uplift to 1.29.x)

### DIFF
--- a/components/brave_rewards/resources/page/components/pageWallet.tsx
+++ b/components/brave_rewards/resources/page/components/pageWallet.tsx
@@ -10,6 +10,7 @@ import {
   ModalActivity,
   ModalBackupRestore,
   ModalPending,
+  ModalQRCode,
   WalletEmpty,
   WalletSummary,
   WalletWrapper
@@ -31,6 +32,7 @@ interface State {
   modalActivity: boolean
   modalPendingContribution: boolean
   modalVerify: boolean
+  modalQRCode: boolean
 }
 
 interface Props extends Rewards.ComponentProps {
@@ -43,7 +45,8 @@ class PageWallet extends React.Component<Props, State> {
       activeTabId: 0,
       modalActivity: false,
       modalPendingContribution: false,
-      modalVerify: false
+      modalVerify: false,
+      modalQRCode: false
     }
   }
 
@@ -213,6 +216,21 @@ class PageWallet extends React.Component<Props, State> {
     }
     this.setState({
       modalVerify: !this.state.modalVerify
+    })
+  }
+
+  toggleQRCodeModal = () => {
+    // If we are opening the QR code panel, then request a payment ID if we do
+    // not already have one and close the backup/restore modal.
+    if (!this.state.modalQRCode) {
+      if (!this.props.rewardsData.paymentId) {
+        this.actions.getPaymentId()
+      }
+      this.actions.onModalBackupClose()
+    }
+
+    this.setState({
+      modalQRCode: !this.state.modalQRCode
     })
   }
 
@@ -807,10 +825,6 @@ class PageWallet extends React.Component<Props, State> {
     const walletType = externalWallet ? externalWallet.type : undefined
     const walletProvider = utils.getWalletProviderName(externalWallet)
 
-    if (!paymentId) {
-      this.props.actions.getPaymentId()
-    }
-
     return (
       <>
         <WalletWrapper
@@ -843,7 +857,6 @@ class PageWallet extends React.Component<Props, State> {
         {
           modalBackup
             ? <ModalBackupRestore
-              paymentId={paymentId}
               activeTabId={this.state.activeTabId}
               backupKey={recoveryKey}
               showBackupNotice={this.showBackupNotice()}
@@ -856,6 +869,7 @@ class PageWallet extends React.Component<Props, State> {
               onRestore={this.onModalBackupOnRestore}
               onVerify={this.onVerifyClick}
               onReset={this.onModalBackupOnReset}
+              onShowQRCode={this.toggleQRCodeModal}
               internalFunds={this.getInternalFunds()}
               error={this.getBackupErrorMessage()}
             />
@@ -884,6 +898,14 @@ class PageWallet extends React.Component<Props, State> {
           this.state.modalActivity
             ? this.generateMonthlyReport()
             : null
+        }
+        {
+          this.state.modalQRCode
+          ? <ModalQRCode
+              paymentId={paymentId}
+              onClose={this.toggleQRCodeModal}
+          />
+          : null
         }
       </>
     )

--- a/components/brave_rewards/resources/ui/components/modalBackupRestore/index.tsx
+++ b/components/brave_rewards/resources/ui/components/modalBackupRestore/index.tsx
@@ -22,7 +22,7 @@ import {
 } from './style'
 import { TextArea, Modal, Button } from 'brave-ui/components'
 import { getLocale } from 'brave-ui/helpers'
-import { Alert, ModalQRCode, Tab } from '../'
+import { Alert, Tab } from '../'
 import ControlWrapper from 'brave-ui/components/formControls/controlWrapper'
 
 export interface Props {
@@ -37,19 +37,18 @@ export interface Props {
   onSaveFile?: (key: string) => void
   onRestore: (key: string) => void
   onVerify?: () => void
+  onShowQRCode: () => void
   error?: React.ReactNode
   id?: string
   testId?: string
   funds?: string
   onReset: () => void
   internalFunds: number
-  paymentId: string
 }
 
 interface State {
   recoveryKey: string
   errorShown: boolean
-  showQRCodeModal: boolean
 }
 
 /*
@@ -62,8 +61,7 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
     super(props)
     this.state = {
       recoveryKey: '',
-      errorShown: false,
-      showQRCodeModal: false
+      errorShown: false
     }
   }
 
@@ -95,12 +93,6 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
     this.setState({
       errorShown: false,
       recoveryKey: event.target.value
-    })
-  }
-
-  toggleQRCodeModal = () => {
-    this.setState({
-      showQRCodeModal: !this.state.showQRCodeModal
     })
   }
 
@@ -241,7 +233,7 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
   }
 
   getRestore = () => {
-    const { error, onClose, funds } = this.props
+    const { error, onShowQRCode, onClose, funds } = this.props
     const errorShown = error && this.state.errorShown
 
     return (
@@ -296,7 +288,7 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
         </StyledTextWrapper>
         <StyledTextWrapper>
           <StyledText>
-            <StyledLink onClick={this.toggleQRCodeModal}>
+            <StyledLink onClick={onShowQRCode}>
               {getLocale('rewardsViewQRCodeText1')}
             </StyledLink> {getLocale('rewardsViewQRCodeText2')}
           </StyledText>
@@ -383,7 +375,6 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
       activeTabId,
       onClose,
       onTabChange,
-      paymentId,
       testId
     } = this.props
 
@@ -408,14 +399,6 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
         </StyledControlWrapper>
         {
           this.getTabContent(activeTabId)
-        }
-        {
-          this.state.showQRCodeModal
-          ? <ModalQRCode
-              paymentId={paymentId}
-              onClose={this.toggleQRCodeModal}
-          />
-          : null
         }
       </Modal>
     )

--- a/components/brave_rewards/resources/ui/stories/modal.tsx
+++ b/components/brave_rewards/resources/ui/stories/modal.tsx
@@ -45,7 +45,6 @@ storiesOf('Rewards/Modal', module)
     return (
       <div style={{ maxWidth: '900px', background: '#fff', padding: '30px' }}>
         <ModalBackupRestore
-          paymentId={'f2e6494e-fb21-44d1-90e9-b5408799acd8'}
           funds={'55 BAT'}
           activeTabId={store.state.activeTabId}
           showBackupNotice={boolean('Show backup notice?', false)}
@@ -59,6 +58,7 @@ storiesOf('Rewards/Modal', module)
           onSaveFile={doNothing}
           onRestore={doNothing}
           onReset={doNothing}
+          onShowQRCode={doNothing}
           internalFunds={0}
         />
       </div>

--- a/components/brave_rewards/resources/ui/stories/settings/pageWallet.tsx
+++ b/components/brave_rewards/resources/ui/stories/settings/pageWallet.tsx
@@ -265,7 +265,6 @@ class PageWallet extends React.Component<Props, State> {
         {
           this.state.modalBackup
             ? <ModalBackupRestore
-              paymentId={'f2e6494e-fb21-44d1-90e9-b5408799acd8'}
               activeTabId={this.state.activeTabId}
               backupKey={'crouch  hint  glow  recall  round  angry  weasel  luggage save  hood  census  near  still   power  vague  balcony camp  law  now  certain  wagon  affair  butter  choice '}
               showBackupNotice={false}
@@ -277,6 +276,7 @@ class PageWallet extends React.Component<Props, State> {
               onSaveFile={doNothing}
               onRestore={doNothing}
               onReset={doNothing}
+              onShowQRCode={doNothing}
               internalFunds={0}
             />
             : null


### PR DESCRIPTION
Uplift of #9710
Resolves https://github.com/brave/brave-browser/issues/17425

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.