### PR TITLE
Revert "Fixed sentence casing on Always Show Full URLs in brave://settings/appearance"

### DIFF
--- a/app/generated_resources.grd
+++ b/app/generated_resources.grd
@@ -5351,6 +5351,11 @@ Keep your key file in a safe place. You will need it to create new versions of y
       <message name="IDS_OMNIBOX_REMOVE_SUGGESTION_BUBBLE_DESCRIPTION" desc="The description of a bubble to delete an omnibox suggestion.">
         This page will also be removed from your history and <ph name="SEARCH_ENGINE">$1<ex>Brave</ex></ph> activity.
       </message>
+      <if expr="use_titlecase">
+        <message name="IDS_CONTEXT_MENU_SHOW_FULL_URLS" desc="In Title Case: The text label of the omnibox context menu option to show full URLs">
+          Always Show Full URLs
+        </message>
+      </if>
       <if expr="not use_titlecase">
         <message name="IDS_CONTEXT_MENU_SHOW_FULL_URLS" desc="The text label of the omnibox context menu option to show full URLs">
           Always show full URLs


### PR DESCRIPTION
Reverts brave/brave-core#9461

Reason: broken macOS build.
```
../../brave/chromium_src/chrome/browser/ui/cocoa/../../../../../../chrome/browser/ui/cocoa/main_menu_builder.mm:250:22: error: use of undeclared identifier 'IDS_CONTEXT_MENU_SHOW_FULL_URLS'
13:39:53                  Item(IDS_CONTEXT_MENU_SHOW_FULL_URLS)
```