### PR TITLE
[Android] Fixed crash on retrieving favicon for private tab (uplift to 1.29.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/BraveRewardsHelper.java
+++ b/android/java/org/chromium/chrome/browser/BraveRewardsHelper.java
@@ -78,6 +78,7 @@ public class BraveRewardsHelper implements LargeIconBridge.LargeIconCallback{
     public static final int THANKYOU_STAY_DURATION = 2000; //ms
     private static final float DP_PER_INCH_MDPI = 160f;
     private Tab mTab;
+    private Profile mProfile;
 
     public static void setRewardsEnvChange(boolean isEnabled) {
         SharedPreferences.Editor sharedPreferencesEditor =
@@ -185,8 +186,9 @@ public class BraveRewardsHelper implements LargeIconBridge.LargeIconCallback{
     public BraveRewardsHelper(Tab tab) {
         mTab = tab;
         assert mTab != null;
-        if (mLargeIconBridge == null && mTab != null) {
-            mLargeIconBridge = new LargeIconBridge(Profile.fromWebContents(mTab.getWebContents()));
+        mProfile = Profile.getLastUsedRegularProfile();
+        if (mLargeIconBridge == null && mTab != null && mProfile != null) {
+            mLargeIconBridge = new LargeIconBridge(mProfile);
         }
     }
 
@@ -201,7 +203,6 @@ public class BraveRewardsHelper implements LargeIconBridge.LargeIconCallback{
         mCallback =  null;
     }
 
-
     public void detach() {
         mCallback =  null;
     }
@@ -213,9 +214,9 @@ public class BraveRewardsHelper implements LargeIconBridge.LargeIconCallback{
     }
 
     private void retrieveLargeIconInternal() {
-        mFetchCount ++;
+        mFetchCount++;
 
-        //favIconURL (or content URL) is still not available, try to read it again
+        // FavIconURL (or content URL) is still not available, try to read it again.
         if (mFaviconUrl == null || mFaviconUrl.isEmpty() || mFaviconUrl.equals("clear")) {
             if (mTab != null) {
                 mFaviconUrl = mTab.getUrl().getSpec();
@@ -231,9 +232,10 @@ public class BraveRewardsHelper implements LargeIconBridge.LargeIconCallback{
             return;
         }
 
-        //get the icon
-        if (mLargeIconBridge!= null && mCallback != null && !mFaviconUrl.isEmpty()) {
-            mLargeIconBridge.getLargeIconForUrl(new GURL(mFaviconUrl),FAVICON_DESIRED_SIZE, this);
+        // Get the icon.
+        if (mLargeIconBridge != null && mCallback != null && !mFaviconUrl.isEmpty()
+                && mProfile.isNativeInitialized()) {
+            mLargeIconBridge.getLargeIconForUrl(new GURL(mFaviconUrl), FAVICON_DESIRED_SIZE, this);
         }
     }
 


### PR DESCRIPTION
Uplift of #9972
Resolves https://github.com/brave/brave-browser/issues/17657

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.