### PR TITLE
Add support for eth_sendTransaction

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -320,7 +320,7 @@ public class BuySendSwapActivity extends AsyncInitializationActivity
                         accountSpinner.getSelectedItemPosition());
                 if (mEthTxController != null) {
                     mEthTxController.addUnapprovedTransaction(data, from,
-                            (success, tx_meta_id)
+                            (success, tx_meta_id, error_message)
                                     -> {
                                             // TODO(sergz): Add an observer and approve transaction
                                     });

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -151,6 +151,7 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
+#include "brave/browser/brave_wallet/eth_tx_controller_factory.h"
 #include "brave/browser/brave_wallet/rpc_controller_factory.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_provider_impl.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
@@ -225,11 +226,16 @@ void MaybeBindBraveWalletProvider(
   if (!rpc_controller)
     return;
 
+  auto tx_controller = brave_wallet::EthTxControllerFactory::GetForContext(
+      frame_host->GetBrowserContext());
+  if (!tx_controller)
+    return;
+
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
   mojo::MakeSelfOwnedReceiver(
       std::make_unique<brave_wallet::BraveWalletProviderImpl>(
-          std::move(rpc_controller),
+          std::move(rpc_controller), std::move(tx_controller),
 #if defined(OS_ANDROID)
           std::make_unique<
               brave_wallet::BraveWalletProviderDelegateImplAndroid>(

--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -115,6 +115,7 @@ source_set("unit_tests") {
     "//brave/browser/brave_wallet",
     "//brave/browser/brave_wallet:tab_helper",
     "//brave/components/brave_wallet/browser",
+    "//brave/components/brave_wallet/browser:ethereum_permission_utils",
     "//brave/components/brave_wallet/common",
     "//brave/components/brave_wallet/common:mojom",
     "//chrome/browser",

--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -13,20 +13,30 @@
 #include "base/test/task_environment.h"
 #include "base/values.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl.h"
+#include "brave/browser/brave_wallet/eth_tx_controller_factory.h"
+#include "brave/browser/brave_wallet/keyring_controller_factory.h"
+#include "brave/browser/brave_wallet/rpc_controller_factory.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/eth_json_rpc_controller.h"
+#include "brave/components/brave_wallet/browser/eth_tx_controller.h"
+#include "brave/components/brave_wallet/browser/ethereum_permission_utils.h"
+#include "brave/components/brave_wallet/browser/hd_keyring.h"
 #include "brave/components/brave_wallet/browser/keyring_controller.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/test/base/testing_profile.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/prefs/pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/test_web_contents_factory.h"
-#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "content/test/test_web_contents.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -55,71 +65,106 @@ void ValidateErrorCode(BraveWalletProviderImpl* provider,
 
 class BraveWalletProviderImplUnitTest : public testing::Test {
  public:
-  BraveWalletProviderImplUnitTest() {
-    TestingProfile::Builder builder;
-    auto prefs =
-        std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
-    RegisterUserProfilePrefs(prefs->registry());
-    builder.SetPrefService(std::move(prefs));
-    profile_ = builder.Build();
+  BraveWalletProviderImplUnitTest() = default;
 
-    shared_url_loader_factory_ =
-        base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
-            &url_loader_factory_);
-    web_contents_ = factory_.CreateWebContents(profile_.get());
+  void TearDown() override {
+    provider_.reset();
+    web_contents_.reset();
+  }
+
+  void SetUp() override {
+    web_contents_ =
+        content::TestWebContents::Create(browser_context(), nullptr);
+    eth_json_rpc_controller_ =
+        brave_wallet::RpcControllerFactory::GetControllerForContext(
+            browser_context());
+    keyring_controller_ =
+        KeyringControllerFactory::GetControllerForContext(browser_context());
+    eth_tx_controller_ =
+        brave_wallet::EthTxControllerFactory::GetControllerForContext(
+            browser_context());
+    eth_json_rpc_controller_->SetNetwork("0x1");
+    keyring_controller()->CreateWallet(
+        "testing123", base::DoNothing::Once<const std::string&>());
+    base::RunLoop().RunUntilIdle();
+    keyring_controller()->AddAccount("Account 1",
+                                     base::DoNothing::Once<bool>());
+    base::RunLoop().RunUntilIdle();
+    provider_ = std::make_unique<BraveWalletProviderImpl>(
+        eth_json_rpc_controller()->MakeRemote(),
+        eth_tx_controller()->MakeRemote(),
+        std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
+            web_contents(), web_contents()->GetMainFrame()),
+        prefs());
   }
 
   ~BraveWalletProviderImplUnitTest() override = default;
 
-  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory() {
-    return shared_url_loader_factory_;
+  content::TestWebContents* web_contents() { return web_contents_.get(); }
+  EthTxController* eth_tx_controller() { return eth_tx_controller_; }
+  EthJsonRpcController* eth_json_rpc_controller() {
+    return eth_json_rpc_controller_;
+  }
+  KeyringController* keyring_controller() { return keyring_controller_; }
+  BraveWalletProviderImpl* provider() { return provider_.get(); }
+  std::string from() {
+    return keyring_controller()->default_keyring_->GetAddress(0);
   }
 
-  content::WebContents* web_contents() { return web_contents_; }
+  content::BrowserContext* browser_context() { return &profile_; }
+  PrefService* prefs() { return profile_.GetPrefs(); }
+  HostContentSettingsMap* host_content_settings_map() {
+    return HostContentSettingsMapFactory::GetForProfile(&profile_);
+  }
 
-  content::BrowserContext* browser_context() { return profile_.get(); }
+  void NavigateAndAddEthereumPermission() {
+    GURL url("https://brave.com");
+    web_contents()->NavigateAndCommit(url);
+    GURL sub_request_origin;
+    ASSERT_TRUE(
+        brave_wallet::GetSubRequestOrigin(url, from(), &sub_request_origin));
+    host_content_settings_map()->SetContentSettingDefaultScope(
+        sub_request_origin, url, ContentSettingsType::BRAVE_ETHEREUM,
+        ContentSetting::CONTENT_SETTING_ALLOW);
+  }
 
-  PrefService* prefs() { return profile_->GetPrefs(); }
+ protected:
+  content::BrowserTaskEnvironment browser_task_environment_;
 
  private:
-  content::BrowserTaskEnvironment browser_task_environment_;
-  std::unique_ptr<TestingProfile> profile_;
+  EthJsonRpcController* eth_json_rpc_controller_;
+  KeyringController* keyring_controller_;
+  EthTxController* eth_tx_controller_;
   content::TestWebContentsFactory factory_;
-  content::WebContents* web_contents_ = nullptr;
+  std::unique_ptr<content::TestWebContents> web_contents_;
+  std::unique_ptr<BraveWalletProviderImpl> provider_;
   network::TestURLLoaderFactory url_loader_factory_;
-  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+  base::ScopedTempDir temp_dir_;
+  TestingProfile profile_;
 };
 
 TEST_F(BraveWalletProviderImplUnitTest, ValidateBrokenPayloads) {
-  brave_wallet::EthJsonRpcController controller(shared_url_loader_factory(),
-                                                prefs());
-
-  BraveWalletProviderImpl provider_impl(
-      controller.MakeRemote(),
-      std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
-          web_contents(), web_contents()->GetMainFrame()),
-      prefs());
-  ValidateErrorCode(&provider_impl, "", ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({})", ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": []})",
+  ValidateErrorCode(provider(), "", ProviderErrors::kInvalidParams);
+  ValidateErrorCode(provider(), R"({})", ProviderErrors::kInvalidParams);
+  ValidateErrorCode(provider(), R"({"params": []})",
                     ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": [{}]})",
+  ValidateErrorCode(provider(), R"({"params": [{}]})",
                     ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": {}})",
+  ValidateErrorCode(provider(), R"({"params": {}})",
                     ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": [{
+  ValidateErrorCode(provider(), R"({"params": [{
         "chainName": 'Binance1 Smart Chain',
       }]})",
                     ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": [{
+  ValidateErrorCode(provider(), R"({"params": [{
       "chainId": '0x386'
     }]})",
                     ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": [{
+  ValidateErrorCode(provider(), R"({"params": [{
       "rpcUrls": ['https://bsc-dataseed.binance.org/'],
     }]})",
                     ProviderErrors::kInvalidParams);
-  ValidateErrorCode(&provider_impl, R"({"params": [{
+  ValidateErrorCode(provider(), R"({"params": [{
       "chainName": 'Binance1 Smart Chain',
       "rpcUrls": ['https://bsc-dataseed.binance.org/'],
     }]})",
