### PR TITLE
Feature param for custom ad notification dark mode background color.

### DIFF
--- a/browser/ui/views/brave_ads/BUILD.gn
+++ b/browser/ui/views/brave_ads/BUILD.gn
@@ -22,6 +22,8 @@ source_set("brave_ads") {
     "ad_notification_view_factory.h",
     "bounds_util.cc",
     "bounds_util.h",
+    "color_util.cc",
+    "color_util.h",
     "insets_util.cc",
     "insets_util.h",
     "padded_image_button.cc",

--- a/browser/ui/views/brave_ads/ad_notification_popup.cc
+++ b/browser/ui/views/brave_ads/ad_notification_popup.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/ui/views/brave_ads/ad_notification_view.h"
 #include "brave/browser/ui/views/brave_ads/ad_notification_view_factory.h"
 #include "brave/browser/ui/views/brave_ads/bounds_util.h"
+#include "brave/browser/ui/views/brave_ads/color_util.h"
 #include "brave/components/brave_ads/common/features.h"
 #include "brave/components/brave_ads/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
@@ -52,9 +53,6 @@ std::map<std::string, AdNotificationPopup* /* NOT OWNED */>
 
 bool g_disable_fade_in_animation_for_testing = false;
 
-constexpr SkColor kLightModeBackgroundColor = SkColorSetRGB(0xed, 0xf0, 0xf2);
-constexpr SkColor kDarkModeBackgroundColor = SkColorSetRGB(0x20, 0x23, 0x27);
-
 constexpr SkColor kLightModeBorderColor = SkColorSetRGB(0xd5, 0xdb, 0xe2);
 constexpr SkColor kDarkModeBorderColor = SkColorSetRGB(0x3f, 0x41, 0x45);
 constexpr int kBorderThickness = 1;
@@ -81,6 +79,23 @@ class DefaultPopupInstanceFactory
     return new AdNotificationPopup(profile, ad_notification);
   }
 };
+
+SkColor GetLightModeBackgroundColor() {
+  return SkColorSetRGB(0xed, 0xf0, 0xf2);
+}
+
+SkColor GetDarkModeBackgroundColor() {
+  const std::string color_param =
+      features::AdNotificationDarkModeBackgroundColor();
+
+  SkColor bg_color;
+  if (!RgbStringToSkColor(color_param, &bg_color)) {
+    NOTREACHED();
+    return SkColorSetRGB(0x20, 0x23, 0x27);
+  }
+
+  return bg_color;
+}
 
 }  // namespace
 
@@ -257,8 +272,9 @@ void AdNotificationPopup::OnPaintBackground(gfx::Canvas* canvas) {
   // Draw background
   cc::PaintFlags background_flags;
   background_flags.setAntiAlias(true);
-  background_flags.setColor(should_use_dark_colors ? kDarkModeBackgroundColor
-                                                   : kLightModeBackgroundColor);
+  background_flags.setColor(should_use_dark_colors
+                                ? GetDarkModeBackgroundColor()
+                                : GetLightModeBackgroundColor());
   canvas->DrawRoundRect(bounds, kCornerRadius, background_flags);
 }
 

--- a/browser/ui/views/brave_ads/color_util.cc
+++ b/browser/ui/views/brave_ads/color_util.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_ads/color_util.h"
+
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_piece.h"
+
+namespace brave_ads {
+
+bool RgbStringToSkColor(base::StringPiece rgb, SkColor* color) {
+  DCHECK(color);
+
+  // Expect three RGB color components with length == 2, e.g. 42fe4c.
+  constexpr size_t kColorComponentsCount = 3;
+  constexpr size_t kColorComponentLen = 2;
+
+  if (rgb.size() != kColorComponentsCount * kColorComponentLen) {
+    return false;
+  }
+
+  uint32_t components[kColorComponentsCount];
+  for (size_t i = 0; i < kColorComponentsCount; ++i) {
+    const size_t beg = kColorComponentLen * i;
+    uint32_t component = 0;
+    if (!base::HexStringToUInt(rgb.substr(beg, kColorComponentLen),
+                               &component)) {
+      return false;
+    }
+    components[i] = component;
+  }
+
+  *color = SkColorSetRGB(components[0], components[1], components[2]);
+  return true;
+}
+
+}  // namespace brave_ads

