### PR TITLE
Fix show bubble for unsupported languages (uplift to 1.33.x)

### DIFF
--- a/components/translate/core/common/brave_translate_language_filter.cc
+++ b/components/translate/core/common/brave_translate_language_filter.cc
@@ -7,6 +7,7 @@
 
 #include "base/containers/contains.h"
 #include "base/strings/string_piece.h"
+#include "brave/components/translate/core/common/brave_translate_features.h"
 
 namespace translate {
 namespace {
@@ -20,10 +21,14 @@ constexpr base::StringPiece kTargetLanguages[] = {"de", "en", "es", "et", "ru"};
 }  // namespace
 
 bool IsSourceLanguageCodeSupported(const std::string& lang_code) {
+  if (!IsBraveTranslateGoAvailable())
+    return true;
   return base::Contains(kSourceLanguages, lang_code);
 }
 
 bool IsTargetLanguageCodeSupported(const std::string& lang_code) {
+  if (!IsBraveTranslateGoAvailable())
+    return true;
   return base::Contains(kTargetLanguages, lang_code);
 }
 


### PR DESCRIPTION
Uplift of #10950
Resolves https://github.com/brave/brave-browser/issues/19300

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.