### PR TITLE
Don't return allowed accounts when keyring is locked (uplift to 1.32.x)

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -171,15 +171,17 @@ void BraveWalletProviderDelegateImpl::ContinueGetAllowedAccounts(
          const absl::optional<std::string>& selected_account,
          brave_wallet::mojom::KeyringInfoPtr keyring_info) {
         std::vector<std::string> addresses;
-        for (const auto& account_info : keyring_info->account_infos) {
-          // If one of the selected accounts is an allowed account, then make
-          // the selected account the first item that is returned.
-          if (selected_account &&
-              base::CompareCaseInsensitiveASCII(account_info->address,
-                                                *selected_account) == 0) {
-            addresses.insert(addresses.begin(), account_info->address);
-          } else {
-            addresses.push_back(account_info->address);
+        if (!keyring_info->is_locked) {
+          for (const auto& account_info : keyring_info->account_infos) {
+            // If one of the selected accounts is an allowed account, then make
+            // the selected account the first item that is returned.
+            if (selected_account &&
+                base::CompareCaseInsensitiveASCII(account_info->address,
+                                                  *selected_account) == 0) {
+              addresses.insert(addresses.begin(), account_info->address);
+            } else {
+              addresses.push_back(account_info->address);
+            }
           }
         }
         permissions::BraveEthereumPermissionContext::GetAllowedAccounts(

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -479,6 +479,14 @@ void BraveWalletProviderImpl::SelectedAccountChanged() {
   UpdateKnownAccounts();
 }
 
+void BraveWalletProviderImpl::Locked() {
+  UpdateKnownAccounts();
+}
+
+void BraveWalletProviderImpl::Unlocked() {
+  UpdateKnownAccounts();
+}
+
 void BraveWalletProviderImpl::OnContentSettingChanged(
     const ContentSettingsPattern& primary_pattern,
     const ContentSettingsPattern& secondary_pattern,

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -146,8 +146,8 @@ class BraveWalletProviderImpl final
   // KeyringControllerObserver
   void KeyringCreated() override {}
   void KeyringRestored() override {}
-  void Locked() override {}
-  void Unlocked() override {}
+  void Locked() override;
+  void Unlocked() override;
   void BackedUp() override {}
   void AccountsChanged() override {}
   void AutoLockMinutesChanged() override {}


### PR DESCRIPTION
Uplift of #10615
Resolves https://github.com/brave/brave-browser/issues/18889

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.