### PR TITLE
Auto lock keyring after 5 minutes + preference to control it

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -801,6 +801,12 @@ By installing this extension, you are agreeing to the Google Widevine Terms of U
       <message name="IDS_SETTINGS_SHOW_BRAVE_WALLET_ICON_ON_TOOLBAR" desc="The description for showing the Brave wallet panel icon on the toolbar">
         Show Brave Wallet icon on toolbar
       </message>
+      <message name="IDS_SETTINGS_AUTO_LOCK_MINUTES" desc="The title for the amount of minutes it takes for the Brave Wallet to automatically lock">
+        Automatically lock Brave Wallet
+      </message>
+      <message name="IDS_SETTINGS_AUTO_LOCK_MINUTES_DESC" desc="The description for the amount of minutes it takes for the Brave Wallet to automatically lock">
+        The number of minutes to wait until the Brave Wallet is automatically locked
+      </message>
       <message name="IDS_SETTINGS_GOOGLE_LOGIN_FOR_EXTENSIONS" desc="Label for a switch control which allows Google login for extension">
         Allow Google login for extensions
       </message>

--- a/browser/brave_wallet/keyring_controller_unittest.cc
+++ b/browser/brave_wallet/keyring_controller_unittest.cc
@@ -1548,6 +1548,32 @@ TEST_F(KeyringControllerUnitTest, AutoLock) {
   ASSERT_FALSE(controller.IsLocked());
   task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(6));
   ASSERT_TRUE(controller.IsLocked());
