### PR TITLE
Updated Wallet DarkTheme Colors and Top Nav Order

### DIFF
--- a/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/style.ts
@@ -83,7 +83,7 @@ export const TabButtonText = styled.span<Partial<StyleProps>>`
   font-weight: 600;
   letter-spacing: 0.01em;
   background: ${(p) =>
-    p.isSelected ? 'linear-gradient(128.18deg, #A43CE4 13.94%, #A72B6D 84.49%)' : `${p.theme.color.text02}`};
+    p.isSelected ? p.theme.color.text01 : p.theme.color.text02};
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 `

--- a/components/brave_wallet_ui/components/desktop/backup-warning-banner/style.ts
+++ b/components/brave_wallet_ui/components/desktop/backup-warning-banner/style.ts
@@ -44,6 +44,9 @@ export const BannerButton = styled.button<StyleProps>`
   font-size: 12px;
   font-weight: 600;
   color: ${(p) => p.buttonType === 'primary' ? p.theme.color.interactive05 : p.theme.color.text02};
+  @media (prefers-color-scheme: dark) {
+    color: ${(p) => p.buttonType === 'primary' ? p.theme.palette.white : p.theme.color.text02};
+  }
   letter-spacing: 0.01em;
   margin-left: 20px;
 `

--- a/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/line-chart/index.tsx
@@ -66,7 +66,7 @@ function LineChart (props: Props) {
           <animate attributeName='r' values='3;8;3;3' dur='3s' begin='0s' repeatCount='indefinite' />
           <animate attributeName='opacity' values='1;0;0;0' dur='3s' begin='0s' repeatCount='indefinite' />
         </circle >
-        <circle fill={isAsset ? isDown ? theme.red600 : theme.teal600 : '#BF14A2'} cx={props.cx} r='3' cy={props.cy} />
+        <circle fill={isAsset ? isDown ? '#EE6374' : '#2AC194' : '#BF14A2'} cx={props.cx} r='3' cy={props.cy} />
       </>
     )
   }
@@ -129,7 +129,7 @@ function LineChart (props: Props) {
             type='monotone'
             dataKey='close'
             strokeWidth={2}
-            stroke={isAsset ? isDown ? theme.red600 : theme.teal600 : priceData.length <= 0 ? '#BF14A2' : `url(#lineGradient)`}
+            stroke={isAsset ? isDown ? '#EE6374' : '#2AC194' : priceData.length <= 0 ? '#BF14A2' : `url(#lineGradient)`}
             fill='none'
           />
           <ReferenceDot x={chartData[lastPoint].date.toString()} y={chartData[lastPoint].close} shape={CustomReferenceDot} />

--- a/components/brave_wallet_ui/components/desktop/select-network-dropdown/style.ts
+++ b/components/brave_wallet_ui/components/desktop/select-network-dropdown/style.ts
@@ -54,6 +54,10 @@ export const DropDown = styled.div`
   background-color: ${(p) => p.theme.color.background02};
   border-radius: 8px;
   box-shadow: 0px 0px 16px rgba(99, 105, 110, 0.18);
+  @media (prefers-color-scheme: dark) {
+    box-shadow: 0px 0px 16px rgba(0, 0, 0, 0.36);
+  }
+  border: 1px solid ${(p) => p.theme.color.divider01};
   position: absolute;
   top: 30px;
   left: 0px;

--- a/components/brave_wallet_ui/components/desktop/top-tab-nav-button/style.ts
+++ b/components/brave_wallet_ui/components/desktop/top-tab-nav-button/style.ts
@@ -26,7 +26,7 @@ export const ButtonText = styled.span<Partial<StyleProps>>`
   line-height: 20px;
   margin-bottom: 10px;
 	background: ${(p) =>
-    p.isSelected ? 'linear-gradient(128.18deg, #A43CE4 13.94%, #A72B6D 84.49%)' : `${p.theme.color.text02}`};
+    p.isSelected ? p.theme.color.text01 : p.theme.color.text02};
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 `

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -136,7 +136,7 @@ export const PercentBubble = styled.div<Partial<StyleProps>>`
   flex-direction: row;
   padding: 4px 8px;
   border-radius: 8px;
-  background-color: ${(p) => p.isDown ? p.theme.palette.red600 : p.theme.palette.teal600};
+  background-color: ${(p) => p.isDown ? '#EE6374' : '#2AC194'};
 `
 
 export const PercentText = styled.span`

--- a/components/brave_wallet_ui/options/top-nav-options.ts
+++ b/components/brave_wallet_ui/options/top-nav-options.ts
@@ -7,11 +7,11 @@ export const TopNavOptions: TopTabNavObjectType[] = [
     name: locale.topNavPortfolio
   },
   {
-    id: 'apps',
-    name: locale.topTabApps
-  },
-  {
     id: 'accounts',
     name: locale.topNavAccounts
+  },
+  {
+    id: 'apps',
+    name: locale.topTabApps
   }
 ]


### PR DESCRIPTION
## Description 
Updated The Wallet DarkTheme Colors and Top Nav Order

1) Changed the `Top Nav` order from 'Portfolio, Apps, Accounts, to 'Portfolio, Accounts, Apps'.
2) Changed the `Top Nav` selected tab's color from `gradient` theme to `Text01` theme.
3) Changed the `BuySendSwap` selected tab's color from `gradient` theme to `Text01` theme.
4) Changed the `BackupBanners` backup `Button` text to be `white` in `DarkMode`.
5) Added a border and changed the `drop shadow` for the `Select Network` dropdown.
6) Changed the `isUp` green color and `isDown` red color in the `LineChart` components.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/17279>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

![Screen Shot 2021-08-17 at 1 33 57 PM](https://user-images.githubusercontent.com/40611140/129789415-95e26bd9-9e29-4dc9-930b-4332501d0a77.png)

After: 

![Screen Shot 2021-08-17 at 1 32 25 PM](https://user-images.githubusercontent.com/40611140/129789452-84b33b00-f243-4ca5-9922-9ae29dae373a.png)
