### PR TITLE
Initiate rewards service start along with rewards extension loading.

### DIFF
--- a/browser/brave_ads/brave_ads_host.h
+++ b/browser/brave_ads/brave_ads_host.h
@@ -37,7 +37,7 @@ class BraveAdsHost : public brave_ads::mojom::BraveAdsHost,
                     bool ads_enabled) override;
 
  private:
-  bool ShowRewardsPopup();
+  bool ShowRewardsPopup(brave_rewards::RewardsService* rewards_service);
   void RunCallbacksAndReset(bool result);
 
   Profile* profile_;


### PR DESCRIPTION
If user rejects Brave talk opt-in popup they still could enable Rewards from the Brave Rewards popup, which requires rewards service being started. 
When Brave Rewards are not enabled then user sees Stub rewards button, which loads extension and runs rewards service on mouse press event. During extension loading Stub button is replaced with extension toolbar icon, so further presses do not initiate rewards service start.
This means that along with extension loading we have to start rewards service, otherwise Rewards popup will be broken.
Current PR adds rewards service start when Ads enable popup is shown.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18686

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Install clean browser (Rewards aren't opted-in) on Desktop
* Run browser with --enable-features=RequestAdsEnabledApi
* Open https://talk.brave.software
* Click Start 1:1 free call
* Dismiss popup
* Click to Brave Rewards icon
* Ensure that Brave Rewards is opened correctly
