### PR TITLE
Upgrade patches from Chromium 95.0.4638.40 to Chromium 95.0.4638.50 (uplift to 1.32.x)

### DIFF
--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index 3e77ef7c56fa10e090be8cd118de884dc19fb50d..31d8337bfbb3daba3b599592ba0e797ffe316feb 100644
+index 957cfabafa12cda8a6cdef49692d6b282f73e830..4434c6db2a8e15fc2a44c6ecef10b1003685fc9d 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@
  MAJOR=95
 -MINOR=0
 -BUILD=4638
--PATCH=40
+-PATCH=50
 +MINOR=1
 +BUILD=32
 +PATCH=69

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-index 98bec14630479dbe1e483077dc5ff30a8592f6da..a82a50d1e3cda87a72aec56b8fad19599bc3f3dd 100644
+index b9270ac30f09b0c511e27a5de0e6fe71c30eb6ab..ed5e9144235366068b28cb64e27629007bd53b23 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
-@@ -2363,6 +2363,7 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+@@ -2362,6 +2362,7 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
      }
  
      private void hideOverview() {

--- a/patches/chrome-browser-BUILD.gn.patch
+++ b/patches/chrome-browser-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
-index 320526795a733a55661dc8ab947840485097c8b2..a3c4bc5e378621d4f8dcfe74755a02fb704c7c34 100644
+index 442c7056f978e4d90fbb68e7c1fc6c3b01885d18..19ff147a72d258f7869ad5099eb849cfa967d050 100644
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
 @@ -2512,6 +2512,7 @@ static_library("browser") {

--- a/patches/chrome-browser-about_flags.cc.patch
+++ b/patches/chrome-browser-about_flags.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
-index f61143aeadd60212228f89cb84e9fbba75abf131..27723a8dd07340da3432e1cbd454f5120f3a6a63 100644
+index 0b850b717a0d9dc0fcae319de533d34917e51742..b20cbf041314d563920855051c92f57852975340 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
 @@ -320,14 +320,14 @@ const FeatureEntry::Choice kTouchTextSelectionStrategyChoices[] = {
@@ -21,7 +21,7 @@ index f61143aeadd60212228f89cb84e9fbba75abf131..27723a8dd07340da3432e1cbd454f512
  
  const FeatureEntry::Choice kLiteVideoDefaultDownlinkBandwidthKbps[] = {
      {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -7745,6 +7745,7 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -7779,6 +7779,7 @@ const FeatureEntry kFeatureEntries[] = {
      // "LoginCustomFlags" in tools/metrics/histograms/enums.xml. See "Flag
      // Histograms" in tools/metrics/histograms/README.md (run the
      // AboutFlagsHistogramTest unit test to verify this process).

--- a/patches/chrome-browser-extensions-extension_management.cc.patch
+++ b/patches/chrome-browser-extensions-extension_management.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/extensions/extension_management.cc b/chrome/browser/extensions/extension_management.cc
-index 698932e7d0285c4c3e2152cea0342231491318f0..69ad625b6ce0046ba78e3c6aae160e63000406e6 100644
+index 68eaecd7829455ff37285c852f6adbfe4a68b6b4..2f5a1525845cfe76d32c634b553e1488fb9c5e26 100644
 --- a/chrome/browser/extensions/extension_management.cc
 +++ b/chrome/browser/extensions/extension_management.cc
-@@ -729,6 +729,7 @@ KeyedService* ExtensionManagementFactory::BuildServiceInstanceFor(
+@@ -731,6 +731,7 @@ KeyedService* ExtensionManagementFactory::BuildServiceInstanceFor(
      content::BrowserContext* context) const {
    TRACE_EVENT0("browser,startup",
                 "ExtensionManagementFactory::BuildServiceInstanceFor");

--- a/patches/chrome-browser-renderer_context_menu-render_view_context_menu.cc.patch
+++ b/patches/chrome-browser-renderer_context_menu-render_view_context_menu.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/renderer_context_menu/render_view_context_menu.cc b/chrome/browser/renderer_context_menu/render_view_context_menu.cc
-index af6d0b7d98ef4eb86d224488fbce9f691d856407..f01d75254f33b0b18685f1fd8697a79d5165a21b 100644
+index dc7dbd4b527bb58ae3963b0ab1da7e4bebe138f2..8089e8552ff8971d539025811cf680ce04d77209 100644
 --- a/chrome/browser/renderer_context_menu/render_view_context_menu.cc
 +++ b/chrome/browser/renderer_context_menu/render_view_context_menu.cc
-@@ -1830,6 +1830,7 @@ void RenderViewContextMenu::AppendSearchProvider() {
+@@ -1832,6 +1832,7 @@ void RenderViewContextMenu::AppendSearchProvider() {
    selection_navigation_url_ = match.destination_url;
    if (!selection_navigation_url_.is_valid())
      return;

--- a/patches/chrome-browser-renderer_context_menu-render_view_context_menu.h.patch
+++ b/patches/chrome-browser-renderer_context_menu-render_view_context_menu.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/renderer_context_menu/render_view_context_menu.h b/chrome/browser/renderer_context_menu/render_view_context_menu.h
-index 66ae6176ca84d2c158f3ec33378c0be7c4250272..1cc9b4d9004feb2c0c2817655dd9af153240bbfb 100644
+index 526f116a0578b50fa11b20c35a5366bec555cd69..47e04f5fee4f0a460ca857f190731dc49d1f895e 100644
 --- a/chrome/browser/renderer_context_menu/render_view_context_menu.h
 +++ b/chrome/browser/renderer_context_menu/render_view_context_menu.h
 @@ -135,6 +135,7 @@ class RenderViewContextMenu : public RenderViewContextMenuBase,

--- a/patches/chrome-renderer-BUILD.gn.patch
+++ b/patches/chrome-renderer-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/renderer/BUILD.gn b/chrome/renderer/BUILD.gn
-index fdbff76b662271e74622cb57fb90874e7e4eba2c..9b22912ed5f340c570d03a3be258c84575254945 100644
+index f8ad4b2fe2646099c71f6dcc3e6b6290dccdf1e9..309004af2534667b26ff3525623eb075c8be0df6 100644
 --- a/chrome/renderer/BUILD.gn
 +++ b/chrome/renderer/BUILD.gn
 @@ -237,6 +237,7 @@ static_library("renderer") {

--- a/patches/chrome-test-BUILD.gn.patch
+++ b/patches/chrome-test-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/test/BUILD.gn b/chrome/test/BUILD.gn
-index 742ec3a2efc27e4a2178c77076ab70b1603b159d..7f129ab4fab44a8b8857894319c41209be33293f 100644
+index 4272be9aa715cb26561e0a118cbe233a926dafd7..ec840340f7ed3f8177c18d8a0c1ae59215d22999 100644
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
 @@ -336,6 +336,7 @@ static_library("test_support") {

--- a/patches/components-omnibox-browser-BUILD.gn.patch
+++ b/patches/components-omnibox-browser-BUILD.gn.patch
@@ -1,8 +1,8 @@
 diff --git a/components/omnibox/browser/BUILD.gn b/components/omnibox/browser/BUILD.gn
-index b918e88a9da14443c14256e39f19d44f46f64500..0d1c83681d8b0f791ebcce1da7d18a8873b1ca3c 100644
+index 96bfa3874bcb35b7eec1d0d373190937ea2f695c..e9b7bc2be7604d2b1b6ca1f8bcd302fc9b94fd70 100644
 --- a/components/omnibox/browser/BUILD.gn
 +++ b/components/omnibox/browser/BUILD.gn
-@@ -274,6 +274,7 @@ static_library("browser") {
+@@ -282,6 +282,7 @@ static_library("browser") {
      "//ui/base",
      "//ui/gfx",
    ]

--- a/patches/components-password_manager-core-browser-login_database.cc.patch
+++ b/patches/components-password_manager-core-browser-login_database.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/components/password_manager/core/browser/login_database.cc b/components/password_manager/core/browser/login_database.cc
-index bc3cbba2d16e39dfbd6e9b8c3b7753dd966d4d15..c624ecd49e0301ebae5ed0d6541f5f9ddcb148f0 100644
+index ed1c22ee6b9445950c7e916024e215bcafeb8355..76d66443de294d143650a29ec11553cd9262fbfa 100644
 --- a/components/password_manager/core/browser/login_database.cc
 +++ b/components/password_manager/core/browser/login_database.cc
-@@ -1757,6 +1757,7 @@ FormRetrievalResult LoginDatabase::StatementToForms(
+@@ -1769,6 +1769,7 @@ FormRetrievalResult LoginDatabase::StatementToForms(
      EncryptionResult result = InitPasswordFormFromStatement(
          *statement, /*decrypt_and_fill_password_value=*/true, &primary_key,
          new_form.get());


### PR DESCRIPTION
Manual uplift of https://github.com/brave/brave-core/pull/10507
Fixes https://github.com/brave/brave-browser/issues/18751
Related PR: https://github.com/brave/brave-browser/pull/18760
