### PR TITLE
Fixes MacOS notifications icon

### DIFF
--- a/patches/chrome-BUILD.gn.patch
+++ b/patches/chrome-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index c25d483469dbc2580f12340daefb85f085b4e127..d9ac59a39c9bade1f6eecd396c4da33fd7d121c0 100644
+index c25d483469dbc2580f12340daefb85f085b4e127..a78f9112b8948f2ee2583980af034df22d4dee05 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -164,6 +164,7 @@ if (!is_android && !is_mac) {
@@ -61,14 +61,14 @@ index c25d483469dbc2580f12340daefb85f085b4e127..d9ac59a39c9bade1f6eecd396c4da33f
      if (is_chrome_branded) {
        # These entitlements are bound to the official Google Chrome signing
        # certificate and will not necessarily work in any other build.
-@@ -665,6 +671,7 @@ if (is_win) {
+@@ -663,6 +669,7 @@ if (is_win) {
+         info_plist_target = invoker.info_plist_target
+       } else {
          info_plist_target = ":chrome_helper_plist"
++        info_plist_target = ":brave_helper_plist"
        }
  
-+      info_plist_target = ":brave_helper_plist"
        extra_substitutions = [
-         "CHROMIUM_BUNDLE_ID=$chrome_mac_bundle_id",
-         "CHROMIUM_SHORT_NAME=$chrome_product_short_name",
 @@ -1137,6 +1144,7 @@ if (is_win) {
      if (is_chrome_branded) {
        bundle_deps += [ ":preinstalled_apps" ]


### PR DESCRIPTION
Fixes brave/brave-browser#18154

Due to Chromium change below our prior patch to chrome/BUILD.gn was
always overwriting plist of all helper apps when it was only meant to do
so for one app.

Chromium change:

https://source.chromium.org/chromium/chromium/src/+/56915522276f86acc55f86b143b4d7b260d6bc36

commit 56915522276f86acc55f86b143b4d7b260d6bc36
Author: Richard Knoll <knollr@chromium.org>
Date:   Fri Mar 5 16:07:34 2021 +0000

    Introduce alert notification helper .app

    This adds a new helper .app on macOS to display alert notifications.
    This app is required to show alert style notifications as the main app
    can only show banner style ones and the XPC service can not use the new
    UNNotification APIs.

    Bug: 1127306

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

