### PR TITLE
window.ethereum compat and signed data display (Uplift to 1.33.x)

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -931,8 +931,8 @@ TEST_F(BraveWalletProviderImplUnitTest, SignMessageRequestQueue) {
   AddEthereumPermission(url, hardware);
   const std::vector<std::string> addresses = GetAddresses();
 
-  const std::string message1 = "0xbeef01";
-  const std::string message2 = "0xbeef02";
+  const std::string message1 = "0x68656c6c6f20776f726c64";
+  const std::string message2 = "0x4120756e69636f646520c68e20737472696e6720c3b1";
   const std::string message3 = "0xbeef03";
   int id1 = SignMessageRequest(addresses[0], message1);
   int id2 = SignMessageRequest(addresses[0], message2);
@@ -944,12 +944,9 @@ TEST_F(BraveWalletProviderImplUnitTest, SignMessageRequestQueue) {
   ASSERT_TRUE(base::HexStringToBytes(message1.substr(2), &message_bytes1));
   ASSERT_TRUE(base::HexStringToBytes(message2.substr(2), &message_bytes2));
   ASSERT_TRUE(base::HexStringToBytes(message3.substr(2), &message_bytes3));
-  const std::string message1_in_queue(message_bytes1.begin(),
-                                      message_bytes1.end());
-  const std::string message2_in_queue(message_bytes2.begin(),
-                                      message_bytes2.end());
-  const std::string message3_in_queue(message_bytes3.begin(),
-                                      message_bytes3.end());
+  const std::string message1_in_queue = "hello world";
+  const std::string message2_in_queue = "A unicode Ǝ string ñ";
+  const std::string message3_in_queue = "0xbeef03";
 
   EXPECT_EQ(GetSignMessageQueueSize(), 3u);
   EXPECT_EQ(GetSignMessageQueueFront()->id, id1);

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -312,8 +312,12 @@ void BraveWalletProviderImpl::ContinueSignMessage(
     return;
   }
 
-  auto request = mojom::SignMessageRequest::New(
-      sign_message_id_++, address, std::string(message.begin(), message.end()));
+  std::string message_str(message.begin(), message.end());
+  if (!base::IsStringUTF8(message_str))
+    message_str = ToHex(message_str);
+
+  auto request =
+      mojom::SignMessageRequest::New(sign_message_id_++, address, message_str);
   if (keyring_controller_->IsHardwareAccount(address)) {
     brave_wallet_service_->AddSignMessageRequest(
         std::move(request),

--- a/components/brave_wallet/resources/brave_wallet_provider.js
+++ b/components/brave_wallet/resources/brave_wallet_provider.js
@@ -15,4 +15,9 @@
       BraveWeb3ProviderEventEmitter.removeListener
   // For webcompat
   window.ethereum.isMetaMask = true
+  window.ethereum._metamask = {
+    isUnlocked: () => {
+      return Promise.resolve(false);
+    }
+  }
 })()


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/10968
Uplift of https://github.com/brave/brave-core/pull/10958


Resolves https://github.com/brave/brave-browser/issues/19228
Resolves https://github.com/brave/brave-browser/issues/19322

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.