### PR TITLE
Fix #17569, #17570 - Fix disconnect state for Gemini when wallet linking fails (uplift to 1.29.x)

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini.cc
@@ -173,6 +173,9 @@ void Gemini::DisconnectWallet(const bool manual) {
   }
 
   wallet = ::ledger::wallet::ResetWallet(std::move(wallet));
+  if (manual) {
+    wallet->status = type::WalletStatus::NOT_CONNECTED;
+  }
 
   const bool shutting_down = ledger_->IsShuttingDown();
 


### PR DESCRIPTION
Uplift of #9817
Resolves https://github.com/brave/brave-browser/issues/17569
Resolves https://github.com/brave/brave-browser/issues/17570

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.