### PR TITLE
Add P3A Sync.Status.2 metric

### DIFF
--- a/browser/sync/brave_sync_service_impl_delegate.h
+++ b/browser/sync/brave_sync_service_impl_delegate.h
@@ -39,6 +39,8 @@ class BraveSyncServiceImplDelegate
 
   void OnSelfDeviceInfoDeleted(void);
 
+  void RecordP3ASyncStatus();
+
   syncer::DeviceInfoTracker* device_info_tracker_;
   syncer::LocalDeviceInfoProvider* local_device_info_provider_;
   base::ScopedObservation<syncer::DeviceInfoTracker,

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -90,7 +90,7 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.Today.WeeklyMaxCardViewsCount",
     "Brave.Today.WeeklyMaxCardVisitsCount",
     "Brave.Today.WeeklySessionCount",
-    "Brave.Sync.Status",
+    "Brave.Sync.Status.2",
     "Brave.Sync.ProgressTokenEverReset",
     "Brave.Uptime.BrowserOpenMinutes",
     "Brave.Welcome.InteractionStatus",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17862

This PR introduces a new P3A metric `Brave.Sync.Status.2`. The meaning:
```
0 - Sync is disabled
1 - Sync chain has 1 device;
2 - Sync chain has 2 devices;
3 - Sync chain has 3 or more devices;
```

This metric histogram is sent in three cases:
1. When browser is started;
2. When the number of devices in chain is changed.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
SECURITY REVIEW IS REQUIRED, https://github.com/brave/security/issues/571
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint` //tried lint and gn_check
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

I don't know how to verify that the metric is sent, so put the trace message into `BraveP3AService::OnHistogramChanged` and build the browser to be able to ensure the message is sent.

1. Launch browser, clean profile
2. Ensure you see `Brave.Sync.Status.2`, `sample=0`;
3. Turn sync on;
4. Ensure you see `Brave.Sync.Status.2`, `sample=1`;
5. Add 2nd device to the chain; 
6. Ensure you see `Brave.Sync.Status.2`, `sample=2`;
7. Add 3rd device to the chain; 
8. Ensure you see `Brave.Sync.Status.2`, `sample=3`;
9. Add 4th device to the chain; 
10. Ensure you see `Brave.Sync.Status.2`, `sample=3`;
11. Turn sync off;
12. Ensure you see `Brave.Sync.Enabled`, `sample=0`.
