### PR TITLE
Uplift 1.30.x - fixed download item filename overlap

### DIFF
--- a/browser/ui/views/download/brave_download_item_view.cc
+++ b/browser/ui/views/download/brave_download_item_view.cc
@@ -11,6 +11,7 @@
 #include "base/auto_reset.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "chrome/browser/themes/theme_properties.h"
+#include "chrome/browser/ui/download/download_item_mode.h"
 #include "chrome/browser/ui/views/download/download_shelf_view.h"
 #include "components/strings/grit/components_strings.h"
 #include "components/vector_icons/vector_icons.h"
@@ -99,7 +100,6 @@ void BraveDownloadItemView::OnPaint(gfx::Canvas* canvas) {
   DownloadItemView::OnPaint(canvas);
   if (is_origin_url_visible_)
     DrawOriginURL(canvas);
-  file_name_label_->SetVisible(!is_origin_url_visible_);
 }
 
 // download::DownloadItem::Observer overrides.
@@ -236,18 +236,31 @@ void BraveDownloadItemView::SetMode(download::DownloadItemMode mode) {
   }
 }
 
+void BraveDownloadItemView::UpdateLabels() {
+  DownloadItemView::UpdateLabels();
+  // Update visibility to avoid artifacts to be shown from upstream
+  file_name_label_->SetVisible(
+      !is_origin_url_visible_ &&
+      (GetMode() == download::DownloadItemMode::kNormal));
+}
+
+void BraveDownloadItemView::SetOriginUrlVisible(bool visible) {
+  is_origin_url_visible_ = visible;
+  UpdateLabels();
+}
+
 void BraveDownloadItemView::OnMouseEntered(const ui::MouseEvent& event) {
-  is_origin_url_visible_ = true;
+  SetOriginUrlVisible(true);
 }
 
 void BraveDownloadItemView::OnMouseExited(const ui::MouseEvent& event) {
-  is_origin_url_visible_ = false;
+  SetOriginUrlVisible(false);
 }
 
 void BraveDownloadItemView::OnViewFocused(View* observed_view) {
-  is_origin_url_visible_ = true;
+  SetOriginUrlVisible(true);
 }
 
 void BraveDownloadItemView::OnViewBlurred(View* observed_view) {
-  is_origin_url_visible_ = false;
+  SetOriginUrlVisible(false);
 }

--- a/browser/ui/views/download/brave_download_item_view.h
+++ b/browser/ui/views/download/brave_download_item_view.h
@@ -50,10 +50,13 @@ class BraveDownloadItemView : public DownloadItemView {
 
   // Overrides the accessible name construction to reflect the origin URL.
   void SetMode(download::DownloadItemMode mode) override;
+  void UpdateLabels() override;
   void OnMouseEntered(const ui::MouseEvent& event) override;
   void OnMouseExited(const ui::MouseEvent& event) override;
   void OnViewFocused(View* observed_view) override;
   void OnViewBlurred(View* observed_view) override;
+
+  void SetOriginUrlVisible(bool visible);
 
   // Brave download item model.
   BraveDownloadItemModel brave_model_;

--- a/chromium_src/chrome/browser/ui/views/download/download_item_view.h
+++ b/chromium_src/chrome/browser/ui/views/download/download_item_view.h
@@ -41,9 +41,11 @@
  protected:                                  \
   bool IsShowingWarningDialog() const;
 
+#define UpdateLabels virtual UpdateLabels
 #define SetMode virtual SetMode
 #include "../../../../../../../chrome/browser/ui/views/download/download_item_view.h"
 #undef SetMode
+#undef UpdateLabels
 #undef BRAVE_DOWNLOAD_DOWNLOAD_ITEM_VIEW_H_
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_DOWNLOAD_ITEM_VIEW_H_


### PR DESCRIPTION
Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 

Initial PR: https://github.com/brave/brave-core/pull/9759
Resolves: https://github.com/brave/brave-browser/issues/17313

> The overlap was caused by a recent change we made on the UX of the download item view.
The duped filename was setting itself visible in all modes. There are various modes to take in to consideration however, we only care about the normal mode.