### PR TITLE
Improve Brave ads performance on iOS by not populating transaction_history and adsShownHistory - 1.30.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/confirmations/confirmations_state.cc
@@ -161,7 +161,9 @@ TransactionList ConfirmationsState::get_transactions() const {
 
 void ConfirmationsState::add_transaction(const TransactionInfo& transaction) {
   DCHECK(is_initialized_);
+#if !defined(OS_IOS)
   transactions_.push_back(transaction);
+#endif
 }
 
 base::Time ConfirmationsState::get_next_token_redemption_date() const {
@@ -627,6 +629,7 @@ bool ConfirmationsState::GetTransactionsFromDictionary(
 
 bool ConfirmationsState::ParseTransactionsFromDictionary(
     base::DictionaryValue* dictionary) {
+#if !defined(OS_IOS)
   DCHECK(dictionary);
 
   base::Value* transactions_dictionary =
@@ -638,6 +641,7 @@ bool ConfirmationsState::ParseTransactionsFromDictionary(
   if (!GetTransactionsFromDictionary(transactions_dictionary, &transactions_)) {
     return false;
   }
+#endif
 
   return true;
 }

--- a/vendor/bat-native-ads/src/bat/ads/internal/client/client.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client/client.cc
@@ -101,6 +101,7 @@ void Client::Initialize(InitializeCallback callback) {
 }
 
 void Client::AppendAdHistory(const AdHistoryInfo& ad_history) {
+#if !defined(OS_IOS)
   DCHECK(is_initialized_);
 
   client_->ads_shown_history.push_front(ad_history);
@@ -118,6 +119,7 @@ void Client::AppendAdHistory(const AdHistoryInfo& ad_history) {
   client_->ads_shown_history.erase(iter, client_->ads_shown_history.end());
 
   Save();
+#endif
 }
 
 const std::deque<AdHistoryInfo>& Client::GetAdsHistory() const {

--- a/vendor/bat-native-ads/src/bat/ads/internal/client/client_info.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client/client_info.cc
@@ -41,6 +41,7 @@ bool ClientInfo::FromJson(const std::string& json) {
     }
   }
 
+#if !defined(OS_IOS)
   if (document.HasMember("adsShownHistory")) {
     for (const auto& ad_shown : document["adsShownHistory"].GetArray()) {
       // adsShownHistory used to be an array of timestamps, so if
@@ -57,6 +58,7 @@ bool ClientInfo::FromJson(const std::string& json) {
       }
     }
   }
+#endif
 
   if (document.HasMember("purchaseIntentSignalHistory")) {
     for (const auto& segment_history :


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/10088
Resolves https://github.com/brave/brave-browser/issues/18118
Resolves https://github.com/brave/brave-ios/issues/3941

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
