### PR TITLE
Allow Backing Up 24 word Seed Phrases

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
@@ -37,6 +37,10 @@ function OnboardingVerify (props: Props) {
     unSelectWord(word)
   }
 
+  const isDisabled = React.useMemo((): boolean => {
+    return sortedPhrase.length !== recoveryPhrase.length
+  }, [sortedPhrase, recoveryPhrase])
+
   return (
     <StyledWrapper>
       <Title>{getLocale('braveWalletVerifyRecoveryTitle')}</Title>
@@ -68,7 +72,7 @@ function OnboardingVerify (props: Props) {
           </RecoveryBubble>
         )}
       </RecoveryPhraseContainer>
-      <NavButton disabled={sortedPhrase.length !== 12} buttonType='primary' text={getLocale('braveWalletButtonVerify')} onSubmit={onSubmit} />
+      <NavButton disabled={isDisabled} buttonType='primary' text={getLocale('braveWalletButtonVerify')} onSubmit={onSubmit} />
     </StyledWrapper>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
@@ -45,7 +45,7 @@ export const SelectedPhraseContainer = styled.div<Partial<StyleProps>>`
   justify-content: ${(p) => p.error ? 'center' : 'flex-start'};
   flex-direction: row;
   flex-wrap: wrap;
-  width: 418px;
+  width: 466px;
   min-height: 112px;
   margin-bottom: 40px;
   border: ${(p) => `1px solid ${p.theme.color.divider01}`};
@@ -99,7 +99,7 @@ export const SelectedBubble = styled.button`
   justify-content: center;
   flex-direction: column;
   background-color: ${(p) => p.theme.color.background01};
-  width: 94px;
+  width: 106px;
   margin-right: 8px;
   margin-bottom: 8px;
   border: ${(p) => `1px solid ${p.theme.color.divider01}`};


### PR DESCRIPTION
## Description 
Allow Backing Up / Verifying 24 word Seed Phrases

1) Added a `isDisabled` method that will return false if `sortedPhrase` length is the same as the `recoveryPhrase` length,
this will now allow verifying for both `12` and `24` word phrases,
2) Adjusted the sizing of the `sorted` box to prevent wrapping for long words.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/18832>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A


Before:

https://user-images.githubusercontent.com/40611140/137770593-dcfedafe-eab6-4481-a4a8-fc676867f982.mov

After:

https://user-images.githubusercontent.com/40611140/137770539-d5486019-6b85-42b1-bd1f-f0701b30097e.mov
