### PR TITLE
Fix use after move when sendAsync fails 

### DIFF
--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -617,6 +617,9 @@ void BraveWalletJSHandler::SendAsync(gin::Arguments* args) {
           isolate, true)) {
     base::Value id;
     std::string input_json;
+    input_value =
+        content::V8ValueConverter::Create()->FromV8Value(
+            input, isolate->GetCurrentContext());
     if (base::JSONWriter::Write(*input_value, &input_json)) {
       std::string method;
       ALLOW_UNUSED_LOCAL(

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -617,9 +617,8 @@ void BraveWalletJSHandler::SendAsync(gin::Arguments* args) {
           isolate, true)) {
     base::Value id;
     std::string input_json;
-    input_value =
-        content::V8ValueConverter::Create()->FromV8Value(
-            input, isolate->GetCurrentContext());
+    input_value = content::V8ValueConverter::Create()->FromV8Value(
+        input, isolate->GetCurrentContext());
     if (base::JSONWriter::Write(*input_value, &input_json)) {
       std::string method;
       ALLOW_UNUSED_LOCAL(

--- a/test/data/brave-wallet/sign_message.html
+++ b/test/data/brave-wallet/sign_message.html
@@ -24,8 +24,50 @@
     })
   }
 
+  function signMessageViaSend(address, message) {
+    window.ethereum.send({
+      id: '1',
+      method: 'eth_sign',
+      params: [address, message]
+    }, (err, result) => {
+      if (err && err.error) {
+        signMessageResult = err.error.message
+        return
+      }
+      if (result && result.result) {
+        signMessageResult = result.result
+      }
+    })
+  }
+
+  function signMessageViaSend2(address, message) {
+    window.ethereum.send('eth_sign', [address, message]).then(result => {
+      signMessageResult = result.result
+    }).catch(error => {
+      signMessageResult = error.error.message
+    })
+  }
+
+  function signMessageViaSendAsync(address, message) {
+    window.ethereum.sendAsync({
+      id: '1',
+      method: 'eth_sign',
+      params: [address, message]
+    }, (err, result) => {
+      if (err && err.error) {
+        signMessageResult = err.error.message
+        return
+      }
+      if (result && result.result) {
+        signMessageResult = result.result
+      }
+    })
+  }
+
   function getSignMessageResult() {
     window.domAutomationController.send(signMessageResult)
+    // Reset signMessageResult
+    signMessageResult = undefined
   }
 </script>
 


### PR DESCRIPTION
This can happen any time sendAsync fails, but the case that it was run into in the wild was because of an eth_sign with an invalid param.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19192

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

