### PR TITLE
Added Create New Password Field to Import Screens

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/create-password/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/create-password/index.tsx
@@ -53,10 +53,10 @@ function OnboardingCreatePassword (props: Props) {
           autoFocus={true}
         />
         <PasswordInput
-          placeholder={locale.createPasswordInput2}
+          placeholder={locale.confirmPasswordInput}
           onChange={onConfirmPasswordChanged}
           onKeyDown={handleKeyDown}
-          error={locale.createPasswordError2}
+          error={locale.confirmPasswordError}
           hasError={hasConfirmPasswordError}
         />
       </InputColumn>

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/index.tsx
@@ -9,8 +9,11 @@ import {
   MetaMaskIcon,
   BraveIcon,
   ArrowIcon,
-  LostButton
+  LostButton,
+  PasswordTitle,
+  CheckboxRow
 } from './style'
+import { Checkbox } from 'brave-ui'
 import { PasswordInput } from '../../../shared'
 import { NavButton } from '../../../extension'
 import locale from '../../../../constants/locale'
@@ -18,20 +21,42 @@ import locale from '../../../../constants/locale'
 export interface Props {
   onSubmit: () => void
   onPasswordChanged: (value: string) => void
+  onConfirmPasswordChanged: (value: string) => void
+  onImportPasswordChanged: (value: string) => void
   onClickLost: () => void
+  onUseSamePassword: (selected: boolean) => void
+  password: string
+  confirmedPassword: string
+  useSamePassword: boolean
   hasImportError: boolean
+  hasPasswordError: boolean
+  hasConfirmPasswordError: boolean
   disabled: boolean
   onboardingStep: WalletOnboardingSteps
+  needsNewPassword: boolean
+  useSamePasswordVerified: boolean
+  importPassword: string
 }
 
 function OnboardingImportMetaMaskOrLegacy (props: Props) {
   const {
     onSubmit,
     onPasswordChanged,
+    onConfirmPasswordChanged,
+    onImportPasswordChanged,
     onClickLost,
+    onUseSamePassword,
+    useSamePasswordVerified,
+    importPassword,
+    password,
+    confirmedPassword,
+    useSamePassword,
+    hasPasswordError,
+    hasConfirmPasswordError,
     hasImportError,
     onboardingStep,
-    disabled
+    disabled,
+    needsNewPassword
   } = props
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -41,6 +66,12 @@ function OnboardingImportMetaMaskOrLegacy (props: Props) {
   }
 
   const isMetaMask = onboardingStep === WalletOnboardingSteps.OnboardingImportMetaMask
+
+  const onSelectUseSamePassword = (key: string, selected: boolean) => {
+    if (key === 'useSamePassword') {
+      onUseSamePassword(selected)
+    }
+  }
 
   return (
     <StyledWrapper>
@@ -64,16 +95,48 @@ function OnboardingImportMetaMaskOrLegacy (props: Props) {
           : locale.importBraveLegacyDescription
         }
       </Description>
-      <InputColumn>
+      <InputColumn useSamePasswordVerified={useSamePasswordVerified}>
         <PasswordInput
           placeholder={isMetaMask ? locale.importMetaMaskInput : locale.importBraveLegacyInput}
-          onChange={onPasswordChanged}
+          onChange={onImportPasswordChanged}
           error={locale.lockScreenError}
-          onKeyDown={handleKeyDown}
           hasError={hasImportError}
           autoFocus={true}
         />
       </InputColumn>
+      {!useSamePasswordVerified &&
+        <PasswordTitle needsNewPassword={needsNewPassword}>
+          {needsNewPassword ?
+            locale.braveWalletImportFromExternalNewPassword
+            : locale.braveWalletImportFromExternalCreatePassword}
+        </PasswordTitle>
+      }
+      {!needsNewPassword &&
+        <CheckboxRow>
+          <Checkbox disabled={importPassword === ''} value={{ useSamePassword: useSamePassword }} onChange={onSelectUseSamePassword}>
+            <div data-key='useSamePassword'>{locale.braveWalletImportFromExternalPasswordCheck}</div>
+          </Checkbox>
+        </CheckboxRow>
+      }
+      {!useSamePasswordVerified &&
+        <InputColumn>
+          <PasswordInput
+            placeholder={locale.createPasswordInput}
+            value={password}
+            onChange={onPasswordChanged}
+            error={locale.createPasswordError}
+            hasError={hasPasswordError}
+          />
+          <PasswordInput
+            placeholder={locale.confirmPasswordInput}
+            value={confirmedPassword}
+            onChange={onConfirmPasswordChanged}
+            onKeyDown={handleKeyDown}
+            error={locale.confirmPasswordError}
+            hasError={hasConfirmPasswordError}
+          />
+        </InputColumn>
+      }
       <NavButton buttonType='primary' text={locale.addAccountImport} onSubmit={onSubmit} disabled={disabled} />
       {!isMetaMask &&
         <LostButton onClick={onClickLost}>{locale.importBraveLegacyAltButton}</LostButton>

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/style.ts
@@ -5,6 +5,8 @@ import AIcon from '../../../../assets/svg-icons/import-arrow-icon.svg'
 
 interface StyleProps {
   isMetaMask: boolean
+  needsNewPassword: boolean
+  useSamePasswordVerified: boolean
 }
 
 export const StyledWrapper = styled.div`
@@ -47,13 +49,13 @@ export const PageIcons = styled.div`
   margin-bottom: 24px;
 `
 
-export const InputColumn = styled.div`
+export const InputColumn = styled.div<Partial<StyleProps>>`
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   width: 250px;
-  margin-bottom: 28px;
+  margin-bottom: ${(p) => p.useSamePasswordVerified ? '0px' : '25px'};
 `
 
 export const MetaMaskIcon = styled.div`
@@ -63,7 +65,7 @@ export const MetaMaskIcon = styled.div`
   margin-right: 4px;
 `
 
-export const BraveIcon = styled.div<StyleProps>`
+export const BraveIcon = styled.div<Partial<StyleProps>>`
   width: ${(p) => p.isMetaMask ? '82px' : '118px'};
   height: ${(p) => p.isMetaMask ? '94px' : '135px'};
   background: url(${BIcon});
@@ -92,4 +94,25 @@ export const LostButton = styled.button`
   letter-spacing: 0.01em;
   color: ${(p) => p.theme.color.text03};
   margin-top: 35px;
+`
+
+export const PasswordTitle = styled.span<Partial<StyleProps>>`
+  width: 295px;
+  text-align: center;
+  font-family: Poppins;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 20px;
+  color: ${(p) => p.needsNewPassword ? p.theme.color.errorText : p.theme.color.text02};
+  letter-spacing: 0.04em;
+  margin-bottom: ${(p) => p.needsNewPassword ? '12px' : '6px'};
+`
+
+export const CheckboxRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-direction: row;
+  margin-bottom: 6px;
+  width: 250px;
 `

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/index.tsx
@@ -158,10 +158,10 @@ function OnboardingRestore (props: Props) {
               error={locale.createPasswordError}
             />
             <PasswordInput
-              placeholder={locale.createPasswordInput2}
+              placeholder={locale.confirmPasswordInput}
               onChange={handleConfirmPasswordChanged}
               hasError={checkConfirmedPassword}
-              error={locale.createPasswordError2}
+              error={locale.confirmPasswordError}
               onKeyDown={handleKeyDown}
             />
           </InputColumn>

--- a/components/brave_wallet_ui/components/shared/password-input/index.tsx
+++ b/components/brave_wallet_ui/components/shared/password-input/index.tsx
@@ -12,13 +12,14 @@ export interface Props {
   onChange: (value: string) => void
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void
   autoFocus?: boolean
+  value?: string
   placeholder: string
   hasError: boolean
   error: string
 }
 
 function OnboardingCreatePassword (props: Props) {
-  const { onChange, onKeyDown, placeholder, error, hasError, autoFocus } = props
+  const { onChange, onKeyDown, placeholder, error, hasError, autoFocus, value } = props
 
   const inputPassword = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.value)
@@ -30,6 +31,7 @@ function OnboardingCreatePassword (props: Props) {
         hasError={hasError}
         type='password'
         placeholder={placeholder}
+        value={value}
         onChange={inputPassword}
         onKeyDown={onKeyDown}
         autoFocus={autoFocus}

--- a/components/brave_wallet_ui/constants/locale.ts
+++ b/components/brave_wallet_ui/constants/locale.ts
@@ -109,11 +109,11 @@ const locale = {
 
   // Create Password
   createPasswordTitle: 'Secure your crypto with a password',
-  createPasswordDescription: 'Password must be at least 7 characters containing at least one number and a special character',
+  createPasswordDescription: 'Passwords must be at least 7 characters containing at least one number and a special character.',
   createPasswordInput: 'Password',
-  createPasswordInput2: 'Re-Type Password',
-  createPasswordError: 'Password must be 7 or more characters',
-  createPasswordError2: 'Re-typed password does not match',
+  confirmPasswordInput: 'Re-Type Password',
+  createPasswordError: 'Passwords must be at least 7 characters containing at least one number and a special character.',
+  confirmPasswordError: 'Re-typed password does not match',
 
   // Lock Screen
   lockScreenTitle: 'Enter password to unlock wallet',
@@ -295,6 +295,11 @@ const locale = {
   connectWithSiteDescription2: 'permitted accounts (required)',
   connectWithSiteNext: 'Next',
   connectWithSiteHeaderTitle: 'Connect With Brave Wallet',
+
+  // Import from external wallets
+  braveWalletImportFromExternalNewPassword: 'A more secure password is required for Brave Wallet',
+  braveWalletImportFromExternalCreatePassword: 'Set a Brave Wallet password',
+  braveWalletImportFromExternalPasswordCheck: 'Use the same password',
 
   // Import from MetaMask
   importMetaMaskTitle: 'Import from MetaMask',

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -143,17 +143,17 @@ function Container (props: Props) {
   }, [swapQuote])
 
   const onSwapParamsChange = React.useCallback((
-      state: {
-        fromAmount: string,
-        toAmount: string
-      },
-      overrides: {
-        toOrFrom: ToOrFromType
-        asset?: AccountAssetOptionType
-        amount?: string
-        slippageTolerance?: SlippagePresetObjectType
-      },
-      full: boolean = false
+    state: {
+      fromAmount: string,
+      toAmount: string
+    },
+    overrides: {
+      toOrFrom: ToOrFromType
+      asset?: AccountAssetOptionType
+      amount?: string
+      slippageTolerance?: SlippagePresetObjectType
+    },
+    full: boolean = false
   ) => {
     if (selectedWidgetTab !== 'swap') {
       return
@@ -164,15 +164,15 @@ function Container (props: Props) {
 
     if (overrides.toOrFrom === 'from') {
       fromAmountWei = toWei(
-          overrides.amount ?? state.fromAmount,
-          fromAsset.asset.decimals
+        overrides.amount ?? state.fromAmount,
+        fromAsset.asset.decimals
       )
     }
 
     if (overrides.toOrFrom === 'to') {
       toAmountWei = toWei(
-          overrides.amount ?? state.toAmount,
-          toAsset.asset.decimals
+        overrides.amount ?? state.toAmount,
+        toAsset.asset.decimals
       )
     }
 
@@ -547,14 +547,12 @@ function Container (props: Props) {
     props.walletPageActions.doneViewingPrivateKey()
   }
 
-  const onImportCryptoWallets = (password: string) => {
-    // TODO(Douglashdaniel): Use different set of password for new password
-    props.walletPageActions.importFromCryptoWallets({ password, newPassword: password })
+  const onImportCryptoWallets = (password: string, newPassword: string) => {
+    props.walletPageActions.importFromCryptoWallets({ password, newPassword })
   }
 
-  const onImportMetaMask = (password: string) => {
-    // TODO(Douglashdaniel): Use different set of password for new password
-    props.walletPageActions.importFromMetaMask({ password, newPassword: password })
+  const onImportMetaMask = (password: string, newPassword: string) => {
+    props.walletPageActions.importFromMetaMask({ password, newPassword })
   }
 
   const checkWalletsToImport = () => {

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -599,8 +599,10 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     })
   }
 
-  const onImportWallet = () => {
-    completeWalletSetup(false)
+  const onImportWallet = (password: string) => {
+    if (password !== 'password') {
+      setImportError(true)
+    }
   }
 
   const onAddHardwareAccounts = (accounts: HardwareWalletAccount[]) => {


### PR DESCRIPTION
## Description 
Added Create New Password Fields to the Onboarding Import Screens for importing from a `MetaMask` or `BraveLegacyWallet`

1) Now Requires to enter a new `Password` on the import screen
2) Gives the option to use same `Password` of the importing wallet, but if it does not meet the new wallet password requirements, will force the user to create a new password that does.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/18264>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A



https://user-images.githubusercontent.com/40611140/134741210-c2d83d11-f17f-45fb-ad17-7c57c68a8b35.mov


## Test Plan:
Please reference the test plan in this pull request https://github.com/brave/brave-core/pull/10161
but with some additional steps for `MetaMask` and `Crypto Wallet`

New Wallet Password Requirements are
`Passwords must be at least 7 characters containing at least one number and a special character.`

### Additional Steps:
1. Input different password from ("referenced  step 1") and input a new password meeting password requirements, click `Import`.
2. There will be an import error message.
3. Input a password that does not meet password requirements into the import password field and click the `Use the same password` check box.
4. The UI should change from `Set a Brave Wallet password` too `A more secure password is required for Brave Wallet` and require you to create a new password that meets the requirements.
5. Input a password that meets password requirements into the import password field and click the `Use the same password` check box.
6. UI will hide the new password fields and allow you to continue or you can uncheck `Use the same password` and enter a new password.
7. Input correct password from ("referenced  step 1"), if you know that that your password meets requirements and want to use it, click the `Use the same password` check box or create a new password.
8. Click `Import`.
8. The wallet will be setup with your new or same password, depending on your preference.
9. Check the mnemonic is same as ("referenced  step 1") 



