### PR TITLE
Improved Brave Wallets Keyboard Accessibility

### DIFF
--- a/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/index.tsx
@@ -48,6 +48,7 @@ function BuySendSwapLayout (props: Props) {
               isSelected={selectedTab === option.id}
               onClick={onChangeTab(option.id)}
               isDisabled={isBuyDisabled && option.id === 'buy' || isSwapDisabled && option.id === 'swap'}
+              disabled={isBuyDisabled && option.id === 'buy' || isSwapDisabled && option.id === 'swap'}
             >
               <RightDivider
                 tabID={option.id}

--- a/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { BuySendSwapTypes } from '../../../constants/types'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   isSelected: boolean
@@ -57,7 +58,7 @@ export const ButtonRow = styled.div`
   top: 0px;
 `
 
-export const TabButton = styled.button<Partial<StyleProps>>`
+export const TabButton = styled(WalletButton) <Partial<StyleProps>>`
   flex: 1;
   display: flex;
   height: 100%;

--- a/components/brave_wallet_ui/components/buy-send-swap/header/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/header/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import SwitchDown from '../../../assets/svg-icons/switch-icon.svg'
+import { WalletButton } from '../../shared/style'
 import {
   CaratCircleODownIcon
 } from 'brave-ui/components/icons'
@@ -24,7 +25,7 @@ export const NameAndIcon = styled.div`
   flex-direction: row;
 `
 
-export const AccountAndAddress = styled.button`
+export const AccountAndAddress = styled(WalletButton)`
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -51,7 +52,7 @@ export const AccountAddress = styled.span`
   letter-spacing: 0.01em;
   color: ${(p) => p.theme.color.text02};
 `
-export const AccountCircle = styled.button<StyleProps>`
+export const AccountCircle = styled(WalletButton) <StyleProps>`
   display: flex;
   cursor: pointer;
   width: 24px;
@@ -76,7 +77,7 @@ export const CaratDownIcon = styled(CaratCircleODownIcon)`
 
 // Will use brave-ui button comp in the future!
 // Currently is missing "tiny" variant
-export const OvalButton = styled.button`
+export const OvalButton = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
-import { AssetIconProps, AssetIconFactory } from '../../shared/style'
+import { AssetIconProps, AssetIconFactory, WalletButton } from '../../shared/style'
 
-export const StyledWrapper = styled.button`
+export const StyledWrapper = styled(WalletButton)`
   display: flex;
   width: 100%;
   flex-direction: row;

--- a/components/brave_wallet_ui/components/buy-send-swap/select-header/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-header/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../shared/style'
 import { CaratStrongLeftIcon } from 'brave-ui/components/icons'
 import Plus from '../../../assets/svg-icons/plus-icon.svg'
 
@@ -20,7 +21,7 @@ export const HeaderText = styled.span`
   color: ${(p) => p.theme.color.text01};
 `
 
-export const Button = styled.button`
+export const Button = styled(WalletButton)`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/style.ts
@@ -3,7 +3,7 @@ import { CaratStrongDownIcon } from 'brave-ui/components/icons'
 import Refresh from '../../../assets/svg-icons/refresh-icon.svg'
 import ClipboardIcon from '../../../assets/svg-icons/clipboard-icon.svg'
 import { BuySendSwapInputType } from './index'
-import { AssetIconProps, AssetIconFactory } from '../../shared/style'
+import { AssetIconProps, AssetIconFactory, WalletButton } from '../../shared/style'
 
 interface StyleProps {
   componentType: BuySendSwapInputType
@@ -31,7 +31,7 @@ export const FromBalanceText = styled.span<Partial<StyleProps>>`
   color: ${(p) => p.theme.color.text03};
 `
 
-export const AssetButton = styled.button<Partial<StyleProps>>`
+export const AssetButton = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -86,7 +86,7 @@ export const PresetRow = styled.div`
   margin-bottom: 4px;
 `
 
-export const PresetButton = styled.button<Partial<StyleProps>>`
+export const PresetButton = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -146,7 +146,7 @@ export const SlippageInput = styled.input<Partial<StyleProps>>`
   }
 `
 
-export const MarketLimitButton = styled.button`
+export const MarketLimitButton = styled(WalletButton)`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -163,7 +163,7 @@ export const MarketLimitButton = styled.button`
   color: ${(p) => p.theme.color.interactive05};
 `
 
-export const RefreshButton = styled.button`
+export const RefreshButton = styled(WalletButton)`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -249,7 +249,7 @@ export const SelectValueText = styled.span`
   margin-right: 4px;
 `
 
-export const PasteButton = styled.button`
+export const PasteButton = styled(WalletButton)`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/components/brave_wallet_ui/components/buy-send-swap/swap/style.ts
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { CaratStrongDownIcon } from 'brave-ui/components/icons'
 import { StyledButton } from '../../extension/buttons/nav-button/style'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -16,7 +17,7 @@ export const ArrowDownIcon = styled(CaratStrongDownIcon)`
   color: ${(p) => p.theme.color.text02};
 `
 
-export const ArrowButton = styled.button`
+export const ArrowButton = styled(WalletButton)`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import TrashIcon from '../../../assets/svg-icons/trash-icon.svg'
 import FlashdriveIcon from '../../../assets/svg-icons/flashdrive-icon.svg'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   orb: string
@@ -36,7 +37,7 @@ export const AccountNameRow = styled.div`
   flex-direction: row;
 `
 
-export const AccountName = styled.button`
+export const AccountName = styled(WalletButton)`
   font-family: Poppins;
   font-size: 13px;
   line-height: 20px;
@@ -49,7 +50,7 @@ export const AccountName = styled.button`
   border: none;
 `
 
-export const AccountAddress = styled.button`
+export const AccountAddress = styled(WalletButton)`
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;
@@ -77,7 +78,7 @@ export const AccountCircle = styled.div<StyleProps>`
   margin-right: 12px;
 `
 
-export const DeleteButton = styled.button`
+export const DeleteButton = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/add-button/style.ts
+++ b/components/brave_wallet_ui/components/desktop/add-button/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../shared/style'
 import icon from '../../../assets/svg-icons/plus-icon.svg'
 import { EditOIcon } from 'brave-ui/components/icons'
 interface StyleProps {
@@ -7,7 +8,7 @@ interface StyleProps {
 
 // Will need to change to brave-ui button
 
-export const StyledButton = styled.button<StyleProps>`
+export const StyledButton = styled(WalletButton) <StyleProps>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import TrashIcon from '../../../assets/svg-icons/trash-icon.svg'
-import { AssetIconProps, AssetIconFactory } from '../../shared/style'
+import { AssetIconProps, AssetIconFactory, WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -80,7 +80,7 @@ export const CheckboxRow = styled.div`
   width: 10%;
 `
 
-export const DeleteButton = styled.button`
+export const DeleteButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/chart-control-bar/style.ts
+++ b/components/brave_wallet_ui/components/desktop/chart-control-bar/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-
+import { WalletButton } from '../../shared/style'
 interface StyleProps {
   isSelected: boolean
 }
@@ -19,7 +19,7 @@ export const StyledWrapper = styled.div`
   }
 `
 
-export const StyledButton = styled.button<Partial<StyleProps>>`
+export const StyledButton = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/lock-screen/style.ts
+++ b/components/brave_wallet_ui/components/desktop/lock-screen/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import SecureIcon from '../../../assets/svg-icons/onboarding/secure-your-crypto.svg'
 import SecureIconDark from '../../../assets/svg-icons/onboarding/secure-your-crypto-dark.svg'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -42,7 +43,7 @@ export const InputColumn = styled.div`
   margin-bottom: 28px;
 `
 
-export const RestoreButton = styled.button`
+export const RestoreButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import ClipboardIcon from '../../../../assets/svg-icons/clipboard-icon.svg'
+import { WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -60,7 +61,7 @@ export const QRCodeWrapper = styled.img`
   margin-bottom: 16px;
 `
 
-export const AddressButton = styled.button`
+export const AddressButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -123,7 +124,7 @@ export const WarningText = styled.span`
   color: ${(p) => p.theme.color.text02};
 `
 
-export const PrivateKeyBubble = styled.button`
+export const PrivateKeyBubble = styled(WalletButton)`
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/style.ts
@@ -3,6 +3,7 @@ import { LoaderIcon } from 'brave-ui/components/icons'
 import LedgerLogo from '../../../../../assets/svg-icons/ledger-logo.svg'
 import TrezorLogo from '../../../../../assets/svg-icons/trezor-logo.svg'
 import { DisclaimerWrapper as DisclaimerWrapperBase } from '../style'
+import { WalletButton } from '../../../../shared/style'
 
 interface StyleProps {
   isSelected: boolean
@@ -28,7 +29,7 @@ export const HardwareButtonRow = styled.div`
   margin-bottom: 35px;
 `
 
-export const HardwareButton = styled.button<Partial<StyleProps>>`
+export const HardwareButton = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,7 +76,7 @@ export const HardwareInfoColumn = styled.div`
   margin-left: 10px;
 `
 
-export const ConnectingButton = styled.button`
+export const ConnectingButton = styled(WalletButton)`
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { LoaderIcon } from 'brave-ui/components/icons'
+import { WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -66,7 +67,7 @@ export const NoAssetText = styled.span`
   color: ${(p) => p.theme.color.text02};
 `
 
-export const NoAssetButton = styled.button`
+export const NoAssetButton = styled(WalletButton)`
   cursor: pointer;
   outline: none;
   border: none;

--- a/components/brave_wallet_ui/components/desktop/popup-modals/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import CloseIcon from '../../extension/assets/close.svg'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -50,8 +51,8 @@ export const Title = styled.span`
   color: ${(p) => p.theme.color.text01};
 `
 
-export const CloseButton = styled.button`
-  display: flex;;
+export const CloseButton = styled(WalletButton)`
+  display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;

--- a/components/brave_wallet_ui/components/desktop/portfolio-account-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-account-item/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { MoreVertRIcon } from 'brave-ui/components/icons'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   orb: string
@@ -22,7 +23,7 @@ export const NameAndIcon = styled.div`
   flex-direction: row;
 `
 
-export const AccountAndAddress = styled.button`
+export const AccountAndAddress = styled(WalletButton)`
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -90,7 +91,7 @@ export const AccountCircle = styled.div<StyleProps>`
   margin-right: 12px;
 `
 
-export const MoreButton = styled.button`
+export const MoreButton = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
-import { AssetIconProps, AssetIconFactory } from '../../shared/style'
+import { AssetIconProps, AssetIconFactory, WalletButton } from '../../shared/style'
 
 interface StyleProps {
   disabled: boolean
 }
 
-export const StyledWrapper = styled.button<StyleProps>`
+export const StyledWrapper = styled(WalletButton) <StyleProps>`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { TransactionStatus } from '../../../constants/types'
 import { MoreVertRIcon, ArrowRightIcon } from 'brave-ui/components/icons'
 import CoinsIconSVG from '../../../assets/svg-icons/coins-icon.svg'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   orb: string
@@ -69,7 +70,7 @@ export const ToCircle = styled.div<Partial<StyleProps>>`
   }
 `
 
-export const MoreButton = styled.button`
+export const MoreButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -166,7 +167,7 @@ export const StatusBubble = styled.div<Partial<StyleProps>>`
   margin-right: 6px;
 `
 
-export const CoinsButton = styled.button`
+export const CoinsButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -187,7 +188,7 @@ export const CoinsIcon = styled.div`
   background-image: url(${CoinsIconSVG});
 `
 
-export const AddressOrAsset = styled.button`
+export const AddressOrAsset = styled(WalletButton)`
   display: inline;
   cursor: pointer;
   outline: none;

--- a/components/brave_wallet_ui/components/desktop/select-network-dropdown/style.ts
+++ b/components/brave_wallet_ui/components/desktop/select-network-dropdown/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import {
   CaratCircleODownIcon
 } from 'brave-ui/components/icons'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -22,8 +23,8 @@ export const CaratDownIcon = styled(CaratCircleODownIcon)`
 
 // Will use brave-ui button comp in the future!
 // Currently is missing "tiny" variant
-export const OvalButton = styled.button`
-  display: flex;;
+export const OvalButton = styled(WalletButton)`
+  display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;

--- a/components/brave_wallet_ui/components/desktop/top-tab-nav-button/style.ts
+++ b/components/brave_wallet_ui/components/desktop/top-tab-nav-button/style.ts
@@ -1,11 +1,12 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   isSelected: boolean
   icon: string
 }
 
-export const StyledButton = styled.button<Partial<StyleProps>>`
+export const StyledButton = styled(WalletButton) <Partial<StyleProps>>`
 	display: flex;
   width: 140px;
 	align-items: center;

--- a/components/brave_wallet_ui/components/desktop/top-tab-nav/style.ts
+++ b/components/brave_wallet_ui/components/desktop/top-tab-nav/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { MoreVertRIcon } from 'brave-ui/components/icons'
 import { LockIconD } from '../../../assets/svg-icons/nav-button-icons'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -27,7 +28,7 @@ export const Line = styled.div`
   background: ${(p) => p.theme.color.divider01};
 `
 
-export const MoreButton = styled.button`
+export const MoreButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/transaction-popup/style.ts
+++ b/components/brave_wallet_ui/components/desktop/transaction-popup/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -15,7 +16,7 @@ export const StyledWrapper = styled.div`
   z-index: 15;
  `
 
-export const PopupButton = styled.button`
+export const PopupButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/components/brave_wallet_ui/components/desktop/views/accounts/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { SettingsAdvancedIcon, EditOIcon } from 'brave-ui/components/icons'
 import { SafeIcon } from '../../../../assets/svg-icons/nav-button-icons'
 import QRICON from '../../../../assets/svg-icons/qr-code-icon.svg'
+import { WalletButton } from '../../../shared/style'
 
 interface StyleProps {
   isHardwareWallet: boolean
@@ -90,7 +91,7 @@ export const ButtonsRow = styled.div`
   padding-right: 20px;
 `
 
-export const BackupButton = styled.button`
+export const BackupButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -111,7 +112,7 @@ export const BackupButtonText = styled.span`
   color: ${(p) => p.theme.color.text01};
 `
 
-export const Button = styled.button`
+export const Button = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -181,7 +182,7 @@ export const WalletName = styled.span`
   margin-right: 15px;
 `
 
-export const WalletAddress = styled.button`
+export const WalletAddress = styled(WalletButton)`
   font-family: Poppins;
   font-size: 15px;
   line-height: 20px;

--- a/components/brave_wallet_ui/components/desktop/wallet-banner/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-banner/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-
+import { WalletButton } from '../../shared/style'
 interface StyleProps {
   buttonType: 'primary' | 'secondary'
   bannerType: 'warning' | 'danger'
@@ -40,8 +40,8 @@ export const ButtonRow = styled.div`
   justify-content: center;
 `
 
-export const BannerButton = styled.button<Partial<StyleProps>>`
-  display: flex;;
+export const BannerButton = styled(WalletButton) <Partial<StyleProps>>`
+  display: flex;
   cursor: pointer;
   outline: none;
   border: none;

--- a/components/brave_wallet_ui/components/desktop/wallet-more-popup/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-more-popup/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { SettingsAdvancedIcon } from 'brave-ui/components/icons'
 import { LockIconD } from '../../../assets/svg-icons/nav-button-icons'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -17,7 +18,7 @@ export const StyledWrapper = styled.div`
   z-index: 10;
  `
 
-export const PopupButton = styled.button`
+export const PopupButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/backup/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/backup/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import BackupIcon from '../../../../assets/svg-icons/onboarding/backup-your-crypto.svg'
 import BackupIconDark from '../../../../assets/svg-icons/onboarding/backup-your-crypto-dark.svg'
+import { WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -78,7 +79,7 @@ export const PageIcon = styled.div`
   }
 `
 
-export const SkipButton = styled.button`
+export const SkipButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/style.ts
@@ -3,6 +3,7 @@ import MMIcon from '../../../../assets/svg-icons/onboarding/import-from-metamask
 import MMIconDark from '../../../../assets/svg-icons/onboarding/import-from-metamask-dark.svg'
 import BIcon from '../../../../assets/svg-icons/onboarding/reset-to-brave-wallet.svg'
 import BIconDark from '../../../../assets/svg-icons/onboarding/reset-to-brave-wallet-dark.svg'
+import { WalletButton } from '../../../shared/style'
 
 interface StyleProps {
   needsNewPassword: boolean
@@ -74,7 +75,7 @@ export const BraveIcon = styled.div<Partial<StyleProps>>`
   }
 `
 
-export const LostButton = styled.button`
+export const LostButton = styled(WalletButton)`
   cursor: pointer;
   outline: none;
   background: none;

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/recovery/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/recovery/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { AlertCircleIcon } from 'brave-ui/components/icons'
+import { WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -33,7 +34,7 @@ export const Description = styled.span`
   margin-bottom: 18px;
 `
 
-export const CopyButton = styled.button`
+export const CopyButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../../shared/style'
 
 interface StyleProps {
   isSelected: boolean
@@ -64,7 +65,7 @@ export const RecoveryPhraseContainer = styled.div`
   margin-bottom: 40px;
 `
 
-export const RecoveryBubble = styled.button<Partial<StyleProps>>`
+export const RecoveryBubble = styled(WalletButton) <Partial<StyleProps>>`
   cursor: ${(p) => p.isSelected ? `default` : 'pointer'};
   outline: none;
   background: none;
@@ -90,7 +91,7 @@ export const RecoveryBubbleText = styled.span<Partial<StyleProps>>`
   color: ${(p) => p.isSelected ? p.theme.color.background02 : p.theme.color.text01};
 `
 
-export const SelectedBubble = styled.button`
+export const SelectedBubble = styled(WalletButton)`
   cursor: pointer;
   outline: none;
   background: none;

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/welcome/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/welcome/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import WelcomeIcon from '../../../../assets/svg-icons/onboarding/brave-wallet.svg'
 import WelcomeIconDark from '../../../../assets/svg-icons/onboarding/brave-wallet-dark.svg'
 import MMIcon from '../../../../assets/svg-icons/meta-mask-icon.svg'
+import { WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -45,7 +46,7 @@ export const PageIcon = styled.div`
   }
 `
 
-export const RestoreButton = styled.button`
+export const RestoreButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -72,7 +73,7 @@ export const Divider = styled.div`
   margin-bottom: 32px;
 `
 
-export const ImportButton = styled.button`
+export const ImportButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -131,7 +132,7 @@ export const CryptoWalletsAlertDescription = styled.span`
   text-align: center;
 `
 
-export const SettingsButton = styled.button`
+export const SettingsButton = styled(WalletButton)`
   cursor: pointer;
   outline: none;
   background: none;

--- a/components/brave_wallet_ui/components/extension/allow-add-change-network-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/allow-add-change-network-panel/style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../shared/style'
 
 export const MessageBox = styled.div`
   display: flex;
@@ -64,7 +65,7 @@ export const MessageBoxColumn = styled.div`
   margin-bottom: 6px;
 `
 
-export const DetailsButton = styled.button`
+export const DetailsButton = styled(WalletButton)`
   font-family: Poppins;
   font-style: normal;
   font-size: 12px;

--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
@@ -3,12 +3,13 @@ import CloseIcon from '../../assets/close.svg'
 import KeyIcon from '../../../../assets/svg-icons/key-icon.svg'
 import CheckIcon from '../../assets/filled-checkmark.svg'
 import { PanelButtonTypes } from './index'
+import { WalletButton } from '../../../shared/style'
 interface StyleProps {
   buttonType: PanelButtonTypes
   disabled?: boolean
 }
 
-export const StyledButton = styled.button<StyleProps>`
+export const StyledButton = styled(WalletButton) <StyleProps>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { ArrowRightIcon } from 'brave-ui/components/icons'
-import { AssetIconProps, AssetIconFactory } from '../../shared/style'
+import { AssetIconProps, AssetIconFactory, WalletButton } from '../../shared/style'
 
 interface StyleProps {
   orb: string
@@ -187,7 +187,7 @@ export const TopColumn = styled.div`
   width: 100%;
 `
 
-export const EditButton = styled.button`
+export const EditButton = styled(WalletButton)`
   font-family: Poppins;
   font-style: normal;
   font-weight: 600;
@@ -272,7 +272,7 @@ export const QueueStepText = styled.span`
   margin-right: 9px;
 `
 
-export const QueueStepButton = styled.button<Partial<StyleProps>>`
+export const QueueStepButton = styled(WalletButton) <Partial<StyleProps>>`
   font-family: Poppins;
   font-style: normal;
   font-weight: 600;

--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import FlashDriveIcon from '../../../assets/svg-icons/graphic-flashdrive-icon.svg'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   isConnected: boolean
@@ -45,7 +46,7 @@ export const PageIcon = styled.div`
   margin-bottom: 35px;
 `
 
-export const InstructionsButton = styled.button`
+export const InstructionsButton = styled(WalletButton)`
   cursor: pointer;
   outline: none;
   background: none;

--- a/components/brave_wallet_ui/components/extension/connected-account-item/style.ts
+++ b/components/brave_wallet_ui/components/extension/connected-account-item/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-
+import { WalletButton } from '../../shared/style'
 interface StyleProps {
   orb: string
 }
@@ -52,7 +52,7 @@ export const AccountAddressText = styled.span`
   color: ${(p) => p.theme.color.text02};
 `
 
-export const DisconnectButton = styled.button<Partial<StyleProps>>`
+export const DisconnectButton = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;;
   cursor: pointer;
   outline: none;

--- a/components/brave_wallet_ui/components/extension/connected-bottom-nav/style.ts
+++ b/components/brave_wallet_ui/components/extension/connected-bottom-nav/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import UnCheckStar from '../../../assets/svg-icons/star-unchecked.svg'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   disabled?: boolean
@@ -34,7 +35,7 @@ export const NavDivider = styled.div`
   background-color: rgba(255,255,255,0.5);
 `
 
-export const NavButton = styled.button<StyleProps>`
+export const NavButton = styled(WalletButton) <StyleProps>`
   flex: 1;
   display: flex;
   height: 100%;

--- a/components/brave_wallet_ui/components/extension/connected-header/style.ts
+++ b/components/brave_wallet_ui/components/extension/connected-header/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import Exand from '../assets/expand.svg'
 import Action from '../assets/actions.svg'
+import { WalletButton } from '../../shared/style'
 
 export const HeaderTitle = styled.span`
   font-family: Poppins;
@@ -24,7 +25,7 @@ export const HeaderWrapper = styled.div`
   position: relative;
 `
 
-export const ExpandIcon = styled.button`
+export const ExpandIcon = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;
@@ -36,7 +37,7 @@ export const ExpandIcon = styled.button`
   border: none;
 `
 
-export const ActionIcon = styled.button`
+export const ActionIcon = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/extension/connected-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/connected-panel/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import CheckMark from '../../../assets/svg-icons/big-checkmark.svg'
 import SwitchDown from '../../../assets/svg-icons/switch-icon.svg'
 import { CaratCircleODownIcon } from 'brave-ui/components/icons'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   panelBackground: string
@@ -29,7 +30,7 @@ export const CenterColumn = styled.div`
   max-width: 300px;
 `
 
-export const AccountCircle = styled.button<Partial<StyleProps>>`
+export const AccountCircle = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   cursor: pointer;
   width: 54px;
@@ -52,7 +53,7 @@ export const AccountNameText = styled.span`
   color: ${(p) => p.theme.palette.white};
 `
 
-export const AccountAddressText = styled.button`
+export const AccountAddressText = styled(WalletButton)`
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;
@@ -105,7 +106,7 @@ export const CaratDownIcon = styled(CaratCircleODownIcon)`
   margin-left: 8px;
 `
 
-export const OvalButton = styled.button`
+export const OvalButton = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/extension/lock-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/lock-panel/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import SecureIcon from '../../../assets/svg-icons/onboarding/secure-your-crypto.svg'
 import SecureIconDark from '../../../assets/svg-icons/onboarding/secure-your-crypto-dark.svg'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -43,7 +44,7 @@ export const Column = styled.div`
   margin-bottom: 8px;
 `
 
-export const RestoreButton = styled.button`
+export const RestoreButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/extension/panel-header/style.ts
+++ b/components/brave_wallet_ui/components/extension/panel-header/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import CloseIcon from '../assets/close.svg'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   hasSearch: boolean
@@ -36,7 +37,7 @@ export const TopRow = styled.div`
   justify-content: space-between;
 `
 
-export const CloseButton = styled.button`
+export const CloseButton = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/extension/panel-tab/style.ts
+++ b/components/brave_wallet_ui/components/extension/panel-tab/style.ts
@@ -1,10 +1,11 @@
 import styled from 'styled-components'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   isSelected: boolean
 }
 
-export const StyledButton = styled.button<Partial<StyleProps>>`
+export const StyledButton = styled(WalletButton) <Partial<StyleProps>>`
 	display: flex;
   width: 240px;
 	align-items: center;

--- a/components/brave_wallet_ui/components/extension/sign-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/sign-panel/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import WaringTriangle from '../../../assets/svg-icons/warning-triangle.svg'
+import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   orb: string
@@ -148,7 +149,7 @@ export const WarningIcon = styled.div`
   margin-right: 6px;
 `
 
-export const LearnMoreButton = styled.button`
+export const LearnMoreButton = styled(WalletButton)`
   font-family: Poppins;
   font-style: normal;
   font-size: 12px;

--- a/components/brave_wallet_ui/components/extension/welcome-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/welcome-panel/style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import WelcomeIcon from '../../../assets/svg-icons/onboarding/brave-wallet.svg'
 import WelcomeIconDark from '../../../assets/svg-icons/onboarding/brave-wallet-dark.svg'
+import { WalletButton } from '../../shared/style'
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -46,7 +47,7 @@ export const PageIcon = styled.div`
   }
 `
 
-export const RestoreButton = styled.button`
+export const RestoreButton = styled(WalletButton)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/shared/back-button/style.ts
+++ b/components/brave_wallet_ui/components/shared/back-button/style.ts
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
 import { CaratStrongLeftIcon } from 'brave-ui/components/icons'
+import { WalletButton } from '../style'
 
 // Will use brave-ui button comp in the future!
 // Currently is missing "tiny" variant
-export const StyledWrapper = styled.button`
+export const StyledWrapper = styled(WalletButton)`
   display: flex;;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/components/shared/select-account-item/style.ts
+++ b/components/brave_wallet_ui/components/shared/select-account-item/style.ts
@@ -1,10 +1,10 @@
 import styled from 'styled-components'
-
+import { WalletButton } from '../style'
 interface StyleProps {
   orb: string
 }
 
-export const StyledWrapper = styled.button`
+export const StyledWrapper = styled(WalletButton)`
   display: flex;
   width: 100%;
   flex-direction: row;

--- a/components/brave_wallet_ui/components/shared/select-network-item/style.ts
+++ b/components/brave_wallet_ui/components/shared/select-network-item/style.ts
@@ -1,10 +1,11 @@
 import styled from 'styled-components'
+import { WalletButton } from '../style'
 
 interface StyleProps {
   orb: string
 }
 
-export const StyledWrapper = styled.button`
+export const StyledWrapper = styled(WalletButton)`
   display: flex;
   width: 100%;
   flex-direction: row;

--- a/components/brave_wallet_ui/components/shared/style.ts
+++ b/components/brave_wallet_ui/components/shared/style.ts
@@ -21,3 +21,11 @@ export const AssetIconFactory = styled.img.attrs<AssetIconProps>(props => ({
   // Ref: https://web.dev/browser-level-image-lazy-loading
   loading: 'lazy'
 }))
+
+export const WalletButton = styled.button`
+  &:focus-visible {
+    outline-style: solid;
+    outline-color: ${p => p.theme.palette.blurple300};
+    outline-width: 2px;
+  }
+ `


### PR DESCRIPTION
## Description 
Improved Brave Wallets Keyboard Accessibility
Before all the buttons in the wallet were not visibly focusable while tabbing through all the elements.
We now have a shared button called `WalletButton` that has `focus-visible` state that is now being used for all buttons in the wallet.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19147>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/140817060-f1b9ac72-e857-49ff-a676-977becaf324a.mov
