### PR TITLE
Redirect URL support for adblock

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -106,6 +106,12 @@ constexpr char kBraveDarkModeBlockName[] =
 constexpr char kBraveDarkModeBlockDescription[] =
     "Always report light mode when fingerprinting protections set to Strict";
 
+constexpr char kAdblockRedirectUrlName[] =
+    "Enable support for $redirect-url filter option for adblock rules";
+constexpr char kAdblockRedirectUrlDescription[] =
+    "Enable support for loading adblock replacement resources over the network "
+    "via the $redirect-url filter option";
+
 constexpr char kBraveDomainBlockName[] = "Enable domain blocking";
 constexpr char kBraveDomainBlockDescription[] =
     "Enable support for blocking domains with an interstitial page";
@@ -355,6 +361,10 @@ constexpr char kBraveTranslateGoDescription[] =
      flag_descriptions::kBraveDarkModeBlockName,                            \
      flag_descriptions::kBraveDarkModeBlockDescription, kOsAll,             \
      FEATURE_VALUE_TYPE(kBraveDarkModeBlock)},                              \
+    {"brave-adblock-redirect-url",                                          \
+     flag_descriptions::kAdblockRedirectUrlName,                            \
+     flag_descriptions::kAdblockRedirectUrlDescription, kOsAll,             \
+     FEATURE_VALUE_TYPE(net::features::kAdblockRedirectUrl)},               \
     {"brave-domain-block",                                                  \
      flag_descriptions::kBraveDomainBlockName,                              \
      flag_descriptions::kBraveDomainBlockDescription, kOsAll,               \

--- a/browser/brave_shields/ad_block_service_browsertest.h
+++ b/browser/brave_shields/ad_block_service_browsertest.h
@@ -20,11 +20,13 @@ class AdBlockServiceTest : public extensions::ExtensionBrowserTest {
   void SetUpOnMainThread() override;
   void SetUp() override;
   void PreRunTestOnMainThread() override;
+  void SetUpCommandLine(base::CommandLine* command_line) override;
 
  protected:
   HostContentSettingsMap* content_settings();
   void UpdateAdBlockInstanceWithRules(const std::string& rules,
-                                      const std::string& resources = "");
+                                      const std::string& resources = "",
+                                      bool include_redirect_urls = false);
   void AssertTagExists(const std::string& tag, bool expected_exists) const;
   void InitEmbeddedTestServer();
   void GetTestDataDir(base::FilePath* test_data_dir);

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.h
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_NET_BRAVE_AD_BLOCK_TP_NETWORK_DELEGATE_HELPER_H_
 
 #include <memory>
+#include <string>
 
 #include "brave/browser/net/url_context.h"
 
@@ -24,6 +25,8 @@ int OnBeforeURLRequest_AdBlockTPPreWork(
 // from being affected.
 void SetAdblockCnameHostResolverForTesting(
     network::HostResolver* host_resolver);
+
+void SetRedirectUrlAllowedDomainForTesting(std::string domain);
 
 }  // namespace brave
 

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -356,11 +356,10 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::
           network::URLLoaderCompletionStatus(net::ERR_BLOCKED_BY_CLIENT));
       return;
     }
-
     auto response = network::mojom::URLResponseHead::New();
     std::string response_data;
-    brave_shields::MakeStubResponse(ctx_->mock_data_url, request_, &response,
-                                    &response_data);
+    brave_shields::MakeStubResponse(ctx_->adblock_replacement_url, request_,
+                                    &response, &response_data);
 
     target_client_->OnReceiveResponse(std::move(response));
 

--- a/browser/net/brave_request_handler.cc
+++ b/browser/net/brave_request_handler.cc
@@ -19,6 +19,7 @@
 #include "brave/browser/net/brave_site_hacks_network_delegate_helper.h"
 #include "brave/browser/net/brave_stp_util.h"
 #include "brave/browser/net/global_privacy_control_network_delegate_helper.h"
+#include "brave/browser/net/url_context.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_referrals/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/browser/net/network_delegate_helper.h"
@@ -284,13 +285,11 @@ void BraveRequestHandler::RunNextCallback(
         IsRequestIdentifierValid(ctx->request_identifier)) {
       *ctx->new_url = GURL(ctx->new_url_spec);
     }
