### PR TITLE
Hide auto-contribute section in brave://settings when region is JP (uplift to 1.33.x)

### DIFF
--- a/browser/extensions/api/brave_rewards_api.cc
+++ b/browser/extensions/api/brave_rewards_api.cc
@@ -973,6 +973,22 @@ void BraveRewardsGetInlineTippingPlatformEnabledFunction::OnInlineTipSetting(
   Respond(OneArgument(base::Value(value)));
 }
 
+BraveRewardsIsAutoContributeSupportedFunction::
+    ~BraveRewardsIsAutoContributeSupportedFunction() {}
+
+ExtensionFunction::ResponseAction
+BraveRewardsIsAutoContributeSupportedFunction::Run() {
+  Profile* profile = Profile::FromBrowserContext(browser_context());
+  RewardsService* rewards_service =
+      RewardsServiceFactory::GetForProfile(profile);
+  if (!rewards_service) {
+    return RespondNow(Error("Rewards service is not initialized"));
+  }
+
+  return RespondNow(
+      OneArgument(base::Value(rewards_service->IsAutoContributeSupported())));
+}
+
 BraveRewardsFetchBalanceFunction::
 ~BraveRewardsFetchBalanceFunction() {
 }

--- a/browser/extensions/api/brave_rewards_api.h
+++ b/browser/extensions/api/brave_rewards_api.h
@@ -350,6 +350,16 @@ class BraveRewardsGetInlineTippingPlatformEnabledFunction :
   void OnInlineTipSetting(bool value);
 };
 
+class BraveRewardsIsAutoContributeSupportedFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("braveRewards.isAutoContributeSupported", UNKNOWN)
+
+ protected:
+  ~BraveRewardsIsAutoContributeSupportedFunction() override;
+
+  ResponseAction Run() override;
+};
+
 class BraveRewardsFetchBalanceFunction : public ExtensionFunction {
  public:
   DECLARE_EXTENSION_FUNCTION("braveRewards.fetchBalance", UNKNOWN)

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_browser_proxy.js
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_browser_proxy.js
@@ -10,6 +10,7 @@ export class BraveRewardsBrowserProxy {
   getLocale() { /* Intentionally empty */ }
   getRewardsEnabled() { /* Intentionally empty */ }
   getRewardsParameters() { /* Intentionally empty */ }
+  isAutoContributeSupported() { /* Intentionally empty */ }
 }
 
 /**
@@ -30,6 +31,11 @@ export class BraveRewardsBrowserProxyImpl {
   getRewardsParameters () {
     return new Promise((resolve) => chrome.braveRewards.getRewardsParameters(
       (parameters) => { resolve(parameters) }))
+  }
+  /** @override */
+  isAutoContributeSupported () {
+    return new Promise((resolve) => chrome.braveRewards.isAutoContributeSupported(
+      (supported) => { resolve(supported) }))
   }
 }
 

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
@@ -39,7 +39,7 @@
       disabled="[[!prefs.brave.brave_ads.enabled.value]]">
     </settings-dropdown-menu>
   </div>
-  <template is="dom-if" if="[[shouldAllowAdsSubdivisionTargeting_()]]" restamp>
+  <template is="dom-if" if="[[shouldAllowAdsSubdivisionTargeting_]]" restamp>
     <div class="settings-box continuation">
       <div class="flex cr-padded-text">
         <div>$i18n{braveRewardsStateLevelAdTargetingLabel}</div>
@@ -55,58 +55,60 @@
   <div class="settings-box continuation">
     <p>$i18nRaw{braveRewardsStateLevelAdTargetingDescLabel}</p>
   </div>