--- a/browser/ui/views/brave_ads/color_util.h
+++ b/browser/ui/views/brave_ads/color_util.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_ADS_COLOR_UTIL_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_ADS_COLOR_UTIL_H_
+
+#include "base/strings/string_piece_forward.h"
+#include "third_party/skia/include/core/SkColor.h"
+
+namespace brave_ads {
+
+bool RgbStringToSkColor(base::StringPiece rgb, SkColor* color);
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_ADS_COLOR_UTIL_H_

--- a/browser/ui/views/brave_ads/color_util_unittest.cc
+++ b/browser/ui/views/brave_ads/color_util_unittest.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/brave_ads/color_util.h"
+#include "base/strings/string_piece.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkColor.h"
+
+// npm run test -- brave_unit_tests --filter=ColorUtilTest.*
+
+TEST(ColorUtilTest, CheckRgbStringToSkColor) {
+  SkColor color;
+  EXPECT_TRUE(brave_ads::RgbStringToSkColor("42fe4c", &color));
+  EXPECT_EQ(SkColorSetRGB(0x42, 0xfe, 0x4c), color);
+
+  EXPECT_FALSE(brave_ads::RgbStringToSkColor("", &color));
+  EXPECT_FALSE(brave_ads::RgbStringToSkColor("42fe4", &color));
+  EXPECT_FALSE(brave_ads::RgbStringToSkColor("h2fe4c", &color));
+}

--- a/components/brave_ads/common/features.cc
+++ b/components/brave_ads/common/features.cc
@@ -40,6 +40,12 @@ const char kFieldTrialParameterAdNotificationFadeDuration[] =
     "ad_notification_fade_duration";
 const int kDefaultAdNotificationFadeDuration = 200;
 
+// Ad notification dark mode background color
+const char kFieldTrialParameterAdNotificationDarkModeBackgroundColor[] =
+    "ad_notification_dark_mode_background_color";
+// Default color value is SkColorSetRGB(0x20, 0x23, 0x27);
+const char kDefaultAdNotificationDarkModeBackgroundColor[] = "202327";
+
 // Ad notification normalized display coordinate for the x component should be
 // between 0.0 and 1.0; coordinates outside this range will be adjusted to fit
 // the work area. Set to 0.0 for left, 0.5 for center or 1.0 for right
@@ -122,6 +128,18 @@ int AdNotificationFadeDuration() {
   return GetFieldTrialParamByFeatureAsInt(
       kCustomAdNotifications, kFieldTrialParameterAdNotificationFadeDuration,
       kDefaultAdNotificationFadeDuration);
+}
+
+std::string AdNotificationDarkModeBackgroundColor() {
+  const std::string param_value = GetFieldTrialParamValueByFeature(
+      kCustomAdNotifications,
+      kFieldTrialParameterAdNotificationDarkModeBackgroundColor);
+
+  if (param_value.empty()) {
+    return kDefaultAdNotificationDarkModeBackgroundColor;
+  }
+
+  return param_value;
 }
 
 double AdNotificationNormalizedDisplayCoordinateX() {

--- a/components/brave_ads/common/features.h
+++ b/components/brave_ads/common/features.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_COMMON_FEATURES_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_COMMON_FEATURES_H_
 
+#include <string>
+
 #include "build/build_config.h"
 
 namespace base {
@@ -27,6 +29,7 @@ bool IsCustomAdNotificationsEnabled();
 bool CanFallbackToCustomAdNotifications();
 #if !defined(OS_ANDROID)
 int AdNotificationFadeDuration();
+std::string AdNotificationDarkModeBackgroundColor();
 double AdNotificationNormalizedDisplayCoordinateX();
 int AdNotificationInsetX();
 double AdNotificationNormalizedDisplayCoordinateY();

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -341,6 +341,11 @@ test("brave_unit_tests") {
     ]
   }
 
+  if (toolkit_views) {
+    sources += [ "//brave/browser/ui/views/brave_ads/color_util_unittest.cc" ]
+    deps += [ "//brave/browser/ui/views/brave_ads" ]
+  }
+
   if (binance_enabled) {
     sources +=
         [ "//brave/components/binance/browser/binance_json_parser_unittest.cc" ]


### PR DESCRIPTION
Background color of custom ad notification in dark mode can be set by following:

Feature: CustomAdNotifications
Parameter name: "ad_notification_dark_mode_background_color"
Default value: "202327", where R=20, G=23, B=27 in hexadecimal numeral system.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17528

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

