### PR TITLE
Added Placeholder Icons for Tokens in Wallet

### DIFF
--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { AccountAssetOptionType } from '../../../constants/types'
+import { withPlaceholderIcon } from '../../shared'
 // Styled Components
 import {
   StyledWrapper,
@@ -17,9 +18,13 @@ export interface Props {
 function SelectAssetItem (props: Props) {
   const { asset, onSelectAsset } = props
 
+  const AssetIconWithPlaceholder = React.useMemo(() => {
+    return withPlaceholderIcon(AssetIcon, { size: 'small', marginLeft: 0, marginRight: 8 })
+  }, [])
+
   return (
     <StyledWrapper onClick={onSelectAsset}>
-      <AssetIcon icon={asset.asset.logo} />
+      <AssetIconWithPlaceholder selectedAsset={asset.asset} />
       <AssetAndBalance>
         <AssetName>{asset.asset.name}</AssetName>
         <AssetBalance>{asset.asset.symbol}</AssetBalance>

--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/style.ts
@@ -45,6 +45,5 @@ export const AssetBalance = styled.span`
 // Ref: https://styled-components.com/docs/advanced#style-objects
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
   width: '24px',
-  height: 'auto',
-  marginRight: '8px'
+  height: 'auto'
 })

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
@@ -13,6 +13,7 @@ import { ExpirationPresetOptions } from '../../../options/expiration-preset-opti
 import { formatWithCommasAndDecimals } from '../../../utils/format-prices'
 import { getLocale } from '../../../../common/locale'
 import { reduceAddress } from '../../../utils/reduce-address'
+import { withPlaceholderIcon } from '../../shared'
 
 // Styled Components
 import {
@@ -203,6 +204,10 @@ function SwapInputComponent (props: Props) {
     validationError === 'insufficientEthBalance'
   )
 
+  const AssetIconWithPlaceholder = React.useMemo(() => {
+    return withPlaceholderIcon(AssetIcon, { size: 'small', marginLeft: 4, marginRight: 8 })
+  }, [])
+
   return (
     <BubbleContainer>
       {componentType !== 'selector' &&
@@ -249,7 +254,7 @@ function SwapInputComponent (props: Props) {
             }
             {componentType !== 'exchange' && componentType !== 'toAddress' &&
               <AssetButton onClick={onShowSelection}>
-                <AssetIcon icon={selectedAsset?.asset.logo} />
+                <AssetIconWithPlaceholder selectedAsset={selectedAsset?.asset} />
                 <AssetTicker>{selectedAsset?.asset.symbol}</AssetTicker>
                 <CaratDownIcon />
               </AssetButton>

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/style.ts
@@ -49,9 +49,7 @@ export const AssetButton = styled.button`
 // Ref: https://styled-components.com/docs/advanced#style-objects
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
   width: '24px',
-  height: 'auto',
-  marginRight: '8px',
-  marginLeft: '4px'
+  height: 'auto'
 })
 
 export const AssetTicker = styled.span`

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import { Checkbox } from 'brave-ui'
 import { TokenInfo } from '../../../constants/types'
-
-// Options
-import { ETH } from '../../../options/asset-options'
+import { withPlaceholderIcon } from '../../shared'
 
 // Styled Components
 import {
@@ -43,10 +41,14 @@ const AssetWatchlistItem = (props: Props) => {
     onRemoveAsset(token)
   }
 
+  const AssetIconWithPlaceholder = React.useMemo(() => {
+    return withPlaceholderIcon(AssetIcon, { size: 'big', marginLeft: 0, marginRight: 8 })
+  }, [])
+
   return (
     <StyledWrapper>
       <NameAndIcon>
-        <AssetIcon icon={(token.symbol === 'ETH' ? ETH.asset.logo : token.logo) ?? ''} />
+        <AssetIconWithPlaceholder selectedAsset={token} />
         <NameAndSymbol>
           <AssetName>{token.name}</AssetName>
           <AssetSymbol>{token.symbol}</AssetSymbol>

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/style.ts
@@ -69,8 +69,7 @@ export const BalanceColumn = styled.div`
 // Ref: https://styled-components.com/docs/advanced#style-objects
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
   width: '40px',
-  height: 'auto',
-  marginRight: '8px'
+  height: 'auto'
 })
 
 export const CheckboxRow = styled.div`

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react'
 
-// Options
-import { ETH } from '../../../options/asset-options'
-
 // Styled Components
 import {
   StyledWrapper,
@@ -14,29 +11,34 @@ import {
   AssetIcon
 } from './style'
 import { formatWithCommasAndDecimals } from '../../../utils/format-prices'
+import { withPlaceholderIcon } from '../../shared'
+import { TokenInfo } from '../../../constants/types'
+
 export interface Props {
   action?: () => void
-  name: string
-  symbol: string
-  logo?: string
   assetBalance: string
   fiatBalance: string
-  isVisible?: boolean
+  token: TokenInfo
 }
 
 const PortfolioAssetItem = (props: Props) => {
-  const { name, assetBalance, fiatBalance, logo, symbol, isVisible, action } = props
+  const { assetBalance, fiatBalance, action, token } = props
+
+  const AssetIconWithPlaceholder = React.useMemo(() => {
+    return withPlaceholderIcon(AssetIcon, { size: 'big', marginLeft: 0, marginRight: 8 })
+  }, [])
+
   return (
     <>
-      {isVisible &&
+      {token.visible &&
         <StyledWrapper onClick={action}>
           <NameAndIcon>
-            <AssetIcon icon={(symbol === 'ETH' ? ETH.asset.logo : logo) ?? ''} />
-            <AssetName>{name}</AssetName>
+            <AssetIconWithPlaceholder selectedAsset={token} />
+            <AssetName>{token.name}</AssetName>
           </NameAndIcon>
           <BalanceColumn>
             <FiatBalanceText>${formatWithCommasAndDecimals(fiatBalance)}</FiatBalanceText>
-            <AssetBalanceText>{formatWithCommasAndDecimals(assetBalance)} {symbol}</AssetBalanceText>
+            <AssetBalanceText>{formatWithCommasAndDecimals(assetBalance)} {token.symbol}</AssetBalanceText>
           </BalanceColumn>
         </StyledWrapper>
       }

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
@@ -58,6 +58,5 @@ export const AssetBalanceText = styled.span`
 // Ref: https://styled-components.com/docs/advanced#style-objects
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
   width: '40px',
