### PR TITLE
Add feature flag to toggle dark mode blocking when fingerprinting=strict

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -37,6 +37,7 @@
 #include "brave/components/brave_shields/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/browser/domain_block_navigation_throttle.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
+#include "brave/components/brave_shields/common/features.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_webtorrent/browser/buildflags/buildflags.h"
 #include "brave/components/cosmetic_filters/browser/cosmetic_filters_resources.h"
@@ -698,7 +699,9 @@ bool BraveContentBrowserClient::OverrideWebPreferencesAfterNavigation(
       HostContentSettingsMapFactory::GetForProfile(profile), url);
   // https://github.com/brave/brave-browser/issues/15265
   // Always use color scheme Light if fingerprinting mode strict
-  if (shields_up && fingerprinting_type == ControlType::BLOCK) {
+  if (base::FeatureList::IsEnabled(
+          brave_shields::features::kBraveDarkModeBlock) &&
+      shields_up && fingerprinting_type == ControlType::BLOCK) {
     prefs->preferred_color_scheme = blink::mojom::PreferredColorScheme::kLight;
     changed = true;
   }

--- a/chromium_src/chrome/browser/about_flags.cc
+++ b/chromium_src/chrome/browser/about_flags.cc
@@ -30,6 +30,7 @@ using brave_shields::features::kBraveAdblockCollapseBlockedElements;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockCosmeticFilteringNative;
 using brave_shields::features::kBraveAdblockCspRules;
+using brave_shields::features::kBraveDarkModeBlock;
 using brave_shields::features::kBraveDomainBlock;
 using brave_shields::features::kBraveExtensionNetworkBlocking;
 using ntp_background_images::features::kBraveNTPBrandedWallpaper;
@@ -172,6 +173,10 @@ using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
      flag_descriptions::kBraveExtensionNetworkBlockingName,                 \
      flag_descriptions::kBraveExtensionNetworkBlockingDescription, kOsAll,  \
      FEATURE_VALUE_TYPE(kBraveExtensionNetworkBlocking)},                   \
+    {"brave-dark-mode-block",                                               \
+     flag_descriptions::kBraveDarkModeBlockName,                            \
+     flag_descriptions::kBraveDarkModeBlockDescription, kOsAll,             \
+     FEATURE_VALUE_TYPE(kBraveDarkModeBlock)},                              \
     SPEEDREADER_FEATURE_ENTRIES                                             \
     BRAVE_SYNC_FEATURE_ENTRIES                                              \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \

--- a/chromium_src/chrome/browser/flag_descriptions.cc
+++ b/chromium_src/chrome/browser/flag_descriptions.cc
@@ -48,6 +48,10 @@ const char kBraveExtensionNetworkBlockingName[] =
     "Enable extension network blocking";
 const char kBraveExtensionNetworkBlockingDescription[] =
     "Enable blocking for network requests initiated by extensions";
+const char kBraveDarkModeBlockName[] =
+    "Enable dark mode blocking fingerprinting protection";
+const char kBraveDarkModeBlockDescription[] =
+    "Always report light mode when fingerprinting protections set to Strict";
 const char kBraveSidebarName[] = "Enable Sidebar";
 // TODO(simon): Use more better description.
 const char kBraveSidebarDescription[] = "Enable Sidebar";

--- a/chromium_src/chrome/browser/flag_descriptions.h
+++ b/chromium_src/chrome/browser/flag_descriptions.h
@@ -31,6 +31,8 @@ extern const char kBraveDomainBlockName[];
 extern const char kBraveDomainBlockDescription[];
 extern const char kBraveExtensionNetworkBlockingName[];
 extern const char kBraveExtensionNetworkBlockingDescription[];
+extern const char kBraveDarkModeBlockName[];
+extern const char kBraveDarkModeBlockDescription[];
 extern const char kBraveSidebarName[];
 extern const char kBraveSidebarDescription[];
 extern const char kBraveSpeedreaderName[];

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -37,6 +37,8 @@ const base::Feature kBraveDomainBlock{"BraveDomainBlock",
 // potentially blocked by Brave Shields.
 const base::Feature kBraveExtensionNetworkBlocking{
     "BraveExtensionNetworkBlocking", base::FEATURE_DISABLED_BY_DEFAULT};
-
+// When enabled, Brave will always report Light in Fingerprinting: Strict mode
+const base::Feature kBraveDarkModeBlock{"BraveDarkModeBlock",
+                                        base::FEATURE_ENABLED_BY_DEFAULT};
 }  // namespace features
 }  // namespace brave_shields

--- a/components/brave_shields/common/features.h
+++ b/components/brave_shields/common/features.h
@@ -19,6 +19,7 @@ extern const base::Feature kBraveAdblockCosmeticFilteringNative;
 extern const base::Feature kBraveAdblockCspRules;
 extern const base::Feature kBraveDomainBlock;
 extern const base::Feature kBraveExtensionNetworkBlocking;
+extern const base::Feature kBraveDarkModeBlock;
 }  // namespace features
 }  // namespace brave_shields
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/17139.

I'm working on a fix to disable Brave Shields when there's a navigation error which will address general issues of that class (plus remove confusing UX), but in the meantime, adding an opt-out for folks who don't want fingerprinting strict to mess with their dark mode. 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

