### PR TITLE
Fixed Text Overflow in Sign Panel (uplift to 1.32.x)

### DIFF
--- a/components/brave_wallet_ui/components/extension/sign-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/sign-panel/style.ts
@@ -76,6 +76,8 @@ export const MessageBox = styled.div`
   height: 140px;
   padding: 8px 14px;
   margin-bottom: 14px;
+  overflow-x: hidden;
+  overflow-y: scroll;
 `
 
 export const MessageText = styled.span`
@@ -85,6 +87,7 @@ export const MessageText = styled.span`
   letter-spacing: 0.01em;
   text-align: left;
   color: ${(p) => p.theme.color.text02};
+  word-break: break-word;
 `
 
 export const ButtonRow = styled.div`


### PR DESCRIPTION
Uplift of #10907
Resolves https://github.com/brave/brave-browser/issues/19227

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.