### PR TITLE
Implement eth_accounts method of ethereum.request

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
@@ -33,6 +33,8 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate {
   void RequestEthereumPermissions(
       RequestEthereumPermissionsCallback callback) override;
 
+  void GetAllowedAccounts(GetAllowedAccountsCallback callback) override;
+
  private:
   void EnsureConnected();
   void OnConnectionError();

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_android.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_android.cc
@@ -16,4 +16,7 @@ BraveWalletProviderDelegateImplAndroid::BraveWalletProviderDelegateImplAndroid(
 void BraveWalletProviderDelegateImplAndroid::RequestEthereumPermissions(
     BraveWalletProviderDelegate::RequestEthereumPermissionsCallback callback) {}
 
+void BraveWalletProviderDelegateImplAndroid::GetAllowedAccounts(
+    BraveWalletProviderDelegate::GetAllowedAccountsCallback callback) {}
+
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_android.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_android.h
@@ -29,6 +29,7 @@ class BraveWalletProviderDelegateImplAndroid
 
   void RequestEthereumPermissions(
       RequestEthereumPermissionsCallback callback) override;
+  void GetAllowedAccounts(GetAllowedAccountsCallback callback) override;
 };
 
 }  // namespace brave_wallet

--- a/browser/permissions/BUILD.gn
+++ b/browser/permissions/BUILD.gn
@@ -25,7 +25,10 @@ if (!is_android) {
     ]
 
     if (brave_wallet_enabled) {
-      sources += [ "permission_manager_browsertest.cc" ]
+      sources += [
+        "brave_ethereum_permission_context_browsertest.cc",
+        "permission_manager_browsertest.cc",
+      ]
 
       deps += [
         "//brave/browser/brave_wallet",

--- a/browser/permissions/brave_ethereum_permission_context_browsertest.cc
+++ b/browser/permissions/brave_ethereum_permission_context_browsertest.cc
@@ -1,0 +1,161 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/bind.h"
+#include "base/command_line.h"
+#include "base/feature_list.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_wallet/browser/ethereum_permission_utils.h"
+#include "brave/components/brave_wallet/common/features.h"
+#include "brave/components/permissions/contexts/brave_ethereum_permission_context.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "components/network_session_configurator/common/network_switches.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "url/gurl.h"
+
+namespace permissions {
+
+namespace {
+
+void OnGetAllowedAccountsResult(
+    bool* was_called,
+    bool expected_success,
+    const std::vector<std::string>& expected_allowed_accounts,
+    bool success,
+    const std::vector<std::string>& allowed_accounts) {
+  ASSERT_FALSE(*was_called);
+  *was_called = true;
+  EXPECT_EQ(expected_success, success);
+  EXPECT_EQ(expected_allowed_accounts, allowed_accounts);
+}
+
+}  // namespace
+
+class BraveEthereumPermissionContextBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveEthereumPermissionContextBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {
+    scoped_feature_list_.InitAndEnableFeature(
+        brave_wallet::features::kNativeBraveWalletFeature);
+  }
+
+  ~BraveEthereumPermissionContextBrowserTest() override = default;
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitch(switches::kIgnoreCertificateErrors);
+  }
+
+  void SetUpOnMainThread() override {
+    host_resolver()->AddRule("*", "127.0.0.1");
+    https_server()->ServeFilesFromDirectory(GetChromeTestDataDir());
+    ASSERT_TRUE(https_server()->Start());
+  }
+
+  HostContentSettingsMap* host_content_settings_map() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  content::WebContents* web_contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  GURL GetLastCommitedOrigin() {
+    return web_contents()->GetLastCommittedURL().GetOrigin();
+  }
+
+  net::EmbeddedTestServer* https_server() { return &https_server_; }
+
+ protected:
+  net::test_server::EmbeddedTestServer https_server_;
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveEthereumPermissionContextBrowserTest,
+                       GetAllowedAccounts) {
+  std::vector<std::string> addresses = {
+      "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8A",
+      "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8B",
+      "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8C"};
+
+  // Fail if rfh is null.
+  bool was_called = false;
+  BraveEthereumPermissionContext::GetAllowedAccounts(
+      nullptr /* rfh */, addresses,
+      base::BindOnce(&OnGetAllowedAccountsResult, &was_called, false,
+                     std::vector<std::string>()));
+  content::RunAllTasksUntilIdle();
+  EXPECT_TRUE(was_called);
+
+  was_called = false;
+  const GURL& url = https_server()->GetURL("a.com", "/empty.html");
+  ui_test_utils::NavigateToURL(browser(), url);
+
+  // No allowed accounts before setting permissions.
+  BraveEthereumPermissionContext::GetAllowedAccounts(
+      web_contents()->GetMainFrame(), addresses,
+      base::BindOnce(&OnGetAllowedAccountsResult, &was_called, true,
+                     std::vector<std::string>()));
+
+  content::RunAllTasksUntilIdle();
+  EXPECT_TRUE(was_called);
+
+  // Return allowed accounts after permissions are set.
+  was_called = false;
+  std::vector<std::string> expected_allowed_accounts = {addresses[0],
+                                                        addresses[2]};
+  for (const auto& account : expected_allowed_accounts) {
+    GURL sub_request_origin;
+    ASSERT_TRUE(brave_wallet::GetSubRequestOrigin(
+        GetLastCommitedOrigin(), account, &sub_request_origin));
+    host_content_settings_map()->SetContentSettingDefaultScope(
+        sub_request_origin, GetLastCommitedOrigin(),
+        ContentSettingsType::BRAVE_ETHEREUM,
+        ContentSetting::CONTENT_SETTING_ALLOW);
+  }
+  BraveEthereumPermissionContext::GetAllowedAccounts(
+      web_contents()->GetMainFrame(), addresses,
+      base::BindOnce(&OnGetAllowedAccountsResult, &was_called, true,
+                     expected_allowed_accounts));
+  content::RunAllTasksUntilIdle();
+  EXPECT_TRUE(was_called);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveEthereumPermissionContextBrowserTest,
+                       GetAllowedAccountsBlock3PIframe) {
+  std::vector<std::string> addresses = {
+      "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8A",
+      "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8B"};
+
+  GURL top_url(https_server()->GetURL("a.com", "/iframe.html"));
+  ui_test_utils::NavigateToURL(browser(), top_url);
+  GURL iframe_url(https_server()->GetURL("b.com", "/"));
+  EXPECT_TRUE(NavigateIframeToURL(web_contents(), "test", iframe_url));
+
+  bool was_called = false;
+  auto* iframe_rfh = ChildFrameAt(web_contents()->GetMainFrame(), 0);
+  BraveEthereumPermissionContext::GetAllowedAccounts(
+      iframe_rfh, addresses,
+      base::BindOnce(&OnGetAllowedAccountsResult, &was_called, false,
+                     std::vector<std::string>()));
+  content::RunAllTasksUntilIdle();
+  EXPECT_TRUE(was_called);
+}
+
+}  // namespace permissions

