### PR TITLE
Handle 0x swap API errors

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -390,8 +390,16 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletEditGasBaseFee", IDS_BRAVE_WALLET_EDIT_GAS_BASE_FEE},
     {"braveWalletEditGasGwei", IDS_BRAVE_WALLET_EDIT_GAS_GWEI},
     {"braveWalletEditGasSetCustom", IDS_BRAVE_WALLET_EDIT_GAS_SET_CUSTOM},
-    {"braveWalletEditGasSetSuggested",
-     IDS_BRAVE_WALLET_EDIT_GAS_SET_SUGGESTED}};
+    {"braveWalletEditGasSetSuggested", IDS_BRAVE_WALLET_EDIT_GAS_SET_SUGGESTED},
+    {"braveWalletSwapInsufficientBalance",
+     IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_BALANCE},
+    {"braveWalletSwapInsufficientEthBalance",
+     IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_ETH_BALANCE},
+    {"braveWalletSwapInsufficientLiquidity",
+     IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_LIQUIDITY},
+    {"braveWalletSwapInsufficientAllowance",
+     IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_ALLOWANCE},
+    {"braveWalletSwapUnknownError", IDS_BRAVE_WALLET_SWAP_UNKNOWN_ERROR}};
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet_ui/common/hooks/balance.ts
+++ b/components/brave_wallet_ui/common/hooks/balance.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+import { AccountAssetOptionType, WalletAccountType } from '../../constants/types'
+import { formatBalance } from '../../utils/format-balances'
+
+export default function useBalance (selectedAccount: WalletAccountType) {
+  return React.useCallback((asset: AccountAssetOptionType) => {
+    let assetBalance = '0'
+    let fiatBalance = '0'
+
+    if (!selectedAccount || !selectedAccount.tokens) {
+      return { assetBalance, fiatBalance }
+    }
+
+    const token = selectedAccount.tokens.find(
+      (token) => token.asset.symbol === asset.asset.symbol
+    )
+    if (!token) {
+      return { assetBalance, fiatBalance }
+    }
+
+    return {
+      assetBalance: formatBalance(token.assetBalance, token.asset.decimals),
+      fiatBalance: token.fiatBalance
+    }
+  }, [selectedAccount])
+}

--- a/components/brave_wallet_ui/common/hooks/index.ts
+++ b/components/brave_wallet_ui/common/hooks/index.ts
@@ -6,5 +6,6 @@
 import useSwap from './swap'
 import useAssets from './assets'
 import useTimeout from './timeout'
+import useBalance from './balance'
 
-export { useAssets, useSwap, useTimeout }
+export { useAssets, useSwap, useTimeout, useBalance }

