### PR TITLE
[IOS] Fix: Changing URLRow last visit time to URLResult visit time  (Uplift to 1.29.x)

### DIFF
--- a/ios/browser/api/history/brave_history_api.mm
+++ b/ios/browser/api/history/brave_history_api.mm
@@ -220,7 +220,7 @@
     IOSHistoryNode* historyNode = [[IOSHistoryNode alloc]
         initWithURL:net::NSURLWithGURL(result.url())
               title:base::SysUTF16ToNSString(result.title())
-          dateAdded:result.last_visit().ToNSDate()];
+          dateAdded:result.visit_time().ToNSDate()];
     [historyNodes addObject:historyNode];
   }
 


### PR DESCRIPTION
Uplift of #9740 
Resolves brave/brave-ios#4039

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.