--- a/components/brave_wallet/browser/brave_wallet_provider_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_delegate.h
@@ -17,6 +17,8 @@ class BraveWalletProviderDelegate {
  public:
   using RequestEthereumPermissionsCallback =
       base::OnceCallback<void(const std::vector<std::string>&)>;
+  using GetAllowedAccountsCallback =
+      base::OnceCallback<void(bool, const std::vector<std::string>&)>;
 
   BraveWalletProviderDelegate() = default;
   BraveWalletProviderDelegate(const BraveWalletProviderDelegate&) = delete;
@@ -26,6 +28,7 @@ class BraveWalletProviderDelegate {
 
   virtual void RequestEthereumPermissions(
       RequestEthereumPermissionsCallback callback) = 0;
+  virtual void GetAllowedAccounts(GetAllowedAccountsCallback callback) = 0;
 };
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -35,9 +35,7 @@ void BraveWalletProviderImpl::Request(const std::string& json_payload,
 }
 
 void BraveWalletProviderImpl::Enable(EnableCallback callback) {
-  if (!delegate_)
-    return;
-
+  DCHECK(delegate_);
   delegate_->RequestEthereumPermissions(
       base::BindOnce(&BraveWalletProviderImpl::OnEnable,
                      weak_factory_.GetWeakPtr(), std::move(callback)));
@@ -47,6 +45,21 @@ void BraveWalletProviderImpl::OnEnable(
     EnableCallback callback,
     const std::vector<std::string>& accounts) {
   std::move(callback).Run(accounts);
+}
+
+void BraveWalletProviderImpl::GetAllowedAccounts(
+    GetAllowedAccountsCallback callback) {
+  DCHECK(delegate_);
+  delegate_->GetAllowedAccounts(
+      base::BindOnce(&BraveWalletProviderImpl::OnGetAllowedAccounts,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveWalletProviderImpl::OnGetAllowedAccounts(
+    GetAllowedAccountsCallback callback,
+    bool success,
+    const std::vector<std::string>& accounts) {
+  std::move(callback).Run(success, accounts);
 }
 
 void BraveWalletProviderImpl::GetChainId(GetChainIdCallback callback) {

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -40,6 +40,10 @@ class BraveWalletProviderImpl final
   void OnEnable(EnableCallback callback,
                 const std::vector<std::string>& accounts);
   void GetChainId(GetChainIdCallback callback) override;
+  void GetAllowedAccounts(GetAllowedAccountsCallback callback) override;
+  void OnGetAllowedAccounts(GetAllowedAccountsCallback callback,
+                            bool success,
+                            const std::vector<std::string>& accounts);
   void Init(
       mojo::PendingRemote<mojom::EventsListener> events_listener) override;
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -18,6 +18,7 @@ interface BraveWalletProvider {
   Request(string json_payload, bool auto_retry_on_network_change) => (int32 http_code, string response, map<string, string> headers);
   Enable() => (array<string> accounts);
   GetChainId() => (string chain_id);
+  GetAllowedAccounts() => (bool success, array<string> accounts);
 };
 
 // Used by the WebUI page to bootstrap bidirectional communication.

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -13,6 +13,8 @@ extern const char kDisconnectEvent[];
 extern const char kChainChangedEvent[];
 extern const char kAccountsChangedEvent[];
 
+// https://eips.ethereum.org/EIPS/eip-1193#provider-errors
+// https://eips.ethereum.org/EIPS/eip-1474#error-codes
 enum class ProviderErrors {
   kUserRejectedRequest = 4001,  // User rejected the request
   kUnauthorized = 4100,         // The requested account and/or method has not
@@ -22,7 +24,11 @@ enum class ProviderErrors {
   kDisconnected = 4900,         // The provider is disconnected from all chains
   kChainDisconnected = 4901,    // The provider is disconnected from the
                                 // specified chain
+  kInternalError = -32603,      // Internal JSON-RPC error
 };
+
+constexpr char kEthAccounts[] = "eth_accounts";
+constexpr char kMethod[] = "method";
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -71,10 +71,6 @@ class BraveWalletJSHandler : public mojom::EventsListener {
                    const int http_code,
                    const std::string& response,
                    const base::flat_map<std::string, std::string>& headers);
-  void OnEnable(v8::Global<v8::Promise::Resolver> promise_resolver,
-                v8::Isolate* isolate,
-                v8::Global<v8::Context> context_old,
-                const std::vector<std::string>& accounts);
 
   content::RenderFrame* render_frame_;
   mojo::Remote<mojom::BraveWalletProvider> brave_wallet_provider_;

--- a/components/permissions/contexts/brave_ethereum_permission_context.h
+++ b/components/permissions/contexts/brave_ethereum_permission_context.h
@@ -57,6 +57,11 @@ class BraveEthereumPermissionContext : public PermissionContextBase {
                              content::WebContents* web_contents);
   static void Cancel(content::WebContents* web_contents);
 
+  static void GetAllowedAccounts(
+      content::RenderFrameHost* rfh,
+      const std::vector<std::string>& addresses,
+      base::OnceCallback<void(bool, const std::vector<std::string>&)> callback);
+
  protected:
   bool IsRestrictedToSecureOrigins() const override;
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17413

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
pre-condition: wallet flag is enabled and the wallet is unlocked.
1. Visit instagram.com and open devtools
2. Run `window.ethereum.request({method:"eth_accounts"}).then((account)=>console.log(account), (error)=>console.log(error))` in the devtools should return an empty array.
3. Run `window.ethereum.enable()` in the devtools and select one or multiple accounts to connect.
4. Run `window.ethereum.request({method:"eth_accounts"}).then((account)=>console.log(account), (error)=>console.log(error))` in the devtools should return those accounts allowed in step 3.
