### PR TITLE
Add check for empty ads segments (uplift to 1.32.x)

### DIFF
--- a/vendor/bat-native-ads/data/test/ml/pipeline/text_processing/empty_segment_classification.json
+++ b/vendor/bat-native-ads/data/test/ml/pipeline/text_processing/empty_segment_classification.json
@@ -1,0 +1,38 @@
+{
+    "version": 1,
+    "timestamp": "2019-03-13 17:33:31.708151",
+    "locale": "en",
+    "transformations": [
+      {
+        "transformation_type": "TO_LOWER"
+      },
+      {
+        "transformation_type": "HASHED_NGRAMS",
+        "params": {
+          "ngrams_range": [
+            1
+          ],
+          "num_buckets": 500
+        }
+      }
+    ],
+    "classifier": {
+      "classifier_type": "LINEAR",
+      "classes": [
+        "ham",
+        ""
+      ],
+      "class_weights": {
+        "ham": [
+          -6.0868
+        ],
+        "": [
+          2.45563
+        ]
+      },
+      "biases": [
+        -0.9163,
+        -1.6094
+      ]
+    }
+  }

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/data_types/behavioral/bandits/epsilon_greedy_bandit_arms.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/data_types/behavioral/bandits/epsilon_greedy_bandit_arms.cc
@@ -12,6 +12,7 @@
 #include "base/json/json_writer.h"
 #include "base/notreached.h"
 #include "base/values.h"
