### PR TITLE
Uplift #10633 to 1.31.x (Fix a crash when clicking a promoted item in Brave News)

### DIFF
--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -659,7 +659,7 @@ void BraveNewTabMessageHandler::HandleTodayOnCardVisit(
   }
   std::string item_id = args[1].GetString();
   std::string creative_instance_id = args[2].GetString();
-  bool is_promoted = args[0].GetList()[3].GetBool();
+  bool is_promoted = (args[3].is_bool() && args[3].GetBool());
   if (is_promoted && !item_id.empty() && !creative_instance_id.empty()) {
     auto* ads_service_ = brave_ads::AdsServiceFactory::GetForProfile(profile_);
     ads_service_->OnPromotedContentAdEvent(


### PR DESCRIPTION
Uplifts fix for brave/brave-browser#18898