### PR TITLE
Update Selected Send Token When Switching Networks

### DIFF
--- a/components/brave_wallet_ui/common/hooks/assets.ts
+++ b/components/brave_wallet_ui/common/hooks/assets.ts
@@ -50,16 +50,17 @@ export default function useAssets (
     [userVisibleTokensInfo]
   )
 
-  const sendAssetOptions = selectedAccount?.tokens?.map((token) => ({
-    ...token,
-    asset: {
-      ...token.asset,
-      logo:
-        token.asset.symbol === 'ETH'
-          ? ETH.asset.logo
-          : token.asset.logo
-    }
-  }))
+  const sendAssetOptions: AccountAssetOptionType[] = React.useMemo(() => {
+    const assets = userVisibleTokenOptions
+      .map((token) => ({
+        asset: token,
+        assetBalance: '0',
+        fiatBalance: '0'
+      }))
+    return assets
+  },
+    [userVisibleTokenOptions]
+  )
 
   return {
     tokenOptions,

--- a/components/brave_wallet_ui/common/hooks/selectPreset.ts
+++ b/components/brave_wallet_ui/common/hooks/selectPreset.ts
@@ -9,15 +9,17 @@ import { WalletAccountType, AccountAssetOptionType } from '../../constants/types
 
 export default function usePreset (
   selectedAccount: WalletAccountType,
-  fromAsset: AccountAssetOptionType,
+  swapAsset: AccountAssetOptionType,
+  sendAsset: AccountAssetOptionType,
   onSetFromAmount: (value: string) => void,
   onSetSendAmount: (value: string) => void
 ) {
   return (sendOrSwap: 'send' | 'swap') => (percent: number) => {
+    const selectedAsset = sendOrSwap === 'send' ? sendAsset : swapAsset
     const asset = selectedAccount.tokens.find(
       (token) => (
-        token.asset.contractAddress === fromAsset.asset.contractAddress ||
-        token.asset.symbol === fromAsset.asset.symbol
+        token.asset.contractAddress === selectedAsset.asset.contractAddress ||
+        token.asset.symbol === selectedAsset.asset.symbol
       )
     )
     const amount = new BigNumber(asset?.assetBalance || '0').times(percent).toString()

--- a/components/brave_wallet_ui/common/hooks/send.ts
+++ b/components/brave_wallet_ui/common/hooks/send.ts
@@ -20,16 +20,26 @@ import { toWeiHex } from '../../utils/format-balances'
 export default function useSend (
   findENSAddress: (address: string) => Promise<GetEthAddrReturnInfo>,
   findUnstoppableDomainAddress: (address: string) => Promise<GetEthAddrReturnInfo>,
+  sendAssetOptions: AccountAssetOptionType[],
   selectedAccount: WalletAccountType,
-  fromAsset: AccountAssetOptionType,
   sendERC20Transfer: SimpleActionCreator<ER20TransferParams>,
   sendTransaction: SimpleActionCreator<SendTransactionParams>,
   sendERC721TransferFrom: SimpleActionCreator<ERC721TransferFromParams>
 ) {
+
+  const [selectedSendAsset, setSelectedSendAsset] = React.useState<AccountAssetOptionType>(sendAssetOptions[0])
   const [toAddressOrUrl, setToAddressOrUrl] = React.useState('')
   const [toAddress, setToAddress] = React.useState('')
   const [addressError, setAddressError] = React.useState('')
   const [sendAmount, setSendAmount] = React.useState('')
+
+  React.useEffect(() => {
+    setSelectedSendAsset(sendAssetOptions[0])
+  }, [sendAssetOptions])
+
+  const onSelectSendAsset = (asset: AccountAssetOptionType) => {
+    setSelectedSendAsset(asset)
+  }
 
   const supportedENSExtensions = ['.eth']
   const supportedUDExtensions = ['.crypto']
@@ -104,25 +114,25 @@ export default function useSend (
   }, [toAddressOrUrl])
 
   const onSubmitSend = () => {
-    fromAsset.asset.isErc20 && sendERC20Transfer({
+    selectedSendAsset.asset.isErc20 && sendERC20Transfer({
       from: selectedAccount.address,
       to: toAddress,
-      value: toWeiHex(sendAmount, fromAsset.asset.decimals),
-      contractAddress: fromAsset.asset.contractAddress
+      value: toWeiHex(sendAmount, selectedSendAsset.asset.decimals),
+      contractAddress: selectedSendAsset.asset.contractAddress
     })
 
-    fromAsset.asset.isErc721 && sendERC721TransferFrom({
+    selectedSendAsset.asset.isErc721 && sendERC721TransferFrom({
       from: selectedAccount.address,
       to: toAddress,
       value: '',
-      contractAddress: fromAsset.asset.contractAddress,
-      tokenId: fromAsset.asset.tokenId ?? ''
+      contractAddress: selectedSendAsset.asset.contractAddress,
+      tokenId: selectedSendAsset.asset.tokenId ?? ''
     })
 
-    !fromAsset.asset.isErc721 && !fromAsset.asset.isErc20 && sendTransaction({
+    !selectedSendAsset.asset.isErc721 && !selectedSendAsset.asset.isErc20 && sendTransaction({
       from: selectedAccount.address,
       to: toAddress,
-      value: toWeiHex(sendAmount, fromAsset.asset.decimals)
+      value: toWeiHex(sendAmount, selectedSendAsset.asset.decimals)
     })
 
     setToAddressOrUrl('')
@@ -133,9 +143,11 @@ export default function useSend (
     onSetSendAmount,
     onSetToAddressOrUrl,
     onSubmitSend,
+    onSelectSendAsset,
     toAddressOrUrl,
     toAddress,
     sendAmount,
-    addressError
+    addressError,
+    selectedSendAsset
   }
 }

--- a/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
+++ b/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
@@ -31,7 +31,7 @@ function withPlaceholderIcon (WrappedComponent: React.ComponentType<any>, config
 
     const bg = React.useMemo(() => {
       if (selectedAsset?.symbol !== 'ETH' && stripERC20TokenImageURL(selectedAsset?.logo) === '') {
-        return background({ seed: selectedAsset?.contractAddress.toLowerCase() })
+        return background({ seed: selectedAsset.contractAddress ? selectedAsset?.contractAddress.toLowerCase() : selectedAsset.name })
       }
     }, [selectedAsset])
 

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -171,25 +171,28 @@ function Container (props: Props) {
     onSetSendAmount,
     onSetToAddressOrUrl,
     onSubmitSend,
+    onSelectSendAsset,
     sendAmount,
     toAddressOrUrl,
     toAddress,
-    addressError
+    addressError,
+    selectedSendAsset
   } = useSend(
     findENSAddress,
     findUnstoppableDomainAddress,
+    sendAssetOptions,
     selectedAccount,
-    fromAsset,
     props.walletActions.sendERC20Transfer,
     props.walletActions.sendTransaction,
     props.walletActions.sendERC721TransferFrom
   )
 
   const getSelectedAccountBalance = useBalance(selectedAccount)
+  const { assetBalance: sendAssetBalance } = getSelectedAccountBalance(selectedSendAsset)
   const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
   const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
 
-  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, onSetFromAmount, onSetSendAmount)
+  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, selectedSendAsset, onSetFromAmount, onSetSendAmount)
 
   const onToggleShowRestore = React.useCallback(() => {
     if (walletLocation === WalletRoutes.Restore) {
@@ -623,6 +626,8 @@ function Container (props: Props) {
             toAddressOrUrl={toAddressOrUrl}
             toAddress={toAddress}
             buyAssetOptions={WyreAccountAssetOptions}
+            selectedSendAsset={selectedSendAsset}
+            sendAssetBalance={sendAssetBalance}
             sendAssetOptions={sendAssetOptions}
             swapAssetOptions={swapAssetOptions}
             isFetchingSwapQuote={isFetchingSwapQuote}
@@ -649,6 +654,7 @@ function Container (props: Props) {
             onSelectAsset={onSelectTransactAsset}
             onSelectTab={setSelectedWidgetTab}
             onSwapQuoteRefresh={onSwapQuoteRefresh}
+            onSelectSendAsset={onSelectSendAsset}
           />
         </WalletWidgetStandIn>
       }

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -152,7 +152,6 @@ function Container (props: Props) {
     toAsset,
     customSlippageTolerance,
     onSetFromAmount,
-    setFromAsset,
     setSwapToOrFrom,
     onToggleOrderType,
     onSwapQuoteRefresh,
@@ -179,15 +178,17 @@ function Container (props: Props) {
     onSetSendAmount,
     onSetToAddressOrUrl,
     onSubmitSend,
+    onSelectSendAsset,
     sendAmount,
     toAddressOrUrl,
     toAddress,
-    addressError
+    addressError,
+    selectedSendAsset
   } = useSend(
     findENSAddress,
     findUnstoppableDomainAddress,
+    sendAssetOptions,
     selectedAccount,
-    fromAsset,
     props.walletActions.sendERC20Transfer,
     props.walletActions.sendTransaction,
     props.walletActions.sendERC721TransferFrom
@@ -198,10 +199,11 @@ function Container (props: Props) {
   }, [selectedAccount])
 
   const getSelectedAccountBalance = useBalance(selectedAccount)
+  const { assetBalance: sendAssetBalance } = getSelectedAccountBalance(selectedSendAsset)
   const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
   const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
 
-  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, onSetFromAmount, onSetSendAmount)
+  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, selectedSendAsset, onSetFromAmount, onSetSendAmount)
 
   const onSetBuyAmount = (value: string) => {
     setBuyAmount(value)
@@ -244,7 +246,7 @@ function Container (props: Props) {
     } else if (selectedPanel === 'swap') {
       onSelectTransactAsset(asset, swapToOrFrom)
     } else {
-      setFromAsset(asset)
+      onSelectSendAsset(asset)
     }
 
     setShowSelectAsset(false)
@@ -668,9 +670,9 @@ function Container (props: Props) {
                 onInputChange={onInputChange}
                 onSelectPresetAmount={onSelectPresetAmountFactory('send')}
                 onSubmit={onSubmitSend}
-                selectedAsset={fromAsset}
+                selectedAsset={selectedSendAsset}
                 selectedAssetAmount={sendAmount}
-                selectedAssetBalance={fromAssetBalance}
+                selectedAssetBalance={sendAssetBalance}
                 addressError={addressError}
                 toAddressOrUrl={toAddressOrUrl}
                 toAddress={toAddress}

--- a/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
+++ b/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
@@ -23,6 +23,8 @@ export interface Props {
   accounts: UserAccountType[]
   networkList: EthereumChain[]
   orderType: OrderTypes
+  selectedSendAsset: AccountAssetOptionType
+  sendAssetBalance: string
   swapToAsset: AccountAssetOptionType
   swapFromAsset: AccountAssetOptionType
   selectedNetwork: EthereumChain
@@ -68,6 +70,7 @@ export interface Props {
   onSelectPresetSendAmount: (percent: number) => void
   onSelectTab: (tab: BuySendSwapTypes) => void
   onSwapQuoteRefresh: () => void
+  onSelectSendAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
 }
 
 function BuySendSwap (props: Props) {
@@ -88,6 +91,8 @@ function BuySendSwap (props: Props) {
     fromAmount,
     toAmount,
     addressError,
+    selectedSendAsset,
+    sendAssetBalance,
     fromAssetBalance,
     toAssetBalance,
     toAddress,
@@ -119,7 +124,8 @@ function BuySendSwap (props: Props) {
     onSelectPresetFromAmount,
     onSelectPresetSendAmount,
     onSelectTab,
-    onSwapQuoteRefresh
+    onSwapQuoteRefresh,
+    onSelectSendAsset
   } = props
 
   React.useMemo(() => {
@@ -194,19 +200,19 @@ function BuySendSwap (props: Props) {
           accounts={accounts}
           networkList={networkList}
           selectedAssetAmount={sendAmount}
-          selectedAssetBalance={fromAssetBalance}
+          selectedAssetBalance={sendAssetBalance}
           toAddressOrUrl={toAddressOrUrl}
           toAddress={toAddress}
           onSelectAccount={onSelectAccount}
           onSelectNetwork={onSelectNetwork}
           onSelectPresetAmount={onSelectPresetSendAmount}
-          onSelectAsset={onSelectAsset}
+          onSelectAsset={onSelectSendAsset}
           onSetSendAmount={onSetSendAmount}
           onSetToAddressOrUrl={onSetToAddressOrUrl}
           onSubmit={onSubmitSend}
           selectedAccount={selectedAccount}
           selectedNetwork={selectedNetwork}
-          selectedAsset={swapFromAsset}
+          selectedAsset={selectedSendAsset}
           showHeader={true}
           assetOptions={sendAssetOptions}
         />

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -788,6 +788,8 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
             sendAmount={sendAmount}
             fromAmount={fromAmount}
             toAmount={toAmount}
+            selectedSendAsset={fromAsset}
+            sendAssetBalance={fromAssetBalance}
             fromAssetBalance={fromAssetBalance}
             toAssetBalance={toAssetBalance}
             toAddressOrUrl={toAddress}
@@ -821,6 +823,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
             swapAssetOptions={AccountAssetOptions}
             networkList={mockNetworks}
             onSwapQuoteRefresh={onSwapQuoteRefresh}
+            onSelectSendAsset={onSelectTransactAsset}
           />
         </WalletWidgetStandIn>
       }


### PR DESCRIPTION
## Description 
Update Selected Send Token to Native Asset When Switching Networks

Refactored some things in this PR:

1) `Send` component now has its own `selectedSendAsset` state and is no longer use `fromAsset` that was being shared between the `Swap` and `Send` components.
2) Updated the `sendAssetOptions` from the `assets` hook to be memoized and build the list based on the `visibleAssetsList`
3) Updated the `usePreset` hook to accept `selectedSendAsset`
4) Fixed an issue where the `PlaceHolder` icon for a custom networks `Native Asset` would change after every render, since it is being passed an empty string for a `contractAddress`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19060>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

https://user-images.githubusercontent.com/40611140/139506013-cc4bda93-61a8-4241-8ba6-b77d1a26a388.mov

After:

https://user-images.githubusercontent.com/40611140/139506030-858835cf-9361-4ce8-85cd-2f1548b5702d.mov