--- a/components/brave_wallet_ui/common/hooks/swap.ts
+++ b/components/brave_wallet_ui/common/hooks/swap.ts
@@ -13,6 +13,8 @@ import {
   ExpirationPresetObjectType,
   OrderTypes,
   SlippagePresetObjectType,
+  SwapErrorResponse,
+  SwapValidationErrorType,
   SwapResponse,
   ToOrFromType,
   WalletAccountType
@@ -25,12 +27,15 @@ import { debounce } from '../../../common/debounce'
 import { SwapParamsPayloadType } from '../constants/action_types'
 import useBalance from './balance'
 
+const SWAP_VALIDATION_ERROR_CODE = 100
+
 export default function useSwap (
   selectedAccount: WalletAccountType,
   selectedNetwork: EthereumChain,
   fetchSwapQuote: SimpleActionCreator<SwapParamsPayloadType>,
   assetOptions: AccountAssetOptionType[],
-  quote?: SwapResponse
+  quote?: SwapResponse,
+  rawError?: SwapErrorResponse
 ) {
   const [exchangeRate, setExchangeRate] = React.useState('')
   const [fromAmount, setFromAmount] = React.useState('')
@@ -42,6 +47,68 @@ export default function useSwap (
   const [toAsset, setToAsset] = React.useState<AccountAssetOptionType>(BAT)
   const [filteredAssetList, setFilteredAssetList] = React.useState<AccountAssetOptionType[]>(assetOptions)
   const [swapToOrFrom, setSwapToOrFrom] = React.useState<ToOrFromType>('from')
+
+  const getBalance = useBalance(selectedAccount)
+  const { assetBalance: fromAssetBalance } = getBalance(fromAsset)
+  const { assetBalance: ethBalance } = getBalance(ETH)
+
+  const feesBN = React.useMemo(() => {
+    if (!quote) {
+      return new BigNumber('0')
+    }
+
+    const { gasPrice, gas } = quote
+    const gasPriceBN = new BigNumber(gasPrice)
+    const gasBN = new BigNumber(gas)
+    return gasPriceBN.multipliedBy(gasBN)
+  }, [quote])
+
+  const swapValidationError: SwapValidationErrorType | undefined = React.useMemo(() => {
+    const fromAmountWei = toWei(fromAmount, fromAsset.asset.decimals)
+    const fromAssetBalanceWei = toWei(fromAssetBalance, fromAsset.asset.decimals)
+    const ethBalanceWei = toWei(ethBalance, ETH.asset.decimals)
+
+    const amountBN = new BigNumber(fromAmountWei)
+    const balanceBN = new BigNumber(fromAssetBalanceWei)
+    const ethBalanceBN = new BigNumber(ethBalanceWei)
+
+    if (amountBN.gt(balanceBN)) {
+      return 'insufficientBalance'
+    }
+
+    if (feesBN.gt(ethBalanceBN)) {
+      return 'insufficientEthBalance'
+    }
+
+    if (fromAsset.asset.symbol === ETH.asset.symbol && amountBN.plus(feesBN).gt(balanceBN)) {
+      return 'insufficientEthBalance'
+    }
+
+    // TODO: Add case for "insufficientAllowance" by querying token allowance.
+    // tslint:disable-next-line:no-constant-condition
+    if (false) {
+      return 'insufficientAllowance'
+    }
+
+    // TODO: provide more granular information about the error.
+    if (rawError === undefined) {
+      return
+    }
+
+    const { code, validationErrors } = rawError
+    switch (code) {
+      case SWAP_VALIDATION_ERROR_CODE:
+        if (validationErrors?.find(err => err.reason === 'INSUFFICIENT_ASSET_LIQUIDITY')) {
+          return 'insufficientLiquidity'
+        }
+        break
+
+      default:
+        return 'unknownError'
+    }
+
+    return
+  }, [fromAsset, fromAmount, fromAssetBalance, ethBalance, feesBN, rawError])
 
   /**
    * React effect to extract fields from the swap quote and write the relevant
@@ -99,18 +166,18 @@ export default function useSwap (
    *                           function on change.
    */
   const onSwapParamsChange = React.useCallback((
-      overrides: {
-        toOrFrom: ToOrFromType
-        fromAsset?: AccountAssetOptionType
-        toAsset?: AccountAssetOptionType
-        amount?: string
-        slippageTolerance?: SlippagePresetObjectType
-      },
-      state: {
-        fromAmount: string,
-        toAmount: string
-      },
-      full: boolean = false
+    overrides: {
+      toOrFrom: ToOrFromType
+      fromAsset?: AccountAssetOptionType
+      toAsset?: AccountAssetOptionType
+      amount?: string
+      slippageTolerance?: SlippagePresetObjectType
+    },
+    state: {
+      fromAmount: string,
+      toAmount: string
+    },
+    full: boolean = false
   ) => {
     // if (selectedWidgetTab !== 'swap') {
     //   return
@@ -287,10 +354,11 @@ export default function useSwap (
   }
 
   const isSwapButtonDisabled = React.useMemo(() => (
-      !quote ||
-      toWei(toAmount, toAsset.asset.decimals) === '0' ||
-      toWei(fromAmount, fromAsset.asset.decimals) === '0'
-  ), [toAmount, fromAmount, toAsset, fromAsset, quote])
+    quote === undefined ||
+    (swapValidationError && swapValidationError !== 'insufficientAllowance') ||
+    toWei(toAmount, toAsset.asset.decimals) === '0' ||
+    toWei(fromAmount, fromAsset.asset.decimals) === '0'
+  ), [toAmount, fromAmount, toAsset, fromAsset, quote, swapValidationError])
 
   const onSelectTransactAsset = (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => {
     if (toOrFrom === 'from') {
@@ -336,6 +404,7 @@ export default function useSwap (
     orderType,
     slippageTolerance,
     swapToOrFrom,
+    swapValidationError,
     toAmount,
     toAsset,
     setFromAsset,

--- a/components/brave_wallet_ui/common/hooks/swap.ts
+++ b/components/brave_wallet_ui/common/hooks/swap.ts
@@ -23,6 +23,7 @@ import { BAT, ETH } from '../../options/asset-options'
 import { formatBalance, toWei } from '../../utils/format-balances'
 import { debounce } from '../../../common/debounce'
 import { SwapParamsPayloadType } from '../constants/action_types'
+import useBalance from './balance'
 
 export default function useSwap (
   selectedAccount: WalletAccountType,

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react'
-import { AccountAssetOptionType, OrderTypes, SlippagePresetObjectType, ExpirationPresetObjectType } from '../../../constants/types'
+import {
+  AccountAssetOptionType,
+  OrderTypes,
+  SlippagePresetObjectType,
+  ExpirationPresetObjectType,
+  SwapValidationErrorType
+} from '../../../constants/types'
 import { AmountPresetOptions } from '../../../options/amount-preset-options'
 import { SlippagePresetOptions } from '../../../options/slippage-preset-options'
 import { ExpirationPresetOptions } from '../../../options/expiration-preset-options'
@@ -44,6 +50,7 @@ export interface Props {
   orderType?: OrderTypes
   slippageTolerance?: SlippagePresetObjectType
   orderExpiration?: ExpirationPresetObjectType
+  validationError?: SwapValidationErrorType
   onInputChange?: (value: string, name: string) => void
   onSelectPresetAmount?: (percent: number) => void
   onSelectSlippageTolerance?: (slippage: SlippagePresetObjectType) => void
@@ -65,6 +72,7 @@ function SwapInputComponent (props: Props) {
     orderType,
     slippageTolerance,
     orderExpiration,
+    validationError,
     onInputChange,
     onPaste,
     onRefresh,
@@ -146,6 +154,11 @@ function SwapInputComponent (props: Props) {
     setSpin(0)
   }
 
+  const fromAmountHasErrors = validationError && (
+    validationError === 'insufficientBalance' ||
+    validationError === 'insufficientEthBalance'
+  )
+
   return (
     <BubbleContainer>
       {componentType !== 'selector' &&
@@ -179,7 +192,7 @@ function SwapInputComponent (props: Props) {
               name={inputName}
               onChange={onInputChanged}
               spellCheck={false}
-              hasError={selectedAssetBalance && componentType === 'fromAmount' ? Number(selectedAssetInputAmount) > Number(selectedAssetBalance) : false}
+              hasError={componentType === 'fromAmount' && fromAmountHasErrors}
               disabled={orderType === 'market' && componentType === 'exchange' || orderType === 'limit' && componentType === 'toAmount'}
             />
             {componentType === 'exchange' && orderType === 'market' &&

--- a/components/brave_wallet_ui/components/buy-send-swap/swap/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap/index.tsx
@@ -5,7 +5,8 @@ import {
   BuySendSwapViewTypes,
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
-  ToOrFromType
+  ToOrFromType,
+  SwapValidationErrorType
 } from '../../../constants/types'
 import { NavButton } from '../../extension'
 import SwapInputComponent from '../swap-input-component'
@@ -28,6 +29,7 @@ export interface Props {
   fromAssetBalance: string
   toAssetBalance: string
   isSubmitDisabled: boolean
+  validationError?: SwapValidationErrorType
   onToggleOrderType: () => void
   onFlipAssets: () => void
   onSubmitSwap: () => void
@@ -53,6 +55,7 @@ function Swap (props: Props) {
     fromAssetBalance,
     toAssetBalance,
     isSubmitDisabled,
+    validationError,
     onToggleOrderType,
     onInputChange,
     onSelectPresetAmount,
@@ -75,6 +78,30 @@ function Swap (props: Props) {
     onFilterAssetList(toAsset)
   }
 
+  const submitText = React.useMemo(() => {
+    if (validationError === 'insufficientBalance') {
+      return 'Insufficient balance'
+    }
+
+    if (validationError === 'insufficientEthBalance') {
+      return 'Insufficient funds for gas'
+    }
+
+    if (validationError === 'insufficientAllowance') {
+      return `Activate ${fromAsset.asset.symbol}`
+    }
+
+    if (validationError === 'insufficientLiquidity') {
+      return 'Insufficient liquidity'
+    }
+
+    if (validationError === 'unknownError') {
+      return 'Unknown error'
+    }
+
+    return 'Swap'
+  }, [validationError])
+
   return (
     <StyledWrapper>
       <SwapInputComponent
@@ -86,6 +113,7 @@ function Swap (props: Props) {
         selectedAssetBalance={fromAssetBalance}
         selectedAsset={fromAsset}
         onShowSelection={onShowAssetFrom}
+        validationError={validationError}
       />
       <ArrowButton onClick={onFlipAssets}>
         <ArrowDownIcon />
@@ -121,7 +149,7 @@ function Swap (props: Props) {
       <NavButton
         disabled={isSubmitDisabled}
         buttonType='primary'
-        text='Swap'
+        text={submitText}
         onSubmit={onSubmitSwap}
       />
     </StyledWrapper>

--- a/components/brave_wallet_ui/components/buy-send-swap/swap/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap/index.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+
+import { getLocale } from '../../../../common/locale'
 import {
   AccountAssetOptionType,
   OrderTypes,
@@ -10,6 +12,7 @@ import {
 } from '../../../constants/types'
 import { NavButton } from '../../extension'
 import SwapInputComponent from '../swap-input-component'
+
 // Styled Components
 import {
   StyledWrapper,
@@ -80,26 +83,27 @@ function Swap (props: Props) {
 
   const submitText = React.useMemo(() => {
     if (validationError === 'insufficientBalance') {
-      return 'Insufficient balance'
+      return getLocale('braveWalletSwapInsufficientBalance')
     }
 
     if (validationError === 'insufficientEthBalance') {
-      return 'Insufficient funds for gas'
+      return getLocale('braveWalletSwapInsufficientEthBalance')
     }
 
     if (validationError === 'insufficientAllowance') {
-      return `Activate ${fromAsset.asset.symbol}`
+      return getLocale('braveWalletSwapInsufficientAllowance')
+        .replace('$1', fromAsset.asset.symbol)
     }
 
     if (validationError === 'insufficientLiquidity') {
-      return 'Insufficient liquidity'
+      return getLocale('braveWalletSwapInsufficientLiquidity')
     }
 
     if (validationError === 'unknownError') {
-      return 'Unknown error'
+      return getLocale('braveWalletSwapUnknownError')
     }
 
-    return 'Swap'
+    return getLocale('braveWalletSwap')
   }, [validationError])
 
   return (

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
@@ -7,7 +7,8 @@ import {
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
   ToOrFromType,
-  EthereumChain
+  EthereumChain,
+  SwapValidationErrorType
 } from '../../../constants/types'
 import {
   AccountsAssetsNetworks,
@@ -32,6 +33,7 @@ export interface Props {
   toAssetBalance: string
   assetOptions: AccountAssetOptionType[]
   isSubmitDisabled: boolean
+  validationError?: SwapValidationErrorType
   onSubmitSwap: () => void
   flipSwapAssets: () => void
   onSelectNetwork: (network: EthereumChain) => void
@@ -65,6 +67,7 @@ function SwapTab (props: Props) {
     toAssetBalance,
     assetOptions,
     isSubmitDisabled,
+    validationError,
     onSubmitSwap,
     flipSwapAssets,
     onSelectNetwork,
@@ -147,6 +150,7 @@ function SwapTab (props: Props) {
             slippageTolerance={slippageTolerance}
             orderExpiration={orderExpiration}
             isSubmitDisabled={isSubmitDisabled}
+            validationError={validationError}
             onInputChange={onInputChange}
             onFlipAssets={flipSwapAssets}
             onSubmitSwap={onSubmitSwap}

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -187,6 +187,7 @@ export interface PanelState {
   connectingAccounts: string[]
   networkPayload: EthereumChain
   swapQuote?: SwapResponse
+  swapError?: SwapErrorResponse
 }
 
 export interface PageState {
@@ -209,6 +210,7 @@ export interface PageState {
   isCryptoWalletsInstalled: boolean
   isMetaMaskInstalled: boolean
   swapQuote?: SwapResponse
+  swapError?: SwapErrorResponse
 }
 
 export interface WalletPageState {
@@ -313,11 +315,24 @@ export interface SwapResponse {
   buyTokenToEthRate: string
 }
 
+export interface SwapErrorResponse {
+  code: number,
+  reason: string,
+  validationErrors: { field: string, code: number, reason: string }[]
+}
+
 export interface SwapResponseReturnInfo {
   success: boolean
-  response: SwapResponse | undefined
-  errorResponse: string | undefined
+  response?: SwapResponse
+  errorResponse?: string
 }
+
+export type SwapValidationErrorType =
+  | 'insufficientBalance'
+  | 'insufficientEthBalance'
+  | 'insufficientAllowance'
+  | 'insufficientLiquidity'
+  | 'unknownError'
 
 export interface GetNetworkReturnInfo {
   network: EthereumChain

--- a/components/brave_wallet_ui/page/actions/wallet_page_actions.ts
+++ b/components/brave_wallet_ui/page/actions/wallet_page_actions.ts
@@ -23,7 +23,7 @@ import {
 import {
   HardwareWalletAccount
 } from '../../components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/types'
-import { SwapResponse, TokenInfo, UpdateAccountNamePayloadType } from '../../constants/types'
+import { SwapResponse, SwapErrorResponse, TokenInfo, UpdateAccountNamePayloadType } from '../../constants/types'
 import { SwapParamsPayloadType } from '../../common/constants/action_types'
 
 export const createWallet = createAction<CreateWalletPayloadType>('createWallet')
@@ -58,4 +58,5 @@ export const importFromCryptoWallets = createAction<ImportFromExternalWalletPayl
 export const importFromMetaMask = createAction<ImportFromExternalWalletPayloadType>('importFromMetaMask')
 export const openWalletSettings = createAction('openWalletSettings')
 export const setPageSwapQuote = createAction<SwapResponse>('setPageSwapQuote')
+export const setPageSwapError = createAction<SwapErrorResponse | undefined>('setPageSwapError')
 export const fetchPageSwapQuote = createAction<SwapParamsPayloadType>('fetchPageSwapQuote')

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -171,7 +171,10 @@ handler.on(WalletActions.newUnapprovedTxAdded.getType(), async (store, payload: 
   await pageHandler.showApprovePanelUI()
 })
 
-handler.on(WalletPageActions.fetchPageSwapQuote.getType(), fetchSwapQuoteFactory(WalletPageActions.setPageSwapQuote))
+handler.on(
+  WalletPageActions.fetchPageSwapQuote.getType(),
+  fetchSwapQuoteFactory(WalletPageActions.setPageSwapQuote, WalletPageActions.setPageSwapError)
+)
 
 handler.on(WalletPageActions.openWalletSettings.getType(), async (store) => {
   chrome.tabs.create({ url: 'chrome://settings/wallet' }, () => {

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -102,7 +102,8 @@ function Container (props: Props) {
     showAddModal,
     isCryptoWalletsInstalled,
     isMetaMaskInstalled,
-    swapQuote
+    swapQuote,
+    swapError
   } = props.page
 
   // const [view, setView] = React.useState<NavTypes>('crypto')
@@ -132,6 +133,7 @@ function Container (props: Props) {
     orderExpiration,
     orderType,
     slippageTolerance,
+    swapValidationError,
     toAmount,
     toAsset,
     onToggleOrderType,
@@ -149,7 +151,8 @@ function Container (props: Props) {
     selectedNetwork,
     props.walletPageActions.fetchPageSwapQuote,
     assetOptions,
-    swapQuote
+    swapQuote,
+    swapError
   )
 
   const getSelectedAccountBalance = useBalance(selectedAccount)
@@ -606,6 +609,7 @@ function Container (props: Props) {
             toAssetBalance='0'
             orderExpiration={orderExpiration}
             slippageTolerance={slippageTolerance}
+            swapValidationError={swapValidationError}
             toAddress={toAddress}
             buyAssetOptions={WyreAccountAssetOptions}
             sendAssetOptions={sendAssetOptions}

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -53,7 +53,7 @@ import {
 import { onConnectHardwareWallet, getBalance } from '../common/async/wallet_async_handler'
 
 import { formatBalance, toWeiHex } from '../utils/format-balances'
-import { useSwap, useAssets, useTimeout } from '../common/hooks'
+import { useSwap, useAssets, useTimeout, useBalance } from '../common/hooks'
 import { stripERC20TokenImageURL } from '../utils/string-utils'
 
 type Props = {
@@ -151,6 +151,9 @@ function Container (props: Props) {
     assetOptions,
     swapQuote
   )
+
+  const getSelectedAccountBalance = useBalance(selectedAccount)
+  const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
 
   const onToggleShowRestore = React.useCallback(() => {
     if (walletLocation === WalletRoutes.Restore) {
@@ -309,14 +312,6 @@ function Container (props: Props) {
     })
     return formated
   }, [selectedAssetPriceHistory])
-
-  const fromAssetBalance = React.useMemo(() => {
-    if (!selectedAccount) {
-      return '0'
-    }
-    const token = selectedAccount.tokens ? selectedAccount.tokens.find((token) => token.asset.symbol === fromAsset.asset.symbol) : undefined
-    return token ? formatBalance(token.assetBalance, token.asset.decimals) : '0'
-  }, [accounts, selectedAccount, fromAsset])
 
   const onSelectPresetFromAmount = (percent: number) => {
     const asset = userVisibleTokenOptions.find((asset) => asset.symbol === fromAsset.asset.symbol)

--- a/components/brave_wallet_ui/page/reducers/page_reducer.ts
+++ b/components/brave_wallet_ui/page/reducers/page_reducer.ts
@@ -9,7 +9,9 @@ import * as Actions from '../actions/wallet_page_actions'
 import {
   PageState,
   AssetPriceTimeframe,
-  TokenInfo, SwapResponse
+  TokenInfo,
+  SwapResponse,
+  SwapErrorResponse
 } from '../../constants/types'
 import {
   WalletCreatedPayloadType,
@@ -35,7 +37,8 @@ const defaultState: PageState = {
   setupStillInProgress: false,
   isCryptoWalletsInstalled: false,
   isMetaMaskInstalled: false,
-  swapQuote: undefined
+  swapQuote: undefined,
+  swapError: undefined
 }
 
 const reducer = createReducer<PageState>({}, defaultState)
@@ -163,6 +166,13 @@ reducer.on(Actions.setPageSwapQuote, (state: any, payload: SwapResponse) => {
   return {
     ...state,
     swapQuote: payload
+  }
+})
+
+reducer.on(Actions.setPageSwapError, (state: any, payload?: SwapErrorResponse) => {
+  return {
+    ...state,
+    swapError: payload
   }
 })
 

--- a/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
+++ b/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
@@ -5,7 +5,7 @@
 
 import { createAction } from 'redux-act'
 import { AccountPayloadType, ShowConnectToSitePayload, EthereumChainPayload, EthereumChainRequestPayload } from '../constants/action_types'
-import { SwapResponse } from '../../constants/types'
+import { SwapErrorResponse, SwapResponse } from '../../constants/types'
 import { SwapParamsPayloadType } from '../../common/constants/action_types'
 
 export const connectToSite = createAction<AccountPayloadType>('connectToSite')
@@ -22,4 +22,5 @@ export const openWalletApps = createAction('openWalletApps')
 export const expandRestoreWallet = createAction('expandRestoreWallet')
 export const navigateTo = createAction<string>('navigateTo')
 export const setPanelSwapQuote = createAction<SwapResponse>('setPanelSwapQuote')
+export const setPanelSwapError = createAction<SwapErrorResponse | undefined>('setPanelSwapError')
 export const fetchPanelSwapQuote = createAction<SwapParamsPayloadType>('fetchPanelSwapQuote')

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -194,6 +194,9 @@ handler.on(WalletActions.transactionStatusChanged.getType(), async (store, paylo
   }
 })
 
-handler.on(PanelActions.fetchPanelSwapQuote.getType(), fetchSwapQuoteFactory(PanelActions.setPanelSwapQuote))
+handler.on(
+  PanelActions.fetchPanelSwapQuote.getType(),
+  fetchSwapQuoteFactory(PanelActions.setPanelSwapQuote, PanelActions.setPanelSwapError)
+)
 
 export default handler.middleware

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -100,7 +100,8 @@ function Container (props: Props) {
     panelTitle,
     selectedPanel,
     networkPayload,
-    swapQuote
+    swapQuote,
+    swapError
   } = props.panel
 
   // TODO(petemill): If initial data or UI takes a noticeable amount of time to arrive
@@ -131,6 +132,7 @@ function Container (props: Props) {
     orderExpiration,
     orderType,
     slippageTolerance,
+    swapValidationError,
     swapToOrFrom,
     toAmount,
     toAsset,
@@ -150,7 +152,8 @@ function Container (props: Props) {
     selectedNetwork,
     props.walletPanelActions.fetchPanelSwapQuote,
     assetOptions,
-    swapQuote
+    swapQuote,
+    swapError
   )
 
   const getSelectedAccountBalance = useBalance(selectedAccount)
@@ -642,6 +645,7 @@ function Container (props: Props) {
                   orderExpiration={orderExpiration}
                   slippageTolerance={slippageTolerance}
                   isSubmitDisabled={isSwapButtonDisabled}
+                  validationError={swapValidationError}
                   fromAssetBalance={fromAssetBalance}
                   toAssetBalance={toAssetBalance}
                   onToggleOrderType={onToggleOrderType}

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -57,7 +57,7 @@ import { BuyAssetUrl } from '../utils/buy-asset-url'
 import { GetNetworkInfo } from '../utils/network-utils'
 
 import { formatBalance, toWeiHex } from '../utils/format-balances'
-import { useAssets, useSwap } from '../common/hooks'
+import { useAssets, useBalance, useSwap } from '../common/hooks'
 
 type Props = {
   panel: PanelState
@@ -153,6 +153,10 @@ function Container (props: Props) {
     swapQuote
   )
 
+  const getSelectedAccountBalance = useBalance(selectedAccount)
+  const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
+  const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
+
   const onSetBuyAmount = (value: string) => {
     setBuyAmount(value)
   }
@@ -207,14 +211,6 @@ function Container (props: Props) {
       setSendAmount(value)
     }
   }
-
-  const getAssetBalance = React.useCallback((asset: AccountAssetOptionType) => {
-    if (!selectedAccount || !selectedAccount.tokens) {
-      return '0'
-    }
-    const token = selectedAccount.tokens.find((token) => token.asset.symbol === asset.asset.symbol)
-    return token ? formatBalance(token.assetBalance, token.asset.decimals) : '0'
-  }, [accounts, selectedAccount])
 
   const onSelectPresetSendAmount = (percent: number) => {
     const amount = Number(fromAsset.assetBalance) * percent
@@ -590,7 +586,7 @@ function Container (props: Props) {
                 onSubmit={onSubmitSend}
                 selectedAsset={fromAsset}
                 selectedAssetAmount={sendAmount}
-                selectedAssetBalance={getAssetBalance(fromAsset)}
+                selectedAssetBalance={fromAssetBalance}
                 toAddress={toAddress}
               />
             </SendWrapper>
@@ -646,8 +642,8 @@ function Container (props: Props) {
                   orderExpiration={orderExpiration}
                   slippageTolerance={slippageTolerance}
                   isSubmitDisabled={isSwapButtonDisabled}
-                  fromAssetBalance={getAssetBalance(fromAsset)}
-                  toAssetBalance={getAssetBalance(toAsset)}
+                  fromAssetBalance={fromAssetBalance}
+                  toAssetBalance={toAssetBalance}
                   onToggleOrderType={onToggleOrderType}
                   onSelectExpiration={onSelectExpiration}
                   onSelectSlippageTolerance={onSelectSlippageTolerance}

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -5,7 +5,7 @@
 /* global window */
 
 import { createReducer } from 'redux-act'
-import { PanelState, SwapResponse } from '../../constants/types'
+import { PanelState, SwapErrorResponse, SwapResponse } from '../../constants/types'
 import * as PanelActions from '../actions/wallet_panel_actions'
 import { ShowConnectToSitePayload, EthereumChainPayload } from '../constants/action_types'
 
@@ -24,7 +24,8 @@ const defaultState: PanelState = {
     rpcUrls: ['https://mainnet-infura.brave.com/'], blockExplorerUrls: [],
     iconUrls: [], symbol: 'ETH', symbolName: 'Ethereum', decimals: 18
   },
-  swapQuote: undefined
+  swapQuote: undefined,
+  swapError: undefined
 }
 
 const reducer = createReducer<PanelState>({}, defaultState)
@@ -63,6 +64,13 @@ reducer.on(PanelActions.setPanelSwapQuote, (state: any, payload: SwapResponse) =
   return {
     ...state,
     swapQuote: payload
+  }
+})
+
+reducer.on(PanelActions.setPanelSwapError, (state: any, payload?: SwapErrorResponse) => {
+  return {
+    ...state,
+    swapError: payload
   }
 })
 

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -233,6 +233,11 @@ provideStrings({
   braveWalletSwapMarket: 'Market',
   braveWalletSwapLimit: 'Limit',
   braveWalletSwapPriceIn: 'Price in',
+  braveWalletSwapInsufficientBalance: 'Insufficient balance',
+  braveWalletSwapInsufficientEthBalance: 'Insufficient funds for gas',
+  braveWalletSwapInsufficientLiquidity: 'Insufficient liquidity',
+  braveWalletSwapInsufficientAllowance: 'Activate token',
+  braveWalletSwapUnknownError: 'Unknown error',
 
   // Buy
   braveWalletBuyTitle: 'Test faucet',

--- a/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
+++ b/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
@@ -9,7 +9,8 @@ import {
   ToOrFromType,
   EthereumChain,
   BuySupportedChains,
-  SwapSupportedChains
+  SwapSupportedChains,
+  SwapValidationErrorType
 } from '../../constants/types'
 import Swap from '../../components/buy-send-swap/tabs/swap-tab'
 import Send from '../../components/buy-send-swap/tabs/send-tab'
@@ -29,6 +30,7 @@ export interface Props {
   selectedTab: BuySendSwapTypes
   exchangeRate: string
   slippageTolerance: SlippagePresetObjectType
+  swapValidationError?: SwapValidationErrorType
   orderExpiration: ExpirationPresetObjectType
   buyAmount: string
   sendAmount: string
@@ -86,6 +88,7 @@ function BuySendSwap (props: Props) {
     buyAssetOptions,
     sendAssetOptions,
     swapAssetOptions,
+    swapValidationError,
     isSwapSubmitDisabled,
     onSubmitBuy,
     onSubmitSend,
@@ -155,6 +158,7 @@ function BuySendSwap (props: Props) {
           fromAssetBalance={fromAssetBalance}
           toAssetBalance={toAssetBalance}
           isSubmitDisabled={isSwapSubmitDisabled}
+          validationError={swapValidationError}
           onSubmitSwap={onSubmitSwap}
           flipSwapAssets={flipSwapAssets}
           onSelectNetwork={onSelectNetwork}

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -273,5 +273,12 @@
     <message name="IDS_BRAVE_WALLET_EDIT_GAS_GWEI" desc="Edit gas panel gwei label">Gwei</message>
     <message name="IDS_BRAVE_WALLET_EDIT_GAS_SET_CUSTOM" desc="Edit gas panel set custom button">Set custom</message>
     <message name="IDS_BRAVE_WALLET_EDIT_GAS_SET_SUGGESTED" desc="Edit gas panel set suggested button">Set suggested</message>
+    <message name="IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_BALANCE" desc="Swap CTA text for insufficient balance">Insufficient balance</message>
+    <message name="IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_ETH_BALANCE" desc="Swap CTA text for insufficient ETH balance">Insufficient funds for gas</message>
+    <message name="IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_LIQUIDITY" desc="Swap CTA text for insufficient liquidity">Insufficient liquidity</message>
+    <message name="IDS_BRAVE_WALLET_SWAP_INSUFFICIENT_ALLOWANCE" desc="Swap CTA text for insufficient allowance">
+      Activate <ph name="FROM_ASSET_SYMBOL">$1</ph>
+    </message>
+    <message name="IDS_BRAVE_WALLET_SWAP_UNKNOWN_ERROR" desc="Swap CTA text for unknown error">Unknown error</message>
   </if>
 </grit-part>


### PR DESCRIPTION
In this PR we do a bunch of things:
* Retrieve error responses returned by the 0x API and log it in the console, for debugging purpose. We also add it to the redux store in order to handle specific errors that require user's attention.
* Perform some validation on the inputs before querying the 0x API. The idea is to prevent the possibility of running into errors while fetching quotes.
* Encode the validation/API error in the CTA button of Swap (inspired by Uniswap - see screenshots).

Here are the error types we support and the CTA text we use for them:
| CTA text | Error description | CTA button disabled |
-|-|-
|Insufficient balance| Token/ETH balance less than amount | Yes |
| Insufficient funds for gas | ETH balance insufficient for paying fees | Yes |
| Activate USDC (not implemented yet) | Insufficient ERC-20 token allowance | No |
| Insufficient liquidity | Not enough tokens in the liquidity pool to buy | Yes |
| Unknown error | Any other unhandled error returned by the 0x API | Yes |


Resolves https://github.com/brave/brave-browser/issues/18383.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Screenshots

|<img width="289" alt="Screenshot 2021-10-01 at 9 47 58 PM" src="https://user-images.githubusercontent.com/3684187/135654167-953e6246-7048-40e8-8b56-f3a8c6c9dbd1.png">|<img width="288" alt="Screenshot 2021-10-01 at 9 48 18 PM" src="https://user-images.githubusercontent.com/3684187/135654210-7fb4e0b2-76c8-4d5f-9f01-1e88d942047f.png">|<img width="290" alt="Screenshot 2021-10-01 at 9 49 03 PM" src="https://user-images.githubusercontent.com/3684187/135654308-a5e6f3ae-4983-4cda-9a51-328303631954.png">|<img width="288" alt="Screenshot 2021-10-01 at 10 45 25 PM" src="https://user-images.githubusercontent.com/3684187/135660873-f710b3c2-e225-4fb1-985c-ac11f76b671c.png">|
-|-|-|-