### PR TITLE
(uplift to 1.33.x ) Fixed crash if transactions notified twice

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -372,6 +372,20 @@ class BraveWalletServiceUnitTest : public testing::Test {
     run_loop.Run();
   }
 
+  std::vector<mojom::SignMessageRequestPtr> GetPendingSignMessageRequests()
+      const {
+    base::RunLoop run_loop;
+    std::vector<mojom::SignMessageRequestPtr> requests_out;
+    service_->GetPendingSignMessageRequests(base::BindLambdaForTesting(
+        [&](std::vector<mojom::SignMessageRequestPtr> requests) {
+          for (const auto& request : requests)
+            requests_out.push_back(request.Clone());
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+    return requests_out;
+  }
+
   void CheckPasswordAndMnemonic(const std::string& new_password,
                                 const std::string& in_mnemonic,
                                 bool* valid_password,
@@ -1207,9 +1221,14 @@ TEST_F(BraveWalletServiceUnitTest, SignMessageHardware) {
                                  ASSERT_TRUE(error.empty());
                                  callback_is_called = true;
                                }));
+  EXPECT_EQ(GetPendingSignMessageRequests().size(), 1u);
   service_->NotifySignMessageHardwareRequestProcessed(
       true, 1, expected_signature, std::string());
   ASSERT_TRUE(callback_is_called);
+  ASSERT_TRUE(GetPendingSignMessageRequests().empty());
+  service_->NotifySignMessageHardwareRequestProcessed(
+      true, 1, expected_signature, std::string());
+  ASSERT_TRUE(GetPendingSignMessageRequests().empty());
   callback_is_called = false;
   std::string expected_error = "error";
   auto request2 = mojom::SignMessageRequest::New(
@@ -1223,9 +1242,48 @@ TEST_F(BraveWalletServiceUnitTest, SignMessageHardware) {
                                  EXPECT_EQ(error, expected_error);
                                  callback_is_called = true;
                                }));
+  EXPECT_EQ(GetPendingSignMessageRequests().size(), 1u);
   service_->NotifySignMessageHardwareRequestProcessed(
       false, 2, expected_signature, expected_error);
   ASSERT_TRUE(callback_is_called);
+  ASSERT_TRUE(GetPendingSignMessageRequests().empty());
+}
+
+TEST_F(BraveWalletServiceUnitTest, SignMessage) {
+  std::string expected_signature = std::string("0xSiGnEd");
+  std::string address = "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c";
+  std::string message = "0xAB";
+  auto request1 = mojom::SignMessageRequest::New(
+      1, address, std::string(message.begin(), message.end()));
+  bool callback_is_called = false;
+  service_->AddSignMessageRequest(
+      std::move(request1), base::BindLambdaForTesting(
+                               [&](bool approved, const std::string& signature,
+                                   const std::string& error) {
+                                 ASSERT_TRUE(approved);
+                                 callback_is_called = true;
+                               }));
+  EXPECT_EQ(GetPendingSignMessageRequests().size(), 1u);
+  service_->NotifySignMessageRequestProcessed(true, 1);
+  ASSERT_TRUE(callback_is_called);
+  ASSERT_TRUE(GetPendingSignMessageRequests().empty());
+  service_->NotifySignMessageRequestProcessed(true, 1);
+  ASSERT_TRUE(GetPendingSignMessageRequests().empty());
+  callback_is_called = false;
+  std::string expected_error = "error";
+  auto request2 = mojom::SignMessageRequest::New(
+      2, address, std::string(message.begin(), message.end()));
+  service_->AddSignMessageRequest(
+      std::move(request2), base::BindLambdaForTesting(
+                               [&](bool approved, const std::string& signature,
+                                   const std::string& error) {
+                                 ASSERT_FALSE(approved);
+                                 callback_is_called = true;
+                               }));
+  EXPECT_EQ(GetPendingSignMessageRequests().size(), 1u);
+  service_->NotifySignMessageRequestProcessed(false, 2);
+  ASSERT_TRUE(callback_is_called);
+  ASSERT_TRUE(GetPendingSignMessageRequests().empty());
 }
 
 }  // namespace brave_wallet

--- a/chromium_src/chrome/browser/ui/views/permission_bubble/chooser_bubble_ui.cc
+++ b/chromium_src/chrome/browser/ui/views/permission_bubble/chooser_bubble_ui.cc
@@ -35,8 +35,12 @@ class BraveBubbleDialogDelegateView : public views::BubbleDialogDelegateView {
   }
   void WindowClosing() override {
     views::BubbleDialogDelegateView::WindowClosing();
+    if (!anchor_widget())
+      return;
     Browser* browser =
         chrome::FindBrowserWithWindow(anchor_widget()->GetNativeWindow());
+    if (!browser || !browser->tab_strip_model())
+      return;
     content::WebContents* active =
         browser->tab_strip_model()->GetActiveWebContents();
     auto* tab_helper =

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -589,7 +589,8 @@ void BraveWalletService::GetPendingSignMessageRequests(
 
 void BraveWalletService::NotifySignMessageRequestProcessed(bool approved,
                                                            int id) {
-  if (sign_message_requests_.front()->id != id) {
+  if (sign_message_requests_.empty() ||
+      sign_message_requests_.front()->id != id) {
     VLOG(1) << "id: " << id << " is not expected, should be "
             << sign_message_requests_.front()->id;
     return;
@@ -606,7 +607,8 @@ void BraveWalletService::NotifySignMessageHardwareRequestProcessed(
     int id,
     const std::string& signature,
     const std::string& error) {
-  if (sign_message_requests_.front()->id != id) {
+  if (sign_message_requests_.empty() ||
+      sign_message_requests_.front()->id != id) {
     VLOG(1) << "id: " << id << " is not expected, should be "
             << sign_message_requests_.front()->id;
     return;


### PR DESCRIPTION
Uplift of #11087
Resolves https://github.com/brave/brave-browser/issues/19443

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.