### PR TITLE
Set Brave as a default browser w/o system UI on Windows

### DIFF
--- a/browser/brave_shell_integration.cc
+++ b/browser/brave_shell_integration.cc
@@ -1,0 +1,47 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_shell_integration.h"
+
+#if defined(OS_WIN)
+#include <shlobj.h>
+
+#include <utility>
+
+#include "brave/browser/default_protocol_handler_utils_win.h"
+#include "chrome/installer/util/shell_util.h"
+#endif
+
+namespace shell_integration {
+
+BraveDefaultBrowserWorker::BraveDefaultBrowserWorker() = default;
+BraveDefaultBrowserWorker::~BraveDefaultBrowserWorker() = default;
+
+void BraveDefaultBrowserWorker::SetAsDefaultImpl(
+    base::OnceClosure on_finished_callback) {
+#if defined(OS_WIN)
+  if (GetDefaultWebClientSetPermission() != SET_DEFAULT_NOT_ALLOWED) {
+    bool success = false;
+    const wchar_t* kAssociations[] = {L"https", L"http", L".html", L".htm"};
+    for (const wchar_t* association : kAssociations) {
+      success =
+          protocol_handler_utils::SetDefaultProtocolHandlerFor(association);
+      if (!success)
+        break;
+    }
+
+    if (success) {
+      std::move(on_finished_callback).Run();
+
+      // Notify shell to refresh icons
+      ::SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+      return;
+    }
+  }
+#endif
+  DefaultBrowserWorker::SetAsDefaultImpl(std::move(on_finished_callback));
+}
+
+}  // namespace shell_integration

--- a/browser/brave_shell_integration.h
+++ b/browser/brave_shell_integration.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_H_
+#define BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_H_
+
+#include "chrome/browser/shell_integration.h"
+
+namespace shell_integration {
+
+class BraveDefaultBrowserWorker : public DefaultBrowserWorker {
+ public:
+  BraveDefaultBrowserWorker();
+
+  BraveDefaultBrowserWorker(const BraveDefaultBrowserWorker&) = delete;
+  BraveDefaultBrowserWorker& operator=(const BraveDefaultBrowserWorker&) =
+      delete;
+
+ protected:
+  ~BraveDefaultBrowserWorker() override;
+
+  void SetAsDefaultImpl(base::OnceClosure on_finished_callback) override;
+};
+
+}  // namespace shell_integration
+
+#endif  // BRAVE_BROWSER_BRAVE_SHELL_INTEGRATION_H_

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -78,6 +78,8 @@ brave_chrome_browser_sources = [
   "//brave/browser/brave_local_state_prefs.h",
   "//brave/browser/brave_profile_prefs.cc",
   "//brave/browser/brave_profile_prefs.h",
+  "//brave/browser/brave_shell_integration.cc",
+  "//brave/browser/brave_shell_integration.h",
   "//brave/browser/brave_tab_helpers.cc",
   "//brave/browser/brave_tab_helpers.h",
   "//brave/browser/browser_context_keyed_service_factories.cc",

--- a/browser/ui/views/brave_default_browser_dialog_view.cc
+++ b/browser/ui/views/brave_default_browser_dialog_view.cc
@@ -9,11 +9,11 @@
 
 #include "base/bind.h"
 #include "base/memory/scoped_refptr.h"
+#include "brave/browser/brave_shell_integration.h"
 #include "brave/browser/ui/browser_dialogs.h"
 #include "brave/common/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/browser_process.h"
-#include "chrome/browser/shell_integration.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "components/constrained_window/constrained_window_views.h"
@@ -159,6 +159,6 @@ void BraveDefaultBrowserDialogView::OnAcceptButtonClicked() {
   // The worker pointer is reference counted. While it is running, the
   // message loops of the FILE and UI thread will hold references to it
   // and it will be automatically freed once all its tasks have finished.
-  base::MakeRefCounted<shell_integration::DefaultBrowserWorker>()
+  base::MakeRefCounted<shell_integration::BraveDefaultBrowserWorker>()
       ->StartSetAsDefault(base::NullCallback());
 }

--- a/chromium_src/chrome/browser/shell_integration.h
+++ b/chromium_src/chrome/browser/shell_integration.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_SHELL_INTEGRATION_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_SHELL_INTEGRATION_H_
+
+#define BRAVE_DEFAULT_BROWSER_WORKER_H friend class BraveDefaultBrowserWorker;
+
+#include "../../../../chrome/browser/shell_integration.h"
+
+#undef BRAVE_DEFAULT_BROWSER_WORKER_H
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_SHELL_INTEGRATION_H_

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_default_browser_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_default_browser_handler.cc
@@ -1,0 +1,10 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_shell_integration.h"
+
+#define DefaultBrowserWorker BraveDefaultBrowserWorker
+#include "../../../../../../../chrome/browser/ui/webui/settings/settings_default_browser_handler.cc"
+#undef DefaultBrowserWorker

--- a/patches/chrome-browser-shell_integration.h.patch
+++ b/patches/chrome-browser-shell_integration.h.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/shell_integration.h b/chrome/browser/shell_integration.h
+index 29e98f5b2839a44a488d6baec756b660935302dd..b761dea9fbb8f0009976997a41d9a10b2aaf3df1 100644
+--- a/chrome/browser/shell_integration.h
++++ b/chrome/browser/shell_integration.h
+@@ -235,6 +235,7 @@ class DefaultBrowserWorker : public DefaultWebClientWorker {
+  protected:
+   ~DefaultBrowserWorker() override;
+ 
++  BRAVE_DEFAULT_BROWSER_WORKER_H
+  private:
+   // Check if Chrome is the default browser.
+   DefaultWebClientState CheckIsDefaultImpl() override;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves  https://github.com/brave/brave-browser/issues/19466

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test 1
1. Set another browser as a default browser
2. Launch Brave and load brave://settings/getStarted
3. Click `Make default` button and this is set as a default browser immediately w/o launching system UI

### Test 2
1. Launch browser with clean profile
2. Make default browser prompt (https://github.com/brave/brave-core/pull/7716)
3. Click `Set as a default` and check browser is set as a default browser w/o system UI

NOTE: This feature is only available from Win10 RS2. Older browser will work like chromium.