### PR TITLE
Fixed Wallet UI bugs due to Translated Strings

### DIFF
--- a/components/brave_wallet_ui/components/desktop/lock-screen/style.ts
+++ b/components/brave_wallet_ui/components/desktop/lock-screen/style.ts
@@ -20,6 +20,7 @@ export const Title = styled.span`
   color: ${(p) => p.theme.color.text01};
   letter-spacing: 0.02em;
   margin-bottom: 10px;
+  text-align: center;
 `
 
 export const PageIcon = styled.div`

--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/index.tsx
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/index.tsx
@@ -22,13 +22,19 @@ export interface Props {
   text: string | undefined
   onSubmit: () => void
   disabled?: boolean
+  needsTopMargin?: boolean
 }
 
 export default class NavButton extends React.PureComponent<Props, {}> {
   render () {
-    const { onSubmit, text, buttonType, disabled } = this.props
+    const { onSubmit, text, buttonType, disabled, needsTopMargin } = this.props
     return (
-      <StyledButton disabled={disabled} buttonType={buttonType} onClick={onSubmit}>
+      <StyledButton
+        disabled={disabled}
+        buttonType={buttonType}
+        onClick={onSubmit}
+        addTopMargin={needsTopMargin && text ? text.length > 20 : false}
+      >
         {buttonType === 'reject' &&
           <RejectIcon />
         }

--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
@@ -7,9 +7,10 @@ import { WalletButton } from '../../../shared/style'
 interface StyleProps {
   buttonType: PanelButtonTypes
   disabled?: boolean
+  addTopMargin?: boolean
 }
 
-export const StyledButton = styled(WalletButton) <StyleProps>`
+export const StyledButton = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,6 +18,7 @@ export const StyledButton = styled(WalletButton) <StyleProps>`
   border-radius: 40px;
   padding: 10px 22px;
   outline: none;
+  margin-top: ${(p) => p.addTopMargin ? '8px' : '0px'};
   background-color: ${(p) =>
     p.disabled ? p.theme.color.disabled
       : p.buttonType === 'primary' ||

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -18,6 +18,7 @@ import { reduceAddress } from '../../../utils/reduce-address'
 import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 import { reduceAccountDisplayName } from '../../../utils/reduce-account-name'
 import { formatBalance, toWeiHex } from '../../../utils/format-balances'
+import { formatWithCommasAndDecimals } from '../../../utils/format-prices'
 import { getLocale } from '../../../../common/locale'
 import { usePricing, useTransactionParser } from '../../../common/hooks'
 import { withPlaceholderIcon } from '../../shared'
@@ -56,7 +57,9 @@ import {
   QueueStepButton,
   TopColumn,
   AssetIcon,
-  ErrorText
+  ErrorText,
+  SectionColumn,
+  SingleRow
 } from './style'
 
 import {
@@ -300,12 +303,12 @@ function ConfirmTransactionPanel (props: Props) {
             {transactionInfo.txType === TransactionType.ERC721TransferFrom ||
               transactionInfo.txType === TransactionType.ERC721SafeTransferFrom
               ? transactionDetails.erc721ERCToken?.name + ' ' + transactionDetails.erc721TokenId
-              : transactionDetails.value + ' ' + transactionDetails.symbol
+              : formatWithCommasAndDecimals(transactionDetails.value) + ' ' + transactionDetails.symbol
             }
           </TransactionAmmountBig>
           {transactionInfo.txType !== TransactionType.ERC721TransferFrom &&
             transactionInfo.txType !== TransactionType.ERC721SafeTransferFrom &&
-            <TransactionFiatAmountBig>${transactionDetails.fiatValue}</TransactionFiatAmountBig>
+            <TransactionFiatAmountBig>${formatWithCommasAndDecimals(transactionDetails.fiatValue)}</TransactionFiatAmountBig>
           }
         </>
       )}
@@ -330,13 +333,13 @@ function ConfirmTransactionPanel (props: Props) {
                   <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
                   <SectionRow>
                     <TransactionTitle>{getLocale('braveWalletAllowSpendTransactionFee')}</TransactionTitle>
-                    <TransactionTypeText>{transactionDetails.gasFee} {selectedNetwork.symbol}</TransactionTypeText>
+                    <TransactionTypeText>{formatWithCommasAndDecimals(transactionDetails.gasFee)} {selectedNetwork.symbol}</TransactionTypeText>
                   </SectionRow>
                   <TransactionText
                     hasError={transactionDetails.insufficientFundsError}
                   >
                     {transactionDetails.insufficientFundsError ? `${getLocale('braveWalletSwapInsufficientBalance')} ` : ''}
-                    ${transactionDetails.gasFeeFiat}
+                    ${formatWithCommasAndDecimals(transactionDetails.gasFeeFiat)}
                   </TransactionText>
                 </TopColumn>
                 <Divider />
@@ -363,24 +366,32 @@ function ConfirmTransactionPanel (props: Props) {
                   <TransactionTitle>{getLocale('braveWalletConfirmTransactionGasFee')}</TransactionTitle>
                   <SectionRightColumn>
                     <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
-                    <TransactionTypeText>{transactionDetails.gasFee} {selectedNetwork.symbol}</TransactionTypeText>
-                    <TransactionText>${transactionDetails.gasFeeFiat}</TransactionText>
+                    <TransactionTypeText>{formatWithCommasAndDecimals(transactionDetails.gasFee)} {selectedNetwork.symbol}</TransactionTypeText>
+                    <TransactionText>${formatWithCommasAndDecimals(transactionDetails.gasFeeFiat)}</TransactionText>
                   </SectionRightColumn>
                 </SectionRow>
                 <Divider />
-                <SectionRow>
-                  <TransactionTitle>{getLocale('braveWalletConfirmTransactionTotal')}</TransactionTitle>
-                  <SectionRightColumn>
-                    <TransactionText>{getLocale('braveWalletConfirmTransactionAmountGas')}</TransactionText>
-                    <GrandTotalText>{transactionDetails.value} {transactionDetails.symbol} + {transactionDetails.gasFee} {selectedNetwork.symbol}</GrandTotalText>
-                    <TransactionText
-                      hasError={transactionDetails.insufficientFundsError}
-                    >
-                      {transactionDetails.insufficientFundsError ? `${getLocale('braveWalletSwapInsufficientBalance')} ` : ''}
-                      ${transactionDetails.fiatTotal}
-                    </TransactionText>
-                  </SectionRightColumn>
-                </SectionRow>
+                <SectionColumn>
+                  <TransactionText>{getLocale('braveWalletConfirmTransactionAmountGas')}</TransactionText>
+                  <SingleRow>
+                    <TransactionTitle>{getLocale('braveWalletConfirmTransactionTotal')}</TransactionTitle>
+                    <GrandTotalText>
+                      {(transactionInfo.txType !== TransactionType.ERC721SafeTransferFrom &&
+                        transactionInfo.txType !== TransactionType.ERC721TransferFrom)
+                        ? formatWithCommasAndDecimals(transactionDetails.value)
+                        : transactionDetails.value
+                      } {transactionDetails.symbol} + {transactionDetails.gasFee} {selectedNetwork.symbol}</GrandTotalText>
+                  </SingleRow>
+                  <TransactionText
+                    hasError={transactionDetails.insufficientFundsError}
+                  >
+                    {transactionDetails.insufficientFundsError
+                      ? `${getLocale('braveWalletSwapInsufficientBalance')} `
+                      : ''}
+                    ${formatWithCommasAndDecimals(transactionDetails.fiatTotal)}
+                  </TransactionText>
+
+                </SectionColumn>
               </>
             }
           </>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -172,6 +172,23 @@ export const SectionRow = styled.div`
   height: inherit;
 `
 
+export const SectionColumn = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  flex-direction: column;
+  width: 100%;
+  height: inherit;
+`
+
+export const SingleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+  width: 100%;
+`
+
 export const SectionRightColumn = styled.div`
   display: flex;
   align-items: flex-end;

