### PR TITLE
Fixes serialization of ProxyServer for mojo.

### DIFF
--- a/chromium_src/net/base/BUILD.gn
+++ b/chromium_src/net/base/BUILD.gn
@@ -1,0 +1,14 @@
+# Copyright 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "brave_proxy_string_util_unittest.cc" ]
+
+  deps = [
+    "//net",
+    "//testing/gtest:gtest",
+  ]
+}

--- a/chromium_src/net/base/brave_proxy_string_util_unittest.cc
+++ b/chromium_src/net/base/brave_proxy_string_util_unittest.cc
@@ -1,0 +1,67 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "net/base/proxy_string_util.h"
+
+#include "net/base/proxy_server.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace net {
+namespace {
+
+TEST(BraveProxySpecificationUtilTest, ProxyUriWithAuthToProxyServer) {
+  const struct {
+    const char* const input_uri;
+    const char* const expected_uri;
+    ProxyServer::Scheme expected_scheme;
+    const char* const expected_host;
+    int expected_port;
+    const char* const expected_username;
+    const char* const expected_password;
+    const char* const expected_pac_string;
+  } tests[] = {
+      {"socks5://foo:bar@foopy",  // No port.
+       "socks5://foo:bar@foopy:1080", ProxyServer::SCHEME_SOCKS5, "foopy", 1080,
+       "foo", "bar", "SOCKS5 foo:bar@foopy:1080"},
+      {"socks5://baz:qux@foopy:10", "socks5://baz:qux@foopy:10",
+       ProxyServer::SCHEME_SOCKS5, "foopy", 10, "baz", "qux",
+       "SOCKS5 baz:qux@foopy:10"},
+  };
+
+  for (const auto& test : tests) {
+    ProxyServer uri =
+      ProxyUriToProxyServer(test.input_uri, ProxyServer::SCHEME_HTTP);
+    EXPECT_TRUE(uri.is_valid());
+    EXPECT_FALSE(uri.is_direct());
+    EXPECT_EQ(test.expected_uri, ProxyServerToProxyUri(uri));
+    EXPECT_EQ(test.expected_scheme, uri.scheme());
+    EXPECT_EQ(test.expected_host, uri.host_port_pair().host());
+    EXPECT_EQ(test.expected_port, uri.host_port_pair().port());
+    EXPECT_EQ(test.expected_username, uri.host_port_pair().username());
+    EXPECT_EQ(test.expected_password, uri.host_port_pair().password());
+    EXPECT_EQ(test.expected_pac_string, ProxyServerToPacResultElement(uri));
+  }
+}
+
+TEST(BraveProxySpecificationUtilTest, PacResultElementWithAuthToProxyServer) {
+  const struct {
+    const char* const input_pac;
+    const char* const expected_uri;
+  } tests[] = {
+      {
+          "PROXY foo:bar@foopy:10",
+          "foo:bar@foopy:10",
+      },
+  };
+
+  for (const auto& test : tests) {
+    ProxyServer uri = PacResultElementToProxyServer(test.input_pac);
+    EXPECT_TRUE(uri.is_valid());
+    EXPECT_EQ(test.expected_uri, ProxyServerToProxyUri(uri));
+  }
+}
+
+}  // namespace
+}  // namespace net

--- a/chromium_src/net/base/brave_proxy_string_util_unittest.cc
+++ b/chromium_src/net/base/brave_proxy_string_util_unittest.cc
@@ -9,7 +9,6 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace net {
-namespace {
 
 TEST(BraveProxySpecificationUtilTest, ProxyUriWithAuthToProxyServer) {
   const struct {
@@ -63,5 +62,4 @@ TEST(BraveProxySpecificationUtilTest, PacResultElementWithAuthToProxyServer) {
   }
 }
 
-}  // namespace
 }  // namespace net

--- a/chromium_src/net/base/brave_proxy_string_util_unittest.cc
+++ b/chromium_src/net/base/brave_proxy_string_util_unittest.cc
@@ -31,7 +31,7 @@ TEST(BraveProxySpecificationUtilTest, ProxyUriWithAuthToProxyServer) {
 
   for (const auto& test : tests) {
     ProxyServer uri =
-      ProxyUriToProxyServer(test.input_uri, ProxyServer::SCHEME_HTTP);
+        ProxyUriToProxyServer(test.input_uri, ProxyServer::SCHEME_HTTP);
     EXPECT_TRUE(uri.is_valid());
     EXPECT_FALSE(uri.is_direct());
     EXPECT_EQ(test.expected_uri, ProxyServerToProxyUri(uri));

--- a/chromium_src/net/base/proxy_string_util.cc
+++ b/chromium_src/net/base/proxy_string_util.cc
@@ -45,7 +45,7 @@ ProxyServer CreateProxyServerWithAuthInfo(
                                host_and_port.substr(password_component.begin,
                                                     password_component.len)});
     }
-    auth_hostname = auth_str + "@" + auth_hostname;
+    auth_hostname = base::StrCat({auth_str, "@", auth_hostname});
   }
 
   return ProxyServer::FromSchemeHostAndPort(scheme, auth_hostname, port);
