### PR TITLE
Introduced BraveVPNServiceObserver

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -70,15 +70,8 @@ BraveBrowserCommandController::BraveBrowserCommandController(Browser* browser)
       browser_(browser),
       brave_command_updater_(nullptr) {
   InitBraveCommandState();
-
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  if (brave_vpn::IsBraveVPNEnabled()) {
-    mojo::PendingRemote<brave_vpn::mojom::ServiceObserver> listener;
-    receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
-    if (auto* vpn_service =
-            BraveVpnServiceFactory::GetForProfile(browser_->profile()))
-      vpn_service->AddObserver(std::move(listener));
-  }
+  Observe(BraveVpnServiceFactory::GetForProfile(browser_->profile()));
 #endif
 }
 

--- a/browser/ui/brave_browser_command_controller.h
+++ b/browser/ui/brave_browser_command_controller.h
@@ -16,8 +16,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-#include "brave/components/brave_vpn/brave_vpn.mojom.h"
-#include "mojo/public/cpp/bindings/receiver.h"
+#include "brave/components/brave_vpn/brave_vpn_service_observer.h"
 #endif
 
 class BraveAppMenuBrowserTest;
@@ -29,7 +28,7 @@ namespace chrome {
 class BraveBrowserCommandController : public chrome::BrowserCommandController
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
     ,
-                                      public brave_vpn::mojom::ServiceObserver
+                                      public BraveVPNServiceObserver
 #endif
 {
  public:
@@ -57,12 +56,8 @@ class BraveBrowserCommandController : public chrome::BrowserCommandController
   bool UpdateCommandEnabled(int id, bool state) override;
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  // brave_vpn::mojom::ServiceObserver overrides:
+  // BraveVPNServiceObserver overrides:
   void OnPurchasedStateChanged(brave_vpn::mojom::PurchasedState state) override;
-  void OnConnectionStateChanged(
-      brave_vpn::mojom::ConnectionState state) override {}
-  void OnConnectionCreated() override {}
-  void OnConnectionRemoved() override {}
 #endif
 
   void InitBraveCommandState();
@@ -80,10 +75,6 @@ class BraveBrowserCommandController : public chrome::BrowserCommandController
   Browser* const browser_;
 
   CommandUpdaterImpl brave_command_updater_;
-
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
-  mojo::Receiver<brave_vpn::mojom::ServiceObserver> receiver_{this};
-#endif
 
   DISALLOW_COPY_AND_ASSIGN(BraveBrowserCommandController);
 };

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -13,7 +13,6 @@
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/themes/theme_properties.h"
-#include "brave/components/brave_vpn/brave_vpn_service.h"
 #include "brave/components/brave_vpn/brave_vpn_service_desktop.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/themes/theme_properties.h"
@@ -59,10 +58,7 @@ BraveVPNButton::BraveVPNButton(Browser* browser)
       browser_(browser),
       service_(BraveVpnServiceFactory::GetForProfile(browser_->profile())) {
   DCHECK(service_);
-
-  mojo::PendingRemote<brave_vpn::mojom::ServiceObserver> listener;
-  receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
-  service_->AddObserver(std::move(listener));
+  Observe(service_);
 
   // Replace ToolbarButton's highlight path generator.
   views::HighlightPathGenerator::Install(

--- a/browser/ui/views/toolbar/brave_vpn_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_button.h
@@ -6,16 +6,14 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_
 
-#include "brave/components/brave_vpn/brave_vpn.mojom.h"
+#include "brave/components/brave_vpn/brave_vpn_service_observer.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
-#include "mojo/public/cpp/bindings/receiver.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
 class BraveVpnServiceDesktop;
 class Browser;
 
-class BraveVPNButton : public ToolbarButton,
-                       public brave_vpn::mojom::ServiceObserver {
+class BraveVPNButton : public ToolbarButton, public BraveVPNServiceObserver {
  public:
   METADATA_HEADER(BraveVPNButton);
 
@@ -25,13 +23,9 @@ class BraveVPNButton : public ToolbarButton,
   BraveVPNButton(const BraveVPNButton&) = delete;
   BraveVPNButton& operator=(const BraveVPNButton&) = delete;
 
-  // brave_vpn::mojom::ServiceObserver overrides:
+  // BraveVPNServiceObserver overrides:
   void OnConnectionStateChanged(
       brave_vpn::mojom::ConnectionState state) override;
-  void OnPurchasedStateChanged(
-      brave_vpn::mojom::PurchasedState state) override {}
-  void OnConnectionCreated() override {}
-  void OnConnectionRemoved() override {}
 
  private:
   void UpdateColorsAndInsets() override;
@@ -44,7 +38,6 @@ class BraveVPNButton : public ToolbarButton,
 
   Browser* browser_ = nullptr;
   BraveVpnServiceDesktop* service_ = nullptr;
-  mojo::Receiver<brave_vpn::mojom::ServiceObserver> receiver_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_BUTTON_H_

--- a/browser/ui/views/toolbar/brave_vpn_status_label.cc
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.cc
@@ -20,10 +20,8 @@ BraveVPNStatusLabel::BraveVPNStatusLabel(Browser* browser)
     : browser_(browser),
       service_(BraveVpnServiceFactory::GetForProfile(browser_->profile())) {
   DCHECK(service_);
-  mojo::PendingRemote<brave_vpn::mojom::ServiceObserver> listener;
-  receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
-  service_->AddObserver(std::move(listener));
 
+  Observe(service_);
   SetAutoColorReadabilityEnabled(false);
   UpdateState();
 

--- a/browser/ui/views/toolbar/brave_vpn_status_label.h
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.h
@@ -6,15 +6,14 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_STATUS_LABEL_H_
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_STATUS_LABEL_H_
 
-#include "brave/components/brave_vpn/brave_vpn.mojom.h"
-#include "mojo/public/cpp/bindings/receiver.h"
+#include "brave/components/brave_vpn/brave_vpn_service_observer.h"
 #include "ui/views/controls/label.h"
 
 class BraveVpnServiceDesktop;
 class Browser;
 
 class BraveVPNStatusLabel : public views::Label,
-                            public brave_vpn::mojom::ServiceObserver {
+                            public BraveVPNServiceObserver {
  public:
   explicit BraveVPNStatusLabel(Browser* browser);
   ~BraveVPNStatusLabel() override;
@@ -23,19 +22,14 @@ class BraveVPNStatusLabel : public views::Label,
   BraveVPNStatusLabel& operator=(const BraveVPNStatusLabel&) = delete;
 
  private:
-  // brave_vpn::mojom::ServiceObserver overrides:
+  // BraveVPNServiceObserver overrides:
   void OnConnectionStateChanged(
       brave_vpn::mojom::ConnectionState state) override;
-  void OnPurchasedStateChanged(
-      brave_vpn::mojom::PurchasedState state) override {}
-  void OnConnectionCreated() override {}
-  void OnConnectionRemoved() override {}
 
   void UpdateState();
 
   Browser* browser_ = nullptr;
   BraveVpnServiceDesktop* service_ = nullptr;
-  mojo::Receiver<brave_vpn::mojom::ServiceObserver> receiver_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_STATUS_LABEL_H_

--- a/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
@@ -19,9 +19,8 @@ BraveVPNToggleButton::BraveVPNToggleButton(Browser* browser)
     : browser_(browser),
       service_(BraveVpnServiceFactory::GetForProfile(browser_->profile())) {
   DCHECK(service_);
-  mojo::PendingRemote<brave_vpn::mojom::ServiceObserver> listener;
-  receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
-  service_->AddObserver(std::move(listener));
+
+  Observe(service_);
 
   SetCallback(base::BindRepeating(&BraveVPNToggleButton::OnButtonPressed,
                                   base::Unretained(this)));

--- a/browser/ui/views/toolbar/brave_vpn_toggle_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_toggle_button.h
@@ -6,15 +6,14 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_TOGGLE_BUTTON_H_
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_TOGGLE_BUTTON_H_
 
-#include "brave/components/brave_vpn/brave_vpn.mojom.h"
-#include "mojo/public/cpp/bindings/receiver.h"
+#include "brave/components/brave_vpn/brave_vpn_service_observer.h"
 #include "ui/views/controls/button/toggle_button.h"
 
 class BraveVpnServiceDesktop;
 class Browser;
 
 class BraveVPNToggleButton : public views::ToggleButton,
-                             public brave_vpn::mojom::ServiceObserver {
+                             public BraveVPNServiceObserver {
  public:
   explicit BraveVPNToggleButton(Browser* browser);
   ~BraveVPNToggleButton() override;
@@ -23,20 +22,15 @@ class BraveVPNToggleButton : public views::ToggleButton,
   BraveVPNToggleButton& operator=(const BraveVPNToggleButton&) = delete;
 
  private:
-  // brave_vpn::mojom::ServiceObserver overrides:
+  // BraveVPNServiceObserver overrides:
   void OnConnectionStateChanged(
       brave_vpn::mojom::ConnectionState state) override;
-  void OnPurchasedStateChanged(
-      brave_vpn::mojom::PurchasedState state) override {}
-  void OnConnectionCreated() override {}
-  void OnConnectionRemoved() override {}
 
   void OnButtonPressed(const ui::Event& event);
   void UpdateState();
 
   Browser* browser_ = nullptr;
   BraveVpnServiceDesktop* service_ = nullptr;
-  mojo::Receiver<brave_vpn::mojom::ServiceObserver> receiver_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_TOGGLE_BUTTON_H_

--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -47,6 +47,8 @@ static_library("brave_vpn") {
       "brave_vpn_os_connection_api_sim.h",
       "brave_vpn_service_desktop.cc",
       "brave_vpn_service_desktop.h",
+      "brave_vpn_service_observer.cc",
+      "brave_vpn_service_observer.h",
       "switches.h",
     ]
 

--- a/components/brave_vpn/brave_vpn_service_observer.cc
+++ b/components/brave_vpn/brave_vpn_service_observer.cc
@@ -1,0 +1,26 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/brave_vpn_service_observer.h"
+
+#include <utility>
+
+#include "brave/components/brave_vpn/brave_vpn_service_desktop.h"
+#include "brave/components/brave_vpn/brave_vpn_utils.h"
+
+BraveVPNServiceObserver::BraveVPNServiceObserver() = default;
+
+BraveVPNServiceObserver::~BraveVPNServiceObserver() = default;
+
+void BraveVPNServiceObserver::Observe(BraveVpnServiceDesktop* service) {
+  if (!service)
+    return;
+
+  if (brave_vpn::IsBraveVPNEnabled()) {
+    mojo::PendingRemote<brave_vpn::mojom::ServiceObserver> listener;
+    receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
+    service->AddObserver(std::move(listener));
+  }
+}

--- a/components/brave_vpn/brave_vpn_service_observer.h
+++ b/components/brave_vpn/brave_vpn_service_observer.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_SERVICE_OBSERVER_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_SERVICE_OBSERVER_H_
+
+#include "brave/components/brave_vpn/brave_vpn.mojom.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+
+class BraveVpnServiceDesktop;
+
+class BraveVPNServiceObserver : public brave_vpn::mojom::ServiceObserver {
+ public:
+  BraveVPNServiceObserver();
+  ~BraveVPNServiceObserver() override;
+  BraveVPNServiceObserver(const BraveVPNServiceObserver&) = delete;
+  BraveVPNServiceObserver& operator=(const BraveVPNServiceObserver&) = delete;
+
+  void Observe(BraveVpnServiceDesktop* service);
+
+  // brave_vpn::mojom::ServiceObserver overrides:
+  void OnConnectionStateChanged(
+      brave_vpn::mojom::ConnectionState state) override {}
+  void OnPurchasedStateChanged(
+      brave_vpn::mojom::PurchasedState state) override {}
+  void OnConnectionCreated() override {}
+  void OnConnectionRemoved() override {}
+
+ private:
+  mojo::Receiver<brave_vpn::mojom::ServiceObserver> receiver_{this};
+};
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BRAVE_VPN_SERVICE_OBSERVER_H_


### PR DESCRIPTION
fix brave/brave-browser#18406

This is convenient wrapper of brave_vpn::mojom::ServiceObserver.
It has common code for observing BraveVPNServiceDesktop
and has default implementation.With this, subclass doesn't need
to care about unused method.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Launch brower with `--brave-vpn-simulate --brave-vpn-test-credentials=aa:bb:cc:dd` and check app menu has post-purchased vpn menu