### PR TITLE
Import private key from UTC/JSON version 3

### DIFF
--- a/chromium_src/crypto/DEPS
+++ b/chromium_src/crypto/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+../../../crypto",
+  "+third_party/boringssl",
+]

--- a/chromium_src/crypto/symmetric_key.cc
+++ b/chromium_src/crypto/symmetric_key.cc
@@ -1,0 +1,40 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "crypto/symmetric_key.h"
+
+#include "../../../crypto/symmetric_key.cc"
+
+#include "crypto/openssl_util.h"
+#include "third_party/boringssl/src/include/openssl/evp.h"
+
+namespace crypto {
+
+// static
+std::unique_ptr<SymmetricKey>
+SymmetricKey::DeriveKeyFromPasswordUsingPbkdf2Sha256(
+    Algorithm algorithm,
+    const std::string& password,
+    const std::string& salt,
+    size_t iterations,
+    size_t key_size_in_bits) {
+  if (!CheckDerivationParameters(algorithm, key_size_in_bits))
+    return nullptr;
+
+  size_t key_size_in_bytes = key_size_in_bits / 8;
+
+  OpenSSLErrStackTracer err_tracer(FROM_HERE);
+  std::unique_ptr<SymmetricKey> key(new SymmetricKey);
+  uint8_t* key_data = reinterpret_cast<uint8_t*>(
+      base::WriteInto(&key->key_, key_size_in_bytes + 1));
+
+  int rv = PKCS5_PBKDF2_HMAC(password.data(), password.length(),
+                             reinterpret_cast<const uint8_t*>(salt.data()),
+                             salt.length(), static_cast<unsigned>(iterations),
+                             EVP_sha256(), key_size_in_bytes, key_data);
+  return rv == 1 ? std::move(key) : nullptr;
+}
+
+}  // namespace crypto

--- a/chromium_src/crypto/symmetric_key.h
+++ b/chromium_src/crypto/symmetric_key.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CRYPTO_SYMMETRIC_KEY_H_
+#define BRAVE_CHROMIUM_SRC_CRYPTO_SYMMETRIC_KEY_H_
+
+#define DeriveKeyFromPasswordUsingPbkdf2                                    \
+  DeriveKeyFromPasswordUsingPbkdf2Sha256(                                   \
+      Algorithm algorithm, const std::string& password,                     \
+      const std::string& salt, size_t iterations, size_t key_size_in_bits); \
+  static std::unique_ptr<SymmetricKey> DeriveKeyFromPasswordUsingPbkdf2
+#include "../../../crypto/symmetric_key.h"
+#undef DeriveKeyFromPasswordUsingPbkdf2
+
+#endif  // BRAVE_CHROMIUM_SRC_CRYPTO_SYMMETRIC_KEY_H_

