### PR TITLE
Fix #17474 - Gemini balance should not be displayed if wallet linking fails (uplift to 1.29.x)

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini.cc
@@ -107,8 +107,8 @@ void Gemini::FetchBalance(FetchBalanceCallback callback) {
     return;
   }
 
-  if (wallet->status == type::WalletStatus::CONNECTED) {
-    BLOG(1, "Wallet is connected");
+  if (wallet->status != type::WalletStatus::VERIFIED) {
+    BLOG(1, "Wallet is not verified");
     callback(type::Result::LEDGER_OK, 0.0);
     return;
   }


### PR DESCRIPTION
Uplift of #9755
Resolves https://github.com/brave/brave-browser/issues/17474

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.