### PR TITLE
Update topsites_provider_data.cc

### DIFF
--- a/components/omnibox/browser/topsites_provider_data.cc
+++ b/components/omnibox/browser/topsites_provider_data.cc
@@ -115,7 +115,7 @@ std::vector<std::string> TopSitesProvider::top_sites_ = {
   "google.pl",
   "ku6.com",
   "bp.blogspot.com",
-  "thepiratebay.se",
+  "thepiratebay.org",
   "dailymotion.com",
   "weather.com",
   "vimeo.com",


### PR DESCRIPTION
The Pirate Bay has been using the .org domain since May 2016.

The "history" section of the Wikipedia page about this website has a nice tl;dr (see at the bottom):

https://en.wikipedia.org/wiki/The_Pirate_Bay#History