### PR TITLE
Determine device region based on current timezone

### DIFF
--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -94,7 +94,12 @@ source_set("unit_tests") {
   if (enable_brave_vpn) {
     testonly = true
 
-    sources = [ "brave_vpn_unittest.cc" ]
+    sources = []
+
+    # Currently, tests are for desktop only (fails on Android).
+    if (is_win || is_mac) {
+      sources += [ "brave_vpn_unittest.cc" ]
+    }
 
     deps = [
       ":brave_vpn",

--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -68,6 +68,7 @@ static_library("brave_vpn") {
     deps += [
       ":brave_vpn_internal",
       ":mojom",
+      "//third_party/icu",
     ]
   }
 }
@@ -99,6 +100,7 @@ source_set("unit_tests") {
       ":brave_vpn",
       "//base",
       "//content/test:test_support",
+      "//services/network:test_support",
       "//testing/gtest",
     ]
   }

--- a/components/brave_vpn/brave_vpn.mojom
+++ b/components/brave_vpn/brave_vpn.mojom
@@ -42,6 +42,7 @@ interface ServiceHandler {
   Connect();
   Disconnect();
   GetAllRegions() => (array<Region> regions);
+  GetDeviceRegion() => (Region device_region);
 };
 
 // WebUI-side handler for requests from the browser.

--- a/components/brave_vpn/brave_vpn_service_desktop.h
+++ b/components/brave_vpn/brave_vpn_service_desktop.h
@@ -57,10 +57,12 @@ class BraveVpnServiceDesktop
   void Disconnect() override;
   void CreateVPNConnection() override;
   void GetAllRegions(GetAllRegionsCallback callback) override;
+  void GetDeviceRegion(GetDeviceRegionCallback callback) override;
 
  private:
   friend class BraveAppMenuBrowserTest;
   friend class BraveBrowserCommandControllerTest;
+  FRIEND_TEST_ALL_PREFIXES(BraveVPNTest, RegionDataTest);
 
   // BraveVpnService overrides:
   void Shutdown() override;
@@ -74,16 +76,25 @@ class BraveVpnServiceDesktop
   void OnDisconnected(const std::string& name) override;
   void OnIsDisconnecting(const std::string& name) override;
 
+  brave_vpn::BraveVPNConnectionInfo GetConnectionInfo();
+  void FetchRegionData();
+  void OnFetchRegionList(const std::string& region_list, bool success);
+  void ParseAndCacheRegionList(base::Value region_value);
+  void OnFetchTimezones(const std::string& timezones_list, bool success);
+  void ParseAndCacheDefaultRegionName(base::Value timezons_value);
+  void SetDeviceRegion(const std::string& name);
+  void SetFallbackDeviceRegion();
+  std::string GetCurrentTimeZone();
+
+  void set_test_timezone(const std::string& timezone) {
+    test_timezone_ = timezone;
+  }
   void set_is_purchased_user_for_test(bool purchased) {
     is_purchased_user_ = purchased;
   }
 
-  brave_vpn::BraveVPNConnectionInfo GetConnectionInfo();
-  void FetchRegionList();
-  void OnFetchRegionList(const std::string& region_list, bool success);
-  void ParseAndCacheRegionList(base::Value region_value);
-
   std::vector<brave_vpn::mojom::Region> regions_;
+  brave_vpn::mojom::Region device_region_;
   ConnectionState state_ = ConnectionState::DISCONNECTED;
   bool is_purchased_user_ = false;
   base::ScopedObservation<brave_vpn::BraveVPNOSConnectionAPI,
@@ -91,6 +102,7 @@ class BraveVpnServiceDesktop
       observed_{this};
   mojo::ReceiverSet<brave_vpn::mojom::ServiceHandler> receivers_;
   mojo::RemoteSet<brave_vpn::mojom::ServiceObserver> observers_;
+  std::string test_timezone_;
 };
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_SERVICE_DESKTOP_H_

--- a/components/brave_vpn/brave_vpn_unittest.cc
+++ b/components/brave_vpn/brave_vpn_unittest.cc
@@ -3,15 +3,168 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <memory>
+
 #include "base/feature_list.h"
+#include "base/memory/scoped_refptr.h"
+#include "brave/components/brave_vpn/brave_vpn_service_desktop.h"
 #include "brave/components/brave_vpn/features.h"
