### PR TITLE
Revert "Revert "[MacOS][Signing] Revert overwriting Alerts helper app id."" (uplift to 1.31.x)

### DIFF
--- a/script/signing_helper.py
+++ b/script/signing_helper.py
@@ -124,15 +124,6 @@ def AddBravePartsForSigning(parts, config):
     parts['helper-app'].options = (CodeSignOptions.RESTRICT
                                    + CodeSignOptions.KILL
                                    + CodeSignOptions.HARDENED_RUNTIME)
-    # Alerts helper is not being distributed with Chrome yet and, because it
-    # uses the same identifier as the current Alerts service, the signing fails.
-    # For now we can set a different identifier and then remove this change once
-    # the helper starts being bundled into the distribution.
-    # Cr94 update: Alrts helper is now distributed with Chrome and the conflicting
-    # XPC Notification service is supposed to be gone, but we still end up with
-    # the signing error. So, let's keep this override and see if it causes any
-    # issues.
-    parts['helper-alerts'].identifier = '{}.helper.alerts'.format(config.base_bundle_id)
 
     return parts
 


### PR DESCRIPTION
Fixes brave/brave-browser#18282
Uplift of #10205

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.