### PR TITLE
Fixed Wallet Onboarding TypeErrors

### DIFF
--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -364,7 +364,7 @@ export interface WalletAPIHandler {
   getAllTokens: () => Promise<GetAllTokensReturnInfo>
   addFavoriteApp: (appItem: AppObjectType) => Promise<void>
   removeFavoriteApp: (appItem: AppObjectType) => Promise<void>
-  setInitialVisibleAssets: (visibleAssets: string[]) => Promise<void>
+  setInitialVisibleTokens: (visibleAssets: string[]) => Promise<void>
 }
 
 export interface EthJsonRpcController {

--- a/components/brave_wallet_ui/options/initial-visible-token-info.ts
+++ b/components/brave_wallet_ui/options/initial-visible-token-info.ts
@@ -1,0 +1,12 @@
+import { TokenInfo } from '../constants/types'
+
+export const InitialVisibleTokenInfo: TokenInfo[] = [
+  {
+    contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
+    decimals: 18,
+    isErc20: true,
+    isErc721: false,
+    name: 'Basic Attention Token',
+    symbol: 'BAT'
+  }
+]


### PR DESCRIPTION
## Description 
Fixed the TypeErrors that we're being thrown during the Wallet Onboarding process.

The issue that was happening here is that during initialization we set and then fetch the users initial `visibleTokenInfo`
from the `getTokenByContract` method and the `ERCTokenRegistry` is not completely built until some time after the user `initialization`. There for it was returning `null` while fetching `TokenInfo`. 

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/17468>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A


