### PR TITLE
Check VPN connection status during startup (Windows)

### DIFF
--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -127,7 +127,7 @@ void BraveVPNButton::UpdateButtonState() {
 }
 
 bool BraveVPNButton::IsConnected() {
-  return service_->IsConnected();
+  return service_->is_connected();
 }
 
 void BraveVPNButton::OnButtonPressed(const ui::Event& event) {

--- a/components/brave_vpn/brave_vpn_os_connection_api.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api.h
@@ -43,6 +43,7 @@ class BraveVPNOSConnectionAPI {
   virtual void Connect(const std::string& name) = 0;
   virtual void Disconnect(const std::string& name) = 0;
   virtual void RemoveVPNConnection(const std::string& name) = 0;
+  virtual void CheckConnection(const std::string& name) = 0;
 
  protected:
   BraveVPNOSConnectionAPI();

--- a/components/brave_vpn/brave_vpn_os_connection_api_mac.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api_mac.h
@@ -32,6 +32,7 @@ class BraveVPNOSConnectionAPIMac : public BraveVPNOSConnectionAPI {
   void RemoveVPNConnection(const std::string& name) override;
   void Connect(const std::string& name) override;
   void Disconnect(const std::string& name) override;
+  void CheckConnection(const std::string& name) override;
 
   BraveVPNConnectionInfo info_;
 };

--- a/components/brave_vpn/brave_vpn_os_connection_api_mac.mm
+++ b/components/brave_vpn/brave_vpn_os_connection_api_mac.mm
@@ -12,6 +12,7 @@
 #include "base/files/file_util.h"
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
+#include "base/notreached.h"
 #include "base/strings/sys_string_conversions.h"
 
 // Referenced GuardianConnect implementation.
@@ -249,6 +250,10 @@ void BraveVPNOSConnectionAPIMac::Disconnect(const std::string& name) {
     for (Observer& obs : observers_)
       obs.OnDisconnected(std::string());
   }];
+}
+
+void BraveVPNOSConnectionAPIMac::CheckConnection(const std::string& name) {
+  NOTIMPLEMENTED();
 }
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/brave_vpn_os_connection_api_sim.cc
+++ b/components/brave_vpn/brave_vpn_os_connection_api_sim.cc
@@ -51,6 +51,10 @@ void BraveVPNOSConnectionAPISim::RemoveVPNConnection(const std::string& name) {
                                 weak_factory_.GetWeakPtr(), name, true));
 }
 