-    if (ctx->blocked_by == brave::kAdBlocked ||
-        ctx->blocked_by == brave::kOtherBlocked) {
-      if (!ctx->ShouldMockRequest()) {
-        RunCallbackForRequestIdentifier(ctx->request_identifier,
-                                        net::ERR_BLOCKED_BY_CLIENT);
-        return;
-      }
+
+    if (ctx->ShouldBlockRequest()) {
+      RunCallbackForRequestIdentifier(ctx->request_identifier,
+                                      net::ERR_BLOCKED_BY_CLIENT);
+      return;
     }
   }
   RunCallbackForRequestIdentifier(ctx->request_identifier, rv);

--- a/browser/net/url_context.h
+++ b/browser/net/url_context.h
@@ -51,6 +51,11 @@ enum BraveNetworkDelegateEventType {
 
 enum BlockedBy { kNotBlocked, kAdBlocked, kOtherBlocked };
 
+// The type of redirect being set by adblock in lib.rs
+// These are specified by either the redirect or redirect-url
+// filter options
+enum class AdblockRedirectType { kNoRedirect, kRemote, kLocal };
+
 struct BraveRequestInfo {
   BraveRequestInfo();
 
@@ -98,12 +103,30 @@ struct BraveRequestInfo {
   GURL* allowed_unsafe_redirect_url = nullptr;
   BraveNetworkDelegateEventType event_type = kUnknownEventType;
   BlockedBy blocked_by = kNotBlocked;
-  std::string mock_data_url;
+
+  // There are two types of redirects supported by adblock-rust:
+  // 1. data: (filter option: $redirect), loads locally
+  // 2. https:// (filter option: $redirect-url), loads over the network
+  std::string adblock_replacement_url;
+  AdblockRedirectType adblock_redirect_type = AdblockRedirectType::kNoRedirect;
+
   GURL ipfs_gateway_url;
   bool ipfs_auto_fallback = false;
 
+  // Only mock a request locally if there is an adblock match, if there is a
+  // replacement URL, and if the redirect type is local (not remote)
   bool ShouldMockRequest() const {
-    return blocked_by == kAdBlocked && !mock_data_url.empty();
+    return blocked_by == kAdBlocked && !adblock_replacement_url.empty() &&
+           adblock_redirect_type == AdblockRedirectType::kLocal;
+  }
+
+  // If we have blocked but we are not going to mock the request and not going
+  // to redirect to a remote resource
+  bool ShouldBlockRequest() const {
+    bool is_blocked =
+        blocked_by == brave::kAdBlocked || blocked_by == brave::kOtherBlocked;
+    return is_blocked && !ShouldMockRequest() &&
+           adblock_redirect_type != brave::AdblockRedirectType::kRemote;
   }
 
   net::NetworkIsolationKey network_isolation_key = net::NetworkIsolationKey();

--- a/chromium_src/net/base/features.cc
+++ b/chromium_src/net/base/features.cc
@@ -12,7 +12,10 @@ const base::Feature kBraveEphemeralStorage{"EphemeralStorage",
                                            base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveEphemeralStorageKeepAlive{
     "BraveEphemeralStorageKeepAlive", base::FEATURE_ENABLED_BY_DEFAULT};
-
+// When enabled, Brave will use SugarCoat filter list to load replacement
+// resources via Private CDN using the $redirect-url filter option
+const base::Feature kAdblockRedirectUrl{"BraveAdblockRedirectUrl",
+                                        base::FEATURE_ENABLED_BY_DEFAULT};
 const base::FeatureParam<int> kBraveEphemeralStorageKeepAliveTimeInSeconds = {
     &kBraveEphemeralStorageKeepAlive,
     "BraveEphemeralStorageKeepAliveTimeInSeconds", 30};

--- a/chromium_src/net/base/features.h
+++ b/chromium_src/net/base/features.h
@@ -14,6 +14,7 @@ namespace features {
 
 NET_EXPORT extern const base::Feature kBraveEphemeralStorage;
 NET_EXPORT extern const base::Feature kBraveEphemeralStorageKeepAlive;
+NET_EXPORT extern const base::Feature kAdblockRedirectUrl;
 NET_EXPORT extern const base::FeatureParam<int>
     kBraveEphemeralStorageKeepAliveTimeInSeconds;
 NET_EXPORT extern const base::Feature kBraveFirstPartyEphemeralStorage;

--- a/chromium_src/third_party/blink/renderer/core/loader/subresource_redirect_util.cc
+++ b/chromium_src/third_party/blink/renderer/core/loader/subresource_redirect_util.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/core/loader/subresource_redirect_util.h"
+#include "net/base/features.h"
+
+#define ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin \
+  ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin_ChromiumImpl
+
+#include "../../../../../../third_party/blink/renderer/core/loader/subresource_redirect_util.cc"
+#undef ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin
+
+namespace blink {
+
+bool ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin(
+    scoped_refptr<SecurityOrigin> litepage_subresource_redirect_origin,
+    mojom::blink::RequestContextType request_context,
+    ResourceRequest::RedirectStatus redirect_status,
+    const KURL& url) {
+  String host = url.Host();
+  bool redirect_url_feature_enabled =
+      base::FeatureList::IsEnabled(net::features::kAdblockRedirectUrl);
+  bool is_script = request_context == mojom::blink::RequestContextType::SCRIPT;
+  // Note that these strings are duplicated in
+  // vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/private_cdn_util.cc
+  // and brave_ad_block_tp_network_delegate_helper.cc
+  bool is_private_cdn_domain = host == "pcdn.brave.com" ||
+                               host == "pcdn.bravesoftware.com" ||
+                               host == "pcdn.brave.software";
+  bool is_redirect =
+      redirect_status == ResourceRequestHead::RedirectStatus::kFollowedRedirect;
+  if (redirect_url_feature_enabled && is_script && is_private_cdn_domain &&
+      is_redirect) {
+    return true;
+  }
+  return ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin_ChromiumImpl(
+      litepage_subresource_redirect_origin, request_context, redirect_status,
+      url);
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/core/loader/subresource_redirect_util.h
+++ b/chromium_src/third_party/blink/renderer/core/loader/subresource_redirect_util.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_LOADER_SUBRESOURCE_REDIRECT_UTIL_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_LOADER_SUBRESOURCE_REDIRECT_UTIL_H_
+
+#include "third_party/blink/renderer/core/loader/subresource_redirect_util.h"
+
+// Overriding this method so as to bypass CSP for $redirect-url filter option
+// in adblock rules. This method was chosen for overriding because it has
+// similar functionality (if a certain kind of subresource redirect then ignore
+// CSP), but there's no relation between Lite Pages and redirect urls
+#define ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin         \
+  ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin(              \
+      scoped_refptr<SecurityOrigin> litepage_subresource_redirect_origin, \
+      mojom::blink::RequestContextType request_context,                   \
+      ResourceRequest::RedirectStatus redirect_status, const KURL& url);  \
+  bool ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin_ChromiumImpl
+
+#include "../../../../../../third_party/blink/renderer/core/loader/subresource_redirect_util.h"
+#undef ShouldDisableCSPCheckForLitePageSubresourceRedirectOrigin
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_CORE_LOADER_SUBRESOURCE_REDIRECT_UTIL_H_

--- a/components/adblock_rust_ffi/src/lib.h
+++ b/components/adblock_rust_ffi/src/lib.h
@@ -37,6 +37,9 @@ bool set_domain_resolver(C_DomainResolverCallback resolver);
  * Create a new `Engine`.
  */
 struct C_Engine* engine_create(const char* rules);
+struct C_Engine* engine_create_with_redirect_urls(
+    const char* rules,
+    const bool include_redirect_urls);
 struct C_Engine* engine_create_from_buffer(const char* data, size_t data_size);
 
 /**

--- a/components/adblock_rust_ffi/src/lib.rs
+++ b/components/adblock_rust_ffi/src/lib.rs
@@ -7,6 +7,7 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::string::String;
+use adblock::lists::ParseOptions;
 
 /// An external callback that receives a hostname and two out-parameters for start and end
 /// position. The callback should fill the start and end positions with the start and end indices
@@ -53,18 +54,25 @@ pub unsafe extern "C" fn engine_create_from_buffer(
         eprintln!("Failed to parse filter list with invalid UTF-8 content");
         ""
     });
-    engine_create_from_str(rules)
+    engine_create_from_str(rules, false)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn engine_create(rules: *const c_char) -> *mut Engine {
     let rules = CStr::from_ptr(rules).to_str().unwrap_or("");
-    engine_create_from_str(rules)
+    engine_create_from_str(rules, false)
 }
 
-fn engine_create_from_str(rules: &str) -> *mut Engine {
+
+#[no_mangle]
+pub unsafe extern "C" fn engine_create_with_redirect_urls(rules: *const c_char, include_redirect_urls: bool) -> *mut Engine {
+    let rules = CStr::from_ptr(rules).to_str().unwrap_or("");
+    engine_create_from_str(rules, include_redirect_urls)
+}
+
+fn engine_create_from_str(rules: &str, include_redirect_urls: bool) -> *mut Engine {
     let mut filter_set = adblock::lists::FilterSet::new(false);
-    filter_set.add_filter_list(&rules, Default::default());
+    filter_set.add_filter_list(&rules, ParseOptions {include_redirect_urls, ..Default::default()});
     let engine = Engine::from_filter_set(filter_set, true);
     Box::into_raw(Box::new(engine))
 }
@@ -112,8 +120,11 @@ pub unsafe extern "C" fn engine_match(
             Ok(y) => y.into_raw(),
             _ => ptr::null_mut(),
         },
-        // Ignore `redirect-url` for now.
-        Some(Redirection::Url(_)) => ptr::null_mut(),
+        // Handle the redirect resource being of type URL
+        Some(Redirection::Url(x)) => match CString::new(x) {
+            Ok(y) => y.into_raw(),
+            _ => ptr::null_mut(),
+        },
         None => ptr::null_mut(),
     };
 }

--- a/components/adblock_rust_ffi/src/wrapper.cc
+++ b/components/adblock_rust_ffi/src/wrapper.cc
@@ -44,6 +44,10 @@ Engine::Engine() : raw(engine_create("")) {}
 
 Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {}
 
+Engine::Engine(const std::string& rules, const bool include_redirect_urls)
+    : raw(engine_create_with_redirect_urls(rules.c_str(),
+                                           include_redirect_urls)) {}
+
 Engine::Engine(const char* data, size_t data_size)
     : raw(engine_create_from_buffer(data, data_size)) {}
 

--- a/components/adblock_rust_ffi/src/wrapper.h
+++ b/components/adblock_rust_ffi/src/wrapper.h
@@ -69,6 +69,7 @@ class ADBLOCK_EXPORT Engine {
   Engine();
   explicit Engine(const std::string& rules);
   Engine(const char* data, size_t data_size);
+  Engine(const std::string& rules, const bool include_redirect_urls);
   void matches(const std::string& url,
                const std::string& host,
                const std::string& tab_host,

--- a/components/brave_perf_predictor/browser/perf_predictor_tab_helper_browsertest.cc
+++ b/components/brave_perf_predictor/browser/perf_predictor_tab_helper_browsertest.cc
@@ -76,7 +76,7 @@ class PerfPredictorTabHelperTest : public InProcessBrowserTest {
     ad_block_service->GetTaskRunner()->PostTask(
         FROM_HERE,
         base::BindOnce(&brave_shields::AdBlockService::ResetForTest,
-                       base::Unretained(ad_block_service), rules, ""));
+                       base::Unretained(ad_block_service), rules, "", false));
 
     WaitForAdBlockServiceThreads();
   }

--- a/components/brave_shields/browser/ad_block_base_service.cc
+++ b/components/brave_shields/browser/ad_block_base_service.cc
@@ -121,7 +121,7 @@ void AdBlockBaseService::ShouldStartRequest(
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
-    std::string* mock_data_url) {
+    std::string* replacement_url) {
   DCHECK(GetTaskRunner()->RunsTasksInCurrentSequence());
   // if (!IsInitialized())
   //   return;
@@ -133,10 +133,10 @@ void AdBlockBaseService::ShouldStartRequest(
       url,
       url::Origin::CreateFromNormalizedTuple("https", tab_host.c_str(), 80),
       INCLUDE_PRIVATE_REGISTRIES);
-  ad_block_client_->matches(
-      url.spec(), url.host(), tab_host, is_third_party,
-      ResourceTypeToString(resource_type), did_match_rule,
-      did_match_exception, did_match_important, mock_data_url);
+  ad_block_client_->matches(url.spec(), url.host(), tab_host, is_third_party,
+                            ResourceTypeToString(resource_type), did_match_rule,
+                            did_match_exception, did_match_important,
+                            replacement_url);
 
   // LOG(ERROR) << "AdBlockBaseService::ShouldStartRequest(), host: "
   //  << tab_host
@@ -282,12 +282,13 @@ bool AdBlockBaseService::Init() {
 }
 
 void AdBlockBaseService::ResetForTest(const std::string& rules,
-                                      const std::string& resources) {
+                                      const std::string& resources,
+                                      bool include_redirect_urls) {
   DCHECK(GetTaskRunner()->RunsTasksInCurrentSequence());
   // This is temporary until adblock-rust supports incrementally adding
   // filter rules to an existing instance. At which point the hack below
   // will dissapear.
-  ad_block_client_.reset(new adblock::Engine(rules));
+  ad_block_client_.reset(new adblock::Engine(rules, include_redirect_urls));
   AddKnownTagsToAdBlockInstance();
   if (!resources.empty()) {
     resources_ = resources;

--- a/components/brave_shields/browser/ad_block_base_service.h
+++ b/components/brave_shields/browser/ad_block_base_service.h
@@ -50,7 +50,7 @@ class AdBlockBaseService : public BaseBraveShieldsService {
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,
-                          std::string* mock_data_url) override;
+                          std::string* replacement_url) override;
   absl::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,
@@ -78,7 +78,9 @@ class AdBlockBaseService : public BaseBraveShieldsService {
                       base::OnceClosure callback = base::DoNothing());
   void AddKnownTagsToAdBlockInstance();
   void AddKnownResourcesToAdBlockInstance();
-  void ResetForTest(const std::string& rules, const std::string& resources);
+  void ResetForTest(const std::string& rules,
+                    const std::string& resources = "",
+                    bool include_redirect_urls = false);
 
   std::unique_ptr<adblock::Engine> ad_block_client_;
 

--- a/components/brave_shields/browser/ad_block_regional_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.cc
@@ -123,7 +123,7 @@ void AdBlockRegionalServiceManager::ShouldStartRequest(
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
-    std::string* mock_data_url) {
+    std::string* adblock_replacement_url) {
   if (!IsInitialized())
     return;
 
@@ -132,7 +132,7 @@ void AdBlockRegionalServiceManager::ShouldStartRequest(
   for (const auto& regional_service : regional_services_) {
     regional_service.second->ShouldStartRequest(
         url, resource_type, tab_host, aggressive_blocking, did_match_rule,
-        did_match_exception, did_match_important, mock_data_url);
+        did_match_exception, did_match_important, adblock_replacement_url);
     if (did_match_important && *did_match_important) {
       return;
     }

--- a/components/brave_shields/browser/ad_block_regional_service_manager.h
+++ b/components/brave_shields/browser/ad_block_regional_service_manager.h
@@ -54,7 +54,7 @@ class AdBlockRegionalServiceManager {
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,
-                          std::string* mock_data_url);
+                          std::string* adblock_replacement_url);
   absl::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -72,7 +72,7 @@ void AdBlockService::ShouldStartRequest(
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
-    std::string* mock_data_url) {
+    std::string* replacement_url) {
   if (!IsInitialized())
     return;
 
@@ -84,7 +84,7 @@ void AdBlockService::ShouldStartRequest(
           net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES)) {
     AdBlockBaseService::ShouldStartRequest(
         url, resource_type, tab_host, aggressive_blocking, did_match_rule,
-        did_match_exception, did_match_important, mock_data_url);
+        did_match_exception, did_match_important, replacement_url);
     if (did_match_important && *did_match_important) {
       return;
     }
@@ -92,21 +92,21 @@ void AdBlockService::ShouldStartRequest(
 
   regional_service_manager()->ShouldStartRequest(
       url, resource_type, tab_host, aggressive_blocking, did_match_rule,
-      did_match_exception, did_match_important, mock_data_url);
+      did_match_exception, did_match_important, replacement_url);
   if (did_match_important && *did_match_important) {
     return;
   }
 
   subscription_service_manager()->ShouldStartRequest(
       url, resource_type, tab_host, aggressive_blocking, did_match_rule,
-      did_match_exception, did_match_important, mock_data_url);
+      did_match_exception, did_match_important, replacement_url);
   if (did_match_important && *did_match_important) {
     return;
   }
 
   custom_filters_service()->ShouldStartRequest(
       url, resource_type, tab_host, aggressive_blocking, did_match_rule,
-      did_match_exception, did_match_important, mock_data_url);
+      did_match_exception, did_match_important, replacement_url);
 }
 
 absl::optional<std::string> AdBlockService::GetCspDirectives(

--- a/components/brave_shields/browser/ad_block_service.h
+++ b/components/brave_shields/browser/ad_block_service.h
@@ -59,7 +59,7 @@ class AdBlockService : public AdBlockBaseService {
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,
-                          std::string* mock_data_url) override;
+                          std::string* replacement_url) override;
   absl::optional<std::string> GetCspDirectives(
       const GURL& url,
       blink::mojom::ResourceType resource_type,

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.cc
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.cc
@@ -370,14 +370,14 @@ void AdBlockSubscriptionServiceManager::ShouldStartRequest(
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
-    std::string* mock_data_url) {
+    std::string* adblock_replacement_url) {
   base::AutoLock lock(subscription_services_lock_);
   for (const auto& subscription_service : subscription_services_) {
     auto info = GetInfo(subscription_service.first);
     if (info && info->enabled) {
       subscription_service.second->ShouldStartRequest(
           url, resource_type, tab_host, aggressive_blocking, did_match_rule,
-          did_match_exception, did_match_important, mock_data_url);
+          did_match_exception, did_match_important, adblock_replacement_url);
       if (did_match_important && *did_match_important) {
         return;
       }

--- a/components/brave_shields/browser/ad_block_subscription_service_manager.h
+++ b/components/brave_shields/browser/ad_block_subscription_service_manager.h
@@ -65,7 +65,7 @@ class AdBlockSubscriptionServiceManager {
                           bool* did_match_rule,
                           bool* did_match_exception,
                           bool* did_match_important,
-                          std::string* mock_data_url);
+                          std::string* adblock_replacement_url);
   void EnableTag(const std::string& tag, bool enabled);
   void AddResources(const std::string& resources);
 

--- a/components/brave_shields/browser/base_brave_shields_service.cc
+++ b/components/brave_shields/browser/base_brave_shields_service.cc
@@ -57,6 +57,6 @@ void BaseBraveShieldsService::ShouldStartRequest(
     bool* did_match_rule,
     bool* did_match_exception,
     bool* did_match_important,
-    std::string* mock_data_url) {}
+    std::string* adblock_replacement_url) {}
 
 }  // namespace brave_shields

--- a/components/brave_shields/browser/base_brave_shields_service.h
+++ b/components/brave_shields/browser/base_brave_shields_service.h
@@ -38,7 +38,7 @@ class BaseBraveShieldsService : public BraveComponent {
                                   bool* did_match_rule,
                                   bool* did_match_exception,
                                   bool* did_match_important,
-                                  std::string* mock_data_url);
+                                  std::string* adblock_replacement_url);
 
  protected:
   virtual bool Init() = 0;

--- a/components/brave_shields/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/browser/domain_block_navigation_throttle.cc
@@ -40,7 +40,7 @@ bool ShouldBlockDomainOnTaskRunner(
   bool did_match_exception = false;
   bool did_match_rule = false;
   bool did_match_important = false;
-  std::string mock_data_url;
+  std::string adblock_replacement_url;
   // force aggressive blocking to `true` for domain blocking - these requests
   // are all "first-party", but the throttle is already only called when
   // necessary.
@@ -48,7 +48,7 @@ bool ShouldBlockDomainOnTaskRunner(
   ad_block_service->ShouldStartRequest(
       url, blink::mojom::ResourceType::kMainFrame, url.host(),
       aggressive_blocking, &did_match_rule, &did_match_exception,
-      &did_match_important, &mock_data_url);
+      &did_match_important, &adblock_replacement_url);
   return (did_match_important || (did_match_rule && !did_match_exception));
 }
 

--- a/test/data/blocking_csp.html
+++ b/test/data/blocking_csp.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+<script>
+// Adds an script to the DOM with the specified src
+function addScript(src) {
+  const script = document.createElement('script')
+  script.src = src
+  script.onload = function() {
+    window.domAutomationController.send(true);
+  };
+  script.onerror = function() {
+    window.domAutomationController.send(false);
+  };
+  document.body.appendChild(script)
+}
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/test/data/redirected.js
+++ b/test/data/redirected.js
@@ -1,0 +1,1 @@
+redirected

--- a/test/data/redirected_return_false.js
+++ b/test/data/redirected_return_false.js
@@ -1,0 +1,3 @@
+function redirected() {
+    window.domAutomationController.send(false);
+}

--- a/test/data/redirected_return_true.js
+++ b/test/data/redirected_return_true.js
@@ -1,0 +1,3 @@
+function redirected() {
+    window.domAutomationController.send(true);
+}


### PR DESCRIPTION
Add support for redirect URLs in adblock ffi
Rename `mock_data_url`
If the adblock url is of type http/https instead of data, redirect instead of stubbing out

Resolves https://github.com/brave/brave-browser/issues/18542

TODO:
~~- [ ] Merge in + update adblock-rust: https://github.com/brave/adblock-rust/pull/191~~ We already do the check for https scheme in the PR
- [x] Add flag
~~- [ ] Remove headers?~~ (deprioritizing because of https://github.com/brave/security/issues/615#issuecomment-939210191)
- [x] https://github.com/brave/security/issues/615


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one: https://github.com/brave/security/issues/615
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

