### PR TITLE
Remove 2nd transaction event for new transactions (uplift to 1.32.x)

### DIFF
--- a/components/brave_wallet/browser/eth_tx_controller.cc
+++ b/components/brave_wallet/browser/eth_tx_controller.cc
@@ -260,11 +260,6 @@ void EthTxController::ContinueAddUnapprovedTransaction(
   meta.created_time = base::Time::Now();
   meta.status = mojom::TransactionStatus::Unapproved;
   tx_state_manager_->AddOrUpdateTx(meta);
-
-  for (const auto& observer : observers_)
-    observer->OnNewUnapprovedTx(
-        EthTxStateManager::TxMetaToTransactionInfo(meta));
-
   std::move(callback).Run(true, meta.id, "");
 }
 


### PR DESCRIPTION
Uplift of #10770
Resolves https://github.com/brave/brave-browser/issues/19101

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.