### PR TITLE
Expose properties chainId and selectedAddress on window.ethereum and fix chainChanged params

### DIFF
--- a/browser/brave_wallet/brave_wallet_event_emitter_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_event_emitter_browsertest.cc
@@ -43,7 +43,7 @@ std::string CheckForEventScript(const std::string& event_var) {
                    });
                    console.log('!!!set connect')
                    window.ethereum.on('chainChanged', function(chainId) {
-                     received_chain_changed_event = true
+                     received_chain_changed_event = chainId == '0x5'
                    });
                    console.log('!!!set chainChanged')
                  }

--- a/browser/brave_wallet/send_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_transaction_browsertest.cc
@@ -185,6 +185,8 @@ class SendTransactionBrowserTest : public InProcessBrowserTest {
 
   void LockWallet() {
     keyring_controller_->Lock();
+    // Needed so KeyringControllerObserver::Locked handler can be hit
+    // which the provider object listens to for the accountsChanged event.
     base::RunLoop().RunUntilIdle();
   }
 
@@ -196,6 +198,8 @@ class SendTransactionBrowserTest : public InProcessBrowserTest {
                                   run_loop.Quit();
                                 }));
     run_loop.Run();
+    // Needed so KeyringControllerObserver::Unlocked handler can be hit
+    // which the provider object listens to for the accountsChanged event.
     base::RunLoop().RunUntilIdle();
   }
 
@@ -249,6 +253,8 @@ class SendTransactionBrowserTest : public InProcessBrowserTest {
     host_content_settings_map()->SetContentSettingDefaultScope(
         sub_request_origin, url, ContentSettingsType::BRAVE_ETHEREUM,
         ContentSetting::CONTENT_SETTING_ALLOW);
+    // Needed so content settings observer handler can be hit
+    // which the provider object listens to for the accountsChanged event.
     base::RunLoop().RunUntilIdle();
   }
 

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -852,9 +852,7 @@ void BraveWalletJSHandler::ChainChangedEvent(const std::string& chain_id) {
   if (chain_id_ == chain_id)
     return;
 
-  base::DictionaryValue event_args;
-  event_args.SetStringKey("chainId", chain_id);
-  FireEvent(kChainChangedEvent, std::move(event_args));
+  FireEvent(kChainChangedEvent, base::Value(chain_id));
   chain_id_ = chain_id;
   UpdateAndBindJSProperties();
 }

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -41,6 +41,10 @@ class BraveWalletJSHandler : public mojom::EventsListener {
   void BindFunctionsToObject(v8::Isolate* isolate,
                              v8::Local<v8::Context> context,
                              v8::Local<v8::Object> javascript_object);
+  void UpdateAndBindJSProperties();
+  void UpdateAndBindJSProperties(v8::Isolate* isolate,
+                                 v8::Local<v8::Context> context,
+                                 v8::Local<v8::Object> ethereum_obj);
 
   // Adds a function to the provided object.
   template <typename Sig>
@@ -151,6 +155,7 @@ class BraveWalletJSHandler : public mojom::EventsListener {
   mojo::Receiver<mojom::EventsListener> receiver_{this};
   bool is_connected_;
   std::string chain_id_;
+  std::string first_allowed_account_;
   base::WeakPtrFactory<BraveWalletJSHandler> weak_ptr_factory_{this};
 };
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -736,6 +736,7 @@ if (!is_android) {
       "//brave/components/brave_shields/common",
       "//brave/components/brave_vpn/buildflags",
       "//brave/components/brave_wallet/browser",
+      "//brave/components/brave_wallet/browser:ethereum_permission_utils",
       "//brave/components/brave_wallet/common",
       "//brave/components/brave_wallet/common:mojom",
       "//brave/components/debounce/browser",

--- a/test/data/brave-wallet/send_transaction.html
+++ b/test/data/brave-wallet/send_transaction.html
@@ -2,10 +2,13 @@
 
 <script>
   var permissionGranted = false
+  var selectedAddress = ''
   window.ethereum.enable().then(accounts => {
       permissionGranted = true
+      selectedAddress = window.ethereum.selectedAddress
   }).catch(error => {
       permissionGranted = false
+      selectedAddress = window.ethereum.selectedAddress
   })
 
   function getPermissionGranted() {
@@ -71,6 +74,13 @@
   }
   function getSendTransactionError() {
     window.domAutomationController.send(sendTransactionError)
+  }
+  // window.ethereum.selectedAddress and not necessarily the selected account
+  function getSelectedAddress() {
+    window.domAutomationController.send(String(selectedAddress))
+  }
+  function getChainId() {
+    window.domAutomationController.send(window.ethereum.chainId)
   }
 </script>
 

--- a/test/data/brave-wallet/send_transaction.html
+++ b/test/data/brave-wallet/send_transaction.html
@@ -2,13 +2,10 @@
 
 <script>
   var permissionGranted = false
-  var selectedAddress = ''
   window.ethereum.enable().then(accounts => {
       permissionGranted = true
-      selectedAddress = window.ethereum.selectedAddress
   }).catch(error => {
       permissionGranted = false
-      selectedAddress = window.ethereum.selectedAddress
   })
 
   function getPermissionGranted() {
@@ -77,7 +74,7 @@
   }
   // window.ethereum.selectedAddress and not necessarily the selected account
   function getSelectedAddress() {
-    window.domAutomationController.send(String(selectedAddress))
+    window.domAutomationController.send(String(window.ethereum.selectedAddress))
   }
   function getChainId() {
     window.domAutomationController.send(window.ethereum.chainId)


### PR DESCRIPTION
This fixes the chainChanged event which is currently emitting an object with chainId as a property, but instead should be just emitting the string chainId. 

This also adds selectedAddress which is the first connected address for MM webcompat
And also chainId which is the chainId that is connected.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19262
Resolves https://github.com/brave/brave-browser/issues/19261

Updated documentation here:
https://github.com/brave/brave-browser/wiki/Ethereum-Provider-API#selectedaddress
and
https://github.com/brave/brave-browser/wiki/Ethereum-Provider-API#chainid

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

