### PR TITLE
Removed drm_tab_helper deps from widevine utils

### DIFF
--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "brave/browser/widevine/constants.h"
 #include "brave/browser/widevine/widevine_utils.h"
 #include "brave/common/pref_names.h"
 #include "chrome/browser/browser_process_impl.h"
@@ -27,8 +28,7 @@ bool IsAlreadyRegistered(ComponentUpdateService* cus) {
   std::vector<std::string> component_ids;
   component_ids = cus->GetComponentIDs();
   return std::find(component_ids.begin(), component_ids.end(),
-                   BraveDrmTabHelper::kWidevineComponentId) !=
-         component_ids.end();
+                   kWidevineComponentId) != component_ids.end();
 }
 #if !defined(OS_LINUX)
 content::WebContents* GetActiveWebContents() {
@@ -44,10 +44,6 @@ void ReloadIfActive(content::WebContents* web_contents) {
 #endif
 
 }  // namespace
-
-// static
-const char BraveDrmTabHelper::kWidevineComponentId[] =
-    "oimompecagnajdejgnnjijobebaeigek";
 
 BraveDrmTabHelper::BraveDrmTabHelper(content::WebContents* contents)
     : WebContentsObserver(contents), brave_drm_receivers_(contents, this) {

--- a/browser/brave_drm_tab_helper.h
+++ b/browser/brave_drm_tab_helper.h
@@ -22,10 +22,6 @@ class BraveDrmTabHelper final
       public brave_drm::mojom::BraveDRM,
       public component_updater::ComponentUpdateService::Observer {
  public:
-  // Copied from widevine_cdm_component_installer.cc.
-  // There is no shared constant value.
-  static const char kWidevineComponentId[];
-
   explicit BraveDrmTabHelper(content::WebContents* contents);
   ~BraveDrmTabHelper() override;
 

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -288,6 +288,7 @@ if (enable_widevine) {
   ]
   brave_chrome_browser_deps += [
     "//brave/browser/widevine",
+    "//brave/browser/widevine:constants",
     "//brave/components/brave_drm",
   ]
 }

--- a/browser/widevine/BUILD.gn
+++ b/browser/widevine/BUILD.gn
@@ -4,6 +4,7 @@ source_set("widevine") {
   # Remove when https://github.com/brave/brave-browser/issues/10644 is resolved
   check_includes = false
   deps = [
+    ":constants",
     "//base",
     "//brave/app:brave_generated_resources_grit",
     "//brave/common:pref_names",
@@ -29,6 +30,10 @@ source_set("widevine") {
     "widevine_utils.cc",
     "widevine_utils.h",
   ]
+}
+
+source_set("constants") {
+  sources = [ "constants.h" ]
 }
 
 source_set("unittest") {

--- a/browser/widevine/BUILD.gn
+++ b/browser/widevine/BUILD.gn
@@ -58,6 +58,7 @@ source_set("browser_tests") {
     ]
 
     deps = [
+      ":constants",
       ":widevine",
       "//base",
       "//brave/browser",

--- a/browser/widevine/constants.h
+++ b/browser/widevine/constants.h
@@ -1,0 +1,11 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_WIDEVINE_CONSTANTS_H_
+#define BRAVE_BROWSER_WIDEVINE_CONSTANTS_H_
+
+constexpr char kWidevineComponentId[] = "oimompecagnajdejgnnjijobebaeigek";
+
+#endif  // BRAVE_BROWSER_WIDEVINE_CONSTANTS_H_

--- a/browser/widevine/widevine_permission_request_browsertest.cc
+++ b/browser/widevine/widevine_permission_request_browsertest.cc
@@ -7,6 +7,7 @@
 
 #include "base/path_service.h"
 #include "brave/browser/brave_drm_tab_helper.h"
+#include "brave/browser/widevine/constants.h"
 #include "brave/browser/widevine/widevine_permission_request.h"
 #include "brave/browser/widevine/widevine_utils.h"
 #include "brave/common/brave_paths.h"
@@ -181,10 +182,9 @@ IN_PROC_BROWSER_TEST_F(WidevinePermissionRequestBrowserTest,
   content::RunAllTasksUntilIdle();
 
   WidevinePermissionRequest::is_test_ = true;
-  GetBraveDrmTabHelper()->OnEvent(
-      component_updater::ComponentUpdateService::Observer
-          ::Events::COMPONENT_UPDATED,
-      BraveDrmTabHelper::kWidevineComponentId);
+  GetBraveDrmTabHelper()->OnEvent(component_updater::ComponentUpdateService::
+                                      Observer ::Events::COMPONENT_UPDATED,
+                                  kWidevineComponentId);
   content::RunAllTasksUntilIdle();
 
   // Check two permission bubble are created.

--- a/browser/widevine/widevine_utils.cc
+++ b/browser/widevine/widevine_utils.cc
@@ -9,7 +9,7 @@
 #include "base/path_service.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
-#include "brave/browser/brave_drm_tab_helper.h"
+#include "brave/browser/widevine/constants.h"
 #include "brave/browser/widevine/widevine_permission_request.h"
 #include "brave/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
@@ -88,7 +88,7 @@ void DisableWidevineCdmComponent() {
 
   SetWidevineOptedIn(false);
   g_browser_process->component_updater()->UnregisterComponent(
-      BraveDrmTabHelper::kWidevineComponentId);
+      kWidevineComponentId);
 }
 
 int GetWidevinePermissionRequestTextFrangmentResourceId(bool for_restart) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/17816

Can't add deps for it to //brave/browser/widevine target.
It was included to get widevine component id from tab helper.h
Instead, new targets //brave/browser/widevine:constants is added
to include its component id.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

