### PR TITLE
Fixed first-run dialog is not launched

### DIFF
--- a/chromium_src/chrome/browser/first_run/first_run_internal_posix.cc
+++ b/chromium_src/chrome/browser/first_run/first_run_internal_posix.cc
@@ -32,8 +32,10 @@
 #if defined(OFFICIAL_BUILD)
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
 #define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
+#define FILE_LOCAL_STATE PATH_END
 #endif
 #include "../../../../../chrome/browser/first_run/first_run_internal_posix.cc"
 #if defined(OFFICIAL_BUILD)
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
+#undef FILE_LOCAL_STATE
 #endif

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -187,14 +187,17 @@ config("constants_configs") {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "brave_paths_unittest.cc" ]
 
-  deps = [
-    "//base",
-    "//brave/common",
-    "//chrome/common",
-    "//testing/gtest",
-  ]
+  if (!is_ios) {
+    sources = [ "brave_paths_unittest.cc" ]
+
+    deps = [
+      "//base",
+      "//brave/common",
+      "//chrome/common",
+      "//testing/gtest",
+    ]
+  }
 }
 
 mojom("mojo_bindings") {

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -185,6 +185,18 @@ config("constants_configs") {
   }
 }
 
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "brave_paths_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//brave/common",
+    "//chrome/common",
+    "//testing/gtest",
+  ]
+}
+
 mojom("mojo_bindings") {
   sources = [ "brave_renderer_configuration.mojom" ]
 

--- a/common/brave_paths_unittest.cc
+++ b/common/brave_paths_unittest.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/common/brave_paths.h"
+#include "base/files/file_path.h"
+#include "base/path_service.h"
+#include "chrome/common/chrome_paths.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(BravePathsTest, PathTest) {
+  base::FilePath test_dir;
+  EXPECT_TRUE(base::PathService::Get(brave::DIR_TEST_DATA, &test_dir));
+  EXPECT_FALSE(base::PathService::Get(chrome::PATH_END, &test_dir));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -175,6 +175,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/components/autofill_assistant/browser:unit_tests",
     "//brave/common:network_constants",
     "//brave/common:pref_names",
+    "//brave/common:unit_tests",
     "//brave/components/adblock_rust_ffi",
     "//brave/components/brave_ads/test:brave_ads_unit_tests",
     "//brave/components/brave_component_updater/browser",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/17667

With https://bugs.chromium.org/p/chromium/issues/detail?id=1243221,
Local State file is created at the startup.
When, "Local State" file is already existed ShouldShowFirstRunDialog().
Due to this, dialog is launched ramdomly only when this file is not
stored in FS becfore calling ShouldShowFirstRunDialog().
Browser only tries to run this dialog when first_run::IsChromeFirstRun()
is true. Checking "Local State" file again is redundant. Removed this
checking.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_unit_tests -- --filter=*BravePathsTest*

1. Laucnh browser with clean profile
2. Check First run dialog is always launched