### PR TITLE
Provide is_eip1559 info for all chains

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -71,6 +71,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                    GetDefaultUserAssets());
   registry->RegisterIntegerPref(kBraveWalletAutoLockMinutes, 5);
   registry->RegisterStringPref(kBraveWalletSelectedAccount, "");
+  registry->RegisterBooleanPref(kSupportEip1559OnLocalhostChain, false);
 }
 
 void RegisterProfilePrefsForMigration(

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -97,6 +97,8 @@ void ClearProfilePrefs(PrefService* prefs) {
   prefs->ClearPref(kBraveWalletUserAssets);
   prefs->ClearPref(kBraveWalletKeyrings);
   prefs->ClearPref(kBraveWalletAutoLockMinutes);
+  prefs->ClearPref(kBraveWalletSelectedAccount);
+  prefs->ClearPref(kSupportEip1559OnLocalhostChain);
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* prefs) {

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -75,6 +75,8 @@ class BraveWalletProviderImpl final
   void ChainChangedEvent(const std::string& chain_id) override;
   void OnAddEthereumChainRequestCompleted(const std::string& chain_id,
                                           const std::string& error) override;
+  void OnIsEip1559Changed(const std::string& chain_id,
+                          bool is_eip1559) override {}
 
   void OnAddEthereumChain(const std::string& chain_id, bool accepted);
   void OnChainApprovalResult(const std::string& chain_id,

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -98,15 +98,17 @@ base::Value TransactionReceiptToValue(const TransactionReceipt& tx_receipt);
 absl::optional<TransactionReceipt> ValueToTransactionReceipt(
     const base::Value& value);
 
-void GetAllKnownChains(std::vector<mojom::EthereumChainPtr>* chains);
-const std::vector<mojom::EthereumChain> GetAllKnownNetworks();
+void GetAllKnownChains(PrefService* prefs,
+                       std::vector<mojom::EthereumChainPtr>* chains);
+const std::vector<mojom::EthereumChain> GetAllKnownNetworksForTesting();
 void GetAllCustomChains(PrefService* prefs,
                         std::vector<mojom::EthereumChainPtr>* result);
 void GetAllChains(PrefService* prefs,
                   std::vector<mojom::EthereumChainPtr>* result);
 GURL GetNetworkURL(PrefService* prefs, const std::string& chain_id);
 std::string GetInfuraSubdomainForKnownChainId(const std::string& chain_id);
-mojom::EthereumChainPtr GetKnownChain(const std::string& chain_id);
+mojom::EthereumChainPtr GetKnownChain(PrefService* prefs,
+                                      const std::string& chain_id);
 std::string GetNetworkId(PrefService* prefs, const std::string& chain_id);
 void SetDefaultWallet(PrefService* prefs, mojom::DefaultWallet default_wallet);
 mojom::DefaultWallet GetDefaultWallet(PrefService* prefs);

--- a/components/brave_wallet/browser/eth_json_rpc_controller.cc
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.cc
@@ -173,10 +173,53 @@ void EthJsonRpcController::SetNetwork(const std::string& chain_id) {
   auto network_url = GetNetworkURL(prefs_, chain_id);
   if (!network_url.is_valid())
     return;
+
   chain_id_ = chain_id;
   network_url_ = network_url;
   prefs_->SetString(kBraveWalletCurrentChainId, chain_id);
+
   FireNetworkChanged();
+  MaybeUpdateIsEip1559(chain_id);
+}
+
+void EthJsonRpcController::MaybeUpdateIsEip1559(const std::string& chain_id) {
+  // Only try to update is_eip1559 for localhost or custom chains.
+  auto chain = GetKnownChain(prefs_, chain_id);
+  if (chain && chain_id != brave_wallet::mojom::kLocalhostChainId)
+    return;
+
+  GetIsEip1559(base::BindOnce(&EthJsonRpcController::UpdateIsEip1559,
+                              weak_ptr_factory_.GetWeakPtr(), chain_id));
+}
+
+void EthJsonRpcController::UpdateIsEip1559(const std::string& chain_id,
+                                           bool success,
+                                           bool is_eip1559) {
+  if (!success)
+    return;
+
+  if (chain_id == brave_wallet::mojom::kLocalhostChainId) {
+    prefs_->SetBoolean(kSupportEip1559OnLocalhostChain, is_eip1559);
+  } else {
+    ListPrefUpdate update(prefs_, kBraveWalletCustomNetworks);
+    for (base::Value& custom_network : update.Get()->GetList()) {
+      if (!custom_network.is_dict())
+        continue;
+
+      const std::string* id = custom_network.FindStringKey("chainId");
+      if (!id || *id != chain_id)
+        continue;
+
+      custom_network.SetBoolKey("is_eip1559", is_eip1559);
+      // Break the loop cuz we don't expect multiple entries with the same
+      // chainId in the list.
+      break;
+    }
+  }
+
+  for (const auto& observer : observers_) {
+    observer->OnIsEip1559Changed(chain_id, is_eip1559);
+  }
 }
 
 void EthJsonRpcController::FireNetworkChanged() {
@@ -602,6 +645,34 @@ void EthJsonRpcController::OnGetGasPrice(
   }
 
   std::move(callback).Run(true, result);
+}
+
+void EthJsonRpcController::GetIsEip1559(GetIsEip1559Callback callback) {
+  auto internal_callback =
+      base::BindOnce(&EthJsonRpcController::OnGetIsEip1559,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  return Request(eth_getBlockByNumber("latest", false), true,
+                 std::move(internal_callback));
+}
+
+void EthJsonRpcController::OnGetIsEip1559(
+    GetIsEip1559Callback callback,
+    const int status,
+    const std::string& body,
+    const base::flat_map<std::string, std::string>& headers) {
+  if (status < 200 || status > 299) {
+    std::move(callback).Run(false, false);
+    return;
+  }
+
+  base::Value result;
+  if (!ParseResult(body, &result) || !result.is_dict()) {
+    std::move(callback).Run(false, false);
+    return;
+  }
+
+  const std::string* base_fee = result.FindStringKey("baseFeePerGas");
+  std::move(callback).Run(true, base_fee && !base_fee->empty());
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_json_rpc_controller.h
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.h
@@ -145,6 +145,10 @@ class EthJsonRpcController : public KeyedService,
       base::OnceCallback<void(bool status, const std::string& result)>;
   void GetGasPrice(GetGasPriceCallback callback);
 
+  using GetIsEip1559Callback =
+      base::OnceCallback<void(bool success, bool is_eip1559)>;
+  void GetIsEip1559(GetIsEip1559Callback callback);
+
  private:
   void FireNetworkChanged();
   void FirePendingRequestCompleted(const std::string& chain_id,
@@ -215,6 +219,16 @@ class EthJsonRpcController : public KeyedService,
                      int status,
                      const std::string& body,
                      const base::flat_map<std::string, std::string>& headers);
+
+  void OnGetIsEip1559(GetIsEip1559Callback callback,
+                      int status,
+                      const std::string& body,
+                      const base::flat_map<std::string, std::string>& headers);
+
+  void MaybeUpdateIsEip1559(const std::string& chain_id);
+  void UpdateIsEip1559(const std::string& chain_id,
+                       bool success,
+                       bool is_eip1559);
 
   api_request_helper::APIRequestHelper api_request_helper_;
   GURL network_url_;

--- a/components/brave_wallet/browser/eth_json_rpc_controller_unittest.cc
+++ b/components/brave_wallet/browser/eth_json_rpc_controller_unittest.cc
@@ -801,6 +801,19 @@ TEST_F(EthJsonRpcControllerUnitTest, UpdateIsEip1559LocalhostChain) {
   EXPECT_TRUE(observer.is_eip1559_changed_called());
   EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
 
+  // Switch to localhost again without changing is_eip1559 should not trigger
+  // event.
+  observer.Reset(mojom::kLocalhostChainId, false);
+  EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
+  SetIsEip1559Interceptor(false);
+
+  rpc_controller_->SetNetwork(mojom::kLocalhostChainId);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_FALSE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
+
   // OnEip1559Changed will not be called if RPC fails.
   observer.Reset(mojom::kLocalhostChainId, false);
   SetErrorInterceptor();
@@ -854,6 +867,19 @@ TEST_F(EthJsonRpcControllerUnitTest, UpdateIsEip1559CustomChain) {
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(observer.chain_changed_called());
   EXPECT_TRUE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
+
+  // Switch to chain2 again without changing is_eip1559 should not trigger
+  // event.
+  observer.Reset(chain2.chain_id, false);
+  EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
+  SetIsEip1559Interceptor(false);
+
+  rpc_controller_->SetNetwork(chain2.chain_id);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_FALSE(observer.is_eip1559_changed_called());
   EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
 
   // OnEip1559Changed will not be called if RPC fails.

--- a/components/brave_wallet/browser/eth_json_rpc_controller_unittest.cc
+++ b/components/brave_wallet/browser/eth_json_rpc_controller_unittest.cc
@@ -69,15 +69,38 @@ void OnStringResponse(bool* callback_called,
   EXPECT_EQ(expected_success, success);
 }
 
-class FakeEthereumChainObserver
+void OnBoolResponse(bool* callback_called,
+                    bool expected_success,
+                    bool expected_response,
+                    bool success,
+                    bool response) {
+  *callback_called = true;
+  EXPECT_EQ(expected_response, response);
+  EXPECT_EQ(expected_success, success);
+}
+
+class TestEthJsonRpcControllerObserver
     : public brave_wallet::mojom::EthJsonRpcControllerObserver {
  public:
-  FakeEthereumChainObserver(base::OnceClosure callback,
-                            const std::string& expected_chain_id,
-                            const bool expected_error_empty) {
+  TestEthJsonRpcControllerObserver(base::OnceClosure callback,
+                                   const std::string& expected_chain_id,
+                                   bool expected_error_empty) {
     callback_ = std::move(callback);
     expected_chain_id_ = expected_chain_id;
     expected_error_empty_ = expected_error_empty;
+  }
+
+  TestEthJsonRpcControllerObserver(const std::string& expected_chain_id,
+                                   bool expected_is_eip1559) {
+    expected_chain_id_ = expected_chain_id;
+    expected_is_eip1559_ = expected_is_eip1559;
+  }
+
+  void Reset(const std::string& expected_chain_id, bool expected_is_eip1559) {
+    expected_chain_id_ = expected_chain_id;
+    expected_is_eip1559_ = expected_is_eip1559;
+    chain_changed_called_ = false;
+    is_eip1559_changed_called_ = false;
   }
 
   void OnAddEthereumChainRequestCompleted(const std::string& chain_id,
@@ -86,14 +109,33 @@ class FakeEthereumChainObserver
     EXPECT_EQ(error.empty(), expected_error_empty_);
     std::move(callback_).Run();
   }
-  void ChainChangedEvent(const std::string& chain_id) override { NOTREACHED(); }
+
+  void ChainChangedEvent(const std::string& chain_id) override {
+    chain_changed_called_ = true;
+    EXPECT_EQ(chain_id, expected_chain_id_);
+  }
+
+  void OnIsEip1559Changed(const std::string& chain_id,
+                          bool is_eip1559) override {
+    is_eip1559_changed_called_ = true;
+    EXPECT_EQ(chain_id, expected_chain_id_);
+    EXPECT_EQ(is_eip1559, expected_is_eip1559_);
+  }
+
+  bool is_eip1559_changed_called() { return is_eip1559_changed_called_; }
+  bool chain_changed_called() { return chain_changed_called_; }
+
   ::mojo::PendingRemote<brave_wallet::mojom::EthJsonRpcControllerObserver>
   GetReceiver() {
     return observer_receiver_.BindNewPipeAndPassRemote();
   }
+
   base::OnceClosure callback_;
   std::string expected_chain_id_;
   bool expected_error_empty_;
+  bool expected_is_eip1559_;
+  bool chain_changed_called_ = false;
+  bool is_eip1559_changed_called_ = false;
   mojo::Receiver<brave_wallet::mojom::EthJsonRpcControllerObserver>
       observer_receiver_{this};
 };
@@ -139,6 +181,28 @@ class EthJsonRpcControllerUnitTest : public testing::Test {
 
   PrefService* prefs() { return &prefs_; }
 
+  bool GetIsEip1559FromPrefs(const std::string& chain_id) {
+    if (chain_id == mojom::kLocalhostChainId)
+      return prefs()->GetBoolean(kSupportEip1559OnLocalhostChain);
+    const base::ListValue* custom_networks =
+        prefs()->GetList(kBraveWalletCustomNetworks);
+    if (!custom_networks)
+      return false;
+
+    for (const auto& chain : custom_networks->GetList()) {
+      if (!chain.is_dict())
+        continue;
+
+      const std::string* id = chain.FindStringKey("chainId");
+      if (!id || *id != chain_id)
+        continue;
+
+      return chain.FindBoolKey("is_eip1559").value_or(false);
+    }
+
+    return false;
+  }
+
   void SetRegistrarResponse() {
     auto localhost_url_spec =
         brave_wallet::GetNetworkURL(prefs(), mojom::kLocalhostChainId).spec();
@@ -183,6 +247,18 @@ class EthJsonRpcControllerUnitTest : public testing::Test {
         }));
   }
 
+  void SetIsEip1559Interceptor(bool is_eip1559) {
+    if (is_eip1559)
+      SetInterceptor(
+          "eth_getBlockByNumber", "latest,false",
+          "{\"jsonrpc\":\"2.0\",\"id\": \"0\",\"result\": "
+          "{\"baseFeePerGas\":\"0x181f22e7a9\", \"gasLimit\":\"0x6691b8\"}}");
+    else
+      SetInterceptor("eth_getBlockByNumber", "latest,false",
+                     "{\"jsonrpc\":\"2.0\",\"id\": \"0\",\"result\": "
+                     "{\"gasLimit\":\"0x6691b8\"}}");
+  }
+
   void ValidateStartWithNetwork(const std::string& chain_id,
                                 const std::string& expected_id) {
     prefs()->SetString(kBraveWalletCurrentChainId, chain_id);
@@ -209,7 +285,7 @@ class EthJsonRpcControllerUnitTest : public testing::Test {
 
 TEST_F(EthJsonRpcControllerUnitTest, SetNetwork) {
   std::vector<mojom::EthereumChainPtr> networks;
-  brave_wallet::GetAllKnownChains(&networks);
+  brave_wallet::GetAllKnownChains(prefs(), &networks);
   for (const auto& network : networks) {
     bool callback_is_called = false;
     rpc_controller_->SetNetwork(network->chain_id);
@@ -239,13 +315,13 @@ TEST_F(EthJsonRpcControllerUnitTest, SetCustomNetwork) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 22);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(prefs(), &values);
@@ -274,13 +350,13 @@ TEST_F(EthJsonRpcControllerUnitTest, GetAllNetworks) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain1(
       "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr1 = chain1.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
 
   brave_wallet::mojom::EthereumChain chain2(
       "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
-      {"https://url2.com"}, "symbol_name2", "symbol2", 22);
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
   auto chain_ptr2 = chain2.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
   UpdateCustomNetworks(prefs(), &values);
@@ -327,7 +403,7 @@ TEST_F(EthJsonRpcControllerUnitTest, ResetCustomChains) {
   std::vector<base::Value> values;
   brave_wallet::mojom::EthereumChain chain(
       "0x1", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
   auto chain_ptr = chain.Clone();
   values.push_back(brave_wallet::EthereumChainToValue(chain_ptr));
   UpdateCustomNetworks(prefs(), &values);
@@ -347,11 +423,11 @@ TEST_F(EthJsonRpcControllerUnitTest, ResetCustomChains) {
 TEST_F(EthJsonRpcControllerUnitTest, AddEthereumChainApproved) {
   brave_wallet::mojom::EthereumChain chain(
       "0x111", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
 
   base::RunLoop loop;
-  std::unique_ptr<FakeEthereumChainObserver> observer(
-      new FakeEthereumChainObserver(loop.QuitClosure(), "0x111", true));
+  std::unique_ptr<TestEthJsonRpcControllerObserver> observer(
+      new TestEthJsonRpcControllerObserver(loop.QuitClosure(), "0x111", true));
 
   rpc_controller_->AddObserver(observer->GetReceiver());
 
@@ -383,11 +459,11 @@ TEST_F(EthJsonRpcControllerUnitTest, AddEthereumChainApproved) {
 TEST_F(EthJsonRpcControllerUnitTest, AddEthereumChainRejected) {
   brave_wallet::mojom::EthereumChain chain(
       "0x111", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
 
   base::RunLoop loop;
-  std::unique_ptr<FakeEthereumChainObserver> observer(
-      new FakeEthereumChainObserver(loop.QuitClosure(), "0x111", false));
+  std::unique_ptr<TestEthJsonRpcControllerObserver> observer(
+      new TestEthJsonRpcControllerObserver(loop.QuitClosure(), "0x111", false));
 
   rpc_controller_->AddObserver(observer->GetReceiver());
 
@@ -420,7 +496,7 @@ TEST_F(EthJsonRpcControllerUnitTest, AddEthereumChainRejected) {
 TEST_F(EthJsonRpcControllerUnitTest, AddEthereumChainError) {
   brave_wallet::mojom::EthereumChain chain(
       "0x111", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
 
   bool callback_is_called = false;
   bool expected = true;
@@ -439,7 +515,7 @@ TEST_F(EthJsonRpcControllerUnitTest, AddEthereumChainError) {
   // other chain, same origin
   brave_wallet::mojom::EthereumChain chain2(
       "0x222", "chain_name", {"https://url1.com"}, {"https://url1.com"},
-      {"https://url1.com"}, "symbol_name", "symbol", 11);
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
 
   bool second_callback_is_called = false;
   bool second_expected = false;
@@ -662,6 +738,134 @@ TEST_F(EthJsonRpcControllerUnitTest, UnstoppableDomainsProxyReaderGetMany) {
       base::BindOnce(&OnStringResponse, &callback_called, false, ""));
   base::RunLoop().RunUntilIdle();
   EXPECT_TRUE(callback_called);
+}
+
+TEST_F(EthJsonRpcControllerUnitTest, GetIsEip1559) {
+  bool callback_called = false;
+
+  SetIsEip1559Interceptor(true);
+  rpc_controller_->GetIsEip1559(
+      base::BindOnce(&OnBoolResponse, &callback_called, true, true));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+
+  callback_called = false;
+  SetIsEip1559Interceptor(false);
+  rpc_controller_->GetIsEip1559(
+      base::BindOnce(&OnBoolResponse, &callback_called, true, false));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+
+  callback_called = false;
+  SetErrorInterceptor();
+  rpc_controller_->GetIsEip1559(
+      base::BindOnce(&OnBoolResponse, &callback_called, false, false));
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_called);
+}
+
+TEST_F(EthJsonRpcControllerUnitTest, UpdateIsEip1559NotCalledForKnownChains) {
+  TestEthJsonRpcControllerObserver observer(mojom::kMainnetChainId, false);
+  rpc_controller_->AddObserver(observer.GetReceiver());
+
+  rpc_controller_->SetNetwork(brave_wallet::mojom::kMainnetChainId);
+  base::RunLoop().RunUntilIdle();
+  EXPECT_FALSE(observer.is_eip1559_changed_called());
+}
+
+TEST_F(EthJsonRpcControllerUnitTest, UpdateIsEip1559LocalhostChain) {
+  TestEthJsonRpcControllerObserver observer(mojom::kLocalhostChainId, true);
+  rpc_controller_->AddObserver(observer.GetReceiver());
+
+  // Switching to localhost should update is_eip1559 to true when is_eip1559 is
+  // true in the RPC response.
+  EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
+  SetIsEip1559Interceptor(true);
+
+  rpc_controller_->SetNetwork(mojom::kLocalhostChainId);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_TRUE(observer.is_eip1559_changed_called());
+  EXPECT_TRUE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
+
+  // Switching to localhost should update is_eip1559 to false when is_eip1559
+  // is false in the RPC response.
+  observer.Reset(mojom::kLocalhostChainId, false);
+  SetIsEip1559Interceptor(false);
+
+  rpc_controller_->SetNetwork(mojom::kLocalhostChainId);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_TRUE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
+
+  // OnEip1559Changed will not be called if RPC fails.
+  observer.Reset(mojom::kLocalhostChainId, false);
+  SetErrorInterceptor();
+
+  rpc_controller_->SetNetwork(mojom::kLocalhostChainId);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_FALSE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
+}
+
+TEST_F(EthJsonRpcControllerUnitTest, UpdateIsEip1559CustomChain) {
+  std::vector<base::Value> values;
+  brave_wallet::mojom::EthereumChain chain1(
+      "chain_id", "chain_name", {"https://url1.com"}, {"https://url1.com"},
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
+  auto chain_ptr1 = chain1.Clone();
+  values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
+
+  brave_wallet::mojom::EthereumChain chain2(
+      "chain_id2", "chain_name2", {"https://url2.com"}, {"https://url2.com"},
+      {"https://url2.com"}, "symbol_name2", "symbol2", 22, true);
+  auto chain_ptr2 = chain2.Clone();
+  values.push_back(brave_wallet::EthereumChainToValue(chain_ptr2));
+  UpdateCustomNetworks(prefs(), &values);
+
+  // Switch to chain1 should trigger is_eip1559 being updated to true when
+  // is_eip1559 is true in the RPC response.
+  TestEthJsonRpcControllerObserver observer(chain1.chain_id, true);
+  rpc_controller_->AddObserver(observer.GetReceiver());
+
+  EXPECT_FALSE(GetIsEip1559FromPrefs(chain1.chain_id));
+  SetIsEip1559Interceptor(true);
+
+  rpc_controller_->SetNetwork(chain1.chain_id);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_TRUE(observer.is_eip1559_changed_called());
+  EXPECT_TRUE(GetIsEip1559FromPrefs(chain1.chain_id));
+
+  // Switch to chain2 should trigger is_eip1559 being updated to false when
+  // is_eip1559 is false in the RPC response.
+  observer.Reset(chain2.chain_id, false);
+  EXPECT_TRUE(GetIsEip1559FromPrefs(chain2.chain_id));
+  SetIsEip1559Interceptor(false);
+
+  rpc_controller_->SetNetwork(chain2.chain_id);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_TRUE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
+
+  // OnEip1559Changed will not be called if RPC fails.
+  observer.Reset(chain2.chain_id, false);
+  SetErrorInterceptor();
+
+  rpc_controller_->SetNetwork(chain2.chain_id);
+
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_FALSE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/eth_response_parser.cc
+++ b/components/brave_wallet/browser/eth_response_parser.cc
@@ -14,6 +14,26 @@
 
 namespace {
 
+bool ParseSingleStringResult(const std::string& json, std::string* result) {
+  DCHECK(result);
+
+  base::Value result_v;
+  if (!brave_wallet::ParseResult(json, &result_v))
+    return false;
+
+  const std::string* result_str = result_v.GetIfString();
+  if (!result_str)
+    return false;
+
+  *result = *result_str;
+
+  return true;
+}
+
+}  // namespace
+
+namespace brave_wallet {
+
 bool ParseResult(const std::string& json, base::Value* result) {
   DCHECK(result);
   base::JSONReader::ValueWithError value_with_error =
@@ -38,26 +58,6 @@ bool ParseResult(const std::string& json, base::Value* result) {
 
   return true;
 }
-
-bool ParseSingleStringResult(const std::string& json, std::string* result) {
-  DCHECK(result);
-
-  base::Value result_v;
-  if (!ParseResult(json, &result_v))
-    return false;
-
-  const std::string* result_str = result_v.GetIfString();
-  if (!result_str)
-    return false;
-
-  *result = *result_str;
-
-  return true;
-}
-
-}  // namespace
-
-namespace brave_wallet {
 
 bool ParseEthGetBlockNumber(const std::string& json, uint256_t* block_num) {
   std::string block_num_str;

--- a/components/brave_wallet/browser/eth_response_parser.h
+++ b/components/brave_wallet/browser/eth_response_parser.h
@@ -13,6 +13,7 @@
 
 namespace brave_wallet {
 
+bool ParseResult(const std::string& json, base::Value* result);
 bool ParseEthGetBlockNumber(const std::string& json, uint256_t* block_num);
 // Returns the balance of the account of given address.
 bool ParseEthGetBalance(const std::string& json, std::string* hex_balance);

--- a/components/brave_wallet/browser/eth_tx_state_manager.h
+++ b/components/brave_wallet/browser/eth_tx_state_manager.h
@@ -74,6 +74,8 @@ class EthTxStateManager : public mojom::EthJsonRpcControllerObserver {
   void ChainChangedEvent(const std::string& chain_id) override;
   void OnAddEthereumChainRequestCompleted(const std::string& chain_id,
                                           const std::string& error) override;
+  void OnIsEip1559Changed(const std::string& chain_id,
+                          bool is_eip1559) override {}
 
   void SetChainCallbackForTesting(base::OnceClosure callback) {
     chain_callback_for_testing_ = std::move(callback);

--- a/components/brave_wallet/browser/pref_names.cc
+++ b/components/brave_wallet/browser/pref_names.cc
@@ -20,6 +20,8 @@ const char kBraveWalletUserAssetEthContractAddressMigrated[] =
     "brave.wallet.user.asset.eth_contract_address_migrated";
 const char kBraveWalletAutoLockMinutes[] = "brave.wallet.auto_lock_minutes";
 const char kBraveWalletSelectedAccount[] = "brave.wallet.selected_account";
+const char kSupportEip1559OnLocalhostChain[] =
+    "brave.wallet.support_eip1559_on_localhost_chain";
 
 // DEPRECATED
 const char kBraveWalletPasswordEncryptorSalt[] =

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -18,6 +18,7 @@ extern const char kBraveWalletUserAssets[];
 extern const char kBraveWalletUserAssetEthContractAddressMigrated[];
 extern const char kBraveWalletAutoLockMinutes[];
 extern const char kBraveWalletSelectedAccount[];
+extern const char kSupportEip1559OnLocalhostChain[];
 
 // DEPRECATED
 extern const char kBraveWalletPasswordEncryptorSalt[];

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -265,6 +265,7 @@ interface SwapController {
 interface EthJsonRpcControllerObserver {
   ChainChangedEvent(string chain_id);
   OnAddEthereumChainRequestCompleted(string chain_id, string error);
+  OnIsEip1559Changed(string chain_id, bool is_eip1559);
 };
 
 struct TxData {
@@ -310,6 +311,7 @@ struct EthereumChain {
   string symbol;
   string symbol_name;
   int32 decimals;
+  bool is_eip1559;
 };
 
 interface EthJsonRpcController {

--- a/components/brave_wallet/common/value_conversion_utils.cc
+++ b/components/brave_wallet/common/value_conversion_utils.cc
@@ -65,6 +65,8 @@ absl::optional<mojom::EthereumChain> ValueToEthereumChain(
       chain.decimals = decimals.value();
     }
   }
+
+  chain.is_eip1559 = params_dict->FindBoolKey("is_eip1559").value_or(false);
   return chain;
 }
 
@@ -72,6 +74,7 @@ base::Value EthereumChainToValue(const mojom::EthereumChainPtr& chain) {
   base::Value dict(base::Value::Type::DICTIONARY);
   dict.SetStringKey("chainId", chain->chain_id);
   dict.SetStringKey("chainName", chain->chain_name);
+  dict.SetBoolKey("is_eip1559", chain->is_eip1559);
 
   base::ListValue blockExplorerUrlsValue;
   if (!chain->block_explorer_urls.empty()) {

--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -8,6 +8,7 @@ import {
   InitializedPayloadType,
   UnlockWalletPayloadType,
   ChainChangedEventPayloadType,
+  IsEip1559Changed,
   NewUnapprovedTxAdded,
   UnapprovedTxUpdated,
   TransactionStatusChanged,
@@ -54,6 +55,7 @@ export const setNetwork = createAction<EthereumChain>('setNetwork')
 export const getAllNetworks = createAction('getAllNetworks')
 export const setAllNetworks = createAction<GetAllNetworksList>('getAllNetworks')
 export const chainChangedEvent = createAction<ChainChangedEventPayloadType>('chainChangedEvent')
+export const isEip1559Changed = createAction<IsEip1559Changed>('isEip1559Changed')
 export const keyringCreated = createAction('keyringCreated')
 export const keyringRestored = createAction('keyringRestored')
 export const locked = createAction('locked')

--- a/components/brave_wallet_ui/common/constants/action_types.ts
+++ b/components/brave_wallet_ui/common/constants/action_types.ts
@@ -30,6 +30,11 @@ export type ChainChangedEventPayloadType = {
   chainId: string
 }
 
+export type IsEip1559Changed = {
+  chainId: string,
+  isEip1559: boolean
+}
+
 export type NewUnapprovedTxAdded = {
   txInfo: TransactionInfo
 }

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -30,6 +30,7 @@ import {
   UnapprovedTxUpdated,
   TransactionStatusChanged,
   ActiveOriginChanged,
+  IsEip1559Changed,
   InitializedPayloadType
 } from '../constants/action_types'
 import { convertMojoTimeToJS } from '../../utils/mojo-time'
@@ -52,7 +53,8 @@ const defaultState: WalletState = {
     iconUrls: [],
     symbol: 'ETH',
     symbolName: 'Ethereum',
-    decimals: 18
+    decimals: 18,
+    isEip1559: true
   } as EthereumChain,
   accounts: [],
   userVisibleTokensInfo: [],
@@ -344,6 +346,11 @@ reducer.on(WalletActions.activeOriginChanged, (state: any, payload: ActiveOrigin
     ...state,
     activeOrigin: payload.origin
   }
+})
+
+reducer.on(WalletActions.isEip1559Changed, (state: any, payload: IsEip1559Changed) => {
+  // TODO: update selectedNetwork and the entry in networkList.
+  return state
 })
 
 reducer.on(WalletActions.setGasEstimates, (state: any, payload: GasEstimation) => {

--- a/components/brave_wallet_ui/common/wallet_api_proxy.js
+++ b/components/brave_wallet_ui/common/wallet_api_proxy.js
@@ -49,6 +49,9 @@ export default class WalletApiProxy {
         store.dispatch(WalletActions.chainChangedEvent({ chainId }))
       },
       onAddEthereumChainRequestCompleted: function (chainId, error) {
+      },
+      onEip1559Changed: function (chainId, isEip1559) {
+        store.dispatch(WalletActions.isEip1559Changed({ chainId, isEip1559 }))
       }
     })
     this.ethJsonRpcController.addObserver(ethJsonRpcControllerObserverReceiver.$.bindNewPipeAndPassRemote());

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -810,7 +810,8 @@ export type EthereumChain = {
   rpcUrls: string[],
   symbol: string,
   symbolName: string,
-  decimals: number
+  decimals: number,
+  isEip1559: boolean
 }
 
 export interface GetAllNetworksList {

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -22,7 +22,7 @@ const defaultState: PanelState = {
   networkPayload: {
     chainId: '0x1', chainName: 'Ethereum Mainnet',
     rpcUrls: ['https://mainnet-infura.brave.com/'], blockExplorerUrls: [],
-    iconUrls: [], symbol: 'ETH', symbolName: 'Ethereum', decimals: 18
+    iconUrls: [], symbol: 'ETH', symbolName: 'Ethereum', decimals: 18, isEip1559: true
   },
   swapQuote: undefined,
   swapError: undefined

--- a/components/brave_wallet_ui/stories/mock-data/mock-networks.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-networks.ts
@@ -11,6 +11,7 @@ export const mockNetworks: EthereumChain[] = [
     symbol: 'ETH',
     symbolName: 'Ethereum',
     decimals: 18,
-    iconUrls: [ETHIconUrl]
+    iconUrls: [ETHIconUrl],
+    isEip1559: true
   }
 ]

--- a/components/brave_wallet_ui/utils/network-utils.ts
+++ b/components/brave_wallet_ui/utils/network-utils.ts
@@ -8,7 +8,7 @@ export const GetNetworkInfo = (chainId: string, list: EthereumChain[]) => {
   }
   return {
     chainId: '', chainName: '', rpcUrls: [], blockExplorerUrls: [],
-    iconUrls: [], symbol: '', symbolName: '', decimals: 0
+    iconUrls: [], symbol: '', symbolName: '', decimals: 0, isEip1559: false
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18323

This PR provides is_eip1559 info for all chains as follows:
- For known chains except for localhost, we will always use is_eip1559 = true.
- For localhost chain, we use kSupportEip1559OnLocalhostChain pref which is default to false, and it will be updated using eth_getBlockByNumber when trying to switch to localhost chain. OnIsEip1559Changed will be fired with chain_id and is_eip1559 when we get a successful RPC response.
- For custom chains, is_eip1559 is saved in each dict in kBraveWalletCustomNetworks pref list, and it's default to false. The value will be updated using eth_getBlockByNumber when trying to switch to that chain. OnIsEip1559Changed will be fired with chain_id and is_eip1559 when we get a successful RPC response.

Also made a basic front-end update in the last commit.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