@@ -55,11 +55,11 @@ std::string GetProxyServerAuthString(const ProxyServer& proxy_server) {
   std::string auth_string;
   const HostPortPair& host_port_pair = proxy_server.host_port_pair();
   if (!host_port_pair.username().empty()) {
-    auth_string += host_port_pair.username();
+    auth_string = host_port_pair.username();
     if (!host_port_pair.password().empty()) {
-      auth_string += ':' + host_port_pair.password();
+      base::StrAppend(&auth_string, {":", host_port_pair.password()});
     }
-    auth_string += '@';
+    base::StrAppend(&auth_string, {"@"});
   }
   return auth_string;
 }
@@ -99,8 +99,8 @@ std::string ProxyServerToProxyUri(const ProxyServer& proxy_server) {
     proxy_uri = proxy_uri.substr(colon + 3);  // Skip past the "://"
   }
 
-  std::string result =
-      scheme_prefix + GetProxyServerAuthString(proxy_server) + proxy_uri;
+  std::string result = base::StrCat(
+      {scheme_prefix, GetProxyServerAuthString(proxy_server), proxy_uri});
   return result;
 }
 
@@ -114,8 +114,8 @@ std::string ProxyServerToPacResultElement(const ProxyServer& proxy_server) {
     proxy_pac = proxy_pac.substr(space + 1);  // Skip past the space
   }
 
-  std::string result =
-      scheme_prefix + GetProxyServerAuthString(proxy_server) + proxy_pac;
+  std::string result = base::StrCat(
+      {scheme_prefix, GetProxyServerAuthString(proxy_server), proxy_pac});
   return result;
 }
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -176,6 +176,7 @@ test("brave_unit_tests") {
     "//brave/browser/widevine:unittest",
     "//brave/chromium_src/chrome/browser/privacy_sandbox:unit_tests",
     "//brave/chromium_src/components/autofill_assistant/browser:unit_tests",
+    "//brave/chromium_src/net/base:unit_tests",
     "//brave/common:network_constants",
     "//brave/common:pref_names",
     "//brave/components/adblock_rust_ffi",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -963,8 +963,8 @@ if (!is_android) {
     configs += [ "//chrome/test:disable_thinlto_cache_flags" ]
 
     sources = [
-      "//brave/browser/net/brave_network_audit_browsertest.cc",
       "//brave/browser/net/brave_network_audit_allowed_lists.h",
+      "//brave/browser/net/brave_network_audit_browsertest.cc",
     ]
 
     deps = [


### PR DESCRIPTION
Previuosly, serialization of ProxyServer's HostPortPair used
its ToString method which we overrode, but now
ProxyServerToPacResultElement explicitly constructs the string
by getting host() and port() members and calling
ConstructHostPortString. We need to override this behavior to insert
auth info.

Fixes brave/brave-browser#19371

Chromium change:

https://source.chromium.org/chromium/chromium/src/+/5dbd4599a981da1fac5dc5211772fe843a06a9b0

commit 5dbd4599a981da1fac5dc5211772fe843a06a9b0
Author: Eric Orth <ericorth@chromium.org>
Date:   Fri Sep 24 21:21:24 2021 +0000

    Stop dealing with HostPortPair in proxy_string_util.(cc/h)

    String->ProxyServer now done using ProxyServer::FromSchemeHostAndPort,
    and ProxyServer->String now done using ProxyServer::GetHost() and
    ProxyServer::GetPort(). With less ProxyServer-external dealing with
    HostPortPair, will aide the future-CL transition to not storing
    HostPortPair for all proxies.

    Also has the effect that construction-from-string now results in
    canonicalization of the ProxyServer hostname. Slight impact on tests
    that were parsing stuff with now-recognized-as-invalid hostnames
    (especially the v8 tracing tests that were hacking information into
    wildly invalid hostnames), but don't expect any real-world impact
    because these are clearly invalid names that shouldn't ever be able to
    resolve to real servers.

    Also moved the hostname:port parsing directly into proxy_string_util.cc
    (from url_util::ParseHostAndPort()) to avoid silliness like stripping
    IPv6 brackets just for them to be added back for canonicalization.

    Bug: 1243398

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

