### PR TITLE
Support EIP-1559 transactions for Swap

### DIFF
--- a/components/brave_wallet_ui/common/async/wallet_async_handler.ts
+++ b/components/brave_wallet_ui/common/async/wallet_async_handler.ts
@@ -539,8 +539,7 @@ export const fetchSwapQuoteFactory = (
         to,
         data,
         value,
-        estimatedGas,
-        gasPrice
+        estimatedGas
       } = quote.response
 
       const params = {
@@ -548,7 +547,6 @@ export const fetchSwapQuoteFactory = (
         to,
         value: toWeiHex(value, 0),
         gas: toWeiHex(estimatedGas, 0),
-        gasPrice: toWeiHex(gasPrice, 0),
         data: hexStrToNumberArray(data)
       }
 

--- a/components/brave_wallet_ui/common/hooks/swap.ts
+++ b/components/brave_wallet_ui/common/hooks/swap.ts
@@ -92,6 +92,8 @@ export default function useSwap (
       return new BigNumber('0')
     }
 
+    // NOTE: Swap will eventually use EIP-1559 gas fields, but we rely on
+    // gasPrice as a fee-ceiling for validation of inputs.
     const { gasPrice, gas } = quote
     const gasPriceBN = new BigNumber(gasPrice)
     const gasBN = new BigNumber(gas)

--- a/components/brave_wallet_ui/options/asset-options.ts
+++ b/components/brave_wallet_ui/options/asset-options.ts
@@ -45,7 +45,7 @@ export const RopstenSwapAssetOptions: AccountAssetOptionType[] = [
       logo: `chrome://erc-token-images/usdc.svg`,
       isErc20: true,
       isErc721: false,
-      decimals: 18
+      decimals: 6
     },
     assetBalance: '0',
     fiatBalance: '0'


### PR DESCRIPTION
## Motivation

0x Swap API always returns the fastest gas price (from ETH Gas Station), which we suggest to the user as default. Unfortunately, we don't have slow/average/fast modes in legacy gas pricing, so the users must manually edit the GWei gas price in the transaction approval screen in order to save on fees. Using EIP-1559 on swap should improve conversion, as we have better gas controls and the fees respond slower to volatility.

In this PR, we're simply ignoring the `gasPrice` returned by the API and choose the right transaction type (type-0 vs type-2) based on the network and keyring. Note that we still use `gasPrice` as a fee-ceiling for the purpose of input validation.

cc: @SergeyZhukovsky to do the same on Android.

Resolves https://github.com/brave/brave-browser/issues/18652.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

https://user-images.githubusercontent.com/3684187/136875918-184b2ded-9051-4b39-90f9-fa0ecbe2ef1c.mov

