### PR TITLE
Hide AC row in rewards summary when AC is disabled (uplift to 1.31.x)

### DIFF
--- a/components/brave_rewards/resources/page/components/pageWallet.tsx
+++ b/components/brave_rewards/resources/page/components/pageWallet.tsx
@@ -817,6 +817,7 @@ class PageWallet extends React.Component<Props, State> {
       adsData,
       balance,
       balanceReport,
+      enabledContribute,
       externalWalletProviderList,
       ui,
       recoveryKey,
@@ -862,6 +863,7 @@ class PageWallet extends React.Component<Props, State> {
           exchangeCurrency={'USD'}
           showSummary={true}
           summaryData={summaryData}
+          autoContributeEnabled={enabledContribute}
           onExternalWalletAction={this.onExternalWalletAction}
           onViewPendingTips={this.onModalPendingToggle}
           onViewStatement={this.onModalActivityToggle}

--- a/components/brave_rewards/resources/rewards_panel/components/panel.tsx
+++ b/components/brave_rewards/resources/rewards_panel/components/panel.tsx
@@ -18,6 +18,7 @@ export function Panel () {
   const host = React.useContext(HostContext)
 
   const [balance, setBalance] = React.useState(host.state.balance)
+  const [settings, setSettings] = React.useState(host.state.settings)
   const [externalWallet, setExternalWallet] =
     React.useState(host.state.externalWallet)
   const [exchangeInfo, setExchangeInfo] =
@@ -33,6 +34,7 @@ export function Panel () {
 
   useHostListener(host, (state) => {
     setBalance(state.balance)
+    setSettings(state.settings)
     setExternalWallet(state.externalWallet)
     setExchangeInfo(state.exchangeInfo)
     setEarningsInfo(state.earningsInfo)
@@ -52,6 +54,7 @@ export function Panel () {
         exchangeCurrency={exchangeInfo.currency}
         showSummary={activeView === 'summary'}
         summaryData={summaryData}
+        autoContributeEnabled={settings.autoContributeEnabled}
         onExternalWalletAction={host.handleExternalWalletAction}
       />
       {activeView === 'tip' && <PublisherCard />}

--- a/components/brave_rewards/resources/shared/components/wallet_card/rewards_summary.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/rewards_summary.tsx
@@ -26,6 +26,7 @@ export interface RewardsSummaryData {
 
 interface Props {
   data: RewardsSummaryData
+  autoContributeEnabled: boolean
   hideAdEarnings: boolean
   earningsLastMonth: number
   nextPaymentDate: number
@@ -101,7 +102,10 @@ export function RewardsSummary (props: Props) {
                 !props.hideAdEarnings &&
                   renderRow(data.adEarnings, 'walletRewardsFromAds', 'ads')
               }
-              {renderRow(-data.autoContributions, 'walletAutoContribute', 'ac')}
+              {
+                props.autoContributeEnabled && renderRow(
+                  -data.autoContributions, 'walletAutoContribute', 'ac')
+              }
               {renderRow(-data.oneTimeTips, 'walletOneTimeTips', 'one-time')}
               {renderRow(-data.monthlyTips, 'walletMonthlyTips', 'monthly')}
             </tbody>

--- a/components/brave_rewards/resources/shared/components/wallet_card/stories/index.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/stories/index.tsx
@@ -68,6 +68,7 @@ export function Wallet () {
             exchangeCurrency={'USD'}
             showSummary={knobs.boolean('Show Summary', true)}
             summaryData={summaryData}
+            autoContributeEnabled={true}
             onExternalWalletAction={actionLogger('onExternalWalletAction')}
             onViewPendingTips={actionLogger('onViewPendingTips')}
             onViewStatement={actionLogger('onViewStatement')}

--- a/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
@@ -33,6 +33,7 @@ interface Props {
   exchangeCurrency: string
   showSummary: boolean
   summaryData: RewardsSummaryData
+  autoContributeEnabled: boolean
   onExternalWalletAction: (action: ExternalWalletAction) => void
   onViewPendingTips?: () => void
   onViewStatement?: () => void
@@ -118,6 +119,7 @@ export function WalletCard (props: Props) {
               </style.summaryActions>
               <RewardsSummary
                 data={props.summaryData}
+                autoContributeEnabled={props.autoContributeEnabled}
                 hideAdEarnings={Boolean(props.externalWallet)}
                 earningsLastMonth={props.earningsLastMonth}
                 nextPaymentDate={props.nextPaymentDate}


### PR DESCRIPTION
Uplift of #10428
Resolves https://github.com/brave/brave-browser/issues/18651

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.