### PR TITLE
Detect if Brave ads native notifications are enabled before serving ads

### DIFF
--- a/browser/brave_ads/notification_helper/notification_helper_impl_mac.mm
+++ b/browser/brave_ads/notification_helper/notification_helper_impl_mac.mm
@@ -6,11 +6,7 @@
 #include "brave/browser/brave_ads/notification_helper/notification_helper_impl_mac.h"
 
 #import <Cocoa/Cocoa.h>
-
-// TODO(https://github.com/brave/brave-browser/issues/5541): Uncomment below
-// code when notification_platform_bridge_mac.mm has been updated to use
-// UNUserNotificationCenter
-// #import <UserNotifications/UserNotifications.h>
+#import <UserNotifications/UserNotifications.h>
 
 #include "base/feature_list.h"
 #include "base/logging.h"
@@ -22,125 +18,116 @@ namespace brave_ads {
 namespace {
 
 bool IsAuthorized() {
-  // TODO(https://github.com/brave/brave-browser/issues/5541): Uncomment below
-  // code when notification_platform_bridge_mac.mm has been updated to use
-  // UNUserNotificationCenter
-  return true;
-
   // #if !defined(OFFICIAL_BUILD)
-  //   VLOG(1) << "Unable to detect the status of native notifications on non"
-  //       " official builds as the app is not code signed";
+  //   LOG(ERROR) << "Unable to detect the status of native notifications on non
+  //   "
+  //              "official builds as the app is not code signed";
   //   return true;
   // #else
-  //   // TODO(https://openradar.appspot.com/27768556): We must mock this
-  //   function
-  //   // using NotificationHelperImplMock as a workaround to
-  //   UNUserNotificationCenter
-  //   // throwing an exception during tests
+  // TODO(https://openradar.appspot.com/27768556): We must mock this function
+  // using NotificationHelperMock as a workaround to UNUserNotificationCenter
+  // throwing an exception during tests
 
-  //   if (@available(macOS 10.14, *)) {
-  //     __block bool is_authorized = false;
+  if (@available(macOS 10.14, *)) {
+    __block bool is_authorized = false;
 
-  //     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-  //     UNUserNotificationCenter *notificationCenter =
-  //         [UNUserNotificationCenter currentNotificationCenter];
+    UNUserNotificationCenter* notification_center =
+        [UNUserNotificationCenter currentNotificationCenter];
 
-  //     [notificationCenter
-  //     requestAuthorizationWithOptions:UNAuthorizationOptionAlert
-  //         completionHandler:^(BOOL granted, NSError * _Nullable error) {
-  //       if (granted) {
-  //         VLOG(1) << "User granted authorization to show notifications";
-  //       } else {
-  //         VLOG(1) << "User denied authorization to show notifications";
-  //       }
+    [notification_center
+        requestAuthorizationWithOptions:UNAuthorizationOptionAlert |
+                                        UNAuthorizationOptionBadge |
+                                        UNAuthorizationOptionSound
+                      completionHandler:^(BOOL granted,
+                                          NSError* _Nullable error) {
+                        if (granted) {
+                          LOG(ERROR) << "User granted authorization to show "
+                                        "notifications";
+                        } else {
+                          LOG(ERROR) << "User denied authorization to show "
+                                        "notifications";
+                        }
 
-  //       is_authorized = granted;
+                        is_authorized = granted;
 
-  //       dispatch_semaphore_signal(semaphore);
-  //     }];
+                        dispatch_semaphore_signal(semaphore);
+                      }];
 
-  //     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-  //     dispatch_release(semaphore);
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    dispatch_release(semaphore);
 
-  //     if (!is_authorized) {
-  //       VLOG(1) << "User is not authorized to show notifications";
-  //     }
+    return is_authorized;
+  }
 
-  //     return is_authorized;
-  //   }
-
-  //   return true;
+  return true;
   // #endif
 }
 
 bool IsEnabled() {
-  // TODO(https://github.com/brave/brave-browser/issues/5541): Uncomment below
-  // code when notification_platform_bridge_mac.mm has been updated to use
-  // UNUserNotificationCenter
-  return true;
-
   // #if !defined(OFFICIAL_BUILD)
-  //   VLOG(1) << "Unable to detect the status of native notifications on non"
-  //       " official builds as the app is not code signed";
+  //   LOG(ERROR) << "Unable to detect the status of native notifications on non
+  //   "
+  //              "official builds as the app is not code signed";
   //   return true;
   // #else
-  //   // TODO(https://openradar.appspot.com/27768556): We must mock this
-  //   function
-  //   // using NotificationHelperImplMock as a workaround to
-  //   UNUserNotificationCenter
-  //   // throwing an exception during tests
+  // TODO(https://openradar.appspot.com/27768556): We must mock this function
+  // using NotificationHelperMock as a workaround to UNUserNotificationCenter
+  // throwing an exception during tests
 
-  //   if (@available(macOS 10.14, *)) {
-  //     __block bool is_authorized = false;
+  if (@available(macOS 10.14, *)) {
+    __block bool is_authorized = false;
 
-  //     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-  //     UNUserNotificationCenter *notificationCenter =
-  //         [UNUserNotificationCenter currentNotificationCenter];
+    UNUserNotificationCenter* notification_center =
+        [UNUserNotificationCenter currentNotificationCenter];
 
-  //     [notificationCenter getNotificationSettingsWithCompletionHandler:
-  //         ^(UNNotificationSettings * _Nonnull settings) {
-  //       switch (settings.authorizationStatus) {
-  //         case UNAuthorizationStatusDenied: {
-  //           VLOG(1) << "Notification authorization status denied";
-  //           is_authorized = false;
-  //           break;
-  //         }
+    [notification_center getNotificationSettingsWithCompletionHandler:^(
+                             UNNotificationSettings* _Nonnull settings) {
+      switch (settings.authorizationStatus) {
+        case UNAuthorizationStatusDenied: {
+          LOG(ERROR) << "Notification authorization status denied";
+          is_authorized = false;
+          break;
+        }
 
-  //         case UNAuthorizationStatusNotDetermined: {
-  //           VLOG(1) << "Notification authorization status not determined";
-  //           is_authorized = true;
-  //           break;
-  //         }
+        case UNAuthorizationStatusNotDetermined: {
+          LOG(ERROR) << "Notification authorization status not determined";
+          is_authorized = true;
+          break;
+        }
 
-  //         case UNAuthorizationStatusAuthorized: {
-  //           VLOG(1) << "Notification authorization status authorized";
-  //           is_authorized = true;
-  //           break;
-  //         }
+        case UNAuthorizationStatusAuthorized: {
+          LOG(ERROR) << "Notification authorization status authorized";
+          is_authorized = true;
+          break;
+        }
 
-  //         case UNAuthorizationStatusProvisional: {
-  //           VLOG(1) << "Notification authorization status provisional";
-  //           is_authorized = true;
-  //           break;
-  //         }
-  //       }
+        case UNAuthorizationStatusProvisional: {
+          LOG(ERROR) << "Notification authorization status provisional";
+          is_authorized = true;
+          break;
+        }
 
-  //       dispatch_semaphore_signal(semaphore);
-  //     }];
+        default: {
+          LOG(ERROR) << "Notification authorization status unknown";
+          is_authorized = true;
+          break;
+        }
+      }
 
-  //     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-  //     dispatch_release(semaphore);
+      dispatch_semaphore_signal(semaphore);
+    }];
 
-  //     if (!is_authorized) {
-  //       VLOG(1) << "Notifications not authorized";
-  //     }
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    dispatch_release(semaphore);
 
-  //     return is_authorized;
-  //   }
+    return is_authorized;
+  }
 
-  //   return true;
+  return true;
   // #endif
 }
 
@@ -151,21 +138,25 @@ NotificationHelperImplMac::NotificationHelperImplMac() = default;
 NotificationHelperImplMac::~NotificationHelperImplMac() = default;
 
 bool NotificationHelperImplMac::CanShowNotifications() {
+  LOG(ERROR) << "FOOBAR: TEST";
+
   if (!base::FeatureList::IsEnabled(::features::kNativeNotifications)) {
-    VLOG(1) << "Native notifications feature is disabled";
+    LOG(ERROR) << "Native notifications feature is disabled";
     return false;
   }
 
   if (base::mac::IsAtMostOS10_13()) {
-    VLOG(1) << "Native notifications are not supported prior to macOS 10.14";
-    return false;
-  }
-
-  if (!IsAuthorized()) {
+    LOG(ERROR) << "Native notifications are not supported prior to macOS 10.14";
     return false;
   }
 
   if (!IsEnabled()) {
+    LOG(ERROR) << "Native notifications are not enabled";
+    return false;
+  }
+
+  if (!IsAuthorized()) {
+    LOG(ERROR) << "Native notifications are not authorized";
     return false;
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18799

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm ads are not served and users are not rewarded if native notifications are disabled on macOS