### PR TITLE
Allow permissions prompt to show up when locked, and open new tab if wallet isn't setup

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -72,7 +72,9 @@ source_set("brave_wallet_delegate") {
     deps += [
       "//brave/browser/brave_wallet",
       "//brave/browser/brave_wallet:tab_helper",
+      "//brave/browser/ui",
       "//brave/components/brave_wallet/common:mojom",
+      "//chrome/browser/ui",
       "//components/content_settings/core/common",
       "//components/permissions",
       "//mojo/public/cpp/bindings",

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
@@ -39,6 +39,8 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate {
       RequestEthereumPermissionsCallback callback) override;
 
   void GetAllowedAccounts(GetAllowedAccountsCallback callback) override;
+  static void SetCallbackForNewSetupNeededForTesting(
+      base::OnceCallback<void()>);
 
  private:
   void EnsureConnected();
@@ -47,6 +49,10 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate {
       RequestEthereumPermissionsCallback callback,
       bool success,
       const std::vector<std::string>& allowed_accounts);
+  void ContinueRequestEthereumPermissionsKeyringInfo(
+      RequestEthereumPermissionsCallback callback,
+      const std::vector<std::string>& allowed_accounts,
+      brave_wallet::mojom::KeyringInfoPtr keyring_info);
 
   mojo::Remote<brave_wallet::mojom::KeyringController> keyring_controller_;
   content::WebContents* web_contents_;

--- a/browser/brave_wallet/keyring_controller_unittest.cc
+++ b/browser/brave_wallet/keyring_controller_unittest.cc
@@ -667,10 +667,10 @@ TEST_F(KeyringControllerUnitTest, AccountMetasForKeyring) {
   const std::string name2 = "Account2";
   const std::string account_path2 = KeyringController::GetAccountPathByIndex(1);
 
-  KeyringController::SetAccountNameForKeyring(GetPrefs(), account_path1, name1,
-                                              "default");
-  KeyringController::SetAccountNameForKeyring(GetPrefs(), account_path2, name2,
-                                              "default");
+  KeyringController::SetAccountMetaForKeyring(GetPrefs(), account_path1, name1,
+                                              address1, "default");
+  KeyringController::SetAccountMetaForKeyring(GetPrefs(), account_path2, name2,
+                                              address2, "default");
 
   const base::Value* account_metas = KeyringController::GetPrefForKeyring(
       GetPrefs(), kAccountMetas, "default");
@@ -685,12 +685,20 @@ TEST_F(KeyringControllerUnitTest, AccountMetasForKeyring) {
   EXPECT_EQ(KeyringController::GetAccountNameForKeyring(
                 GetPrefs(), account_path1, "default"),
             name1);
+  EXPECT_EQ(KeyringController::GetAccountAddressForKeyring(
+                GetPrefs(), account_path1, "default"),
+            address1);
   EXPECT_EQ(KeyringController::GetAccountNameForKeyring(
                 GetPrefs(), account_path2, "default"),
             name2);
+  EXPECT_EQ(KeyringController::GetAccountAddressForKeyring(
+                GetPrefs(), account_path2, "default"),
+            address2);
   EXPECT_EQ(controller.GetAccountMetasNumberForKeyring("default"), 2u);
   EXPECT_EQ(controller.GetAccountMetasNumberForKeyring("keyring1"), 0u);
 
+  // GetAccountInfosForKeyring should work even if the keyring is locked
+  controller.Lock();
   std::vector<mojom::AccountInfoPtr> account_infos =
       controller.GetAccountInfosForKeyring("default");
   EXPECT_EQ(account_infos.size(), 2u);
@@ -1153,7 +1161,7 @@ TEST_F(KeyringControllerUnitTest, GetPrivateKeyForDefaultKeyringAccount) {
   EXPECT_TRUE(callback_called);
 }
 
-TEST_F(KeyringControllerUnitTest, SetDefaultKeyringDerivedAccountName) {
+TEST_F(KeyringControllerUnitTest, SetDefaultKeyringDerivedAccountMeta) {
   KeyringController controller(GetPrefs());
   const std::string kUpdatedName = "Updated";
   bool callback_called = false;
@@ -1176,16 +1184,22 @@ TEST_F(KeyringControllerUnitTest, SetDefaultKeyringDerivedAccountName) {
   const std::string name2 = "Account2";
   const std::string account_path2 = KeyringController::GetAccountPathByIndex(1);
 
-  KeyringController::SetAccountNameForKeyring(GetPrefs(), account_path1, name1,
-                                              "default");
-  KeyringController::SetAccountNameForKeyring(GetPrefs(), account_path2, name2,
-                                              "default");
+  KeyringController::SetAccountMetaForKeyring(GetPrefs(), account_path1, name1,
+                                              address1, "default");
+  KeyringController::SetAccountMetaForKeyring(GetPrefs(), account_path2, name2,
+                                              address2, "default");
   EXPECT_EQ(KeyringController::GetAccountNameForKeyring(
                 GetPrefs(), account_path1, "default"),
             name1);
+  EXPECT_EQ(KeyringController::GetAccountAddressForKeyring(
+                GetPrefs(), account_path1, "default"),
+            address1);
   EXPECT_EQ(KeyringController::GetAccountNameForKeyring(
                 GetPrefs(), account_path2, "default"),
             name2);
+  EXPECT_EQ(KeyringController::GetAccountAddressForKeyring(
+                GetPrefs(), account_path2, "default"),
+            address2);
 
   callback_called = false;
   controller.SetDefaultKeyringDerivedAccountName(

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -45,6 +45,9 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
                                               const std::string& key,
                                               const std::string& id);
   static base::Value* GetPrefForHardwareKeyringUpdate(PrefService* prefs);
+  static base::Value* GetPrefForKeyringUpdate(PrefService* prefs,
+                                              const std::string& key,
+                                              const std::string& id);
   // If keyring dicionary for id doesn't exist, it will be created.
   static void SetPrefForKeyring(PrefService* prefs,
                                 const std::string& key,
@@ -52,13 +55,20 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
                                 const std::string& id);
 
   // Account path will be used as key in kAccountMetas
-  static void SetAccountNameForKeyring(PrefService* prefs,
-                                       const std::string& account_path,
-                                       const std::string& name,
-                                       const std::string& id);
+  static void SetAccountMetaForKeyring(
+      PrefService* prefs,
+      const std::string& account_path,
+      const absl::optional<std::string> name,
+      const absl::optional<std::string> address,
+      const std::string& id);
+
   static std::string GetAccountNameForKeyring(PrefService* prefs,
                                               const std::string& account_path,
                                               const std::string& id);
+  static std::string GetAccountAddressForKeyring(
+      PrefService* prefs,
+      const std::string& account_path,
+      const std::string& id);
 
   static std::string GetAccountPathByIndex(size_t index);
 
@@ -167,7 +177,7 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest,
                            GetPrivateKeyForDefaultKeyringAccount);
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest,
-                           SetDefaultKeyringDerivedAccountName);
+                           SetDefaultKeyringDerivedAccountMeta);
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest, RestoreLegacyBraveWallet);
   friend class BraveWalletProviderImplUnitTest;
 


### PR DESCRIPTION
Before it would give an error and not show a permission prompt if the wallet was already locked.
Now it will show the permission prompt when it is locked.
If the wallet is not setup yet, it will open brave://wallet

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18136

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

