### PR TITLE
feat(wallet): add asset icons in wallet UI

### DIFF
--- a/components/brave_wallet_ui/common/async/wallet_async_handler.ts
+++ b/components/brave_wallet_ui/common/async/wallet_async_handler.ts
@@ -93,6 +93,9 @@ async function refreshWalletInfo (store: Store) {
   const current = GetNetworkInfo(chainId.chainId, networkList.networks)
   store.dispatch(WalletActions.setNetwork(current))
 
+  // Populate tokens from ERC-20 token registry.
+  store.dispatch(WalletActions.getAllTokensList())
+
   const braveWalletService = apiProxy.braveWalletService
   const visibleTokensInfo = await braveWalletService.getUserAssets(chainId.chainId)
   store.dispatch(WalletActions.setVisibleTokensInfo(visibleTokensInfo.tokens))

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -137,16 +137,9 @@ reducer.on(WalletActions.setAllNetworks, (state: any, payload: GetAllNetworksLis
 })
 
 reducer.on(WalletActions.setAllTokensList, (state: any, payload: GetAllTokensReturnInfo) => {
-  const tokens = payload.tokens.map(
-    token => ({
-      ...token,
-      logo: `chrome://erc-token-images/${token.logo}`
-    })
-  )
-
   return {
     ...state,
-    fullTokenList: tokens
+    fullTokenList: payload.tokens
   }
 })
 

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -137,9 +137,16 @@ reducer.on(WalletActions.setAllNetworks, (state: any, payload: GetAllNetworksLis
 })
 
 reducer.on(WalletActions.setAllTokensList, (state: any, payload: GetAllTokensReturnInfo) => {
+  const tokens = payload.tokens.map(
+    token => ({
+      ...token,
+      logo: `chrome://erc-token-images/${token.logo}`
+    })
+  )
+
   return {
     ...state,
-    fullTokenList: payload.tokens
+    fullTokenList: tokens
   }
 })
 

--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/index.tsx
@@ -21,7 +21,7 @@ function SelectAssetItem (props: Props) {
 
   return (
     <StyledWrapper onClick={onSelectAsset}>
-      <AssetIcon icon={asset.asset.icon} />
+      <AssetIcon icon={asset.asset.logo} />
       <AssetAndBalance>
         <AssetName>{asset.asset.name}</AssetName>
         <AssetBalance>{formatBalance(asset.assetBalance, asset.asset.decimals)} {asset.asset.symbol}</AssetBalance>

--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/style.ts
@@ -44,7 +44,7 @@ export const AssetBalance = styled.span`
 export const AssetIcon = styled.div<StyleProps>`
   width: 24px;
   height: 24px;
-  background: ${(p) => `url(${p.icon})`};
+  background: no-repeat ${(p) => `url(${p.icon})`};
   margin-right: 8px;
   background-size: 100%;
 `

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
@@ -192,7 +192,7 @@ function SwapInputComponent (props: Props) {
             }
             {componentType !== 'exchange' && componentType !== 'toAddress' &&
               <AssetButton onClick={onShowSelection}>
-                <AssetIcon icon={selectedAsset?.asset.icon} />
+                <AssetIcon icon={selectedAsset?.asset.logo} />
                 <AssetTicker>{selectedAsset?.asset.symbol}</AssetTicker>
                 <CaratDownIcon />
               </AssetButton>

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/style.ts
@@ -44,7 +44,7 @@ export const AssetButton = styled.button`
 export const AssetIcon = styled.div<Partial<StyleProps>>`
   width: 24px;
   height: 24px;
-  background: ${(p) => `url(${p.icon})`};
+  background: no-repeat ${(p) => `url(${p.icon})`};
   margin-right: 8px;
   margin-left: 4px;
   background-size: 100%;

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
@@ -40,7 +40,7 @@ const AssetWatchlistItem = (props: Props) => {
   return (
     <StyledWrapper>
       <NameAndIcon>
-        <AssetIcon icon={token.icon ? token.icon : ''} />
+        <AssetIcon icon={token.logo ? token.logo : ''} />
         <AssetName>{token.name}</AssetName>
       </NameAndIcon>
       <RightSide>

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import { Checkbox } from 'brave-ui'
 import { TokenInfo } from '../../../constants/types'
+
+// Options
+import { ETH } from '../../../options/asset-options'
+
 // Styled Components
 import {
   StyledWrapper,
@@ -40,7 +44,7 @@ const AssetWatchlistItem = (props: Props) => {
   return (
     <StyledWrapper>
       <NameAndIcon>
-        <AssetIcon icon={token.logo ? token.logo : ''} />
+        <AssetIcon icon={(token.symbol === 'ETH' ? ETH.asset.logo : token.logo) ?? ''} />
         <AssetName>{token.name}</AssetName>
       </NameAndIcon>
       <RightSide>

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/style.ts
@@ -54,7 +54,8 @@ export const AssetIcon = styled.div<StyleProps>`
   width: 40px;
   height: 40px;
   border-radius: 100%;
-  background: ${(p) => p.icon ? `url(${p.icon})` : p.theme.color.background01}};
+  background: no-repeat ${(p) => p.icon ? `url(${p.icon})` : p.theme.color.background01};
+  background-size: 40px;
   margin-right: 8px;
 `
 

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 
+// Options
+import { ETH } from '../../../options/asset-options'
+
 // Styled Components
 import {
   StyledWrapper,
@@ -28,7 +31,7 @@ const PortfolioAssetItem = (props: Props) => {
       {isVisible &&
         <StyledWrapper onClick={action}>
           <NameAndIcon>
-            <AssetIcon icon={logo ? logo : ''} />
+            <AssetIcon icon={(symbol === 'ETH' ? ETH.asset.logo : logo) ?? ''} />
             <AssetName>{name}</AssetName>
           </NameAndIcon>
           <BalanceColumn>

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -15,20 +15,20 @@ export interface Props {
   action?: () => void
   name: string
   symbol: string
-  icon?: string
+  logo?: string
   assetBalance: string
   fiatBalance: string
   isVisible?: boolean
 }
 
 const PortfolioAssetItem = (props: Props) => {
-  const { name, assetBalance, fiatBalance, icon, symbol, isVisible, action } = props
+  const { name, assetBalance, fiatBalance, logo, symbol, isVisible, action } = props
   return (
     <>
       {isVisible &&
         <StyledWrapper onClick={action}>
           <NameAndIcon>
-            <AssetIcon icon={icon ? icon : ''} />
+            <AssetIcon icon={logo ? logo : ''} />
             <AssetName>{name}</AssetName>
           </NameAndIcon>
           <BalanceColumn>

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
@@ -59,6 +59,7 @@ export const AssetIcon = styled.div<StyleProps>`
   width: 40px;
   height: 40px;
   border-radius: 100%;
-  background: ${(p) => p.icon ? `url(${p.icon})` : p.theme.color.background01}};
+  background: no-repeat ${(p) => p.icon ? `url(${p.icon})` : p.theme.color.background01};
+  background-size: 40px;
   margin-right: 8px;
 `

--- a/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
@@ -235,7 +235,7 @@ function Accounts (props: Props) {
               assetBalance={formatBalance(item.assetBalance, item.asset.decimals)}
               fiatBalance={item.fiatBalance}
               symbol={item.asset.symbol}
-              icon={item.asset.icon}
+              logo={item.asset.logo}
               isVisible={item.asset.visible}
             />
           )}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
@@ -273,7 +273,7 @@ const Portfolio = (props: Props) => {
       ) : (
         <InfoColumn>
           <AssetRow>
-            <AssetIcon icon={selectedAsset.icon} />
+            <AssetIcon icon={selectedAsset.logo} />
             <AssetNameText>{selectedAsset.name}</AssetNameText>
           </AssetRow>
           <DetailText>{selectedAsset.name} {locale.price} ({selectedAsset.symbol})</DetailText>
@@ -354,7 +354,7 @@ const Portfolio = (props: Props) => {
               assetBalance={item.assetBalance}
               fiatBalance={item.fiatBalance}
               symbol={item.asset.symbol}
-              icon={item.asset.icon}
+              logo={item.asset.logo}
               isVisible={item.asset.visible}
             />
           )}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -109,7 +109,7 @@ export const AssetIcon = styled.div<Partial<StyleProps>>`
   width: 40px;
   height: 40px;
   border-radius: 100%;
-  background: ${(p) => p.icon ? `url(${p.icon})` : p.theme.color.background01}};
+  background: no-repeat ${(p) => p.icon ? `url(${p.icon})` : p.theme.color.background01}};
   margin-right: 12px;
 `
 

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -19,7 +19,7 @@ export interface AssetOptionType {
   id: string
   name: string
   symbol: string
-  icon: string
+  logo: string
 }
 
 export interface UserAssetOptionType {
@@ -363,7 +363,6 @@ export interface TokenInfo {
   symbol: string
   decimals: number
   visible?: boolean
-  icon?: string
   logo?: string
 }
 

--- a/components/brave_wallet_ui/options/asset-options.ts
+++ b/components/brave_wallet_ui/options/asset-options.ts
@@ -1,4 +1,4 @@
-import { AccountAssetOptionType, AssetOptionType, TokenInfo } from '../constants/types'
+import { AccountAssetOptionType, TokenInfo } from '../constants/types'
 import {
   ALGOIconUrl,
   BATIconUrl,
@@ -8,51 +8,41 @@ import {
   ZRXIconUrl
 } from '../assets/asset-icons'
 
-export const AssetOptions: AssetOptionType[] = [
-  {
-    id: '1',
+export const ETH: AccountAssetOptionType = {
+  asset: {
+    contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     name: 'Ethereum',
     symbol: 'ETH',
-    icon: ETHIconUrl
+    logo: ETHIconUrl,
+    isErc20: false,
+    isErc721: false,
+    decimals: 18
   },
-  {
-    id: '2',
+  assetBalance: '0',
+  fiatBalance: '0'
+}
+
+export const BAT: AccountAssetOptionType = {
+  asset: {
+    contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
     name: 'Basic Attention Token',
     symbol: 'BAT',
-    icon: BATIconUrl
+    logo: `chrome://erc-token-images/bat.svg`,
+    isErc20: true,
+    isErc721: false,
+    decimals: 18
   },