--- a/chromium_src/crypto/symmetric_key_unittest.cc
+++ b/chromium_src/crypto/symmetric_key_unittest.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "../../../crypto/symmetric_key_unittest.cc"
+
+class SymmetricKeyDeriveKeyFromPasswordUsingPbkdf2Sha256Test
+    : public testing::TestWithParam<PBKDF2TestVector> {};
+
+TEST_P(SymmetricKeyDeriveKeyFromPasswordUsingPbkdf2Sha256Test,
+       DeriveKeyFromPasswordUsingPbkdf2Sha256) {
+  PBKDF2TestVector test_data(GetParam());
+  std::unique_ptr<crypto::SymmetricKey> key(
+      crypto::SymmetricKey::DeriveKeyFromPasswordUsingPbkdf2Sha256(
+          test_data.algorithm, test_data.password, test_data.salt,
+          test_data.rounds, test_data.key_size_in_bits));
+  ASSERT_TRUE(key);
+
+  const std::string& raw_key = key->key();
+  EXPECT_EQ(test_data.key_size_in_bits / 8, raw_key.size());
+  EXPECT_EQ(test_data.expected, base::ToLowerASCII(base::HexEncode(
+                                    raw_key.data(), raw_key.size())));
+}
+
+static const PBKDF2TestVector kTestVectorsPbkdf2Sha256[] = {
+    {
+        crypto::SymmetricKey::AES,
+        "password",
+        "salt",
+        1,
+        256,
+        "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b",
+    },
+    {
+        crypto::SymmetricKey::AES,
+        "password",
+        "salt",
+        2,
+        256,
+        "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43",
+    },
+    {
+        crypto::SymmetricKey::AES,
+        "password",
+        "salt",
+        4096,
+        256,
+        "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a",
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(All,
+                         SymmetricKeyDeriveKeyFromPasswordUsingPbkdf2Sha256Test,
+                         testing::ValuesIn(kTestVectorsPbkdf2Sha256));

--- a/components/brave_wallet/browser/hd_key.cc
+++ b/components/brave_wallet/browser/hd_key.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/hd_key.h"
 
 #include "base/check.h"
+#include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
@@ -14,8 +15,13 @@
 #include "brave/third_party/bitcoin-core/src/src/base58.h"
 #include "brave/third_party/bitcoin-core/src/src/crypto/ripemd160.h"
 #include "brave/third_party/bitcoin-core/src/src/secp256k1/include/secp256k1_recovery.h"
+#include "crypto/encryptor.h"
 #include "crypto/sha2.h"
+#include "crypto/symmetric_key.h"
 #include "third_party/boringssl/src/include/openssl/hmac.h"
+
+using crypto::Encryptor;
+using crypto::SymmetricKey;
 
 namespace brave_wallet {
 
@@ -134,6 +140,181 @@ std::unique_ptr<HDKey> HDKey::GenerateFromPrivateKey(
   std::unique_ptr<HDKey> hd_key = std::make_unique<HDKey>(0, 0, 0);
   hd_key->SetPrivateKey(private_key);
   return hd_key;
+}
+
+// static
+std::unique_ptr<HDKey> HDKey::GenerateFromV3UTC(const std::string& password,
+                                                const std::string& json) {
+  if (password.empty()) {
+    VLOG(0) << __func__ << "empty password";
+    return nullptr;
+  }
+  base::JSONReader::ValueWithError parsed_json =
+      base::JSONReader::ReadAndReturnValueWithError(json);
+  if (!parsed_json.value) {
+    VLOG(0) << __func__ << ": UTC v3 json parsed failed because "
+            << parsed_json.error_message;
+    return nullptr;
+  }
+  // check version
+  auto version = parsed_json.value->FindIntKey("version");
+  if (!version || *version != 3) {
+    VLOG(0) << __func__ << ": missing version or version is not 3";
+    return nullptr;
+  }
+
+  const auto* crypto = parsed_json.value->FindKey("crypto");
+  if (!crypto) {
+    VLOG(0) << __func__ << ": missing crypto";
+    return nullptr;
+  }
+  const auto* kdf = crypto->FindStringKey("kdf");
+  if (!kdf) {
+    VLOG(0) << __func__ << ": missing kdf";
+    return nullptr;
+  }
+
+  std::unique_ptr<SymmetricKey> derived_key = nullptr;
+  const auto* kdfparams = crypto->FindKey("kdfparams");
+  if (!kdfparams) {
+    VLOG(0) << __func__ << ": missing kdfparams";
+    return nullptr;
+  }
+  auto dklen = kdfparams->FindIntKey("dklen");
+  if (!dklen) {
+    VLOG(0) << __func__ << ": missing dklen";
+    return nullptr;
+  }
+  if (*dklen < 32) {
+    VLOG(0) << __func__ << ": dklen must be >=32";
+    return nullptr;
+  }
+  const auto* salt = kdfparams->FindStringKey("salt");
+  if (!salt) {
+    VLOG(0) << __func__ << ": missing salt";
+    return nullptr;
+  }
+  std::vector<uint8_t> salt_bytes;
+  if (!base::HexStringToBytes(*salt, &salt_bytes)) {
+    VLOG(1) << __func__ << ": invalid salt";
+    return nullptr;
+  }
+  if (*kdf == "pbkdf2") {
+    auto c = kdfparams->FindIntKey("c");
+    if (!c) {
+      VLOG(0) << __func__ << ": missing c";
+      return nullptr;
+    }
+    const auto* prf = crypto->FindStringKey("prf");
+    if (!prf) {
+      VLOG(0) << __func__ << ": missing prf";
+      return nullptr;
+    }
+    // Use PKCS5_PBKDF2_HMAC for SHA256
+  } else if (*kdf == "scrypt") {
+    auto n = kdfparams->FindIntKey("n");
+    if (!n) {
+      VLOG(0) << __func__ << ": missing n";
+      return nullptr;
+    }
+    auto r = kdfparams->FindIntKey("r");
+    if (!r) {
+      VLOG(0) << __func__ << ": missing r";
+      return nullptr;
+    }
+    auto p = kdfparams->FindIntKey("p");
+    if (!p) {
+      VLOG(0) << __func__ << ": missing p";
+      return nullptr;
+    }
+    derived_key = SymmetricKey::DeriveKeyFromPasswordUsingScrypt(
+        SymmetricKey::AES, password,
+        std::string(salt_bytes.begin(), salt_bytes.end()), (size_t)*n,
+        (size_t)*r, (size_t)*p, 512 * 1024 * 1024, (size_t)*dklen * 8);
+    if (!derived_key) {
+      VLOG(1) << __func__ << ": scrypt derivation failed";
+      return nullptr;
+    }
+  } else {
+    VLOG(0) << __func__
+            << ": kdf is not supported. (Only support pbkdf2 and scrypt)";
+    return nullptr;
+  }
+
+  const auto* mac = crypto->FindStringKey("mac");
+  if (!mac) {
+    VLOG(0) << __func__ << ": missing mac";
+    return nullptr;
+  }
+  const auto* ciphertext = crypto->FindStringKey("ciphertext");
+  if (!ciphertext) {
+    VLOG(0) << __func__ << ": missing ciphertext";
+    return nullptr;
+  }
+  std::vector<uint8_t> ciphertext_bytes;
+  if (!base::HexStringToBytes(*ciphertext, &ciphertext_bytes)) {
+    VLOG(1) << __func__ << ": invalid ciphertext";
+    return nullptr;
+  }
+
+  std::vector<uint8_t> mac_verification_input(
+      derived_key->key().end() - *dklen / 2, derived_key->key().end());
+  mac_verification_input.insert(mac_verification_input.end(),
+                                ciphertext_bytes.begin(),
+                                ciphertext_bytes.end());
+  // verify password
+  std::vector<uint8_t> mac_verification(KeccakHash(mac_verification_input));
+  if (base::ToLowerASCII(base::HexEncode(mac_verification)) != *mac) {
+    VLOG(0) << "password does not match";
+    return nullptr;
+  }
+
+  const auto* cipher = crypto->FindStringKey("cipher");
+  if (!cipher) {
+    VLOG(0) << __func__ << ": missing cipher";
+    return nullptr;
+  }
+  if (*cipher != "aes-128-ctr") {
+    VLOG(0) << __func__
+            << ": AES-128-CTR is the minimal requirement of version 3";
+    return nullptr;
+  }
+
+  std::vector<uint8_t> iv_bytes;
+  const auto* iv = crypto->FindStringPath("cipherparams.iv");
+  if (!iv) {
+    VLOG(0) << __func__ << ": missing cipherparams.iv";
+    return nullptr;
+  }
+  if (!base::HexStringToBytes(*iv, &iv_bytes)) {
+    VLOG(1) << __func__ << ": invalid iv";
+    return nullptr;
+  }
+
+  std::vector<uint8_t> private_key;
+  std::unique_ptr<SymmetricKey> decryption_key = SymmetricKey::Import(
+      SymmetricKey::AES, derived_key->key().substr(0, *dklen / 2));
+  if (!decryption_key) {
+    VLOG(1) << __func__ << ": raw key has to be 16 or 32 bytes for AES import";
+    return nullptr;
+  }
+  Encryptor encryptor;
+  if (!encryptor.Init(decryption_key.get(), Encryptor::Mode::CTR,
+                      std::vector<uint8_t>())) {
+    VLOG(0) << __func__ << ": encryptor init failed";
+    return nullptr;
+  }
+  if (!encryptor.SetCounter(iv_bytes)) {
+    VLOG(0) << __func__ << ": encryptor set counter failed";
+    return nullptr;
+  }
+
+  if (!encryptor.Decrypt(ciphertext_bytes, &private_key)) {
+    VLOG(0) << __func__ << ": encryptor decrypt failed";
+    return nullptr;
+  }
+
+  return GenerateFromPrivateKey(private_key);
 }
 
 void HDKey::SetPrivateKey(const std::vector<uint8_t>& value) {

--- a/components/brave_wallet/browser/hd_key.h
+++ b/components/brave_wallet/browser/hd_key.h
@@ -28,12 +28,17 @@ class HDKey {
   static std::unique_ptr<HDKey> GenerateFromExtendedKey(const std::string& key);
   static std::unique_ptr<HDKey> GenerateFromPrivateKey(
       const std::vector<uint8_t>& private_key);
+  // https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
+  static std::unique_ptr<HDKey> GenerateFromV3UTC(const std::string& password,
+                                                  const std::string& json);
 
   // value must be 32 bytes
   void SetPrivateKey(const std::vector<uint8_t>& value);
   // base58 encoded of hash160 of private key
   std::string GetPrivateExtendedKey() const;
   std::string GetHexEncodedPrivateKey() const;
+  // TODO(darkdh): For exporting private key as keystore file
+  // std::string GetPrivateKeyinV3UTC() const;
 
   // value must be 33 bytes valid public key (compressed)
   void SetPublicKey(const std::vector<uint8_t>& value);

--- a/components/brave_wallet/browser/hd_key.h
+++ b/components/brave_wallet/browser/hd_key.h
@@ -37,6 +37,7 @@ class HDKey {
   // base58 encoded of hash160 of private key
   std::string GetPrivateExtendedKey() const;
   std::string GetHexEncodedPrivateKey() const;
+  const std::vector<uint8_t>& private_key() const { return private_key_; }
   // TODO(darkdh): For exporting private key as keystore file
   // std::string GetPrivateKeyinV3UTC() const;
 
@@ -79,9 +80,7 @@ class HDKey {
   FRIEND_TEST_ALL_PREFIXES(HDKeyUnitTest, GenerateFromExtendedKey);
   FRIEND_TEST_ALL_PREFIXES(HDKeyUnitTest, SetPrivateKey);
   FRIEND_TEST_ALL_PREFIXES(HDKeyUnitTest, SetPublicKey);
-  FRIEND_TEST_ALL_PREFIXES(HDKeyUnitTest, DeriveChildFromPath);
   FRIEND_TEST_ALL_PREFIXES(HDKeyUnitTest, SignAndVerifyAndRecover);
-  FRIEND_TEST_ALL_PREFIXES(HDKeyUnitTest, GetHexEncodedPrivateKey);
 
   void GeneratePublicKey();
   const std::vector<uint8_t> Hash160(const std::vector<uint8_t>& input);

--- a/components/brave_wallet/browser/hd_key_unittest.cc
+++ b/components/brave_wallet/browser/hd_key_unittest.cc
@@ -183,7 +183,7 @@ TEST(HDKeyUnitTest, GenerateFromExtendedKey) {
   EXPECT_EQ(hdkey_from_pri->index_, 2u);
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(hdkey_from_pri->chain_code_)),
             "9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271");
-  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(hdkey_from_pri->private_key_)),
+  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(hdkey_from_pri->private_key())),
             "bb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23");
   EXPECT_EQ(
       base::ToLowerASCII(base::HexEncode(hdkey_from_pri->public_key_)),
@@ -200,7 +200,7 @@ TEST(HDKeyUnitTest, GenerateFromExtendedKey) {
   EXPECT_EQ(hdkey_from_pub->index_, 2u);
   EXPECT_EQ(base::ToLowerASCII(base::HexEncode(hdkey_from_pub->chain_code_)),
             "9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271");
-  EXPECT_TRUE(hdkey_from_pub->private_key_.empty());
+  EXPECT_TRUE(hdkey_from_pub->private_key().empty());
   EXPECT_EQ(
       base::ToLowerASCII(base::HexEncode(hdkey_from_pub->public_key_)),
       "024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c");
@@ -287,11 +287,11 @@ TEST(HDKeyUnitTest, SignAndVerifyAndRecover) {
 TEST(HDKeyUnitTest, SetPrivateKey) {
   HDKey key;
   key.SetPrivateKey(std::vector<uint8_t>(31));
-  ASSERT_TRUE(key.private_key_.empty());
+  ASSERT_TRUE(key.private_key().empty());
   key.SetPrivateKey(std::vector<uint8_t>(33));
-  ASSERT_TRUE(key.private_key_.empty());
+  ASSERT_TRUE(key.private_key().empty());
   key.SetPrivateKey(std::vector<uint8_t>(32, 0x1));
-  EXPECT_FALSE(key.private_key_.empty());
+  EXPECT_FALSE(key.private_key().empty());
   EXPECT_TRUE(!IsPublicKeyEmpty(key.public_key_));
 }
 
@@ -358,19 +358,19 @@ TEST(HDKeyUnitTest, DeriveChildFromPath) {
         "xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAv"
         "KjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr");
     EXPECT_EQ(
-        base::ToLowerASCII(base::HexEncode(key->private_key_)),
+        base::ToLowerASCII(base::HexEncode(key->private_key())),
         "00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd");
     std::unique_ptr<HDKey> derived_key =
         key->DeriveChildFromPath("m/44'/0'/0'/0/0'");
     EXPECT_EQ(
-        base::ToLowerASCII(base::HexEncode(derived_key->private_key_)),
+        base::ToLowerASCII(base::HexEncode(derived_key->private_key())),
         "3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb");
   }
 }
 
 TEST(HDKeyUnitTest, GetHexEncodedPrivateKey) {
   HDKey key;
-  ASSERT_TRUE(key.private_key_.empty());
+  ASSERT_TRUE(key.private_key().empty());
   EXPECT_EQ("", key.GetHexEncodedPrivateKey());
 
   std::unique_ptr<HDKey> key2 = HDKey::GenerateFromExtendedKey(
@@ -407,6 +407,8 @@ TEST(HDKeyUnitTest, GenerateFromV3UTC) {
   ASSERT_TRUE(hd_key);
   EXPECT_EQ(GetHexAddr(hd_key.get()),
             "0xb14ab53e38da1c172f877dbc6d65e4a1b0474c3c");
+  EXPECT_EQ(base::ToLowerASCII(base::HexEncode(hd_key->private_key())),
+            "efca4cdd31923b50f4214af5d2ae10e7ac45a5019e9431cc195482d707485378");
 
   // wrong password
   EXPECT_FALSE(HDKey::GenerateFromV3UTC("brave1234", json));

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -19,6 +19,7 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 class PrefService;
 
@@ -106,6 +107,10 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   void AddImportedAccount(const std::string& account_name,
                           const std::string& private_key,
                           AddImportedAccountCallback callback) override;
+  void AddImportedAccountFromJson(const std::string& account_name,
+                                  const std::string& password,
+                                  const std::string& json,
+                                  AddImportedAccountCallback callback) override;
   void GetPrivateKeyForImportedAccount(
       const std::string& address,
       GetPrivateKeyForImportedAccountCallback callback) override;
@@ -167,6 +172,11 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
                            SetDefaultKeyringDerivedAccountName);
 
   void AddAccountForDefaultKeyring(const std::string& account_name);
+
+  // Address will be returned when success
+  absl::optional<std::string> AddImportedAccountForDefaultKeyring(
+      const std::string& account_name,
+      const std::vector<uint8_t>& private_key);
 
   size_t GetAccountMetasNumberForKeyring(const std::string& id);
 

--- a/components/brave_wallet/browser/keyring_controller_unittest.cc
+++ b/components/brave_wallet/browser/keyring_controller_unittest.cc
@@ -983,6 +983,103 @@ TEST_F(KeyringControllerUnitTest, ImportedAccounts) {
   EXPECT_NE(encrypted_private_key, base::Base64Encode(private_key0));
 }
 
+TEST_F(KeyringControllerUnitTest, ImportedAccountFromJson) {
+  const std::string json(
+      R"({
+          "address":"b14ab53e38da1c172f877dbc6d65e4a1b0474c3c",
+          "crypto" : {
+              "cipher" : "aes-128-ctr",
+              "cipherparams" : {
+                  "iv" : "cecacd85e9cb89788b5aab2f93361233"
+              },
+              "ciphertext" : "c52682025b1e5d5c06b816791921dbf439afe7a053abb9fac19f38a57499652c",
+              "kdf" : "scrypt",
+              "kdfparams" : {
+                  "dklen" : 32,
+                  "n" : 262144,
+                  "p" : 1,
+                  "r" : 8,
+                  "salt" : "dc9e4a98886738bd8aae134a1f89aaa5a502c3fbd10e336136d4d5fe47448ad6"
+              },
+              "mac" : "27b98c8676dc6619d077453b38db645a4c7c17a3e686ee5adaf53c11ac1b890e"
+          },
+          "id" : "7e59dc02-8d42-409d-b29a-a8a0f862cc81",
+          "version" : 3
+      })");
+  const std::string expected_private_key =
+      "efca4cdd31923b50f4214af5d2ae10e7ac45a5019e9431cc195482d707485378";
+  const std::string expected_address =
+      "0xB14Ab53E38DA1C172f877DBC6d65e4a1B0474C3c";
+
+  KeyringController controller(GetPrefs());
+  controller.CreateWallet("brave", base::DoNothing::Once<const std::string&>());
+  base::RunLoop().RunUntilIdle();
+
+  bool callback_called = false;
+  controller.AddImportedAccountFromJson(
+      "Imported 1", "wrong password", json,
+      base::BindLambdaForTesting([&](bool success, const std::string& address) {
+        EXPECT_FALSE(success);
+        EXPECT_TRUE(address.empty());
+        callback_called = true;
+      }));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+
+  callback_called = false;
+  controller.AddImportedAccountFromJson(
+      "Imported 1", "testtest", "{crypto: 123}",
+      base::BindLambdaForTesting([&](bool success, const std::string& address) {
+        EXPECT_FALSE(success);
+        EXPECT_TRUE(address.empty());
+        callback_called = true;
+      }));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+
+  callback_called = false;
+  controller.AddImportedAccountFromJson(
+      "Imported 1", "testtest", json,
+      base::BindLambdaForTesting([&](bool success, const std::string& address) {
+        EXPECT_TRUE(success);
+        EXPECT_EQ(address, expected_address);
+        callback_called = true;
+      }));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+
+  controller.Lock();
+  controller.Unlock("brave", base::DoNothing::Once<bool>());
+  base::RunLoop().RunUntilIdle();
+
+  // check restore by getting private key
+  callback_called = false;
+  controller.GetPrivateKeyForImportedAccount(
+      expected_address, base::BindLambdaForTesting(
+                            [&](bool success, const std::string& private_key) {
+                              EXPECT_TRUE(success);
+                              EXPECT_EQ(expected_private_key, private_key);
+                              callback_called = true;
+                            }));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+
+  // private key is encrypted
+  const base::Value* imported_accounts_value =
+      KeyringController::GetPrefForKeyring(GetPrefs(), kImportedAccounts,
+                                           "default");
+  ASSERT_TRUE(imported_accounts_value);
+  const std::string encrypted_private_key =
+      imported_accounts_value->GetList()[0]
+          .FindKey(kEncryptedPrivateKey)
+          ->GetString();
+  EXPECT_FALSE(encrypted_private_key.empty());
+
+  std::vector<uint8_t> private_key;
+  ASSERT_TRUE(base::HexStringToBytes(expected_private_key, &private_key));
+  EXPECT_NE(encrypted_private_key, base::Base64Encode(private_key));
+}
+
 TEST_F(KeyringControllerUnitTest, GetPrivateKeyForDefaultKeyringAccount) {
   KeyringController controller(GetPrefs());
   EXPECT_TRUE(controller.CreateEncryptorForKeyring("brave", "default"));

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -191,6 +191,8 @@ interface KeyringController {
     => (bool success, string privateKey);
   AddImportedAccount(string accountName, string privateKey)
     => (bool success, string address);
+  AddImportedAccountFromJson(string accountName, string password, string json)
+    => (bool success, string address);
   GetPrivateKeyForImportedAccount(string address)
     => (bool success, string privateKey);
   RemoveImportedAccount(string address) => (bool success);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -150,6 +150,7 @@ test("brave_unit_tests") {
   defines = brave_service_key_defines
 
   deps = [
+    ":crypto_unittests",
     ":test_support",
     "//brave/app:command_ids",
     "//brave/app/theme:brave_theme_resources_grit",
@@ -486,6 +487,18 @@ test("brave_unit_tests") {
   if (enable_ipfs) {
     deps += [ "//brave/browser/ipfs/test:unittests" ]
   }
+}
+
+source_set("crypto_unittests") {
+  testonly = true
+
+  sources = [ "//crypto/symmetric_key_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//crypto",
+    "//testing/gtest",
+  ]
 }
 
 if (!is_android && !is_ios) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17099

UTC/JSON definition
https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition

1.  `HDKey::GenerateFromV3UTC` support deriving decryption key through `scrypt` or `pbkdf2` 
2.  `password` will be verified through `mac` before using derived decryption key to decrypt account's private key.
3.  Adding `SymmetricKey::DeriveKeyFromPasswordUsingPbkdf2Sha256` through chromium override to support `PBKDF2-HMAC-SHA256` because`SymmetricKey::DeriveKeyFromPasswordUsingPbkdf2` is using `SHA1`
4. Integrate derived hdkey into existing `AddImportedAccount` path, so when restoring imported accounts, it will use encrypted private key stored in prefs, instead of having to derive key from UTC/JSON and do different decryption for every unlock

security review: https://github.com/brave/security/issues/563

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

