### PR TITLE
Fix unnecessary reset problem for RestoreDefaultKeyring

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -209,7 +209,7 @@ std::string GenerateMnemonicForTest(const std::vector<uint8_t>& entropy) {
 std::unique_ptr<std::vector<uint8_t>> MnemonicToSeed(
     const std::string& mnemonic,
     const std::string& passphrase) {
-  if (bip39_mnemonic_validate(nullptr, mnemonic.c_str()) != WALLY_OK) {
+  if (!IsValidMnemonic(mnemonic)) {
     LOG(ERROR) << __func__ << ": Invalid mnemonic: " << mnemonic;
     return nullptr;
   }
@@ -221,6 +221,10 @@ std::unique_ptr<std::vector<uint8_t>> MnemonicToSeed(
                              salt.length(), 2048, EVP_sha512(), seed->size(),
                              seed->data());
   return rv == 1 ? std::move(seed) : nullptr;
+}
+
+bool IsValidMnemonic(const std::string& mnemonic) {
+  return bip39_mnemonic_validate(nullptr, mnemonic.c_str()) == WALLY_OK;
 }
 
 bool EncodeString(const std::string& input, std::string* output) {

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -62,6 +62,7 @@ std::string GenerateMnemonicForTest(const std::vector<uint8_t>& entropy);
 std::unique_ptr<std::vector<uint8_t>> MnemonicToSeed(
     const std::string& mnemonic,
     const std::string& passphrase);
+bool IsValidMnemonic(const std::string& mnemonic);
 
 bool EncodeString(const std::string& input, std::string* output);
 bool EncodeStringArray(const std::vector<std::string>& input,

--- a/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
@@ -309,6 +309,17 @@ TEST(BraveWalletUtilsUnitTest, MnemonicToSeed) {
   EXPECT_EQ(MnemonicToSeed("", ""), nullptr);
 }
 
+TEST(BraveWalletUtilsUnitTest, IsValidMnemonic) {
+  EXPECT_TRUE(
+      IsValidMnemonic("kingdom possible coast island six arrow fluid "
+                      "spell chunk loud glue street"));
+  EXPECT_FALSE(
+      IsValidMnemonic("lingdom possible coast island six arrow fluid "
+                      "spell chunk loud glue street"));
+  EXPECT_FALSE(IsValidMnemonic("kingdom possible coast island six arrow"));
+  EXPECT_FALSE(IsValidMnemonic(""));
+}
+
 TEST(BraveWalletUtilsUnitTest, EncodeString) {
   std::string output;
   EXPECT_TRUE(EncodeString("one", &output));


### PR DESCRIPTION
1. Invalid mnemonic and invalid password won't trigger reset
2. Same mnemonic and same password won't trigger reset
3. Otherwise, reset will be called and restore from a fresh state

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17384

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
All test plans requires brave://flags/#native-brave-wallet enabled

### Invalid mnemonic
1. Create wallet
2. Add second account with customized name
3. Lock wallet
4. In unlock screen, restore with invalid mnemonic ex. some random strings
5. Go to unlock screen again and enter correct password
6. Wallet should not be erased and accounts are remained

### Same mnemonic and same password
1. Create wallet and copy the backup code
2. Add second account with customized name
3. Lock wallet
4. In unlock screen, restore with same password and same backup code
5. Wallet will be unlocked and accounts are remained

### Same mnemonic and different password
1. Create wallet and copy the backup code
2. Add second account with customized name
3. Lock wallet
4. In unlock screen, restore with different password and same backup code
5. Wallet will be reset to default state, which is one account with name "Account 1"