-  {
-    id: '3',
-    name: 'Binance Coin',
-    symbol: 'BNB',
-    icon: BNBIconUrl
-  },
-  {
-    id: '4',
-    name: 'Bitcoin',
-    symbol: 'BTC',
-    icon: BTCIconUrl
-  },
-  {
-    id: '5',
-    name: 'Algorand',
-    symbol: 'ALGO',
-    icon: ALGOIconUrl
-  },
-  {
-    id: '6',
-    name: '0x',
-    symbol: 'ZRX',
-    icon: ZRXIconUrl
-  }
-]
+  assetBalance: '0',
+  fiatBalance: '0'
+}
 
+// Use only with storybook as dummy data.
 export const NewAssetOptions: TokenInfo[] = [
   {
     contractAddress: '1',
     name: 'Ethereum',
     symbol: 'ETH',
-    icon: ETHIconUrl,
+    logo: ETHIconUrl,
     isErc20: true,
     isErc721: false,
     decimals: 18
@@ -61,7 +51,7 @@ export const NewAssetOptions: TokenInfo[] = [
     contractAddress: '2',
     name: 'Basic Attention Token',
     symbol: 'BAT',
-    icon: BATIconUrl,
+    logo: BATIconUrl,
     isErc20: true,
     isErc721: false,
     decimals: 18
@@ -70,7 +60,7 @@ export const NewAssetOptions: TokenInfo[] = [
     contractAddress: '3',
     name: 'Binance Coin',
     symbol: 'BNB',
-    icon: BNBIconUrl,
+    logo: BNBIconUrl,
     isErc20: true,
     isErc721: false,
     decimals: 18
@@ -79,7 +69,7 @@ export const NewAssetOptions: TokenInfo[] = [
     contractAddress: '4',
     name: 'Bitcoin',
     symbol: 'BTC',
-    icon: BTCIconUrl,
+    logo: BTCIconUrl,
     isErc20: true,
     isErc721: false,
     decimals: 18
@@ -88,7 +78,7 @@ export const NewAssetOptions: TokenInfo[] = [
     contractAddress: '5',
     name: 'Algorand',
     symbol: 'ALGO',
-    icon: ALGOIconUrl,
+    logo: ALGOIconUrl,
     isErc20: true,
     isErc721: false,
     decimals: 18
@@ -97,46 +87,29 @@ export const NewAssetOptions: TokenInfo[] = [
     contractAddress: '6',
     name: '0x',
     symbol: 'ZRX',
-    icon: ZRXIconUrl,
+    logo: ZRXIconUrl,
     isErc20: true,
     isErc721: false,
     decimals: 18
   }
 ]
 
+// Use only with storybook as dummy data.
 export const AccountAssetOptions: AccountAssetOptionType[] = [
+  ETH,
   {
+    ...BAT,
     asset: {
-      contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-      name: 'Ethereum',
-      symbol: 'ETH',
-      icon: ETHIconUrl,
-      isErc20: false,
-      isErc721: false,
-      decimals: 18
-    },
-    assetBalance: '0',
-    fiatBalance: '0'
-  },
-  {
-    asset: {
-      contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
-      name: 'Basic Attention Token',
-      symbol: 'BAT',
-      icon: BATIconUrl,
-      isErc20: true,
-      isErc721: false,
-      decimals: 18
-    },
-    assetBalance: '0',
-    fiatBalance: '0'
+      ...BAT.asset,
+      logo: BATIconUrl
+    }
   },
   {
     asset: {
       contractAddress: '3',
       name: 'Binance Coin',
       symbol: 'BNB',
-      icon: BNBIconUrl,
+      logo: BNBIconUrl,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -149,7 +122,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '4',
       name: 'Bitcoin',
       symbol: 'BTC',
-      icon: BTCIconUrl,
+      logo: BTCIconUrl,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -162,7 +135,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '5',
       name: 'Algorand',
       symbol: 'ALGO',
-      icon: ALGOIconUrl,
+      logo: ALGOIconUrl,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -175,7 +148,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '0xE41d2489571d322189246DaFA5ebDe1F4699F498',
       name: '0x',
       symbol: 'ZRX',
-      icon: ZRXIconUrl,
+      logo: ZRXIconUrl,
       isErc20: true,
       isErc721: false,
       decimals: 18

--- a/components/brave_wallet_ui/options/wyre-asset-options.ts
+++ b/components/brave_wallet_ui/options/wyre-asset-options.ts
@@ -30,127 +30,127 @@ export const WyreAssetOptions: AssetOptionType[] = [
     id: '1',
     name: 'Basic Attention Token',
     symbol: 'BAT',
-    icon: BATIconUrl
+    logo: BATIconUrl
   },
   {
     id: '2',
     name: 'Ethereum',
     symbol: 'ETH',
-    icon: ETHIconUrl
+    logo: ETHIconUrl
   },
   {
     id: '3',
     name: 'USD Coin',
     symbol: 'USDC',
-    icon: UsdcIconURL
+    logo: UsdcIconURL
   },
   {
     id: '4',
     name: 'DAI',
     symbol: 'DAI',
-    icon: DaiIconURL
+    logo: DaiIconURL
   },
   {
     id: '5',
     name: 'AAVE',
     symbol: 'AAVE',
-    icon: AaveIconURL
+    logo: AaveIconURL
   },
   {
     id: '6',
     name: 'Binance USD',
     symbol: 'BUSD',
-    icon: BusdIconURL
+    logo: BusdIconURL
   },
   {
     id: '7',
     name: 'Compound',
     symbol: 'COMP',
-    icon: CompIconURL
+    logo: CompIconURL
   },
   {
     id: '8',
     name: 'Curve',
     symbol: 'CRV',
-    icon: CrvIconURL
+    logo: CrvIconURL
   },
   {
     id: '9',
     name: 'Gemini Dollar',
     symbol: 'GUSD',
-    icon: GusdIconURL
+    logo: GusdIconURL
   },
   {
     id: '10',
     name: 'Chainlink',
     symbol: 'LINK',
-    icon: LinkIconURL
+    logo: LinkIconURL
   },
   {
     id: '11',
     name: 'Maker',
     symbol: 'MKR',
-    icon: MkrIconURL
+    logo: MkrIconURL
   },
   {
     id: '12',
     name: 'Paxos Standard',
     symbol: 'PAX',
-    icon: PaxIconURL
+    logo: PaxIconURL
   },
   {
     id: '13',
     name: 'Synthetix',
     symbol: 'SNX',
-    icon: SnxIconURL
+    logo: SnxIconURL
   },
   {
     id: '14',
     name: 'UMA',
     symbol: 'UMA',
-    icon: UmaIconURL
+    logo: UmaIconURL
   },
   {
     id: '15',
     name: 'Uniswap',
     symbol: 'UNI',
-    icon: UniIconURL
+    logo: UniIconURL
   },
   {
     id: '16',
     name: 'Stably Dollar',
     symbol: 'USDS',
-    icon: UsdsIconURL
+    logo: UsdsIconURL
   },
   {
     id: '17',
     name: 'Tether',
     symbol: 'USDT',
-    icon: UsdtIconURL
+    logo: UsdtIconURL
   },
   {
     id: '18',
     name: 'Wrapped Bitcoin',
     symbol: 'WBTC',
-    icon: WbtcIconURL
+    logo: WbtcIconURL
   },
   {
     id: '19',
     name: 'Yearn.Fianance',
     symbol: 'YFI',
-    icon: YfiIconURL
+    logo: YfiIconURL
   },
   {
     id: '20',
     name: 'Palm DAI',
     symbol: 'PDAI',
-    icon: PdaiIconURL
+    logo: PdaiIconURL
   },
   {
     id: '21',
     name: 'Matic USDC',
     symbol: 'MUSDC',
-    icon: MusdcIconURL
+    logo: MusdcIconURL
   }
 ]
 
@@ -160,7 +160,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '1',
       name: 'Basic Attention Token',
       symbol: 'BAT',
-      icon: BATIconUrl,
+      logo: BATIconUrl,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -173,7 +173,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '2',
       name: 'Ethereum',
       symbol: 'ETH',
-      icon: ETHIconUrl,
+      logo: ETHIconUrl,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -186,7 +186,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '3',
       name: 'USD Coin',
       symbol: 'USDC',
-      icon: UsdcIconURL,
+      logo: UsdcIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -199,7 +199,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '4',
       name: 'DAI',
       symbol: 'DAI',
-      icon: DaiIconURL,
+      logo: DaiIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -212,7 +212,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '5',
       name: 'AAVE',
       symbol: 'AAVE',
-      icon: AaveIconURL,
+      logo: AaveIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -225,7 +225,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '6',
       name: 'Binance USD',
       symbol: 'BUSD',
-      icon: BusdIconURL,
+      logo: BusdIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -238,7 +238,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '7',
       name: 'Compound',
       symbol: 'COMP',
-      icon: CompIconURL,
+      logo: CompIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -251,7 +251,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '8',
       name: 'Curve',
       symbol: 'CRV',
-      icon: CrvIconURL,
+      logo: CrvIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -264,7 +264,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '9',
       name: 'Gemini Dollar',
       symbol: 'GUSD',
-      icon: GusdIconURL,
+      logo: GusdIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -277,7 +277,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '10',
       name: 'Chainlink',
       symbol: 'LINK',
-      icon: LinkIconURL,
+      logo: LinkIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -290,7 +290,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '11',
       name: 'Maker',
       symbol: 'MKR',
-      icon: MkrIconURL,
+      logo: MkrIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -303,7 +303,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '12',
       name: 'Paxos Standard',
       symbol: 'PAX',
-      icon: PaxIconURL,
+      logo: PaxIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -316,7 +316,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '13',
       name: 'Synthetix',
       symbol: 'SNX',
-      icon: SnxIconURL,
+      logo: SnxIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -329,7 +329,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '14',
       name: 'UMA',
       symbol: 'UMA',
-      icon: UmaIconURL,
+      logo: UmaIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -342,7 +342,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '15',
       name: 'Uniswap',
       symbol: 'UNI',
-      icon: UniIconURL,
+      logo: UniIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -355,7 +355,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '16',
       name: 'Stably Dollar',
       symbol: 'USDS',
-      icon: UsdsIconURL,
+      logo: UsdsIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -368,7 +368,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '17',
       name: 'Tether',
       symbol: 'USDT',
-      icon: UsdtIconURL,
+      logo: UsdtIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -381,7 +381,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '18',
       name: 'Wrapped Bitcoin',
       symbol: 'WBTC',
-      icon: WbtcIconURL,
+      logo: WbtcIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -394,7 +394,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '19',
       name: 'Yearn.Fianance',
       symbol: 'YFI',
-      icon: YfiIconURL,
+      logo: YfiIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -407,7 +407,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '20',
       name: 'Palm DAI',
       symbol: 'PDAI',
-      icon: PdaiIconURL,
+      logo: PdaiIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8
@@ -420,7 +420,7 @@ export const WyreAccountAssetOptions: AccountAssetOptionType[] = [
       contractAddress: '21',
       name: 'Matic USDC',
       symbol: 'MUSDC',
-      icon: MusdcIconURL,
+      logo: MusdcIconURL,
       isErc20: true,
       isErc721: false,
       decimals: 8

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -49,7 +49,7 @@ import BackupWallet from '../stories/screens/backup-wallet'
 import { formatPrices } from '../utils/format-prices'
 import { BuyAssetUrl } from '../utils/buy-asset-url'
 import { convertMojoTimeToJS } from '../utils/mojo-time'
-import { AssetOptions, AccountAssetOptions } from '../options/asset-options'
+import { ETH, BAT } from '../options/asset-options'
 import { WyreAccountAssetOptions } from '../options/wyre-asset-options'
 import { SlippagePresetOptions } from '../options/slippage-preset-options'
 import { ExpirationPresetOptions } from '../options/expiration-preset-options'
@@ -125,9 +125,21 @@ function Container (props: Props) {
   const [orderType, setOrderType] = React.useState<OrderTypes>('market')
   const [selectedWidgetTab, setSelectedWidgetTab] = React.useState<BuySendSwapTypes>('buy')
 
+  const accountAssetOptions: AccountAssetOptionType[] = React.useMemo(() => {
+    const tokens = fullTokenList
+      .filter(token => token.symbol !== 'BAT')
+      .map(token => ({
+        asset: token,
+        assetBalance: '0',
+        fiatBalance: '0'
+      }))
+
+    return [ETH, BAT, ...tokens]
+  }, [fullTokenList])
+
   // TODO (DOUGLAS): This needs to be set up in the Reducer in a future PR
-  const [fromAsset, setFromAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
-  const [toAsset, setToAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[1])
+  const [fromAsset, setFromAsset] = React.useState<AccountAssetOptionType>(ETH)
+  const [toAsset, setToAsset] = React.useState<AccountAssetOptionType>(BAT)
 
   React.useEffect(() => {
     if (!swapQuote) {
@@ -397,17 +409,11 @@ function Container (props: Props) {
 
   // This looks at the users asset list and returns the full balance for each asset
   const userAssetList = React.useMemo(() => {
-    const newListWithIcon = userVisibleTokensInfo.map((asset) => {
-      const icon = AssetOptions.find((a) => asset.symbol === a.symbol)?.icon
-      return { ...asset, icon: icon }
-    })
-    return newListWithIcon.map((asset) => {
-      return {
-        asset: asset,
-        assetBalance: fullAssetBalance(asset).toString(),
-        fiatBalance: fullAssetFiatBalance(asset).toString()
-      }
-    })
+    return userVisibleTokensInfo.map((asset) => ({
+      asset: asset,
+      assetBalance: fullAssetBalance(asset).toString(),
+      fiatBalance: fullAssetFiatBalance(asset).toString()
+    }))
   }, [userVisibleTokensInfo, accounts])
 
   const onSelectAsset = (asset: TokenInfo) => {
@@ -743,7 +749,7 @@ function Container (props: Props) {
             toAddress={toAddress}
             buyAssetOptions={WyreAccountAssetOptions}
             sendAssetOptions={selectedAccount.tokens}
-            swapAssetOptions={AccountAssetOptions}
+            swapAssetOptions={accountAssetOptions}
             isSwapSubmitDisabled={isSwapButtonDisabled()}
             onSetBuyAmount={onSetBuyAmount}
             onSetToAddress={onSetToAddress}

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -50,7 +50,7 @@ import {
 } from '../constants/types'
 import { AppsList } from '../options/apps-list-options'
 import LockPanel from '../components/extension/lock-panel'
-import { AccountAssetOptions } from '../options/asset-options'
+import { ETH, BAT } from '../options/asset-options'
 import { WyreAccountAssetOptions } from '../options/wyre-asset-options'
 import { BuyAssetUrl } from '../utils/buy-asset-url'
 import { GetNetworkInfo } from '../utils/network-utils'
@@ -91,7 +91,8 @@ function Container (props: Props) {
     userVisibleTokensInfo,
     isWalletCreated,
     networkList,
-    transactionSpotPrices
+    transactionSpotPrices,
+    fullTokenList
   } = props.wallet
 
   const {
@@ -108,12 +109,24 @@ function Container (props: Props) {
   const [selectedAccounts, setSelectedAccounts] = React.useState<WalletAccountType[]>([])
   const [filteredAppsList, setFilteredAppsList] = React.useState<AppsListType[]>(AppsList)
   const [walletConnected, setWalletConnected] = React.useState<boolean>(true)
-  const [selectedAsset, setSelectedAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
+  const [selectedAsset, setSelectedAsset] = React.useState<AccountAssetOptionType>(ETH)
   const [selectedWyreAsset, setSelectedWyreAsset] = React.useState<AccountAssetOptionType>(WyreAccountAssetOptions[0])
   const [showSelectAsset, setShowSelectAsset] = React.useState<boolean>(false)
   const [toAddress, setToAddress] = React.useState('')
   const [sendAmount, setSendAmount] = React.useState('')
   const [buyAmount, setBuyAmount] = React.useState('')
+
+  const accountAssetOptions: AccountAssetOptionType[] = React.useMemo(() => {
+    const tokens = fullTokenList
+      .filter(token => token.symbol !== 'BAT')
+      .map(token => ({
+        asset: token,
+        assetBalance: '0',
+        fiatBalance: '0'
+      }))
+
+    return [ETH, BAT, ...tokens]
+  }, [fullTokenList])
 
   const onSetBuyAmount = (value: string) => {
     setBuyAmount(value)
@@ -432,7 +445,7 @@ function Container (props: Props) {
     } else if (selectedPanel === 'send') {
       assets = selectedAccount.tokens
     } else {  // swap
-      assets = AccountAssetOptions
+      assets = accountAssetOptions
     }
     return (
       <PanelWrapper isLonger={false}>


### PR DESCRIPTION
This PR brings ERC-20 token logos to the wallet. It uses https://github.com/brave/brave-browser/issues/18238, which packs image assets into the user profile directory and serves them over `brave://erc-token-images/<logo>`.

⚠️ One difference in swap assets between ethereum-remote-client and native wallet is that we're using the same list for both Send as well as Swap. Instead of maintaining two separate lists, we'll display an appropriate warning if 0x has no liquidity for the chosen asset.

⚠️ The logo of default visible assets (ETH, and BAT) is not displayed because of a bug in the C++ controller returning empty strings.

Resolves https://github.com/brave/brave-browser/issues/17645.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [z] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [z] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

https://user-images.githubusercontent.com/3684187/134941550-c0c42106-bcda-4125-b642-6e68c3e1f750.mov



