### PR TITLE
Use empty string as contract address for ETH

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -303,10 +303,10 @@ TEST_F(BraveWalletServiceUnitTest, AddUserAsset) {
   EXPECT_TRUE(callback_called);
   ASSERT_EQ(token->symbol, "CK");
 
-  // Token with empty contract address will fail.
+  // Token with empty contract address with symbol that's not eth will fail.
   auto token_with_empty_contract_address = token.Clone();
   token_with_empty_contract_address->contract_address = "";
-  AddUserAsset(std::move(token_with_empty_contract_address), "0x1",
+  AddUserAsset(std::move(token_with_empty_contract_address), "0x4",
                &callback_called, &success);
   EXPECT_TRUE(callback_called);
   EXPECT_FALSE(success);

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -16,6 +16,7 @@
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -92,7 +93,7 @@ class BraveWalletServiceUnitTest : public testing::Test {
     ASSERT_EQ(token2_->symbol, "UNI");
 
     eth_token_ = mojom::ERCToken::New();
-    eth_token_->contract_address = "eth";
+    eth_token_->contract_address = "";
     eth_token_->name = "Ethereum";
     eth_token_->symbol = "ETH";
     eth_token_->is_erc20 = false;
@@ -394,7 +395,7 @@ TEST_F(BraveWalletServiceUnitTest, RemoveUserAsset) {
   EXPECT_EQ(tokens[0], token2);
 
   // Remove token with invalid contract_address returns false.
-  RemoveUserAsset("", "0x1", &callback_called, &success);
+  RemoveUserAsset("eth", "0x1", &callback_called, &success);
   EXPECT_TRUE(callback_called);
   EXPECT_FALSE(success);
 
@@ -467,8 +468,8 @@ TEST_F(BraveWalletServiceUnitTest, SetUserAssetVisible) {
   EXPECT_EQ(tokens.size(), 1u);
   EXPECT_EQ(tokens[0], token2);
 
-  // Empty contract_address return false.
-  SetUserAssetVisible("", "0x1", false, &callback_called, &success);
+  // Invalid contract_address return false.
+  SetUserAssetVisible("eth", "0x1", false, &callback_called, &success);
   EXPECT_TRUE(callback_called);
   EXPECT_FALSE(success);
 
@@ -536,6 +537,12 @@ TEST_F(BraveWalletServiceUnitTest, GetChecksumAddress) {
   EXPECT_EQ(addr.value(), "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d");
 
   addr = service_->GetChecksumAddress("", "0x1");
+  EXPECT_EQ(addr.value(), "");
+
+  addr = service_->GetChecksumAddress("eth", "0x1");
+  EXPECT_FALSE(addr.has_value());
+
+  addr = service_->GetChecksumAddress("ETH", "0x1");
   EXPECT_FALSE(addr.has_value());
 
   addr = service_->GetChecksumAddress("0x123", "0x1");
@@ -564,6 +571,86 @@ TEST_F(BraveWalletServiceUnitTest, GetAndSetDefaultWallet) {
 
   SetDefaultWallet(mojom::DefaultWallet::Ask);
   EXPECT_EQ(GetDefaultWallet(), mojom::DefaultWallet::Ask);
+}
+
+TEST_F(BraveWalletServiceUnitTest, EthAddRemoveSetUserAssetVisible) {
+  bool success = false;
+  bool callback_called = false;
+
+  // Add ETH with eth as the contract address will fail.
+  auto invalid_eth = GetEthToken();
+  invalid_eth->contract_address = "eth";
+  AddUserAsset(std::move(invalid_eth), "0x4", &callback_called, &success);
+  EXPECT_TRUE(callback_called);
+  EXPECT_FALSE(success);
+
+  // Add ETH with empty contract address.
+  AddUserAsset(GetEthToken(), "0x4", &callback_called, &success);
+  EXPECT_TRUE(callback_called);
+  EXPECT_TRUE(success);
+
+  std::vector<mojom::ERCTokenPtr> tokens;
+  GetUserAssets("0x4", &callback_called, &tokens);
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(GetEthToken(), tokens[0]);
+
+  // Test setting visibility of ETH.
+  SetUserAssetVisible("", "0x4", false, &callback_called, &success);
+  EXPECT_TRUE(callback_called);
+  EXPECT_TRUE(success);
+
+  GetUserAssets("0x4", &callback_called, &tokens);
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(tokens.size(), 1u);
+  EXPECT_FALSE(tokens[0]->visible);
+
+  // Test removing ETH from user asset list.
+  RemoveUserAsset("", "0x4", &callback_called, &success);
+  EXPECT_TRUE(callback_called);
+  EXPECT_TRUE(success);
+
+  GetUserAssets("0x4", &callback_called, &tokens);
+  EXPECT_TRUE(callback_called);
+  EXPECT_TRUE(tokens.empty());
+}
+
+TEST_F(BraveWalletServiceUnitTest, MigrateUserAssetEthContractAddress) {
+  EXPECT_FALSE(
+      GetPrefs()->GetBoolean(kBraveWalletUserAssetEthContractAddressMigrated));
+
+  DictionaryPrefUpdate update(GetPrefs(), kBraveWalletUserAssets);
+  base::DictionaryValue* user_assets_pref = update.Get();
+  base::Value* user_assets_list =
+      user_assets_pref->SetKey("rinkeby", base::Value(base::Value::Type::LIST));
+
+  base::Value value(base::Value::Type::DICTIONARY);
+  value.SetKey("contract_address", base::Value("eth"));
+  value.SetKey("name", base::Value("Ethereum"));
+  value.SetKey("symbol", base::Value("ETH"));
+  value.SetKey("is_erc20", base::Value(false));
+  value.SetKey("is_erc721", base::Value(false));
+  value.SetKey("decimals", base::Value(18));
+  value.SetKey("visible", base::Value(true));
+  user_assets_list->Append(std::move(value));
+
+  bool callback_called = false;
+  std::vector<mojom::ERCTokenPtr> tokens;
+  GetUserAssets("0x4", &callback_called, &tokens);
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(tokens[0]->contract_address, "eth");
+
+  BraveWalletService::MigrateUserAssetEthContractAddress(GetPrefs());
+
+  callback_called = false;
+  GetUserAssets("0x4", &callback_called, &tokens);
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(tokens[0]->contract_address, "");
+
+  EXPECT_TRUE(
+      GetPrefs()->GetBoolean(kBraveWalletUserAssetEthContractAddressMigrated));
 }
 
 }  // namespace brave_wallet

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -36,6 +36,7 @@
 #endif
 
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
+#include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/keyring_controller.h"
 #endif
 
@@ -67,6 +68,7 @@ void MigrateObsoleteProfilePrefs(Profile* profile) {
 #if BUILDFLAG(BRAVE_WALLET_ENABLED)
   brave_wallet::KeyringController::MigrateObsoleteProfilePrefs(
       profile->GetPrefs());
+  brave_wallet::MigrateObsoleteProfilePrefs(profile->GetPrefs());
 #endif
 
   // Added 04/2021

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -22,7 +22,7 @@ base::Value GetDefaultUserAssets() {
       user_assets_pref.SetKey("mainnet", base::Value(base::Value::Type::LIST));
 
   base::Value eth(base::Value::Type::DICTIONARY);
-  eth.SetKey("contract_address", base::Value("eth"));
+  eth.SetKey("contract_address", base::Value(""));
   eth.SetKey("name", base::Value("Ethereum"));
   eth.SetKey("symbol", base::Value("ETH"));
   eth.SetKey("is_erc20", base::Value(false));

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
@@ -81,6 +82,10 @@ void RegisterProfilePrefsForMigration(
   registry->RegisterIntegerPref(kBraveWalletDefaultKeyringAccountNum, 0);
   registry->RegisterBooleanPref(kBraveWalletBackupComplete, false);
   registry->RegisterListPref(kBraveWalletAccountNames);
+
+  // Added 10/2021
+  registry->RegisterBooleanPref(kBraveWalletUserAssetEthContractAddressMigrated,
+                                false);
 }
 
 void ClearProfilePrefs(PrefService* prefs) {
@@ -91,6 +96,12 @@ void ClearProfilePrefs(PrefService* prefs) {
   prefs->ClearPref(kBraveWalletUserAssets);
   prefs->ClearPref(kBraveWalletKeyrings);
   prefs->ClearPref(kBraveWalletAutoLockMinutes);
+}
+
+void MigrateObsoleteProfilePrefs(PrefService* prefs) {
+  // Added 10/2021 for migrating the contract address for eth in user asset
+  // list from 'eth' to an empty string.
+  BraveWalletService::MigrateUserAssetEthContractAddress(prefs);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -18,7 +18,7 @@ namespace {
 base::Value GetDefaultUserAssets() {
   // Show ETH and BAT by default for mainnet.
   base::Value user_assets_pref(base::Value::Type::DICTIONARY);
-  base::Value* user_assets_dict =
+  base::Value* user_assets_list =
       user_assets_pref.SetKey("mainnet", base::Value(base::Value::Type::LIST));
 
   base::Value eth(base::Value::Type::DICTIONARY);
@@ -29,7 +29,7 @@ base::Value GetDefaultUserAssets() {
   eth.SetKey("is_erc721", base::Value(false));
   eth.SetKey("decimals", base::Value(18));
   eth.SetKey("visible", base::Value(true));
-  user_assets_dict->Append(std::move(eth));
+  user_assets_list->Append(std::move(eth));
 
   base::Value bat(base::Value::Type::DICTIONARY);
   bat.SetKey("contract_address",
@@ -41,7 +41,7 @@ base::Value GetDefaultUserAssets() {
   bat.SetKey("decimals", base::Value(18));
   bat.SetKey("visible", base::Value(true));
   bat.SetKey("logo", base::Value("bat.svg"));
-  user_assets_dict->Append(std::move(bat));
+  user_assets_list->Append(std::move(bat));
 
   return user_assets_pref;
 }

--- a/components/brave_wallet/browser/brave_wallet_prefs.h
+++ b/components/brave_wallet/browser/brave_wallet_prefs.h
@@ -18,6 +18,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
 void RegisterProfilePrefsForMigration(
     user_prefs::PrefRegistrySyncable* registry);
 void ClearProfilePrefs(PrefService* prefs);
+void MigrateObsoleteProfilePrefs(PrefService* prefs);
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -213,7 +213,12 @@ void BraveWalletService::AddUserAsset(mojom::ERCTokenPtr token,
     std::move(callback).Run(false);
     return;
   }
+
   const std::string checksum_address = optional_checksum_address.value();
+  if (checksum_address.empty() && base::ToLowerASCII(token->symbol) != "eth") {
+    std::move(callback).Run(false);
+    return;
+  }
 
   const std::string network_id = GetNetworkId(prefs_, chain_id);
   if (network_id.empty()) {

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -65,13 +65,13 @@
 namespace {
 
 base::CheckedContiguousIterator<base::Value> FindAsset(
-    base::Value* user_assets_dict,
+    base::Value* user_assets_list,
     const std::string& contract_address) {
-  DCHECK(user_assets_dict && user_assets_dict->is_list() &&
+  DCHECK(user_assets_list && user_assets_list->is_list() &&
          !contract_address.empty());
 
   auto iter = std::find_if(
-      user_assets_dict->GetList().begin(), user_assets_dict->GetList().end(),
+      user_assets_list->GetList().begin(), user_assets_list->GetList().end(),
       [&](const base::Value& value) {
         if (!value.is_dict()) {
           return false;
@@ -221,14 +221,14 @@ void BraveWalletService::AddUserAsset(mojom::ERCTokenPtr token,
   DictionaryPrefUpdate update(prefs_, kBraveWalletUserAssets);
   base::DictionaryValue* user_assets_pref = update.Get();
 
-  base::Value* user_assets_dict = user_assets_pref->FindKey(network_id);
-  if (!user_assets_dict) {
-    user_assets_dict = user_assets_pref->SetKey(
+  base::Value* user_assets_list = user_assets_pref->FindKey(network_id);
+  if (!user_assets_list) {
+    user_assets_list = user_assets_pref->SetKey(
         network_id, base::Value(base::Value::Type::LIST));
   }
 
-  auto it = FindAsset(user_assets_dict, checksum_address);
-  if (it != user_assets_dict->GetList().end()) {
+  auto it = FindAsset(user_assets_list, checksum_address);
+  if (it != user_assets_list->GetList().end()) {
     std::move(callback).Run(false);
     return;
   }
@@ -243,7 +243,7 @@ void BraveWalletService::AddUserAsset(mojom::ERCTokenPtr token,
   value.SetKey("decimals", base::Value(token->decimals));
   value.SetKey("visible", base::Value(true));
 
-  user_assets_dict->Append(std::move(value));
+  user_assets_list->Append(std::move(value));
   std::move(callback).Run(true);
 }
 
@@ -267,14 +267,14 @@ void BraveWalletService::RemoveUserAsset(const std::string& contract_address,
   DictionaryPrefUpdate update(prefs_, kBraveWalletUserAssets);
   base::DictionaryValue* user_assets_pref = update.Get();
 
-  base::Value* user_assets_dict = user_assets_pref->FindKey(network_id);
-  if (!user_assets_dict) {
+  base::Value* user_assets_list = user_assets_pref->FindKey(network_id);
+  if (!user_assets_list) {
     std::move(callback).Run(false);
     return;
   }
 
-  user_assets_dict->EraseListIter(
-      FindAsset(user_assets_dict, checksum_address));
+  user_assets_list->EraseListIter(
+      FindAsset(user_assets_list, checksum_address));
   std::move(callback).Run(true);
 }
 
@@ -300,14 +300,14 @@ void BraveWalletService::SetUserAssetVisible(
   DictionaryPrefUpdate update(prefs_, kBraveWalletUserAssets);
   base::DictionaryValue* user_assets_pref = update.Get();
 
-  base::Value* user_assets_dict = user_assets_pref->FindKey(network_id);
-  if (!user_assets_dict) {
+  base::Value* user_assets_list = user_assets_pref->FindKey(network_id);
+  if (!user_assets_list) {
     std::move(callback).Run(false);
     return;
   }
 
-  auto it = FindAsset(user_assets_dict, checksum_address);
-  if (it == user_assets_dict->GetList().end()) {
+  auto it = FindAsset(user_assets_list, checksum_address);
+  if (it == user_assets_list->GetList().end()) {
     std::move(callback).Run(false);
     return;
   }

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -22,7 +22,7 @@
 //    "mainnet": {  // network_id
 //      [
 //        {
-//          "contract_address": "eth",
+//          "contract_address": "",
 //          "name": "Ethereum",
 //          "symbol": "ETH",
 //          "is_erc20": false,
@@ -67,8 +67,7 @@ namespace {
 base::CheckedContiguousIterator<base::Value> FindAsset(
     base::Value* user_assets_list,
     const std::string& contract_address) {
-  DCHECK(user_assets_list && user_assets_list->is_list() &&
-         !contract_address.empty());
+  DCHECK(user_assets_list && user_assets_list->is_list());
 
   auto iter = std::find_if(
       user_assets_list->GetList().begin(), user_assets_list->GetList().end(),
@@ -111,6 +110,10 @@ void BraveWalletService::Bind(
 absl::optional<std::string> BraveWalletService::GetChecksumAddress(
     const std::string& contract_address,
     const std::string& chain_id) {
+  if (contract_address.empty()) {
+    return "";
+  }
+
   const auto eth_addr = EthAddress::FromHex(contract_address);
   if (eth_addr.IsEmpty()) {
     return absl::nullopt;

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -37,6 +37,8 @@ class BraveWalletService : public KeyedService,
   mojo::PendingRemote<mojom::BraveWalletService> MakeRemote();
   void Bind(mojo::PendingReceiver<mojom::BraveWalletService> receiver);
 
+  static void MigrateUserAssetEthContractAddress(PrefService* prefs);
+
   // mojom::BraveWalletService:
   void GetUserAssets(const std::string& chain_id,
                      GetUserAssetsCallback callback) override;

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -17,7 +17,7 @@ const char kBraveWalletCurrentChainId[] =
 const char kBraveWalletKeyrings[] = "brave.wallet.keyrings";
 const char kBraveWalletUserAssets[] = "brave.wallet.user_assets";
 const char kBraveWalletUserAssetEthContractAddressMigrated[] =
-    "brave.wallet.user.asset.eth.contract.address.migrated";
+    "brave.wallet.user.asset.eth_contract_address_migrated";
 const char kBraveWalletAutoLockMinutes[] = "brave.wallet.auto_lock_minutes";
 const char kBraveWalletSelectedAccount[] = "brave.wallet.selected_account";
 

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -16,6 +16,8 @@ const char kBraveWalletCurrentChainId[] =
     "brave.wallet.wallet_current_chain_id";
 const char kBraveWalletKeyrings[] = "brave.wallet.keyrings";
 const char kBraveWalletUserAssets[] = "brave.wallet.user_assets";
+const char kBraveWalletUserAssetEthContractAddressMigrated[] =
+    "brave.wallet.user.asset.eth.contract.address.migrated";
 const char kBraveWalletAutoLockMinutes[] = "brave.wallet.auto_lock_minutes";
 const char kBraveWalletSelectedAccount[] = "brave.wallet.selected_account";
 

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -14,6 +14,8 @@ extern const char kBraveWalletKeyrings[];
 extern const char kBraveWalletCustomNetworks[];
 extern const char kBraveWalletCurrentChainId[];
 extern const char kBraveWalletUserAssets[];
+// Added 10/2021 to migrate contract address to an empty string for ETH.
+extern const char kBraveWalletUserAssetEthContractAddressMigrated[];
 extern const char kBraveWalletAutoLockMinutes[];
 extern const char kBraveWalletSelectedAccount[];
 

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -177,7 +177,7 @@ reducer.on(WalletActions.tokenBalancesUpdated, (state: any, payload: GetERC20Tok
       let assetBalance = '0'
       let fiatBalance = '0'
 
-      if (userVisibleTokensInfo[tokenIndex].contractAddress === 'eth') {
+      if (userVisibleTokensInfo[tokenIndex].contractAddress === '') {
         assetBalance = account.balance
         fiatBalance = account.fiatBalance
       } else if (info.success) {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
@@ -9,6 +9,7 @@ import {
 import { NavButton } from '../../../extension'
 import { SearchBar } from '../../../shared'
 import { getLocale } from '../../../../../common/locale'
+import { ETH } from '../../../../options/initial-visible-token-info'
 
 // Styled Components
 import {
@@ -89,7 +90,8 @@ const EditVisibleAssetsModal = (props: Props) => {
 
   const tokenList = React.useMemo(() => {
     const visibleContracts = userVisibleTokensInfo.map((token) => token.contractAddress)
-    const notVisibleList = fullAssetList.filter((token) => !visibleContracts.includes(token.contractAddress))
+    const fullList = visibleContracts.includes('') ? fullAssetList : [ETH, ...fullAssetList]
+    const notVisibleList = fullList.filter((token) => !visibleContracts.includes(token.contractAddress))
     return [...userVisibleTokensInfo, ...notVisibleList]
   }, [fullAssetList, userVisibleTokensInfo])
 

--- a/components/brave_wallet_ui/options/initial-visible-token-info.ts
+++ b/components/brave_wallet_ui/options/initial-visible-token-info.ts
@@ -1,12 +1,12 @@
 import { TokenInfo } from '../constants/types'
 
-export const InitialVisibleTokenInfo: TokenInfo[] = [
-  {
-    contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
-    decimals: 18,
-    isErc20: true,
-    isErc721: false,
-    name: 'Basic Attention Token',
-    symbol: 'BAT'
-  }
-]
+export const ETH: TokenInfo = {
+  contractAddress: '',
+  decimals: 18,
+  isErc20: false,
+  isErc721: false,
+  logo: '',
+  name: 'Ethereum',
+  symbol: 'ETH',
+  visible: true
+}


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18487
Resolves https://github.com/brave/brave-browser/issues/18454

This PR update the default value of user assets pref to use empty string as ETH's contract address.
And also migrate the pref to reset ETH's contract address to an empty string from all stored assets.

@Douglashdaniel also fixed front-end usage where we sometimes use `eth` as the contract address in this PR.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

