### PR TITLE
Mitigate scriptlet injection races

### DIFF
--- a/components/cosmetic_filters/browser/cosmetic_filters_resources.h
+++ b/components/cosmetic_filters/browser/cosmetic_filters_resources.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/callback.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "brave/components/cosmetic_filters/common/cosmetic_filters.mojom.h"
@@ -35,20 +36,17 @@ class CosmeticFiltersResources final
                            brave_shields::AdBlockService* ad_block_service);
   ~CosmeticFiltersResources() override;
 
-  // Sends back to renderer a response: do we need to apply cosmetic filters
-  // for the url.
-  void ShouldDoCosmeticFiltering(
-      const std::string& url,
-      ShouldDoCosmeticFilteringCallback callback) override;
-
   // Sends back to renderer a response about rules that has to be applied
   // for the specified selectors.
   void HiddenClassIdSelectors(const std::string& input,
                               const std::vector<std::string>& exceptions,
                               HiddenClassIdSelectorsCallback callback) override;
 
-  // Sends back to renderer a response what rules and scripts has to be
-  // applied for the specified url.
+  // If cosmetic filtering is enabled, sends the renderer a response including
+  // whether or not to apply cosmetic filtering to first party elements along
+  // with an initial set of rules and scripts to apply for the given URL.
+  // If cosmetic filtering is disabled, `enabled` will be set to false and the
+  // other return values should be ignored.
   void UrlCosmeticResources(const std::string& url,
                             UrlCosmeticResourcesCallback callback) override;
 
@@ -56,7 +54,7 @@ class CosmeticFiltersResources final
   void HiddenClassIdSelectorsOnUI(HiddenClassIdSelectorsCallback callback,
                                   absl::optional<base::Value> resources);
 
-  void UrlCosmeticResourcesOnUI(UrlCosmeticResourcesCallback callback,
+  void UrlCosmeticResourcesOnUI(base::OnceCallback<void(base::Value)> callback,
                                 absl::optional<base::Value> resources);
 
   HostContentSettingsMap* settings_map_;             // Not owned

--- a/components/cosmetic_filters/common/cosmetic_filters.mojom
+++ b/components/cosmetic_filters/common/cosmetic_filters.mojom
@@ -3,10 +3,11 @@ module cosmetic_filters.mojom;
 import "mojo/public/mojom/base/values.mojom";
 
 interface CosmeticFiltersResources {
-  ShouldDoCosmeticFiltering(string url) => (bool enabled,
-                                            bool first_party_enabled);
-  UrlCosmeticResources(string url) => (mojo_base.mojom.Value result);
   // Receives an input string which is JSON object.
   HiddenClassIdSelectors(string input, array<string> exceptions) => (
       mojo_base.mojom.Value result);
+
+  UrlCosmeticResources(string url) => (bool enabled,
+                                       bool first_party_enabled,
+                                       mojo_base.mojom.Value result);
 };

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -305,20 +305,6 @@ void CosmeticFiltersJSHandler::ProcessURL(const GURL& url,
   if (!EnsureConnected() || url_.is_empty() || !url_.is_valid())
     return;
 
-  cosmetic_filters_resources_->ShouldDoCosmeticFiltering(
-      url_.spec(),
-      base::BindOnce(&CosmeticFiltersJSHandler::OnShouldDoCosmeticFiltering,
-                     base::Unretained(this), std::move(callback)));
-}
-
-void CosmeticFiltersJSHandler::OnShouldDoCosmeticFiltering(
-    base::OnceClosure callback,
-    bool enabled,
-    bool first_party_enabled) {
-  if (!enabled || !EnsureConnected())
-    return;
-
-  enabled_1st_party_cf_ = first_party_enabled;
   cosmetic_filters_resources_->UrlCosmeticResources(
       url_.spec(),
       base::BindOnce(&CosmeticFiltersJSHandler::OnUrlCosmeticResources,
@@ -327,7 +313,12 @@ void CosmeticFiltersJSHandler::OnShouldDoCosmeticFiltering(
 
 void CosmeticFiltersJSHandler::OnUrlCosmeticResources(
     base::OnceClosure callback,
+    bool enabled,
+    bool first_party_enabled,
     base::Value result) {
+  if (!enabled || !EnsureConnected())
+    return;
+  enabled_1st_party_cf_ = first_party_enabled;
   resources_dict_ = base::DictionaryValue::From(
       base::Value::ToUniquePtrValue(std::move(result)));
   std::move(callback).Run();

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.h
@@ -57,10 +57,10 @@ class CosmeticFiltersJSHandler {
   // A function to be called from JS
   void HiddenClassIdSelectors(const std::string& input);
 
-  void OnShouldDoCosmeticFiltering(base::OnceClosure callback,
-                                   bool enabled,
-                                   bool first_party_enabled);
-  void OnUrlCosmeticResources(base::OnceClosure callback, base::Value result);
+  void OnUrlCosmeticResources(base::OnceClosure callback,
+                              bool enabled,
+                              bool first_party_enabled,
+                              base::Value result);
   void CSSRulesRoutine(base::DictionaryValue* resources_dict);
   void OnHiddenClassIdSelectors(base::Value result);
   bool OnIsFirstParty(const std::string& url_string);

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
@@ -84,9 +84,14 @@ void CosmeticFiltersJsRenderFrameObserver::ReadyToCommitNavigation(
 }
 
 void CosmeticFiltersJsRenderFrameObserver::RunScriptsAtDocumentStart() {
-  ready_->Post(FROM_HERE,
-               base::BindOnce(&CosmeticFiltersJsRenderFrameObserver::ApplyRules,
-                              weak_factory_.GetWeakPtr()));
+  if (ready_->is_signaled()) {
+    ApplyRules();
+  } else {
+    ready_->Post(
+        FROM_HERE,
+        base::BindOnce(&CosmeticFiltersJsRenderFrameObserver::ApplyRules,
+                       weak_factory_.GetWeakPtr()));
+  }
 }
 
 void CosmeticFiltersJsRenderFrameObserver::ApplyRules() {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18228

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

The issue probably only ever occurred with a fast internet connection, so a wired connection is ideal for trying to reproduce it.

1. Copy the URL `https://icloud.com` into your clipboard.
1. Hold down <kbd>Ctrl</kbd> + <kbd>Shift</kbd>, and while holding those modifiers hit the <kbd>N</kbd> <kbd>V</kbd> <kbd>Enter</kbd> keys in rapid succession (releasing after each press). The idea is to open a new private tab, paste the URL into the URL bar, and navigate to the page in a new window, all within as short a time as possible. This maximizes the chance of triggering the race condition from my testing.
1. The page should never redirect to a "Your browser is not supported" message (located at https://icloud.com/unsupported_browser for reference).

The failure is not consistent, so repeat 5 times at maximum speed once you've had sufficient finger practice (I guess some kind of hotkey scripting would work here too, if you're feeling fancy :smile:).