### PR TITLE
Display hex string for signing when string is not a UTF8 string

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -931,8 +931,8 @@ TEST_F(BraveWalletProviderImplUnitTest, SignMessageRequestQueue) {
   AddEthereumPermission(url, hardware);
   const std::vector<std::string> addresses = GetAddresses();
 
-  const std::string message1 = "0xbeef01";
-  const std::string message2 = "0xbeef02";
+  const std::string message1 = "0x68656c6c6f20776f726c64";
+  const std::string message2 = "0x4120756e69636f646520c68e20737472696e6720c3b1";
   const std::string message3 = "0xbeef03";
   int id1 = SignMessageRequest(addresses[0], message1);
   int id2 = SignMessageRequest(addresses[0], message2);
@@ -944,12 +944,9 @@ TEST_F(BraveWalletProviderImplUnitTest, SignMessageRequestQueue) {
   ASSERT_TRUE(base::HexStringToBytes(message1.substr(2), &message_bytes1));
   ASSERT_TRUE(base::HexStringToBytes(message2.substr(2), &message_bytes2));
   ASSERT_TRUE(base::HexStringToBytes(message3.substr(2), &message_bytes3));
-  const std::string message1_in_queue(message_bytes1.begin(),
-                                      message_bytes1.end());
-  const std::string message2_in_queue(message_bytes2.begin(),
-                                      message_bytes2.end());
-  const std::string message3_in_queue(message_bytes3.begin(),
-                                      message_bytes3.end());
+  const std::string message1_in_queue = "hello world";
+  const std::string message2_in_queue = "A unicode Ǝ string ñ";
+  const std::string message3_in_queue = "0xbeef03";
 
   EXPECT_EQ(GetSignMessageQueueSize(), 3u);
   EXPECT_EQ(GetSignMessageQueueFront()->id, id1);

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -312,8 +312,12 @@ void BraveWalletProviderImpl::ContinueSignMessage(
     return;
   }
 
-  auto request = mojom::SignMessageRequest::New(
-      sign_message_id_++, address, std::string(message.begin(), message.end()));
+  std::string message_str(message.begin(), message.end());
+  if (!base::IsStringUTF8(message_str))
+    message_str = ToHex(message_str);
+
+  auto request =
+      mojom::SignMessageRequest::New(sign_message_id_++, address, message_str);
   if (keyring_controller_->IsHardwareAccount(address)) {
     brave_wallet_service_->AddSignMessageRequest(
         std::move(request),


### PR DESCRIPTION
When the string is printable we display the string, otherwise we will now display the 0x prefixed hex of the signing data.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19228

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:


Clone this:
https://github.com/bbondy/eth-manual-tests

python -m SimpleHTTPServer 8081
Navigate to http://localhost:8081/request.html

Use eth_requestAccounts so you can eth_sign with the test data below.

Here are 3 test cases to try:


0x68656c6c6f20776f726c64
Should produce: hello world


0xdeadbeef
Should produce 0xdeadbeef

Unicode string
0x4120756e69636f646520c68e20737472696e6720c3b1


