### PR TITLE
Introduce GN target for Storybook

### DIFF
--- a/.storybook/BUILD.gn
+++ b/.storybook/BUILD.gn
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+
+group("storybook") {
+  # Depend on any generated JS output that will
+  # be imported by any JS code used in any Brave
+  # storybook JS.
+  # Explicitly defined here so that even when those targets
+  # are disabled in a regular brave build due to build flags,
+  # they will be generated before storybook is compiled.
+  deps = [ "//ui/webui/resources/js:cr.m" ]
+}

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -491,3 +491,7 @@ group("tools") {
     deps = [ "//brave/components/brave_vpn:vpntool" ]
   }
 }
+
+group("storybook") {
+  deps = [ "//brave/.storybook:storybook" ]
+}

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -815,6 +815,10 @@ Config.prototype.update = function (options) {
       opts.push(value)
     })
   }
+
+  if (options.target) {
+    this.buildTarget = options.target
+  }
 }
 
 Config.prototype.getCachePath = function () {

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -103,6 +103,7 @@ program
   .option('--is_asan', 'is asan enabled')
   .option('--use_goma', 'whether to use Goma for building')
   .option('--force_gn_gen', 'always run gn gen')
+  .option('--target <target>', 'Custom target to build, instead of the default browser target')
   .arguments('[build_config]')
   .action(build)
 

--- a/components/brave_vpn/BUILD.gn
+++ b/components/brave_vpn/BUILD.gn
@@ -10,9 +10,8 @@ import("//tools/grit/preprocess_if_expr.gni")
 preprocess_folder = "preprocessed"
 preprocess_mojo_manifest = "preprocessed_mojo_manifest.json"
 
-assert(enable_brave_vpn)
-
 static_library("brave_vpn") {
+  assert(enable_brave_vpn)
   sources = [
     "brave_vpn_service.cc",
     "brave_vpn_service.h",


### PR DESCRIPTION
Intention is to be able to build the deps only required which JS compiled by storybook uses.

Also allows gn target to be specified with --target flag, e.g. `npm run build -- --use_goma --target=brave:storybook`

I decided not to add this as a prefix to the current `npm run build-storybook` command since I didn't want to run the risk of causing developers a full build if e.g. the `--use_goma` flag wasn't included. When we have more reliable goma/no-goma builds, we can introduce this.


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18551
Resolves https://github.com/brave/brave-browser/issues/16124
This will be followed-up with a change in the build scripts to run this build target before generating storybook.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

