### PR TITLE
Revert "Disable Web Discovery Project in Tor windows"

### DIFF
--- a/browser/tor/tor_profile_manager.cc
+++ b/browser/tor/tor_profile_manager.cc
@@ -131,9 +131,4 @@ void TorProfileManager::InitTorProfileUserPrefs(Profile* profile) {
     BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
   pref_service->SetBoolean(translate::prefs::kOfferTranslateEnabled, false);
 #endif
-
-  // Disable Web Discovery Project in Tor
-#if BUILDFLAG(ENABLE_EXTENSIONS)
-  pref_service->SetBoolean(kWebDiscoveryEnabled, false);
-#endif
 }

--- a/browser/tor/tor_profile_manager_unittest.cc
+++ b/browser/tor/tor_profile_manager_unittest.cc
@@ -58,7 +58,6 @@ class TorProfileManagerUnitTest : public testing::Test {
 };
 
 TEST_F(TorProfileManagerUnitTest, InitTorProfileUserPrefs) {
-  profile()->GetPrefs()->SetBoolean(kWebDiscoveryEnabled, true);
   Profile* tor_profile =
       TorProfileManager::GetInstance().GetTorProfile(profile());
   ASSERT_EQ(tor_profile->GetOriginalProfile(), profile());
@@ -82,10 +81,5 @@ TEST_F(TorProfileManagerUnitTest, InitTorProfileUserPrefs) {
   // Check translate.enabled for translate bubble.
   EXPECT_FALSE(tor_profile->GetPrefs()->GetBoolean(
       translate::prefs::kOfferTranslateEnabled));
-#endif
-
-#if BUILDFLAG(ENABLE_EXTENSIONS)
-  // Check WDP status.
-  EXPECT_FALSE(tor_profile->GetPrefs()->GetBoolean(kWebDiscoveryEnabled));
 #endif
 }


### PR DESCRIPTION
Reverts brave/brave-core#10609

Following up on https://github.com/brave/brave-browser/issues/18958 it seems that this was not the right way to go about it. I will open a PR with another fix.

Cc @kjozwiak 