### PR TITLE
Add ability to build arm64 iOS simulator builds (uplift to 1.32.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -84,6 +84,7 @@ const Config = function () {
   this.gClientVerbose = getNPMConfig(['gclient_verbose']) || false
   this.targetArch = getNPMConfig(['target_arch']) || 'x64'
   this.targetOS = getNPMConfig(['target_os'])
+  this.targetEnvironment = getNPMConfig(['target_environment'])
   this.gypTargetArch = 'x64'
   this.targetAndroidBase = 'classic'
   this.braveGoogleApiKey = getNPMConfig(['brave_google_api_key']) || 'AIzaSyAREPLACEWITHYOUROWNGOOGLEAPIKEY2Q'
@@ -408,6 +409,9 @@ Config.prototype.buildArgs = function () {
 
   if (this.targetOS === 'ios') {
     args.target_os = 'ios'
+    if (this.targetEnvironment) {
+      args.target_environment = this.targetEnvironment
+    }
     args.enable_dsyms = true
     args.enable_stripping = !this.isDebug()
     args.use_xcode_clang = false
@@ -589,6 +593,10 @@ Config.prototype.update = function (options) {
 
   if (options.target_os) {
     this.targetOS = options.target_os
+  }
+
+  if (options.target_environment) {
+    this.targetEnvironment = options.target_environment
   }
 
   if (options.is_asan) {
@@ -905,6 +913,9 @@ Object.defineProperty(Config.prototype, 'outputDir', {
     }
     if (this.targetOS) {
       buildConfigDir = this.targetOS + "_" + buildConfigDir
+    }
+    if (this.targetEnvironment) {
+      buildConfigDir = buildConfigDir  + "_" + this.targetEnvironment
     }
 
     return path.join(baseDir, buildConfigDir)

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -58,6 +58,7 @@ program
   .option('--target_os <target_os>', 'target OS')
   .option('--target_arch <target_arch>', 'target architecture')
   .option('--target_android_base <target_android_base>', 'target Android OS apk (classic, modern, mono)', 'classic')
+  .option('--target_environment <target_environment>', 'target environment (device, catalyst, simulator)')
   .arguments('[build_config]')
   .action(gnCheck)
 
@@ -73,6 +74,7 @@ program
   .option('--target_arch <target_arch>', 'target architecture')
   .option('--target_android_base <target_android_base>', 'target Android SDK level for apk or aab  (classic, modern, mono)', 'classic')
   .option('--target_android_output_format <target_android_output_format>', 'target Android output format (apk, aab)')
+  .option('--target_environment <target_environment>', 'target environment (device, catalyst, simulator)')
   .option('--android_override_version_name <android_override_version_name>', 'Android version number')
   .option('--mac_signing_identifier <id>', 'The identifier to use for signing')
   .option('--mac_signing_keychain <keychain>', 'The identifier to use for signing', 'login')

--- a/build/rust/config.gni
+++ b/build/rust/config.gni
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import("//build/config/ios/config.gni")
 import("//build/config/sysroot.gni")
 
 rustc_target = ""
@@ -49,7 +50,11 @@ if (is_win) {
   }
 } else if (is_ios) {
   if (current_cpu == "arm64") {
-    rustc_target = "aarch64-apple-ios"
+    if (target_environment == "simulator") {
+      rustc_target = "aarch64-apple-ios-sim"
+    } else {
+      rustc_target = "aarch64-apple-ios"
+    }
   } else if (current_cpu == "x64") {
     rustc_target = "x86_64-apple-ios"
   }


### PR DESCRIPTION
Uplift of #10805

b-b issue: https://github.com/brave/brave-browser/issues/19245

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.