### PR TITLE
Fix #18835 - Suppress RUSTSEC-2020-0071 and RUSTSEC-2020-0159 advisories (uplift to 1.32.x)

### DIFF
--- a/script/audit_deps.py
+++ b/script/audit_deps.py
@@ -22,6 +22,16 @@ NPM_EXCLUDE_PATHS = [
     os.path.join('vendor', 'brave-extension', 'node_modules'),
 ]
 
+# Tag @sec-team before adding any advisory to this list
+# Ignore these rust advisories
+IGNORED_CARGO_ADVISORIES = [
+# Remove when:
+# https://github.com/chronotope/chrono/issues/602 is resolved
+# Tracking issue: https://github.com/brave/brave-browser/issues/18838
+    'RUSTSEC-2020-0071',
+    'RUSTSEC-2020-0159'
+]
+
 # Use only these (sub)paths for cargo audit.
 CARGO_INCLUDE_PATHS = [
     os.path.join('build', 'rust'),
@@ -151,6 +161,9 @@ def cargo_audit_deps(path, args):
     cargo_args.append("audit")
     cargo_args.append("--file")
     cargo_args.append(os.path.join(path, "Cargo.lock"))
+    for advisory in IGNORED_CARGO_ADVISORIES:
+        cargo_args.append("--ignore")
+        cargo_args.append(advisory)
 
     return subprocess.call(cargo_args, env=env)
 


### PR DESCRIPTION
Uplift of #10573
Resolves https://github.com/brave/brave-browser/issues/18835

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.