### PR TITLE
[cr93 followup] Removed disablement of kEnablePasswordsAccountStorage.

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -226,7 +226,6 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
     net::features::kFirstPartySets.name,
     network::features::kTrustTokens.name,
     network_time::kNetworkTimeServiceQuerying.name,
-    password_manager::features::kEnablePasswordsAccountStorage.name,
 #if defined(OS_ANDROID)
     features::kWebNfc.name,
     feed::kInterestFeedContentSuggestions.name,

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -92,7 +92,6 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
     &net::features::kFirstPartySets,
     &network::features::kTrustTokens,
     &network_time::kNetworkTimeServiceQuerying,
-    &password_manager::features::kEnablePasswordsAccountStorage,
   };
 
   for (const auto* feature : disabled_features)


### PR DESCRIPTION
This feature flag no longer works as all the code it wasn't guarding has
been removed and password account storage is the only option now.

This also means that we will regress on
https://github.com/brave/brave-browser/issues/16926 again, but this can
be addressed in a different fix.

Chromium issue:

https://bugs.chromium.org/p/chromium/issues/detail?id=1108738

https://chromium.googlesource.com/chromium/src.git/+/90ac58cb2c56df119ca3d5631cbbc3feabb8a82b

commit 90ac58cb2c56df119ca3d5631cbbc3feabb8a82b
Author: Marc Treib <treib@chromium.org>
Date:   Fri Jul 9 10:43:20 2021 +0000

    B4P cleanup, part 2: Delete old Save/Update bubble

    PasswordSaveUpdateView has been replaced by
    PasswordSaveUpdateWithAccountStoreView, similar for the corresponding
    controller. This CL deletes the old, non-AccountStore versions.

    This is a no-op on Win/Mac/Linux/ChromeOS (which already always used
    the new versions) and on Android/iOS (which don't use this UI at all).
    (Note that ChromeOS doesn't actually use/support the account-scoped
    storage, since the signed-in non-syncing state doesn't exist. But the
    new UI code is a strict superset of the old, so using it on ChromeOS as
    well is just simpler and more consistent - and this was already the
    case.)

    This CL also ports some recent unit test improvements (see
    crrev.com/c/3006215) from the old to the new controller.

    Bug: 1108738
 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

