### PR TITLE
Don't drop mojo callback in LocalStorageImpl::DeleteStorage.

### DIFF
--- a/chromium_src/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/chromium_src/components/services/storage/dom_storage/local_storage_impl.cc
@@ -59,6 +59,8 @@ void LocalStorageImpl::DeleteStorage(const url::Origin& origin,
       in_memory_local_storage_->DeleteStorage(*non_opaque_origin,
                                               std::move(callback));
       non_opaque_origins_.erase(origin);
+    } else {
+      std::move(callback).Run();
     }
   } else {
     local_storage_->DeleteStorage(origin, std::move(callback));


### PR DESCRIPTION
Uplift of #9629
Resolves https://github.com/brave/brave-browser/issues/17325 (the original issue on browser shutdown which is already merged to ```master``` and ```1.30.x```)
Resolves https://github.com/brave/brave-browser/issues/17859 (the production issue which breaks ```localStorage``` in some cases, but is also fixed by this change)

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.