### PR TITLE
Implement gas estimation for EIP1559 transactions

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -329,10 +329,10 @@ TEST_F(BraveWalletProviderImplUnitTest, AddUnapproved1559Transaction) {
   NavigateAndAddEthereumPermission();
   provider()->AddUnapproved1559Transaction(
       mojom::TxData1559::New(
-          mojom::TxData::New("0x00", "", "0x00",
+          mojom::TxData::New("0x00", "", "0x1",
                              "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
                              "0x00", std::vector<uint8_t>()),
-          "0x04", "0x0", "0x0", nullptr),
+          "0x04", "0x1", "0x1", nullptr),
       from(),
       base::BindLambdaForTesting([&](bool success, const std::string& id,
                                      const std::string& error_message) {

--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -332,7 +332,7 @@ TEST_F(BraveWalletProviderImplUnitTest, AddUnapproved1559Transaction) {
           mojom::TxData::New("0x00", "", "0x00",
                              "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
                              "0x00", std::vector<uint8_t>()),
-          "0x04", "0x0", "0x0"),
+          "0x04", "0x0", "0x0", nullptr),
       from(),
       base::BindLambdaForTesting([&](bool success, const std::string& id,
                                      const std::string& error_message) {
@@ -377,7 +377,7 @@ TEST_F(BraveWalletProviderImplUnitTest, AddUnapproved1559TransactionError) {
           mojom::TxData::New("0x00", "0x01", "0x00",
                              "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
                              "0x00", std::vector<uint8_t>()),
-          "0x04", "0x0", "0x0"),
+          "0x04", "0x0", "0x0", nullptr),
       from(),
       base::BindLambdaForTesting([&](bool success, const std::string& id,
                                      const std::string& error_message) {
@@ -401,7 +401,7 @@ TEST_F(BraveWalletProviderImplUnitTest,
           mojom::TxData::New("0x00", "", "0x00",
                              "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
                              "0x00", std::vector<uint8_t>()),
-          "0x04", "0x0", "0x0"),
+          "0x04", "0x0", "0x0", nullptr),
       "0xbe862ad9abfe6f22bcb087716c7d89a26051f74d",
       base::BindLambdaForTesting([&](bool success, const std::string& id,
                                      const std::string& error_message) {

--- a/browser/brave_wallet/eth_tx_controller_factory.cc
+++ b/browser/brave_wallet/eth_tx_controller_factory.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "brave/browser/brave_wallet/asset_ratio_controller_factory.h"
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
 #include "brave/browser/brave_wallet/keyring_controller_factory.h"
 #include "brave/browser/brave_wallet/rpc_controller_factory.h"
@@ -55,6 +56,7 @@ EthTxControllerFactory::EthTxControllerFactory()
           BrowserContextDependencyManager::GetInstance()) {
   DependsOn(brave_wallet::RpcControllerFactory::GetInstance());
   DependsOn(brave_wallet::KeyringControllerFactory::GetInstance());
+  DependsOn(brave_wallet::AssetRatioControllerFactory::GetInstance());
 }
 
 EthTxControllerFactory::~EthTxControllerFactory() {}
@@ -64,6 +66,7 @@ KeyedService* EthTxControllerFactory::BuildServiceInstanceFor(
   return brave_wallet::BuildEthTxController(
              RpcControllerFactory::GetControllerForContext(context),
              KeyringControllerFactory::GetControllerForContext(context),
+             AssetRatioControllerFactory::GetControllerForContext(context),
              user_prefs::UserPrefs::Get(context))
       .release();
 }

--- a/components/brave_wallet/browser/asset_ratio_controller.h
+++ b/components/brave_wallet/browser/asset_ratio_controller.h
@@ -57,6 +57,14 @@ class AssetRatioController : public KeyedService,
   static GURL GetPriceHistoryURL(
       const std::string& asset,
       brave_wallet::mojom::AssetPriceTimeframe timeframe);
+
+  void GetEstimatedTime(const std::string& gas_price,
+                        GetEstimatedTimeCallback callback) override;
+  void GetGasOracle(GetGasOracleCallback callback) override;
+
+  static GURL GetEstimatedTimeURL(const std::string& gas_price);
+  static GURL GetGasOracleURL();
+
   static void SetBaseURLForTest(const GURL& base_url_for_test);
 
  private:
@@ -71,6 +79,17 @@ class AssetRatioController : public KeyedService,
       const int status,
       const std::string& body,
       const base::flat_map<std::string, std::string>& headers);
+
+  void OnGetEstimatedTime(
+      GetEstimatedTimeCallback callback,
+      const int status,
+      const std::string& body,
+      const base::flat_map<std::string, std::string>& headers);
+
+  void OnGetGasOracle(GetGasOracleCallback callback,
+                      const int status,
+                      const std::string& body,
+                      const base::flat_map<std::string, std::string>& headers);
 
   mojo::ReceiverSet<mojom::AssetRatioController> receivers_;
 

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -204,22 +204,8 @@ std::string ParseEstimatedTime(const std::string& json) {
     return "";
   }
 
-  auto* payload = response_dict->FindKey("payload");
-  if (!payload) {
-    return "";
-  }
-
-  const base::DictionaryValue* payload_dict;
-  if (!payload->GetAsDictionary(&payload_dict)) {
-    return "";
-  }
-
-  const std::string* result = payload->FindStringKey("result");
-  if (!result) {
-    return "";
-  }
-
-  return *result;
+  const std::string* result = response_dict->FindStringPath("payload.result");
+  return result ? *result : "";
 }
 
 brave_wallet::mojom::GasEstimation1559Ptr ParseGasOracle(
@@ -255,23 +241,8 @@ brave_wallet::mojom::GasEstimation1559Ptr ParseGasOracle(
     return nullptr;
   }
 
-  auto* payload = response_dict->FindKey("payload");
-  if (!payload) {
-    return nullptr;
-  }
-
-  const base::DictionaryValue* payload_dict;
-  if (!payload->GetAsDictionary(&payload_dict)) {
-    return nullptr;
-  }
-
-  auto* result = payload->FindKey("result");
-  if (!result) {
-    return nullptr;
-  }
-
-  const base::DictionaryValue* result_dict;
-  if (!result->GetAsDictionary(&result_dict)) {
+  auto* result = response_dict->FindPath("payload.result");
+  if (!result || !result->is_dict()) {
     return nullptr;
   }
 

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -10,6 +10,8 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
 #include "base/time/time.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_types.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace brave_wallet {
@@ -176,6 +178,182 @@ bool ParseAssetPriceHistory(
   }
 
   return true;
+}
+
+std::string ParseEstimatedTime(const std::string& json) {
+  // {
+  //   "payload": {
+  //     "status": "1",
+  //     "message": "",
+  //     "result": "3615"
+  //   },
+  //   "lastUpdated": "2021-09-22T21:45:40.015Z"
+  // }
+
+  base::JSONReader::ValueWithError value_with_error =
+      base::JSONReader::ReadAndReturnValueWithError(
+          json, base::JSONParserOptions::JSON_PARSE_RFC);
+  absl::optional<base::Value>& records_v = value_with_error.value;
+  if (!records_v) {
+    LOG(ERROR) << "Invalid response, could not parse JSON, JSON is: " << json;
+    return "";
+  }
+
+  const base::DictionaryValue* response_dict;
+  if (!records_v->GetAsDictionary(&response_dict)) {
+    return "";
+  }
+
+  auto* payload = response_dict->FindKey("payload");
+  if (!payload) {
+    return "";
+  }
+
+  const base::DictionaryValue* payload_dict;
+  if (!payload->GetAsDictionary(&payload_dict)) {
+    return "";
+  }
+
+  const std::string* result = payload->FindStringKey("result");
+  if (!result) {
+    return "";
+  }
+
+  return *result;
+}
+
+brave_wallet::mojom::GasEstimation1559Ptr ParseGasOracle(
+    const std::string& json) {
+  // {
+  //   "payload": {
+  //     "status": "1",
+  //     "message": "",
+  //     "result": {
+  //       "LastBlock": "13243541",
+  //       "SafeGasPrice": "47",
+  //       "ProposeGasPrice": "48",
+  //       "FastGasPrice": "48",
+  //       "suggestBaseFee": "46.574033786",
+  //       "gasUsedRatio": "0.27036175840958,0.0884828740801432,
+  //           0.0426623303159149,0.972173412918789,0.319781207901446"
+  //     }
+  //   },
+  //   "lastUpdated": "2021-09-22T21:45:40.015Z"
+  // }
+
+  base::JSONReader::ValueWithError value_with_error =
+      base::JSONReader::ReadAndReturnValueWithError(
+          json, base::JSONParserOptions::JSON_PARSE_RFC);
+  absl::optional<base::Value>& records_v = value_with_error.value;
+  if (!records_v) {
+    LOG(ERROR) << "Invalid response, could not parse JSON, JSON is: " << json;
+    return nullptr;
+  }
+
+  const base::DictionaryValue* response_dict;
+  if (!records_v->GetAsDictionary(&response_dict)) {
+    return nullptr;
+  }
+
+  auto* payload = response_dict->FindKey("payload");
+  if (!payload) {
+    return nullptr;
+  }
+
+  const base::DictionaryValue* payload_dict;
+  if (!payload->GetAsDictionary(&payload_dict)) {
+    return nullptr;
+  }
+
+  auto* result = payload->FindKey("result");
+  if (!result) {
+    return nullptr;
+  }
+
+  const base::DictionaryValue* result_dict;
+  if (!result->GetAsDictionary(&result_dict)) {
+    return nullptr;
+  }
+
+  const std::string* safe_gas_price = result->FindStringKey("SafeGasPrice");
+  if (!safe_gas_price || safe_gas_price->empty()) {
+    return nullptr;
+  }
+
+  const std::string* proposed_gas_price =
+      result->FindStringKey("ProposeGasPrice");
+  if (!proposed_gas_price || proposed_gas_price->empty()) {
+    return nullptr;
+  }
+
+  const std::string* fast_gas_price = result->FindStringKey("FastGasPrice");
+  if (!fast_gas_price || fast_gas_price->empty()) {
+    return nullptr;
+  }
+
+  const std::string* base_fee = result->FindStringKey("suggestBaseFee");
+  if (!base_fee || base_fee->empty()) {
+    return nullptr;
+  }
+
+  mojom::GasEstimation1559Ptr estimation =
+      brave_wallet::mojom::GasEstimation1559::New();
+
+  // We save the original value in wei as the base_fee_per_gas, but use only
+  // the integer part in gwei value to calculate the priority fee.
+  size_t point = base_fee->find(".");
+  std::string gwei_str = base_fee->substr(0, point);
+  // Takes at most 9 digits and convert to wei, zeros will be padded if needed.
+  std::string fractional =
+      point == std::string::npos ? "" : base_fee->substr(point + 1, 9);
+  size_t padding_len = 9 - fractional.size();
+  std::string wei_str = gwei_str + fractional + std::string(padding_len, '0');
+
+  uint64_t base_fee_gwei;
+  if (!base::StringToUint64(gwei_str, &base_fee_gwei)) {
+    return nullptr;
+  }
+
+  uint64_t base_fee_wei;
+  if (!base::StringToUint64(wei_str, &base_fee_wei)) {
+    return nullptr;
+  }
+  estimation->base_fee_per_gas = Uint256ValueToHex(base_fee_wei);
+
+  uint64_t safe_gas_price_gwei;
+  if (!base::StringToUint64(*safe_gas_price, &safe_gas_price_gwei)) {
+    return nullptr;
+  }
+  estimation->slow_max_fee_per_gas =
+      Uint256ValueToHex(static_cast<uint256_t>(safe_gas_price_gwei) *
+                        static_cast<uint256_t>(1e9));
+  estimation->slow_max_priority_fee_per_gas = Uint256ValueToHex(
+      static_cast<uint256_t>(safe_gas_price_gwei - base_fee_gwei) *
+      static_cast<uint256_t>(1e9));
+
+  uint64_t proposed_gas_price_gwei;
+  if (!base::StringToUint64(*proposed_gas_price, &proposed_gas_price_gwei)) {
+    return nullptr;
+  }
+  estimation->avg_max_fee_per_gas =
+      Uint256ValueToHex(static_cast<uint256_t>(proposed_gas_price_gwei) *
+                        static_cast<uint256_t>(1e9));
+  estimation->avg_max_priority_fee_per_gas = Uint256ValueToHex(
+      static_cast<uint256_t>(proposed_gas_price_gwei - base_fee_gwei) *
+      static_cast<uint256_t>(1e9));
+
+  uint64_t fast_gas_price_gwei;
+  if (!base::StringToUint64(*fast_gas_price, &fast_gas_price_gwei)) {
+    return nullptr;
+  }
+  estimation->fast_max_fee_per_gas =
+      Uint256ValueToHex(static_cast<uint256_t>(fast_gas_price_gwei) *
+                        static_cast<uint256_t>(1e9));
+  estimation->fast_max_priority_fee_per_gas = Uint256ValueToHex(
+      static_cast<uint256_t>(fast_gas_price_gwei - base_fee_gwei) *
+      static_cast<uint256_t>(1e9));
+
+  return estimation;
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/asset_ratio_response_parser.h
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.h
@@ -23,6 +23,10 @@ bool ParseAssetPriceHistory(
     const std::string& json,
     std::vector<brave_wallet::mojom::AssetTimePricePtr>* values);
 
+std::string ParseEstimatedTime(const std::string& json);
+brave_wallet::mojom::GasEstimation1559Ptr ParseGasOracle(
+    const std::string& json);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ASSET_RATIO_RESPONSE_PARSER_H_

--- a/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser_unittest.cc
@@ -8,7 +8,9 @@
 #include <vector>
 
 #include "base/i18n/time_formatting.h"
+#include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/browser/asset_ratio_response_parser.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -72,13 +74,13 @@ TEST(AssetRatioResponseParserUnitTest, ParseAssetPrice) {
 TEST(AssetRatioResponseParserUnitTest, ParseAssetPriceHistory) {
   // https://ratios.bsg.bravesoftware.com/v2/history/coingecko/basic-attention-token/usd/2021-06-03T15%3A00%3A00.000Z/2021-06-03T18%3A00%3A00.000Z
   std::string json(R"(
-    { 
+    {
       "payload": {
         "prices":[[1622733088498,0.8201346624954003],[1622737203757,0.8096978545029869]],
         "market_caps":[[1622733088498,1223507820.383275],[1622737203757,1210972881.4928021]],
         "total_volumes":[[1622733088498,163426828.00299588],[1622737203757,157618689.0971025]]
       }
-    } 
+    }
   )");
 
   std::vector<brave_wallet::mojom::AssetTimePricePtr> values;
@@ -108,6 +110,108 @@ TEST(AssetRatioResponseParserUnitTest, ParseAssetPriceHistory) {
   EXPECT_FALSE(ParseAssetPriceHistory(json, &values));
   json = "";
   EXPECT_FALSE(ParseAssetPriceHistory(json, &values));
+}
+
+TEST(AssetRatioResponseParserUnitTest, ParseEstimatedTime) {
+  std::string json(R"(
+    {
+      "payload": {
+        "status": "1",
+        "message": "",
+        "result": "3615"
+      },
+      "lastUpdated": "2021-09-22T21:45:40.015Z"
+    }
+  )");
+
+  EXPECT_EQ(ParseEstimatedTime(json), "3615");
+
+  // Invalid json input
+  EXPECT_EQ(ParseEstimatedTime("{\"result\": \"3615\"}"), "");
+  EXPECT_EQ(ParseEstimatedTime("3615"), "");
+  EXPECT_EQ(ParseEstimatedTime("[3615]"), "");
+  EXPECT_EQ(ParseEstimatedTime(""), "");
+}
+
+TEST(AssetRatioResponseParserUnitTest, ParseGasOracle) {
+  std::string json(R"(
+    {
+      "payload": {
+        "status": "1",
+        "message": "",
+        "result": {
+          "LastBlock": "13243541",
+          "SafeGasPrice": "47",
+          "ProposeGasPrice": "48",
+          "FastGasPrice": "49",
+          "suggestBaseFee": "46.574033786",
+          "gasUsedRatio": "0.27036175840958,0.0884828740801432,0.0426623303159149,0.972173412918789,0.319781207901446"
+        }
+      },
+      "lastUpdated": "2021-09-22T21:45:40.015Z"
+    }
+  )");
+
+  brave_wallet::mojom::GasEstimation1559Ptr expected_estimation =
+      brave_wallet::mojom::GasEstimation1559::New(
+          "0x3b9aca00" /* Hex of 1 * 1e9 */,
+          "0xaf16b1600" /* Hex of 47 * 1e9 */,
+          "0x77359400" /* Hex of 2 * 1e9 */,
+          "0xb2d05e000" /* Hex of 48 * 1e9 */,
+          "0xb2d05e00" /* Hex of 3 * 1e9 */,
+          "0xb68a0aa00" /* Hex of 49 * 1e9 */,
+          "0xad8075b7a" /* Hex of 46574033786 */);
+  EXPECT_EQ(ParseGasOracle(json), expected_estimation);
+
+  // Test suggest base fee with more than 9 digis in the fraction part.
+  base::ReplaceFirstSubstringAfterOffset(&json, 0, "46.574033786",
+                                         "46.5740337861");
+  EXPECT_EQ(ParseGasOracle(json), expected_estimation);
+
+  base::ReplaceFirstSubstringAfterOffset(&json, 0, "46.5740337861", "46.57403");
+  expected_estimation->base_fee_per_gas = "0xad8074cb0";  // 46.57403 * 1e9
+  EXPECT_EQ(ParseGasOracle(json), expected_estimation);
+
+  // Test suggest base fee without point.
+  base::ReplaceFirstSubstringAfterOffset(&json, 0, "46.57403", "46");
+  expected_estimation->base_fee_per_gas = "0xab5d04c00";  // 46 * 1e9
+  EXPECT_EQ(ParseGasOracle(json), expected_estimation);
+
+  const std::string valid_json = json;
+  // Test if safe_gas_price is not integer.
+  base::ReplaceFirstSubstringAfterOffset(&json, 0, "47", "47.2");
+  EXPECT_FALSE(ParseGasOracle(json));
+
+  // Test if propose_gas_price is not integer.
+  json = valid_json;
+  base::ReplaceFirstSubstringAfterOffset(&json, 0, "48", "48.3");
+  EXPECT_FALSE(ParseGasOracle(json));
+
+  // Test if fast_gas_price is not integer.
+  json = valid_json;
+  base::ReplaceFirstSubstringAfterOffset(&json, 0, "49", "49.3");
+  EXPECT_FALSE(ParseGasOracle(json));
+
+  // Test invalid json.
+  json = R"(
+    {
+      "payload": {
+        "status": "1",
+        "message": "",
+        "result": {
+          "LastBlock": "13243541",
+          "SafeGasPrice": "47",
+          "ProposeGasPrice": "48",
+          "FastGasPrice": "49",
+          "gasUsedRatio": "0.27036175840958,0.0884828740801432,0.0426623303159149,0.972173412918789,0.319781207901446"
+        }
+      },
+      "lastUpdated": "2021-09-22T21:45:40.015Z"
+    }
+  )";
+  EXPECT_FALSE(ParseGasOracle(json));  // Missing required base fee field.
+  EXPECT_FALSE(ParseGasOracle("{\"result\": \"3615\"}"));
+  EXPECT_FALSE(ParseGasOracle(""));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eip1559_transaction.h
+++ b/components/brave_wallet/browser/eip1559_transaction.h
@@ -15,6 +15,26 @@ namespace brave_wallet {
 
 class Eip1559Transaction : public Eip2930Transaction {
  public:
+  struct GasEstimation {
+    GasEstimation() = default;
+    ~GasEstimation() = default;
+    GasEstimation(const GasEstimation&) = default;
+    bool operator==(const GasEstimation&) const;
+
+    static absl::optional<GasEstimation> FromMojomGasEstimation1559(
+        mojom::GasEstimation1559Ptr gas_estimation);
+    static mojom::GasEstimation1559Ptr ToMojomGasEstimation1559(
+        GasEstimation gas_estimation);
+
+    uint256_t slow_max_priority_fee_per_gas = 0;
+    uint256_t avg_max_priority_fee_per_gas = 0;
+    uint256_t fast_max_priority_fee_per_gas = 0;
+    uint256_t slow_max_fee_per_gas = 0;
+    uint256_t avg_max_fee_per_gas = 0;
+    uint256_t fast_max_fee_per_gas = 0;
+    uint256_t base_fee_per_gas = 0;
+  };
+
   Eip1559Transaction();
   Eip1559Transaction(const Eip1559Transaction&);
   ~Eip1559Transaction() override;
@@ -29,6 +49,17 @@ class Eip1559Transaction : public Eip2930Transaction {
     return max_priority_fee_per_gas_;
   }
   uint256_t max_fee_per_gas() const { return max_fee_per_gas_; }
+  GasEstimation gas_estimation() const { return gas_estimation_; }
+
+  void set_max_fee_per_gas(uint256_t max_fee_per_gas) {
+    max_fee_per_gas_ = max_fee_per_gas;
+  }
+  void set_max_priority_fee_per_gas(uint256_t max_priority_fee_per_gas) {
+    max_priority_fee_per_gas_ = max_priority_fee_per_gas;
+  }
+  void set_gas_estimation(GasEstimation estimation) {
+    gas_estimation_ = estimation;
+  }
 
   // keccak256(0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas,
   // gasLimit, destination, value, data, access_list]))
@@ -53,10 +84,14 @@ class Eip1559Transaction : public Eip2930Transaction {
                      const std::vector<uint8_t>& data,
                      uint256_t chain_id,
                      uint256_t max_priority_fee_per_gas,
-                     uint256_t max_fee_per_gas);
+                     uint256_t max_fee_per_gas,
+                     GasEstimation gas_estimation);
 
   uint256_t max_priority_fee_per_gas_;
   uint256_t max_fee_per_gas_;
+
+  // Gas estimation result
+  GasEstimation gas_estimation_;
 };
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_tx_controller.cc
+++ b/components/brave_wallet/browser/eth_tx_controller.cc
@@ -683,7 +683,8 @@ void EthTxController::SetGasFeeAndLimitForUnapprovedTransaction(
 
   std::unique_ptr<EthTxStateManager::TxMeta> tx_meta =
       tx_state_manager_->GetTx(tx_meta_id);
-  if (!tx_meta || tx_meta->status != mojom::TransactionStatus::Unapproved) {
+  if (!tx_meta || tx_meta->status != mojom::TransactionStatus::Unapproved ||
+      tx_meta->tx->type() != 2 /* Eip1559 */) {
     std::move(callback).Run(false);
     return;
   }

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -67,11 +67,19 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
                             MakeERC20ApproveDataCallback) override;
   void GetAllTransactionInfo(const std::string& from,
                              GetAllTransactionInfoCallback) override;
+
   void SetGasPriceAndLimitForUnapprovedTransaction(
       const std::string& tx_meta_id,
       const std::string& gas_price,
       const std::string& gas_limit,
       SetGasPriceAndLimitForUnapprovedTransactionCallback callback) override;
+  void SetGasFeeAndLimitForUnapprovedTransaction(
+      const std::string& tx_meta_id,
+      const std::string& max_priority_fee_per_gas,
+      const std::string& max_fee_per_gas,
+      const std::string& gas_limit,
+      SetGasFeeAndLimitForUnapprovedTransactionCallback callback) override;
+
   void ApproveHardwareTransaction(
       const std::string& tx_meta_id,
       ApproveHardwareTransactionCallback callback) override;
@@ -80,6 +88,7 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
                               const std::string& r,
                               const std::string& s,
                               ProcessLedgerSignatureCallback callback) override;
+
   void AddObserver(
       ::mojo::PendingRemote<mojom::EthTxControllerObserver> observer) override;
 

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "brave/components/brave_wallet/browser/eip1559_transaction.h"
 #include "brave/components/brave_wallet/browser/eth_nonce_tracker.h"
 #include "brave/components/brave_wallet/browser/eth_pending_tx_tracker.h"
 #include "brave/components/brave_wallet/browser/eth_transaction.h"
@@ -26,6 +27,7 @@ class SequencedTaskRunner;
 
 namespace brave_wallet {
 
+class AssetRatioController;
 class EthJsonRpcController;
 class KeyringController;
 
@@ -34,6 +36,7 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
   explicit EthTxController(
       EthJsonRpcController* eth_json_rpc_controller,
       KeyringController* keyring_controller,
+      AssetRatioController* asset_ratio_controller,
       std::unique_ptr<EthTxStateManager> tx_state_manager,
       std::unique_ptr<EthNonceTracker> nonce_tracker,
       std::unique_ptr<EthPendingTxTracker> pending_tx_tracker,
@@ -105,21 +108,33 @@ class EthTxController : public KeyedService, public mojom::EthTxController {
   void OnPublishTransaction(std::string tx_meta_id,
                             bool status,
                             const std::string& tx_hash);
-  void OnGetEstimateGas(const std::string& from,
-                        const std::string& gas_price,
-                        std::unique_ptr<EthTransaction> tx,
-                        AddUnapprovedTransactionCallback callback,
-                        bool success,
-                        const std::string& result);
+  void OnGetGasPrice(const std::string& from,
+                     const std::string& to,
+                     const std::string& value,
+                     const std::string& data,
+                     const std::string& gas_limit,
+                     std::unique_ptr<EthTransaction> tx,
+                     AddUnapprovedTransactionCallback callback,
+                     bool success,
+                     const std::string& result);
   void ContinueAddUnapprovedTransaction(
       const std::string& from,
       std::unique_ptr<EthTransaction> tx,
       AddUnapprovedTransactionCallback callback,
       bool success,
       const std::string& result);
+  void OnGetGasOracle(const std::string& from,
+                      const std::string& to,
+                      const std::string& value,
+                      const std::string& data,
+                      const std::string& gas_limit,
+                      std::unique_ptr<Eip1559Transaction> tx,
+                      AddUnapprovedTransactionCallback callback,
+                      mojom::GasEstimation1559Ptr gas_estimation);
 
   EthJsonRpcController* rpc_controller_;   // NOT OWNED
   KeyringController* keyring_controller_;  // NOT OWNED
+  AssetRatioController* asset_ratio_controller_;  // NOT OWNED
   std::unique_ptr<EthTxStateManager> tx_state_manager_;
   std::unique_ptr<EthNonceTracker> nonce_tracker_;
   std::unique_ptr<EthPendingTxTracker> pending_tx_tracker_;

--- a/components/brave_wallet/browser/eth_tx_state_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_state_manager.cc
@@ -82,6 +82,8 @@ mojom::TransactionInfoPtr EthTxStateManager::TxMetaToTransactionInfo(
   std::string chain_id;
   std::string max_priority_fee_per_gas;
   std::string max_fee_per_gas;
+
+  mojom::GasEstimation1559Ptr gas_estimation_1559_ptr = nullptr;
   if (meta.tx->type() == 1) {
     // When type is 1 it's always Eip2930Transaction
     auto* tx2930 = reinterpret_cast<Eip2930Transaction*>(meta.tx.get());
@@ -93,6 +95,9 @@ mojom::TransactionInfoPtr EthTxStateManager::TxMetaToTransactionInfo(
     max_priority_fee_per_gas =
         Uint256ValueToHex(tx1559->max_priority_fee_per_gas());
     max_fee_per_gas = Uint256ValueToHex(tx1559->max_fee_per_gas());
+    gas_estimation_1559_ptr =
+        Eip1559Transaction::GasEstimation::ToMojomGasEstimation1559(
+            tx1559->gas_estimation());
   }
 
   mojom::TransactionType tx_type;
@@ -114,7 +119,8 @@ mojom::TransactionInfoPtr EthTxStateManager::TxMetaToTransactionInfo(
               Uint256ValueToHex(meta.tx->gas_price()),
               Uint256ValueToHex(meta.tx->gas_limit()), meta.tx->to().ToHex(),
               Uint256ValueToHex(meta.tx->value()), meta.tx->data()),
-          chain_id, max_priority_fee_per_gas, max_fee_per_gas),
+          chain_id, max_priority_fee_per_gas, max_fee_per_gas,
+          std::move(gas_estimation_1559_ptr)),
       meta.status, tx_type, tx_params, tx_args);
 }
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -363,6 +363,7 @@ interface EthTxController {
   ApproveTransaction(string tx_meta_id) => (bool status);
   RejectTransaction(string tx_meta_id) => (bool status);
   SetGasPriceAndLimitForUnapprovedTransaction(string tx_meta_id, string gas_price, string gas_limit) => (bool success);
+  SetGasFeeAndLimitForUnapprovedTransaction(string tx_meta_id, string max_priority_fee_per_gas, string max_fee_per_gas, string gas_limit) => (bool success);
   MakeERC20TransferData(string to_address, string amount) => (bool success, array<uint8> data);
   MakeERC20ApproveData(string spender_address, string amount) => (bool success, array<uint8> data);
   // This returns different data depending on which network is currently selected in EthJsonRpcController

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -284,6 +284,7 @@ struct TxData1559 {
   string chain_id;
   string max_priority_fee_per_gas;
   string max_fee_per_gas;
+  GasEstimation1559? gas_estimation;
 };
 
 const string kMainnetChainId = "0x1";

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -241,6 +241,11 @@ interface AssetRatioController {
       (bool success, array<AssetPrice> values);
   GetPriceHistory(string asset, AssetPriceTimeframe timeframe) =>
       (bool success, array<AssetTimePrice> values);
+
+  // Gas estimation APIs
+  GetEstimatedTime(string gas_price /* decimal string in wei */) =>
+      (bool success, string seconds);
+  GetGasOracle() => (GasEstimation1559? estimation);
 };
 
 interface SwapController {
@@ -262,6 +267,16 @@ struct TxData {
   string to;
   string value;
   array<uint8> data;
+};
+
+struct GasEstimation1559 {
+  string slow_max_priority_fee_per_gas;
+  string slow_max_fee_per_gas;
+  string avg_max_priority_fee_per_gas;
+  string avg_max_fee_per_gas;
+  string fast_max_priority_fee_per_gas;
+  string fast_max_fee_per_gas;
+  string base_fee_per_gas;
 };
 
 struct TxData1559 {

--- a/components/brave_wallet/factory/eth_tx_controller_factory_helper.cc
+++ b/components/brave_wallet/factory/eth_tx_controller_factory_helper.cc
@@ -17,6 +17,7 @@ namespace brave_wallet {
 std::unique_ptr<EthTxController> BuildEthTxController(
     EthJsonRpcController* rpc_controller,
     KeyringController* keyring_controller,
+    AssetRatioController* asset_ratio_controller,
     PrefService* prefs) {
   auto tx_state_manager =
       std::make_unique<EthTxStateManager>(prefs, rpc_controller->MakeRemote());
@@ -25,8 +26,9 @@ std::unique_ptr<EthTxController> BuildEthTxController(
   auto eth_pending_tx_tracker = std::make_unique<EthPendingTxTracker>(
       tx_state_manager.get(), rpc_controller, eth_nonce_tracker.get());
   return std::make_unique<EthTxController>(
-      rpc_controller, keyring_controller, std::move(tx_state_manager),
-      std::move(eth_nonce_tracker), std::move(eth_pending_tx_tracker), prefs);
+      rpc_controller, keyring_controller, asset_ratio_controller,
+      std::move(tx_state_manager), std::move(eth_nonce_tracker),
+      std::move(eth_pending_tx_tracker), prefs);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/factory/eth_tx_controller_factory_helper.h
+++ b/components/brave_wallet/factory/eth_tx_controller_factory_helper.h
@@ -12,6 +12,7 @@ class PrefService;
 
 namespace brave_wallet {
 
+class AssetRatioController;
 class EthJsonRpcController;
 class EthTxController;
 class KeyringController;
@@ -19,6 +20,7 @@ class KeyringController;
 std::unique_ptr<EthTxController> BuildEthTxController(
     EthJsonRpcController* rpc_controller,
     KeyringController* keyring_controller,
+    AssetRatioController* asset_ratio_controller,
     PrefService* prefs);
 
 }  // namespace brave_wallet

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -451,11 +451,22 @@ export class TxData {
   data: Uint8Array
 }
 
+export class GasEstimation {
+  slowMaxPriorityFeePerGas: string
+  avgMaxPriorityFeePerGas: string
+  fastMaxPriorityFeePerGas: string
+  slowMaxFeePerGas: string
+  avgMaxFeePerGas: string
+  fastMaxFeePerGas: string
+  baseFeePerGas: string
+}
+
 export class TxData1559 {
   baseData: TxData
   chainId: string
   maxPriorityFeePerGas: string
   maxFeePerGas: string
+  gasEstimation?: GasEstimation
 }
 
 export interface AddUnapprovedTransactionReturnInfo {
@@ -471,6 +482,10 @@ export interface AddUnapproved1559TransactionReturnInfo {
 }
 
 export interface SetGasPriceAndLimitForUnapprovedTransactionReturnInfo {
+  success: boolean
+}
+
+export interface SetGasFeeAndLimitForUnapprovedTransactionReturnInfo {
   success: boolean
 }
 
@@ -533,6 +548,7 @@ export interface EthTxController {
   addUnapprovedTransaction: (txData: TxData, from: string) => Promise<AddUnapprovedTransactionReturnInfo>
   addUnapproved1559Transaction: (txData: TxData1559, from: string) => (AddUnapproved1559TransactionReturnInfo)
   setGasPriceAndLimitForUnapprovedTransaction: (txMetaId: string, gasPrice: string, gasLimit: string) => Promise<SetGasPriceAndLimitForUnapprovedTransactionReturnInfo>
+  setGasFeeAndLimitForUnapprovedTransaction: (txMetaId: string, maxPriorityFeePerGas: string, maxFeePerGas: string, gasLimit: string) => Promise<SetGasFeeAndLimitForUnapprovedTransactionReturnInfo>
   approveTransaction: (txMetaId: string) => Promise<ApproveTransactionReturnInfo>
   rejectTransaction: (txMetaId: string) => Promise<RejectTransactionReturnInfo>
   makeERC20TransferData: (toAddress: string, amount: string) => Promise<MakeERC20TransferDataReturnInfo>
@@ -559,9 +575,20 @@ export interface SwapController {
   getTransactionPayload: (swapParams: SwapParams) => Promise<SwapResponseReturnInfo>
 }
 
+export interface GetEstimatedTimeReturnInfo {
+  success: boolean
+  seconds: string
+}
+
+export interface GetGasOracleReturnInfo {
+  gasEstimation?: GasEstimation
+}
+
 export interface AssetRatioController {
   getPrice: (fromAssets: string[], toAssets: string[], timeframe: AssetPriceTimeframe) => Promise<GetPriceReturnInfo>
   getPriceHistory: (asset: string, timeframe: AssetPriceTimeframe) => Promise<GetPriceHistoryReturnObjectInfo>
+  getEstimatedTime: (gasPrice: string /* decimal string in wei */) => Promise<GetEstimatedTimeReturnInfo>
+  getGasOracle: () => Promise<GetGasOracleReturnInfo>
 }
 
 export interface KeyringController {

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -27,6 +27,7 @@
     <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GET_GAS_PRICE_FAILED" desc="Failed to get gas price">Failed to get the gas price for the transaction</message>
     <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GET_GAS_LIMIT_FAILED" desc="Failed to get gas limit">Failed to get the gas limit for the transaction</message>
     <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GET_TX_TYPE_FAILED" desc="Failed to get tx type">Failed to get the type for the transaction</message>
+    <message name="IDS_WALLET_ETH_SEND_TRANSACTION_GET_GAS_ESTIMATION_FAILED" desc="Failed to get gas estimation">Failed to get the gas estimation for EIP-1559 transaction</message>
     <message name="IDS_BRAVE_WALLET_DEFI_CATEGORY" desc="Defi apps title">Defi apps</message>
     <message name="IDS_BRAVE_WALLET_NFT_CATEGORY" desc="NFT marketplace title">NFT marketplaces</message>
     <message name="IDS_BRAVE_WALLET_SEARCH_CATEGORY" desc="Filter apps placeholder">Search results</message>

--- a/ios/browser/brave_wallet/asset_ratio_controller_factory.cc
+++ b/ios/browser/brave_wallet/asset_ratio_controller_factory.cc
@@ -24,6 +24,13 @@ mojom::AssetRatioController* AssetRatioControllerFactory::GetForBrowserState(
 }
 
 // static
+AssetRatioController* AssetRatioControllerFactory::GetControllerForBrowserState(
+    ChromeBrowserState* browser_state) {
+  return static_cast<AssetRatioController*>(
+      GetInstance()->GetServiceForBrowserState(browser_state, true));
+}
+
+// static
 AssetRatioControllerFactory* AssetRatioControllerFactory::GetInstance() {
   return base::Singleton<AssetRatioControllerFactory>::get();
 }

--- a/ios/browser/brave_wallet/asset_ratio_controller_factory.h
+++ b/ios/browser/brave_wallet/asset_ratio_controller_factory.h
@@ -21,10 +21,14 @@ class BrowserState;
 
 namespace brave_wallet {
 
+class AssetRatioController;
+
 class AssetRatioControllerFactory : public BrowserStateKeyedServiceFactory {
  public:
   // Creates the service if it doesn't exist already for |browser_state|.
   static mojom::AssetRatioController* GetForBrowserState(
+      ChromeBrowserState* browser_state);
+  static AssetRatioController* GetControllerForBrowserState(
       ChromeBrowserState* browser_state);
 
   static AssetRatioControllerFactory* GetInstance();

--- a/ios/browser/brave_wallet/eth_tx_controller_factory.cc
+++ b/ios/browser/brave_wallet/eth_tx_controller_factory.cc
@@ -10,6 +10,7 @@
 #include "brave/components/brave_wallet/browser/eth_tx_controller.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/factory/eth_tx_controller_factory_helper.h"
+#include "brave/ios/browser/brave_wallet/asset_ratio_controller_factory.h"
 #include "brave/ios/browser/brave_wallet/eth_json_rpc_controller_factory.h"
 #include "brave/ios/browser/brave_wallet/keyring_controller_factory.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -37,6 +38,7 @@ EthTxControllerFactory::EthTxControllerFactory()
           BrowserStateDependencyManager::GetInstance()) {
   DependsOn(EthJsonRpcControllerFactory::GetInstance());
   DependsOn(KeyringControllerFactory::GetInstance());
+  DependsOn(AssetRatioControllerFactory::GetInstance());
 }
 
 EthTxControllerFactory::~EthTxControllerFactory() = default;
@@ -48,7 +50,10 @@ std::unique_ptr<KeyedService> EthTxControllerFactory::BuildServiceInstanceFor(
       EthJsonRpcControllerFactory::GetControllerForBrowserState(browser_state);
   auto* keyring_controller =
       KeyringControllerFactory::GetControllerForBrowserState(browser_state);
+  auto* asset_ratio_controller =
+      AssetRatioControllerFactory::GetControllerForBrowserState(browser_state);
   return brave_wallet::BuildEthTxController(rpc_controller, keyring_controller,
+                                            asset_ratio_controller,
                                             browser_state->GetPrefs());
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18169

Easiest to review per commit.
Summary of commits:
- Add `GetEstimatedTime` and `GetGasOracle` in `AssetRatioController` to get time and gas estimation using etherscan API. (passthrough via bat-ratios server)
- Store `GasEstimation` info in Eip1559Transaction for UI to use.
- In `EthTxController::AddUnapproved1559Transaction`, 
    - Call `GetGasOracle` if max_priority_fee_per_gas or max_fee_per_gas is not specified, avg fees will be used by default.
    - Call `GetEstimateGas` if gas limit is not specified.
- Add `EthTxController::SetGasFeeAndLimitForUnapprovedTransaction` to update unapproved transaction.
- Expose to JS.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