+#include "content/public/test/browser_task_environment.h"
+#include "services/network/test/test_shared_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace brave_vpn {
+class BraveVPNTest : public testing::Test {
+ public:
+  void SetUp() override {
+    service_ = std::make_unique<BraveVpnServiceDesktop>(
+        base::MakeRefCounted<network::TestSharedURLLoaderFactory>());
+  }
 
-TEST(BraveVPNTest, Basic) {
-  // Disable by default till we implement all brave vpn features.
-  EXPECT_FALSE(base::FeatureList::IsEnabled(features::kBraveVPN));
+  std::string GetRegionsData() {
+    // Give 11 region data.
+    return R"([
+        {
+          "continent": "europe",
+          "name": "eu-es",
+          "name-pretty": "Spain"
+        },
+        {
+          "continent": "south-america",
+          "name": "sa-br",
+          "name-pretty": "Brazil"
+        },
+        {
+          "continent": "europe",
+          "name": "eu-ch",
+          "name-pretty": "Switzerland"
+        },
+        {
+          "continent": "europe",
+          "name": "eu-de",
+          "name-pretty": "Germany"
+        },
+        {
+          "continent": "asia",
+          "name": "asia-sg",
+          "name-pretty": "Singapore"
+        },
+        {
+          "continent": "north-america",
+          "name": "ca-east",
+          "name-pretty": "Canada"
+        },
+        {
+          "continent": "asia",
+          "name": "asia-jp",
+          "name-pretty": "Japan"
+        },
+        {
+          "continent": "europe",
+          "name": "eu-en",
+          "name-pretty": "United Kingdom"
+        },
+        {
+          "continent": "europe",
+          "name": "eu-nl",
+          "name-pretty": "Netherlands"
+        },
+        {
+          "continent": "north-america",
+          "name": "us-west",
+          "name-pretty": "USA West"
+        },
+        {
+          "continent": "oceania",
+          "name": "au-au",
+          "name-pretty": "Australia"
+        }
+      ])";
+  }
+
+  std::string GetTimeZonesData() {
+    return R"([
+        {
+          "name": "us-central",
+          "timezones": [
+            "America/Guatemala",
+            "America/Guayaquil",
+            "America/Guyana",
+            "America/Havana"
+          ]
+        },
+        {
+          "name": "eu-es",
+          "timezones": [
+            "Europe/Madrid",
+            "Europe/Gibraltar",
+            "Africa/Casablanca",
+            "Africa/Algiers"
+          ]
+        },
+        {
+          "name": "eu-ch",
+          "timezones": [
+            "Europe/Zurich"
+          ]
+        },
+        {
+          "name": "eu-nl",
+          "timezones": [
+            "Europe/Amsterdam",
+            "Europe/Brussels"
+          ]
+        },
+        {
+          "name": "asia-sg",
+          "timezones": [
+            "Asia/Aden",
+            "Asia/Almaty",
+            "Asia/Seoul"
+          ]
+        },
+        {
+          "name": "asia-jp",
+          "timezones": [
+            "Pacific/Guam",
+            "Pacific/Saipan",
+            "Asia/Tokyo"
+          ]
+        }
+      ])";
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<BraveVpnServiceDesktop> service_;
+};
+
+TEST_F(BraveVPNTest, FeatureTest) {
+  EXPECT_FALSE(base::FeatureList::IsEnabled(brave_vpn::features::kBraveVPN));
 }
 
-}  // namespace brave_vpn
+TEST_F(BraveVPNTest, RegionDataTest) {
+  // Test invalid region data.
+  service_->OnFetchRegionList(std::string(), true);
+  EXPECT_TRUE(service_->regions_.empty());
+
+  // Test valid region data parsing.
+  service_->OnFetchRegionList(GetRegionsData(), true);
+  const size_t kRegionCount = 11;
+  EXPECT_EQ(kRegionCount, service_->regions_.size());
+
+  // First region in region list is set as a device region when fetch is failed.
+  service_->OnFetchTimezones(std::string(), false);
+  EXPECT_EQ(service_->regions_[0], service_->device_region_);
+
+  // Test proper device region is set when valid timezone is used.
+  // "asia-sg" region is used for "Asia/Seoul" tz.
+  service_->device_region_ = brave_vpn::mojom::Region();
+  service_->set_test_timezone("Asia/Seoul");
+  service_->OnFetchTimezones(GetTimeZonesData(), true);
+  EXPECT_EQ("asia-sg", service_->device_region_.name);
+
+  // Test first region is set as a device region when invalid timezone is set.
+  service_->device_region_ = brave_vpn::mojom::Region();
+  service_->set_test_timezone("Invalid");
+  service_->OnFetchTimezones(GetTimeZonesData(), true);
+  EXPECT_EQ(service_->regions_[0], service_->device_region_);
+}


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/18078

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_unit_tests -- --filter=*BraveVPNTest*`

1. Launch browser and enable vpn via brave://flags
2. Re-launch browser with `--vmodule=*vpn*=2 --enable-logging=stderr`
3. Find log - `Found default region: xxxxx`