### PR TITLE
Don't resize tooltip popup after moving it

### DIFF
--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -174,7 +174,7 @@ void BraveTooltipPopup::OnWorkAreaChanged() {
 void BraveTooltipPopup::OnPaintBackground(gfx::Canvas* canvas) {
   DCHECK(canvas);
 
-  gfx::RectF bounds(GetWidget()->GetLayer()->bounds());
+  gfx::Rect bounds(GetWidget()->GetLayer()->bounds());
   bounds.Inset(-GetShadowMargin());
 
   const bool should_use_dark_colors = GetNativeTheme()->ShouldUseDarkColors();
@@ -224,6 +224,12 @@ void BraveTooltipPopup::OnWidgetDestroyed(views::Widget* widget) {
   if (delegate) {
     delegate->OnTooltipWidgetDestroyed(tooltip_->id());
   }
+}
+
+void BraveTooltipPopup::OnWidgetBoundsChanged(views::Widget* widget,
+                                              const gfx::Rect& new_bounds) {
+  DCHECK(widget);
+  widget_origin_ = new_bounds.origin();
 }
 
 void BraveTooltipPopup::AnimationEnded(const gfx::Animation* animation) {
@@ -309,12 +315,13 @@ gfx::Point BraveTooltipPopup::GetDefaultOriginForSize(const gfx::Size& size) {
   return bounds.origin();
 }
 
-gfx::Rect BraveTooltipPopup::CalculateBounds() {
+gfx::Rect BraveTooltipPopup::CalculateBounds(bool use_default_origin) {
   DCHECK(tooltip_view_);
   gfx::Size size = tooltip_view_->size();
   DCHECK(!size.IsEmpty());
 
-  const gfx::Point origin = GetDefaultOriginForSize(size);
+  const gfx::Point origin =
+      use_default_origin ? GetDefaultOriginForSize(size) : widget_origin_;
   return gfx::Rect(origin, size);
 }
 
@@ -352,7 +359,7 @@ void BraveTooltipPopup::CreateWidgetView() {
   params.z_order = ui::ZOrderLevel::kFloatingWindow;
   params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
   params.shadow_type = views::Widget::InitParams::ShadowType::kNone;
-  params.bounds = CalculateBounds();
+  params.bounds = CalculateBounds(true);
 
   views::Widget* widget = new views::Widget();
   widget->set_focus_on_creation(false);

--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.h
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.h
@@ -84,6 +84,8 @@ class BraveTooltipPopup : public views::WidgetDelegateView,
   // User pressed the Cancel button
   void OnCancelButtonPressed();
 
+  gfx::Rect CalculateBounds(bool use_default_origin);
+
   void set_normalized_display_coordinates(double x, double y);
 
   void set_display_work_area_insets(int x, int y);
@@ -111,6 +113,8 @@ class BraveTooltipPopup : public views::WidgetDelegateView,
   // views::WidgetObserver:
   void OnWidgetCreated(views::Widget* widget) override;
   void OnWidgetDestroyed(views::Widget* widget) override;
+  void OnWidgetBoundsChanged(views::Widget* widget,
+                             const gfx::Rect& new_bounds) override;
 
   // AnimationDelegate:
   void AnimationEnded(const gfx::Animation* animation) override;
@@ -121,8 +125,6 @@ class BraveTooltipPopup : public views::WidgetDelegateView,
   void CreatePopup();
 
   gfx::Point GetDefaultOriginForSize(const gfx::Size& size);
-
-  gfx::Rect CalculateBounds();
 
   void RecomputeAlignment();
 
@@ -145,6 +147,8 @@ class BraveTooltipPopup : public views::WidgetDelegateView,
   std::unique_ptr<BraveTooltip> tooltip_;
 
   BraveTooltipView* tooltip_view_ = nullptr;  // NOT OWNED
+
+  gfx::Point widget_origin_ = {0, 0};
 
   double normalized_display_coordinate_x_ = 1.0;
   double normalized_display_coordinate_y_ = 0.0;

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
@@ -126,8 +126,7 @@ bool BraveTooltipView::OnMouseDragged(const ui::MouseEvent& event) {
     return false;
   }
 
-  gfx::Rect bounds =
-      GetWidget()->GetContentsView()->GetBoundsInScreen() + movement;
+  gfx::Rect bounds = tooltip_popup_->CalculateBounds(false) + movement;
   const gfx::NativeView native_view = GetWidget()->GetNativeView();
   AdjustBoundsToFitWorkAreaForNativeView(&bounds, native_view);
   GetWidget()->SetBounds(bounds);
@@ -146,6 +145,13 @@ void BraveTooltipView::OnMouseReleased(const ui::MouseEvent& event) {
   }
 
   View::OnMouseReleased(event);
+}
+
+void BraveTooltipView::OnDeviceScaleFactorChanged(
+    float old_device_scale_factor,
+    float new_device_scale_factor) {
+  GetWidget()->DeviceScaleFactorChanged(old_device_scale_factor,
+                                        new_device_scale_factor);
 }
 
 void BraveTooltipView::OnThemeChanged() {

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.h
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.h
@@ -48,6 +48,8 @@ class BraveTooltipView : public views::View {
   bool OnMousePressed(const ui::MouseEvent& event) override;
   bool OnMouseDragged(const ui::MouseEvent& event) override;
   void OnMouseReleased(const ui::MouseEvent& event) override;
+  void OnDeviceScaleFactorChanged(float old_device_scale_factor,
+                                  float new_device_scale_factor) override;
   void OnThemeChanged() override;
 
  private:


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18891

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Schedule an adaptive captcha
- Wait for tooltip to appear on Windows
- Drag tooltip window and ensure it doesn't resize
- Open display settings and change your display's scale factor (e.g., make it 150%)
- Drag tooltip window and ensure it doesn't resize
- Don't forget to reset your scale factor :-)