### PR TITLE
Fixes text in Additional Settings button being cut off. (uplift to 1.28.x)

### DIFF
--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -133,6 +133,7 @@ RegisterStyleOverride(
         margin-top: 30px !important;
         line-height: 1.25 !important;
         border: none !important;
+        :host { border-radius: 0 !important; }
       }
 
       #advancedButton > iron-icon {


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/17109
Uplift of #9537

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
