### PR TITLE
Disable navigator.keyboard API when fingerprinting protection is on.

### DIFF
--- a/browser/farbling/BUILD.gn
+++ b/browser/farbling/BUILD.gn
@@ -14,6 +14,7 @@ if (!is_android) {
       "brave_enumeratedevices_farbling_browsertest.cc",
       "brave_navigator_devicememory_farbling_browsertest.cc",
       "brave_navigator_hardwareconcurrency_farbling_browsertest.cc",
+      "brave_navigator_keyboard_api_browsertest.cc",
       "brave_navigator_plugins_farbling_browsertest.cc",
       "brave_navigator_useragent_farbling_browsertest.cc",
       "brave_offscreencanvas_farbling_browsertest.cc",

--- a/browser/farbling/brave_navigator_keyboard_api_browsertest.cc
+++ b/browser/farbling/brave_navigator_keyboard_api_browsertest.cc
@@ -1,0 +1,134 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/containers/contains.h"
+#include "base/path_service.h"
+#include "brave/browser/brave_content_browser_client.h"
+#include "brave/common/brave_paths.h"
+#include "brave/components/brave_shields/browser/brave_shields_util.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_content_client.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/network_session_configurator/common/network_switches.h"
+#include "components/permissions/permission_request.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "url/gurl.h"
+
+using brave_shields::ControlType;
+
+const char kGetLayoutMapScript[] =
+    "(async function testKeyboardAPI() {"
+    "  keyboardLayoutMap = await navigator.keyboard.getLayoutMap();"
+    "  return keyboardLayoutMap.get('KeyA');"
+    "})()";
+
+class BraveNavigatorKeyboardAPIBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveNavigatorKeyboardAPIBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    base::PathService::Get(brave::DIR_TEST_DATA, &test_data_dir);
+    https_server_.SetSSLConfig(net::EmbeddedTestServer::CERT_OK);
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    EXPECT_TRUE(https_server_.Start());
+    top_level_page_url_ = https_server_.GetURL("a.com", "/");
+    test_url_ = https_server_.GetURL("a.com", "/simple.html");
+  }
+
+  BraveNavigatorKeyboardAPIBrowserTest(
+      const BraveNavigatorKeyboardAPIBrowserTest&) = delete;
+  BraveNavigatorKeyboardAPIBrowserTest& operator=(
+      const BraveNavigatorKeyboardAPIBrowserTest&) = delete;
+
+  ~BraveNavigatorKeyboardAPIBrowserTest() override {}
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    // HTTPS server only serves a valid cert for localhost, so this is needed
+    // to load pages from other hosts without an error
+    command_line->AppendSwitch(switches::kIgnoreCertificateErrors);
+  }
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    content_client_.reset(new ChromeContentClient);
+    content::SetContentClient(content_client_.get());
+    browser_content_client_.reset(new BraveContentBrowserClient());
+    content::SetBrowserClientForTesting(browser_content_client_.get());
+
+    host_resolver()->AddRule("*", "127.0.0.1");
+  }
+
+  void TearDown() override {
+    browser_content_client_.reset();
+    content_client_.reset();
+  }
+
+ protected:
+  net::EmbeddedTestServer https_server_;
+
+  const GURL& test_url() { return test_url_; }
+
+  HostContentSettingsMap* content_settings() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  void AllowFingerprinting() {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::ALLOW, top_level_page_url_);
+  }
+
+  void BlockFingerprinting() {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::BLOCK, top_level_page_url_);
+  }
+
+  void SetFingerprintingDefault() {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::DEFAULT, top_level_page_url_);
+  }
+
+  content::WebContents* contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+ private:
+  GURL top_level_page_url_;
+  GURL test_url_;
+  std::unique_ptr<ChromeContentClient> content_client_;
+  std::unique_ptr<BraveContentBrowserClient> browser_content_client_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveNavigatorKeyboardAPIBrowserTest,
+                       TestKeyboardAPIAvilability) {
+  // Fingerprinting level: off
+  // get real navigator.keyboard.getLayoutMap key
+  AllowFingerprinting();
+  EXPECT_TRUE(ui_test_utils::NavigateToURL(browser(), test_url()));
+  EXPECT_EQ("a", EvalJs(contents(), kGetLayoutMapScript));
+
+  // Fingerprinting level: standard (default)
+  // navigator.keyboard will be null
+  SetFingerprintingDefault();
+  EXPECT_TRUE(ui_test_utils::NavigateToURL(browser(), test_url()));
+  auto result_standard = EvalJs(contents(), kGetLayoutMapScript);
+  EXPECT_TRUE(base::Contains(
+      result_standard.error,
+      "Cannot read properties of null (reading 'getLayoutMap')"));
+
+  // Fingerprinting level: blocked (same as standard for this test)
+  BlockFingerprinting();
+  EXPECT_TRUE(ui_test_utils::NavigateToURL(browser(), test_url()));
+  auto result_blocked = EvalJs(contents(), kGetLayoutMapScript);
+  EXPECT_TRUE(base::Contains(
+      result_blocked.error,
+      "Cannot read properties of null (reading 'getLayoutMap')"));
+}