@@ -127,10 +172,9 @@ TEST_F(BraveWalletProviderImplUnitTest, ValidateBrokenPayloads) {
 }
 
 TEST_F(BraveWalletProviderImplUnitTest, EmptyDelegate) {
-  brave_wallet::EthJsonRpcController controller(shared_url_loader_factory(),
-                                                prefs());
-  BraveWalletProviderImpl provider_impl(controller.MakeRemote(), nullptr,
-                                        prefs());
+  BraveWalletProviderImpl provider_impl(eth_json_rpc_controller()->MakeRemote(),
+                                        eth_tx_controller()->MakeRemote(),
+                                        nullptr, prefs());
   ValidateErrorCode(&provider_impl,
                     R"({"params": [{
         "chainId": "0x111",
@@ -141,15 +185,8 @@ TEST_F(BraveWalletProviderImplUnitTest, EmptyDelegate) {
 }
 
 TEST_F(BraveWalletProviderImplUnitTest, OnAddEthereumChain) {
-  brave_wallet::EthJsonRpcController controller(shared_url_loader_factory(),
-                                                prefs());
-  BraveWalletProviderImpl provider_impl(
-      controller.MakeRemote(),
-      std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
-          web_contents(), web_contents()->GetMainFrame()),
-      prefs());
   bool callback_is_called = false;
-  provider_impl.AddEthereumChain(
+  provider()->AddEthereumChain(
       R"({"params": [{
         "chainId": "0x111",
         "chainName": "Binance1 Smart Chain",
@@ -165,21 +202,14 @@ TEST_F(BraveWalletProviderImplUnitTest, OnAddEthereumChain) {
             callback_is_called = true;
           }));
   ASSERT_FALSE(callback_is_called);
-  provider_impl.OnAddEthereumChain("0x111", false);
+  provider()->OnAddEthereumChain("0x111", false);
   ASSERT_TRUE(callback_is_called);
 }
 
 TEST_F(BraveWalletProviderImplUnitTest,
        OnAddEthereumChainRequestCompletedError) {
-  brave_wallet::EthJsonRpcController controller(shared_url_loader_factory(),
-                                                prefs());
-  BraveWalletProviderImpl provider_impl(
-      controller.MakeRemote(),
-      std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
-          web_contents(), web_contents()->GetMainFrame()),
-      prefs());
   int callback_is_called = 0;
-  provider_impl.AddEthereumChain(
+  provider()->AddEthereumChain(
       R"({"params": [{
         "chainId": "0x111",
         "chainName": "Binance1 Smart Chain",
@@ -195,41 +225,193 @@ TEST_F(BraveWalletProviderImplUnitTest,
             callback_is_called++;
           }));
   EXPECT_EQ(callback_is_called, 0);
-  provider_impl.OnAddEthereumChainRequestCompleted("0x111", "test message");
+  provider()->OnAddEthereumChainRequestCompleted("0x111", "test message");
   EXPECT_EQ(callback_is_called, 1);
-  provider_impl.OnAddEthereumChainRequestCompleted("0x111", "test message");
+  provider()->OnAddEthereumChainRequestCompleted("0x111", "test message");
   EXPECT_EQ(callback_is_called, 1);
 }
 
