### PR TITLE
Redo BroadcastChannel partitioning using channel name altering approach.

### DIFF
--- a/chromium_src/third_party/blink/renderer/modules/broadcastchannel/broadcast_channel.cc
+++ b/chromium_src/third_party/blink/renderer/modules/broadcastchannel/broadcast_channel.cc
@@ -3,30 +3,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#if 0
-#include "third_party/blink/public/mojom/broadcastchannel/broadcast_channel.mojom-blink.h"
+#include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/modules/storage/brave_dom_window_storage.h"
+#include "third_party/blink/renderer/platform/weborigin/security_origin_hash.h"
 
-// Ephemeral origin substitution is applied only to frame-based
+// Ephemeral origin channel name altering is applied only to frame-based
 // ExecutionContexts. This is fine because any Worker-based context still
 // wouldn't be able to communicate with a frame in both directions because a
 // frame-based BroadcastChannel will use an ephemeral origin instead of the one
 // the worker is using.
-#define ConnectToChannel                                                   \
-  Version_;                                                                \
-  {                                                                        \
-    LocalDOMWindow* window = DynamicTo<LocalDOMWindow>(execution_context); \
-    if (window) {                                                          \
-      if (auto* origin = GetEphemeralStorageOrigin(window)) {              \
-        origin_ = origin;                                                  \
-      }                                                                    \
-    }                                                                      \
-  }                                                                        \
-  provider->ConnectToChannel
-#endif
+#define GetRemoteNavigationAssociatedInterfaces                          \
+  should_send_resource_timing_info_to_parent(); /* no-op */              \
+  if (auto* origin = GetEphemeralStorageOrigin(window)) {                \
+    name_ = name_ + String::Number(SecurityOriginHash::GetHash(origin)); \
+  }                                                                      \
+  frame->GetRemoteNavigationAssociatedInterfaces
 
 #include "../../../../../../../third_party/blink/renderer/modules/broadcastchannel/broadcast_channel.cc"
 
-#if 0
-#undef ConnectToChannel
-#endif
+#undef GetRemoteNavigationAssociatedInterfaces


### PR DESCRIPTION
Redo BroadcastChannel partitioning using channel name altering approach.

Chromium change:

https://chromium.googlesource.com/chromium/src.git/+/61e816d489f1f574b609435922de3a48334c7b8d

commit 61e816d489f1f574b609435922de3a48334c7b8d
Author: Andrew Williams <awillia@google.com>
Date:   Mon Nov 1 04:41:04 2021 +0000

    BroadcastChannel: Partition using StorageKey instead of Origin

    This CL updates the BroadcastChannel implementation so that partitioning
    is done by StorageKey instead of Origin. To facilitate this, it also
    changes the way in which Mojo messages are sent to preserve per-thread
    message ordering (as required by the BroadcastChannel specification).

    Previously, a shared, per-thread Remote was used to send messages from
    the renderer to RenderProcessHost on the browser side. This message would
    contain the origin, which the browser code would verify was accurate, and
    would then be used to establish the channel connection. This approach
    presents a challenge when switching to StorageKey, in that there's not a
    way to have the renderer send the StorageKey and have the browser verify
    it at the process level.

    This CL removes the origin from the message definition and replaces the
    RenderProcessHost handler (BroadcastChannelProvider instance) with
    separate ones for RenderFrameHostImpl, DedicatedWorkerHost,
    SharedWorkerHost, and ServiceWorkerHost instances. These new handles
    associate incoming connection attempts with their StorageKeys, allowing
    partitioning to be done without any information directly provided by the
    renderer. Shared per-thread Remotes are still used for workers to send
    messages to their corresponding host instance's BroadcastChannelProvider,
    and for frames a channel-associated interface is used to ensure that
    renderer messages are received in-order by the corresponding
    RenderFrameHostImpl.

    For more details, see the "Partitioned BroadcastChannel Design" document:

    https://docs.google.com/document/d/1CchMLU8QmDEx_tA0y57qLyQWvaTT3dlWF-4P_ncc06E/edit?usp=sharing

    Bug: 1239274

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

