### PR TITLE
Fix #17692 - Add messaging in the UI about 5% tipping fee when tipping

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -968,6 +968,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "monthlyText", IDS_BRAVE_UI_MONTHLY_TEXT },
         { "nextContributionDate", IDS_BRAVE_REWARDS_TIP_NEXT_CONTRIBUTION_DATE },  // NOLINT
         { "notEnoughTokens", IDS_BRAVE_REWARDS_TIP_NOT_ENOUGH_TOKENS },
+        { "tippingFeeNote", IDS_BRAVE_REWARDS_TIPPING_FEE_NOTE },
         { "on", IDS_BRAVE_UI_ON },
         { "onboardingMaybeLater", IDS_BRAVE_REWARDS_ONBOARDING_MAYBE_LATER },
         { "onboardingSetupAdsHeader", IDS_BRAVE_REWARDS_ONBOARDING_SETUP_ADS_HEADER },  // NOLINT

--- a/components/brave_rewards/resources/tip/components/bat_tip_form.style.ts
+++ b/components/brave_rewards/resources/tip/components/bat_tip_form.style.ts
@@ -104,3 +104,10 @@ export const notEnoughFunds = styled.div`
     color: var(--brave-palette-neutral300);
   }
 `
+
+export const feeNote = styled.div`
+  text-align: center;
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--brave-palette-neutral600);
+`

--- a/components/brave_rewards/resources/tip/components/bat_tip_form.tsx
+++ b/components/brave_rewards/resources/tip/components/bat_tip_form.tsx
@@ -160,6 +160,9 @@ export function BatTipForm (props: Props) {
       </style.main>
       <style.footer>
         <style.terms>
+          <style.feeNote>
+            {getString('tippingFeeNote')}
+          </style.feeNote>
           <TermsOfService />
         </style.terms>
         {

--- a/components/brave_rewards/resources/tip/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/tip/stories/locale_strings.ts
@@ -42,6 +42,7 @@ export const localeStrings = {
   supportThisCreator: 'Support this creator',
   thanksForTheSupport: 'Thanks for the support!',
   tipHasBeenSent: 'Your one-time tip has been sent.',
+  tippingFeeNote: 'Brave collects 5% of the tip amount as a processing fee.',
   tipPostSubtitle: 'for their post',
   tokens: 'tokens',
   tweetAboutSupport: 'Tweet about your support',

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -613,6 +613,7 @@
       <message name="IDS_BRAVE_REWARDS_TIP_MONTHLY_CONTRIBUTION_SET" desc="">Monthly contribution has been set.</message>
       <message name="IDS_BRAVE_REWARDS_TIP_NEXT_CONTRIBUTION_DATE" desc="">Next contribution date:</message>
       <message name="IDS_BRAVE_REWARDS_TIP_NOT_ENOUGH_TOKENS" desc="">Not enough tokens. Please <ph name="LINK_BEGIN">$1</ph>add funds<ph name="LINK_END">$2</ph>.</message>
+      <message name="IDS_BRAVE_REWARDS_TIPPING_FEE_NOTE" desc="">Brave collects 5% of the tip amount as a processing fee.</message>
       <message name="IDS_BRAVE_REWARDS_TIP_ONE_TIME_TIP" desc="">One-Time Tip</message>
       <message name="IDS_BRAVE_REWARDS_TIP_ONE_TIME_TIP_AMOUNT" desc="">One-time tip amount:</message>
       <message name="IDS_BRAVE_REWARDS_TIP_OPT_IN_REQUIRED" desc="">Hold on, you can’t tip yet</message>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17692

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Try initiating a tip to a creator. Messaging should be updated to -

```
Brave collects 5% of the tip amount as a processing fee. By proceeding, you agree to the Terms of Service and Privacy Policy.
```

<img width="399" alt="Screen Shot 2021-08-26 at 11 36 33 PM" src="https://user-images.githubusercontent.com/1903815/131072419-21645fcd-bc84-4e9b-9b2a-3ef846eedf93.png">
 