### PR TITLE
Storybook can use output in gen/ and chrome://resources browser-build-generated output directories

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const AliasPlugin = require('enhanced-resolve/lib/AliasPlugin')
 
 // Export a function. Accept the base config as the only param.
 module.exports = async ({ config, mode }) => {
@@ -8,6 +9,10 @@ module.exports = async ({ config, mode }) => {
     loader: require.resolve('ts-loader'),
     exclude: /node_modules\/(?!brave-ui)/,
     options: {
+      // TODO(petemill): point to the tsconfig in gen/[target] that
+      // is made during build-time, or generate a new one. For both those
+      // options, use a cli arg or environment variable to obtain the correct
+      // build target.
       configFile: path.resolve(__dirname, '..', 'tsconfig-storybook.json'),
       allowTsInNodeModules: true,
       getCustomTransformers: path.join(__dirname, '../components/webpack/webpack-ts-transformers.js'),
@@ -17,21 +22,55 @@ module.exports = async ({ config, mode }) => {
     test: /\.avif$/,
     loader: 'file-loader'
   })
-  config.resolve.alias = {
-    ...config.resolve.alias,
-    // Put mojom-generated output (either copied from real generated
-    // output or manually create modules exporting expected types) so
-    // that storybook UI may use them. This is preferred to be copied here so that
-    // 1. Storybook can be compiled without the browser being compiled,
-    // and 2. To act as a snapshot.
-    'gen': path.resolve(__dirname, 'gen-mock'),
-    // If stories include calls to chromium code, the functions should be mocked.
-    'chrome://resources': path.resolve(__dirname, 'chrome-resources-mock'),
-    'brave-ui': path.resolve(__dirname, '../node_modules/brave-ui/src'),
-    // Force same styled-components module for brave-core and brave-ui
-    // which ensure both repos code use the same singletons, e.g. ThemeContext.
-    'styled-components': path.resolve(__dirname, '../node_modules/styled-components'),
-  }
+  // Use webpack resolve.alias from v5 whilst still using webpack v4,
+  // so that we can use an array as value
+  config.resolve.plugins = [
+    ...config.resolve.plugins,
+    new AliasPlugin(
+      'described-resolve', [
+        {
+          name: 'brave-ui',
+          alias: path.resolve(__dirname, '../node_modules/brave-ui/src'),
+        },
+        {
+          // Force same styled-components module for brave-core and brave-ui
+          // which ensure both repos code use the same singletons, e.g. ThemeContext.
+          name: 'styled-components',
+          alias: path.resolve(__dirname, '../node_modules/styled-components'),
+        },
+        {
+          name: 'chrome://resources',
+          alias: [
+            // Mock chromium code where possible
+            path.resolve(__dirname, 'chrome-resources-mock'),
+            // TODO(petemill): This is not ideal since if the dev is using a Static
+            // build, but has previously made a Component build, then an outdated
+            // version of a module will be used. Instead, accept a cli argument
+            // or environment variable containing which build target to use.
+            path.resolve(__dirname, '../../out/Component/gen/ui/webui/resources'),
+            path.resolve(__dirname, '../../out/Static/gen/ui/webui/resources'),
+            path.resolve(__dirname, '../../out/Debug/gen/ui/webui/resources'),
+            path.resolve(__dirname, '../../out/Release/gen/ui/webui/resources'),
+          ]
+        },
+        {
+          name: 'gen',
+          alias: [
+            // Mock chromium code where possible
+            path.resolve(__dirname, 'gen-mock'),
+            // TODO(petemill): This is not ideal since if the dev is using a Static
+            // build, but has previously made a Component build, then an outdated
+            // version of a module will be used. Instead, accept a cli argument
+            // or environment variable containing which build target to use.
+            path.resolve(__dirname, '../../out/Component/gen'),
+            path.resolve(__dirname, '../../out/Static/gen'),
+            path.resolve(__dirname, '../../out/Debug/gen'),
+            path.resolve(__dirname, '../../out/Release/gen'),
+          ]
+        },
+      ], 'resolve'
+    )
+  ]
   config.resolve.extensions.push('.ts', '.tsx')
   return config
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9037,25 +9037,20 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+      "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
       },
       "dependencies": {
-        "memory-fs": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-          "dev": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+          "dev": true
         }
       }
     },
@@ -18499,6 +18494,17 @@
             "supports-color": "^5.3.0"
           }
         },
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
         "json5": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -18517,6 +18523,16 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
+          }
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         }
       }
@@ -19738,6 +19754,29 @@
             }
           }
         },
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+              "dev": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            }
+          }
+        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -19932,6 +19971,17 @@
             "wrap-ansi": "^5.1.0"
           }
         },
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -19991,6 +20041,16 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "p-locate": {

--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
     "csstype": "2.6.15",
     "deep-freeze-node": "1.1.3",
     "emptykit.css": "1.0.1",
+    "enhanced-resolve": "5.8.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "ethereum-blockies": "github:brave/blockies#07ebdfa3ed79fceec8234ef8c880ebdefd79bf0a",


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/18399
Requires https://github.com/brave/devops/pull/5914

Disadvantage is that Storybook will now rely on a browser build. But I think that's the point we're at. It's possible we could have it depend on only the targets which make JS output in the `gen/` directory. That would certainly be a much much smaller build, but would still require the chromium source being synced.

I have not requested a security review for the package update, since it is a version increase of a package which is already included as part of webpack.

I think this might also be the first PR to upgrade the package-lock.json format to v2, but it is backwards-compatible with npm v6.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- `npm run storybook` should still work