### PR TITLE
fix(wallet): prevent Trezor device from returning busyness errors

### DIFF
--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -170,9 +170,9 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
   }
 
   const apiProxy = getWalletPanelApiProxy()
-  await navigateToConnectHardwareWallet(store)
 
   if (hardwareAccount.hardware.vendor === LEDGER_HARDWARE_VENDOR) {
+    await navigateToConnectHardwareWallet(store)
     const { success, error, deviceError } = await signLedgerTransaction(apiProxy, hardwareAccount.hardware.path, txInfo)
     if (!success) {
       if (deviceError) {
@@ -192,6 +192,7 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
       refreshTransactionHistory(txInfo.fromAddress)
     }
   } else if (hardwareAccount.hardware.vendor === TREZOR_HARDWARE_VENDOR) {
+    apiProxy.panelHandler.setCloseOnDeactivate(false)
     const { success, error } = await signTrezorTransaction(apiProxy, hardwareAccount.hardware.path, txInfo)
     if (!success) {
       console.log(error)
@@ -200,7 +201,7 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
       refreshTransactionHistory(txInfo.fromAddress)
     }
 
-    await store.dispatch(PanelActions.navigateToMain())
+    apiProxy.panelHandler.setCloseOnDeactivate(true)
   }
 })
 


### PR DESCRIPTION
The hardware wallet connect UX is causing Trezor device to throw an error indicating that the device is busy processing the previous request. Avoid this situation by using the connect screen exclusively for Ledger.

⚠️ This is a hotfix, and we intend to bring back the connect screen for Trezor once we find a way to detect if device is connected without making the device return busyness errors.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19482.
Resolves https://github.com/brave/brave-browser/issues/19487.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

