### PR TITLE
Separate symbols archives for apk and aab

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -333,7 +333,7 @@ if (target_cpu == "x86") {
 
 action("create_symbols_dist") {
   if (is_android) {
-    output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_output_format-$target_android_base-$target_cpu-symbols.zip"
+    output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_base-$target_cpu-symbols-$target_android_output_format.zip"
   } else {
     output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-symbols.zip"
   }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -333,7 +333,7 @@ if (target_cpu == "x86") {
 
 action("create_symbols_dist") {
   if (is_android) {
-    output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_base-$target_cpu-symbols.zip"
+    output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_android_output_format-$target_android_base-$target_cpu-symbols.zip"
   } else {
     output = "$brave_dist_dir/$brave_product_name-v$brave_version-$brave_platform-$target_arch-symbols.zip"
   }

--- a/build/commands/lib/createDist.js
+++ b/build/commands/lib/createDist.js
@@ -7,7 +7,14 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
   util.updateBranding()
-  fs.removeSync(path.join(config.outputDir, 'dist'))
+  // On Android CI does two builds sequentially: for aab and for apk.
+  // Symbols are uploaded after 2nd build, but we need to preserve the symbols
+  // from the 1st build, so don't clean here dist folder; in anyway symbols zips
+  // are overwritten and brave.breakpad.syms dir is cleared before generating
+  // the symbols.
+  if (config.targetOS !== 'android') {
+    fs.removeSync(path.join(config.outputDir, 'dist'))
+  }
   if (config.shouldSign() && process.platform === 'win32') {
     // Sign binaries used for widevine sig file generation.
     // Other binaries will be done during the create_dist.


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17902

This PR:
- adds package type for breakpad symbols archive name for Android (apk/aab);
- skips clear for dist folder on Android to keep symbols archive both for apk, aab.


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
after the commands
```
npm run create_dist -- Release  --target_os=android --target_arch=arm64 --target_android_base=mono  --target_android_output_format=aab
npm run create_dist -- Release  --target_os=android --target_arch=arm64 --target_android_base=mono  --target_android_output_format=apk
```
there are two breakpad symbols archive in `out/<ConfigName>/dist` , one for apk, other from aab