+
+  // Changing the auto lock pref should reset the timer
+  controller.Unlock(
+      "brave", base::BindOnce(&KeyringControllerUnitTest::GetBooleanCallback,
+                              base::Unretained(this)));
+  ASSERT_FALSE(controller.IsLocked());
+  task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(4));
+  GetPrefs()->SetInteger(kBraveWalletAutoLockMinutes, 3);
+  task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(2));
+  EXPECT_FALSE(controller.IsLocked());
+  task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(1));
+  EXPECT_TRUE(controller.IsLocked());
+
+  // Changing the auto lock pref should reset the timer even if higher
+  // for simplicity of logic
+  controller.Unlock(
+      "brave", base::BindOnce(&KeyringControllerUnitTest::GetBooleanCallback,
+                              base::Unretained(this)));
+  ASSERT_FALSE(controller.IsLocked());
+  task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(2));
+  EXPECT_FALSE(controller.IsLocked());
+  GetPrefs()->SetInteger(kBraveWalletAutoLockMinutes, 10);
+  task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(9));
+  EXPECT_FALSE(controller.IsLocked());
+  task_environment_.FastForwardBy(base::TimeDelta::FromMinutes(1));
+  EXPECT_TRUE(controller.IsLocked());
 }
 
 TEST_F(KeyringControllerUnitTest, NotifyUserInteraction) {

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -230,6 +230,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::PREF_TYPE_NUMBER;
   (*s_brave_allowlist)[kShowWalletIconOnToolbar] =
       settings_api::PrefType::PREF_TYPE_BOOLEAN;
+  (*s_brave_allowlist)[kBraveWalletAutoLockMinutes] =
+      settings_api::PrefType::PREF_TYPE_NUMBER;
 #endif
   // IPFS pref
 #if BUILDFLAG(ENABLE_IPFS)

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -32,14 +32,30 @@
                               menu-options="[[wallets_]]">
       </settings-dropdown-menu>
     </div>
-<template is="dom-if" if="[[isNativeWalletEnabled_]]" restamp>
-    <settings-toggle-button id="showBraveWalletIconOnToolbar"
-        class="cr-row"
-        pref="{{prefs.brave.wallet.show_wallet_icon_on_toolbar}}"
-        label="$i18n{showBravewalletIconOnToolbar}">
-</template>
-
-    </settings-toggle-button>
+    <template is="dom-if" if="[[isNativeWalletEnabled_]]" restamp>
+      <settings-toggle-button id="showBraveWalletIconOnToolbar"
+          class="cr-row"
+          pref="{{prefs.brave.wallet.show_wallet_icon_on_toolbar}}"
+          label="$i18n{showBravewalletIconOnToolbar}">
+      </settings-toggle-button>
+    </template>
+    <template is="dom-if" if="[[isNativeWalletEnabled_]]" restamp>
+    <div class="settings-box">
+      <div class="flex cr-padded-text">
+        <div>$i18n{autoLockMinutes}</div>
+        <div class="secondary">$i18n{autoLockMinutesDesc}</div>
+      </div>
+      <cr-input
+          id="walletAutoLockMinutes" type="number"
+          class="flex-container"
+          value="$i18n{autoLockMinutesValue}"
+          on-change="onChangeAutoLockMinutes_"
+          min="1"
+          max="10080"
+      >
+      </cr-input>
+    </div>
+    </template>
   </template>
   <script src="brave_wallet_page.js"></script>
 </dom-module>

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.js
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.js
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {PrefsBehavior} from '../prefs/prefs_behavior.js';
  
 (function() {
 'use strict';
@@ -14,6 +16,7 @@ Polymer({
 
   behaviors: [
     WebUIListenerBehavior,
+    PrefsBehavior,
   ],
 
   properties: {
@@ -37,10 +40,19 @@ Polymer({
     this.browserProxy_.isNativeWalletEnabled().then(val => {
       this.isNativeWalletEnabled_ = val;
     });
+    this.onChangeAutoLockMinutes_ = this.onChangeAutoLockMinutes_.bind(this)
   },
 
   onBraveWalletEnabledChange_: function() {
     this.browserProxy_.setBraveWalletEnabled(this.$.braveWalletEnabled.checked);
+  },
+
+  onChangeAutoLockMinutes_: function() {
+    let value = Number(this.$.walletAutoLockMinutes.value)
+    if (Number.isNaN(value) || value < 1 || value > 10080) {
+      return
+    }
+    this.setPrefValue('brave.wallet.auto_lock_minutes', value)
   },
 });
 })();

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/common/url_constants.h"
 #include "brave/components/brave_vpn/buildflags/buildflags.h"
+#include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/ipfs/ipfs_constants.h"
 #include "brave/components/ipfs/pref_names.h"
 #include "brave/components/sidebar/buildflags/buildflags.h"
@@ -19,6 +20,10 @@
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_service.h"
 #include "extensions/buildflags/buildflags.h"
+
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#endif
 
 namespace settings {
 void BraveAddLocalizedStrings(content::WebUIDataSource*, Profile*);
@@ -247,6 +252,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
     {"defaultWalletDesc", IDS_SETTINGS_DEFAULT_WALLET_DESC},
     {"showBravewalletIconOnToolbar",
      IDS_SETTINGS_SHOW_BRAVE_WALLET_ICON_ON_TOOLBAR},
+    {"autoLockMinutes", IDS_SETTINGS_AUTO_LOCK_MINUTES},
+    {"autoLockMinutesDesc", IDS_SETTINGS_AUTO_LOCK_MINUTES_DESC},
     {"googleLoginForExtensionsDesc", IDS_SETTINGS_GOOGLE_LOGIN_FOR_EXTENSIONS},
     {"hangoutsEnabledDesc", IDS_SETTINGS_HANGOUTS_ENABLED_DESC},
     {"mediaRouterEnabledDesc", IDS_SETTINGS_MEDIA_ROUTER_ENABLED_DESC},
@@ -341,6 +348,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
               GURL(extension_urls::GetWebstoreExtensionsCategoryURL()),
               g_browser_process->GetApplicationLocale())
               .spec()));
+#if BUILDFLAG(BRAVE_WALLET_ENABLED)
+  html_source->AddString("autoLockMinutesValue",
+                         std::to_string(profile->GetPrefs()->GetInteger(
+                             kBraveWalletAutoLockMinutes)));
+#endif
   html_source->AddString(
       "ipfsStorageMaxValue",
       std::to_string(profile->GetPrefs()->GetInteger(kIpfsStorageMax)));

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -68,6 +68,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                brave_wallet::mojom::kMainnetChainId);
   registry->RegisterDictionaryPref(kBraveWalletUserAssets,
                                    GetDefaultUserAssets());
