### PR TITLE
Wired up Brave Wallet to NotifyUserInteraction

### DIFF
--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -74,3 +74,4 @@ export const rejectTransaction = createAction<TransactionInfo>('rejectTransactio
 export const knownTransactionsUpdated = createAction<TransactionInfo[]>('knownTransactionsUpdated')
 export const setTransactionList = createAction<TransactionListInfo[]>('setTransactionList')
 export const defaultWalletUpdated = createAction<DefaultWallet>('defaultWalletUpdated')
+export const notifyUserInteraction = createAction('notifyUserInteraction')

--- a/components/brave_wallet_ui/common/async/wallet_async_handler.ts
+++ b/components/brave_wallet_ui/common/async/wallet_async_handler.ts
@@ -378,7 +378,7 @@ export const fetchSwapQuoteFactory = (
   }
 
   const quote = await (
-      full ? swapController.getTransactionPayload(swapParams) : swapController.getPriceQuote(swapParams)
+    full ? swapController.getTransactionPayload(swapParams) : swapController.getPriceQuote(swapParams)
   )
 
   if (quote.success && quote.response) {
@@ -406,6 +406,11 @@ export const fetchSwapQuoteFactory = (
     }
   }
 }
+
+handler.on(WalletActions.notifyUserInteraction.getType(), async (store) => {
+  const keyringController = (await getAPIProxy()).keyringController
+  await keyringController.notifyUserInteraction()
+})
 
 export default handler.middleware
 

--- a/components/brave_wallet_ui/common/hooks/index.ts
+++ b/components/brave_wallet_ui/common/hooks/index.ts
@@ -5,5 +5,6 @@
 
 import useSwap from './swap'
 import useAssets from './assets'
+import useTimeout from './timeout'
 
-export { useAssets, useSwap }
+export { useAssets, useSwap, useTimeout }

--- a/components/brave_wallet_ui/common/hooks/timeout.ts
+++ b/components/brave_wallet_ui/common/hooks/timeout.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+export default function useTimeout (
+  notifyUserInteraction: () => void,
+  isWalletLocked: boolean
+) {
+  const [lastCheckedTime, setLastCheckedTime] = React.useState<number>()
+  const [currentMousePosition, setCurrentMousePosition] = React.useState({ x: 0, y: 0 })
+  const [lastMousePosition, setLastMousePosition] = React.useState({ x: 0, y: 0 })
+  React.useMemo(() => {
+    const { x, y } = currentMousePosition
+    // Checks to see if the mouse moved everytime lastCheckTime is updated
+    if (lastMousePosition.x !== x || lastMousePosition.y !== y) {
+      setLastMousePosition({ x, y })
+      // If mouse has moved will notify keyring here.
+      notifyUserInteraction()
+    }
+  }, [lastCheckedTime])
+
+  React.useEffect(() => {
+    // Starts tracking mouse move events when wallet is unlocked
+    if (!isWalletLocked) {
+      const mousePosition = (event: MouseEvent) => setCurrentMousePosition({ x: event.clientX, y: event.clientY })
+      window.addEventListener('mousemove', mousePosition)
+      return () => window.removeEventListener('mousemove', mousePosition)
+    }
+    return
+  }, [isWalletLocked])
+
+  React.useEffect(() => {
+    // If wallet is unlocked, will start interval
+    // and setLastCheckedTime every 50 seconds to trigger
+    // a check to see if the mouse moved.
+    if (!isWalletLocked) {
+      const interval = setInterval(() => {
+        const date = Date.now()
+        setLastCheckedTime(date)
+      }, 50000)
+      return () => clearInterval(interval)
+    }
+    return
+  }, [isWalletLocked])
+}

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -53,7 +53,7 @@ import {
 import { onConnectHardwareWallet, getBalance } from '../common/async/wallet_async_handler'
 
 import { formatBalance, toWeiHex } from '../utils/format-balances'
-import { useSwap, useAssets } from '../common/hooks'
+import { useSwap, useAssets, useTimeout } from '../common/hooks'
 import { stripERC20TokenImageURL } from '../utils/string-utils'
 
 type Props = {
@@ -111,6 +111,11 @@ function Container (props: Props) {
   const [buyAmount, setBuyAmount] = React.useState('')
   const [sendAmount, setSendAmount] = React.useState('')
   const [selectedWidgetTab, setSelectedWidgetTab] = React.useState<BuySendSwapTypes>('buy')
+
+  const notifyUserInteraction = () => {
+    props.walletActions.notifyUserInteraction()
+  }
+  useTimeout(notifyUserInteraction, isWalletLocked)
 
   const {
     tokenOptions,


### PR DESCRIPTION
## Description 
Wired up the Brave Desktop Wallet to the `NotifyUserInteraction` method.

1) Created an event listener for mouse movements that starts when the wallet is unlocked and will stop after the wallet is locked.
2) Created an interval timer that will start once the wallet is unlocked that will trigger a check to see if the mouse has moved every 50 seconds, if the mouse has moved it will call the `NotifyUserInteraction` method to reset the timeout countdown.
If the wallet is locked, the interval will stop.

Note: (In the video, the interval is set to every 5 seconds for demo purposes.)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/18444>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/135361398-468bd476-bcd2-4990-b224-e78c991d2d57.mov
