### PR TITLE
fix(wallet): prevent Trezor device from returning busyness errors  (uplift to 1.33.x)

### DIFF
--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -170,9 +170,9 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
   }
 
   const apiProxy = getWalletPanelApiProxy()
-  await navigateToConnectHardwareWallet(store)
 
   if (hardwareAccount.hardware.vendor === LEDGER_HARDWARE_VENDOR) {
+    await navigateToConnectHardwareWallet(store)
     const { success, error, deviceError } = await signLedgerTransaction(apiProxy, hardwareAccount.hardware.path, txInfo)
     if (!success) {
       if (deviceError) {
@@ -192,6 +192,7 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
       refreshTransactionHistory(txInfo.fromAddress)
     }
   } else if (hardwareAccount.hardware.vendor === TREZOR_HARDWARE_VENDOR) {
+    apiProxy.panelHandler.setCloseOnDeactivate(false)
     const { success, error } = await signTrezorTransaction(apiProxy, hardwareAccount.hardware.path, txInfo)
     if (!success) {
       console.log(error)
@@ -200,7 +201,7 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
       refreshTransactionHistory(txInfo.fromAddress)
     }
 
-    await store.dispatch(PanelActions.navigateToMain())
+    apiProxy.panelHandler.setCloseOnDeactivate(true)
   }
 })
 


### PR DESCRIPTION
Emergency uplift of https://github.com/brave/brave-core/pull/11111.
Resolves brave/brave-browser#19482.

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.