### PR TITLE
Brave News: do not request ad content multiple times for the same ad unit

### DIFF
--- a/components/brave_new_tab_ui/components/default/braveToday/cards/displayAd/useTriggerOnNearViewport.ts
+++ b/components/brave_new_tab_ui/components/default/braveToday/cards/displayAd/useTriggerOnNearViewport.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+let instanceCount = 0
+
+export default function useTriggerOnNearViewport (handlerRef: React.MutableRefObject<Function>) {
+  // When we're intersecting for the first time, ask for an Ad
+  const hasPassedAdRequestThreshold = React.useRef(false)
+  // Element which will be observed to trigger ad fetch
+  const contentTrigger = React.useRef<HTMLDivElement>(null)
+  // Observer which will observe elements scroll position to trigger ad fetch
+  const contentTriggerObserver = React.useRef<IntersectionObserver>()
+  const debugInstanceId = React.useMemo(function () {
+    return instanceCount++
+  }, [])
+  // Setup ad fetch trigger observer on first mount
+  React.useEffect(() => {
+    console.debug('Brave News: creating observer', debugInstanceId)
+    contentTriggerObserver.current = new IntersectionObserver(async (entries) => {
+      // Only request an ad the first time it passes threshold
+      if (!hasPassedAdRequestThreshold.current && entries.some((entry) => entry.isIntersecting)) {
+        hasPassedAdRequestThreshold.current = true
+        console.debug('Brave News: asking for an ad', debugInstanceId)
+        handlerRef.current && handlerRef.current()
+      }
+    }, {
+      // Trigger ad fetch when the ad unit is 1000px away from the viewport
+      rootMargin: '0px 0px 1000px 0px'
+    })
+  }, [])
+  // Observe and disconnect from content trigger when it's appropriate
+  React.useEffect(() => {
+    if (hasPassedAdRequestThreshold.current || !contentTrigger.current || !contentTriggerObserver.current) {
+      console.debug('Brave News: not creating trigger', debugInstanceId)
+      return
+    }
+    const observer = contentTriggerObserver.current
+    console.debug('Brave News: ad fetch trigger observer connected', debugInstanceId)
+    observer.observe(contentTrigger.current)
+    return () => {
+      console.debug('Brave News: ad fetch trigger observer disconnected', debugInstanceId)
+      observer.disconnect()
+    }
+  }, [
+    // Disconnect when we have asked for an ad
+    // (opportunistically at the next render as ref mutations don't cause effects to run)
+    hasPassedAdRequestThreshold.current,
+    // Observer or Disconnect when we have a new element (should have caused a render, so this should get run)
+    contentTrigger.current,
+    // Observe or Disconnect when we have a new intersection observer (should be at first mount)
+    contentTriggerObserver.current
+  ])
+  return [contentTrigger]
+}

--- a/components/brave_new_tab_ui/stories/default/data/getBraveNewsDisplayAd.ts
+++ b/components/brave_new_tab_ui/stories/default/data/getBraveNewsDisplayAd.ts
@@ -7,7 +7,7 @@ let callCount = 0
 
 export default function getBraveNewsDisplayAd (always: boolean = false) {
   callCount++
-  const ad = (always || callCount % 2)
+  const ad: BraveToday.DisplayAd | null = (always || callCount % 2)
     ? {
       description: 'Technica',
       uuid: '0abc',
@@ -19,5 +19,7 @@ export default function getBraveNewsDisplayAd (always: boolean = false) {
       dimensions: '1x3'
     }
     : null
-  return Promise.resolve(ad)
+  return new Promise<BraveToday.DisplayAd | null>(function (resolve) {
+    setTimeout(() => resolve(ad), 2400)
+  })
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17471

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Open NTP
- Open DevTools and ensure "debug" messages are being shown. Feel free to filter to "Brave News"
![image](https://user-images.githubusercontent.com/741836/129273145-a81179b2-828d-4c98-a267-e86ba8091ac8.png)
- When scrolling down to Brave Today, ensure that only a single "Brave News: asking for an ad" is logged.
