### PR TITLE
Allowed the Restore Input Except Multiple Mnemonic Lengths

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/style.ts
@@ -56,6 +56,13 @@ export const ErrorText = styled.span`
   margin-bottom: 10px;
 `
 
+export const LegacyCheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+`
+
 export const CheckboxRow = styled.div`
   display: flex;
   align-items: center;

--- a/components/brave_wallet_ui/constants/locale.ts
+++ b/components/brave_wallet_ui/constants/locale.ts
@@ -135,6 +135,7 @@ const locale = {
   restoreError: 'The recovery phrase entered is invalid.',
   restorePlaceholder: 'Paste recovery phrase from clipboard',
   restoreShowPhrase: 'Show recovery phrase',
+  restoreLegacyCheckBox: 'Import from legacy Brave Crypto Wallet?',
   restoreFormText: 'New Password',
 
   // Tool Tips

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -204,7 +204,8 @@ function Container (props: Props) {
     props.walletPageActions.walletBackupComplete()
   }
 
-  const restoreWallet = (mnemonic: string, password: string) => {
+  const restoreWallet = (mnemonic: string, password: string, isLegacy: boolean) => {
+    // isLegacy prop will be passed into the restoreWallet action once the keyring is setup handle the derivation.
     props.walletPageActions.restoreWallet({ mnemonic, password })
   }
 


### PR DESCRIPTION
## Description 

1) Restore input now allows for 12, 15, 18, 21, 24 mnemonic lengths.
2) Added a `isLegacy` check box that appears only if the mnemonic length is 24 characters. 
(Note: This has not been setup in keyring yet, but the prop is there and ready to pass into the `restoreWallet` action once it is.)


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/17532>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/129966716-6e7883b1-3381-4fe1-8918-bea2fdc0d00d.mov
