### PR TITLE
Fix lint.py

### DIFF
--- a/build/commands/scripts/lint.py
+++ b/build/commands/scripts/lint.py
@@ -37,7 +37,7 @@ def HasFormatErrors():
             print(git_diff)
             print('Format errors have been auto-fixed. Please review and commit these'
                 ' changes if lint was run locally. Otherwise run npm format to fix.')
-        return True
+            return True
     return False
 
 def RunFormatCheck(upstream_branch): # pylint: disable=inconsistent-return-statements


### PR DESCRIPTION
It seems some semantic indents got lost in 7c3fbe3af69e2cc9d3f806e5f97f8512fc4bc76e and the fix 49874507d148b958b28adfcb1110c263a9d91246 missed one. This leads to false positive lint failures in CI, for example in #10883:

```
Running cpplint...
[2021-11-08T10:48:14.396Z] Skipping file DEPS
[2021-11-08T10:48:14.396Z] Skipping file chromium_src/google_update/google_update_idl.idl
[2021-11-08T10:48:14.396Z] Ignoring file win_build_output/midl/google_update/x64/google_update_idl.h
[2021-11-08T10:48:14.396Z] Skipping file win_build_output/midl/google_update/x64/google_update_idl.tlb
[2021-11-08T10:48:14.396Z] Skipping file win_build_output/midl/google_update/x64/google_update_idl_i.c
[2021-11-08T10:48:14.396Z] Skipping file win_build_output/midl/google_update/x64/google_update_idl_p.c
[2021-11-08T10:48:14.396Z] Ignoring file win_build_output/midl/google_update/x86/google_update_idl.h
[2021-11-08T10:48:14.396Z] Skipping file win_build_output/midl/google_update/x86/google_update_idl.tlb
[2021-11-08T10:48:14.396Z] Skipping file win_build_output/midl/google_update/x86/google_update_idl_i.c
[2021-11-08T10:48:14.396Z] Skipping file win_build_output/midl/google_update/x86/google_update_idl_p.c
[2021-11-08T10:48:14.396Z] Running git cl/gn format on the diff from 6f1ffc49e01358d23dc0b51a60af28209c3e5bd6
[2021-11-08T10:48:14.396Z] ...
[2021-11-08T10:48:17.668Z] Format check failed.
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on

## Test Plan:

Only CI is affected so (I think) no extra tests are necessary.