### PR TITLE
Fixes custom ad notifications are not shown when system notification are disabled - 1.31.x

### DIFF
--- a/components/brave_ads/common/features.cc
+++ b/components/brave_ads/common/features.cc
@@ -18,6 +18,12 @@ const base::Feature kCustomAdNotifications{"CustomAdNotifications",
 
 namespace {
 
+// Set to true to fallback to custom ad notifications if native notifications
+// are disabled or false to never fallback
+const char kFieldTrialParameterCanFallbackToCustomAdNotifications[] =
+    "can_fallback_to_custom_notifications";
+const bool kDefaultCanFallbackToCustomAdNotifications = false;
+
 // Ad notification timeout in seconds. Set to 0 to never time out
 const char kFieldTrialParameterAdNotificationTimeout[] =
     "ad_notification_timeout";
@@ -26,12 +32,6 @@ const int kDefaultAdNotificationTimeout = 120;
 #else
 const int kDefaultAdNotificationTimeout = 30;
 #endif
-
-// Set to true to fallback from native to custom ad notifications or false to
-// never fallback
-const char kFieldTrialParameterCanFallbackToCustomAdNotifications[] =
-    "can_fallback_to_custom_notifications";
-const bool kDefaultCanFallbackToCustomAdNotifications = false;
 
 #if !defined(OS_ANDROID)
 
@@ -105,6 +105,12 @@ bool IsAdNotificationsEnabled() {
   return base::FeatureList::IsEnabled(kAdNotifications);
 }
 
+bool CanFallbackToCustomAdNotifications() {
+  return GetFieldTrialParamByFeatureAsBool(
+      kAdNotifications, kFieldTrialParameterCanFallbackToCustomAdNotifications,
+      kDefaultCanFallbackToCustomAdNotifications);
+}
+
 int AdNotificationTimeout() {
   return GetFieldTrialParamByFeatureAsInt(
       kAdNotifications, kFieldTrialParameterAdNotificationTimeout,
@@ -113,13 +119,6 @@ int AdNotificationTimeout() {
 
 bool IsCustomAdNotificationsEnabled() {
   return base::FeatureList::IsEnabled(kCustomAdNotifications);
-}
-
-bool CanFallbackToCustomAdNotifications() {
-  return GetFieldTrialParamByFeatureAsBool(
-      kCustomAdNotifications,
-      kFieldTrialParameterCanFallbackToCustomAdNotifications,
-      kDefaultCanFallbackToCustomAdNotifications);
 }
 
 #if !defined(OS_ANDROID)

--- a/components/brave_ads/common/features.h
+++ b/components/brave_ads/common/features.h
@@ -20,13 +20,12 @@ namespace features {
 extern const base::Feature kAdNotifications;
 
 bool IsAdNotificationsEnabled();
+bool CanFallbackToCustomAdNotifications();
 int AdNotificationTimeout();
 
 extern const base::Feature kCustomAdNotifications;
 
 bool IsCustomAdNotificationsEnabled();
-
-bool CanFallbackToCustomAdNotifications();
 #if !defined(OS_ANDROID)
 int AdNotificationFadeDuration();
 std::string AdNotificationDarkModeBackgroundColor();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/10252
Resolves https://github.com/brave/brave-browser/issues/18351

- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
