### PR TITLE
Disable CNAME uncloaking when a proxy extension with a socks fallback is enabled

### DIFF
--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -247,7 +247,10 @@ void UseCnameResult(scoped_refptr<base::SequencedTaskRunner> task_runner,
 // If only particular types of network traffic are being proxied, or if no
 // proxy is configured, it should be safe to continue making unproxied DNS
 // queries. However, in SingleProxy mode all types of network traffic should go
-// through the proxy, so additional DNS queries should be avoided.
+// through the proxy, so additional DNS queries should be avoided. Also, in the
+// case of per-scheme proxy configurations, a fallback for any non-matching
+// request can be configured, in which case additional DNS queries should be
+// avoided as well.
 bool ProxySettingsAllowUncloaking(content::BrowserContext* browser_context) {
   DCHECK(browser_context);
 
@@ -269,7 +272,10 @@ bool ProxySettingsAllowUncloaking(content::BrowserContext* browser_context) {
       net::ProxyConfigService::ConfigAvailability::CONFIG_VALID) {
     // PROXY_LIST corresponds to SingleProxy mode.
     if (config.value().proxy_rules().type ==
-        net::ProxyConfig::ProxyRules::Type::PROXY_LIST) {
+            net::ProxyConfig::ProxyRules::Type::PROXY_LIST ||
+        (config.value().proxy_rules().type ==
+             net::ProxyConfig::ProxyRules::Type::PROXY_LIST_PER_SCHEME &&
+         !config.value().proxy_rules().fallback_proxies.IsEmpty())) {
       can_uncloak = false;
     }
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19070

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Install the [Proxy SwitchyOmega](https://chrome.google.com/webstore/detail/proxy-switchyomega/padekgcemlokbadohgkifijomclgjgif) extension
1. In the extension settings page, set the Proxy Servers section to have a single entry, as follows:
   |Scheme|Protocol|Server|Port|
   |------|--------|------|----|
   |(default)|SOCKS5|127.0.0.1|8081|
1. Clear the "Bypass List" section in the extension settings page
1. Ensure the above changes are applied by clicking the "Apply changes" button in the left column
1. Start a SOCKS5 proxy server on the device. This can be done by entering `ssh 127.0.0.1 -D 8081` on Linux and probably macOS. You're welcome to run it on a different device, but the Proxy Servers setting above will need to be modified accordingly.
1. Add the following line to the `Custom filters` section in brave://adblock:
   ```
   ||dev-pages.brave.software/static/images/test.jpg
   ```
1. Visit https://test-cname.brave.software/cname-uncloaking.html
1. Use the Proxy SwitchyOmega icon in the "puzzle piece" extensions menu to enable `proxy` mode (should be the 3rd option).
1. Press the `Run test` button
1. The request should be `allowed` (green).
1. In the "puzzle piece" extensions menu, change to `[System Proxy]` and run the test again. The request should be `blocked` (red).
1. In the "puzzle piece" extensions menu, change to `[Direct]` and run the test again. The request should be `blocked` (red).