### PR TITLE
Fix a few missing dependencies

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -37,7 +37,6 @@ static_library("browser") {
     "//brave/app:brave_generated_resources_grit",
     "//brave/browser/notifications",
     "//brave/common",
-    "//brave/components/brave_adaptive_captcha/buildflags:buildflags",
     "//brave/components/brave_ads/common",
     "//brave/components/brave_ads/resources",
     "//brave/components/brave_component_updater/browser",
@@ -47,6 +46,8 @@ static_library("browser") {
     "//brave/components/ntp_background_images/common",
     "//brave/components/rpill/common",
     "//brave/components/services/bat_ads/public/cpp",
+    "//brave/components/services/bat_ads/public/interfaces",
+    "//brave/components/weekly_storage",
     "//chrome/common:buildflags",
     "//components/history/core/browser",
     "//components/history/core/common",
@@ -124,6 +125,8 @@ static_library("browser") {
 
   if (brave_adaptive_captcha_enabled) {
     sources += [ "ads_tooltips_delegate.h" ]
+    deps += [ "//brave/components/brave_adaptive_captcha" ]
+    public_deps += [ "//brave/components/brave_adaptive_captcha/buildflags" ]
   }
 }
 

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -123,10 +123,11 @@ static_library("browser") {
     ]
   }
 
+  public_deps += [ "//brave/components/brave_adaptive_captcha/buildflags" ]
+
   if (brave_adaptive_captcha_enabled) {
     sources += [ "ads_tooltips_delegate.h" ]
     deps += [ "//brave/components/brave_adaptive_captcha" ]
-    public_deps += [ "//brave/components/brave_adaptive_captcha/buildflags" ]
   }
 }
 


### PR DESCRIPTION
Helps address some of https://github.com/brave/brave-browser/issues/17664
Fixes https://github.com/brave/brave-browser/issues/18049

Still a lot of layer violations

Specifically solves these:
```
< ERROR at //brave/components/brave_ads/browser/ads_p2a.cc:15:11: Include not allowed.
< #include "brave/components/weekly_storage/weekly_storage.h"
<           ^-----------------------------------------------
< It is not in any dependency of
<   //brave/components/brave_ads/browser:browser
< The include file is in the target(s):
<   //brave/components/weekly_storage:weekly_storage
< which should somehow be reachable.
< ___________________
< ERROR at //brave/components/brave_ads/browser/ads_service_impl.h:32:11: Can't include this header from here.
< #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
<           ^------------------------------------------------------------------
< The target:
<   //brave/components/brave_ads/browser:browser
< is including a file from the target:
<   //brave/components/services/bat_ads/public/interfaces:interfaces__generator
<
< It's usually best to depend directly on the destination target.
< In some cases, the destination target is considered a subcomponent
< of an intermediate target. In this case, the intermediate target
< should depend publicly on the destination to forward the ability
< to include headers.
<
< Dependency chain (there may also be others):
<   //brave/components/brave_ads/browser:browser -->
<   //brave/components/services/bat_ads/public/cpp:cpp --[private]-->
<   //brave/components/services/bat_ads/public/interfaces:interfaces -->
<   //brave/components/services/bat_ads/public/interfaces:interfaces__generator
<
< ___________________
153,161d122
< ERROR at //brave/components/brave_ads/browser/ads_service_impl.h:45:11: Include not allowed.
< #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h"
<           ^-----------------------------------------------------------------------
< It is not in any dependency of
<   //brave/components/brave_ads/browser:browser
< The include file is in the target(s):
<   //brave/components/brave_adaptive_captcha:brave_adaptive_captcha
< which should somehow be reachable.
< ___________________
239,259d199
< ERROR at //brave/components/brave_ads/browser/ads_service_impl.cc:66:11: Can't include this header from here.
< #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
<           ^------------------------------------------------------------------
< The target:
<   //brave/components/brave_ads/browser:browser
< is including a file from the target:
<   //brave/components/services/bat_ads/public/interfaces:interfaces__generator
<
< It's usually best to depend directly on the destination target.
< In some cases, the destination target is considered a subcomponent
< of an intermediate target. In this case, the intermediate target
< should depend publicly on the destination to forward the ability
< to include headers.
<
< Dependency chain (there may also be others):
<   //brave/components/brave_ads/browser:browser -->
<   //brave/components/services/bat_ads/public/cpp:cpp --[private]-->
<   //brave/components/services/bat_ads/public/interfaces:interfaces -->
<   //brave/components/services/bat_ads/public/interfaces:interfaces__generator
<
< ___________________
412,422c352
<   //third_party/dom_distiller_js:dom_distiller_proto_gen
<
< ___________________
< ERROR at //brave/components/brave_ads/browser/ads_service_impl.cc:111:11: Include not allowed.
< #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h"
<           ^-----------------------------------------------------------------------
< It is not in any dependency of
<   //brave/components/brave_ads/browser:browser
< The include file is in the target(s):
<   //brave/components/brave_adaptive_captcha:brave_adaptive_captcha
< which should somehow be reachable.
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Comment out https://github.com/brave/brave-core/blob/bc9a4a8726ab3fb7887ba8905e7c1af374aca366/components/brave_ads/browser/BUILD.gn#L6
2. Run `npm run gn_check`
3. None of the above violations should be happening anymore