### PR TITLE
Fixes Brave ads estimated earnings do not reconcile after a users wallet has changed through restore or corruption - 1.29.x

### DIFF
--- a/components/brave_ads/test/BUILD.gn
+++ b/components/brave_ads/test/BUILD.gn
@@ -15,6 +15,7 @@ source_set("brave_ads_unit_tests") {
       "//brave/vendor/bat-native-ads/src/bat/ads/ad_event_history_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_delegate_mock.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_delegate_mock.h",
+      "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_issue_17412_test.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_util_unittest.cc",
       "//brave/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments_unittest.cc",

--- a/vendor/bat-native-ads/data/test/confirmations_issue_17412.json
+++ b/vendor/bat-native-ads/data/test/confirmations_issue_17412.json
@@ -1,0 +1,57 @@
+{
+  "ads_rewards": {
+    "payments": [
+      {
+        "balance": 0.845,
+        "month": "2021-05",
+        "transaction_count": "41"
+      },
+      {
+        "balance": 1.7035,
+        "month": "2021-04",
+        "transaction_count": "134"
+      },
+      {
+        "balance": 2.16,
+        "month": "2021-03",
+        "transaction_count": "205"
+      },
+      {
+        "balance": 0.995,
+        "month": "2021-02",
+        "transaction_count": "76"
+      },
+      {
+        "balance": 1.515,
+        "month": "2021-01",
+        "transaction_count": "141"
+      },
+      {
+        "balance": 9.315,
+        "month": "2020-12",
+        "transaction_count": "175"
+      },
+      {
+        "balance": 10.36,
+        "month": "2020-11",
+        "transaction_count": "133"
+      },
+      {
+        "balance": 7.75,
+        "month": "2020-10",
+        "transaction_count": "158"
+      }
+    ]
+  },
+  "catalog_issuers": {
+  },
+  "confirmations": {
+    "failed_confirmations": []
+  },
+  "next_token_redemption_date_in_seconds": "4102444799",
+  "transaction_history": {
+    "transactions": []
+  },
+  "unblinded_payment_tokens": [],
+  "unblinded_tokens": []
+}

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/account.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/account.h
@@ -74,14 +74,12 @@ class Account : public AdRewardsDelegate,
 
   void ProcessUnclearedTransactions();
 
-  void NotifyWalletChanged(const WalletInfo& wallet) const;
-  void NotifyWalletRestored(const WalletInfo& wallet) const;
-  void NotifyWalletInvalid() const;
-  void NotifyCatalogIssuersChanged(
+  void NotifyWalletDidUpdate(const WalletInfo& wallet) const;
+  void NotifyWalletDidChange(const WalletInfo& wallet) const;
+  void NotifyInvalidWallet() const;
+  void NotifyCatalogIssuersDidChange(
       const CatalogIssuersInfo& catalog_issuers) const;
-  void NotifyAdRewardsChanged() const;
-  void NotifyTransactionsChanged() const;
-  void NotifyUnclearedTransactionsProcessed() const;
+  void NotifyStatementOfAccountsDidChange() const;
 
   // AdRewardsDelegate implementation
   void OnDidReconcileAdRewards() override;

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/account_observer.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/account_observer.h
@@ -15,27 +15,21 @@ struct WalletInfo;
 
 class AccountObserver : public base::CheckedObserver {
  public:
-  // Invoked when the wallet has changed
-  virtual void OnWalletChanged(const WalletInfo& wallet) {}
+  // Invoked when the wallet has updated
+  virtual void OnWalletDidUpdate(const WalletInfo& wallet) {}
 
-  // Invoked when a wallet is restored
-  virtual void OnWalletRestored(const WalletInfo& wallet) {}
+  // Invoked when a wallet has changed
+  virtual void OnWalletDidChange(const WalletInfo& wallet) {}
 
   // Invoked if the wallet is invalid
-  virtual void OnWalletInvalid() {}
+  virtual void OnInvalidWallet() {}
 
   // Invoked when the catalog issuers have changed
-  virtual void OnCatalogIssuersChanged(
+  virtual void OnCatalogIssuersDidChange(
       const CatalogIssuersInfo& catalog_issuers) {}
 
-  // Invoked when ad rewards have changed
-  virtual void OnAdRewardsChanged() {}
-
-  // Invoked when transactions have changed
-  virtual void OnTransactionsChanged() {}
-
-  // Invoked when uncleared transactions have been processed
-  virtual void OnUnclearedTransactionsProcessed() {}
+  // Invoked when the statement of accounts has changed
+  virtual void OnStatementOfAccountsDidChange() {}
 
  protected:
   ~AccountObserver() override = default;

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
@@ -197,6 +197,20 @@ bool AdRewards::SetFromDictionary(base::Value* dictionary) {
   return true;
 }
 
+void AdRewards::Reset() {
+  payments_->reset();
+
+  ConfirmationsState::Get()->reset_failed_confirmations();
+
+  ConfirmationsState::Get()->reset_transactions();
+
+  privacy::UnblindedTokens* unblinded_payment_tokens =
+      ConfirmationsState::Get()->get_unblinded_payment_tokens();
+  unblinded_payment_tokens->RemoveAllTokens();
+
+  ConfirmationsState::Get()->Save();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void AdRewards::Reconcile() {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.h
@@ -47,6 +47,8 @@ class AdRewards {
   base::Value GetAsDictionary();
   bool SetFromDictionary(base::Value* dictionary);
 
+  void Reset();
+
  private:
   bool is_processing_ = false;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_issue_17412_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_issue_17412_test.cc
@@ -1,0 +1,87 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ads/internal/account/ad_rewards/ad_rewards.h"
+
+#include "bat/ads/internal/unittest_base.h"
+#include "bat/ads/internal/unittest_util.h"
+#include "net/http/http_status_code.h"
+
+// npm run test -- brave_unit_tests --filter=BatAds*
+
+namespace ads {
+
+class BatAdsAdRewardsIssue17412IntegrationTest : public UnitTestBase {
+ protected:
+  BatAdsAdRewardsIssue17412IntegrationTest() = default;
+
+  ~BatAdsAdRewardsIssue17412IntegrationTest() override = default;
+
+  void SetUp() override {
+    ASSERT_TRUE(CopyFileFromTestPathToTempDir("confirmations_issue_17412.json",
+                                              "confirmations.json"));
+
+    UnitTestBase::SetUpForTesting(/* integration_test */ true);
+  }
+};
+
+TEST_F(BatAdsAdRewardsIssue17412IntegrationTest, GetAdRewards) {
+  // Arrange
+  const URLEndpoints endpoints = {
+      {"/v1/confirmation/payment/c387c2d8-a26d-4451-83e4-5c0c6fd942be",
+       {{net::HTTP_OK,
+         R"([
+              {
+                "balance": "0.1325",
+                "month": "2021-08",
+                "transactionCount": "23"
+              },
+              {
+                "balance": "0.6525",
+                "month": "2021-07",
+                "transactionCount": "90"
+              },
+              {
+                "balance": "1.1525",
+                "month": "2021-06",
+                "transactionCount": "192"
+              },
+              {
+                "balance": "0.63",
+                "month": "2021-05",
+                "transactionCount": "141"
+              }
+            ])"}}}};
+
+  MockUrlRequest(ads_client_mock_, endpoints);
+
+  InitializeAds();
+
+  AdvanceClock(TimeFromDateString("8 August 2021"));
+
+  // Act
+  GetAds()->GetAccountStatement(
+      [](const bool success, const StatementInfo& statement) {
+        ASSERT_TRUE(success);
+
+        StatementInfo expected_statement;
+        expected_statement.next_payment_date =
+            TimestampFromDateString("5 September 2021");
+
+        // Calculated from earnings in April configured in
+        // |data/test/confirmations.json|
+        expected_statement.earnings_this_month = 0.1325;
+
+        // Calculated from earnings in March configured in
+        // |data/test/confirmations.json|
+        expected_statement.earnings_last_month = 0.6525;
+
+        EXPECT_EQ(expected_statement, statement);
+      });
+
+  // Assert
+}
+
+}  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards_test.cc
@@ -32,9 +32,9 @@ TEST_F(BatAdsAdRewardsIntegrationTest,
        {{net::HTTP_OK,
          R"([
               {
-                "balance": 48.0,
+                "balance": "48.0",
                 "month": "2021-04",
-                "transaction_count": "16"
+                "transactionCount": "16"
               }
             ])"}}}};
 
@@ -75,9 +75,9 @@ TEST_F(BatAdsAdRewardsIntegrationTest,
        {{net::HTTP_OK,
          R"([
               {
-                "balance": 48.001,
+                "balance": "48.001",
                 "month": "2021-04",
-                "transaction_count": "16"
+                "transactionCount": "16"
               }
             ])"}}}};
 
@@ -98,7 +98,7 @@ TEST_F(BatAdsAdRewardsIntegrationTest,
 
         // Calculated from earnings in April configured in
         // |data/test/confirmations.json|
-        expected_statement.earnings_this_month = 48.0;
+        expected_statement.earnings_this_month = 48.001;
 
         // Calculated from earnings in March configured in
         // |data/test/confirmations.json|
@@ -118,9 +118,9 @@ TEST_F(BatAdsAdRewardsIntegrationTest,
        {{net::HTTP_OK,
          R"([
               {
-                "balance": 47.999,
+                "balance": "47.999",
                 "month": "2021-04",
-                "transaction_count": "16"
+                "transactionCount": "16"
               }
             ])"}}}};
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
@@ -38,7 +38,7 @@ bool Payments::SetFromJson(const std::string& json) {
   }
 
   const PaymentList payments = GetFromList(list);
-  if (!DidReconcile(payments)) {
+  if (!ShouldForceReconciliation(payments) && !DidReconcile(payments)) {
     BLOG(0, "Payment balance not ready");
     return false;
   }
@@ -205,6 +205,10 @@ double Payments::GetBalanceForPayments(const PaymentList& payments) const {
   }
 
   return balance;
+}
+
+bool Payments::ShouldForceReconciliation(const PaymentList& payments) const {
+  return payments.size() != payments_.size();
 }
 
 bool Payments::DidReconcile(const PaymentList& payments) const {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.h
@@ -33,10 +33,14 @@ class Payments {
 
   PaymentInfo GetForMonth(const base::Time& time) const;
 
+  void reset() { payments_ = {}; }
+
  private:
   PaymentList payments_;
 
   double GetBalanceForPayments(const PaymentList& payments) const;
+
+  bool ShouldForceReconciliation(const PaymentList& payments) const;
 
   bool DidReconcile(const PaymentList& payments) const;
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
@@ -16,7 +16,6 @@
 #include "bat/ads/internal/legacy_migration/legacy_migration_util.h"
 #include "bat/ads/internal/logging.h"
 #include "bat/ads/internal/privacy/challenge_bypass_ristretto_util.h"
-#include "bat/ads/internal/privacy/unblinded_tokens/unblinded_tokens.h"
 #include "wrapper.hpp"
 
 namespace ads {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.h
@@ -14,15 +14,12 @@
 #include "bat/ads/ads.h"
 #include "bat/ads/internal/account/confirmations/confirmation_info.h"
 #include "bat/ads/internal/catalog/catalog_issuers_info.h"
+#include "bat/ads/internal/privacy/unblinded_tokens/unblinded_tokens.h"
 #include "bat/ads/transaction_info.h"
 
 namespace ads {
 
 class AdRewards;
-
-namespace privacy {
-class UnblindedTokens;
-}  // namespace privacy
 
 class ConfirmationsState {
  public:
@@ -45,9 +42,11 @@ class ConfirmationsState {
   ConfirmationList get_failed_confirmations() const;
   void append_failed_confirmation(const ConfirmationInfo& confirmation);
   bool remove_failed_confirmation(const ConfirmationInfo& confirmation);
+  void reset_failed_confirmations() { failed_confirmations_ = {}; }
 
   TransactionList get_transactions() const;
   void add_transaction(const TransactionInfo& transaction);
+  void reset_transactions() { transactions_ = {}; }
 
   base::Time get_next_token_redemption_date() const;
   void set_next_token_redemption_date(

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.cc
@@ -384,6 +384,10 @@ AdsHistoryInfo AdsImpl::GetAdsHistory(
     const AdsHistoryInfo::SortType sort_type,
     const uint64_t from_timestamp,
     const uint64_t to_timestamp) {
+  if (!IsInitialized()) {
+    return {};
+  }
+
   return history::Get(filter_type, sort_type, from_timestamp, to_timestamp);
 }
 
@@ -695,7 +699,7 @@ void AdsImpl::MaybeTopUpUnblindedTokens() {
   account_->TopUpUnblindedTokens();
 }
 
-void AdsImpl::OnWalletChanged(const WalletInfo& wallet) {
+void AdsImpl::OnWalletDidUpdate(const WalletInfo& wallet) {
   BLOG(1, "Successfully set wallet");
 
   MaybeTopUpUnblindedTokens();
@@ -703,15 +707,17 @@ void AdsImpl::OnWalletChanged(const WalletInfo& wallet) {
   MaybeServeAdNotificationsAtRegularIntervals();
 }
 
-void AdsImpl::OnWalletInvalid() {
+void AdsImpl::OnWalletDidChange(const WalletInfo& wallet) {
+  BLOG(0, "Wallet changed");
+
+  ReconcileAdRewards();
+}
+
+void AdsImpl::OnInvalidWallet() {
   BLOG(0, "Failed to set wallet");
 }
 
-void AdsImpl::OnAdRewardsChanged() {
-  AdsClientHelper::Get()->OnAdRewardsChanged();
-}
-
-void AdsImpl::OnTransactionsChanged() {
+void AdsImpl::OnStatementOfAccountsDidChange() {
   AdsClientHelper::Get()->OnAdRewardsChanged();
 }
 

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_impl.h
@@ -270,10 +270,10 @@ class AdsImpl : public Ads,
   void MaybeTopUpUnblindedTokens();
 
   // AccountObserver implementation
-  void OnWalletChanged(const WalletInfo& wallet) override;
-  void OnWalletInvalid() override;
-  void OnAdRewardsChanged() override;
-  void OnTransactionsChanged() override;
+  void OnWalletDidUpdate(const WalletInfo& wallet) override;
+  void OnWalletDidChange(const WalletInfo& wallet) override;
+  void OnInvalidWallet() override;
+  void OnStatementOfAccountsDidChange() override;
 
   // AdServerObserver implementation
   void OnCatalogUpdated(const Catalog& catalog) override;

--- a/vendor/bat-native-ads/src/bat/ads/internal/client/client.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client/client.h
@@ -49,6 +49,7 @@ class Client {
 
   void AppendAdHistoryToAdsHistory(const AdHistoryInfo& ad_history);
   const std::deque<AdHistoryInfo>& GetAdsHistory() const;
+
   void AppendToPurchaseIntentSignalHistoryForSegment(
       const std::string& segment,
       const PurchaseIntentSignalHistoryInfo& history);


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/9714
Resolves https://github.com/brave/brave-browser/issues/17412

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.