### PR TITLE
Fix #17290 - Cancel gemini transaction if status is not completed after 3 retries

### DIFF
--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2438,6 +2438,17 @@ void RewardsServiceImpl::HandleFlags(const std::string& options) {
       continue;
     }
 
+    if (name == "gemini-retries") {
+      int retries;
+      bool success = base::StringToInt(value, &retries);
+
+      if (success && retries >= 0) {
+        SetGeminiRetries(retries);
+      }
+
+      continue;
+    }
+
     // The "persist-logs" command-line flag is deprecated and will be removed
     // in a future version. Use --enable-features=BraveRewardsVerboseLogging
     // instead.
@@ -2574,6 +2585,10 @@ void RewardsServiceImpl::GetRetryInterval(GetRetryIntervalCallback callback) {
   bat_ledger_service_->GetRetryInterval(std::move(callback));
 }
 
+void RewardsServiceImpl::GetGeminiRetries(GetGeminiRetriesCallback callback) {
+  bat_ledger_service_->GetGeminiRetries(std::move(callback));
+}
+
 void RewardsServiceImpl::SetEnvironment(ledger::type::Environment environment) {
   bat_ledger_service_->SetEnvironment(environment);
 }
@@ -2588,6 +2603,10 @@ void RewardsServiceImpl::SetReconcileInterval(const int32_t interval) {
 
 void RewardsServiceImpl::SetRetryInterval(int32_t interval) {
   bat_ledger_service_->SetRetryInterval(interval);
+}
+
+void RewardsServiceImpl::SetGeminiRetries(const int32_t retries) {
+  bat_ledger_service_->SetGeminiRetries(retries);
 }
 
 void RewardsServiceImpl::GetPendingContributionsTotal(

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -77,6 +77,7 @@ using GetEnvironmentCallback =
     base::OnceCallback<void(ledger::type::Environment)>;
 using GetDebugCallback = base::OnceCallback<void(bool)>;
 using GetReconcileIntervalCallback = base::OnceCallback<void(int32_t)>;
+using GetGeminiRetriesCallback = base::OnceCallback<void(int32_t)>;
 using GetRetryIntervalCallback = base::OnceCallback<void(int32_t)>;
 using GetTestResponseCallback = base::RepeatingCallback<void(
     const std::string& url,
@@ -203,6 +204,8 @@ class RewardsServiceImpl : public RewardsService,
   void GetEnvironment(GetEnvironmentCallback callback);
   void SetDebug(bool debug);
   void GetDebug(GetDebugCallback callback);
+  void SetGeminiRetries(const int32_t retries);
+  void GetGeminiRetries(GetGeminiRetriesCallback callback);
   void SetReconcileInterval(const int32_t interval);
   void GetReconcileInterval(GetReconcileIntervalCallback callback);
   void SetRetryInterval(int32_t interval);

--- a/components/services/bat_ledger/bat_ledger_service_impl.cc
+++ b/components/services/bat_ledger/bat_ledger_service_impl.cc
@@ -62,6 +62,10 @@ void BatLedgerServiceImpl::SetTesting() {
   ledger::is_testing = true;
 }
 
+void BatLedgerServiceImpl::SetGeminiRetries(int32_t retries) {
+  ledger::gemini_retries = retries;
+}
+
 void BatLedgerServiceImpl::GetEnvironment(GetEnvironmentCallback callback) {
   std::move(callback).Run(ledger::_environment);
 }
@@ -77,6 +81,10 @@ void BatLedgerServiceImpl::GetReconcileInterval(
 
 void BatLedgerServiceImpl::GetRetryInterval(GetRetryIntervalCallback callback) {
   std::move(callback).Run(ledger::retry_interval);
+}
+
+void BatLedgerServiceImpl::GetGeminiRetries(GetGeminiRetriesCallback callback) {
+  std::move(callback).Run(ledger::gemini_retries);
 }
 
 }  // namespace bat_ledger

--- a/components/services/bat_ledger/bat_ledger_service_impl.h
+++ b/components/services/bat_ledger/bat_ledger_service_impl.h
@@ -39,11 +39,13 @@ class BatLedgerServiceImpl : public mojom::BatLedgerService {
   void SetReconcileInterval(const int32_t interval) override;
   void SetRetryInterval(int32_t interval) override;
   void SetTesting() override;
+  void SetGeminiRetries(int32_t retries) override;
 
   void GetEnvironment(GetEnvironmentCallback callback) override;
   void GetDebug(GetDebugCallback callback) override;
   void GetReconcileInterval(GetReconcileIntervalCallback callback) override;
   void GetRetryInterval(GetRetryIntervalCallback callback) override;
+  void GetGeminiRetries(GetGeminiRetriesCallback callback) override;
 
  private:
   mojo::Receiver<mojom::BatLedgerService> receiver_;

--- a/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
+++ b/components/services/bat_ledger/public/interfaces/bat_ledger.mojom
@@ -12,12 +12,14 @@ interface BatLedgerService {
          pending_associated_receiver<BatLedger> database) => ();
   SetEnvironment(ledger.mojom.Environment environment);
   SetDebug(bool isDebug);
+  SetGeminiRetries(int32 retries);
   SetReconcileInterval(int32 interval);
   SetRetryInterval(int32 interval);
   SetTesting();
 
   GetEnvironment() => (ledger.mojom.Environment environment);
   GetDebug() => (bool debug);
+  GetGeminiRetries() => (int32 retries);
   GetReconcileInterval() => (int32 interval);
   GetRetryInterval() => (int32 retry_interval);
 };

--- a/vendor/bat-native-ledger/BUILD.gn
+++ b/vendor/bat-native-ledger/BUILD.gn
@@ -328,6 +328,8 @@ source_set("ledger") {
     "src/bat/ledger/internal/endpoint/gemini/post_account/post_account_gemini.h",
     "src/bat/ledger/internal/endpoint/gemini/post_balance/post_balance_gemini.cc",
     "src/bat/ledger/internal/endpoint/gemini/post_balance/post_balance_gemini.h",
+    "src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.cc",
+    "src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.h",
     "src/bat/ledger/internal/endpoint/gemini/post_oauth/post_oauth_gemini.cc",
     "src/bat/ledger/internal/endpoint/gemini/post_oauth/post_oauth_gemini.h",
     "src/bat/ledger/internal/endpoint/gemini/post_recipient_id/post_recipient_id_gemini.cc",

--- a/vendor/bat-native-ledger/include/bat/ledger/ledger.h
+++ b/vendor/bat-native-ledger/include/bat/ledger/ledger.h
@@ -20,6 +20,7 @@
 namespace ledger {
 
 extern type::Environment _environment;
+extern int gemini_retries;
 extern bool is_debug;
 extern bool is_testing;
 extern int reconcile_interval;  // minutes

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/gemini_server.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/gemini_server.cc
@@ -14,6 +14,8 @@ GeminiServer::GeminiServer(LedgerImpl* ledger)
     : get_transaction_(std::make_unique<gemini::GetTransaction>(ledger)),
       post_account_(std::make_unique<gemini::PostAccount>(ledger)),
       post_balance_(std::make_unique<gemini::PostBalance>(ledger)),
+      post_cancel_transaction_(
+          std::make_unique<gemini::PostCancelTransaction>(ledger)),
       post_oauth_(std::make_unique<gemini::PostOauth>(ledger)),
       post_recipient_id_(std::make_unique<gemini::PostRecipientId>(ledger)),
       post_transaction_(std::make_unique<gemini::PostTransaction>(ledger)) {}
@@ -30,6 +32,10 @@ gemini::PostAccount* GeminiServer::post_account() const {
 
 gemini::PostBalance* GeminiServer::post_balance() const {
   return post_balance_.get();
+}
+
+gemini::PostCancelTransaction* GeminiServer::post_cancel_transaction() const {
+  return post_cancel_transaction_.get();
 }
 
 gemini::PostOauth* GeminiServer::post_oauth() const {

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/gemini_server.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/gemini_server.h
@@ -11,6 +11,7 @@
 #include "bat/ledger/internal/endpoint/gemini/get_transaction/get_transaction_gemini.h"
 #include "bat/ledger/internal/endpoint/gemini/post_account/post_account_gemini.h"
 #include "bat/ledger/internal/endpoint/gemini/post_balance/post_balance_gemini.h"
+#include "bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.h"
 #include "bat/ledger/internal/endpoint/gemini/post_oauth/post_oauth_gemini.h"
 #include "bat/ledger/internal/endpoint/gemini/post_recipient_id/post_recipient_id_gemini.h"
 #include "bat/ledger/internal/endpoint/gemini/post_transaction/post_transaction_gemini.h"
@@ -32,6 +33,8 @@ class GeminiServer {
 
   gemini::PostBalance* post_balance() const;
 
+  gemini::PostCancelTransaction* post_cancel_transaction() const;
+
   gemini::PostOauth* post_oauth() const;
 
   gemini::PostRecipientId* post_recipient_id() const;
@@ -42,6 +45,7 @@ class GeminiServer {
   std::unique_ptr<gemini::GetTransaction> get_transaction_;
   std::unique_ptr<gemini::PostAccount> post_account_;
   std::unique_ptr<gemini::PostBalance> post_balance_;
+  std::unique_ptr<gemini::PostCancelTransaction> post_cancel_transaction_;
   std::unique_ptr<gemini::PostOauth> post_oauth_;
   std::unique_ptr<gemini::PostRecipientId> post_recipient_id_;
   std::unique_ptr<gemini::PostTransaction> post_transaction_;

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.cc
@@ -1,0 +1,64 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.h"
+
+#include <utility>
+
+#include "base/strings/stringprintf.h"
+#include "bat/ledger/internal/endpoint/gemini/gemini_utils.h"
+#include "bat/ledger/internal/ledger_impl.h"
+
+using std::placeholders::_1;
+
+namespace {
+
+std::string GetUrl(const std::string& tx_ref) {
+  return ledger::endpoint::gemini::GetApiServerUrl(
+      base::StringPrintf("/v1/payment/cancel/%s", tx_ref.c_str()));
+}
+
+}  // namespace
+
+namespace ledger {
+namespace endpoint {
+namespace gemini {
+
+PostCancelTransaction::PostCancelTransaction(LedgerImpl* ledger)
+    : ledger_(ledger) {
+  DCHECK(ledger_);
+}
+
+PostCancelTransaction::~PostCancelTransaction() = default;
+
+void PostCancelTransaction::Request(const std::string& token,
+                                    const std::string& tx_ref,
+                                    PostCancelTransactionCallback callback) {
+  auto url_callback =
+      std::bind(&PostCancelTransaction::OnRequest, this, _1, callback);
+  auto request = type::UrlRequest::New();
+  request->url = GetUrl(tx_ref);
+  request->method = type::UrlMethod::POST;
+  request->headers = RequestAuthorization(token);
+  ledger_->LoadURL(std::move(request), url_callback);
+}
+
+void PostCancelTransaction::OnRequest(const type::UrlResponse& response,
+                                      PostCancelTransactionCallback callback) {
+  ledger::LogUrlResponse(__func__, response);
+
+  type::Result result = CheckStatusCode(response.status_code);
+
+  if (result != type::Result::LEDGER_OK) {
+    callback(result);
+    return;
+  }
+
+  callback(result);
+}
+
+}  // namespace gemini
+}  // namespace endpoint
+}  // namespace ledger

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_ENDPOINT_GEMINI_POST_CANCEL_TRANSACTION_POST_CANCEL_TRANSACTION_GEMINI_H_
+#define BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_ENDPOINT_GEMINI_POST_CANCEL_TRANSACTION_POST_CANCEL_TRANSACTION_GEMINI_H_
+
+#include <string>
+
+#include "bat/ledger/ledger.h"
+
+// GET https://api.gemini.com/v1/payment/cancel
+//
+// Success code:
+// HTTP_OK (200)
+//
+// Error codes:
+// HTTP_UNAUTHORIZED (401)
+
+namespace ledger {
+class LedgerImpl;
+
+namespace endpoint {
+namespace gemini {
+
+using PostCancelTransactionCallback =
+    std::function<void(const type::Result result)>;
+
+class PostCancelTransaction {
+ public:
+  explicit PostCancelTransaction(LedgerImpl* ledger);
+  ~PostCancelTransaction();
+
+  void Request(const std::string& token,
+               const std::string& tx_ref,
+               PostCancelTransactionCallback callback);
+
+ private:
+  void OnRequest(const type::UrlResponse& response,
+                 PostCancelTransactionCallback callback);
+
+  LedgerImpl* ledger_;  // NOT OWNED
+};
+
+}  // namespace gemini
+}  // namespace endpoint
+}  // namespace ledger
+
+#endif  // BRAVE_VENDOR_BAT_NATIVE_LEDGER_SRC_BAT_LEDGER_INTERNAL_ENDPOINT_GEMINI_POST_CANCEL_TRANSACTION_POST_CANCEL_TRANSACTION_GEMINI_H_

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini_unittest.cc
@@ -1,0 +1,136 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "base/test/task_environment.h"
+#include "bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini.h"
+#include "bat/ledger/internal/ledger_client_mock.h"
+#include "bat/ledger/internal/ledger_impl_mock.h"
+#include "bat/ledger/ledger.h"
+#include "net/http/http_status_code.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=GeminiPostCancelTransactionTest.*
+
+using ::testing::_;
+using ::testing::Invoke;
+
+namespace ledger {
+namespace endpoint {
+namespace gemini {
+
+class GeminiPostCancelTransactionTest : public testing::Test {
+ private:
+  base::test::TaskEnvironment scoped_task_environment_;
+
+ protected:
+  std::unique_ptr<ledger::MockLedgerClient> mock_ledger_client_;
+  std::unique_ptr<ledger::MockLedgerImpl> mock_ledger_impl_;
+  std::unique_ptr<PostCancelTransaction> post_cancel_transaction_;
+
+  GeminiPostCancelTransactionTest() {
+    mock_ledger_client_ = std::make_unique<ledger::MockLedgerClient>();
+    mock_ledger_impl_ =
+        std::make_unique<ledger::MockLedgerImpl>(mock_ledger_client_.get());
+    post_cancel_transaction_ =
+        std::make_unique<PostCancelTransaction>(mock_ledger_impl_.get());
+  }
+};
+
+TEST_F(GeminiPostCancelTransactionTest, ServerOK) {
+  ON_CALL(*mock_ledger_client_, LoadURL(_, _))
+      .WillByDefault(Invoke(
+          [](type::UrlRequestPtr request, client::LoadURLCallback callback) {
+            type::UrlResponse response;
+            response.status_code = net::HTTP_OK;
+            response.url = request->url;
+            response.body = "";
+            callback(response);
+          }));
+
+  post_cancel_transaction_->Request(
+      "4c2b665ca060d912fec5c735c734859a06118cc8",
+      "A5721BF3-530C-42AF-8DEE-005DCFF76970", [](const type::Result result) {
+        EXPECT_EQ(result, type::Result::LEDGER_OK);
+      });
+}
+
+TEST_F(GeminiPostCancelTransactionTest, ServerError401) {
+  ON_CALL(*mock_ledger_client_, LoadURL(_, _))
+      .WillByDefault(Invoke(
+          [](type::UrlRequestPtr request, client::LoadURLCallback callback) {
+            type::UrlResponse response;
+            response.status_code = net::HTTP_UNAUTHORIZED;
+            response.url = request->url;
+            response.body = "";
+            callback(response);
+          }));
+
+  post_cancel_transaction_->Request(
+      "4c2b665ca060d912fec5c735c734859a06118cc8",
+      "A5721BF3-530C-42AF-8DEE-005DCFF76970", [](const type::Result result) {
+        EXPECT_EQ(result, type::Result::EXPIRED_TOKEN);
+      });
+}
+
+TEST_F(GeminiPostCancelTransactionTest, ServerError403) {
+  ON_CALL(*mock_ledger_client_, LoadURL(_, _))
+      .WillByDefault(Invoke(
+          [](type::UrlRequestPtr request, client::LoadURLCallback callback) {
+            type::UrlResponse response;
+            response.status_code = net::HTTP_FORBIDDEN;
+            response.url = request->url;
+            response.body = "";
+            callback(response);
+          }));
+
+  post_cancel_transaction_->Request(
+      "4c2b665ca060d912fec5c735c734859a06118cc8",
+      "A5721BF3-530C-42AF-8DEE-005DCFF76970", [](const type::Result result) {
+        EXPECT_EQ(result, type::Result::EXPIRED_TOKEN);
+      });
+}
+
+TEST_F(GeminiPostCancelTransactionTest, ServerError404) {
+  ON_CALL(*mock_ledger_client_, LoadURL(_, _))
+      .WillByDefault(Invoke(
+          [](type::UrlRequestPtr request, client::LoadURLCallback callback) {
+            type::UrlResponse response;
+            response.status_code = net::HTTP_BAD_REQUEST;
+            response.url = request->url;
+            response.body = "";
+            callback(response);
+          }));
+
+  post_cancel_transaction_->Request(
+      "4c2b665ca060d912fec5c735c734859a06118cc8",
+      "A5721BF3-530C-42AF-8DEE-005DCFF76970", [](const type::Result result) {
+        EXPECT_EQ(result, type::Result::LEDGER_ERROR);
+      });
+}
+
+TEST_F(GeminiPostCancelTransactionTest, ServerErrorRandom) {
+  ON_CALL(*mock_ledger_client_, LoadURL(_, _))
+      .WillByDefault(Invoke(
+          [](type::UrlRequestPtr request, client::LoadURLCallback callback) {
+            type::UrlResponse response;
+            response.status_code = 418;
+            response.url = request->url;
+            response.body = "";
+            callback(response);
+          }));
+
+  post_cancel_transaction_->Request(
+      "4c2b665ca060d912fec5c735c734859a06118cc8",
+      "A5721BF3-530C-42AF-8DEE-005DCFF76970", [](const type::Result result) {
+        EXPECT_EQ(result, type::Result::LEDGER_ERROR);
+      });
+}
+
+}  // namespace gemini
+}  // namespace endpoint
+}  // namespace ledger

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_transfer.h
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/gemini/gemini_transfer.h
@@ -50,6 +50,9 @@ class GeminiTransfer {
                                    const int attempts,
                                    client::TransactionCallback callback);
 
+  void CancelTransaction(const std::string& id,
+                         client::TransactionCallback callback);
+
   std::map<std::string, base::OneShotTimer> retry_timer_;
   LedgerImpl* ledger_;  // NOT OWNED
   std::unique_ptr<endpoint::GeminiServer> gemini_server_;

--- a/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/ledger.cc
@@ -13,6 +13,7 @@ namespace ledger {
 
 type::Environment _environment = type::Environment::PRODUCTION;
 
+int gemini_retries = 3;
 bool is_debug = false;
 bool is_testing = false;
 int reconcile_interval = 0;  // minutes

--- a/vendor/bat-native-ledger/test/BUILD.gn
+++ b/vendor/bat-native-ledger/test/BUILD.gn
@@ -42,6 +42,7 @@ source_set("bat_native_ledger_tests") {
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/gemini_utils_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_account/post_account_gemini_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_balance/post_balance_gemini_unittest.cc",
+    "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_cancel_transaction/post_cancel_transaction_gemini_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_oauth/post_oauth_gemini_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_recipient_id/post_recipient_id_gemini_unittest.cc",
     "//brave/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/gemini/post_transaction/post_transaction_gemini_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17290

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

#### Cancellation

1. With a clean profile, run brave with the flag `--rewards=gemini-retries=0`
2. Enable verbose logging and rewards
3. Verify with Gemini
4. Navigate to `jumde.github.io` and send a tip 
5. Navigate to `brave://rewards-internals` and verify that the transaction was successfully cancelled.

#### Successful tips and auto-contribute

1. With a clean profile, start brave with the flag `-rewards=reconcile-interval=5`
2. Enable verbose logging and rewards
3. Verify with Gemini
4. Navigate to `jumde.github.io` and send a tip 
5. Tip should be successful
6. Auto-Contribute should be successful after 5 mins