### PR TITLE
Add v8 patch to fix invalid WASM compilation. (uplift to 1.31.x)

### DIFF
--- a/patches/v8/src-wasm-module-compiler.cc.patch
+++ b/patches/v8/src-wasm-module-compiler.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/src/wasm/module-compiler.cc b/src/wasm/module-compiler.cc
+index ea714cbe4c58673b5663ab93b37d1adefe43b813..303270059deab54a6d59eaad92109678496da8ee 100644
+--- a/src/wasm/module-compiler.cc
++++ b/src/wasm/module-compiler.cc
+@@ -3052,13 +3052,13 @@ void CompilationStateImpl::InitializeCompilationProgressAfterDeserialization(
+     }
+     compilation_progress_.assign(module->num_declared_functions,
+                                  kProgressAfterDeserialization);
+-    uint32_t num_imported_functions = module->num_imported_functions;
+     for (auto func_index : missing_functions) {
+       if (FLAG_wasm_lazy_compilation) {
+-        native_module_->UseLazyStub(num_imported_functions + func_index);
++        native_module_->UseLazyStub(func_index);
+       }
+-      compilation_progress_[func_index] = SetupCompilationProgressForFunction(
+-          lazy_module, module, enabled_features, func_index);
++      compilation_progress_[declared_function_index(module, func_index)] =
++          SetupCompilationProgressForFunction(lazy_module, module,
++                                              enabled_features, func_index);
+     }
+   }
+   auto builder = std::make_unique<CompilationUnitBuilder>(native_module_);


### PR DESCRIPTION
Uplift of #10366
Resolves https://github.com/brave/brave-browser/issues/18562

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.