### PR TITLE
Revert "[MacOS][Signing] Revert overwriting Alerts helper app id."

### DIFF
--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -124,6 +124,15 @@ def AddBravePartsForSigning(parts, config):
     parts['helper-app'].options = (CodeSignOptions.RESTRICT
                                    + CodeSignOptions.KILL
                                    + CodeSignOptions.HARDENED_RUNTIME)
+    # Alerts helper is not being distributed with Chrome yet and, because it
+    # uses the same identifier as the current Alerts service, the signing fails.
+    # For now we can set a different identifier and then remove this change once
+    # the helper starts being bundled into the distribution.
+    # Cr94 update: Alrts helper is now distributed with Chrome and the conflicting
+    # XPC Notification service is supposed to be gone, but we still end up with
+    # the signing error. So, let's keep this override and see if it causes any
+    # issues.
+    parts['helper-alerts'].identifier = '{}.helper.alerts'.format(config.base_bundle_id)
 
     return parts
 


### PR DESCRIPTION
This reverts commit e509b8065d68fff6b35cd40373f0784b4585ae12.

Seems like we need to keep the original fix after all, since we are
getting the same signing error again:

<pre>
Brave Browser Nightly.app: nested code is modified or invalid
Brave Browser Nightly.app/Contents/Frameworks/Brave Browser Nightly Framework.framework
file modified: Brave Browser Nightly.app/Contents/Frameworks/Brave Browser Nightly Framework.framework/Versions/Current/Helpers/Brave Browser Nightly Helper (Alerts).app
</pre>

Fixes brave/brave-browser#18099

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

