### PR TITLE
Hide idle detection UI elements in Settings. (uplift to 1.31.x)

### DIFF
--- a/browser/resources/settings/brave_overrides/privacy_page.js
+++ b/browser/resources/settings/brave_overrides/privacy_page.js
@@ -5,6 +5,7 @@
 
 import {RegisterPolymerTemplateModifications} from 'chrome://brave-resources/polymer_overriding.js'
 import {I18nBehavior} from 'chrome://resources/js/i18n_behavior.m.js'
+import {loadTimeData} from 'chrome://resources/js/load_time_data.m.js';
 
 RegisterPolymerTemplateModifications({
   'settings-privacy-page': (templateContent) => {
@@ -12,6 +13,14 @@ RegisterPolymerTemplateModifications({
     if (!pages) {
       console.error(`[Brave Settings Overrides] Couldn't find privacy_page #pages`)
     } else {
+      if (!loadTimeData.getBoolean('isIdleDetectionFeatureEnabled')) {
+        const idleDetection = templateContent.querySelector('[route-path="/content/idleDetection"]')
+        if (!idleDetection) {
+          console.error(`[Brave Settings Overrides] Couldn't find idle detection template`)
+        } else {
+          idleDetection.content.firstElementChild.hidden = true
+        }
+      }
       pages.insertAdjacentHTML('beforeend', `
         <template is="dom-if" route-path="/content/autoplay" no-search>
           <settings-subpage page-title="${I18nBehavior.i18n('siteSettingsCategoryAutoplay')}">

--- a/browser/resources/settings/brave_overrides/site_details.js
+++ b/browser/resources/settings/brave_overrides/site_details.js
@@ -5,9 +5,18 @@
 
 import {RegisterPolymerTemplateModifications} from 'chrome://brave-resources/polymer_overriding.js'
 import {I18nBehavior} from 'chrome://resources/js/i18n_behavior.m.js'
+import {loadTimeData} from 'chrome://resources/js/load_time_data.m.js';
 
 RegisterPolymerTemplateModifications({
   'site-details': (templateContent) => {
+    if (!loadTimeData.getBoolean('isIdleDetectionFeatureEnabled')) {
+      const idleDetectionItem = templateContent.querySelector('[category="[[contentSettingsTypesEnum_.IDLE_DETECTION]]"]')
+      if (!idleDetectionItem) {
+        console.error(`[Brave Settings Overrides] Couldn't find idle detection item`)
+      } else {
+        idleDetectionItem.hidden = true
+      }
+    }
     const firstPermissionItem = templateContent.querySelector('div.list-frame > site-details-permission:nth-child(1)')
     if (!firstPermissionItem) {
       console.error(`[Brave Settings Overrides] Couldn't find first permission item`)

--- a/browser/resources/settings/brave_overrides/site_settings_page.js
+++ b/browser/resources/settings/brave_overrides/site_settings_page.js
@@ -5,6 +5,7 @@
 
 import {define, RegisterPolymerComponentReplacement} from 'chrome://brave-resources/polymer_overriding.js'
 import {ContentSettingsTypes} from '../site_settings/constants.js'
+import {loadTimeData} from 'chrome://resources/js/load_time_data.m.js';
 import {SettingsSiteSettingsPageElement} from '../site_settings_page/site_settings_page.js'
 import {routes} from '../route.js'
 import './config.js'
@@ -45,6 +46,14 @@ RegisterPolymerComponentReplacement(
         if (!lists_.permissionsAdvanced) {
           console.error('[Brave Settings Overrides] did not get lists_.permissionsAdvanced data')
         } else {
+          if (!loadTimeData.getBoolean('isIdleDetectionFeatureEnabled')) {
+            let indexForIdleDetection = lists_.permissionsAdvanced.findIndex(item => item.id === ContentSettingsTypes.IDLE_DETECTION)
+            if (indexForIdleDetection === -1) {
+              console.error('Could not find idle detection site settings item')
+            } else {
+              lists_.permissionsAdvanced.splice(indexForIdleDetection, 1)
+            }
+          }
           let indexForAutoplay = lists_.permissionsAdvanced.findIndex(item => item.id === ContentSettingsTypes.AUTOMATIC_DOWNLOADS)
           if (indexForAutoplay === -1) {
             console.error('Could not find automatic downloads site settings item')

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -28,6 +28,7 @@
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
 #include "components/sync/driver/sync_driver_switches.h"
 #include "content/public/browser/web_ui_data_source.h"
+#include "content/public/common/content_features.h"
 
 #if BUILDFLAG(ENABLE_SPARKLE)
 #include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
@@ -84,6 +85,9 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
   NavigationBarDataProvider::Initialize(html_source);
   if (auto* service = ViewCounterServiceFactory::GetForProfile(profile))
     service->InitializeWebUIDataSource(html_source);
+  html_source->AddBoolean(
+      "isIdleDetectionFeatureEnabled",
+      base::FeatureList::IsEnabled(features::kIdleDetection));
 #if BUILDFLAG(ENABLE_SIDEBAR)
   // TODO(simonhong): Remove this when sidebar is shipped by default in all
   // channels.


### PR DESCRIPTION
Fixes brave/brave-browser#18409
Uplift of #10299

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.