### PR TITLE
Fixes "Ad notifications received this month" and "Estimated earnings" are reset to 0 at midnight UTC time not local time - 1.30.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/ad_rewards.cc
@@ -99,7 +99,7 @@ uint64_t AdRewards::GetAdsReceivedForMonth(const base::Time& time) const {
 
   for (const auto& transaction : transactions) {
     if (transaction.timestamp == 0) {
-      // Workaround for Windows crash when passing 0 to UTCExplode
+      // Workaround for Windows crash when passing 0 to LocalExplode
       continue;
     }
 
@@ -137,7 +137,7 @@ double AdRewards::GetEarningsForMonth(const base::Time& time) const {
 double AdRewards::GetUnclearedEarningsForThisMonth() const {
   const base::Time now = base::Time::Now();
   base::Time::Exploded exploded;
-  now.UTCExplode(&exploded);
+  now.LocalExplode(&exploded);
 
   exploded.day_of_month = 1;
   exploded.hour = 0;
@@ -145,7 +145,7 @@ double AdRewards::GetUnclearedEarningsForThisMonth() const {
   exploded.second = 0;
 
   base::Time from_time;
-  const bool success = base::Time::FromUTCExploded(exploded, &from_time);
+  const bool success = base::Time::FromLocalExploded(exploded, &from_time);
   DCHECK(success);
 
   const int64_t from_timestamp = static_cast<int64_t>(from_time.ToDoubleT());

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/ad_rewards/payments/payments.cc
@@ -347,7 +347,7 @@ PaymentInfo Payments::GetPaymentForTransactionMonth(
 
 std::string Payments::GetTransactionMonth(const base::Time& time) const {
   base::Time::Exploded time_exploded;
-  time.UTCExplode(&time_exploded);
+  time.LocalExplode(&time_exploded);
 
   return GetFormattedTransactionMonth(time_exploded.year, time_exploded.month);
 }
@@ -355,7 +355,7 @@ std::string Payments::GetTransactionMonth(const base::Time& time) const {
 std::string Payments::GetPreviousTransactionMonth(
     const base::Time& time) const {
   base::Time::Exploded time_exploded;
-  time.UTCExplode(&time_exploded);
+  time.LocalExplode(&time_exploded);
 
   time_exploded.month--;
   if (time_exploded.month < 1) {

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/statement/statement.cc
@@ -48,7 +48,7 @@ double Statement::GetEarningsForThisMonth() const {
 double Statement::GetEarningsForLastMonth() const {
   const base::Time now = base::Time::Now();
   base::Time::Exploded exploded;
-  now.UTCExplode(&exploded);
+  now.LocalExplode(&exploded);
 
   exploded.month--;
   if (exploded.month < 1) {
@@ -59,7 +59,7 @@ double Statement::GetEarningsForLastMonth() const {
   exploded.day_of_month = 1;
 
   base::Time last_month;
-  const bool success = base::Time::FromUTCExploded(exploded, &last_month);
+  const bool success = base::Time::FromLocalExploded(exploded, &last_month);
   DCHECK(success);
 
   return ad_rewards_->GetEarningsForMonth(last_month);

--- a/vendor/bat-native-ads/src/bat/ads/internal/account/transactions/transactions.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/transactions/transactions.cc
@@ -68,7 +68,7 @@ uint64_t GetCountForMonth(const base::Time& time) {
 
   for (const auto& transaction : transactions) {
     if (transaction.timestamp == 0) {
-      // Workaround for Windows crash when passing 0 to UTCExplode
+      // Workaround for Windows crash when passing 0 to LocalExplode
       continue;
     }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/10104
Resolves https://github.com/brave/brave-browser/issues/11618

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.