### PR TITLE
Added Error Handling for Fetching VisibleTokenInfo

### DIFF
--- a/components/brave_wallet_ui/common/async/wallet_async_handler.ts
+++ b/components/brave_wallet_ui/common/async/wallet_async_handler.ts
@@ -89,10 +89,10 @@ async function refreshWalletInfo (store: Store) {
   const visibleTokensInfo = await Promise.all(visibleTokensPayload.map(async (i) => {
     const ercTokenRegistry = (await getAPIProxy()).ercTokenRegistry
     const info = await ercTokenRegistry.getTokenByContract(i)
-    const icon = AssetOptions.find((a) => info.token.symbol === a.symbol)?.icon
+    const icon = AssetOptions.find((a) => info.token.symbol === a.symbol)?.icon ?? ''
     return { ...info.token, icon: icon }
-  }))
-  if (visibleTokensInfo[0]) {
+  })).catch((e) => [])
+  if (visibleTokensInfo.length !== 0) {
     store.dispatch(WalletActions.setVisibleTokensInfo(visibleTokensInfo))
   } else {
     store.dispatch(WalletActions.setVisibleTokensInfo(InitialVisibleTokenInfo))


### PR DESCRIPTION
## Description 
1) Added a catch to return an empty `[ ]` if the `ercTokenRegistry` is returning `null`
2) If visibleTokensInfo.length is `0` will use `InitialVisibleTokenInfo` instead

Additional changes with be added in this issue https://github.com/brave/brave-browser/issues/18139
where `visibleTokenInfo` will be returned from the `GetUserAssets` method in the `BraveWalletService`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/18232>

## Submitter Checklist:

- [] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

https://user-images.githubusercontent.com/40611140/134079493-93560b06-a829-4d78-921c-20ea6eba03d6.mov

After: 

https://user-images.githubusercontent.com/40611140/134079520-01eed5f2-5469-46b8-93b6-4c030b0f0714.mov
