### PR TITLE
Hide auto-contribute section in brave://settings when region is JP

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -973,6 +973,22 @@ void BraveRewardsGetInlineTippingPlatformEnabledFunction::OnInlineTipSetting(
   Respond(OneArgument(base::Value(value)));
 }
 
+BraveRewardsIsAutoContributeSupportedFunction::
+    ~BraveRewardsIsAutoContributeSupportedFunction() {}
+
+ExtensionFunction::ResponseAction
+BraveRewardsIsAutoContributeSupportedFunction::Run() {
+  Profile* profile = Profile::FromBrowserContext(browser_context());
+  RewardsService* rewards_service =
+      RewardsServiceFactory::GetForProfile(profile);
+  if (!rewards_service) {
+    return RespondNow(Error("Rewards service is not initialized"));
+  }
+
+  return RespondNow(
+      OneArgument(base::Value(rewards_service->IsAutoContributeSupported())));
+}
+
 BraveRewardsFetchBalanceFunction::
 ~BraveRewardsFetchBalanceFunction() {
 }

--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -350,6 +350,16 @@ class BraveRewardsGetInlineTippingPlatformEnabledFunction :
   void OnInlineTipSetting(bool value);
 };
 
+class BraveRewardsIsAutoContributeSupportedFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("braveRewards.isAutoContributeSupported", UNKNOWN)
+
+ protected:
+  ~BraveRewardsIsAutoContributeSupportedFunction() override;
+
+  ResponseAction Run() override;
+};
+
 class BraveRewardsFetchBalanceFunction : public ExtensionFunction {
  public:
   DECLARE_EXTENSION_FUNCTION("braveRewards.fetchBalance", UNKNOWN)

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_browser_proxy.js
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_browser_proxy.js
@@ -10,6 +10,7 @@ export class BraveRewardsBrowserProxy {
   getLocale() { /* Intentionally empty */ }
   getRewardsEnabled() { /* Intentionally empty */ }
   getRewardsParameters() { /* Intentionally empty */ }
+  isAutoContributeSupported() { /* Intentionally empty */ }
 }
 
 /**
@@ -30,6 +31,11 @@ export class BraveRewardsBrowserProxyImpl {
   getRewardsParameters () {
     return new Promise((resolve) => chrome.braveRewards.getRewardsParameters(
       (parameters) => { resolve(parameters) }))
+  }
+  /** @override */
+  isAutoContributeSupported () {
+    return new Promise((resolve) => chrome.braveRewards.isAutoContributeSupported(
+      (supported) => { resolve(supported) }))
   }
 }
 

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
@@ -39,7 +39,7 @@
       disabled="[[!prefs.brave.brave_ads.enabled.value]]">
     </settings-dropdown-menu>
   </div>
-  <template is="dom-if" if="[[shouldAllowAdsSubdivisionTargeting_()]]" restamp>
+  <template is="dom-if" if="[[shouldAllowAdsSubdivisionTargeting_]]" restamp>
     <div class="settings-box continuation">
       <div class="flex cr-padded-text">
         <div>$i18n{braveRewardsStateLevelAdTargetingLabel}</div>
@@ -55,58 +55,60 @@
   <div class="settings-box continuation">
     <p>$i18nRaw{braveRewardsStateLevelAdTargetingDescLabel}</p>
   </div>
