### PR TITLE
Add BraveKeychainPasswordTest

### DIFF
--- a/chromium_src/components/os_crypt/keychain_password_mac_browsertest.mm
+++ b/chromium_src/components/os_crypt/keychain_password_mac_browsertest.mm
@@ -1,0 +1,69 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/os_crypt/keychain_password_mac.h"
+#include "content/public/test/browser_test.h"
+
+namespace {
+struct TestParams {
+  const char* switch_to_append;
+  const char* service_name;
+  const char* account_name;
+};
+
+static const TestParams kTestVectors[] = {
+    {
+        nullptr,
+        "Brave Safe Storage",
+        "Brave",
+    },
+    {
+        "import-brave",
+        "Chromium Safe Storage",
+        "Chromium",
+    },
+    {
+        "import-chromium",
+        "Chromium Safe Storage",
+        "Chromium",
+    },
+    {
+        "import-chrome",
+        "Chrome Safe Storage",
+        "Chrome",
+    },
+};
+}  // namespace
+
+class BraveKeychainPasswordTest
+    : public InProcessBrowserTest,
+      public ::testing::WithParamInterface<TestParams> {
+ public:
+  BraveKeychainPasswordTest() : InProcessBrowserTest() {}
+  BraveKeychainPasswordTest(const BraveKeychainPasswordTest&) = delete;
+  BraveKeychainPasswordTest& operator=(const BraveKeychainPasswordTest&) =
+      delete;
+};
+
+// It has to be browser test instead of unit test becasue GetServiceName() and
+// GetAccountName() uses a static variable inside the function, only browser
+// test can exit program for each test suite
+IN_PROC_BROWSER_TEST_P(BraveKeychainPasswordTest, ServiceAndAccountName) {
+  TestParams test_data(GetParam());
+  if (test_data.switch_to_append) {
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        test_data.switch_to_append);
+  }
+  EXPECT_STREQ(KeychainPassword::GetServiceName().c_str(),
+               test_data.service_name);
+  EXPECT_STREQ(KeychainPassword::GetAccountName().c_str(),
+               test_data.account_name);
+}
+
+INSTANTIATE_TEST_SUITE_P(/*no prefix*/,
+                         BraveKeychainPasswordTest,
+                         testing::ValuesIn(kTestVectors));

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -696,13 +696,6 @@ if (!is_android) {
       "//chrome/browser/ui/test/test_browser_ui.h",
     ]
 
-    if (is_mac) {
-      sources += [
-        "//chrome/browser/ui/test/test_browser_dialog_mac.h",
-        "//chrome/browser/ui/test/test_browser_dialog_mac.mm",
-      ]
-    }
-
     deps = [
       "//brave/browser/autoplay:browser_tests",
       "//brave/browser/brave_ads",
@@ -742,6 +735,16 @@ if (!is_android) {
       "//media:test_support",
       "//testing/gmock",
     ]
+
+    if (is_mac) {
+      sources += [
+        "//brave/chromium_src/components/os_crypt/keychain_password_mac_browsertest.mm",
+        "//chrome/browser/ui/test/test_browser_dialog_mac.h",
+        "//chrome/browser/ui/test/test_browser_dialog_mac.mm",
+      ]
+
+      deps += [ "//components/os_crypt:test_support" ]
+    }
 
     if (use_aura) {
       deps += [ "//ui/aura:test_support" ]


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18145

I've tried this with unit tests and it won't work because of the static variable in the functions we tested.
Each test case won't exit the program even when it is written in different test suites. I also tried exit the case in the end but that will make following cases skipped and the case itself shows crashed. Using `EXPECT_EXIT` with exit or crash intentionally doesn't really make the program exited/crashed, so the static variable problem remains.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

