### PR TITLE
Disabled Sending for Insufficient Balances

### DIFF
--- a/components/brave_wallet_ui/common/hooks/balance.ts
+++ b/components/brave_wallet_ui/common/hooks/balance.ts
@@ -18,7 +18,7 @@ export default function useBalance (selectedAccount: WalletAccountType) {
     }
 
     const token = selectedAccount.tokens.find(
-      (token) => token.asset.symbol === asset.asset.symbol
+      (token) => token.asset.symbol === asset?.asset.symbol
     )
     if (!token) {
       return { assetBalance, fiatBalance }

--- a/components/brave_wallet_ui/common/hooks/index.ts
+++ b/components/brave_wallet_ui/common/hooks/index.ts
@@ -11,6 +11,7 @@ import useSend from './send'
 import { useTransactionParser, useTransactionFeesParser } from './transaction-parser'
 import useAddressLabels from './address-labels'
 import usePricing from './pricing'
+import usePreset from './selectPreset'
 
 export {
   useAssets,
@@ -21,5 +22,6 @@ export {
   useTransactionFeesParser,
   usePricing,
   useAddressLabels,
-  useSend
+  useSend,
+  usePreset
 }

--- a/components/brave_wallet_ui/common/hooks/selectPreset.ts
+++ b/components/brave_wallet_ui/common/hooks/selectPreset.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BigNumber from 'bignumber.js'
+import { formatBalance } from '../../utils/format-balances'
+import { WalletAccountType, AccountAssetOptionType } from '../../constants/types'
+
+export default function usePreset (
+  selectedAccount: WalletAccountType,
+  fromAsset: AccountAssetOptionType,
+  onSetFromAmount: (value: string) => void,
+  onSetSendAmount: (value: string) => void
+) {
+  return (sendOrSwap: 'send' | 'swap') => (percent: number) => {
+    const asset = selectedAccount.tokens.find(
+      (token) => (
+        token.asset.contractAddress === fromAsset.asset.contractAddress ||
+        token.asset.symbol === fromAsset.asset.symbol
+      )
+    )
+    const amount = new BigNumber(asset?.assetBalance || '0').times(percent).toString()
+    const formattedAmount = formatBalance(amount.toString(), asset?.asset.decimals ?? 18)
+
+    if (sendOrSwap === 'send') {
+      onSetSendAmount(formattedAmount)
+    } else {
+      onSetFromAmount(formattedAmount)
+    }
+  }
+}

--- a/components/brave_wallet_ui/components/buy-send-swap/send/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/send/index.tsx
@@ -7,6 +7,7 @@ import {
 import { NavButton } from '../../extension'
 import SwapInputComponent from '../swap-input-component'
 import { getLocale } from '../../../../common/locale'
+import { ErrorText } from '../shared-styles'
 // Styled Components
 import {
   StyledWrapper
@@ -48,6 +49,13 @@ function Send (props: Props) {
     onInputChange(address, 'address')
   }
 
+  const insuficientFundsError = React.useMemo((): boolean => {
+    if (parseFloat(selectedAssetAmount) === 0) {
+      return false
+    }
+    return selectedAssetAmount > selectedAssetBalance
+  }, [selectedAssetBalance, selectedAssetAmount])
+
   return (
     <StyledWrapper>
       <SwapInputComponent
@@ -69,8 +77,16 @@ function Send (props: Props) {
         inputName='address'
         onPaste={onPasteFromClipboard}
       />
+      {insuficientFundsError &&
+        <ErrorText>{getLocale('braveWalletSwapInsufficientBalance')}</ErrorText>
+      }
       <NavButton
-        disabled={addressError !== '' || toAddressOrUrl === ''}
+        disabled={addressError !== ''
+          || toAddressOrUrl === ''
+          || parseFloat(selectedAssetAmount) === 0
+          || selectedAssetAmount === ''
+          || insuficientFundsError
+        }
         buttonType='primary'
         text={getLocale('braveWalletSend')}
         onSubmit={onSubmit}

--- a/components/brave_wallet_ui/components/buy-send-swap/shared-styles.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/shared-styles.ts
@@ -48,3 +48,12 @@ export const SelectScrollContainer = styled.div`
   left: 18px;
   right: 18px;
 `
+
+export const ErrorText = styled.span`
+  font-family: Poppins;
+  letter-spacing: 0.01em;
+  font-size: 12px;
+  color: ${(p) => p.theme.color.errorText};
+  word-break: break-word;
+  margin-bottom: 12px;
+`

--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
@@ -12,7 +12,7 @@ export const StyledButton = styled.button<StyleProps>`
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  cursor: ${(p) => p.disabled ? 'default' : 'pointer'};
   border-radius: 40px;
   padding: 10px 22px;
   outline: none;

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -52,7 +52,8 @@ import {
   URLText,
   QueueStepText,
   QueueStepRow,
-  QueueStepButton
+  QueueStepButton,
+  TopColumn
 } from './style'
 
 import {
@@ -296,20 +297,25 @@ function ConfirmTransactionPanel (props: Props) {
           <>
             {transactionInfo.txType === TransactionType.ERC20Approve &&
               <>
-                <SectionRow>
-                  <TransactionTitle>{getLocale('braveWalletAllowSpendTransactionFee')}</TransactionTitle>
-                  <SectionRightColumn>
-                    <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
+                <TopColumn>
+                  <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
+                  <SectionRow>
+                    <TransactionTitle>{getLocale('braveWalletAllowSpendTransactionFee')}</TransactionTitle>
                     <TransactionTypeText>{transactionDetails.gasFee} {selectedNetwork.symbol}</TransactionTypeText>
-                    <TransactionText>${transactionDetails.gasFeeFiat}</TransactionText>
-                  </SectionRightColumn>
-                </SectionRow>
+                  </SectionRow>
+                  <TransactionText
+                    hasError={transactionDetails.insufficientFundsError}
+                  >
+                    {transactionDetails.insufficientFundsError ? `${getLocale('braveWalletSwapInsufficientBalance')} ` : ''}
+                    ${transactionDetails.gasFeeFiat}
+                  </TransactionText>
+                </TopColumn>
                 <Divider />
                 <SectionRow>
                   <TransactionTitle>{getLocale('braveWalletAllowSpendCurrentAllowance')}</TransactionTitle>
                   <SectionRightColumn>
                     <TransactionTypeText>{currentTokenAllowance} {transactionDetails.symbol}</TransactionTypeText>
-                    <TransactionText/>
+                    <TransactionText />
                   </SectionRightColumn>
                 </SectionRow>
                 <Divider />
@@ -317,7 +323,7 @@ function ConfirmTransactionPanel (props: Props) {
                   <TransactionTitle>{getLocale('braveWalletAllowSpendProposedAllowance')}</TransactionTitle>
                   <SectionRightColumn>
                     <TransactionTypeText>{transactionDetails.value} {transactionDetails.symbol}</TransactionTypeText>
-                    <TransactionText/>
+                    <TransactionText />
                   </SectionRightColumn>
                 </SectionRow>
               </>
@@ -338,7 +344,12 @@ function ConfirmTransactionPanel (props: Props) {
                   <SectionRightColumn>
                     <TransactionText>{getLocale('braveWalletConfirmTransactionAmountGas')}</TransactionText>
                     <GrandTotalText>{transactionDetails.value} {transactionDetails.symbol} + {transactionDetails.gasFee} {selectedNetwork.symbol}</GrandTotalText>
-                    <TransactionText>${transactionDetails.fiatTotal}</TransactionText>
+                    <TransactionText
+                      hasError={transactionDetails.insufficientFundsError}
+                    >
+                      {transactionDetails.insufficientFundsError ? `${getLocale('braveWalletSwapInsufficientBalance')} ` : ''}
+                      ${transactionDetails.fiatTotal}
+                    </TransactionText>
                   </SectionRightColumn>
                 </SectionRow>
               </>
@@ -364,6 +375,8 @@ function ConfirmTransactionPanel (props: Props) {
           buttonType='confirm'
           text={getLocale('braveWalletAllowSpendConfirmButton')}
           onSubmit={onConfirm}
+          disabled={transactionDetails.insufficientFundsError}
+
         />
       </ButtonRow>
     </StyledWrapper>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -6,6 +6,7 @@ interface StyleProps {
   isDetails: boolean
   isApprove: boolean
   needsMargin: boolean
+  hasError: boolean
 }
 
 export const StyledWrapper = styled.div`
@@ -177,6 +178,14 @@ export const SectionRightColumn = styled.div`
   flex-direction: column;
 `
 
+export const TopColumn = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  flex-direction: column;
+  width: 100%;
+`
+
 export const EditButton = styled.button`
   font-family: Poppins;
   font-style: normal;
@@ -193,12 +202,12 @@ export const EditButton = styled.button`
   padding: 0px;
 `
 
-export const TransactionText = styled.span`
+export const TransactionText = styled.span<Partial<StyleProps>>`
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;
   letter-spacing: 0.01em;
-  color: ${(p) => p.theme.color.text03};
+  color: ${(p) => p.hasError ? p.theme.color.errorText : p.theme.color.text03};
 `
 
 export const GrandTotalText = styled.span`

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -7,7 +7,6 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import { Switch, Route, useHistory, useLocation } from 'react-router-dom'
-import BigNumber from 'bignumber.js'
 
 import * as WalletPageActions from './actions/wallet_page_actions'
 import * as WalletActions from '../common/actions/wallet_actions'
@@ -61,7 +60,7 @@ import {
 } from '../common/async/lib'
 
 import { formatBalance } from '../utils/format-balances'
-import { useSwap, useAssets, useTimeout, useBalance, useSend } from '../common/hooks'
+import { useSwap, useAssets, useTimeout, useBalance, useSend, usePreset } from '../common/hooks'
 import { stripERC20TokenImageURL } from '../utils/string-utils'
 
 type Props = {
@@ -189,6 +188,8 @@ function Container (props: Props) {
   const getSelectedAccountBalance = useBalance(selectedAccount)
   const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
   const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
+
+  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, onSetFromAmount, onSetSendAmount)
 
   const onToggleShowRestore = React.useCallback(() => {
     if (walletLocation === WalletRoutes.Restore) {
@@ -341,23 +342,6 @@ function Container (props: Props) {
     })
     return formated
   }, [selectedAssetPriceHistory])
-
-  const onSelectPresetAmountFactory = (sendOrSwap: 'send' | 'swap') => (percent: number) => {
-    const asset = selectedAccount.tokens.find(
-      (token) => (
-        token.asset.contractAddress === fromAsset.asset.contractAddress ||
-        token.asset.symbol === fromAsset.asset.symbol
-      )
-    )
-    const amount = new BigNumber(asset?.assetBalance || '0').times(percent).toString()
-    const formattedAmount = formatBalance(amount.toString(), asset?.asset.decimals ?? 18)
-
-    if (sendOrSwap === 'send') {
-      onSetSendAmount(formattedAmount)
-    } else {
-      onSetFromAmount(formattedAmount)
-    }
-  }
 
   const onShowAddModal = () => {
     props.walletPageActions.setShowAddModal(true)

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -63,8 +63,7 @@ import {
   getERC20Allowance
 } from '../common/async/lib'
 
-import { formatBalance } from '../utils/format-balances'
-import { useAssets, useBalance, useSwap, useSend, useTimeout } from '../common/hooks'
+import { useAssets, useBalance, useSwap, useSend, useTimeout, usePreset } from '../common/hooks'
 
 type Props = {
   panel: PanelState
@@ -152,6 +151,7 @@ function Container (props: Props) {
     toAmount,
     toAsset,
     customSlippageTolerance,
+    onSetFromAmount,
     setFromAsset,
     setSwapToOrFrom,
     onToggleOrderType,
@@ -200,6 +200,8 @@ function Container (props: Props) {
   const getSelectedAccountBalance = useBalance(selectedAccount)
   const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
   const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
+
+  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, onSetFromAmount, onSetSendAmount)
 
   const onSetBuyAmount = (value: string) => {
     setBuyAmount(value)
@@ -254,12 +256,6 @@ function Container (props: Props) {
     } else {
       onSetSendAmount(value)
     }
-  }
-
-  const onSelectPresetSendAmount = (percent: number) => {
-    const amount = Number(fromAsset.assetBalance) * percent
-    const formatedAmmount = formatBalance(amount.toString(), fromAsset.asset.decimals)
-    onSetSendAmount(formatedAmmount)
   }
 
   const [readyToConnect, setReadyToConnect] = React.useState<boolean>(false)
@@ -670,7 +666,7 @@ function Container (props: Props) {
               <Send
                 onChangeSendView={onChangeSendView}
                 onInputChange={onInputChange}
-                onSelectPresetAmount={onSelectPresetSendAmount}
+                onSelectPresetAmount={onSelectPresetAmountFactory('send')}
                 onSubmit={onSubmitSend}
                 selectedAsset={fromAsset}
                 selectedAssetAmount={sendAmount}
@@ -744,7 +740,7 @@ function Container (props: Props) {
                 onFlipAssets={flipSwapAssets}
                 onSubmitSwap={onSubmitSwap}
                 onQuoteRefresh={onSwapQuoteRefresh}
-                onSelectPresetAmount={onSelectPresetSendAmount}
+                onSelectPresetAmount={onSelectPresetAmountFactory('swap')}
                 onInputChange={onSwapInputChange}
                 onFilterAssetList={onFilterAssetList}
                 onChangeSwapView={onChangeSwapView}


### PR DESCRIPTION
## Description 
Disabled Sending for Insufficient Balances

1) `Buy/SendSwap` `Send` tab will display a `Insufficient balance` error and disable the `Send` button if the user enters more than their account balance.
2) `ConfirmTransactions` panel will now display a `Insufficient balance` error and disable the `Confirm` button if transaction request is more than their balance or if the `gasfee` + `asset` send amount is more than their account balance.
3) While testing I noticed that selecting a `Preset Amount` in the `Panel` was not working for `Send` and `Swap`.
Fixed that and moved the `onSelectPresetAmountFactory` to its own hook to be shared between the `Panel` and `Page`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19014>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/139157482-b8eac8c8-b5b0-40ff-8b2c-53375984d692.mov