-  <div class="settings-box space-between">
-    <div class="label rewards-primary-title">$i18n{braveRewardsAutoContributeTitle}</div>
+  <template is="dom-if" if="[[shouldShowAutoContributeSettings_]]">
+    <div class="settings-box space-between">
+      <div class="label rewards-primary-title">$i18n{braveRewardsAutoContributeTitle}</div>
+      <settings-toggle-button
+        pref="{{prefs.brave.rewards.ac.enabled}}">
+      </settings-toggle-button>
+    </div>
+    <div class="settings-box continuation">
+      <div class="flex cr-padded-text">
+        <div>$i18n{braveRewardsAutoContributeMonthlyLimitLabel}</div>
+      </div>
+      <settings-dropdown-menu
+        label="$i18n{braveRewardsAutoContributeMonthlyLimitLabel}"
+        pref="{{prefs.brave.rewards.ac.amount}}"
+        menu-options="[[autoContributeMonthlyLimit_]]"
+        disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
+      </settings-dropdown-menu>
+    </div>
+    <div class="settings-box continuation">
+      <div class="flex cr-padded-text">
+        <div>$i18n{braveRewardsAutoContributeMinVisitTimeLabel}</div>
+      </div>
+      <settings-dropdown-menu
+        label="$i18n{braveRewardsAutoContributeMinVisitTimeLabel}"
+        pref="{{prefs.brave.rewards.ac.min_visit_time}}"
+        menu-options="[[autoContributeMinVisitTimeOptions_]]"
+        disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
+      </settings-dropdown-menu>
+    </div>
+    <div class="settings-box continuation">
+      <div class="flex cr-padded-text">
+        <div>$i18n{braveRewardsAutoContributeMinVisitsLabel}</div>
+      </div>
+      <settings-dropdown-menu
+        label="$i18n{braveRewardsAutoContributeMinVisitsLabel}"
+        pref="{{prefs.brave.rewards.ac.min_visits}}"
+        menu-options="[[autoContributeMinVisitsOptions_]]"
+        disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
+      </settings-dropdown-menu>
+    </div>
     <settings-toggle-button
-      pref="{{prefs.brave.rewards.ac.enabled}}">
+      label="$i18n{braveRewardsAutoContributeShowNonVerifiedSitesLabel}"
+      pref="{{prefs.brave.rewards.ac.allow_non_verified}}"
+      disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
     </settings-toggle-button>
-  </div>
-  <div class="settings-box continuation">
-    <div class="flex cr-padded-text">
-      <div>$i18n{braveRewardsAutoContributeMonthlyLimitLabel}</div>
-    </div>
-    <settings-dropdown-menu
-      label="$i18n{braveRewardsAutoContributeMonthlyLimitLabel}"
-      pref="{{prefs.brave.rewards.ac.amount}}"
-      menu-options="[[autoContributeMonthlyLimit_]]"
+    <settings-toggle-button
+      label="$i18n{braveRewardsAutoContributeAllowVideoContributionsLabel}"
+      pref="{{prefs.brave.rewards.ac.allow_video_contributions}}"
       disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-    </settings-dropdown-menu>
-  </div>
-  <div class="settings-box continuation">
-    <div class="flex cr-padded-text">
-      <div>$i18n{braveRewardsAutoContributeMinVisitTimeLabel}</div>
+    </settings-toggle-button>
+    <div class="settings-box continuation">
+      <p>$i18nRaw{braveRewardsAutoContributeDescLabel}</p></p>
     </div>
-    <settings-dropdown-menu
-      label="$i18n{braveRewardsAutoContributeMinVisitTimeLabel}"
-      pref="{{prefs.brave.rewards.ac.min_visit_time}}"
-      menu-options="[[autoContributeMinVisitTimeOptions_]]"
-      disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-    </settings-dropdown-menu>
-  </div>
-  <div class="settings-box continuation">
-    <div class="flex cr-padded-text">
-      <div>$i18n{braveRewardsAutoContributeMinVisitsLabel}</div>
-    </div>
-    <settings-dropdown-menu
-      label="$i18n{braveRewardsAutoContributeMinVisitsLabel}"
-      pref="{{prefs.brave.rewards.ac.min_visits}}"
-      menu-options="[[autoContributeMinVisitsOptions_]]"
-      disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-    </settings-dropdown-menu>
-  </div>
-  <settings-toggle-button
-    label="$i18n{braveRewardsAutoContributeShowNonVerifiedSitesLabel}"
-    pref="{{prefs.brave.rewards.ac.allow_non_verified}}"
-    disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-  </settings-toggle-button>
-  <settings-toggle-button
-    label="$i18n{braveRewardsAutoContributeAllowVideoContributionsLabel}"
-    pref="{{prefs.brave.rewards.ac.allow_video_contributions}}"
-    disabled="[[!prefs.brave.rewards.ac.enabled.value]]">
-  </settings-toggle-button>
-  <div class="settings-box continuation">
-    <p>$i18nRaw{braveRewardsAutoContributeDescLabel}</p></p>
-  </div>
+  </template>
   <div class="settings-box">
     <div class="label rewards-primary-title">$i18n{braveRewardsTipButtonsTitle}</div>
   </div>

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
@@ -128,7 +128,18 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
           ]
         }
       },