--- a/chromium_src/third_party/blink/renderer/DEPS
+++ b/chromium_src/third_party/blink/renderer/DEPS
@@ -11,6 +11,7 @@ include_rules = [
   "+../../../../../../../third_party/blink/renderer/modules/broadcastchannel",
   "+../../../../../../../third_party/blink/renderer/modules/cookie_store",
   "+../../../../../../../third_party/blink/renderer/modules/encryptedmedia",
+  "+../../../../../../../third_party/blink/renderer/modules/keyboard",
   "+../../../../../../../third_party/blink/renderer/modules/mediastream",
   "+../../../../../../../third_party/blink/renderer/modules/quota",
   "+../../../../../../../third_party/blink/renderer/modules/storage",

--- a/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc
+++ b/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "third_party/blink/renderer/modules/keyboard/navigator_keyboard.h"
+
+#include "brave/third_party/blink/renderer/brave_farbling_constants.h"
+#include "third_party/blink/public/platform/web_content_settings_client.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+
+#define keyboard keyboard_ChromiumImpl
+#include "../../../../../../../third_party/blink/renderer/modules/keyboard/navigator_keyboard.cc"
+#undef keyboard
+
+namespace blink {
+
+// static
+Keyboard* NavigatorKeyboard::keyboard(Navigator& navigator) {
+  if (ExecutionContext* context = navigator.GetExecutionContext()) {
+    if (WebContentSettingsClient* settings =
+            brave::GetContentSettingsClientFor(context)) {
+      if (settings->GetBraveFarblingLevel() != BraveFarblingLevel::OFF) {
+        return nullptr;
+      }
+    }
+  }
+  return keyboard_ChromiumImpl(navigator);
+}
+
+}  // namespace blink

--- a/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.h
+++ b/chromium_src/third_party/blink/renderer/modules/keyboard/navigator_keyboard.h
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_MODULES_KEYBOARD_NAVIGATOR_KEYBOARD_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_MODULES_KEYBOARD_NAVIGATOR_KEYBOARD_H_
+
+#define keyboard                     \
+  keyboard_ChromiumImpl(Navigator&); \
+  static Keyboard* keyboard
+
+#include "../../../../../../../third_party/blink/renderer/modules/keyboard/navigator_keyboard.h"
+#undef keyboard
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_MODULES_KEYBOARD_NAVIGATOR_KEYBOARD_H_


### PR DESCRIPTION
Fixes brave/brave-browser#3964

Have not found a convenient way to return navigator.keyboard as
`undefined` yet, so for now making it a null. 

Since this API is not supported by all browsers making an assumption
that web developers would check the API availability before using it
in the form of `if (navigator.keyboard)...`, in which case a null
should work just as well.

Maybe @pilgrim-brave or @bridiver have a better idea on making it `undefined`.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

