### PR TITLE
speedreader: Improve description truncation

### DIFF
--- a/components/speedreader/rust/lib/src/readability/src/lib.rs
+++ b/components/speedreader/rust/lib/src/readability/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 pub mod dom;
 pub mod error;
 pub mod extractor;
+mod nlp;
 pub mod scorer;
 pub mod statistics;
 mod util;

--- a/components/speedreader/rust/lib/src/readability/src/nlp.rs
+++ b/components/speedreader/rust/lib/src/readability/src/nlp.rs
@@ -1,0 +1,121 @@
+use regex::{Regex, RegexSet};
+use std::cmp::max;
+use std::collections::HashSet;
+
+// A list of common abbreviations
+static EN_ABBREVIATIONS_LIST: [&str; 80] = [
+    "abbr.", "Acad.", "alt.", "A.D.", "A.M.", "apt.", "Assn.", "Aug.", "Ave.", "B.A.", "B.S.",
+    "B.C.", "Blvd.", "Capt.", "ctr.", "cent.", "Col.", "Cpl.", "Corp.", "Ct.", "D.C.", "Dr.",
+    "Dr.", "ed.", "etc.", "Feb.", "ft.", "Ft.", "gal.", "Gen.", "Gov.", "hwy.", "e.g.", "i.e.",
+    "in.", "inc.", "Jan.", "Jr.", "Lk.", "Ln.", "lib.", "lat.", "lib.", "Lt.", "Ltd.", "long.",
+    "M.D.", "Mr.", "Msgr.", "mo.", "mt.", "mus.", "Nov.", "no.", "Oct.", "oz.", "p.", "pt.", "pl.",
+    "pop.", "P.M.", "Prof.", "qt.", "Rd.", "R.N.", "Sept.", "Sgt.", "Sr.", "Sta.", "St.", "ste.",
+    "Sun.", "Ter.", "Tpk.", "Univ.", "U.S.", "U.S.A.", "vol.", "wt.", "EE.UU.",
+];
+
+lazy_static! {
+    // MAX_ABBREVIATION_LEN is the maximum size we consider for an abbreviation.
+    pub static ref MAX_ABBREVIATION_LEN: usize = EN_ABBREVIATIONS_LIST
+        .iter()
+        .fold(0, |m, x| return max(m, x.chars().count()));
+    static ref EN_ABBREVIATIONS: HashSet<&'static str> =
+        EN_ABBREVIATIONS_LIST.iter().cloned().collect();
+    static ref POSSIBLE_SENTENCE_BOUNDARIES: Regex = Regex::new(r"[\S^(.?!)]+[.?!] ").unwrap();
+    static ref ABBREVIATION_HEURISTICS: RegexSet = RegexSet::new(&[
+        r"^\p{Uppercase}\p{Lowercase}\.$",
+        r"^\p{Uppercase}\.(?:\p{Uppercase}\.)?$",
+    ]).unwrap();
+}
+
+/// Determines if a slice is an abbreviation by checking a list of common abbreviations and some
+/// simple heuristics.
+#[inline]
+pub fn is_abbreviation(s: &str) -> bool {
+    let len = s.chars().count();
+    if len > *MAX_ABBREVIATION_LEN {
+        false
+    } else {
+        EN_ABBREVIATIONS.contains(s) || ABBREVIATION_HEURISTICS.is_match(s)
+    }
+}
+
+/// Looks for the first sentence boundary
+pub fn first_sentence_boundary(s: &str) -> Option<usize> {
+    for m in POSSIBLE_SENTENCE_BOUNDARIES.find_iter(&s) {
+        let byte_offset = m.end() - 1;
+        if m.as_str().ends_with(". ") {
+            if !is_abbreviation(&m.as_str().trim_end()) {
+                return Some(byte_offset);
+            }
+        } else {
+            return Some(byte_offset);
+        }
+    }
+    None
+}
+
+#[macro_use]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_abbreviation_len() {
+        // Sanity check. Need to change this if extending list size.
+        assert_eq!(*MAX_ABBREVIATION_LEN, 6);
+    }
+
+    #[test]
+    fn test_is_abbreviation() {
+        // In the set
+        assert!(is_abbreviation("Sr."));
+        assert!(is_abbreviation("Nov."));
+        assert!(is_abbreviation("P.M."));
+        assert!(is_abbreviation("e.g."));
+
+        // Not in set, matches first heuristic
+        assert!(is_abbreviation("Ms."));
+
+        // Not in set, matches second heuristic
+        assert!(is_abbreviation("A."));
+        assert!(is_abbreviation("F.A."));
+
+        // Things that shouldn't match
+        assert!(!is_abbreviation("Baseball."));
+        assert!(!is_abbreviation("Soccer."));
+        assert!(!is_abbreviation("and."));
+        assert!(!is_abbreviation("TH.EN."));
+        assert!(!is_abbreviation("America."));
+        assert!(!is_abbreviation("it."));
+    }
+
+    macro_rules! test_first_sentence_boundary {
+        ($name:ident, $input:expr, $expected:expr) => {
+            #[test]
+            fn $name() {
+                let mut s = $input.to_string();
+                let byte_offset = first_sentence_boundary(&s).unwrap();
+                s.truncate(byte_offset);
+                assert_eq!($expected, s);
+            }
+        };
+    }
+
+    test_first_sentence_boundary!(
+        many_abbreviations,
+        "Dr. Stevens is the best surgeon in the U.S.A. and all of North America. Next sentence here.",
+        "Dr. Stevens is the best surgeon in the U.S.A. and all of North America."
+    );
+
+    test_first_sentence_boundary!(
+        other_punctuation,
+        "Dr. Stevens is the best surgeon in the U.S.A.! Next sentence here.",
+        "Dr. Stevens is the best surgeon in the U.S.A.!"
+    );
+
+    test_first_sentence_boundary!(
+        espanol,
+        "EE.UU. saluda \"cooperación\" de talibanes en nueva evacuación tras su retirada de Afganistán. Eliminar este oración",
+        "EE.UU. saluda \"cooperación\" de talibanes en nueva evacuación tras su retirada de Afganistán."
+    );
+}

--- a/components/speedreader/rust/lib/src/readability/src/nlp.rs
+++ b/components/speedreader/rust/lib/src/readability/src/nlp.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 use std::collections::HashSet;
 
 // A list of common abbreviations
+// Taken from https://www.enchantedlearning.com/abbreviations/
 static EN_ABBREVIATIONS_LIST: [&str; 80] = [
     "abbr.", "Acad.", "alt.", "A.D.", "A.M.", "apt.", "Assn.", "Aug.", "Ave.", "B.A.", "B.S.",
     "B.C.", "Blvd.", "Capt.", "ctr.", "cent.", "Col.", "Cpl.", "Corp.", "Ct.", "D.C.", "Dr.",

--- a/components/speedreader/rust/lib/src/readability/src/scorer.rs
+++ b/components/speedreader/rust/lib/src/readability/src/scorer.rs
@@ -371,7 +371,7 @@ fn unwrap_noscript(handle: &Handle, useless_nodes: &mut Vec<Handle>) -> Option<H
                 useless_nodes.push(sibling.as_node().clone());
             }
         }
-        return Some(img)
+        return Some(img);
     }
     None
 }


### PR DESCRIPTION
For sentences that are more than 200 characters (roughly 3 sentences)
truncate the result at the first sentence. Right now some descriptions
are getting prematurely truncated on abbreviations.

Resolves https://github.com/brave/brave-browser/issues/17983

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

