### PR TITLE
speedreader: Pass result correctly for CR94

### DIFF
--- a/components/speedreader/speedreader_throttle.cc
+++ b/components/speedreader/speedreader_throttle.cc
@@ -60,8 +60,8 @@ void SpeedReaderThrottle::WillProcessResponse(
   SpeedReaderURLLoader* speedreader_loader;
   std::tie(new_remote, new_receiver, speedreader_loader) =
       SpeedReaderURLLoader::CreateLoader(weak_factory_.GetWeakPtr(),
-                                         response_url, task_runner_,
-                                         rewriter_service_);
+                                         result_delegate_, response_url,
+                                         task_runner_, rewriter_service_);
   delegate_->InterceptResponse(std::move(new_remote), std::move(new_receiver),
                                &source_loader, &source_client_receiver);
   speedreader_loader->Start(std::move(source_loader),
@@ -70,13 +70,6 @@ void SpeedReaderThrottle::WillProcessResponse(
 
 void SpeedReaderThrottle::Resume() {
   delegate_->Resume();
-}
-
-void SpeedReaderThrottle::OnDistillComplete() {
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  if (result_delegate_) {
-    result_delegate_->OnDistillComplete();
-  }
 }
 
 }  // namespace speedreader

--- a/components/speedreader/speedreader_throttle.h
+++ b/components/speedreader/speedreader_throttle.h
@@ -55,7 +55,6 @@ class SpeedReaderThrottle : public blink::URLLoaderThrottle {
 
   // Called from SpeedReaderURLLoader.
   void Resume();
-  void OnDistillComplete();
 
  private:
   SpeedreaderRewriterService* rewriter_service_;  // not owned

--- a/components/speedreader/speedreader_url_loader.h
+++ b/components/speedreader/speedreader_url_loader.h
@@ -14,6 +14,7 @@
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/strings/string_piece.h"
+#include "brave/components/speedreader/speedreader_result_delegate.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -71,12 +72,14 @@ class SpeedReaderURLLoader : public network::mojom::URLLoaderClient,
                     mojo::PendingReceiver<network::mojom::URLLoaderClient>,
                     SpeedReaderURLLoader*>
   CreateLoader(base::WeakPtr<SpeedReaderThrottle> throttle,
+               base::WeakPtr<SpeedreaderResultDelegate> delegate,
                const GURL& response_url,
                scoped_refptr<base::SingleThreadTaskRunner> task_runner,
                SpeedreaderRewriterService* rewriter_service);
 
  private:
   SpeedReaderURLLoader(base::WeakPtr<SpeedReaderThrottle> throttle,
+                       base::WeakPtr<SpeedreaderResultDelegate> delegate,
                        const GURL& response_url,
                        mojo::PendingRemote<network::mojom::URLLoaderClient>
                            destination_url_loader_client,
@@ -124,6 +127,7 @@ class SpeedReaderURLLoader : public network::mojom::URLLoaderClient,
   void Abort();
 
   base::WeakPtr<SpeedReaderThrottle> throttle_;
+  base::WeakPtr<SpeedreaderResultDelegate> delegate_;
 
   mojo::Receiver<network::mojom::URLLoaderClient> source_url_client_receiver_{
       this};


### PR DESCRIPTION
Prior to CR94 we were able to assume that the URLLoaderThrottle would
outlive the URLLoader. This is no longer the case, so we pass the
result_delegate_ to the loader.

Resolves https://github.com/brave/brave-browser/issues/18151 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