+#include "bat/ads/internal/logging.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace ads {
@@ -39,7 +40,7 @@ bool GetArmFromDictionary(const base::DictionaryValue* dictionary,
   EpsilonGreedyBanditArmInfo arm;
 
   const std::string* segment = dictionary->FindStringKey(kSegmentKey);
-  if (!segment) {
+  if (!segment || segment->empty()) {
     return false;
   }
   arm.segment = *segment;
@@ -62,26 +63,36 @@ EpsilonGreedyBanditArmMap GetArmsFromDictionary(
     return arms;
   }
 
+  bool found_errors = false;
   for (const auto value : dictionary->DictItems()) {
+    if (value.first.empty()) {
+      found_errors = true;
+      continue;
+    }
+
     if (!value.second.is_dict()) {
-      NOTREACHED();
+      found_errors = true;
       continue;
     }
 
     const base::DictionaryValue* arm_dictionary = nullptr;
     value.second.GetAsDictionary(&arm_dictionary);
     if (!arm_dictionary) {
-      NOTREACHED();
+      found_errors = true;
       continue;
     }
 
     EpsilonGreedyBanditArmInfo arm;
     if (!GetArmFromDictionary(arm_dictionary, &arm)) {
-      NOTREACHED();
+      found_errors = true;
       continue;
     }
 
     arms[value.first] = arm;
+  }
+
+  if (found_errors) {
+    BLOG(0, "Errors detected when parsing epsilon greedy bandit arms");
   }
 
   return arms;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/processors/behavioral/bandits/epsilon_greedy_bandit_processor_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ad_targeting/processors/behavioral/bandits/epsilon_greedy_bandit_processor_unittest.cc
@@ -15,6 +15,17 @@
 
 // npm run test -- brave_unit_tests --filter=BatAds*
 
+namespace {
+
+constexpr char kArmsWithEmptySegmentJson[] = R"(
+  {
+    "travel":{"pulls":0,"segment":"travel","value":1.0},
+    "":{"pulls":0,"segment":"","value":1.0}
+  }
+)";
+
+}  // namespace
+
 namespace ads {
 namespace ad_targeting {
 
@@ -185,6 +196,20 @@ TEST_F(BatAdsEpsilonGreedyBanditProcessorTest, ProcessChildSegment) {
   expected_arm.pulls = 1;
 
   EXPECT_EQ(expected_arm, arm);
+}
+
+TEST_F(BatAdsEpsilonGreedyBanditProcessorTest,
+       InitializeArmsFromResourceWithEmptySegments) {
+  // Arrange
+
+  // Act
+  const EpsilonGreedyBanditArmMap arms =
+      EpsilonGreedyBanditArms::FromJson(kArmsWithEmptySegmentJson);
+
+  // Assert
+  // Empty segments are skipped.
+  EXPECT_EQ(1U, arms.size());
+  EXPECT_EQ(1U, arms.count("travel"));
 }
 
 }  // namespace ad_targeting

--- a/vendor/bat-native-ads/src/bat/ads/internal/ml/pipeline/pipeline_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ml/pipeline/pipeline_util.cc
@@ -120,11 +120,16 @@ absl::optional<model::Linear> ParsePipelineClassifier(
 
   std::vector<std::string> classes;
   for (const base::Value& class_name : specified_classes->GetList()) {
-    if (class_name.is_string()) {
-      classes.push_back(class_name.GetString());
-    } else {
+    if (!class_name.is_string()) {
       return absl::nullopt;
     }
+
+    const std::string class_string = class_name.GetString();
+    if (class_string.empty()) {
+      return absl::nullopt;
+    }
+
+    classes.push_back(class_string);
   }
 
   base::Value* class_weights = classifier_value->FindDictKey("class_weights");

--- a/vendor/bat-native-ads/src/bat/ads/internal/ml/pipeline/text_processing/text_processing.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ml/pipeline/text_processing/text_processing.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 #include "base/check.h"
+#include "bat/ads/internal/logging.h"
 #include "bat/ads/internal/ml/data/text_data.h"
 #include "bat/ads/internal/ml/data/vector_data.h"
 #include "bat/ads/internal/ml/ml_transformation_util.h"
@@ -67,6 +68,7 @@ bool TextProcessing::FromJson(const std::string& json) {
     is_initialized_ = true;
   } else {
     is_initialized_ = false;
+    BLOG(0, "Failed to parse text classification pipeline JSON");
   }
 
   return is_initialized_;

--- a/vendor/bat-native-ads/src/bat/ads/internal/ml/pipeline/text_processing/text_processing_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ml/pipeline/text_processing/text_processing_unittest.cc
@@ -30,6 +30,9 @@ namespace {
 const char kValidSegmentClassificationPipeline[] =
     "ml/pipeline/text_processing/valid_segment_classification_min.json";
 
+const char kEmptySegmentClassificationPipeline[] =
+    "ml/pipeline/text_processing/empty_segment_classification.json";
+
 const char kInvalidSpamClassificationPipeline[] =
     "ml/pipeline/text_processing/invalid_spam_classification.json";
 
@@ -152,6 +155,21 @@ TEST_F(BatAdsTextProcessingPipelineTest, InvalidModelTest) {
   ASSERT_TRUE(json_optional.has_value());
   const std::string json = json_optional.value();
   bool loaded_successfully = text_processing_pipeline.FromJson(json);
+
+  // Assert
+  EXPECT_FALSE(loaded_successfully);
+}
+
+TEST_F(BatAdsTextProcessingPipelineTest, EmptySegmentModelTest) {
+  // Arrange
+  pipeline::TextProcessing text_processing_pipeline;
+  const absl::optional<std::string> json_optional =
+      ReadFileFromTestPathToString(kEmptySegmentClassificationPipeline);
+
+  // Act
+  ASSERT_TRUE(json_optional.has_value());
+  const std::string json = json_optional.value();
+  const bool loaded_successfully = text_processing_pipeline.FromJson(json);
 
   // Assert
   EXPECT_FALSE(loaded_successfully);

--- a/vendor/bat-native-ads/src/bat/ads/internal/resources/behavioral/purchase_intent/purchase_intent_resource.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/resources/behavioral/purchase_intent/purchase_intent_resource.cc
@@ -101,8 +101,13 @@ bool PurchaseIntent::FromJson(const std::string& json) {
   }
 
   std::vector<std::string> segments;
-  for (auto& segment : list3->GetList()) {
-    segments.push_back(segment.GetString());
+  for (const auto& segment_value : list3->GetList()) {
+    const std::string segment = segment_value.GetString();
+    if (segment.empty()) {
+      BLOG(1, "Failed to load from JSON, empty segment found");
+      return false;
+    }
+    segments.push_back(segment);
   }
 
   // Parsing field: "segment_keywords"
@@ -129,6 +134,10 @@ bool PurchaseIntent::FromJson(const std::string& json) {
     ad_targeting::PurchaseIntentSegmentKeywordInfo info;
     info.keywords = it.key();
     for (const auto& segment_ix : it.value().GetList()) {
+      if (static_cast<size_t>(segment_ix.GetInt()) >= segments.size()) {
+        BLOG(1, "Failed to load from JSON, segment keywords are ill-formed");
+        return false;
+      }
       info.segments.push_back(segments.at(segment_ix.GetInt()));
     }
 


### PR DESCRIPTION
Uplift of #10200
Resolves https://github.com/brave/brave-browser/issues/17865

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.