### PR TITLE
Allow scrolling of grant captcha overlay in rewards panel

### DIFF
--- a/components/brave_rewards/resources/shared/components/modal.tsx
+++ b/components/brave_rewards/resources/shared/components/modal.tsx
@@ -14,12 +14,12 @@ const style = {
     left: 0;
     bottom: 0;
     right: 0;
+    overflow: auto;
     background: rgba(0, 0, 0, 0.33);
     z-index: 9999;
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0 20px;
   `,
 
   topSpacer: styled.div`


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18436

Currently, overlays implemented using `modal.tsx` use `fixed` positioning to cover the window and center the overlay. This change adds `overflow: auto` to the window-covering element so that overlays that are larger than the current window size can be scrolled.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Programmatically simulating a constrained panel

I have not yet been able to find display settings that will cause the grant captcha UI to extend outside of the panel area. However, this situation can be simulated by programmatically reducing the size of the panel in the developer console:

- Open the rewards panel.
- Right-click in the rewards panel and click "inspect".
- In the developer tools, switch to the Console tab and execute the following JS:

```js
document.getElementById('root').style.height = '400px';
document.getElementById('root').style.overflow = 'auto';
```

### Scenario: Solving captcha when rewards panel is constrained

- Given that the user has enabled rewards
- And has an Ad or UGP grant available
- And the rewards panel is space-constrained (see steps above for simulating a constrained panel)
- When the user attempts to claim the grant
- Then scrollbars should appear
- And scrolling should affect the viewable area of the captcha
- And the user should be able to solve the captcha.