### PR TITLE
Updated UI for Edit Visible Assets Modal

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -222,6 +222,7 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletWatchListTokenDecimals",
      IDS_BRAVE_WALLET_WATCH_LIST_TOKEN_DECIMALS},
     {"braveWalletWatchListAdd", IDS_BRAVE_WALLET_WATCH_LIST_ADD},
+    {"braveWalletWatchListDoneButton", IDS_BRAVE_WALLET_WATCH_LIST_DONE_BUTTON},
     {"braveWalletWatchListSuggestion", IDS_BRAVE_WALLET_WATCH_LIST_SUGGESTION},
     {"braveWalletWatchListNoAsset", IDS_BRAVE_WALLET_WATCH_LIST_NO_ASSET},
     {"braveWalletWatchListSearchPlaceholder",

--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
@@ -24,7 +24,8 @@ import {
   Input,
   Divider,
   ButtonRow,
-  ErrorText
+  ErrorText,
+  TopRow
 } from './style'
 
 export interface Props {
@@ -93,8 +94,12 @@ const EditVisibleAssetsModal = (props: Props) => {
     return [...userVisibleTokensInfo, ...notVisibleList]
   }, [fullAssetList, userVisibleTokensInfo])
 
-  React.useMemo(() => {
-    setFilteredTokenList(tokenList)
+  React.useEffect(() => {
+    // Added this timeout to throttle setting the list
+    // to allow the modal to appear instantly
+    setTimeout(function () {
+      setFilteredTokenList(tokenList)
+    }, 500)
     if (!addUserAssetError) {
       setShowAddCustomToken(false)
     }
@@ -105,7 +110,9 @@ const EditVisibleAssetsModal = (props: Props) => {
   const filterWatchlist = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const search = event.target.value
     if (search === '') {
-      setFilteredTokenList(tokenList)
+      setTimeout(function () {
+        setFilteredTokenList(tokenList)
+      }, 100)
     } else {
       const filteredList = tokenList.filter((item) => {
         return (
@@ -207,7 +214,7 @@ const EditVisibleAssetsModal = (props: Props) => {
         <Divider />
       }
       <StyledWrapper>
-        {fullAssetList.length === 0 || isLoading ? (
+        {(filteredTokenList.length === 0 && searchValue === '') || isLoading ? (
           <LoadingWrapper>
             <LoadIcon />
           </LoadingWrapper>
@@ -269,6 +276,13 @@ const EditVisibleAssetsModal = (props: Props) => {
                   placeholder={getLocale('braveWalletWatchListSearchPlaceholder')}
                   action={filterWatchlist}
                 />
+                {!searchValue.toLowerCase().startsWith('0x') &&
+                  <TopRow>
+                    <NoAssetButton onClick={toggleShowAddCustomToken}>
+                      {getLocale('braveWalletWatchlistAddCustomAsset')}
+                    </NoAssetButton>
+                  </TopRow>
+                }
                 <WatchlistScrollContainer>
                   <>
                     {filteredTokenList.map((token) =>
@@ -293,8 +307,8 @@ const EditVisibleAssetsModal = (props: Props) => {
                   </>
                 </WatchlistScrollContainer>
                 <NavButton
-                  onSubmit={toggleShowAddCustomToken}
-                  text={getLocale('braveWalletWatchlistAddCustomAsset')}
+                  onSubmit={onClose}
+                  text={getLocale('braveWalletWatchListDoneButton')}
                   buttonType='primary'
                 />
               </>

--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/style.ts
@@ -138,6 +138,14 @@ export const Input = styled.input`
   }
 `
 
+export const TopRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+`
+
 export const ButtonRow = styled.div`
   display: flex;
   flex-direction: row;

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
@@ -199,7 +199,7 @@ const Portfolio = (props: Props) => {
   }
 
   const toggleShowVisibleAssetModal = () => {
-    if (!showVisibleAssetsModal) {
+    if (fullAssetList.length === 0) {
       fetchFullTokenList()
     }
     setShowVisibleAssetsModal(!showVisibleAssetsModal)

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -192,6 +192,7 @@ provideStrings({
   braveWalletWatchListTokenSymbol: 'Token symbol',
   braveWalletWatchListTokenDecimals: 'Decimals of percision',
   braveWalletWatchListAdd: 'Add',
+  braveWalletWatchListDoneButton: 'Done',
   braveWalletWatchListSuggestion: 'as a custtom token',
   braveWalletWatchListNoAsset: 'No assets named',
   braveWalletWatchListSearchPlaceholder: 'Search assets or contract address',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -157,6 +157,7 @@
     <message name="IDS_BRAVE_WALLET_WATCH_LIST_TOKEN_SYMBOL" desc="Visible assets modal token symbol label">Token symbol</message>
     <message name="IDS_BRAVE_WALLET_WATCH_LIST_TOKEN_DECIMALS" desc="Visible assets modal decimals label">Decimals of percision</message>
     <message name="IDS_BRAVE_WALLET_WATCH_LIST_ADD" desc="Visible assets modal add button">Add</message>
+    <message name="IDS_BRAVE_WALLET_WATCH_LIST_DONE_BUTTON" desc="Visible assets modal done button">Done</message>
     <message name="IDS_BRAVE_WALLET_WATCH_LIST_SUGGESTION" desc="Visible assets modal suggestion second half button">as a custtom token</message>
     <message name="IDS_BRAVE_WALLET_WATCH_LIST_NO_ASSET" desc="Visible assets modal no results placeholder">No assets named</message>
     <message name="IDS_BRAVE_WALLET_WATCH_LIST_SEARCH_PLACEHOLDER" desc="Visible assets modal search input placeholder">Search assets or contract address</message>


### PR DESCRIPTION
## Description 
Updated the UI for Edit Visible Assets Modal.
 
1) Moved the `Add custom asset` button to the top left above the list and made it a secondary button.
2) Added primary `Done` button to the bottom of the modal.
3) Fixed an async `error` that was occurring when removing an asset from the list.
4) Added error handling for when adding a new asset that the `pricingAPI` doesn't recognize, will now return a zero balance for that asset instead of failing the entire portfolio price information.
5) Added a timeout method to the `EditVisibleAssets` modal to throttle the `fullAssetList` to allow the modal to display instantly and then load asset data.
6) Added checks in places that were calling the `getAllTokensList` method, to only call if the `fullAssetList` length is `0`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/18474>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/135563649-d508234e-088a-40b8-b145-ecedf9de6f4c.mov
