### PR TITLE
Fix #18661 - Updated ignored npm advisories for node modules with no updates available (uplift to 1.30.x)

### DIFF
--- a/script/audit_deps.py
+++ b/script/audit_deps.py
@@ -29,11 +29,18 @@ CARGO_INCLUDE_PATHS = [
 
 # Ping security team before adding to ignored_npm_advisories
 ignored_npm_advisories = [
-    1700,   # high RxDoS vector, we don't use MDX in storybook
-    1747,    # moderate RxDoS vector, not fixed in @storybook/addon-essentials
-    1751     # moderate RxDoS vector, not fixed in webpack 4
+    # These are issues in dev depencies, no updates are available yet
+    # To-Do (@jumde) - Remove when https://github.com/brave/brave-browser/issues/18662 is fixed
+    1002401,    # https://github.com/advisories/GHSA-93q8-gq69-wqmw
+    1002422,    # https://github.com/advisories/GHSA-hqhp-5p83-hx96
+    1002475,    # https://github.com/advisories/GHSA-4jqc-8m5r-9rpr
+    1002487,    # https://github.com/advisories/GHSA-c36v-fmgq-m8hx
+    1002492,    # https://github.com/advisories/GHSA-33f9-j839-rf8h
+    1002522,    # https://github.com/advisories/GHSA-whgm-jr23-g3j9
+    1002627,    # https://github.com/advisories/GHSA-ww39-953v-wcq6
+    1002655,    # https://github.com/advisories/GHSA-w8qv-6jwh-64r5
+    1002775     # https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
 ]
-
 
 def main():
     """Audit a specified path, or the whole project."""
@@ -64,14 +71,14 @@ def audit_path(path, args):
        os.path.isdir(os.path.join(path, 'node_modules')) and \
        not any(full_path.startswith(os.path.join(args.source_root, p, "")) \
                for p in NPM_EXCLUDE_PATHS):
-        print('Auditing (npm) %s' % path)
+        print(f'Auditing (npm) {path}')
         return npm_audit_deps(path, args)
 
     if os.path.isfile(os.path.join(path, 'Cargo.toml')) and \
          os.path.isfile(os.path.join(path, 'Cargo.lock')) and \
          any(full_path.startswith(os.path.join(args.source_root, p, "")) \
              for p in CARGO_INCLUDE_PATHS):
-        print('Auditing (cargo) %s' % path)
+        print(f'Auditing (cargo) {path}')
         return cargo_audit_deps(path, args)
 
     return 0


### PR DESCRIPTION
Uplift of #10434
Resolves https://github.com/brave/brave-browser/issues/18661

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.