-  <div class="settings-box space-between">
-    <div class="label rewards-primary-title">$i18n{braveRewardsAutoContributeTitle}</div>
+  <template is="dom-if" if="[[shouldShowAutoContributeSettings_]]">
+    <div class="settings-box space-between">
+      <div class="label rewards-primary-title">$i18n{braveRewardsAutoContributeTitle}</div>
+      <settings-toggle-button
+        pref="{{prefs.brave.rewards.ac.enabled}}">
+      </settings-toggle-button>
+    </div>
+    <div class="settings-box continuation">
+      <div class="flex cr-padded-text">
+        <div>$i18n{braveRewardsAutoContributeMonthlyLimitLabel}</div>
+      </div>
+      <settings-dropdown-menu
+        label="$i18n{braveRewardsAutoContributeMonthlyLimitLabel}"
+        pref="{{prefs.brave.rewards.ac.amount}}"
+        menu-options="[[autoContributeMonthlyLimit_]]"
+        disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
+      </settings-dropdown-menu>
+    </div>
+    <div class="settings-box continuation">
+      <div class="flex cr-padded-text">
+        <div>$i18n{braveRewardsAutoContributeMinVisitTimeLabel}</div>
+      </div>
+      <settings-dropdown-menu
+        label="$i18n{braveRewardsAutoContributeMinVisitTimeLabel}"
+        pref="{{prefs.brave.rewards.ac.min_visit_time}}"
+        menu-options="[[autoContributeMinVisitTimeOptions_]]"
+        disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
+      </settings-dropdown-menu>
+    </div>
+    <div class="settings-box continuation">
+      <div class="flex cr-padded-text">
+        <div>$i18n{braveRewardsAutoContributeMinVisitsLabel}</div>
+      </div>
+      <settings-dropdown-menu
+        label="$i18n{braveRewardsAutoContributeMinVisitsLabel}"
+        pref="{{prefs.brave.rewards.ac.min_visits}}"
+        menu-options="[[autoContributeMinVisitsOptions_]]"
+        disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
+      </settings-dropdown-menu>
+    </div>
     <settings-toggle-button
-      pref="{{prefs.brave.rewards.ac.enabled}}">
+      label="$i18n{braveRewardsAutoContributeShowNonVerifiedSitesLabel}"
+      pref="{{prefs.brave.rewards.ac.allow_non_verified}}"
+      disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
     </settings-toggle-button>
-  </div>
-  <div class="settings-box continuation">
-    <div class="flex cr-padded-text">
-      <div>$i18n{braveRewardsAutoContributeMonthlyLimitLabel}</div>
-    </div>
-    <settings-dropdown-menu
-      label="$i18n{braveRewardsAutoContributeMonthlyLimitLabel}"
-      pref="{{prefs.brave.rewards.ac.amount}}"
-      menu-options="[[autoContributeMonthlyLimit_]]"
+    <settings-toggle-button
+      label="$i18n{braveRewardsAutoContributeAllowVideoContributionsLabel}"
+      pref="{{prefs.brave.rewards.ac.allow_video_contributions}}"
       disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-    </settings-dropdown-menu>
-  </div>
-  <div class="settings-box continuation">
-    <div class="flex cr-padded-text">
-      <div>$i18n{braveRewardsAutoContributeMinVisitTimeLabel}</div>
+    </settings-toggle-button>
+    <div class="settings-box continuation">
+      <p>$i18nRaw{braveRewardsAutoContributeDescLabel}</p></p>
     </div>
-    <settings-dropdown-menu
-      label="$i18n{braveRewardsAutoContributeMinVisitTimeLabel}"
-      pref="{{prefs.brave.rewards.ac.min_visit_time}}"
-      menu-options="[[autoContributeMinVisitTimeOptions_]]"
-      disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-    </settings-dropdown-menu>
-  </div>
-  <div class="settings-box continuation">
-    <div class="flex cr-padded-text">
-      <div>$i18n{braveRewardsAutoContributeMinVisitsLabel}</div>
-    </div>
-    <settings-dropdown-menu
-      label="$i18n{braveRewardsAutoContributeMinVisitsLabel}"
-      pref="{{prefs.brave.rewards.ac.min_visits}}"
-      menu-options="[[autoContributeMinVisitsOptions_]]"
-      disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-    </settings-dropdown-menu>
-  </div>
-  <settings-toggle-button
-    label="$i18n{braveRewardsAutoContributeShowNonVerifiedSitesLabel}"
-    pref="{{prefs.brave.rewards.ac.allow_non_verified}}"
-    disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-  </settings-toggle-button>
-  <settings-toggle-button
-    label="$i18n{braveRewardsAutoContributeAllowVideoContributionsLabel}"
-    pref="{{prefs.brave.rewards.ac.allow_video_contributions}}"
-    disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-  </settings-toggle-button>
-  <div class="settings-box continuation">
-    <p>$i18nRaw{braveRewardsAutoContributeDescLabel}</p></p>
-  </div>
+  </template>
   <div class="settings-box">
     <div class="label rewards-primary-title">$i18n{braveRewardsTipButtonsTitle}</div>
   </div>

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
@@ -128,7 +128,18 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
           ]
         }
       },
