### PR TITLE
Allow users to disable Brave custom ad notification fallback from brave://flags

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -97,9 +97,15 @@ constexpr char kBraveAdblockDefault1pBlockingDescription[] =
     "blocking mode";
 
 constexpr char kBraveAdsCustomNotificationsName[] =
-    "Enable Brave Ads custom notifications";
+    "Enable Brave Ads custom push notifications";
 constexpr char kBraveAdsCustomNotificationsDescription[] =
-    "Enable Brave Ads custom notifications to support rich media";
+    "Enable Brave Ads custom push notifications to support rich media";
+
+constexpr char kBraveAdsCustomNotificationsFallbackName[] =
+    "Allow Brave Ads to fallback from native to custom push notifications";
+constexpr char kBraveAdsCustomNotificationsFallbackDescription[] =
+    "Allow Brave Ads to fallback from native to custom push notifications on "
+    "operating systems which do not support native notifications";
 
 constexpr char kBraveDarkModeBlockName[] =
     "Enable dark mode blocking fingerprinting protection";
@@ -424,11 +430,17 @@ constexpr char kFileSystemAccessAPIDescription[] =
      flag_descriptions::kBraveRewardsVerboseLoggingDescription,             \
      kOsDesktop | kOsAndroid,                                               \
      FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature)},  \
-    {"brave-ads-custom-notifications",                                      \
+    {"brave-ads-custom-push-notifications-ads",                             \
      flag_descriptions::kBraveAdsCustomNotificationsName,                   \
      flag_descriptions::kBraveAdsCustomNotificationsDescription,            \
-     kOsDesktop | kOsAndroid,                                               \
+     kOsAll,                                                                \
      FEATURE_VALUE_TYPE(brave_ads::features::kCustomAdNotifications)},      \
+    {"brave-ads-allowed-to-fallback-to-custom-push-notification-ads",       \
+     flag_descriptions::kBraveAdsCustomNotificationsFallbackName,           \
+     flag_descriptions::kBraveAdsCustomNotificationsFallbackDescription,    \
+     kOsAll,                                                                \
+     FEATURE_VALUE_TYPE(                                                    \
+       brave_ads::features::kAllowedToFallbackToCustomAdNotifications)},    \
     {"brave-sync-v2",                                                       \
       flag_descriptions::kBraveSyncName,                                    \
       flag_descriptions::kBraveSyncDescription, kOsDesktop,                 \

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1082,10 +1082,16 @@ bool AdsServiceImpl::ShouldShowCustomAdNotifications() {
   const bool can_show_native_notifications =
       NotificationHelper::GetInstance()->CanShowNativeNotifications();
 
-  const bool can_fallback_to_custom_ad_notifications =
+  bool can_fallback_to_custom_ad_notifications =
       features::CanFallbackToCustomAdNotifications();
   if (!can_fallback_to_custom_ad_notifications) {
     ClearPref(prefs::kAdNotificationDidFallbackToCustom);
+  } else {
+    const bool allowed_to_fallback_to_custom_ad_notifications =
+        features::IsAllowedToFallbackToCustomAdNotificationsEnabled();
+    if (!allowed_to_fallback_to_custom_ad_notifications) {
+      can_fallback_to_custom_ad_notifications = false;
+    }
   }
 
   const bool should_show = features::IsCustomAdNotificationsEnabled();

--- a/components/brave_ads/common/features.cc
+++ b/components/brave_ads/common/features.cc
@@ -16,6 +16,10 @@ const base::Feature kAdNotifications{"AdNotifications",
 const base::Feature kCustomAdNotifications{"CustomAdNotifications",
                                            base::FEATURE_DISABLED_BY_DEFAULT};
 
+const base::Feature kAllowedToFallbackToCustomAdNotifications{
+    "AllowedToFallbackToCustomAdNotifications",
+    base::FEATURE_ENABLED_BY_DEFAULT};
+
 const base::Feature kRequestAdsEnabledApi{"RequestAdsEnabledApi",
                                           base::FEATURE_DISABLED_BY_DEFAULT};
 
@@ -183,6 +187,11 @@ int AdNotificationInsetY() {
 }
 
 #endif  // !defined(OS_ANDROID)
+
+bool IsAllowedToFallbackToCustomAdNotificationsEnabled() {
+  return base::FeatureList::IsEnabled(
+      kAllowedToFallbackToCustomAdNotifications);
+}
 
 bool IsRequestAdsEnabledApiEnabled() {
   return base::FeatureList::IsEnabled(kRequestAdsEnabledApi);

--- a/components/brave_ads/common/features.h
+++ b/components/brave_ads/common/features.h
@@ -18,14 +18,13 @@ namespace brave_ads {
 namespace features {
 
 extern const base::Feature kAdNotifications;
-
 bool IsAdNotificationsEnabled();
 bool ShouldSupportMultipleDisplays();
 bool CanFallbackToCustomAdNotifications();
+bool AllowedToFallbackToCustomAdNotifications();
 int AdNotificationTimeout();
 
 extern const base::Feature kCustomAdNotifications;
-
 bool IsCustomAdNotificationsEnabled();
 #if !defined(OS_ANDROID)
 int AdNotificationFadeDuration();
@@ -36,8 +35,10 @@ double AdNotificationNormalizedDisplayCoordinateY();
 int AdNotificationInsetY();
 #endif  // !defined(OS_ANDROID)
 
-extern const base::Feature kRequestAdsEnabledApi;
+extern const base::Feature kAllowedToFallbackToCustomAdNotifications;
+bool IsAllowedToFallbackToCustomAdNotificationsEnabled();
 
+extern const base::Feature kRequestAdsEnabledApi;
 bool IsRequestAdsEnabledApiEnabled();
 
 }  // namespace features


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18846

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm user can override the `can_fallback_to_custotm_notifications` Griffin field trial flag to disallow falling back to custom ad notifications by disabling `Allowed to fallback to custom push notification ads` in brave://flags or by disabling the `AllowedToFallbackToCustomAdNotifications` Griffin feature. Default value for `AllowedToFallbackToCustomAdNotifications` is Enabled.