### PR TITLE
Pull Request template encourages squashing of fixup / review feedback commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Resolves
 - [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
 - [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
 - [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
+- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
 - [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
 - [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
 - [ ] Ran `git rebase master` (if needed)


### PR DESCRIPTION
Encouraging a clean git history makes for a more readable log of file changes. 
Commit message are much more readable when they talk about features or bug fixes (as described in the existing checklist item about good commit descriptions).

Aim is to prevent a lot of commits which talk about the journey of a PR, such as fixing CI build issues and addressing review feedback, rather than talking about improvements to the project.
