### PR TITLE
[cr93 followup] Fix for webtorrent crash.

### DIFF
--- a/patches/extensions-browser-api-sockets_tcp_server-sockets_tcp_server_api.cc.patch
+++ b/patches/extensions-browser-api-sockets_tcp_server-sockets_tcp_server_api.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.cc b/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.cc
+index fcba8ac797b18084efd5a79ae7cdf25487a61407..abf5c544601b32ca6898f64b9bd3927dceff4a41 100644
+--- a/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.cc
++++ b/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.cc
+@@ -256,15 +256,15 @@ SocketsTcpServerGetInfoFunction::~SocketsTcpServerGetInfoFunction() = default;
+ ExtensionFunction::ResponseAction SocketsTcpServerGetInfoFunction::Work() {
+   std::unique_ptr<sockets_tcp_server::GetInfo::Params> params =
+       sockets_tcp_server::GetInfo::Params::Create(*args_);
+-  EXTENSION_FUNCTION_VALIDATE(params_.get());
++  EXTENSION_FUNCTION_VALIDATE(params.get());
+ 
+-  ResumableTCPServerSocket* socket = GetTcpSocket(params_->socket_id);
++  ResumableTCPServerSocket* socket = GetTcpSocket(params->socket_id);
+   if (!socket) {
+     return RespondNow(Error(kSocketNotFoundError));
+   }
+ 
+   sockets_tcp_server::SocketInfo socket_info =
+-      CreateSocketInfo(params_->socket_id, socket);
++      CreateSocketInfo(params->socket_id, socket);
+   return RespondNow(
+       ArgumentList(sockets_tcp_server::GetInfo::Results::Create(socket_info)));
+ }

--- a/patches/extensions-browser-api-sockets_tcp_server-sockets_tcp_server_api.h.patch
+++ b/patches/extensions-browser-api-sockets_tcp_server-sockets_tcp_server_api.h.patch
@@ -1,0 +1,14 @@
+diff --git a/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.h b/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.h
+index 39d68080d449de6a3de282afe4d6335652402e06..d60fa8bbe677c83037f26c5b3cfd286d6a79bd8a 100644
+--- a/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.h
++++ b/extensions/browser/api/sockets_tcp_server/sockets_tcp_server_api.h
+@@ -134,9 +134,6 @@ class SocketsTcpServerGetInfoFunction : public TCPServerSocketApiFunction {
+ 
+   // SocketApiFunction:
+   ResponseAction Work() override;
+-
+- private:
+-  std::unique_ptr<sockets_tcp_server::GetInfo::Params> params_;
+ };
+ 
+ class SocketsTcpServerGetSocketsFunction : public TCPServerSocketApiFunction {

--- a/patches/extensions-test-data-sockets_tcp_server-api-background.js.patch
+++ b/patches/extensions-test-data-sockets_tcp_server-api-background.js.patch
@@ -1,0 +1,16 @@
+diff --git a/extensions/test/data/sockets_tcp_server/api/background.js b/extensions/test/data/sockets_tcp_server/api/background.js
+index 8a2ff5ee95c74b1cc4e9a9e6bf62db889fe83309..f25b1e7dead44c84bc3019103a95a3c9101f9a91 100644
+--- a/extensions/test/data/sockets_tcp_server/api/background.js
++++ b/extensions/test/data/sockets_tcp_server/api/background.js
+@@ -43,6 +43,11 @@ var testSocketListening = function() {
+   function onServerSocketCreate(socketInfo) {
+     console.log("Server socket created: sd=" + socketInfo.socketId);
+     socketId = socketInfo.socketId;
++    chrome.sockets.tcpServer.getInfo(socketId, onGetInfo);
++  }
++
++  function onGetInfo(socketInfo) {
++    chrome.test.assertEq(socketInfo.socketId, socketId);
+     chrome.sockets.tcpServer.listen(socketId, address, port, onListen);
+   }
+ 


### PR DESCRIPTION
Fixes brave/brave-browser#17652

This is an upstream bug introduced in this Chromium change:

https://source.chromium.org/chromium/chromium/src/+/301dd60948a8b3a628cf6bd3a0f9da0ab91743ef

commit 301dd60948a8b3a628cf6bd3a0f9da0ab91743ef
Author: Nicolas Ouellet-Payeur <nicolaso@chromium.org>
Date:   Tue Jun 15 13:43:57 2021 +0000

    [Extensions] Migrate sockets_tcp_server_api.cc to SocketApiFunction

    The new SocketApiFunction class has a more simple API than
    SocketAsyncApiFunction. Change extension functions in
    sockets_tcp_server_api.cc so they extend SocketApiFunction.

    Bug: 1200440

The bug is that the SocketsTcpServerGetInfoFunction::Work was changed to
get args into local variable params, but then the instance variable
params_ was left to be used in the rest of the menthod's code.

The fix has already been merged upstream but has not made it to Cr93
yet:

https://chromium.googlesource.com/chromium/src/+/427152d3d98fce04457af56b0c362c45eb1ec042

commit 427152d3d98fce04457af56b0c362c45eb1ec042
Author: Reilly Grant <reillyg@chromium.org>
Date:   Tue Aug 24 22:29:18 2021 +0000

    Fix parameter validation for chrome.tcpServer.getInfo()

    In crrev.com/c/2961688 the implementation of this function was
    simplified however an error was introduced where the parsed function
    parameters were stored in a local variable but still accessed from an
    instance variable.

    This change removes the instance variable as it should have been in the
    original change.

    Bug: 1239520

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

