### PR TITLE
Fixes Additional Settings button text being cutoff. (uplift to 1.31.x)

### DIFF
--- a/browser/resources/settings/brave_overrides/settings_menu.js
+++ b/browser/resources/settings/brave_overrides/settings_menu.js
@@ -133,7 +133,6 @@ RegisterStyleOverride(
         margin-top: 30px !important;
         line-height: 1.25 !important;
         border: none !important;
-        :host { border-radius: 0 !important; }
       }
 
       #advancedButton > iron-icon {

--- a/ui/webui/resources/overrides/cr_button.js
+++ b/ui/webui/resources/overrides/cr_button.js
@@ -35,6 +35,9 @@ export default html`
       border-radius: 100px !important; /* absurdly large to make sure is
                                           rounded at any height */
     }
+    :host([role='menuitem']) {
+      border-radius: 0px !important;
+    }
     :host(:not([style]):hover) {
       --text-color: var(--brave-brand-color) !important;
       --border-color: var(--text-color) !important;


### PR DESCRIPTION
Fixes brave/brave-browser#17461
Uplift of #9994

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.