### PR TITLE
[iOS] Fix Cr93 variations runtime crash (uplift to 1.29.x)

### DIFF
--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -30,6 +30,7 @@ source_set("browser") {
     "//brave/chromium_src/ios/chrome/browser/prefs",
     "//components/flags_ui",
     "//components/metrics_services_manager",
+    "//components/variations",
     "//components/variations/service",
     "//ios/chrome/browser",
     "//ios/chrome/browser:browser_impl",

--- a/ios/browser/brave_web_main_parts.mm
+++ b/ios/browser/brave_web_main_parts.mm
@@ -14,6 +14,7 @@
 #include "components/flags_ui/pref_service_flags_storage.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "components/variations/service/variations_service.h"
+#include "components/variations/variations_ids_provider.h"
 #include "ios/chrome/browser/application_context_impl.h"
 #include "ios/chrome/browser/browser_state/browser_state_keyed_service_factories.h"
 #include "ios/chrome/browser/browser_state/chrome_browser_state.h"
@@ -68,6 +69,9 @@ void BraveWebMainParts::PreCreateThreads() {
       application_context_->GetLocalState());
   ConvertFlagsToSwitches(&flags_storage,
                          base::CommandLine::ForCurrentProcess());
+
+  variations::VariationsIdsProvider::Create(
+      variations::VariationsIdsProvider::Mode::kUseSignedInState);
 
   SetupFieldTrials();
 


### PR DESCRIPTION
Uplift of #9843
Fixes https://github.com/brave/brave-browser/issues/17685

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.