### PR TITLE
Enabled TorDisabled policy on macOS

### DIFF
--- a/script/policy_source_helper.py
+++ b/script/policy_source_helper.py
@@ -16,13 +16,19 @@ def AddBravePolicies(template_file_contents):
             'name': 'TorDisabled',
             'type': 'main',
             'schema': {'type': 'boolean'},
-            'supported_on': ['chrome.win:78-'],
-            'features': {'dynamic_refresh': False, 'per_profile': False},
+            'supported_on': ['chrome.win:78-', 'chrome.mac:93-', 'chrome.linux:93-'],
+            'features': {
+                'dynamic_refresh': False,
+                'per_profile': False,
+                'can_be_recommended': False,
+                'can_be_mandatory': True
+            },
             'example_value': True,
             'id': 0,
             'caption': '''Disables the tor feature.''',
             'tags': [],
-            'desc': '''This policy allows an admin to specify that tor feature must be disabled at startup.''',
+            'desc': '''This policy allows an admin to specify that tor feature must be disabled
+                    at startup.''',
         },
         {
             'name': 'IPFSEnabled',
@@ -30,25 +36,26 @@ def AddBravePolicies(template_file_contents):
             'schema': {'type': 'boolean'},
             'supported_on': ['chrome.*:87-'],
             'features': {
-              'dynamic_refresh': False,
-              'per_profile': True,
-              'can_be_recommended': False,
-              'can_be_mandatory': True
+                'dynamic_refresh': False,
+                'per_profile': True,
+                'can_be_recommended': False,
+                'can_be_mandatory': True
             },
             'example_value': True,
             'id': 1,
             'caption': '''Enable IPFS feature''',
             'tags': [],
-            'desc': '''This policy allows an admin to specify whether IPFS feature can be enabled.''',
+            'desc': '''This policy allows an admin to specify whether IPFS feature can be
+                    enabled.''',
         }
     ]
 
-    """Our new polices are added with highest id"""
+    # Our new polices are added with highest id
     next_id = highest_id
     for policy in policies:
         next_id += 1
         policy['id'] = next_id
         template_file_contents['policy_definitions'].append(policy)
 
-    """Update highest id"""
+    # Update highest id
     template_file_contents['highest_id_currently_used'] = highest_id + len(policies)


### PR DESCRIPTION
fix: https://github.com/brave/brave-browser/issues/17530

So far, this policy is not available on macOS.
This change enables this policy on macOS and makes brave://policy
displays this policy status properly on macOS/linux.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

###  macOS
Below command will modify TorDisabled policy for dev build.
`defaults write com.brave.Browser.Development TorDisabled -boolean true`
you can change app id to `com.brave.Browser.nightly` (`com.brave.Browser` for stable) to test this on nightly

When this policy is off with above command, brave://policy will show like below and can't use tor from Brave.
![image](https://user-images.githubusercontent.com/6786187/130165537-b809a201-73ed-47f5-9c31-0fe0648fb669.png)

###  linux
On linux, TorDisabled policy works w/o this PR. but brave://policy displays this as Unknow like below.
(See https://www.github.com/brave/brave-browser/issues/12426 how to add policy on linux.)
![Screenshot from 2021-08-20 13-04-58](https://user-images.githubusercontent.com/6786187/130177445-98429e97-1e75-4523-b5d3-19163967dc69.png)

With this PR, TorDisabled policy w/o error
![Screenshot from 2021-08-20 13-01-41](https://user-images.githubusercontent.com/6786187/130177523-bdfed161-0bfc-4bfa-825a-ed8352cdaa88.png)

