### PR TITLE
Fix #19069 - IsWebstoreUpdateUrl should return true for kChromeWebstoreUpdateURL even when component-updater switch is set

### DIFF
--- a/chromium_src/extensions/common/extension_urls.cc
+++ b/chromium_src/extensions/common/extension_urls.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "extensions/common/extension_urls.h"
+
+#define IsWebstoreUpdateUrl IsWebstoreUpdateUrl_ChromiumImpl
+#include "../../../../extensions/common/extension_urls.cc"
+#undef IsWebstoreUpdateUrl
+
+namespace extension_urls {
+
+namespace {
+
+bool IsDefaultWebstoreUpdateUrl(const GURL& update_url) {
+  GURL store_url = GetDefaultWebstoreUpdateUrl();
+  return (update_url.host_piece() == store_url.host_piece() &&
+          update_url.path_piece() == store_url.path_piece());
+}
+
+}  // namespace
+
+bool IsWebstoreUpdateUrl(const GURL& update_url) {
+  return IsDefaultWebstoreUpdateUrl(update_url) ||
+         IsWebstoreUpdateUrl_ChromiumImpl(update_url);
+}
+
+}  // namespace extension_urls

--- a/chromium_src/extensions/common/extension_urls_browsertest.cc
+++ b/chromium_src/extensions/common/extension_urls_browsertest.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "chrome/test/base/chrome_test_utils.h"
+#include "components/component_updater/component_updater_switches.h"
+#include "content/public/test/browser_test.h"
+#include "extensions/common/extension_urls.h"
+
+using ExtensionUrlsBrowserTest = PlatformBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(ExtensionUrlsBrowserTest, IsWebstoreUpdateUrl) {
+  GURL url = GURL(extension_urls::kChromeWebstoreUpdateURL);
+  EXPECT_TRUE(extension_urls::IsWebstoreUpdateUrl(url));
+
+  url = GURL(UPDATER_PROD_ENDPOINT);
+  EXPECT_TRUE(base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kComponentUpdater));
+  EXPECT_TRUE(extension_urls::IsWebstoreUpdateUrl(url));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -657,6 +657,7 @@ if (!is_android) {
       "//brave/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view_browsertest.cc",
       "//brave/chromium_src/components/content_settings/core/browser/brave_content_settings_registry_browsertest.cc",
       "//brave/chromium_src/components/favicon/core/favicon_database_browsertest.cc",
+      "//brave/chromium_src/extensions/common/extension_urls_browsertest.cc",
       "//brave/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc",
       "//brave/chromium_src/third_party/blink/renderer/core/frame/reporting_observer_browsertest.cc",
       "//brave/common/brave_channel_info_browsertest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19069

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open Brave Browser with a clean profile and verify that all components are installed correctly.
2. Navigate to: https://chrome.google.com/webstore/detail/google-translate/aapbdbdomjkkjkaonfhkkikfgjllcleb
3. Add to Brave
4. Navigate to brave://extensions/
5. Click details
6. Verify the source says `Web Extensions Store`