### PR TITLE
Allow users to override `brave_ads::features::kCustomAdNotifications` feature by a flag in `about://flags`

### DIFF
--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -111,6 +111,7 @@ brave_chrome_browser_deps = [
   "//brave/common:switches",
   "//brave/components/binance/browser/buildflags",
   "//brave/components/brave_ads/browser/buildflags",
+  "//brave/components/brave_ads/common",
   "//brave/components/brave_federated_learning",
   "//brave/components/brave_referrals/buildflags",
   "//brave/components/brave_search/browser",

--- a/browser/ui/brave_ads/ad_notfication_popup_browsertest.cc
+++ b/browser/ui/brave_ads/ad_notfication_popup_browsertest.cc
@@ -9,7 +9,7 @@
 #include "brave/browser/ui/brave_ads/ad_notification.h"
 #include "brave/browser/ui/brave_ads/ad_notification_popup.h"
 #include "brave/common/brave_paths.h"
-#include "brave/components/brave_ads/browser/features.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "brave/test/snapshot/widget_snapshot_checker.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/brave_ads/ad_notification_popup.cc
+++ b/browser/ui/brave_ads/ad_notification_popup.cc
@@ -14,7 +14,7 @@
 #include "brave/browser/ui/brave_ads/ad_notification_view.h"
 #include "brave/browser/ui/brave_ads/ad_notification_view_factory.h"
 #include "brave/browser/ui/brave_ads/bounds_util.h"
-#include "brave/components/brave_ads/browser/features.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "build/build_config.h"

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -8,6 +8,7 @@
 #include "base/strings/string_util.h"
 #include "brave/common/brave_features.h"
 #include "brave/common/pref_names.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_rewards/common/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/common/features.h"
@@ -211,6 +212,11 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      flag_descriptions::kBraveRewardsVerboseLoggingDescription,             \
      kOsDesktop | kOsAndroid,                                               \
      FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature)},  \
