### PR TITLE
fixed download item filename overlap

### DIFF
--- a/browser/ui/views/download/brave_download_item_view.cc
+++ b/browser/ui/views/download/brave_download_item_view.cc
@@ -11,6 +11,7 @@
 #include "base/auto_reset.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/ui/download/download_item_mode.h"
 #include "chrome/browser/ui/views/download/download_shelf_view.h"
 #include "components/strings/grit/components_strings.h"
 #include "components/vector_icons/vector_icons.h"
@@ -99,7 +100,6 @@ void BraveDownloadItemView::OnPaint(gfx::Canvas* canvas) {
   DownloadItemView::OnPaint(canvas);
   if (is_origin_url_visible_)
     DrawOriginURL(canvas);
-  file_name_label_->SetVisible(!is_origin_url_visible_);
 }
 
 // download::DownloadItem::Observer overrides.
@@ -236,18 +236,31 @@ void BraveDownloadItemView::SetMode(download::DownloadItemMode mode) {
   }
 }
 
+void BraveDownloadItemView::UpdateLabels() {
+  DownloadItemView::UpdateLabels();
+  // Update visibility to avoid artifacts to be shown from upstream
+  file_name_label_->SetVisible(
+      !is_origin_url_visible_ &&
+      (GetMode() == download::DownloadItemMode::kNormal));
+}
+
+void BraveDownloadItemView::SetOriginUrlVisible(bool visible) {
+  is_origin_url_visible_ = visible;
+  UpdateLabels();
+}
+
 void BraveDownloadItemView::OnMouseEntered(const ui::MouseEvent& event) {
-  is_origin_url_visible_ = true;
+  SetOriginUrlVisible(true);
 }
 
 void BraveDownloadItemView::OnMouseExited(const ui::MouseEvent& event) {
-  is_origin_url_visible_ = false;
+  SetOriginUrlVisible(false);
 }
 
 void BraveDownloadItemView::OnViewFocused(View* observed_view) {
-  is_origin_url_visible_ = true;
+  SetOriginUrlVisible(true);
 }
 
 void BraveDownloadItemView::OnViewBlurred(View* observed_view) {
-  is_origin_url_visible_ = false;
+  SetOriginUrlVisible(false);
 }

--- a/browser/ui/views/download/brave_download_item_view.h
+++ b/browser/ui/views/download/brave_download_item_view.h
@@ -50,10 +50,13 @@ class BraveDownloadItemView : public DownloadItemView {
 
   // Overrides the accessible name construction to reflect the origin URL.
   void SetMode(download::DownloadItemMode mode) override;
+  void UpdateLabels() override;
   void OnMouseEntered(const ui::MouseEvent& event) override;
   void OnMouseExited(const ui::MouseEvent& event) override;
   void OnViewFocused(View* observed_view) override;
   void OnViewBlurred(View* observed_view) override;
+
+  void SetOriginUrlVisible(bool visible);
 
   // Brave download item model.
   BraveDownloadItemModel brave_model_;

--- a/chromium_src/chrome/browser/ui/views/download/download_item_view.h
+++ b/chromium_src/chrome/browser/ui/views/download/download_item_view.h
@@ -41,9 +41,11 @@
  protected:                                  \
   bool IsShowingWarningDialog() const;
 
+#define UpdateLabels virtual UpdateLabels
 #define SetMode virtual SetMode
 #include "../../../../../../../chrome/browser/ui/views/download/download_item_view.h"
 #undef SetMode
+#undef UpdateLabels
 #undef BRAVE_DOWNLOAD_DOWNLOAD_ITEM_VIEW_H_
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_DOWNLOAD_ITEM_VIEW_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17313

The overlap was caused by a recent change we made on the UX of the download item view.
The duped filename was setting itself visible in all modes. There are various modes to take in to consideration however, we only care about the normal mode.

This is what upstream is doing: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/download/download_item_view.cc;l=816;bpv=0;bpt=1

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
A detailed test plan is described in the issue.
