### PR TITLE
Fix use after move when sendAsync fails (uplift to 1.32.x)

### DIFF
--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -617,6 +617,8 @@ void BraveWalletJSHandler::SendAsync(gin::Arguments* args) {
           isolate, true)) {
     base::Value id;
     std::string input_json;
+    input_value = content::V8ValueConverter::Create()->FromV8Value(
+        input, isolate->GetCurrentContext());
     if (base::JSONWriter::Write(*input_value, &input_json)) {
       std::string method;
       ALLOW_UNUSED_LOCAL(

--- a/test/data/brave-wallet/sign_message.html
+++ b/test/data/brave-wallet/sign_message.html
@@ -24,8 +24,50 @@
     })
   }
 
+  function signMessageViaSend(address, message) {
+    window.ethereum.send({
+      id: '1',
+      method: 'eth_sign',
+      params: [address, message]
+    }, (err, result) => {
+      if (err && err.error) {
+        signMessageResult = err.error.message
+        return
+      }
+      if (result && result.result) {
+        signMessageResult = result.result
+      }
+    })
+  }
+
+  function signMessageViaSend2(address, message) {
+    window.ethereum.send('eth_sign', [address, message]).then(result => {
+      signMessageResult = result.result
+    }).catch(error => {
+      signMessageResult = error.error.message
+    })
+  }
+
+  function signMessageViaSendAsync(address, message) {
+    window.ethereum.sendAsync({
+      id: '1',
+      method: 'eth_sign',
+      params: [address, message]
+    }, (err, result) => {
+      if (err && err.error) {
+        signMessageResult = err.error.message
+        return
+      }
+      if (result && result.result) {
+        signMessageResult = result.result
+      }
+    })
+  }
+
   function getSignMessageResult() {
     window.domAutomationController.send(signMessageResult)
+    // Reset signMessageResult
+    signMessageResult = undefined
   }
 </script>
 


### PR DESCRIPTION
Uplift of #10828
Resolves https://github.com/brave/brave-browser/issues/19192

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.