+TEST_F(BraveWalletProviderImplUnitTest, AddUnapprovedTransaction) {
+  // This makes sure the state manager gets the chain ID
+  browser_task_environment_.RunUntilIdle();
+  bool callback_called = false;
+  std::string tx_meta_id;
+  NavigateAndAddEthereumPermission();
+  provider()->AddUnapprovedTransaction(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      from(),
+      base::BindLambdaForTesting([&](bool success, const std::string& id,
+                                     const std::string& error_message) {
+        EXPECT_TRUE(success);
+        EXPECT_FALSE(id.empty());
+        EXPECT_TRUE(error_message.empty());
+        callback_called = true;
+        tx_meta_id = id;
+      }));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+
+  // Make sure the transaction info is available
+  callback_called = false;
+  eth_tx_controller()->GetAllTransactionInfo(
+      from(),
+      base::BindLambdaForTesting([&](std::vector<mojom::TransactionInfoPtr> v) {
+        ASSERT_EQ(v.size(), 1UL);
+        EXPECT_TRUE(
+            base::EqualsCaseInsensitiveASCII(v[0]->from_address, from()));
+        CHECK_EQ(v[0]->tx_status, mojom::TransactionStatus::Unapproved);
+        CHECK_EQ(v[0]->id, tx_meta_id);
+        callback_called = true;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+}
+
+TEST_F(BraveWalletProviderImplUnitTest, AddUnapprovedTransactionError) {
+  // This makes sure the state manager gets the chain ID
+  browser_task_environment_.RunUntilIdle();
+
+  // We don't need to check every error type since that is checked by
+  // eth_tx_controller_unittest but make sure an error type is handled
+  // correctly.
+  bool callback_called = false;
+  NavigateAndAddEthereumPermission();
+  provider()->AddUnapprovedTransaction(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
+                         // Bad address
+                         "0xbe8", "0x016345785d8a0000", std::vector<uint8_t>()),
+      from(),
+      base::BindLambdaForTesting([&](bool success, const std::string& id,
+                                     const std::string& error_message) {
+        EXPECT_FALSE(success);
+        EXPECT_TRUE(id.empty());
+        EXPECT_FALSE(error_message.empty());
+        callback_called = true;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+}
+
+TEST_F(BraveWalletProviderImplUnitTest, AddUnapprovedTransactionNoPermission) {
+  // This makes sure the state manager gets the chain ID
+  browser_task_environment_.RunUntilIdle();
+
+  // We don't need to check every error type since that is checked by
+  // eth_tx_controller_unittest but make sure an error type is handled
+  // correctly.
+  bool callback_called = false;
+  provider()->AddUnapprovedTransaction(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      "0xbe862ad9abfe6f22bcb087716c7d89a26051f74d",
+      base::BindLambdaForTesting([&](bool success, const std::string& id,
+                                     const std::string& error_message) {
+        EXPECT_FALSE(success);
+        EXPECT_TRUE(id.empty());
+        EXPECT_FALSE(error_message.empty());
+        callback_called = true;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+}
+
+TEST_F(BraveWalletProviderImplUnitTest, AddUnapproved1559Transaction) {
+  // This makes sure the state manager gets the chain ID
+  browser_task_environment_.RunUntilIdle();
+  bool callback_called = false;
+  std::string tx_meta_id;
+  NavigateAndAddEthereumPermission();
+  provider()->AddUnapproved1559Transaction(
+      mojom::TxData1559::New(
+          mojom::TxData::New("0x00", "", "0x00",
+                             "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                             "0x00", std::vector<uint8_t>()),
+          "0x04", "0x0", "0x0"),
+      from(),
+      base::BindLambdaForTesting([&](bool success, const std::string& id,
+                                     const std::string& error_message) {
+        EXPECT_TRUE(success);
+        EXPECT_FALSE(id.empty());
+        EXPECT_TRUE(error_message.empty());
+        callback_called = true;
+        tx_meta_id = id;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+
+  // Make sure the transaction info is available
+  callback_called = false;
+  eth_tx_controller()->GetAllTransactionInfo(
+      from(),
+      base::BindLambdaForTesting([&](std::vector<mojom::TransactionInfoPtr> v) {
+        ASSERT_EQ(v.size(), 1UL);
+        EXPECT_TRUE(
+            base::EqualsCaseInsensitiveASCII(v[0]->from_address, from()));
+        CHECK_EQ(v[0]->tx_status, mojom::TransactionStatus::Unapproved);
+        CHECK_EQ(v[0]->id, tx_meta_id);
+        callback_called = true;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+}
+
+TEST_F(BraveWalletProviderImplUnitTest, AddUnapproved1559TransactionError) {
+  // This makes sure the state manager gets the chain ID
+  browser_task_environment_.RunUntilIdle();
+
+  // We don't need to check every error type since that is checked by
+  // eth_tx_controller_unittest but make sure an error type is handled
+  // correctly.
+  bool callback_called = false;
+  NavigateAndAddEthereumPermission();
+  provider()->AddUnapproved1559Transaction(
+      mojom::TxData1559::New(
+          // Can't specify both gas price and max fee per gas
+          mojom::TxData::New("0x00", "0x01", "0x00",
+                             "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                             "0x00", std::vector<uint8_t>()),
+          "0x04", "0x0", "0x0"),
+      from(),
+      base::BindLambdaForTesting([&](bool success, const std::string& id,
+                                     const std::string& error_message) {
+        EXPECT_FALSE(success);
+        EXPECT_TRUE(id.empty());
+        EXPECT_FALSE(error_message.empty());
+        callback_called = true;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
+}
+
 TEST_F(BraveWalletProviderImplUnitTest,
-       OnAddEthereumChainRequestCompletedSuccess) {
-  brave_wallet::EthJsonRpcController controller(shared_url_loader_factory(),
-                                                prefs());
-  BraveWalletProviderImpl provider_impl(
-      controller.MakeRemote(),
-      std::make_unique<brave_wallet::BraveWalletProviderDelegateImpl>(
-          web_contents(), web_contents()->GetMainFrame()),
-      prefs());
-  int callback_is_called = 0;
-  provider_impl.AddEthereumChain(
-      R"({"params": [{
-        "chainId": "0x111",
-        "chainName": "Binance1 Smart Chain",
-        "rpcUrls": ["https://bsc-dataseed.binance.org/"]
-      }]})",
-      base::BindLambdaForTesting(
-          [&callback_is_called](bool success, int error_code,
-                                const std::string& error_message) {
-            base::Value empty;
-            EXPECT_EQ(error_code, 0);
-            ASSERT_TRUE(error_message.empty());
-            callback_is_called++;
-          }));
-  EXPECT_EQ(callback_is_called, 0);
-  provider_impl.OnAddEthereumChainRequestCompleted("0x111", "");
-  EXPECT_EQ(callback_is_called, 1);
-  provider_impl.OnAddEthereumChainRequestCompleted("0x111", "");
-  EXPECT_EQ(callback_is_called, 1);
+       AddUnapproved1559TransactionNoPermission) {
+  // This makes sure the state manager gets the chain ID
+  browser_task_environment_.RunUntilIdle();
+
+  // We don't need to check every error type since that is checked by
+  // eth_tx_controller_unittest but make sure an error type is handled
+  // correctly.
+  bool callback_called = false;
+  provider()->AddUnapproved1559Transaction(
+      mojom::TxData1559::New(
+          // Can't specify both gas price and max fee per gas
+          mojom::TxData::New("0x00", "0x01", "0x00",
+                             "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                             "0x00", std::vector<uint8_t>()),
+          "0x04", "0x0", "0x0"),
+      "0xbe862ad9abfe6f22bcb087716c7d89a26051f74d",
+      base::BindLambdaForTesting([&](bool success, const std::string& id,
+                                     const std::string& error_message) {
+        EXPECT_FALSE(success);
+        EXPECT_TRUE(id.empty());
+        EXPECT_FALSE(error_message.empty());
+        callback_called = true;
+      }));
+  browser_task_environment_.RunUntilIdle();
+  EXPECT_EQ(callback_called, true);
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -261,8 +261,8 @@ TEST_F(BraveWalletProviderImplUnitTest, AddUnapprovedTransaction) {
         ASSERT_EQ(v.size(), 1UL);
         EXPECT_TRUE(
             base::EqualsCaseInsensitiveASCII(v[0]->from_address, from()));
-        CHECK_EQ(v[0]->tx_status, mojom::TransactionStatus::Unapproved);
-        CHECK_EQ(v[0]->id, tx_meta_id);
+        EXPECT_EQ(v[0]->tx_status, mojom::TransactionStatus::Unapproved);
+        EXPECT_EQ(v[0]->id, tx_meta_id);
         callback_called = true;
       }));
   browser_task_environment_.RunUntilIdle();
@@ -298,9 +298,6 @@ TEST_F(BraveWalletProviderImplUnitTest, AddUnapprovedTransactionNoPermission) {
   // This makes sure the state manager gets the chain ID
   browser_task_environment_.RunUntilIdle();
 
-  // We don't need to check every error type since that is checked by
-  // eth_tx_controller_unittest but make sure an error type is handled
-  // correctly.
   bool callback_called = false;
   provider()->AddUnapprovedTransaction(
       mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
@@ -350,8 +347,8 @@ TEST_F(BraveWalletProviderImplUnitTest, AddUnapproved1559Transaction) {
         ASSERT_EQ(v.size(), 1UL);
         EXPECT_TRUE(
             base::EqualsCaseInsensitiveASCII(v[0]->from_address, from()));
-        CHECK_EQ(v[0]->tx_status, mojom::TransactionStatus::Unapproved);
-        CHECK_EQ(v[0]->id, tx_meta_id);
+        EXPECT_EQ(v[0]->tx_status, mojom::TransactionStatus::Unapproved);
+        EXPECT_EQ(v[0]->id, tx_meta_id);
         callback_called = true;
       }));
   browser_task_environment_.RunUntilIdle();
@@ -391,14 +388,10 @@ TEST_F(BraveWalletProviderImplUnitTest,
   // This makes sure the state manager gets the chain ID
   browser_task_environment_.RunUntilIdle();
 
-  // We don't need to check every error type since that is checked by
-  // eth_tx_controller_unittest but make sure an error type is handled
-  // correctly.
   bool callback_called = false;
   provider()->AddUnapproved1559Transaction(
       mojom::TxData1559::New(
-          // Can't specify both gas price and max fee per gas
-          mojom::TxData::New("0x00", "0x01", "0x00",
+          mojom::TxData::New("0x00", "", "0x00",
                              "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
                              "0x00", std::vector<uint8_t>()),
           "0x04", "0x0", "0x0"),

--- a/components/brave_wallet/browser/eip1559_transaction.cc
+++ b/components/brave_wallet/browser/eip1559_transaction.cc
@@ -14,7 +14,8 @@
 
 namespace brave_wallet {
 
-Eip1559Transaction::Eip1559Transaction() {
+Eip1559Transaction::Eip1559Transaction()
+    : max_priority_fee_per_gas_(0), max_fee_per_gas_(0) {
   type_ = 2;
 }
 
@@ -51,8 +52,8 @@ bool Eip1559Transaction::operator==(const Eip1559Transaction& tx) const {
 absl::optional<Eip1559Transaction> Eip1559Transaction::FromTxData(
     const mojom::TxData1559Ptr& tx_data1559,
     bool strict) {
-  uint256_t chain_id;
-  if (!HexValueToUint256(tx_data1559->chain_id, &chain_id))
+  uint256_t chain_id = 0;
+  if (!HexValueToUint256(tx_data1559->chain_id, &chain_id) && strict)
     return absl::nullopt;
 
   absl::optional<Eip2930Transaction> tx_2930 =
@@ -60,12 +61,14 @@ absl::optional<Eip1559Transaction> Eip1559Transaction::FromTxData(
   if (!tx_2930)
     return absl::nullopt;
 
-  uint256_t max_priority_fee_per_gas;
+  uint256_t max_priority_fee_per_gas = 0;
   if (!HexValueToUint256(tx_data1559->max_priority_fee_per_gas,
-                         &max_priority_fee_per_gas))
+                         &max_priority_fee_per_gas) &&
+      strict)
     return absl::nullopt;
-  uint256_t max_fee_per_gas;
-  if (!HexValueToUint256(tx_data1559->max_fee_per_gas, &max_fee_per_gas))
+  uint256_t max_fee_per_gas = 0;
+  if (!HexValueToUint256(tx_data1559->max_fee_per_gas, &max_fee_per_gas) &&
+      strict)
     return absl::nullopt;
 
   Eip1559Transaction tx(tx_2930->nonce(), tx_2930->gas_price(),

--- a/components/brave_wallet/browser/eip1559_transaction.cc
+++ b/components/brave_wallet/browser/eip1559_transaction.cc
@@ -49,13 +49,14 @@ bool Eip1559Transaction::operator==(const Eip1559Transaction& tx) const {
 
 // static
 absl::optional<Eip1559Transaction> Eip1559Transaction::FromTxData(
-    const mojom::TxData1559Ptr& tx_data1559) {
+    const mojom::TxData1559Ptr& tx_data1559,
+    bool strict) {
   uint256_t chain_id;
   if (!HexValueToUint256(tx_data1559->chain_id, &chain_id))
     return absl::nullopt;
 
   absl::optional<Eip2930Transaction> tx_2930 =
-      Eip2930Transaction::FromTxData(tx_data1559->base_data, chain_id);
+      Eip2930Transaction::FromTxData(tx_data1559->base_data, chain_id, strict);
   if (!tx_2930)
     return absl::nullopt;
 

--- a/components/brave_wallet/browser/eip1559_transaction.h
+++ b/components/brave_wallet/browser/eip1559_transaction.h
@@ -21,7 +21,8 @@ class Eip1559Transaction : public Eip2930Transaction {
   bool operator==(const Eip1559Transaction&) const;
 
   static absl::optional<Eip1559Transaction> FromTxData(
-      const mojom::TxData1559Ptr& tx_data);
+      const mojom::TxData1559Ptr& tx_data,
+      bool strict = true);
   static absl::optional<Eip1559Transaction> FromValue(const base::Value& value);
 
   uint256_t max_priority_fee_per_gas() const {

--- a/components/brave_wallet/browser/eip2930_transaction.cc
+++ b/components/brave_wallet/browser/eip2930_transaction.cc
@@ -55,7 +55,7 @@ Eip2930Transaction::Eip2930Transaction(uint256_t nonce,
       chain_id_(chain_id) {
   type_ = 1;
 }
-Eip2930Transaction::Eip2930Transaction() {
+Eip2930Transaction::Eip2930Transaction() : chain_id_(0) {
   type_ = 1;
 }
 Eip2930Transaction::~Eip2930Transaction() = default;

--- a/components/brave_wallet/browser/eip2930_transaction.cc
+++ b/components/brave_wallet/browser/eip2930_transaction.cc
@@ -69,9 +69,10 @@ bool Eip2930Transaction::operator==(const Eip2930Transaction& tx) const {
 // static
 absl::optional<Eip2930Transaction> Eip2930Transaction::FromTxData(
     const mojom::TxDataPtr& tx_data,
-    uint256_t chain_id) {
+    uint256_t chain_id,
+    bool strict) {
   absl::optional<EthTransaction> legacy_tx =
-      EthTransaction::FromTxData(tx_data);
+      EthTransaction::FromTxData(tx_data, strict);
   if (!legacy_tx)
     return absl::nullopt;
   return Eip2930Transaction(legacy_tx->nonce(), legacy_tx->gas_price(),

--- a/components/brave_wallet/browser/eip2930_transaction.h
+++ b/components/brave_wallet/browser/eip2930_transaction.h
@@ -38,7 +38,8 @@ class Eip2930Transaction : public EthTransaction {
   bool operator==(const Eip2930Transaction&) const;
 
   static absl::optional<Eip2930Transaction> FromTxData(const mojom::TxDataPtr&,
-                                                       uint256_t chain_id);
+                                                       uint256_t chain_id,
+                                                       bool strict = true);
   static absl::optional<Eip2930Transaction> FromValue(const base::Value& value);
 
   static std::vector<base::Value> AccessListToValue(const AccessList&);

--- a/components/brave_wallet/browser/eip2930_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eip2930_transaction_unittest.cc
@@ -209,4 +209,44 @@ TEST(Eip2930TransactionUnitTest, GetBaseFee) {
   EXPECT_EQ(tx3.GetBaseFee(), fee3);
 }
 
+TEST(Eip2930TransactionUnitTest, FromTxData) {
+  auto tx = Eip2930Transaction::FromTxData(
+      mojom::TxData::New("0x01", "0x3E8", "0x989680",
+                         "0x3535353535353535353535353535353535353535", "0x2A",
+                         std::vector<uint8_t>{1}),
+      1);
+  ASSERT_TRUE(tx);
+  EXPECT_EQ(tx->nonce(), uint256_t(1));
+  EXPECT_EQ(tx->gas_price(), uint256_t(1000));
+  EXPECT_EQ(tx->gas_limit(), uint256_t(10000000));
+  EXPECT_EQ(tx->to(),
+            EthAddress::FromHex("0x3535353535353535353535353535353535353535"));
+  EXPECT_EQ(tx->value(), uint256_t(42));
+  EXPECT_EQ(tx->data(), std::vector<uint8_t>{1});
+  EXPECT_EQ(tx->chain_id(), uint256_t(1));
+
+  // Simplified just test cases since EthTransaction has detailed tests for a
+  // single missing value
+  EXPECT_FALSE(Eip2930Transaction::FromTxData(
+      mojom::TxData::New("", "0x3E8", "0x989680",
+                         "0x3535353535353535353535353535353535353535", "0x2A",
+                         std::vector<uint8_t>{1}),
+      0));
+
+  // But missing data is allowed when strict is false
+  tx = Eip2930Transaction::FromTxData(
+      mojom::TxData::New("", "0x3E8", "",
+                         "0x3535353535353535353535353535353535353535", "",
+                         std::vector<uint8_t>{1}),
+      1, false);
+  ASSERT_TRUE(tx);
+  // Unspecified value defaults to 0
+  EXPECT_EQ(tx->nonce(), uint256_t(0));
+  EXPECT_EQ(tx->gas_limit(), uint256_t(0));
+  EXPECT_EQ(tx->value(), uint256_t(0));
+  // you can still get at other data that is specified
+  EXPECT_EQ(tx->gas_price(), uint256_t(1000));
+  EXPECT_EQ(tx->chain_id(), uint256_t(1));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_transaction.cc
+++ b/components/brave_wallet/browser/eth_transaction.cc
@@ -23,7 +23,9 @@ constexpr uint256_t kTxDataZeroCostPerByte = 4;
 constexpr uint256_t kTxDataCostPerByte = 16;
 }  // namespace
 
-EthTransaction::EthTransaction() = default;
+EthTransaction::EthTransaction()
+    : nonce_(0), gas_price_(0), gas_limit_(0), value_(0) {}
+
 EthTransaction::EthTransaction(const EthTransaction&) = default;
 EthTransaction::EthTransaction(uint256_t nonce,
                                uint256_t gas_price,

--- a/components/brave_wallet/browser/eth_transaction.cc
+++ b/components/brave_wallet/browser/eth_transaction.cc
@@ -49,16 +49,17 @@ bool EthTransaction::operator==(const EthTransaction& tx) const {
 
 // static
 absl::optional<EthTransaction> EthTransaction::FromTxData(
-    const mojom::TxDataPtr& tx_data) {
+    const mojom::TxDataPtr& tx_data,
+    bool strict) {
   EthTransaction tx;
-  if (!HexValueToUint256(tx_data->nonce, &tx.nonce_))
+  if (!HexValueToUint256(tx_data->nonce, &tx.nonce_) && strict)
     return absl::nullopt;
-  if (!HexValueToUint256(tx_data->gas_price, &tx.gas_price_))
+  if (!HexValueToUint256(tx_data->gas_price, &tx.gas_price_) && strict)
     return absl::nullopt;
-  if (!HexValueToUint256(tx_data->gas_limit, &tx.gas_limit_))
+  if (!HexValueToUint256(tx_data->gas_limit, &tx.gas_limit_) && strict)
     return absl::nullopt;
   tx.to_ = EthAddress::FromHex(tx_data->to);
-  if (!HexValueToUint256(tx_data->value, &tx.value_))
+  if (!HexValueToUint256(tx_data->value, &tx.value_) && strict)
     return absl::nullopt;
   tx.data_ = tx_data->data;
   return tx;

--- a/components/brave_wallet/browser/eth_transaction.h
+++ b/components/brave_wallet/browser/eth_transaction.h
@@ -32,7 +32,8 @@ class EthTransaction {
   bool operator==(const EthTransaction&) const;
 
   static absl::optional<EthTransaction> FromTxData(
-      const mojom::TxDataPtr& tx_data);
+      const mojom::TxDataPtr& tx_data,
+      bool strict = true);
   static absl::optional<EthTransaction> FromValue(const base::Value& value);
 
   uint8_t type() const { return type_; }

--- a/components/brave_wallet/browser/eth_transaction_unittest.cc
+++ b/components/brave_wallet/browser/eth_transaction_unittest.cc
@@ -219,4 +219,60 @@ TEST(EthTransactionUnitTest, GetUpFrontCost) {
   EXPECT_EQ(tx.GetUpfrontCost(), uint256_t(10000000042));
 }
 
+TEST(EthTransactionUnitTest, FromTxData) {
+  auto tx = EthTransaction::FromTxData(mojom::TxData::New(
+      "0x01", "0x3E8", "0x989680", "0x3535353535353535353535353535353535353535",
+      "0x2A", std::vector<uint8_t>{1}));
+  ASSERT_TRUE(tx);
+  EXPECT_EQ(tx->nonce(), uint256_t(1));
+  EXPECT_EQ(tx->gas_price(), uint256_t(1000));
+  EXPECT_EQ(tx->gas_limit(), uint256_t(10000000));
+  EXPECT_EQ(tx->to(),
+            EthAddress::FromHex("0x3535353535353535353535353535353535353535"));
+  EXPECT_EQ(tx->value(), uint256_t(42));
+  EXPECT_EQ(tx->data(), std::vector<uint8_t>{1});
+
+  // Missing values should not parse correctly
+  EXPECT_FALSE(EthTransaction::FromTxData(mojom::TxData::New(
+      "", "0x3E8", "0x989680", "0x3535353535353535353535353535353535353535",
+      "0x2A", std::vector<uint8_t>{1})));
+  EXPECT_FALSE(EthTransaction::FromTxData(mojom::TxData::New(
+      "0x01", "", "0x989680", "0x3535353535353535353535353535353535353535",
+      "0x2A", std::vector<uint8_t>{1})));
+  EXPECT_FALSE(EthTransaction::FromTxData(mojom::TxData::New(
+      "0x01", "0x3E8", "", "0x3535353535353535353535353535353535353535", "0x2A",
+      std::vector<uint8_t>{1})));
+  EXPECT_FALSE(EthTransaction::FromTxData(mojom::TxData::New(
+      "0x01", "0x3E8", "0x989680", "0x3535353535353535353535353535353535353535",
+      "", std::vector<uint8_t>{1})));
+
+  // But missing data is allowed when strict is false
+  tx = EthTransaction::FromTxData(
+      mojom::TxData::New("", "0x3E8", "",
+                         "0x3535353535353535353535353535353535353535", "",
+                         std::vector<uint8_t>{1}),
+      false);
+  ASSERT_TRUE(tx);
+  // Unspecified value defaults to 0
+  EXPECT_EQ(tx->nonce(), uint256_t(0));
+  EXPECT_EQ(tx->gas_limit(), uint256_t(0));
+  EXPECT_EQ(tx->value(), uint256_t(0));
+  // you can still get at other data that is specified
+  EXPECT_EQ(tx->gas_price(), uint256_t(1000));
+
+  // And try for missing gas_price too since the last test didn't try that
+  tx = EthTransaction::FromTxData(
+      mojom::TxData::New("0x1", "", "0x989680",
+                         "0x3535353535353535353535353535353535353535", "0x2A",
+                         std::vector<uint8_t>{1}),
+      false);
+  ASSERT_TRUE(tx);
+  // Unspecified value defaults to 0
+  EXPECT_EQ(tx->gas_price(), uint256_t(0));
+  // you can still get at other data that is specified
+  EXPECT_EQ(tx->nonce(), uint256_t(1));
+  EXPECT_EQ(tx->value(), uint256_t(42));
+  EXPECT_EQ(tx->gas_limit(), uint256_t(10000000));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_tx_controller.cc
+++ b/components/brave_wallet/browser/eth_tx_controller.cc
@@ -25,19 +25,6 @@
 namespace brave_wallet {
 
 // static
-void EthTxController::FixMissingTxData(mojom::TxDataPtr* tx_data) {
-  CHECK(tx_data);
-  if ((*tx_data)->value.empty())
-    (*tx_data)->value = "0x00";
-}
-
-// static
-void EthTxController::FixMissingTxData1559(mojom::TxData1559Ptr* tx_data) {
-  CHECK(tx_data);
-  FixMissingTxData(&(*tx_data)->base_data);
-}
-
-// static
 bool EthTxController::ValidateTxData(const mojom::TxDataPtr& tx_data,
                                      std::string* error) {
   CHECK(error);
@@ -146,7 +133,6 @@ void EthTxController::AddUnapprovedTransaction(
     mojom::TxDataPtr tx_data,
     const std::string& from,
     AddUnapprovedTransactionCallback callback) {
-  FixMissingTxData(&tx_data);
   if (from.empty()) {
     std::move(callback).Run(
         false, "",
@@ -185,7 +171,6 @@ void EthTxController::AddUnapproved1559Transaction(
     mojom::TxData1559Ptr tx_data,
     const std::string& from,
     AddUnapproved1559TransactionCallback callback) {
-  FixMissingTxData1559(&tx_data);
   if (from.empty()) {
     std::move(callback).Run(
         false, "",

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -68,8 +68,6 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
   void AddObserver(
       ::mojo::PendingRemote<mojom::EthTxControllerObserver> observer) override;
 
-  static void FixMissingTxData(mojom::TxDataPtr* tx_data);
-  static void FixMissingTxData1559(mojom::TxData1559Ptr* tx_data);
   static bool ValidateTxData(const mojom::TxDataPtr& tx_data,
                              std::string* error);
   static bool ValidateTxData1559(const mojom::TxData1559Ptr& tx_data,

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -68,6 +68,13 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
   void AddObserver(
       ::mojo::PendingRemote<mojom::EthTxControllerObserver> observer) override;
 
+  static void FixMissingTxData(mojom::TxDataPtr* tx_data);
+  static void FixMissingTxData1559(mojom::TxData1559Ptr* tx_data);
+  static bool ValidateTxData(const mojom::TxDataPtr& tx_data,
+                             std::string* error);
+  static bool ValidateTxData1559(const mojom::TxData1559Ptr& tx_data,
+                                 std::string* error);
+
  private:
   void NotifyTransactionStatusChanged(EthTxStateManager::TxMeta* meta);
   void OnConnectionError();

--- a/components/brave_wallet/browser/eth_tx_controller_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_controller_unittest.cc
@@ -1,0 +1,99 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/eth_tx_controller.h"
+
+#include <vector>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_wallet {
+
+TEST(EthTxControllerUnitTest, FixMissingTxData) {
+  auto tx_data = mojom::TxData::New(
+      "0x06", "0x09184e72a000", "0x0974",
+      "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c", "", std::vector<uint8_t>());
+  EthTxController::FixMissingTxData(&tx_data);
+  CHECK_EQ(tx_data->value, "0x00");
+}
+
+TEST(EthTxControllerUnitTest, FixMissingTxData1559) {
+  auto tx_data = mojom::TxData1559::New(
+      mojom::TxData::New("0x00", "", "0x00",
+                         "0x0101010101010101010101010101010101010101", "0x00",
+                         std::vector<uint8_t>()),
+      "0x04", "0x0", "0x1");
+  EthTxController::FixMissingTxData1559(&tx_data);
+  CHECK_EQ(tx_data->base_data->value, "0x00");
+}
+
+TEST(EthTxControllerUnitTest, ValidateTxData) {
+  std::string error_message;
+  EXPECT_TRUE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      &error_message));
+
+  // Make sure if params are specified that they are valid hex strings
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("hello", "0x09184e72a000", "0x0974",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      &error_message));
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "hello", "0x0974",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      &error_message));
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "0x09184e72a000", "hello",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      &error_message));
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974", "hello",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      &error_message));
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
+                         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c", "hello",
+                         std::vector<uint8_t>()),
+      &error_message));
+  // to must not only be a valid hex string but also an address
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974",
+                         "0xbe",  // Invalid address
+                         "hello", std::vector<uint8_t>()),
+      &error_message));
+
+  // To can't be missing if Data is missing
+  EXPECT_FALSE(EthTxController::ValidateTxData(
+      mojom::TxData::New("0x06", "0x09184e72a000", "0x0974", "",
+                         "0x016345785d8a0000", std::vector<uint8_t>()),
+      &error_message));
+}
+
+TEST(EthTxControllerUnitTest, ValidateTxData1559) {
+  std::string error_message;
+  EXPECT_TRUE(EthTxController::ValidateTxData1559(
+      mojom::TxData1559::New(
+          mojom::TxData::New("0x00", "", "0x00",
+                             "0x0101010101010101010101010101010101010101",
+                             "0x00", std::vector<uint8_t>()),
+          "0x04", "0x0", "0x1"),
+      &error_message));
+
+  // Can't specify both gas price and max fee per gas
+  EXPECT_FALSE(EthTxController::ValidateTxData1559(
+      mojom::TxData1559::New(
+          mojom::TxData::New("0x00", "0x1", "0x00",
+                             "0x0101010101010101010101010101010101010101",
+                             "0x00", std::vector<uint8_t>()),
+          "0x04", "0x0", "0x1"),
+      &error_message));
+}
+
+}  //  namespace brave_wallet

--- a/components/brave_wallet/browser/eth_tx_controller_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_controller_unittest.cc
@@ -11,24 +11,6 @@
 
 namespace brave_wallet {
 
-TEST(EthTxControllerUnitTest, FixMissingTxData) {
-  auto tx_data = mojom::TxData::New(
-      "0x06", "0x09184e72a000", "0x0974",
-      "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c", "", std::vector<uint8_t>());
-  EthTxController::FixMissingTxData(&tx_data);
-  CHECK_EQ(tx_data->value, "0x00");
-}
-
-TEST(EthTxControllerUnitTest, FixMissingTxData1559) {
-  auto tx_data = mojom::TxData1559::New(
-      mojom::TxData::New("0x00", "", "0x00",
-                         "0x0101010101010101010101010101010101010101", "0x00",
-                         std::vector<uint8_t>()),
-      "0x04", "0x0", "0x1");
-  EthTxController::FixMissingTxData1559(&tx_data);
-  CHECK_EQ(tx_data->base_data->value, "0x00");
-}
-
 TEST(EthTxControllerUnitTest, ValidateTxData) {
   std::string error_message;
   EXPECT_TRUE(EthTxController::ValidateTxData(

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -28,6 +28,7 @@ namespace brave_wallet {
 class HDKeyring;
 class EthTransaction;
 class KeyringControllerUnitTest;
+class BraveWalletProviderImplUnitTest;
 
 // This class is not thread-safe and should have single owner
 class KeyringController : public KeyedService, public mojom::KeyringController {
@@ -163,6 +164,7 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest,
                            SetDefaultKeyringDerivedAccountName);
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest, RestoreLegacyBraveWallet);
+  friend class BraveWalletProviderImplUnitTest;
 
   void AddAccountForDefaultKeyring(const std::string& account_name);
 

--- a/components/brave_wallet/browser/test/BUILD.gn
+++ b/components/brave_wallet/browser/test/BUILD.gn
@@ -26,6 +26,7 @@ source_set("brave_wallet_unit_tests") {
       "//brave/components/brave_wallet/browser/eth_requests_unittest.cc",
       "//brave/components/brave_wallet/browser/eth_response_parser_unittest.cc",
       "//brave/components/brave_wallet/browser/eth_transaction_unittest.cc",
+      "//brave/components/brave_wallet/browser/eth_tx_controller_unittest.cc",
       "//brave/components/brave_wallet/browser/ethereum_permission_utils_unittest.cc",
       "//brave/components/brave_wallet/browser/hd_key_unittest.cc",
       "//brave/components/brave_wallet/browser/hd_keyring_unittest.cc",

--- a/components/brave_wallet/browser/test/BUILD.gn
+++ b/components/brave_wallet/browser/test/BUILD.gn
@@ -42,7 +42,6 @@ source_set("brave_wallet_unit_tests") {
       "//brave/components/brave_wallet/browser:ethereum_permission_utils",
       "//brave/components/brave_wallet/common",
       "//brave/components/brave_wallet/common:mojom",
-      "//brave/components/brave_wallet/renderer/test:brave_wallet_response_unit_tests",
       "//components/prefs",
       "//components/prefs:test_support",
       "//components/sync_preferences:test_support",

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -18,6 +18,8 @@ interface BraveWalletProvider {
   Request(string json_payload, bool auto_retry_on_network_change) => (int32 http_code, string response, map<string, string> headers);
   RequestEthereumPermissions() => (bool success, array<string> accounts);
   AddEthereumChain(string json_payload) => (bool success, int32 error, string message);
+  AddUnapprovedTransaction(TxData tx_data, string from) => (bool success, string tx_meta_id, string error_message);
+  AddUnapproved1559Transaction(TxData1559 tx_data, string from) => (bool success, string tx_meta_id, string error_message);
   GetChainId() => (string chain_id);
   GetAllowedAccounts() => (bool success, array<string> accounts);
 };
@@ -314,8 +316,8 @@ interface EthTxControllerObserver {
 };
 
 interface EthTxController {
-  AddUnapprovedTransaction(TxData tx_data, string from) => (bool success, string tx_meta_id);
-  AddUnapproved1559Transaction(TxData1559 tx_data, string from) => (bool success, string tx_meta_id);
+  AddUnapprovedTransaction(TxData tx_data, string from) => (bool success, string tx_meta_id, string error_message);
+  AddUnapproved1559Transaction(TxData1559 tx_data, string from) => (bool success, string tx_meta_id, string error_message);
   ApproveTransaction(string tx_meta_id) => (bool status);
   RejectTransaction(string tx_meta_id) => (bool status);
   MakeERC20TransferData(string to_address, string amount) => (bool success, array<uint8> data);

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -32,6 +32,7 @@ enum class ProviderErrors {
 
 constexpr char kEthAccounts[] = "eth_accounts";
 constexpr char kEthRequestAccounts[] = "eth_requestAccounts";
+constexpr char kEthSendTransaction[] = "eth_sendTransaction";
 constexpr char kMethod[] = "method";
 constexpr char kParams[] = "params";
 constexpr char kAddEthereumChainMethod[] = "wallet_addEthereumChain";

--- a/components/brave_wallet/renderer/BUILD.gn
+++ b/components/brave_wallet/renderer/BUILD.gn
@@ -4,6 +4,8 @@ source_set("renderer") {
     "brave_wallet_js_handler.h",
     "brave_wallet_response_helpers.cc",
     "brave_wallet_response_helpers.h",
+    "eth_request_parser.cc",
+    "eth_request_parser.h",
   ]
 
   deps = [

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -16,6 +16,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "brave/components/brave_wallet/renderer/brave_wallet_response_helpers.h"
+#include "brave/components/brave_wallet/renderer/eth_request_parser.h"
 #include "brave/components/brave_wallet/resources/grit/brave_wallet_script_generated.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/v8_value_converter.h"
@@ -25,8 +26,6 @@
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
 #include "ui/base/resource/resource_bundle.h"
-
-#include "brave/components/brave_wallet/renderer/eth_request_parser.h"
 
 namespace {
 
@@ -192,6 +191,42 @@ void OnAddEthereumChain(v8::Global<v8::Promise::Resolver> promise_resolver,
         brave_wallet::ToProviderResponse(nullptr, error_response.get());
     v8::Local<v8::Value> result =
         content::V8ValueConverter::Create()->ToV8Value(response.get(), context);
+    ALLOW_UNUSED_LOCAL(resolver->Reject(context, result));
+  }
+}
+
+void OnAddUnapprovedTransaction(
+    v8::Global<v8::Promise::Resolver> promise_resolver,
+    v8::Isolate* isolate,
+    v8::Global<v8::Context> context_old,
+    bool success,
+    const std::string& tx_meta_id,
+    const std::string& error_message) {
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context = context_old.Get(isolate);
+  v8::Context::Scope context_scope(context);
+  v8::MicrotasksScope microtasks(isolate,
+                                 v8::MicrotasksScope::kDoNotRunMicrotasks);
+  // TODO(bbondy): Should return the transaction hash, or the zero hash
+  // if the transaction is not yet available
+  std::unique_ptr<base::Value> response;
+  if (success) {
+    base::Value value("0x0");
+    response = brave_wallet::ToProviderResponse(&value, nullptr);
+  } else {
+    auto error_response = FormProviderResponse(
+        brave_wallet::ProviderErrors::kInvalidParams, error_message);
+    response = brave_wallet::ToProviderResponse(nullptr, error_response.get());
+  }
+
+  v8::Local<v8::Value> result;
+  result =
+      content::V8ValueConverter::Create()->ToV8Value(response.get(), context);
+
+  v8::Local<v8::Promise::Resolver> resolver = promise_resolver.Get(isolate);
+  if (success) {
+    ALLOW_UNUSED_LOCAL(resolver->Resolve(context, result));
+  } else {
     ALLOW_UNUSED_LOCAL(resolver->Reject(context, result));
   }
 }
@@ -410,8 +445,7 @@ v8::Local<v8::Promise> BraveWalletJSHandler::Request(
 
     brave_wallet_provider_->AddUnapprovedTransaction(
         std::move(tx_data), from,
-        base::BindOnce(&BraveWalletJSHandler::OnAddUnapprovedTransaction,
-                       base::Unretained(this), std::move(promise_resolver),
+        base::BindOnce(&OnAddUnapprovedTransaction, std::move(promise_resolver),
                        isolate, std::move(context_old)));
   } else {
     std::string formed_input;
@@ -428,42 +462,6 @@ v8::Local<v8::Promise> BraveWalletJSHandler::Request(
   }
 
   return resolver.ToLocalChecked()->GetPromise();
-}
-
-void BraveWalletJSHandler::OnAddUnapprovedTransaction(
-    v8::Global<v8::Promise::Resolver> promise_resolver,
-    v8::Isolate* isolate,
-    v8::Global<v8::Context> context_old,
-    bool success,
-    const std::string& tx_meta_id,
-    const std::string& error_message) {
-  v8::HandleScope handle_scope(isolate);
-  v8::Local<v8::Context> context = context_old.Get(isolate);
-  v8::Context::Scope context_scope(context);
-  v8::MicrotasksScope microtasks(isolate,
-                                 v8::MicrotasksScope::kDoNotRunMicrotasks);
-  // TODO(bbondy): Should return the transaction hash, or the zero hash
-  // if the transaction is not yet available
-  std::unique_ptr<base::Value> response;
-  if (success) {
-    base::Value value("0x0");
-    response = brave_wallet::ToProviderResponse(&value, nullptr);
-  } else {
-    auto error_response =
-        FormProviderResponse(ProviderErrors::kInvalidParams, error_message);
-    response = brave_wallet::ToProviderResponse(nullptr, error_response.get());
-  }
-
-  v8::Local<v8::Value> result;
-  result =
-      content::V8ValueConverter::Create()->ToV8Value(response.get(), context);
-
-  v8::Local<v8::Promise::Resolver> resolver = promise_resolver.Get(isolate);
-  if (success) {
-    ALLOW_UNUSED_LOCAL(resolver->Resolve(context, result));
-  } else {
-    ALLOW_UNUSED_LOCAL(resolver->Reject(context, result));
-  }
 }
 
 void BraveWalletJSHandler::OnRequest(

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -71,13 +71,7 @@ class BraveWalletJSHandler : public mojom::EventsListener {
                    const int http_code,
                    const std::string& response,
                    const base::flat_map<std::string, std::string>& headers);
-  void OnAddUnapprovedTransaction(
-      v8::Global<v8::Promise::Resolver> promise_resolver,
-      v8::Isolate* isolate,
-      v8::Global<v8::Context> context_old,
-      bool success,
-      const std::string& meta_tx_id,
-      const std::string& error_message);
+
   content::RenderFrame* render_frame_;
   mojo::Remote<mojom::BraveWalletProvider> brave_wallet_provider_;
   mojo::Receiver<mojom::EventsListener> receiver_{this};

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -71,7 +71,13 @@ class BraveWalletJSHandler : public mojom::EventsListener {
                    const int http_code,
                    const std::string& response,
                    const base::flat_map<std::string, std::string>& headers);
-
+  void OnAddUnapprovedTransaction(
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate,
+      v8::Global<v8::Context> context_old,
+      bool success,
+      const std::string& meta_tx_id,
+      const std::string& error_message);
   content::RenderFrame* render_frame_;
   mojo::Remote<mojom::BraveWalletProvider> brave_wallet_provider_;
   mojo::Receiver<mojom::EventsListener> receiver_{this};

--- a/components/brave_wallet/renderer/eth_request_parser.cc
+++ b/components/brave_wallet/renderer/eth_request_parser.cc
@@ -1,0 +1,122 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/renderer/eth_request_parser.h"
+
+#include <utility>
+#include <vector>
+
+#include "base/json/json_reader.h"
+#include "base/logging.h"
+#include "base/strings/string_number_conversions.h"
+#include "brave/components/brave_wallet/common/web3_provider_constants.h"
+
+namespace brave_wallet {
+
+absl::optional<base::Value> GetObjectFromParamsList(const std::string& json) {
+  auto json_value = base::JSONReader::Read(json);
+  if (!json_value || !json_value->is_dict())
+    return absl::nullopt;
+
+  const base::Value* params = json_value->FindListPath(brave_wallet::kParams);
+  if (!params || !params->is_list())
+    return absl::nullopt;
+  const auto list = params->GetList();
+  if (list.size() != 1 || !list.front().is_dict())
+    return absl::nullopt;
+
+  return list.front().Clone();
+}
+
+// This is a best effort parsing of the data
+mojom::TxDataPtr ValueToTxData(const base::Value& tx_value,
+                               std::string* from_out) {
+  CHECK(from_out);
+  auto tx_data = mojom::TxData::New();
+  const base::DictionaryValue* params_dict = nullptr;
+  if (!tx_value.GetAsDictionary(&params_dict) || !params_dict)
+    return nullptr;
+
+  const std::string* from = params_dict->FindStringKey("from");
+  if (from)
+    *from_out = *from;
+
+  const std::string* to = params_dict->FindStringKey("to");
+  if (to)
+    tx_data->to = *to;
+
+  const std::string* gas = params_dict->FindStringKey("gas");
+  if (gas)
+    tx_data->gas_limit = *gas;
+
+  const std::string* gas_price = params_dict->FindStringKey("gasPrice");
+  if (gas_price)
+    tx_data->gas_price = *gas_price;
+
+  const std::string* value = params_dict->FindStringKey("value");
+  if (value)
+    tx_data->value = *value;
+
+  const std::string* data = params_dict->FindStringKey("data");
+  if (data) {
+    // If data is specified it's best to make sure it's valid
+    if (data->length() <= 2 || data->substr(0, 2) != "0x")
+      return nullptr;
+    std::string hex_substr = data->substr(2);
+    std::vector<uint8_t> bytes;
+    // HexStringToBytes needs an even number of bytes
+    if (hex_substr.length() % 2 == 1)
+      hex_substr = "0" + hex_substr;
+    if (!base::HexStringToBytes(hex_substr, &bytes))
+      return nullptr;
+    tx_data->data = bytes;
+  }
+
+  return tx_data;
+}
+
+mojom::TxDataPtr ParseEthSendTransactionParams(const std::string& json,
+                                               std::string* from) {
+  CHECK(from);
+  from->clear();
+
+  auto param_obj = GetObjectFromParamsList(json);
+  if (!param_obj)
+    return nullptr;
+  return brave_wallet::ValueToTxData(*param_obj, from);
+}
+
+mojom::TxData1559Ptr ParseEthSendTransaction1559Params(const std::string& json,
+                                                       std::string* from) {
+  CHECK(from);
+  from->clear();
+  auto param_obj = GetObjectFromParamsList(json);
+  if (!param_obj)
+    return nullptr;
+
+  auto tx_data = mojom::TxData1559::New();
+  auto base_data_ret = brave_wallet::ValueToTxData(*param_obj, from);
+  if (!base_data_ret)
+    return nullptr;
+
+  tx_data->base_data = std::move(base_data_ret);
+  const base::DictionaryValue* params_dict = nullptr;
+  if (!param_obj->GetAsDictionary(&params_dict) || !params_dict)
+    return nullptr;
+
+  const std::string* max_priority_fee_per_gas =
+      params_dict->FindStringKey("maxPriorityFeePerGas");
+  if (max_priority_fee_per_gas)
+    tx_data->max_priority_fee_per_gas = *max_priority_fee_per_gas;
+
+  const std::string* max_fee_per_gas =
+      params_dict->FindStringKey("maxFeePerGas");
+  if (max_fee_per_gas)
+    tx_data->max_fee_per_gas = *max_fee_per_gas;
+
+  return tx_data;
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/renderer/eth_request_parser.cc
+++ b/components/brave_wallet/renderer/eth_request_parser.cc
@@ -9,11 +9,10 @@
 #include <vector>
 
 #include "base/json/json_reader.h"
-#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
 
-namespace brave_wallet {
+namespace {
 
 absl::optional<base::Value> GetObjectFromParamsList(const std::string& json) {
   auto json_value = base::JSONReader::Read(json);
@@ -31,10 +30,10 @@ absl::optional<base::Value> GetObjectFromParamsList(const std::string& json) {
 }
 
 // This is a best effort parsing of the data
-mojom::TxDataPtr ValueToTxData(const base::Value& tx_value,
-                               std::string* from_out) {
+brave_wallet::mojom::TxDataPtr ValueToTxData(const base::Value& tx_value,
+                                             std::string* from_out) {
   CHECK(from_out);
-  auto tx_data = mojom::TxData::New();
+  auto tx_data = brave_wallet::mojom::TxData::New();
   const base::DictionaryValue* params_dict = nullptr;
   if (!tx_value.GetAsDictionary(&params_dict) || !params_dict)
     return nullptr;
@@ -77,6 +76,10 @@ mojom::TxDataPtr ValueToTxData(const base::Value& tx_value,
   return tx_data;
 }
 
+}  // namespace
+
+namespace brave_wallet {
+
 mojom::TxDataPtr ParseEthSendTransactionParams(const std::string& json,
                                                std::string* from) {
   CHECK(from);
@@ -85,7 +88,7 @@ mojom::TxDataPtr ParseEthSendTransactionParams(const std::string& json,
   auto param_obj = GetObjectFromParamsList(json);
   if (!param_obj)
     return nullptr;
-  return brave_wallet::ValueToTxData(*param_obj, from);
+  return ValueToTxData(*param_obj, from);
 }
 
 mojom::TxData1559Ptr ParseEthSendTransaction1559Params(const std::string& json,
@@ -97,7 +100,7 @@ mojom::TxData1559Ptr ParseEthSendTransaction1559Params(const std::string& json,
     return nullptr;
 
   auto tx_data = mojom::TxData1559::New();
-  auto base_data_ret = brave_wallet::ValueToTxData(*param_obj, from);
+  auto base_data_ret = ValueToTxData(*param_obj, from);
   if (!base_data_ret)
     return nullptr;
 

--- a/components/brave_wallet/renderer/eth_request_parser.h
+++ b/components/brave_wallet/renderer/eth_request_parser.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_RENDERER_ETH_REQUEST_PARSER_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_RENDERER_ETH_REQUEST_PARSER_H_
+
+#include <string>
+
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+
+namespace brave_wallet {
+
+mojom::TxDataPtr ParseEthSendTransactionParams(const std::string& json,
+                                               std::string* from);
+mojom::TxData1559Ptr ParseEthSendTransaction1559Params(const std::string& json,
+                                                       std::string* from);
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_RENDERER_ETH_REQUEST_PARSER_H_

--- a/components/brave_wallet/renderer/eth_request_parser_unittest.cc
+++ b/components/brave_wallet/renderer/eth_request_parser_unittest.cc
@@ -26,22 +26,22 @@ TEST(EthRequestParserUnitTest, ParseEthSendTransactionParams) {
       })");
   std::string from;
   mojom::TxDataPtr tx_data = ParseEthSendTransactionParams(json, &from);
-  ASSERT_TRUE(!!tx_data);
-  CHECK_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
-  CHECK_EQ(tx_data->to, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
-  CHECK_EQ(tx_data->gas_limit, "0x146");
-  CHECK_EQ(tx_data->gas_price, "0x123");
-  CHECK_EQ(tx_data->value, "0x25F38E9E0000000");
-  ASSERT_EQ(tx_data->data, (std::vector<uint8_t>{1, 2, 3}));
+  ASSERT_TRUE(tx_data);
+  EXPECT_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  EXPECT_EQ(tx_data->to, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
+  EXPECT_EQ(tx_data->gas_limit, "0x146");
+  EXPECT_EQ(tx_data->gas_price, "0x123");
+  EXPECT_EQ(tx_data->value, "0x25F38E9E0000000");
+  EXPECT_EQ(tx_data->data, (std::vector<uint8_t>{1, 2, 3}));
 
   // Invalid things to pass in for parsing
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("not json data", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[{},{}]}", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[0]}", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("{}", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("[]", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("[[]]", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("[0]", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("not json data", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("{\"params\":[{},{}]}", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("{\"params\":[0]}", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("{}", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("[]", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("[[]]", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("[0]", &from));
 }
 
 TEST(EthResponseParserUnitTest, ParseEthSendTransaction1559Params) {
@@ -59,16 +59,16 @@ TEST(EthResponseParserUnitTest, ParseEthSendTransaction1559Params) {
       })");
   std::string from;
   mojom::TxData1559Ptr tx_data = ParseEthSendTransaction1559Params(json, &from);
-  ASSERT_TRUE(!!tx_data);
-  CHECK_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
-  CHECK_EQ(tx_data->base_data->to,
-           "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
-  CHECK_EQ(tx_data->base_data->gas_limit, "0x146");
-  CHECK_EQ(tx_data->base_data->gas_price.empty(), true);
-  CHECK_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
-  ASSERT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
-  CHECK_EQ(tx_data->max_priority_fee_per_gas, "0x1");
-  CHECK_EQ(tx_data->max_fee_per_gas, "0x2");
+  ASSERT_TRUE(tx_data);
+  EXPECT_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  EXPECT_EQ(tx_data->base_data->to,
+            "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
+  EXPECT_EQ(tx_data->base_data->gas_limit, "0x146");
+  EXPECT_EQ(tx_data->base_data->gas_price.empty(), true);
+  EXPECT_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
+  EXPECT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_EQ(tx_data->max_priority_fee_per_gas, "0x1");
+  EXPECT_EQ(tx_data->max_fee_per_gas, "0x2");
 
   json =
       R"({
@@ -81,27 +81,27 @@ TEST(EthResponseParserUnitTest, ParseEthSendTransaction1559Params) {
         }]
       })";
   tx_data = ParseEthSendTransaction1559Params(json, &from);
-  ASSERT_TRUE(!!tx_data);
-  CHECK_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
-  CHECK_EQ(tx_data->base_data->to,
-           "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
-  CHECK_EQ(tx_data->base_data->gas_limit, "0x146");
-  CHECK_EQ(tx_data->base_data->gas_price.empty(), true);
-  CHECK_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
-  ASSERT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
+  ASSERT_TRUE(tx_data);
+  EXPECT_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  EXPECT_EQ(tx_data->base_data->to,
+            "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
+  EXPECT_EQ(tx_data->base_data->gas_limit, "0x146");
+  EXPECT_EQ(tx_data->base_data->gas_price.empty(), true);
+  EXPECT_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
+  EXPECT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
   // Allowed to parse without these fields, the client should determine
   // reasonable values in this case.
   EXPECT_TRUE(tx_data->max_priority_fee_per_gas.empty());
   EXPECT_TRUE(tx_data->max_fee_per_gas.empty());
 
   // Invalid things to pass in for parsing
-  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("not json data", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[{},{}]}", &from));
-  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[0]}", &from));
-  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("{}", &from));
-  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("[]", &from));
-  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("[[]]", &from));
-  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("[0]", &from));
+  EXPECT_FALSE(ParseEthSendTransaction1559Params("not json data", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("{\"params\":[{},{}]}", &from));
+  EXPECT_FALSE(ParseEthSendTransactionParams("{\"params\":[0]}", &from));
+  EXPECT_FALSE(ParseEthSendTransaction1559Params("{}", &from));
+  EXPECT_FALSE(ParseEthSendTransaction1559Params("[]", &from));
+  EXPECT_FALSE(ParseEthSendTransaction1559Params("[[]]", &from));
+  EXPECT_FALSE(ParseEthSendTransaction1559Params("[0]", &from));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/renderer/eth_request_parser_unittest.cc
+++ b/components/brave_wallet/renderer/eth_request_parser_unittest.cc
@@ -1,0 +1,107 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "brave/components/brave_wallet/renderer/eth_request_parser.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_wallet {
+
+TEST(EthRequestParserUnitTest, ParseEthSendTransactionParams) {
+  std::string json(
+      R"({
+        "params": [{
+          "from": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8",
+          "to": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7",
+          "gas": "0x146",
+          "gasPrice": "0x123",
+          "value": "0x25F38E9E0000000",
+          "data": "0x010203"
+        }]
+      })");
+  std::string from;
+  mojom::TxDataPtr tx_data = ParseEthSendTransactionParams(json, &from);
+  ASSERT_TRUE(!!tx_data);
+  CHECK_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  CHECK_EQ(tx_data->to, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
+  CHECK_EQ(tx_data->gas_limit, "0x146");
+  CHECK_EQ(tx_data->gas_price, "0x123");
+  CHECK_EQ(tx_data->value, "0x25F38E9E0000000");
+  ASSERT_EQ(tx_data->data, (std::vector<uint8_t>{1, 2, 3}));
+
+  // Invalid things to pass in for parsing
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("not json data", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[{},{}]}", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[0]}", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("{}", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("[]", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("[[]]", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("[0]", &from));
+}
+
+TEST(EthResponseParserUnitTest, ParseEthSendTransaction1559Params) {
+  std::string json(
+      R"({
+        "params": [{
+          "from": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8",
+          "to": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7",
+          "gas": "0x146",
+          "value": "0x25F38E9E0000000",
+          "data": "0x010203",
+          "maxPriorityFeePerGas": "0x1",
+          "maxFeePerGas": "0x2"
+        }]
+      })");
+  std::string from;
+  mojom::TxData1559Ptr tx_data = ParseEthSendTransaction1559Params(json, &from);
+  ASSERT_TRUE(!!tx_data);
+  CHECK_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  CHECK_EQ(tx_data->base_data->to,
+           "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
+  CHECK_EQ(tx_data->base_data->gas_limit, "0x146");
+  CHECK_EQ(tx_data->base_data->gas_price.empty(), true);
+  CHECK_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
+  ASSERT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
+  CHECK_EQ(tx_data->max_priority_fee_per_gas, "0x1");
+  CHECK_EQ(tx_data->max_fee_per_gas, "0x2");
+
+  json =
+      R"({
+        "params": [{
+          "from": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8",
+          "to": "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7",
+          "gas": "0x146",
+          "value": "0x25F38E9E0000000",
+          "data": "0x010203"
+        }]
+      })";
+  tx_data = ParseEthSendTransaction1559Params(json, &from);
+  ASSERT_TRUE(!!tx_data);
+  CHECK_EQ(from, "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C8");
+  CHECK_EQ(tx_data->base_data->to,
+           "0x7f84E0DfF3ffd0af78770cF86c1b1DdFF99d51C7");
+  CHECK_EQ(tx_data->base_data->gas_limit, "0x146");
+  CHECK_EQ(tx_data->base_data->gas_price.empty(), true);
+  CHECK_EQ(tx_data->base_data->value, "0x25F38E9E0000000");
+  ASSERT_EQ(tx_data->base_data->data, (std::vector<uint8_t>{1, 2, 3}));
+  // Allowed to parse without these fields, the client should determine
+  // reasonable values in this case.
+  EXPECT_TRUE(tx_data->max_priority_fee_per_gas.empty());
+  EXPECT_TRUE(tx_data->max_fee_per_gas.empty());
+
+  // Invalid things to pass in for parsing
+  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("not json data", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[{},{}]}", &from));
+  EXPECT_FALSE(!!ParseEthSendTransactionParams("{\"params\":[0]}", &from));
+  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("{}", &from));
+  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("[]", &from));
+  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("[[]]", &from));
+  EXPECT_FALSE(!!ParseEthSendTransaction1559Params("[0]", &from));
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/renderer/test/BUILD.gn
+++ b/components/brave_wallet/renderer/test/BUILD.gn
@@ -6,7 +6,7 @@
 import("//brave/build/config.gni")
 import("//testing/test.gni")
 
-source_set("brave_wallet_response_unit_tests") {
+source_set("unit_tests") {
   testonly = true
   sources = [
     "//brave/components/brave_wallet/renderer/brave_wallet_response_helpers_unittest.cc",
@@ -25,4 +25,4 @@ source_set("brave_wallet_response_unit_tests") {
     "//third_party/blink/public/common",
     "//v8",
   ]
-}  # source_set("brave_wallet_response_unit_tests")
+}  # source_set("unit_tests")

--- a/components/brave_wallet/renderer/test/BUILD.gn
+++ b/components/brave_wallet/renderer/test/BUILD.gn
@@ -8,7 +8,10 @@ import("//testing/test.gni")
 
 source_set("brave_wallet_response_unit_tests") {
   testonly = true
-  sources = [ "//brave/components/brave_wallet/renderer/brave_wallet_response_helpers_unittest.cc" ]
+  sources = [
+    "//brave/components/brave_wallet/renderer/brave_wallet_response_helpers_unittest.cc",
+    "//brave/components/brave_wallet/renderer/eth_request_parser_unittest.cc",
+  ]
 
   deps = [
     "//base",

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -433,11 +433,13 @@ export class TxData1559 {
 export interface AddUnapprovedTransactionReturnInfo {
   success: boolean
   txMetaId: string
+  errorMessage: string
 }
 
 export interface AddUnapproved1559TransactionReturnInfo {
   success: boolean
   txMetaId: string
+  errorMessage: string
 }
 
 export interface ApproveTransactionReturnInfo {

--- a/components/permissions/contexts/brave_ethereum_permission_context.cc
+++ b/components/permissions/contexts/brave_ethereum_permission_context.cc
@@ -205,12 +205,12 @@ void BraveEthereumPermissionContext::GetAllowedAccounts(
     GURL sub_request_origin;
     bool success =
         brave_wallet::GetSubRequestOrigin(origin, address, &sub_request_origin);
-    DCHECK(success);
-
-    PermissionResult result = permission_manager->GetPermissionStatusForFrame(
-        ContentSettingsType::BRAVE_ETHEREUM, rfh, sub_request_origin);
-    if (result.content_setting == CONTENT_SETTING_ALLOW) {
-      allowed_accounts.push_back(address);
+    if (success) {
+      PermissionResult result = permission_manager->GetPermissionStatusForFrame(
+          ContentSettingsType::BRAVE_ETHEREUM, rfh, sub_request_origin);
+      if (result.content_setting == CONTENT_SETTING_ALLOW) {
+        allowed_accounts.push_back(address);
+      }
     }
   }
 

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -10,5 +10,19 @@
     <message name="IDS_WALLET_CHAIN_EXISTS" desc="The text of the response for wallet_addEthereumChain call with existing chain id">This Chain ID is currently used</message>
     <message name="IDS_WALLET_INTERNAL_ERROR" desc="The text of the response for wallet_addEthereumChain call with internal error">An internal error has occurred</message>
     <message name="IDS_WALLET_ALREADY_IN_PROGRESS_ERROR" desc="The text of the response for wallet_addEthereumChain call for existing request">A request is already in progress</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_NO_TX_DATA" desc="The text of the response for eth_sendTransaction">Transaction data is missing</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_FROM_NOT_AUTHED" desc="The text of the response for eth_sendTransaction">'from' is not authorized to send transactions</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_TO_OR_DATA" desc="Transaction data is not validated">Transaction data 'to' or 'data' must be specified</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_NONCE_INVALID" desc="Transaction data is not validated">Transaction data 'nonce' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GAS_PRICE_INVALID" desc="Transaction data is not validated">Transaction data 'gasPrice' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GAS_LIMIT_INVALID" desc="Transaction data is not validated">Transaction data 'gas' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_VALUE_INVALID" desc="Transaction data is not validated">Transaction data 'value' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_TO_INVALID" desc="Transaction data is not validated">Transaction data 'to' must be a valid address when specified</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GAS_PRICING_EXISTS" desc="Transaction data is not validated">Transaction data 'gasPrice' or 'maxFeePerGas' must be specified</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_CHAIN_ID_INVALID" desc="Transaction data is not validated">Transaction data 'chainId' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_MAX_FEE_PER_GAS_INVALID" desc="Transaction data is not validated">Transaction data 'maxFeePerGas' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_MAX_PRIORITY_FEE_PER_GAS_INVALID" desc="Transaction data is not validated">Transaction data 'maxPriorityFeePerGas' is not valid</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_CONVERT_TX_DATA" desc="Transaction data is not validated">Could not convert transaction data</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_FROM_EMPTY" desc="Transaction data is not validated">Transaction data 'from' must be specified</message>
   </if>
 </grit-part>

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -198,6 +198,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_wallet/browser/test:brave_wallet_unit_tests",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/brave_wallet/common/test:brave_wallet_common_unit_tests",
+    "//brave/components/brave_wallet/renderer/test:unit_tests",
     "//brave/components/child_process_monitor:unittests",
     "//brave/components/ipfs/buildflags",
     "//brave/components/ipfs/test:brave_ipfs_unit_tests",


### PR DESCRIPTION
This adds the ability for window.ethereum.request to be able to initiate an approve transaction UI. 
This is accomplished by support `eth_sendTransaction`.

No transaction can be added in an approved state, so I didn't mark this for a security review. 

If you'd like to try it you can put this code in an html file and serve it from an https site. I used some python code for that which I found online with `python ./server.py`. Then I added a fake host name to my hosts file because there was a problem with window.ethereum.enable from localhost (not diagnosed yet)

```
# taken from http://www.piware.de/2011/01/creating-an-https-server-in-python/
# generate server.xml with the following command:
#    openssl req -new -x509 -keyout server.pem -out server.pem -days 365 -nodes
# run as follows:
#    python simple-https-server.py
# then in your browser, visit:
#    https://localhost:4443

import BaseHTTPServer, SimpleHTTPServer
import ssl

httpd = BaseHTTPServer.HTTPServer(('localhost', 4443), SimpleHTTPServer.SimpleHTTPRequestHandler)
httpd.socket = ssl.wrap_socket (httpd.socket, certfile='./server.pem', server_side=True)
httpd.serve_forever()
```

```
<html>
  <script>
  const sendTransaction = ({ to, gasPrice }) =>
  new Promise((resolve, reject) => {
    if (window.ethereum) {
      const ethereum = window.ethereum;
      try {
        ethereum.enable().then(accounts => {
          const from = accounts[0];
          const params = {
            from,
            to,
            gasPrice: "0x25F38E9E",
            gas: "0x25F38E9E",
            value: "0x25F38E9E0000000",
            //value: "0x00",
            //data: "0x0",
            //maxPriorityFeePergas: "0x1",
            //maxPriorityFeePerGas: "0x1234005500061",
            //maxFeePerGas: "0x21232132001000"
          }
          console.log('params: ', params)
          window.ethereum.request({
              method: 'eth_sendTransaction',
              params: [params]
          }).then((a, b) => {
                    console.log('a: ', a)
                    console.log('b: ', b)
          })
        });
      } catch (error) {
        reject(error);
      }
    } else {
      console.log(
        "Non-Ethereum browser detected. You should consider trying MetaMask!"
      );
    }
  });

    sendTransaction({to: '0x37cc7fb2e9DD5673d759fb1e2ddd0D29fAcb1413', gasPrice: '0x25F38E9E00'})

</script>
</html>

```

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18108

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

