### PR TITLE
Fixes Brave news display ads/advertisers should round robin before showing the same ads

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_events/inline_content_ads/inline_content_ad_event_served.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_events/inline_content_ads/inline_content_ad_event_served.cc
@@ -8,6 +8,7 @@
 #include "bat/ads/confirmation_type.h"
 #include "bat/ads/internal/ad_events/ad_events.h"
 #include "bat/ads/internal/ads_history/ads_history.h"
+#include "bat/ads/internal/client/client.h"
 #include "bat/ads/internal/logging.h"
 
 namespace ads {
@@ -30,6 +31,8 @@ void AdEventServed::FireEvent(const InlineContentAdInfo& ad) {
 
     BLOG(1, "Successfully logged inline content ad served event");
   });
+
+  Client::Get()->UpdateSeenAd(ad);
 }
 
 }  // namespace inline_content_ads


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/10141
Resolves https://github.com/brave/brave-browser/issues/18184

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.