### PR TITLE
[iOS] Add Obj-C wrappers for top-level mojo constants (string + numbers)

### DIFF
--- a/build/ios/mojom/objc_templates/module.h.tmpl
+++ b/build/ios/mojom/objc_templates/module.h.tmpl
@@ -26,6 +26,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+{# Constants #}
+{%- for const in constants %}
+{%-   set name = const.name|objc_enum_formatter -%}
+OBJC_EXPORT {{const.kind|objc_wrapper_type}} const {{class_prefix}}{{name}} NS_SWIFT_NAME({{class_prefix}}.{{name}});
+{% endfor -%}
+
 {# Define a namespace class for Swift types to use #}
 OBJC_EXPORT
 NS_SWIFT_NAME({{class_prefix}})

--- a/build/ios/mojom/objc_templates/module.mm.tmpl
+++ b/build/ios/mojom/objc_templates/module.mm.tmpl
@@ -17,6 +17,12 @@
 #error "This file requires ARC support."
 #endif
 
+{# Constants #}
+{%- for const in constants %}
+{%-   set name = const.name|objc_enum_formatter %}
+{{const.kind|objc_wrapper_type}} const {{class_prefix}}{{name}} = {{const|const_objc_assign}};
+{% endfor %}
+
 @implementation _{{class_prefix}}
 @end
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/17952

This adds support for generating Obj-C versions of mojo top-level string and number constants (no nested support currently)

Example generation:

```
// .mojom
const string kMainnetChainId = "0x1";
```

Becomes

```
// .h
OBJC_EXPORT NSString* const BraveWalletMainnetChainId NS_SWIFT_NAME(BraveWallet.MainnetChainId);
// .mm
NSString* const BraveWalletMainnetChainId = @"0x1";
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