-  height: 'auto',
-  marginRight: '8px'
+  height: 'auto'
 })

--- a/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
@@ -265,12 +265,9 @@ function Accounts (props: Props) {
           {selectedAccount.tokens.map((item) =>
             <PortfolioAssetItem
               key={item.asset.contractAddress}
-              name={item.asset.name}
               assetBalance={formatBalance(item.assetBalance, item.asset.decimals)}
               fiatBalance={item.fiatBalance}
-              symbol={item.asset.symbol}
-              logo={item.asset.logo}
-              isVisible={item.asset.visible}
+              token={item.asset}
             />
           )}
           <SubviewSectionTitle>{getLocale('braveWalletTransactions')}</SubviewSectionTitle>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
@@ -20,10 +20,10 @@ import { formatBalance } from '../../../../utils/format-balances'
 
 // Options
 import { ChartTimelineOptions } from '../../../../options/chart-timeline-options'
-import { ETH } from '../../../../options/asset-options'
+// import { ETH } from '../../../../options/asset-options'
 
 // Components
-import { SearchBar, BackButton } from '../../../shared'
+import { SearchBar, BackButton, withPlaceholderIcon } from '../../../shared'
 import {
   ChartControlBar,
   LineChart,
@@ -247,6 +247,10 @@ const Portfolio = (props: Props) => {
     return filteredAssetList.find((asset) => asset.asset.contractAddress.toLowerCase() === selectedAsset?.contractAddress.toLowerCase())
   }, [filteredAssetList, selectedAsset])
 
+  const AssetIconWithPlaceholder = React.useMemo(() => {
+    return withPlaceholderIcon(AssetIcon, { size: 'big', marginLeft: 0, marginRight: 12 })
+  }, [])
+
   return (
     <StyledWrapper onClick={onHideNetworkDropdown}>
       <TopRow>
@@ -277,7 +281,7 @@ const Portfolio = (props: Props) => {
       ) : (
         <InfoColumn>
           <AssetRow>
-            <AssetIcon icon={selectedAsset.symbol === 'ETH' ? ETH.asset.logo : selectedAsset.logo} />
+            <AssetIconWithPlaceholder selectedAsset={selectedAsset} />
             <AssetNameText>{selectedAsset.name}</AssetNameText>
           </AssetRow>
           <DetailText>{selectedAsset.name} {getLocale('braveWalletPrice')} ({selectedAsset.symbol})</DetailText>
@@ -358,12 +362,9 @@ const Portfolio = (props: Props) => {
             <PortfolioAssetItem
               action={selectAsset(item.asset)}
               key={item.asset.contractAddress}
-              name={item.asset.name}
               assetBalance={item.assetBalance}
               fiatBalance={item.fiatBalance}
-              symbol={item.asset.symbol}
-              logo={item.asset.logo}
-              isVisible={item.asset.visible}
+              token={item.asset}
             />
           )}
           <ButtonRow>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -111,8 +111,7 @@ export const DetailText = styled.span`
 // Ref: https://styled-components.com/docs/advanced#style-objects
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
   width: '40px',
-  height: 'auto',
-  marginRight: '12px'
+  height: 'auto'
 })
 
 export const SubDivider = styled.div`

--- a/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
+++ b/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { TokenInfo } from '../../../constants/types'
+import { IconWrapper, PlaceholderText } from './style'
+import { stripERC20TokenImageURL } from '../../../utils/string-utils'
+import { background } from 'ethereum-blockies'
+import { ETH } from '../../../options/asset-options'
+
+interface Config {
+  size: 'big' | 'small'
+  marginLeft?: number
+  marginRight?: number
+}
+
+interface Props {
+  selectedAsset?: TokenInfo
+}
+
+function withPlaceholderIcon (WrappedComponent: React.ComponentType<any>, config: Config) {
+  const {
+    size,
+    marginLeft,
+    marginRight
+  } = config
+
+  return function (props: Props) {
+    const { selectedAsset } = props
+
+    if (!selectedAsset) {
+      return null
+    }
+
+    const bg = React.useMemo(() => {
+      if (selectedAsset?.symbol !== 'ETH' && stripERC20TokenImageURL(selectedAsset?.logo) === '') {
+        return background({ seed: selectedAsset?.contractAddress.toLowerCase() })
+      }
+    }, [selectedAsset])
+
+    if (selectedAsset?.symbol !== 'ETH' && stripERC20TokenImageURL(selectedAsset?.logo) === '') {
+      return (
+        <IconWrapper
+          panelBackground={bg}
+          isPlaceholder={true}
+          size={size}
+          marginLeft={marginLeft ?? 0}
+          marginRight={marginRight ?? 0}
+        >
+          <PlaceholderText size={size}>{selectedAsset?.symbol.charAt(0)}</PlaceholderText>
+        </IconWrapper>
+      )
+    }
+    return (
+      <IconWrapper
+        isPlaceholder={false}
+        size={size}
+        marginLeft={marginLeft ?? 0}
+        marginRight={marginRight ?? 0}
+      >
+        <WrappedComponent icon={selectedAsset?.symbol === 'ETH' ? ETH.asset.logo : selectedAsset?.logo} />
+      </IconWrapper>
+    )
+
+  }
+}
+
+export default withPlaceholderIcon

--- a/components/brave_wallet_ui/components/shared/create-placeholder-icon/style.ts
+++ b/components/brave_wallet_ui/components/shared/create-placeholder-icon/style.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components'
+
+interface StyleProps {
+  isPlaceholder: boolean
+  panelBackground?: string
+  size: 'big' | 'small'
+  marginLeft: number
+  marginRight: number
+}
+
+export const IconWrapper = styled.div<StyleProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  width: ${(p) => p.size === 'big' ? '40px' : '24px'};
+  height: ${(p) => p.isPlaceholder ? p.size === 'big' ? '40px' : '24px' : 'auto'};
+  border-radius: ${(p) => p.isPlaceholder ? '100%' : '0px'};
+  margin-right: ${(p) => `${p.marginRight}px`};
+  margin-left: ${(p) => `${p.marginLeft}px`};
+  background: ${(p) => p.panelBackground ? p.panelBackground : 'none'};
+`
+
+export const PlaceholderText = styled.span<Partial<StyleProps>>`
+  font-family: Poppins;
+  font-size: ${(p) => p.size === 'big' ? '16px' : '12px'};
+  font-weight: 600
+  letter-spacing: 0.01em;
+  color: ${(p) => p.theme.palette.white};
+`

--- a/components/brave_wallet_ui/components/shared/index.ts
+++ b/components/brave_wallet_ui/components/shared/index.ts
@@ -6,6 +6,7 @@ import PasswordInput from './password-input'
 import Tooltip from './tooltip'
 import SelectNetwork from './select-network'
 import SelectAccount from './select-account'
+import withPlaceholderIcon from './create-placeholder-icon'
 
 export {
   AppListItem,
@@ -15,5 +16,6 @@ export {
   PasswordInput,
   Tooltip,
   SelectNetwork,
-  SelectAccount
+  SelectAccount,
+  withPlaceholderIcon
 }


### PR DESCRIPTION
## Description 
Added Placeholder icons for Tokens with missing icons throughout the wallet.
If a Token does not have an icon, it will generate unique background (Same as what we use in the panel) and display the first character of the Token symbol as an Icon.


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/18922>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

https://user-images.githubusercontent.com/40611140/138373446-c17fb0c3-2be8-446d-8f16-7c3d54c1a5f6.mov

After:

https://user-images.githubusercontent.com/40611140/138526312-614f362d-31e6-4b6c-b972-2d01ec05381a.mov
