### PR TITLE
Move iOS Brave browser state factories out of chromium_src override (uplift to 1.32.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/browser_state/browser_state_keyed_service_factories.mm
+++ b/chromium_src/ios/chrome/browser/browser_state/browser_state_keyed_service_factories.mm
@@ -5,12 +5,6 @@
 
 #include "ios/chrome/browser/browser_state/browser_state_keyed_service_factories.h"
 
-#include "brave/ios/browser/brave_wallet/asset_ratio_controller_factory.h"
-#include "brave/ios/browser/brave_wallet/brave_wallet_service_factory.h"
-#include "brave/ios/browser/brave_wallet/eth_json_rpc_controller_factory.h"
-#include "brave/ios/browser/brave_wallet/eth_tx_controller_factory.h"
-#include "brave/ios/browser/brave_wallet/keyring_controller_factory.h"
-#include "brave/ios/browser/brave_wallet/swap_controller_factory.h"
 #include "ios/chrome/browser/autofill/personal_data_manager_factory.h"
 #include "ios/chrome/browser/bookmarks/bookmark_model_factory.h"
 #include "ios/chrome/browser/favicon/favicon_service_factory.h"
@@ -37,12 +31,6 @@
 
 void EnsureBrowserStateKeyedServiceFactoriesBuilt() {
   autofill::PersonalDataManagerFactory::GetInstance();
-  brave_wallet::AssetRatioControllerFactory::GetInstance();
-  brave_wallet::BraveWalletServiceFactory::GetInstance();
-  brave_wallet::EthJsonRpcControllerFactory::GetInstance();
-  brave_wallet::EthTxControllerFactory::GetInstance();
-  brave_wallet::KeyringControllerFactory::GetInstance();
-  brave_wallet::SwapControllerFactory::GetInstance();
   ConsentAuditorFactory::GetInstance();
   ios::AccountConsistencyServiceFactory::GetInstance();
   ios::BookmarkModelFactory::GetInstance();

--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -28,6 +28,7 @@ source_set("browser") {
     "//base",
     "//brave/browser/sync",
     "//brave/chromium_src/ios/chrome/browser/prefs",
+    "//brave/ios/browser/browser_state",
     "//components/flags_ui",
     "//components/metrics_services_manager",
     "//components/variations",

--- a/ios/browser/brave_web_main_parts.mm
+++ b/ios/browser/brave_web_main_parts.mm
@@ -11,6 +11,7 @@
 #include "base/sequenced_task_runner.h"
 #include "base/task/post_task.h"
 #include "base/task/thread_pool.h"
+#include "brave/ios/browser/browser_state/brave_browser_state_keyed_service_factories.h"
 #include "components/flags_ui/pref_service_flags_storage.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "components/variations/service/variations_service.h"
@@ -119,6 +120,7 @@ void BraveWebMainParts::PreMainMessageLoopRun() {
 
   // Ensure that the browser state is initialized.
   EnsureBrowserStateKeyedServiceFactoriesBuilt();
+  brave::EnsureBrowserStateKeyedServiceFactoriesBuilt();
   ios::ChromeBrowserStateManager* browser_state_manager =
       application_context_->GetChromeBrowserStateManager();
   ChromeBrowserState* last_used_browser_state =

--- a/ios/browser/browser_state/BUILD.gn
+++ b/ios/browser/browser_state/BUILD.gn
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import("//build/config/ios/rules.gni")
+import("//ios/build/config.gni")
+
+source_set("browser_state") {
+  sources = [
+    "brave_browser_state_keyed_service_factories.cc",
+    "brave_browser_state_keyed_service_factories.h",
+  ]
+  deps = [
+    "//base",
+    "//brave/ios/browser/brave_wallet",
+  ]
+}

--- a/ios/browser/browser_state/brave_browser_state_keyed_service_factories.cc
+++ b/ios/browser/browser_state/brave_browser_state_keyed_service_factories.cc
@@ -1,0 +1,26 @@
+/* Copyright (c) 2020 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/ios/browser/browser_state/brave_browser_state_keyed_service_factories.h"
+
+#include "brave/ios/browser/brave_wallet/asset_ratio_controller_factory.h"
+#include "brave/ios/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/ios/browser/brave_wallet/eth_json_rpc_controller_factory.h"
+#include "brave/ios/browser/brave_wallet/eth_tx_controller_factory.h"
+#include "brave/ios/browser/brave_wallet/keyring_controller_factory.h"
+#include "brave/ios/browser/brave_wallet/swap_controller_factory.h"
+
+namespace brave {
+
+void EnsureBrowserStateKeyedServiceFactoriesBuilt() {
+  brave_wallet::AssetRatioControllerFactory::GetInstance();
+  brave_wallet::BraveWalletServiceFactory::GetInstance();
+  brave_wallet::EthJsonRpcControllerFactory::GetInstance();
+  brave_wallet::EthTxControllerFactory::GetInstance();
+  brave_wallet::KeyringControllerFactory::GetInstance();
+  brave_wallet::SwapControllerFactory::GetInstance();
+}
+
+}  // namespace brave

--- a/ios/browser/browser_state/brave_browser_state_keyed_service_factories.h
+++ b/ios/browser/browser_state/brave_browser_state_keyed_service_factories.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_BROWSER_STATE_BRAVE_BROWSER_STATE_KEYED_SERVICE_FACTORIES_H_
+#define BRAVE_IOS_BROWSER_BROWSER_STATE_BRAVE_BROWSER_STATE_KEYED_SERVICE_FACTORIES_H_
+
+namespace brave {
+
+void EnsureBrowserStateKeyedServiceFactoriesBuilt();
+
+}  // namespace brave
+
+#endif  // BRAVE_IOS_BROWSER_BROWSER_STATE_BRAVE_BROWSER_STATE_KEYED_SERVICE_FACTORIES_H_


### PR DESCRIPTION
Uplift of #10705
Resolves https://github.com/brave/brave-browser/issues/19002

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.