### PR TITLE
Reset sync chain and clear prefs right away when transaport state is not active (uplift to 1.31.x)

### DIFF
--- a/components/brave_sync/sync_service_impl_helper.cc
+++ b/components/brave_sync/sync_service_impl_helper.cc
@@ -20,7 +20,7 @@ void ResetSync(syncer::BraveSyncServiceImpl* sync_service_impl,
                base::OnceClosure on_reset_done) {
   if (sync_service_impl->GetTransportState() !=
       syncer::SyncService::TransportState::ACTIVE) {
-    std::move(on_reset_done).Run();
+    sync_service_impl->OnSelfDeviceInfoDeleted(std::move(on_reset_done));
     return;
   }
   syncer::DeviceInfoTracker* tracker =


### PR DESCRIPTION
Uplift of #10841
Resolves https://github.com/brave/brave-browser/issues/19199

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.