### PR TITLE
Fix RequestEthereumPermissionsTabClosed test (uplift to 1.29.x)

### DIFF
--- a/browser/permissions/permission_manager_browsertest.cc
+++ b/browser/permissions/permission_manager_browsertest.cc
@@ -268,9 +268,6 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest,
   browser()->tab_strip_model()->CloseWebContentsAt(0,
                                                    TabStripModel::CLOSE_NONE);
   tab_destroyed_watcher.Wait();
-
-  EXPECT_FALSE(permission_request_manager->IsRequestInProgress());
-  EXPECT_FALSE(observer->IsShowingBubble());
   EXPECT_TRUE(IsPendingGroupedRequestsEmpty());
 }
 


### PR DESCRIPTION
Uplift of #9777
Resolves https://github.com/brave/brave-browser/issues/17539

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.