### PR TITLE
Adjust unverified publisher note display logic

### DIFF
--- a/components/brave_rewards/resources/rewards_panel/components/publisher_card.tsx
+++ b/components/brave_rewards/resources/rewards_panel/components/publisher_card.tsx
@@ -43,20 +43,36 @@ export function PublisherCard () {
     return null
   }
 
-  function renderPendingBubble () {
+  function shouldRenderPendingBubble () {
     if (!publisherInfo) {
-      return null
+      return false
     }
 
-    const { supportedWalletProviders } = publisherInfo
+    const { registered, supportedWalletProviders } = publisherInfo
 
-    if (supportedWalletProviders.length > 0) {
-      if (!externalWallet) {
-        return null
-      }
-      if (supportedWalletProviders.includes(externalWallet.provider)) {
-        return null
-      }
+    // Show the bubble if the publisher is not registered.
+    if (!registered) {
+      return true
+    }
+
+    // Do not show the bubble if the publisher is registered and the user does
+    // not have an external wallet.
+    if (!externalWallet) {
+      return false
+    }
+
+    // Do not show the bubble if the publisher has a wallet provider address
+    // that matches the user's wallet provider.
+    if (supportedWalletProviders.includes(externalWallet.provider)) {
+      return false
+    }
+
+    return true
+  }
+
+  function renderPendingBubble () {
+    if (!publisherInfo || !shouldRenderPendingBubble()) {
+      return null
     }
 
     return (

--- a/components/brave_rewards/resources/tip/components/publisher_banner.tsx
+++ b/components/brave_rewards/resources/tip/components/publisher_banner.tsx
@@ -163,14 +163,13 @@ function showUnverifiedNotice (
   publisherInfo: PublisherInfo,
   externalWalletInfo?: ExternalWalletInfo
 ) {
-  // Show the notice if the publisher is not registered, or if the publisher
-  // does not have a verified payment address
-  if (publisherInfo.status === PublisherStatus.NOT_VERIFIED ||
-      publisherInfo.status === PublisherStatus.CONNECTED) {
+  // Show the notice if the publisher is not registered.
+  if (publisherInfo.status === PublisherStatus.NOT_VERIFIED) {
     return true
   }
 
-  // If the user does not have a connected wallet, do not show the notice
+  // Do not show the notice if the publisher is registered and the user does
+  // not have a connected external wallet.
   if (!externalWalletInfo) {
     return false
   }
@@ -182,7 +181,7 @@ function showUnverifiedNotice (
   }
 
   // Show the notice if the publisher is verified and their wallet provider does
-  // not match the user's external wallet provider
+  // not match the user's external wallet provider.
   switch (publisherInfo.status) {
     case PublisherStatus.UPHOLD_VERIFIED:
       return externalWalletInfo.type !== 'uphold'
@@ -192,7 +191,7 @@ function showUnverifiedNotice (
       return externalWalletInfo.type !== 'gemini'
   }
 
-  return false
+  return true
 }
 
 function getUnverifiedNotice (


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18341

Previously, an "unverified tipping note" would appear in the following case:

- The user does not have an external wallet
- The publisher is registered but does not have a verified wallet provider address.

Per clarification in https://github.com/brave/brave-browser/issues/18137, the user should *not* see the message in this case on either the rewards panel or the tipping banner.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Message 1: "This creator is not signed up yet. Any tip you make will remain pending in your wallet and retry automatically for 90 days. Learn more."

Message 2: "This creator is currently not configured to receive tips from your wallet. Any tip you make will remain pending in your wallet and retry automatically for 90 days. Learn more."

### Case 1: Not registered

Example staging creator: `apple.com`

- Given that the user has enabled rewards
- When the user navigates to a publisher page
- And the publisher is not a registered creator
- Then the Rewards panel publisher status indicator should display message 1 on hover.

### Case 2: Registered but not verified, user not verified

Example staging creator: `www.reddit.com/user/jsadler-brave`

- Given that the user has enabled rewards
- And the user does not have a connected external wallet
- When the user navigates to a publisher page
- And the publisher is a registered creator
- And the publisher is not verified with any wallet provider
- Then the Rewards panel publisher status indicator should not display a message on hover.

### Case 3: Registered but not verified, user verified

Example staging creator: `www.reddit.com/user/jsadler-brave`

- Given that the user has enabled rewards
- And the user has a connected external wallet
- When the user navigates to a publisher page
- And the publisher is a registered creator
- And the publisher is not verified with any wallet provider
- Then the Rewards panel publisher status indicator should display message 2 on hover.

### Case 4: Verified and user is not connected

Example staging creator: `laurenwags.github.io`

- Given that the user has enabled rewards
- And has not connected to an external wallet provider
- When the user navigates to a publisher page
- And the publisher is verified with any wallet provider
- Then the Rewards panel publisher status indicator should not display a message on hover

### Case 5: Verified with non-matching wallet provider

- Given that the user has enabled rewards
- And has connected to an external wallet provider
- When the user navigates to a publisher page
- And the publisher is verified with a different wallet provider
- Then the Rewards panel publisher status indicator should display message 2 on hover.

### Case 6: Verified with matching wallet provider

- Given that the user has enabled rewards
- And has connected to an external wallet provider
- When the user navigates to a publisher page
- And the publisher is verified with the same wallet provider
- Then the Rewards panel publisher status indicator should not display a message on hover.