### PR TITLE
Fixed accent top border is only visible on Windows (uplift to 1.31.x)

### DIFF
--- a/browser/themes/brave_theme_helper_win.cc
+++ b/browser/themes/brave_theme_helper_win.cc
@@ -13,12 +13,9 @@ SkColor BraveThemeHelperWin::GetDefaultColor(
     const CustomThemeSupplier* theme_supplier) const {
   // Prevent dcheck in chrome/browser/themes/theme_properties.cc(384)
   // It assumes these ids are handled in theme service.
-  if (DwmColorsAllowed(theme_supplier)) {
-    if (id == ThemeProperties::COLOR_ACCENT_BORDER_ACTIVE)
-      return dwm_accent_border_color_;
-    // In Windows 10, native inactive borders are #555555 with 50% alpha.
-    if (id == ThemeProperties::COLOR_ACCENT_BORDER_INACTIVE)
-      return SkColorSetARGB(0x80, 0x55, 0x55, 0x55);
+  if (id == ThemeProperties::COLOR_ACCENT_BORDER_ACTIVE ||
+      id == ThemeProperties::COLOR_ACCENT_BORDER_INACTIVE) {
+    return ThemeHelperWin::GetDefaultColor(id, incognito, theme_supplier);
   }
   // Skip ThemeHelperWin::GetDefaultColor() to prevent using dwm frame color.
   return BraveThemeHelper::GetDefaultColor(id, incognito, theme_supplier);


### PR DESCRIPTION
Uplift of #10398
fix https://github.com/brave/brave-browser/issues/9420

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.