### PR TITLE
Revert uplift of #10989 to 1.32.x

### DIFF
--- a/components/brave_extension/extension/brave_extension/background/webDiscoveryProject.ts
+++ b/components/brave_extension/extension/brave_extension/background/webDiscoveryProject.ts
@@ -27,7 +27,7 @@ function onCommitted (details: chrome.webNavigation.WebNavigationTransitionCallb
   }
 }
 
-if (!chrome.extension.inIncognitoContext) {
+if (App !== undefined && !chrome.extension.inIncognitoContext) {
   const APP = new App({
     version: chrome.runtime.getManifest().version
   })


### PR DESCRIPTION
1.32.x does not have the WDP dep update, so doesn't need this corresponding code change. It breaks lint in a different way.