--- a/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
+++ b/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
@@ -287,6 +287,7 @@ const EditGas = (props: Props) => {
         <ButtonRow>
           <NavButton
             buttonType='secondary'
+            needsTopMargin={true}
             text={!isEIP1559Transaction ? getLocale('braveWalletBackupButtonCancel')
               : maxPriorityPanel === MaxPriorityPanels.setCustom ? getLocale('braveWalletEditGasSetSuggested')
                 : getLocale('braveWalletEditGasSetCustom')

--- a/components/brave_wallet_ui/components/extension/edit-gas/style.ts
+++ b/components/brave_wallet_ui/components/extension/edit-gas/style.ts
@@ -72,6 +72,7 @@ export const ButtonRow = styled.div`
   justify-content: center;
   flex-direction: row;
   width: 100%;
+  flex-wrap: wrap-reverse;
 `
 
 export const Description = styled.span`

--- a/components/brave_wallet_ui/components/extension/lock-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/lock-panel/style.ts
@@ -21,6 +21,7 @@ export const Title = styled.span`
   color: ${(p) => p.theme.color.text01};
   letter-spacing: 0.04em;
   margin-bottom: 12px;
+  text-align: center;
 `
 
 export const PanelIcon = styled.div`

--- a/components/brave_wallet_ui/panel/style.ts
+++ b/components/brave_wallet_ui/panel/style.ts
@@ -9,7 +9,7 @@ export const PanelWrapper = styled.div<StyleProps>`
   align-items: center;
   justify-content: center;
   width: 320px;
-  height: ${(p) => p.isLonger ? '500px' : '400px'};
+  height: ${(p) => p.isLonger ? '540px' : '400px'};
 `
 
 export const SendWrapper = styled.div`

--- a/components/brave_wallet_ui/utils/format-prices.ts
+++ b/components/brave_wallet_ui/utils/format-prices.ts
@@ -23,6 +23,6 @@ export const formatWithCommasAndDecimals = (value: string) => {
   }
 
   const calculatedDecimalPlace = -Math.floor(Math.log(valueToNumber) / Math.log(10) + 1)
-  const added = Number(calculatedDecimalPlace) + 4
+  const added = Number(calculatedDecimalPlace) + 3
   return addCommas(valueToNumber.toFixed(added))
 }


### PR DESCRIPTION
## Description 
Fixed Various Wallet UI bugs due to Translated Strings

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19349>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before Picture can be viewed in the Issue:

![Bildschirmfoto 2021-11-16 um 4 34 23 PM](https://user-images.githubusercontent.com/40611140/142084681-0778fc22-3333-4265-8ab4-92debad7a357.png)
![Bildschirmfoto 2021-11-16 um 4 34 48 PM](https://user-images.githubusercontent.com/40611140/142084682-3784db07-f46e-4ddb-9f89-4b1579dd8fa5.png)
![Bildschirmfoto 2021-11-16 um 4 38 37 PM](https://user-images.githubusercontent.com/40611140/142084685-ab40a917-f160-4e86-b2c8-ed85da9d82d3.png)
![Bildschirmfoto 2021-11-16 um 4 38 58 PM](https://user-images.githubusercontent.com/40611140/142084687-0c10a896-116d-4173-bdd3-32bce1e32222.png)
![Bildschirmfoto 2021-11-16 um 4 39 27 PM](https://user-images.githubusercontent.com/40611140/142084688-086546c1-a44d-4f84-8d65-5b500c66bd88.png)
![Bildschirmfoto 2021-11-16 um 4 34 59 PM](https://user-images.githubusercontent.com/40611140/142084690-684cd01f-71df-4725-aa70-24dce6d8582a.png)


