### PR TITLE
[cr95-followup] Fixes browser tests build.

### DIFF
--- a/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
@@ -329,7 +329,7 @@ IN_PROC_BROWSER_TEST_F(BraveWalletEthereumChainTest, CheckIncognitoTab) {
   GURL url =
       https_server()->GetURL("a.com", "/brave_wallet_ethereum_chain.html");
   Browser* private_browser = CreateIncognitoBrowser(nullptr);
-  ui_test_utils::NavigateToURL(private_browser, url);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(private_browser, url));
   content::WebContents* contents =
       private_browser->tab_strip_model()->GetActiveWebContents();
   WaitForLoadStop(contents);


### PR DESCRIPTION
Fixes brave/brave-browser#18579

ui_test_utils::NavigateToURL is now WARN_UNUSED_RESULT

Chromium change:

https://chromium.googlesource.com/chromium/src/+/fb432b1ad18bc0654844e147bf089237e97b6cd3

commit fb432b1ad18bc0654844e147bf089237e97b6cd3
Author: Lukasz Anforowicz <lukasza@chromium.org>
Date:   Wed Sep 8 22:16:13 2021 +0000

    Mark ui_test_utils::NavigateToURL as WARN_UNUSED_RESULT.

    This is step 2 from https://crbug.com/1246568 - it adds
    WARN_UNUSED_RESULT annotation to ui_test_utils::NavigateToURL to ensure
    the callers verify if the navigation has succeeded.

    The CL has to add ASSERT_TRUE in a few places that have already started
    backsliding since https://crrev.com/c/3140783 and
    https://crrev.com/c/3149434.

    Bug: 1246568

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