-      autoContributeMonthlyLimit_: Array
+      autoContributeMonthlyLimit_: {
+	type: Array,
+	value: []
+      },
+      shouldAllowAdsSubdivisionTargeting_: {
+	type: Boolean,
+	value: false
+      },
+      shouldShowAutoContributeSettings_: {
+        type: Boolean,
+        value: true
+      }
     }
   }
 
@@ -138,12 +149,24 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
     super.ready()
     this.openRewardsPanel_ = () => {
       chrome.braveRewards.openBrowserActionUI('brave_rewards_panel.html')
+      this.isAutoContributeSupported_()
       this.populateAutoContributeAmountDropdown_()
     }
+    this.browserProxy_.getLocale().then((locale) => {
+      this.shouldAllowAdsSubdivisionTargeting_ = locale === 'en-US'
+    })
     this.browserProxy_.getRewardsEnabled().then((enabled) => {
       if (enabled) {
+        this.isAutoContributeSupported_()
         this.populateAutoContributeAmountDropdown_()
       }
+    })
+  }
+
+  isAutoContributeSupported_() {
+    this.browserProxy_.isAutoContributeSupported().then((supported) => {
+      // Show auto-contribute settings if this profile supports it
+      this.shouldShowAutoContributeSettings_ = supported
     })
   }
 
@@ -160,11 +183,6 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
       })
       this.autoContributeMonthlyLimit_ = autoContributeChoices
     })
-  }
-
-  async shouldAllowAdsSubdivisionTargeting_() {
-    const locale = await this.browserProxy_.getLocale()
-    return locale === 'en-US'
   }
 }
 

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -1071,6 +1071,23 @@
         ]
       },
       {
+        "name": "isAutoContributeSupported",
+        "type": "function",
+        "description": "Determines whether the current profile supports auto-contribute",
+        "parameters": [
+          {
+            "type": "function",
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "type",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "name": "fetchBalance",
         "type": "function",
         "description": "Fetch balance",

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -308,6 +308,8 @@ class RewardsService : public KeyedService {
 
   virtual void FetchBalance(FetchBalanceCallback callback) = 0;
 
+  virtual bool IsAutoContributeSupported() const = 0;
+
   virtual void GetExternalWallet(GetExternalWalletCallback callback) = 0;
 
   virtual const std::vector<std::string> GetExternalWalletProviders() const = 0;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2842,6 +2842,11 @@ void RewardsServiceImpl::FetchBalance(FetchBalanceCallback callback) {
                      std::move(callback)));
 }
 
+bool RewardsServiceImpl::IsAutoContributeSupported() const {
+  // Auto-contribute is currently not supported in bitFlyer regions
+  return !IsBitFlyerRegion();
+}
+
 std::string RewardsServiceImpl::GetLegacyWallet() {
   auto* dict = profile_->GetPrefs()->GetDictionary(prefs::kExternalWallets);
 

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -288,6 +288,8 @@ class RewardsServiceImpl : public RewardsService,
 
   void SetPublisherMinVisitTime(int duration_in_seconds) const override;
 
+  bool IsAutoContributeSupported() const override;
+
   void FetchBalance(FetchBalanceCallback callback) override;
 
   std::string GetLegacyWallet() override;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19355

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### JP Region

- Clean profile
- Run brave with `--rewards=countryid=19024` option to simulate running in JP region
- Visit brave://settings
- Click on Rewards
- Click link in right pane to open Rewards panel
- Enable Rewards
- Verify that auto-contribution settings aren't shown in settings

### Non-JP Region

- Clean profile
- Visit brave://settings
- Click on Rewards
- Click link in right pane to open Rewards panel
- Enable Rewards
- Verify that auto-contribution settings are shown in settings