+  registry->RegisterIntegerPref(kBraveWalletAutoLockMinutes, 5);
 }
 
 void RegisterProfilePrefsForMigration(
@@ -88,6 +89,7 @@ void ClearProfilePrefs(PrefService* prefs) {
   prefs->ClearPref(kBraveWalletTransactions);
   prefs->ClearPref(kBraveWalletUserAssets);
   prefs->ClearPref(kBraveWalletKeyrings);
+  prefs->ClearPref(kBraveWalletAutoLockMinutes);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/keyring_controller.cc
+++ b/components/brave_wallet/browser/keyring_controller.cc
@@ -135,9 +135,12 @@ void SerializeHardwareAccounts(const base::Value* account_value,
 
 KeyringController::KeyringController(PrefService* prefs) : prefs_(prefs) {
   DCHECK(prefs);
+  auto_lock_timer_ = std::make_unique<base::OneShotTimer>();
 }
 
-KeyringController::~KeyringController() {}
+KeyringController::~KeyringController() {
+  auto_lock_timer_.reset();
+}
 
 mojo::PendingRemote<mojom::KeyringController> KeyringController::MakeRemote() {
   mojo::PendingRemote<mojom::KeyringController> remote;
@@ -415,6 +418,7 @@ HDKeyring* KeyringController::CreateDefaultKeyring(
   for (const auto& observer : observers_) {
     observer->KeyringCreated();
   }
+  ResetAutoLockTimer();
 
   return default_keyring_.get();
 }
@@ -503,6 +507,7 @@ HDKeyring* KeyringController::RestoreDefaultKeyring(
   for (const auto& observer : observers_) {
     observer->KeyringRestored();
   }
+  ResetAutoLockTimer();
 
   return default_keyring_.get();
 }
@@ -900,6 +905,7 @@ void KeyringController::Lock() {
   for (const auto& observer : observers_) {
     observer->Locked();
   }
+  StopAutoLockTimer();
 }
 
 void KeyringController::Unlock(const std::string& password,
@@ -914,7 +920,13 @@ void KeyringController::Unlock(const std::string& password,
   for (const auto& observer : observers_) {
     observer->Unlocked();
   }
+  ResetAutoLockTimer();
+
   std::move(callback).Run(true);
+}
+
+void KeyringController::OnAutoLockFired() {
+  Lock();
 }
 
 void KeyringController::IsLocked(IsLockedCallback callback) {
@@ -922,10 +934,24 @@ void KeyringController::IsLocked(IsLockedCallback callback) {
 }
 
 void KeyringController::Reset() {
+  StopAutoLockTimer();
   encryptor_.reset();
   default_keyring_.reset();
 
   ClearProfilePrefs(prefs_);
+}
+
+void KeyringController::StopAutoLockTimer() {
+  auto_lock_timer_->Stop();
+}
+
+void KeyringController::ResetAutoLockTimer() {
+  if (auto_lock_timer_->IsRunning()) {
+    auto_lock_timer_->Reset();
+  } else {
+    auto_lock_timer_->Start(FROM_HERE, base::TimeDelta::FromMinutes(5), this,
+                            &KeyringController::OnAutoLockFired);
+  }
 }
 
 bool KeyringController::GetPrefInBytesForKeyring(const std::string& key,
@@ -1032,6 +1058,10 @@ bool KeyringController::IsDefaultKeyringCreated() {
 void KeyringController::AddObserver(
     ::mojo::PendingRemote<mojom::KeyringControllerObserver> observer) {
   observers_.Add(std::move(observer));
+}
+
+void KeyringController::NotifyUserInteraction() {
+  auto_lock_timer_->Reset();
 }
 
 void KeyringController::SetDefaultKeyringDerivedAccountName(

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -23,6 +23,10 @@
 
 class PrefService;
 
+namespace base {
+class OneShotTimer;
+}
+
 namespace brave_wallet {
 
 class HDKeyring;
@@ -147,6 +151,7 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
 
   void AddObserver(::mojo::PendingRemote<mojom::KeyringControllerObserver>
                        observer) override;
+  void NotifyUserInteraction() override;
 
   /* TODO(darkdh): For other keyrings support
   void DeleteKeyring(size_t index);
@@ -179,10 +184,12 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest,
                            SetDefaultKeyringDerivedAccountMeta);
   FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest, RestoreLegacyBraveWallet);
+  FRIEND_TEST_ALL_PREFIXES(KeyringControllerUnitTest, AutoLock);
   friend class BraveWalletProviderImplUnitTest;
   friend class EthTxControllerUnitTest;
 
   void AddAccountForDefaultKeyring(const std::string& account_name);
+  void OnAutoLockFired();
 
   // Address will be returned when success
   absl::optional<std::string> ImportAccountForDefaultKeyring(
@@ -219,9 +226,12 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   HDKeyring* ResumeDefaultKeyring(const std::string& password);
 
   void NotifyAccountsChanged();
+  void StopAutoLockTimer();
+  void ResetAutoLockTimer();
 
   std::unique_ptr<PasswordEncryptor> encryptor_;
   std::unique_ptr<HDKeyring> default_keyring_;
+  std::unique_ptr<base::OneShotTimer> auto_lock_timer_;
 
   // TODO(darkdh): For other keyrings support
   // std::vector<std::unique_ptr<HDKeyring>> keyrings_;

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -21,6 +21,7 @@
 #include "mojo/public/cpp/bindings/remote_set.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
+class PrefChangeRegistrar;
 class PrefService;
 
 namespace base {
@@ -228,10 +229,12 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
   void NotifyAccountsChanged();
   void StopAutoLockTimer();
   void ResetAutoLockTimer();
+  void OnAutoLockPreferenceChanged();
 
   std::unique_ptr<PasswordEncryptor> encryptor_;
   std::unique_ptr<HDKeyring> default_keyring_;
   std::unique_ptr<base::OneShotTimer> auto_lock_timer_;
+  std::unique_ptr<PrefChangeRegistrar> pref_change_registrar_;
 
   // TODO(darkdh): For other keyrings support
   // std::vector<std::unique_ptr<HDKeyring>> keyrings_;

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -16,6 +16,7 @@ const char kBraveWalletCurrentChainId[] =
     "brave.wallet.wallet_current_chain_id";
 const char kBraveWalletKeyrings[] = "brave.wallet.keyrings";
 const char kBraveWalletUserAssets[] = "brave.wallet.user_assets";
+const char kBraveWalletAutoLockMinutes[] = "brave.wallet.auto_lock_minutes";
 
 // DEPRECATED
 const char kBraveWalletPasswordEncryptorSalt[] =

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -14,6 +14,7 @@ extern const char kBraveWalletKeyrings[];
 extern const char kBraveWalletCustomNetworks[];
 extern const char kBraveWalletCurrentChainId[];
 extern const char kBraveWalletUserAssets[];
+extern const char kBraveWalletAutoLockMinutes[];
 
 // DEPRECATED
 extern const char kBraveWalletPasswordEncryptorSalt[];

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -231,6 +231,7 @@ interface KeyringController {
   AddHardwareAccounts(array<HardwareWalletAccount> info);
   GetHardwareAccounts() => (array<AccountInfo> accounts);
   RemoveHardwareAccount(string address);
+  NotifyUserInteraction();
 };
 
 interface AssetRatioController {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -557,6 +557,7 @@ export interface KeyringController {
   unlock: (password: string) => Promise<UnlockReturnInfo>
   addAccount: (accountName: string) => Promise<AddAccountReturnInfo>
   getHardwareAccounts: () => Promise<{ accounts: AccountInfo[] }>
+  notifyUserInteraction: () => Promise<void>
 }
 
 export interface GetUserAssetsReturnInfo {


### PR DESCRIPTION
Tasks done in this PR:
- Auto locks the keyring after 5 minutes
- Exposes a way for the UI to notify the keyring that there was user activity and the timer should be reset
- Adds a new auto lock preference for the number of minutes
- Resetting the preference will reset the timer.

<img width="919" alt="Screen Shot 2021-09-28 at 1 48 09 PM" src="https://user-images.githubusercontent.com/831718/135139127-0f9ea4f8-b8e5-4703-8115-20afcfef9b73.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18172

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

