### PR TITLE
Include eth.link in public suffix only when include_private is true (uplift to 1.30.x)

### DIFF
--- a/chromium_src/net/base/lookup_string_in_fixed_set.cc
+++ b/chromium_src/net/base/lookup_string_in_fixed_set.cc
@@ -53,7 +53,9 @@ int LookupSuffixInReversedSet(const unsigned char* graph,
     *suffix_length = strlen(decentralized_dns::kEthDomain) - 1;
     return kDafsaFound;
   }
-  if (base::EndsWith(host, decentralized_dns::kDNSForEthDomain)) {
+
+  if (include_private &&
+      base::EndsWith(host, decentralized_dns::kDNSForEthDomain)) {
     *suffix_length = strlen(decentralized_dns::kDNSForEthDomain) - 1;
     return kDafsaFound;
   }


### PR DESCRIPTION
Uplift of #9951
Resolves https://github.com/brave/brave-browser/issues/17815

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.