-      autoContributeMonthlyLimit_: Array
+      autoContributeMonthlyLimit_: {
+	type: Array,
+	value: []
+      },
+      shouldAllowAdsSubdivisionTargeting_: {
+	type: Boolean,
+	value: false
+      },
+      shouldShowAutoContributeSettings_: {
+        type: Boolean,
+        value: true
+      }
     }
   }
 
@@ -138,12 +149,24 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
     super.ready()
     this.openRewardsPanel_ = () => {
       chrome.braveRewards.openBrowserActionUI('brave_rewards_panel.html')
+      this.isAutoContributeSupported_()
       this.populateAutoContributeAmountDropdown_()
     }
+    this.browserProxy_.getLocale().then((locale) => {
+      this.shouldAllowAdsSubdivisionTargeting_ = locale === 'en-US'
+    })
     this.browserProxy_.getRewardsEnabled().then((enabled) => {
       if (enabled) {
+        this.isAutoContributeSupported_()
         this.populateAutoContributeAmountDropdown_()
       }
+    })
+  }
+
+  isAutoContributeSupported_() {
+    this.browserProxy_.isAutoContributeSupported().then((supported) => {
+      // Show auto-contribute settings if this profile supports it
+      this.shouldShowAutoContributeSettings_ = supported
     })
   }
 
@@ -160,11 +183,6 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
       })
       this.autoContributeMonthlyLimit_ = autoContributeChoices
     })
-  }
-
-  async shouldAllowAdsSubdivisionTargeting_() {
-    const locale = await this.browserProxy_.getLocale()
-    return locale === 'en-US'
   }
 }
 

--- a/common/extensions/api/brave_rewards.json
+++ b/common/extensions/api/brave_rewards.json
@@ -1071,6 +1071,23 @@
         ]
       },
       {
+        "name": "isAutoContributeSupported",
+        "type": "function",
+        "description": "Determines whether the current profile supports auto-contribute",
+        "parameters": [
+          {
+            "type": "function",
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "type",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "name": "fetchBalance",
         "type": "function",
         "description": "Fetch balance",

--- a/components/brave_rewards/browser/rewards_service.h
+++ b/components/brave_rewards/browser/rewards_service.h
@@ -308,6 +308,8 @@ class RewardsService : public KeyedService {
 
   virtual void FetchBalance(FetchBalanceCallback callback) = 0;
 
+  virtual bool IsAutoContributeSupported() const = 0;
+
   virtual void GetExternalWallet(GetExternalWalletCallback callback) = 0;
 
   virtual const std::vector<std::string> GetExternalWalletProviders() const = 0;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2842,6 +2842,11 @@ void RewardsServiceImpl::FetchBalance(FetchBalanceCallback callback) {
                      std::move(callback)));
 }
 
+bool RewardsServiceImpl::IsAutoContributeSupported() const {
+  // Auto-contribute is currently not supported in bitFlyer regions
+  return !IsBitFlyerRegion();
+}
+
 std::string RewardsServiceImpl::GetLegacyWallet() {
   auto* dict = profile_->GetPrefs()->GetDictionary(prefs::kExternalWallets);
 

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -288,6 +288,8 @@ class RewardsServiceImpl : public RewardsService,
 
   void SetPublisherMinVisitTime(int duration_in_seconds) const override;
 
+  bool IsAutoContributeSupported() const override;
+
   void FetchBalance(FetchBalanceCallback callback) override;
 
   std::string GetLegacyWallet() override;


### PR DESCRIPTION
Uplift of #11014
Resolves https://github.com/brave/brave-browser/issues/19355

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.