### PR TITLE
Fix #17505 - Retry logic for Gemini should support multiple transactions

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_transfer.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_transfer.cc
@@ -73,7 +73,7 @@ void GeminiTransfer::StartTransactionStatusTimer(
   size_t mins = 3 * new_attempts;
   base::TimeDelta delay = base::TimeDelta::FromMinutes(mins);
   BLOG(1, "Will fetch transaction status after " << mins << " minutes");
-  retry_timer_.Start(
+  retry_timer_[id].Start(
       FROM_HERE, delay,
       base::BindOnce(&GeminiTransfer::FetchTransactionStatus,
                      base::Unretained(this), id, new_attempts, callback));
@@ -100,6 +100,8 @@ void GeminiTransfer::OnTransactionStatus(const type::Result result,
                                          const std::string& id,
                                          const int attempts,
                                          client::TransactionCallback callback) {
+  retry_timer_.erase(id);
+  BLOG(0, "Number of active retry timers: " << retry_timer_.size());
   if (result == type::Result::LEDGER_OK) {
     callback(result, id);
     return;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_transfer.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_transfer.h
@@ -50,7 +50,7 @@ class GeminiTransfer {
                                    const int attempts,
                                    client::TransactionCallback callback);
 
-  base::OneShotTimer retry_timer_;
+  std::map<std::string, base::OneShotTimer> retry_timer_;
   LedgerImpl* ledger_;  // NOT OWNED
   std::unique_ptr<endpoint::GeminiServer> gemini_server_;
 };


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17505

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Initiate two tips one after the other, verify that both tips complete after the settlement time.
2. Initiate a tip once the re-concile interval finishes, verify that both auto-contribute and tips complete after the settlement time elapses.