+    {"brave-ads-custom-notifications",                                      \
+     flag_descriptions::kBraveAdsCustomNotificationsName,                   \
+     flag_descriptions::kBraveAdsCustomNotificationsDescription,            \
+     kOsDesktop | kOsAndroid,                                               \
+     FEATURE_VALUE_TYPE(brave_ads::features::kCustomAdNotifications)},      \
     {"brave-talk",                                                          \
      flag_descriptions::kBraveTalkName,                                     \
      flag_descriptions::kBraveTalkDescription,                              \

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -76,6 +76,10 @@ const char kBraveRewardsVerboseLoggingDescription[] =
     "information such as browsing history and credentials such as passwords "
     "and access tokens depending on your activity. Please do not share it "
     "unless asked to by Brave staff.";
+const char kBraveAdsCustomNotificationsName[] =
+    "Enable Brave Ads custom notifications";
+const char kBraveAdsCustomNotificationsDescription[] =
+    "Enable Brave Ads custom notifications to support rich media";
 const char kNativeBraveWalletName[] = "Enable experimental Brave native wallet";
 const char kNativeBraveWalletDescription[] =
     "Experimental native cryptocurrency wallet support without the use of "

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -51,6 +51,8 @@ extern const char kBraveRewardsGeminiDescription[];
 
 extern const char kBraveRewardsVerboseLoggingName[];
 extern const char kBraveRewardsVerboseLoggingDescription[];
+extern const char kBraveAdsCustomNotificationsName[];
+extern const char kBraveAdsCustomNotificationsDescription[];
 extern const char kNativeBraveWalletName[];
 extern const char kNativeBraveWalletDescription[];
 extern const char kBraveSearchDefaultAPIName[];

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -53,8 +53,6 @@ static_library("browser") {
       "component_updater/resource_component.h",
       "component_updater/resource_component_observer.h",
       "component_updater/resource_info.h",
-      "features.cc",
-      "features.h",
       "frequency_capping_helper.cc",
       "frequency_capping_helper.h",
       "notification_helper.cc",

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -46,9 +46,9 @@
 #include "brave/common/brave_channel_info.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_ads/browser/ads_p2a.h"
-#include "brave/components/brave_ads/browser/features.h"
 #include "brave/components/brave_ads/browser/frequency_capping_helper.h"
 #include "brave/components/brave_ads/browser/notification_helper.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/components/brave_ads/common/switches.h"
 #include "brave/components/brave_rewards/browser/rewards_notification_service.h"
@@ -1015,7 +1015,7 @@ bool AdsServiceImpl::ShouldShowCustomAdNotifications() {
     ClearPref(prefs::kAdNotificationDidFallbackToCustom);
   }
 
-  const bool should_show = features::ShouldShowCustomAdNotifications();
+  const bool should_show = features::IsCustomAdNotificationsEnabled();
 
   const bool should_fallback =
       !can_show_native_notifications && can_fallback_to_custom_ad_notifications;

--- a/components/brave_ads/browser/notification_helper_android.cc
+++ b/components/brave_ads/browser/notification_helper_android.cc
@@ -14,7 +14,7 @@
 #include "brave/browser/brave_ads/android/jni_headers/BraveAds_jni.h"
 #include "brave/build/android/jni_headers/BraveNotificationSettingsBridge_jni.h"
 #include "brave/components/brave_ads/browser/background_helper.h"
-#include "brave/components/brave_ads/browser/features.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "chrome/browser/notifications/jni_headers/NotificationSystemStatusUtil_jni.h"
 #include "chrome/browser/notifications/notification_channels_provider_android.h"
 
@@ -34,7 +34,7 @@ NotificationHelperAndroid::NotificationHelperAndroid() = default;
 NotificationHelperAndroid::~NotificationHelperAndroid() = default;
 
 bool NotificationHelperAndroid::ShouldShowNotifications() {
-  if (features::ShouldShowCustomAdNotifications()) {
+  if (features::IsCustomAdNotificationsEnabled()) {
     return true;
   }
 
@@ -70,7 +70,7 @@ bool NotificationHelperAndroid::ShowMyFirstAdNotification() {
   }
 
   const bool should_show_custom_notifications =
-      features::ShouldShowCustomAdNotifications();
+      features::IsCustomAdNotificationsEnabled();
 
   JNIEnv* env = base::android::AttachCurrentThread();
   Java_BraveAdsSignupDialog_enqueueOnboardingNotificationNative(
@@ -80,7 +80,7 @@ bool NotificationHelperAndroid::ShowMyFirstAdNotification() {
 }
 
 bool NotificationHelperAndroid::CanShowBackgroundNotifications() const {
-  if (features::ShouldShowCustomAdNotifications()) {
+  if (features::IsCustomAdNotificationsEnabled()) {
     return true;
   }
 

--- a/components/brave_ads/browser/notification_helper_linux.cc
+++ b/components/brave_ads/browser/notification_helper_linux.cc
@@ -5,7 +5,7 @@
 
 #include "brave/components/brave_ads/browser/notification_helper_linux.h"
 
-#include "brave/components/brave_ads/browser/features.h"
+#include "brave/components/brave_ads/common/features.h"
 
 namespace brave_ads {
 
@@ -14,7 +14,7 @@ NotificationHelperLinux::NotificationHelperLinux() = default;
 NotificationHelperLinux::~NotificationHelperLinux() = default;
 
 bool NotificationHelperLinux::ShouldShowNotifications() {
-  return features::ShouldShowCustomAdNotifications();
+  return features::IsCustomAdNotificationsEnabled();
 }
 
 bool NotificationHelperLinux::CanShowNativeNotifications() {

--- a/components/brave_ads/browser/notification_helper_mac.mm
+++ b/components/brave_ads/browser/notification_helper_mac.mm
@@ -13,8 +13,8 @@
 #include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/mac/mac_util.h"
-#include "brave/components/brave_ads/browser/features.h"
 #include "brave/components/brave_ads/browser/notification_helper_mac.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "chrome/common/chrome_features.h"
 
 namespace brave_ads {
@@ -24,7 +24,7 @@ NotificationHelperMac::NotificationHelperMac() = default;
 NotificationHelperMac::~NotificationHelperMac() = default;
 
 bool NotificationHelperMac::ShouldShowNotifications() {
-  if (features::ShouldShowCustomAdNotifications()) {
+  if (features::IsCustomAdNotificationsEnabled()) {
     return true;
   }
 

--- a/components/brave_ads/browser/notification_helper_win.cc
+++ b/components/brave_ads/browser/notification_helper_win.cc
@@ -12,7 +12,7 @@
 #include "base/win/core_winrt_util.h"
 #include "base/win/scoped_hstring.h"
 #include "base/win/windows_version.h"
-#include "brave/components/brave_ads/browser/features.h"
+#include "brave/components/brave_ads/common/features.h"
 #include "chrome/common/chrome_features.h"
 #include "chrome/install_static/install_util.h"
 #include "chrome/installer/util/install_util.h"
@@ -65,7 +65,7 @@ NotificationHelperWin::NotificationHelperWin() = default;
 NotificationHelperWin::~NotificationHelperWin() = default;
 
 bool NotificationHelperWin::ShouldShowNotifications() {
-  if (features::ShouldShowCustomAdNotifications()) {
+  if (features::IsCustomAdNotificationsEnabled()) {
     return true;
   }
 

--- a/components/brave_ads/common/BUILD.gn
+++ b/components/brave_ads/common/BUILD.gn
@@ -1,8 +1,12 @@
 static_library("common") {
   sources = [
+    "features.cc",
+    "features.h",
     "pref_names.cc",
     "pref_names.h",
     "switches.cc",
     "switches.h",
   ]
+
+  deps = [ "//base" ]
 }

--- a/components/brave_ads/common/features.cc
+++ b/components/brave_ads/common/features.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_ads/browser/features.h"
+#include "brave/components/brave_ads/common/features.h"
 
 #include "base/feature_list.h"
 
@@ -13,19 +13,10 @@ namespace features {
 const base::Feature kAdNotifications{"AdNotifications",
                                      base::FEATURE_ENABLED_BY_DEFAULT};
 
+const base::Feature kCustomAdNotifications{"CustomAdNotifications",
+                                           base::FEATURE_DISABLED_BY_DEFAULT};
+
 namespace {
-
-// Set to true to show custom ad notifications or false to show native ad
-// notifications
-const char kFieldTrialParameterShouldShowCustomAdNotifications[] =
-    "should_show_custom_notifications";
-const bool kDefaultShouldShowCustomAdNotifications = false;
-
-// Set to true to fallback from native to custom ad notifications or false to
-// never fallback
-const char kFieldTrialParameterCanFallbackToCustomAdNotifications[] =
-    "can_fallback_to_custom_notifications";
-const bool kDefaultCanFallbackToCustomAdNotifications = false;
 
 // Ad notification timeout in seconds. Set to 0 to never time out
 const char kFieldTrialParameterAdNotificationTimeout[] =
@@ -35,6 +26,12 @@ const int kDefaultAdNotificationTimeout = 120;
 #else
 const int kDefaultAdNotificationTimeout = 30;
 #endif
+
+// Set to true to fallback from native to custom ad notifications or false to
+// never fallback
+const char kFieldTrialParameterCanFallbackToCustomAdNotifications[] =
+    "can_fallback_to_custom_notifications";
+const bool kDefaultCanFallbackToCustomAdNotifications = false;
 
 #if !defined(OS_ANDROID)
 
@@ -102,55 +99,54 @@ bool IsAdNotificationsEnabled() {
   return base::FeatureList::IsEnabled(kAdNotifications);
 }
 
-bool ShouldShowCustomAdNotifications() {
-  return GetFieldTrialParamByFeatureAsBool(
-      kAdNotifications, kFieldTrialParameterShouldShowCustomAdNotifications,
-      kDefaultShouldShowCustomAdNotifications);
-}
-
-bool CanFallbackToCustomAdNotifications() {
-  return GetFieldTrialParamByFeatureAsBool(
-      kAdNotifications, kFieldTrialParameterCanFallbackToCustomAdNotifications,
-      kDefaultCanFallbackToCustomAdNotifications);
-}
-
 int AdNotificationTimeout() {
   return GetFieldTrialParamByFeatureAsInt(
       kAdNotifications, kFieldTrialParameterAdNotificationTimeout,
       kDefaultAdNotificationTimeout);
 }
 
+bool IsCustomAdNotificationsEnabled() {
+  return base::FeatureList::IsEnabled(kCustomAdNotifications);
+}
+
+bool CanFallbackToCustomAdNotifications() {
+  return GetFieldTrialParamByFeatureAsBool(
+      kCustomAdNotifications,
+      kFieldTrialParameterCanFallbackToCustomAdNotifications,
+      kDefaultCanFallbackToCustomAdNotifications);
+}
+
 #if !defined(OS_ANDROID)
 
 int AdNotificationFadeDuration() {
   return GetFieldTrialParamByFeatureAsInt(
-      kAdNotifications, kFieldTrialParameterAdNotificationFadeDuration,
+      kCustomAdNotifications, kFieldTrialParameterAdNotificationFadeDuration,
       kDefaultAdNotificationFadeDuration);
 }
 
 double AdNotificationNormalizedDisplayCoordinateX() {
   return GetFieldTrialParamByFeatureAsDouble(
-      kAdNotifications,
+      kCustomAdNotifications,
       kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateX,
       kDefaultAdNotificationNormalizedDisplayCoordinateX);
 }
 
 int AdNotificationInsetX() {
   return GetFieldTrialParamByFeatureAsInt(
-      kAdNotifications, kFieldTrialParameterAdNotificationInsetX,
+      kCustomAdNotifications, kFieldTrialParameterAdNotificationInsetX,
       kDefaultAdNotificationInsetX);
 }
 
 double AdNotificationNormalizedDisplayCoordinateY() {
   return GetFieldTrialParamByFeatureAsDouble(
-      kAdNotifications,
+      kCustomAdNotifications,
       kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateY,
       kDefaultAdNotificationNormalizedDisplayCoordinateY);
 }
 
 int AdNotificationInsetY() {
   return GetFieldTrialParamByFeatureAsInt(
-      kAdNotifications, kFieldTrialParameterAdNotificationInsetY,
+      kCustomAdNotifications, kFieldTrialParameterAdNotificationInsetY,
       kDefaultAdNotificationInsetY);
 }
 

--- a/components/brave_ads/common/features.h
+++ b/components/brave_ads/common/features.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_FEATURES_H_
-#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_FEATURES_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_COMMON_FEATURES_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_COMMON_FEATURES_H_
 
 #include "build/build_config.h"
 
@@ -18,25 +18,22 @@ namespace features {
 extern const base::Feature kAdNotifications;
 
 bool IsAdNotificationsEnabled();
-
-bool ShouldShowCustomAdNotifications();
-
-bool CanFallbackToCustomAdNotifications();
-
 int AdNotificationTimeout();
 
+extern const base::Feature kCustomAdNotifications;
+
+bool IsCustomAdNotificationsEnabled();
+
+bool CanFallbackToCustomAdNotifications();
 #if !defined(OS_ANDROID)
-
 int AdNotificationFadeDuration();
-
 double AdNotificationNormalizedDisplayCoordinateX();
 int AdNotificationInsetX();
 double AdNotificationNormalizedDisplayCoordinateY();
 int AdNotificationInsetY();
-
 #endif  // !defined(OS_ANDROID)
 
 }  // namespace features
 }  // namespace brave_ads
 
-#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_FEATURES_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_COMMON_FEATURES_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17439

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm `CustomAdNotifications` feature is disabled by default unless overridden by griffin.

Confirm `can_fallback_to_custom_notifications`, `ad_notification_fade_duration`, `ad_notification_normalized_display_coordinate_x`, `ad_notification_inset_x`, `ad_notification_normalized_display_coordinate_y` and `ad_notification_inset_y` field trial parameters work as expected for custom ad notifications