+void BraveVPNOSConnectionAPISim::CheckConnection(const std::string& name) {
+  // Do nothing.
+}
+
 void BraveVPNOSConnectionAPISim::OnCreated(const std::string& name,
                                            bool success) {
   if (!success)

--- a/components/brave_vpn/brave_vpn_os_connection_api_sim.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api_sim.h
@@ -32,6 +32,7 @@ class BraveVPNOSConnectionAPISim : public BraveVPNOSConnectionAPI {
   void RemoveVPNConnection(const std::string& name) override;
   void Connect(const std::string& name) override;
   void Disconnect(const std::string& name) override;
+  void CheckConnection(const std::string& name) override;
 
  private:
   void OnCreated(const std::string& name, bool success);

--- a/components/brave_vpn/brave_vpn_os_connection_api_win.h
+++ b/components/brave_vpn/brave_vpn_os_connection_api_win.h
@@ -13,6 +13,9 @@
 #include "brave/components/brave_vpn/brave_vpn_os_connection_api.h"
 
 namespace brave_vpn {
+namespace internal {
+enum class CheckConnectionResult;
+}  // namespace internal
 
 class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPI {
  public:
@@ -32,12 +35,15 @@ class BraveVPNOSConnectionAPIWin : public BraveVPNOSConnectionAPI {
   void RemoveVPNConnection(const std::string& name) override;
   void Connect(const std::string& name) override;
   void Disconnect(const std::string& name) override;
+  void CheckConnection(const std::string& name) override;
 
  private:
   void OnCreated(const std::string& name, bool success);
   void OnConnected(const std::string& name, bool success);
   void OnDisconnected(const std::string& name, bool success);
   void OnRemoved(const std::string& name, bool success);
+  void OnCheckConnection(const std::string& name,
+                         internal::CheckConnectionResult result);
 
   base::WeakPtrFactory<BraveVPNOSConnectionAPIWin> weak_factory_{this};
 };

--- a/components/brave_vpn/brave_vpn_service_desktop.h
+++ b/components/brave_vpn/brave_vpn_service_desktop.h
@@ -42,12 +42,13 @@ class BraveVpnServiceDesktop
 
   void Connect();
   void Disconnect();
-  bool IsConnected() const;
   void CreateVPNConnection();
   void RemoveVPNConnnection();
 
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
+
+  bool is_connected() const { return is_connected_; }
 
   void BindInterface(
       mojo::PendingReceiver<brave_vpn::mojom::ServiceHandler> receiver);

--- a/components/brave_vpn/utils_win.h
+++ b/components/brave_vpn/utils_win.h
@@ -13,6 +13,12 @@ namespace brave_vpn {
 
 namespace internal {
 
+enum class CheckConnectionResult {
+  CONNECTED,
+  NOT_CONNECTED,
+  UNKNOWN,
+};
+
 void PrintRasError(DWORD error);
 std::wstring GetPhonebookPath();
 
@@ -23,6 +29,8 @@ bool CreateEntry(const std::wstring& entry_name,
 bool RemoveEntry(const std::wstring& entry_name);
 bool DisconnectEntry(const std::wstring& entry_name);
 bool ConnectEntry(const std::wstring& entry_name);
+
+CheckConnectionResult CheckConnection(const std::wstring& entry_name);
 
 }  // namespace internal
 

--- a/components/brave_vpn/winvpntool.cc
+++ b/components/brave_vpn/winvpntool.cc
@@ -35,6 +35,7 @@
 #define DEFAULT_PHONE_BOOK NULL
 
 constexpr char kConnectionsCommand[] = "connections";
+constexpr char kCheckConnectionCommand[] = "check-connection";
 constexpr char kDevicesCommand[] = "devices";
 constexpr char kEntriesCommand[] = "entries";
 constexpr char kCreateCommand[] = "create";
@@ -46,6 +47,8 @@ constexpr char kVPNName[] = "vpn_name";
 constexpr char kUserName[] = "user_name";
 constexpr char kPassword[] = "password";
 
+using brave_vpn::internal::CheckConnection;
+using brave_vpn::internal::CheckConnectionResult;
 using brave_vpn::internal::ConnectEntry;
 using brave_vpn::internal::CreateEntry;
 using brave_vpn::internal::DisconnectEntry;
@@ -685,6 +688,21 @@ int main(int argc, char* argv[]) {
 
   if (command_line->HasSwitch(kConnectionsCommand))
     PrintConnections();
+
+  if (command_line->HasSwitch(kCheckConnectionCommand)) {
+    const std::wstring vpn_name = command_line->GetSwitchValueNative(kVPNName);
+    if (vpn_name.empty()) {
+      LOG(ERROR) << "missing parameters for has-connection!";
+      LOG(ERROR) << "usage: vpntool.exe --has-connection --vpn_name=entry_name";
+      return 0;
+    }
+
+    if (CheckConnection(vpn_name) == CheckConnectionResult::CONNECTED) {
+      wprintf(L"\tFound %s connection", vpn_name.c_str());
+    } else {
+      wprintf(L"\tNot found %s connection", vpn_name.c_str());
+    }
+  }
 
   if (command_line->HasSwitch(kDevicesCommand))
     PrintDevices();


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/17705

With this, browser can display connection state in UI after startup.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Below command checks whether Windows has vpn entry named `BraveVPN` and it's already connected.
`..\out\Component\vpntool --check-connection --vpn_name=BraveVPN`