### PR TITLE
Fix #17692 - Add messaging in the UI about 5% tipping fee when tipping (uplift to 1.30.x)

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -966,6 +966,7 @@ void CustomizeWebUIHTMLSource(const std::string &name,
         { "monthlyText", IDS_BRAVE_UI_MONTHLY_TEXT },
         { "nextContributionDate", IDS_BRAVE_REWARDS_TIP_NEXT_CONTRIBUTION_DATE },  // NOLINT
         { "notEnoughTokens", IDS_BRAVE_REWARDS_TIP_NOT_ENOUGH_TOKENS },
+        { "tippingFeeNote", IDS_BRAVE_REWARDS_TIPPING_FEE_NOTE },
         { "on", IDS_BRAVE_UI_ON },
         { "onboardingMaybeLater", IDS_BRAVE_REWARDS_ONBOARDING_MAYBE_LATER },
         { "onboardingSetupAdsHeader", IDS_BRAVE_REWARDS_ONBOARDING_SETUP_ADS_HEADER },  // NOLINT

--- a/components/brave_rewards/resources/tip/components/bat_tip_form.style.ts
+++ b/components/brave_rewards/resources/tip/components/bat_tip_form.style.ts
@@ -104,3 +104,10 @@ export const notEnoughFunds = styled.div`
     color: var(--brave-palette-neutral300);
   }
 `
+
+export const feeNote = styled.div`
+  text-align: center;
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--brave-palette-neutral600);
+`

--- a/components/brave_rewards/resources/tip/components/bat_tip_form.tsx
+++ b/components/brave_rewards/resources/tip/components/bat_tip_form.tsx
@@ -160,6 +160,9 @@ export function BatTipForm (props: Props) {
       </style.main>
       <style.footer>
         <style.terms>
+          <style.feeNote>
+            {getString('tippingFeeNote')}
+          </style.feeNote>
           <TermsOfService />
         </style.terms>
         {

--- a/components/brave_rewards/resources/tip/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/tip/stories/locale_strings.ts
@@ -42,6 +42,7 @@ export const localeStrings = {
   supportThisCreator: 'Support this creator',
   thanksForTheSupport: 'Thanks for the support!',
   tipHasBeenSent: 'Your one-time tip has been sent.',
+  tippingFeeNote: 'Brave collects 5% of the tip amount as a processing fee.',
   tipPostSubtitle: 'for their post',
   tokens: 'tokens',
   tweetAboutSupport: 'Tweet about your support',

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -613,6 +613,7 @@
       <message name="IDS_BRAVE_REWARDS_TIP_MONTHLY_CONTRIBUTION_SET" desc="">Monthly contribution has been set.</message>
       <message name="IDS_BRAVE_REWARDS_TIP_NEXT_CONTRIBUTION_DATE" desc="">Next contribution date:</message>
       <message name="IDS_BRAVE_REWARDS_TIP_NOT_ENOUGH_TOKENS" desc="">Not enough tokens. Please <ph name="LINK_BEGIN">$1</ph>add funds<ph name="LINK_END">$2</ph>.</message>
+      <message name="IDS_BRAVE_REWARDS_TIPPING_FEE_NOTE" desc="">Brave collects 5% of the tip amount as a processing fee.</message>
       <message name="IDS_BRAVE_REWARDS_TIP_ONE_TIME_TIP" desc="">One-Time Tip</message>
       <message name="IDS_BRAVE_REWARDS_TIP_ONE_TIME_TIP_AMOUNT" desc="">One-time tip amount:</message>
       <message name="IDS_BRAVE_REWARDS_TIP_OPT_IN_REQUIRED" desc="">Hold on, you can’t tip yet</message>


### PR DESCRIPTION
Uplift of #9867
Resolves https://github.com/brave/brave-browser/issues/17692

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.