### PR TITLE
Lock Brave custom ad notification position to the main display

### DIFF
--- a/browser/ui/views/brave_ads/ad_notification_popup.cc
+++ b/browser/ui/views/brave_ads/ad_notification_popup.cc
@@ -86,7 +86,12 @@ void AdjustBoundsAndSnapToFitWorkAreaForWidget(views::Widget* widget,
 
   gfx::Rect fit_bounds = bounds;
   const gfx::NativeView native_view = widget->GetNativeView();
-  AdjustBoundsAndSnapToFitWorkAreaForNativeView(native_view, &fit_bounds);
+  const bool should_support_multiple_displays =
+      features::ShouldSupportMultipleDisplays();
+
+  AdjustBoundsAndSnapToFitWorkAreaForNativeView(
+      native_view, &fit_bounds, should_support_multiple_displays);
+
   widget->SetBounds(fit_bounds);
 }
 

--- a/browser/ui/views/brave_ads/bounds_util.cc
+++ b/browser/ui/views/brave_ads/bounds_util.cc
@@ -33,6 +33,10 @@ gfx::Rect GetDisplayScreenWorkArea(gfx::Rect* bounds,
   return work_area;
 }
 
+gfx::Rect GetPrimaryDisplayScreenWorkArea() {
+  return display::Screen::GetScreen()->GetPrimaryDisplay().work_area();
+}
+
 void AdjustBoundsToFitWorkArea(const gfx::Rect& work_area, gfx::Rect* bounds) {
   DCHECK(bounds);
 
@@ -41,11 +45,19 @@ void AdjustBoundsToFitWorkArea(const gfx::Rect& work_area, gfx::Rect* bounds) {
 
 }  // namespace
 
-void AdjustBoundsAndSnapToFitWorkAreaForNativeView(gfx::NativeView native_view,
-                                                   gfx::Rect* bounds) {
+void AdjustBoundsAndSnapToFitWorkAreaForNativeView(
+    gfx::NativeView native_view,
+    gfx::Rect* bounds,
+    bool should_support_multiple_displays) {
   DCHECK(bounds);
 
-  const gfx::Rect work_area = GetDisplayScreenWorkArea(bounds, native_view);
+  gfx::Rect work_area;
+  if (should_support_multiple_displays) {
+    work_area = GetDisplayScreenWorkArea(bounds, native_view);
+  } else {
+    work_area = GetPrimaryDisplayScreenWorkArea();
+  }
+
   AdjustBoundsToFitWorkArea(work_area, bounds);
   SnapBoundsToEdgeOfWorkArea(work_area, bounds);
 }

--- a/browser/ui/views/brave_ads/bounds_util.h
+++ b/browser/ui/views/brave_ads/bounds_util.h
@@ -14,8 +14,10 @@ class Rect;
 
 namespace brave_ads {
 
-void AdjustBoundsAndSnapToFitWorkAreaForNativeView(gfx::NativeView native_view,
-                                                   gfx::Rect* bounds);
+void AdjustBoundsAndSnapToFitWorkAreaForNativeView(
+    gfx::NativeView native_view,
+    gfx::Rect* bounds,
+    bool should_support_multiple_displays);
 
 // Exposed here to be available in tests.
 void SnapBoundsToEdgeOfWorkArea(const gfx::Rect& work_area, gfx::Rect* bounds);

--- a/components/brave_ads/common/features.cc
+++ b/components/brave_ads/common/features.cc
@@ -21,6 +21,12 @@ const base::Feature kRequestAdsEnabledApi{"RequestAdsEnabledApi",
 
 namespace {
 
+// Set to true to support multiple displays or false to only support the primary
+// display
+const char kFieldTrialParameterShouldSupportMultipleDisplays[] =
+    "should_support_multiple_displays";
+const bool kDefaultShouldSupportMultipleDisplays = false;
+
 // Set to true to fallback to custom ad notifications if native notifications
 // are disabled or false to never fallback
 const char kFieldTrialParameterCanFallbackToCustomAdNotifications[] =
@@ -106,6 +112,12 @@ const int kDefaultAdNotificationInsetY = 18;
 
 bool IsAdNotificationsEnabled() {
   return base::FeatureList::IsEnabled(kAdNotifications);
+}
+
+bool ShouldSupportMultipleDisplays() {
+  return GetFieldTrialParamByFeatureAsBool(
+      kAdNotifications, kFieldTrialParameterShouldSupportMultipleDisplays,
+      kDefaultShouldSupportMultipleDisplays);
 }
 
 bool CanFallbackToCustomAdNotifications() {

--- a/components/brave_ads/common/features.h
+++ b/components/brave_ads/common/features.h
@@ -20,6 +20,7 @@ namespace features {
 extern const base::Feature kAdNotifications;
 
 bool IsAdNotificationsEnabled();
+bool ShouldSupportMultipleDisplays();
 bool CanFallbackToCustomAdNotifications();
 int AdNotificationTimeout();
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18845

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm custom ad notifications can only be repositioned around the edge of the primary display unless `AdNotifications/should_support_multiple_displays` griffin flag is set to true
