### PR TITLE
Dismiss sync warning after timeout on scanning QR code

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -164,6 +164,7 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     private EditText mCodeWords;
     private FrameLayout mLayoutMobile;
     private FrameLayout mLayoutLaptop;
+    private AlertDialog mFinalWarningDialog;
 
     BraveSyncWorker getBraveSyncWorker() {
         return BraveSyncWorker.get();
@@ -761,16 +762,21 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
                 (dialog, which) -> {
                     runWhenYes.run();
                     dialog.dismiss();
+                    mFinalWarningDialog = null;
                 });
         confirmDialog.setNegativeButton(
                 getActivity().getResources().getString(android.R.string.cancel),
                 (dialog, which) -> {
                     runWhenCancel.run();
                     dialog.dismiss();
+                    mFinalWarningDialog = null;
                 });
-        confirmDialog.setOnCancelListener((dialog) -> { runWhenCancel.run(); });
+        confirmDialog.setOnCancelListener((dialog) -> {
+            runWhenCancel.run();
+            mFinalWarningDialog = null;
+        });
 
-        confirmDialog.show();
+        mFinalWarningDialog = confirmDialog.show();
     }
 
     private void seedWordsReceivedImpl(String seedWords) {
@@ -901,7 +907,13 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
         } catch (RuntimeException e) {
             Log.e(TAG, "Could not start camera source.", e);
         }
-        setAppropriateView();
+
+        if (mFinalWarningDialog != null) {
+            mFinalWarningDialog.dismiss();
+            synchronized (mQrInProcessingLock) {
+                mQrInProcessing = false;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/826

This PR fixes the case when warning dialog wasn't dismissed and then was impossible to continue scan QR code.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [?] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Use one from https://github.com/brave/internal/issues/826 . 
Or 
1. Try to join the sync chain with scanning of QR code
2. When warning dialog appears, turn screen of the phone off
3. Turn screen of the phone on
4. Unlock phone  - expected to see no warning dialog








