### PR TITLE
Fix Ads notification crash on Android S (uplift to 1.31.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/notifications/BraveOnboardingNotification.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BraveOnboardingNotification.java
@@ -84,11 +84,8 @@ public class BraveOnboardingNotification extends BroadcastReceiver {
     public static PendingIntentProvider getDeepLinkIntent(Context context) {
         Intent intent = new Intent(context, BraveOnboardingNotification.class);
         intent.setAction(DEEP_LINK);
-        return new PendingIntentProvider(
-                PendingIntent.getBroadcast(context, 0, intent,
-                        PendingIntent.FLAG_UPDATE_CURRENT
-                                | IntentUtils.getPendingIntentMutabilityFlag(true)),
-                0, 0);
+        return PendingIntentProvider.getBroadcast(
+                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT, true);
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/notifications/BraveSetDefaultBrowserNotificationService.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BraveSetDefaultBrowserNotificationService.java
@@ -150,8 +150,8 @@ public class BraveSetDefaultBrowserNotificationService extends BroadcastReceiver
         intent.setAction(CANCEL_NOTIFICATION);
         intent.putExtra(NOTIFICATION_ID_EXTRA, notification_id);
 
-        return PendingIntent.getBroadcast(context, notification_id, intent,
-                0 | IntentUtils.getPendingIntentMutabilityFlag(true));
+        return PendingIntent.getBroadcast(
+                context, notification_id, intent, IntentUtils.getPendingIntentMutabilityFlag(true));
     }
 
     private boolean hasAskedAt1122() {

--- a/android/java/org/chromium/chrome/browser/upgrade/NotificationIntent.java
+++ b/android/java/org/chromium/chrome/browser/upgrade/NotificationIntent.java
@@ -17,6 +17,7 @@ import android.view.View;
 
 import androidx.core.app.NotificationCompat;
 
+import org.chromium.base.IntentUtils;
 import org.chromium.base.Log;
 import org.chromium.base.ThreadUtils;
 import org.chromium.chrome.R;
@@ -63,7 +64,8 @@ public class NotificationIntent {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(URL));
         intent.putExtra(BravePreferenceKeys.BRAVE_UPDATE_EXTRA_PARAM, true);
         intent.setPackage(context.getPackageName());
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                context, 0, intent, IntentUtils.getPendingIntentMutabilityFlag(true));
 
         mBuilder.setContentIntent(pendingIntent);
         mBuilder.setAutoCancel(true);


### PR DESCRIPTION
Uplift of #10802
Resolves brave/brave-browser/issues/19149.

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.