### PR TITLE
Fix #17700 - Add messaging in tipping flow to tell users that tips could take a few minutes to process (uplift to 1.30.x)

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -1019,6 +1019,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "sorryToSeeYouGo", IDS_BRAVE_REWARDS_TIP_SORRY_TO_SEE_YOU_GO },
         { "supportThisCreator", IDS_BRAVE_REWARDS_TIP_SUPPORT_THIS_CREATOR },
         { "thanksForTheSupport", IDS_BRAVE_REWARDS_TIP_THANKS_FOR_THE_SUPPORT },  // NOLINT
+        { "tipDelayNote", IDS_BRAVE_REWARDS_TIP_DELAY_NOTE },
         { "tipHasBeenSent", IDS_BRAVE_REWARDS_TIP_TIP_HAS_BEEN_SET },
         { "tipPostSubtitle", IDS_BRAVE_REWARDS_TIP_TIP_POST_SUBTITLE },
         { "tokens", IDS_BRAVE_UI_TOKENS },

--- a/components/brave_rewards/resources/tip/components/tip_complete.style.ts
+++ b/components/brave_rewards/resources/tip/components/tip_complete.style.ts
@@ -45,8 +45,21 @@ export const message = styled.div`
   color: var(--brave-palette-neutral900);
 `
 
+export const note = styled.span`
+  font-size: 11px;
+  line-height: 17px;
+  font-weight: 400;
+  padding: 6px;
+  background-color: var(--brave-palette-neutral000);
+  border-radius: 4px;
+
+  strong {
+    font-weight: 600;
+  }
+`
 export const table = styled.div`
   margin-top: 17px;
+  margin-bottom: 23px;
   text-align: left;
   font-size: 14px;
   line-height: 21px;

--- a/components/brave_rewards/resources/tip/components/tip_complete.tsx
+++ b/components/brave_rewards/resources/tip/components/tip_complete.tsx
@@ -8,7 +8,7 @@ import { TwitterColorIcon } from 'brave-ui/components/icons'
 
 import { TipKind } from '../lib/interfaces'
 import { HostContext } from '../lib/host_context'
-import { LocaleContext } from '../../shared/lib/locale_context'
+import { formatMessage, LocaleContext } from '../../shared/lib/locale_context'
 
 import { TokenAmount } from '../../shared/components/token_amount'
 
@@ -108,6 +108,17 @@ export function TipComplete (props: Props) {
           <style.table>
             {getSummaryTable()}
           </style.table>
+          <style.note>
+          {
+            formatMessage(getString('tipDelayNote'), {
+              tags: {
+                $1: (content) => (
+                  <strong key='label'>{content}</strong>
+                )
+              }
+            })
+          }
+          </style.note>
         </style.main>
         <style.share>
           <button onClick={onShareClick}>

--- a/components/brave_rewards/resources/tip/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/tip/stories/locale_strings.ts
@@ -41,6 +41,7 @@ export const localeStrings = {
   sorryToSeeYouGo: 'Sorry to see you go…',
   supportThisCreator: 'Support this creator',
   thanksForTheSupport: 'Thanks for the support!',
+  tipDelayNote: 'Note: Your tip can take several minutes to process',
   tipHasBeenSent: 'Your one-time tip has been sent.',
   tipPostSubtitle: 'for their post',
   tokens: 'tokens',

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -621,6 +621,7 @@
       <message name="IDS_BRAVE_REWARDS_TIP_SORRY_TO_SEE_YOU_GO" desc="">Sorry to see you go…</message>
       <message name="IDS_BRAVE_REWARDS_TIP_SUPPORT_THIS_CREATOR" desc="">Support this creator</message>
       <message name="IDS_BRAVE_REWARDS_TIP_THANKS_FOR_THE_SUPPORT" desc="">Thanks for the support!</message>
+      <message name="IDS_BRAVE_REWARDS_TIP_DELAY_NOTE" desc=""><ph name="BOLD_BEGIN">$1</ph>Note: <ph name="BOLD_END">$2</ph>Your tip can take several minutes to process</message>
       <message name="IDS_BRAVE_REWARDS_TIP_TIP_HAS_BEEN_SET" desc="">Your one-time tip has been sent.</message>
       <message name="IDS_BRAVE_REWARDS_TIP_TIP_POST_SUBTITLE" desc="">for their post</message>
       <message name="IDS_BRAVE_REWARDS_TIP_TWEET_ABOUT_SUPPORT" desc="">Tweet about your support</message>


### PR DESCRIPTION
Uplift of #9873
Resolves https://github.com/brave/brave-browser/issues/17700

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.