### PR TITLE
Fix #17742 - Enable Gemini (uplift to 1.29.x)

### DIFF
--- a/components/brave_rewards/common/features.cc
+++ b/components/brave_rewards/common/features.cc
@@ -12,7 +12,7 @@ namespace features {
 
 #if BUILDFLAG(ENABLE_GEMINI_WALLET)
 const base::Feature kGeminiFeature{"BraveRewardsGemini",
-                                   base::FEATURE_DISABLED_BY_DEFAULT};
+                                   base::FEATURE_ENABLED_BY_DEFAULT};
 #endif
 
 const base::Feature kVerboseLoggingFeature{"BraveRewardsVerboseLogging",


### PR DESCRIPTION
Uplift of #9889
Resolves https://github.com/brave/brave-browser/issues/17742

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.