### PR TITLE
Restore network cookies access in 3p-allowed frames. (uplift to 1.29.x)

### DIFF
--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -648,8 +648,7 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageBrowserTest,
   EXPECT_EQ("", values_after.iframe_2.cookies);
 }
 
-IN_PROC_BROWSER_TEST_F(EphemeralStorageBrowserTest,
-                       NetworkCookiesAreNotSentIn3p) {
+IN_PROC_BROWSER_TEST_F(EphemeralStorageBrowserTest, NetworkCookiesAreSentIn3p) {
   WebContents* site_a_tab = LoadURLInNewTab(a_site_ephemeral_storage_url_);
   SetValuesInFrames(site_a_tab, "a.com", "from=a.com");
 
@@ -658,14 +657,11 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageBrowserTest,
   // Non 3p request should have cookies in headers.
   EXPECT_TRUE(http_request_monitor_.HasHttpRequestWithCookie(
       a_site_ephemeral_storage_url_, "from=a.com"));
-  // 3p requests should NOT have cookies in headers, even from the ephemeral
+  // 3p requests should have cookies in headers from the ephemeral
   // storage.
-  // https://chromium-review.googlesource.com/c/chromium/src/+/2367394
-  // "<...> when the NetworkDelegate forces PrivacyMode, it will disable sending
-  // auth credentials".
-  EXPECT_FALSE(http_request_monitor_.HasHttpRequestWithCookie(
+  EXPECT_TRUE(http_request_monitor_.HasHttpRequestWithCookie(
       b_site_ephemeral_storage_url_, "from=a.com"));
-  EXPECT_FALSE(http_request_monitor_.HasHttpRequestWithCookie(
+  EXPECT_TRUE(http_request_monitor_.HasHttpRequestWithCookie(
       b_site_ephemeral_storage_url_.Resolve("/simple.html"), "from=a.com"));
 
   // Cookie values should be available via JS API.

--- a/chromium_src/services/network/cookie_settings.cc
+++ b/chromium_src/services/network/cookie_settings.cc
@@ -25,6 +25,18 @@ bool CookieSettings::IsEphemeralCookieAccessible(
   return IsCookieAccessible(cookie, url, site_for_cookies, top_frame_origin);
 }
 
+bool CookieSettings::IsEphemeralPrivacyModeEnabled(
+    const GURL& url,
+    const GURL& site_for_cookies,
+    const absl::optional<url::Origin>& top_frame_origin,
+    net::SamePartyContext::Type same_party_cookie_context_type) const {
+  if (IsEphemeralCookieAccessAllowed(url, site_for_cookies, top_frame_origin))
+    return false;
+
+  return IsPrivacyModeEnabled(url, site_for_cookies, top_frame_origin,
+                              same_party_cookie_context_type);
+}
+
 bool CookieSettings::AnnotateAndMoveUserBlockedEphemeralCookies(
     const GURL& url,
     const GURL& site_for_cookies,

--- a/chromium_src/services/network/cookie_settings.h
+++ b/chromium_src/services/network/cookie_settings.h
@@ -13,6 +13,13 @@
       const absl::optional<url::Origin>& top_frame_origin) const; \
   bool IsCookieAccessible
 
+#define IsPrivacyModeEnabled                                      \
+  IsEphemeralPrivacyModeEnabled(                                  \
+      const GURL& url, const GURL& site_for_cookies,              \
+      const absl::optional<url::Origin>& top_frame_origin,        \
+      net::SamePartyContext::Type same_party_context_type) const; \
+  bool IsPrivacyModeEnabled
+
 #define AnnotateAndMoveUserBlockedCookies                   \
   AnnotateAndMoveUserBlockedEphemeralCookies(               \
       const GURL& url, const GURL& site_for_cookies,        \
@@ -24,6 +31,7 @@
 #include "../../../../services/network/cookie_settings.h"
 
 #undef AnnotateAndMoveUserBlockedCookies
+#undef IsPrivacyModeEnabled
 #undef IsCookieAccessible
 
 #endif  // BRAVE_CHROMIUM_SRC_SERVICES_NETWORK_COOKIE_SETTINGS_H_

--- a/chromium_src/services/network/network_service_network_delegate.cc
+++ b/chromium_src/services/network/network_service_network_delegate.cc
@@ -8,44 +8,12 @@
 #include "services/network/cookie_settings.h"
 
 #define IsCookieAccessible IsEphemeralCookieAccessible
-#define OnAnnotateAndMoveUserBlockedCookies \
-  OnAnnotateAndMoveUserBlockedCookies_ChromiumImpl
-#define OnCanSetCookie OnCanSetCookie_ChromiumImpl
+#define IsPrivacyModeEnabled IsEphemeralPrivacyModeEnabled
+#define AnnotateAndMoveUserBlockedCookies \
+  AnnotateAndMoveUserBlockedEphemeralCookies
 
 #include "../../../../services/network/network_service_network_delegate.cc"
 
-#undef OnCanSetCookie
-#undef OnAnnotateAndMoveUserBlockedCookies
+#undef AnnotateAndMoveUserBlockedCookies
+#undef IsPrivacyModeEnabled
 #undef IsCookieAccessible
-
-namespace network {
-
-bool NetworkServiceNetworkDelegate::OnAnnotateAndMoveUserBlockedCookies(
-    const net::URLRequest& request,
-    net::CookieAccessResultList& maybe_included_cookies,
-    net::CookieAccessResultList& excluded_cookies,
-    bool allowed_from_caller) {
-  // Enable ephemeral storage support for the call.
-  auto scoped_ephemeral_storage_awareness =
-      network_context_->cookie_manager()
-          ->cookie_settings()
-          .CreateScopedEphemeralStorageAwareness();
-  return OnAnnotateAndMoveUserBlockedCookies_ChromiumImpl(
-      request, maybe_included_cookies, excluded_cookies, allowed_from_caller);
-}
-
-bool NetworkServiceNetworkDelegate::OnCanSetCookie(
-    const net::URLRequest& request,
-    const net::CanonicalCookie& cookie,
-    net::CookieOptions* options,
-    bool allowed_from_caller) {
-  // Enable ephemeral storage support for the call.
-  auto scoped_ephemeral_storage_awareness =
-      network_context_->cookie_manager()
-          ->cookie_settings()
-          .CreateScopedEphemeralStorageAwareness();
-  return OnCanSetCookie_ChromiumImpl(request, cookie, options,
-                                     allowed_from_caller);
-}
-
-}  // namespace network

--- a/chromium_src/services/network/network_service_network_delegate.h
+++ b/chromium_src/services/network/network_service_network_delegate.h
@@ -6,20 +6,6 @@
 #ifndef BRAVE_CHROMIUM_SRC_SERVICES_NETWORK_NETWORK_SERVICE_NETWORK_DELEGATE_H_
 #define BRAVE_CHROMIUM_SRC_SERVICES_NETWORK_NETWORK_SERVICE_NETWORK_DELEGATE_H_
 
-#define FinishedCanSendReportingReports                                   \
-  NotUsed() {}                                                            \
-  bool OnAnnotateAndMoveUserBlockedCookies_ChromiumImpl(                  \
-      const net::URLRequest& request,                                     \
-      net::CookieAccessResultList& maybe_included_cookies,                \
-      net::CookieAccessResultList& excluded_cookies,                      \
-      bool allowed_from_caller);                                          \
-  bool OnCanSetCookie_ChromiumImpl(                                       \
-      const net::URLRequest& request, const net::CanonicalCookie& cookie, \
-      net::CookieOptions* options, bool allowed_from_caller);             \
-  void FinishedCanSendReportingReports
-
 #include "../../../../services/network/network_service_network_delegate.h"
-
-#undef FinishedCanSendReportingReports
 
 #endif  // BRAVE_CHROMIUM_SRC_SERVICES_NETWORK_NETWORK_SERVICE_NETWORK_DELEGATE_H_


### PR DESCRIPTION
Uplift of #9940
Resolves https://github.com/brave/brave-browser/issues/17795

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.