### PR TITLE
[iOS] Create a brave providers target that doesn't include the MC bundle

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -422,6 +422,8 @@ Config.prototype.buildArgs = function () {
     args.ios_enable_credential_provider_extension = false
     args.ios_enable_widget_kit_extension = false
 
+    args.ios_provider_target = "//brave/ios/browser/providers:brave_providers"
+
     delete args.safebrowsing_api_endpoint
     delete args.updater_prod_endpoint
     delete args.updater_dev_endpoint

--- a/ios/browser/providers/BUILD.gn
+++ b/ios/browser/providers/BUILD.gn
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This is a variant of //ios/chrome/browser/providers:chromium_providers which
+# does not include bundling the MaterialComponents framework or Chromium
+# providers we don't need.
+group("brave_providers") {
+  deps = [
+    # The target providing the ChromeBrowserProvider factory.
+    "//ios/chrome/browser/providers:chromium_provider_factory",
+
+    # The individual API implementations.
+    "//ios/chrome/browser/providers/modals:chromium_modals",
+    "//ios/chrome/browser/providers/text_zoom:chromium_text_zoom",
+
+    # The provider API needs to provide MaterialDesignComponent API (as the
+    # internal provider provides an alternate implementation).
+    "//ios/third_party/material_components_ios:material_components_ios+link",
+  ]
+}


### PR DESCRIPTION
The new default `ios_provider_target` points to `//ios/chrome/browser/providers:chromium_providers`, which includes the dep: `//ios/third_party/material_components_ios:material_components_ios+bundle`, which causes MaterialComponents.framework to be embedded within the BraveCore.framework which is not allowed.

This commit creates a Brave specific provider target without that bundle dep and sets the GN arg to point to it

Resolves https://github.com/brave/brave-browser/issues/17783

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

