### PR TITLE
Change default position for custom Brave ad notifications on Windows

### DIFF
--- a/components/brave_ads/common/features.cc
+++ b/components/brave_ads/common/features.cc
@@ -67,7 +67,7 @@ const double kDefaultAdNotificationNormalizedDisplayCoordinateX = 1.0;
 const char kFieldTrialParameterAdNotificationInsetX[] =
     "ad_notification_inset_x";
 #if defined(OS_WIN)
-const int kDefaultAdNotificationInsetX = -13;
+const int kDefaultAdNotificationInsetX = -370;
 #elif defined(OS_MAC)
 const int kNativeNotificationWidth = 360;
 const int kDefaultAdNotificationInsetX = -(10 + kNativeNotificationWidth);
@@ -81,7 +81,7 @@ const int kDefaultAdNotificationInsetX = -13;
 const char kFieldTrialParameterAdNotificationNormalizedDisplayCoordinateY[] =
     "ad_notification_normalized_display_coordinate_y";
 #if defined(OS_WIN)
-const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 0.0;
+const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 1.0;
 #elif defined(OS_MAC)
 const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 0.0;
 #elif defined(OS_LINUX)
@@ -93,7 +93,7 @@ const double kDefaultAdNotificationNormalizedDisplayCoordinateY = 0.0;
 const char kFieldTrialParameterAdNotificationInsetY[] =
     "ad_notification_inset_y";
 #if defined(OS_WIN)
-const int kDefaultAdNotificationInsetY = 18;
+const int kDefaultAdNotificationInsetY = -10;
 #elif defined(OS_MAC)
 const int kDefaultAdNotificationInsetY = 11;
 #elif defined(OS_LINUX)


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19463

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm the default position for custom ad notifications on Wiindows is bottom right (shifted to the left of system notifications)