### PR TITLE
Preserve query strings on IPFS redirect

### DIFF
--- a/browser/ipfs/test/ipfs_service_browsertest.cc
+++ b/browser/ipfs/test/ipfs_service_browsertest.cc
@@ -947,6 +947,21 @@ IN_PROC_BROWSER_TEST_F(IpfsServiceBrowserTest, TopLevelAutoRedirectsOn) {
   EXPECT_EQ(contents->GetURL().host(), gateway.host());
 }
 
+IN_PROC_BROWSER_TEST_F(IpfsServiceBrowserTest,
+                       TopLevelAutoRedirectsOnWithQuery) {
+  ResetTestServer(
+      base::BindRepeating(&IpfsServiceBrowserTest::HandleEmbeddedSrvrRequest,
+                          base::Unretained(this)));
+  browser()->profile()->GetPrefs()->SetBoolean(kIPFSAutoRedirectGateway, true);
+  GURL gateway = GetURL("b.com", "/");
+  SetIPFSDefaultGatewayForTest(gateway);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), GetURL("a.com", "/simple.html?abc=123xyz&other=qwerty")));
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  EXPECT_EQ(contents->GetURL().query(), "abc=123xyz&other=qwerty");
+}
+
 IN_PROC_BROWSER_TEST_F(IpfsServiceBrowserTest, TopLevelAutoRedirectsOff) {
   ResetTestServer(
       base::BindRepeating(&IpfsServiceBrowserTest::HandleEmbeddedSrvrRequest,

--- a/browser/net/ipfs_redirect_network_delegate_helper.cc
+++ b/browser/net/ipfs_redirect_network_delegate_helper.cc
@@ -70,6 +70,11 @@ int OnHeadersReceived_IPFSRedirectWork(
       !ctx->request_url.DomainIs(ctx->ipfs_gateway_url.host())) {
     GURL::Replacements replacements;
     replacements.SetPathStr(ipfs_path);
+
+    if (ctx->request_url.has_query()) {
+      replacements.SetQueryStr(ctx->request_url.query_piece());
+    }
+
     GURL new_url = ctx->ipfs_gateway_url.ReplaceComponents(replacements);
 
     *override_response_headers =


### PR DESCRIPTION
From https://github.com/brave/brave-core/pull/10313:

When the setting Redirect IPFS resources to the configured IPFS gateway is on, previously query strings would not be preserved on the redirection. This PR fixes that and adds a test for this case. See linked issue for a full example and real world test case.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18367

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

