### PR TITLE
Disable kConversionMeasurement feature.

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -207,6 +207,7 @@ bool BraveMainDelegate::BasicStartupComplete(int* exit_code) {
   std::unordered_set<const char*> disabled_features = {
     autofill::features::kAutofillEnableAccountWalletStorage.name,
     autofill::features::kAutofillServerCommunication.name,
+    blink::features::kConversionMeasurement.name,
     blink::features::kFledgeInterestGroupAPI.name,
     blink::features::kFledgeInterestGroups.name,
     blink::features::kHandwritingRecognitionWebPlatformApiFinch.name,

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -72,6 +72,7 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
   const base::Feature* disabled_features[] = {
       &autofill::features::kAutofillEnableAccountWalletStorage,
       &autofill::features::kAutofillServerCommunication,
+      &blink::features::kConversionMeasurement,
       &blink::features::kFledgeInterestGroupAPI,
       &blink::features::kFledgeInterestGroups,
       &blink::features::kHandwritingRecognitionWebPlatformApiFinch,

--- a/chromium_src/third_party/blink/renderer/core/origin_trials/origin_trials.cc
+++ b/chromium_src/third_party/blink/renderer/core/origin_trials/origin_trials.cc
@@ -22,13 +22,16 @@ namespace origin_trials {
 
 bool IsTrialDisabledInBrave(const StringView& trial_name) {
   // When updating also update the array in the overload below.
+  // clang-format off
   static const char* const kBraveDisabledTrialNames[] = {
+      "ConversionMeasurement",
       "DigitalGoods",
       "HandwritingRecognition",
       "SignedExchangeSubresourcePrefetch",
       "SubresourceWebBundles",
       "TrustTokens",
   };
+  // clang-format on
 
   if (base::Contains(kBraveDisabledTrialNames, trial_name)) {
     // Check if this is still a valid trial name in Chromium. If not, it needs
@@ -42,13 +45,16 @@ bool IsTrialDisabledInBrave(const StringView& trial_name) {
 
 bool IsTrialDisabledInBrave(OriginTrialFeature feature) {
   // When updating also update the array in the overload above.
-  static const std::array<OriginTrialFeature, 5> kBraveDisabledTrialFeatures = {
+  // clang-format off
+  static const std::array<OriginTrialFeature, 6> kBraveDisabledTrialFeatures = {
+      OriginTrialFeature::kConversionMeasurement,
       OriginTrialFeature::kDigitalGoods,
       OriginTrialFeature::kHandwritingRecognition,
       OriginTrialFeature::kSignedExchangeSubresourcePrefetch,
       OriginTrialFeature::kSubresourceWebBundles,
       OriginTrialFeature::kTrustTokens,
   };
+  // clang-format on
 
   return base::Contains(kBraveDisabledTrialFeatures, feature);
 }


### PR DESCRIPTION
Fixes brave/brave-browser#17843

Chromium change:

https://source.chromium.org/chromium/chromium/src/+/5dc98f948153f12276ff522b7b540788d12dd75a

commit 5dc98f948153f12276ff522b7b540788d12dd75a
Author: Andrew Paseltiner <apaseltiner@chromium.org>
Date:   Thu May 27 23:26:38 2021 +0000

    [attribution_reporting] Move browser feature to blink

    This switches depends_on usage to directly branching the add OT token
    code, and will allow us to work around subtle behavior affecting IDL-
    generated attributes in crrev.com/c/2897497.

    We also update feature uses now that it is enabled by default.

    Change-Id: I9fd7c520560ce04266c3a4d0de967b4a54c58f0e
    Bug: 1202170

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

