### PR TITLE
Fix handling of request,send,sendASync

### DIFF
--- a/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
@@ -73,7 +73,7 @@ const char kScriptRunEmptyAndCheckChainResult[] = R"(
 
 const char kRejectedResult[] =
     R"(window.domAutomationController.send(
-        result.error && result.error.code == %s))";
+        result.code == %s))";
 
 }  // namespace
 

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -60,19 +60,78 @@ class BraveWalletJSHandler : public mojom::EventsListener {
   v8::Local<v8::Value> IsConnected();
   v8::Local<v8::Promise> Enable();
   void SendAsync(gin::Arguments* args);
+  bool CommonRequestOrSendAsync(
+      v8::Local<v8::Value> input,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> callback,
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate);
 
-  void OnRequest(v8::Global<v8::Promise::Resolver> promise_resolver,
-                 v8::Isolate* isolate,
-                 v8::Global<v8::Context> context_old,
-                 base::Value id,
-                 const int http_code,
-                 const std::string& response,
-                 const base::flat_map<std::string, std::string>& headers);
-  void OnSendAsync(std::unique_ptr<v8::Global<v8::Function>> callback,
-                   base::Value id,
+  void OnCommonRequestOrSendAsync(
+      base::Value id,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> callback,
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate,
+      const int http_code,
+      const std::string& response,
+      const base::flat_map<std::string, std::string>& headers);
+  void OnSendAsync(base::Value id,
+                   v8::Global<v8::Context> global_context,
+                   std::unique_ptr<v8::Global<v8::Function>> callback,
                    const int http_code,
                    const std::string& response,
                    const base::flat_map<std::string, std::string>& headers);
+  void OnEthereumPermissionRequested(
+      base::Value id,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> callback,
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate,
+      bool success,
+      const std::vector<std::string>& accounts);
+  void OnGetAllowedAccounts(base::Value id,
+                            v8::Global<v8::Context> global_context,
+                            std::unique_ptr<v8::Global<v8::Function>> callback,
+                            v8::Global<v8::Promise::Resolver> promise_resolver,
+                            v8::Isolate* isolate,
+                            bool success,
+                            const std::vector<std::string>& accounts);
+  void OnAddEthereumChain(base::Value id,
+                          v8::Global<v8::Context> global_context,
+                          std::unique_ptr<v8::Global<v8::Function>> callback,
+                          v8::Global<v8::Promise::Resolver> promise_resolver,
+                          v8::Isolate* isolate,
+                          bool success,
+                          int provider_error,
+                          const std::string& error_message);
+  void OnAddUnapprovedTransaction(
+      base::Value id,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> callback,
+      v8::Global<v8::Promise::Resolver> resolver,
+      v8::Isolate* isolate,
+      bool success,
+      const std::string& tx_meta_id,
+      const std::string& error_message);
+  void SendResponse(base::Value id,
+                    v8::Global<v8::Context> global_context,
+                    std::unique_ptr<v8::Global<v8::Function>> callback,
+                    v8::Global<v8::Promise::Resolver> promise_resolver,
+                    v8::Isolate* isolate,
+                    std::unique_ptr<base::Value> formed_response,
+                    bool success);
+#if 0
+  void OnSignMessage(
+                   base::Value id,
+                   v8::Global<v8::Context> global_context,
+                   std::unique_ptr<v8::Global<v8::Function>> global_callback,
+                   v8::Global<v8::Promise::Resolver> promise_resolver,
+                   v8::Isolate* isolate,
+                   const std::string& signature,
+                   int error,
+                   const std::string& error_message);
+#endif
 
   content::RenderFrame* render_frame_;
   mojo::Remote<mojom::BraveWalletProvider> brave_wallet_provider_;

--- a/test/data/brave-wallet/brave_wallet_ethereum_chain.html
+++ b/test/data/brave-wallet/brave_wallet_ethereum_chain.html
@@ -22,10 +22,10 @@
   window.ethereum.request(
       { method: 'wallet_addEthereumChain', params:data }).then(result => {
         request_finished = true;
-        chain_added_result = (!result.result && !result.error)
+        chain_added_result = result === null
       }).catch(error => {
         request_finished = true;
-        chain_added_result = !(result.error && result.error.code == 4001)
+        chain_added_result = result.code != 4001
       })
 </script></head>
 <body></body>


### PR DESCRIPTION
This makes it so we handle our custom actions for all the different methods for `send` and `sendASync` too.

`ethereum.request`will now return the result or error dictionary directly
`ethereum.send` and `ethereum.sendAsync` will now send the full HTTP response.
Verified common functions against MM for expected returns.
I have some manual tests here to try it:
https://github.com/bbondy/eth-manual-tests/blob/main/request.html

Not as part of this PR, and not introduced by this PR, but we should have better tests for js handler expected results and errors. We do it only for wallet_addEthereumChain for now which I updated.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18616

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

