### PR TITLE
[IOS] Aligning Sync API initialization with other iOS API classes

### DIFF
--- a/ios/app/brave_core_main.h
+++ b/ios/app/brave_core_main.h
@@ -10,6 +10,7 @@
 
 @class BraveBookmarksAPI;
 @class BraveHistoryAPI;
+@class BraveSyncAPI;
 @class BraveSyncProfileServiceIOS;
 @protocol BraveWalletERCTokenRegistry;
 
@@ -27,6 +28,8 @@ OBJC_EXPORT
 @property(nonatomic, readonly) BraveBookmarksAPI* bookmarksAPI;
 
 @property(nonatomic, readonly) BraveHistoryAPI* historyAPI;
+
+@property(nonatomic, readonly) BraveSyncAPI* syncAPI;
 
 @property(nonatomic, readonly) BraveSyncProfileServiceIOS* syncProfileService;
 

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -183,8 +183,7 @@ static bool CustomLogHandler(int severity,
 
 - (BraveSyncAPI*)syncAPI {
   if (!_syncAPI) {
-    _syncAPI = [[BraveSyncAPI alloc]
-        initWithBrowserState:_mainBrowserState];
+    _syncAPI = [[BraveSyncAPI alloc] initWithBrowserState:_mainBrowserState];
   }
   return _syncAPI;
 }

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -16,6 +16,7 @@
 #include "brave/ios/browser/api/bookmarks/brave_bookmarks_api+private.h"
 #include "brave/ios/browser/api/brave_wallet/brave_wallet.mojom.objc+private.h"
 #include "brave/ios/browser/api/history/brave_history_api+private.h"
+#include "brave/ios/browser/api/sync/brave_sync_api+private.h"
 #include "brave/ios/browser/api/sync/driver/brave_sync_profile_service+private.h"
 #include "brave/ios/browser/brave_web_client.h"
 #include "components/history/core/browser/history_service.h"
@@ -45,6 +46,7 @@ static BraveCoreLogHandler _Nullable _logHandler = nil;
 }
 @property(nonatomic) BraveBookmarksAPI* bookmarksAPI;
 @property(nonatomic) BraveHistoryAPI* historyAPI;
+@property(nonatomic) BraveSyncAPI* syncAPI;
 @property(nonatomic) BraveSyncProfileServiceIOS* syncProfileService;
 @end
 
@@ -177,6 +179,14 @@ static bool CustomLogHandler(int severity,
                                       webHistoryService:web_history_service_];
   }
   return _historyAPI;
+}
+
+- (BraveSyncAPI*)syncAPI {
+  if (!_syncAPI) {
+    _syncAPI = [[BraveSyncAPI alloc]
+        initWithBrowserState:_mainBrowserState];
+  }
+  return _syncAPI;
 }
 
 - (BraveSyncProfileServiceIOS*)syncProfileService {

--- a/ios/browser/api/sync/brave_sync_api+private.h
+++ b/ios/browser/api/sync/brave_sync_api+private.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_API_SYNC_BRAVE_SYNC_API_PRIVATE_H_
+#define BRAVE_IOS_BROWSER_API_SYNC_BRAVE_SYNC_API_PRIVATE_H_
+
+#import <Foundation/Foundation.h>
+
+#include "brave/ios/browser/api/sync/brave_sync_api.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+class ChromeBrowserState;
+
+@interface BraveSyncAPI (Private)
+- (instancetype)initWithBrowserState:(ChromeBrowserState*) mainBrowserState;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_SYNC_BRAVE_SYNC_API_PRIVATE_H_

--- a/ios/browser/api/sync/brave_sync_api+private.h
+++ b/ios/browser/api/sync/brave_sync_api+private.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 class ChromeBrowserState;
 
 @interface BraveSyncAPI (Private)
-- (instancetype)initWithBrowserState:(ChromeBrowserState*) mainBrowserState;
+- (instancetype)initWithBrowserState:(ChromeBrowserState*)mainBrowserState;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/sync/brave_sync_api.h
+++ b/ios/browser/api/sync/brave_sync_api.h
@@ -14,10 +14,10 @@ NS_ASSUME_NONNULL_BEGIN
 OBJC_EXPORT
 @interface BraveSyncAPI : NSObject
 
-@property(class, readonly, strong)
-    BraveSyncAPI* sharedSyncAPI NS_SWIFT_NAME(shared);
 @property(nonatomic) bool syncEnabled;
 @property(nonatomic, readonly) bool isSyncFeatureActive;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 - (void)resetSync;
 

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -80,7 +80,7 @@
 
 @implementation BraveSyncAPI
 
-- (instancetype)initWithBrowserState:(ChromeBrowserState*) mainBrowserState {
+- (instancetype)initWithBrowserState:(ChromeBrowserState*)mainBrowserState {
   if ((self = [super init])) {
     _chromeBrowserState = mainBrowserState;
     _worker.reset(new BraveSyncWorker(_chromeBrowserState));

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -80,20 +80,9 @@
 
 @implementation BraveSyncAPI
 
-+ (instancetype)sharedSyncAPI {
-  static BraveSyncAPI* instance = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    instance = [[BraveSyncAPI alloc] init];
-  });
-  return instance;
-}
-
-- (instancetype)init {
+- (instancetype)initWithBrowserState:(ChromeBrowserState*) mainBrowserState {
   if ((self = [super init])) {
-    ios::ChromeBrowserStateManager* browserStateManager =
-        GetApplicationContext()->GetChromeBrowserStateManager();
-    _chromeBrowserState = browserStateManager->GetLastUsedBrowserState();
+    _chromeBrowserState = mainBrowserState;
     _worker.reset(new BraveSyncWorker(_chromeBrowserState));
   }
   return self;


### PR DESCRIPTION
The usage of how constructors in SyncAPI should be aligned with other API classes. (History, Bookmarks, SyncProfile)

The usage of singleton instance should be removed and constructor should be initialized with assigning the browserState directly.

So the lifetime observation of these services will be under control of brave_core_main. Also the initializer should be used privately and moved to a private header file.

Resolves brave/brave-browser#18320

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A
