### PR TITLE
Don't add AUTH info to HostPortPair when using direct:// schemes

### DIFF
--- a/chromium_src/net/base/BUILD.gn
+++ b/chromium_src/net/base/BUILD.gn
@@ -5,7 +5,10 @@
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "brave_proxy_string_util_unittest.cc" ]
+  sources = [
+    "brave_proxy_string_util_unittest.cc",
+    "//net/base/proxy_string_util_unittest.cc",
+  ]
 
   deps = [
     "//net",

--- a/chromium_src/net/base/brave_proxy_string_util_unittest.cc
+++ b/chromium_src/net/base/brave_proxy_string_util_unittest.cc
@@ -50,8 +50,8 @@ TEST(BraveProxySpecificationUtilTest, PacResultElementWithAuthToProxyServer) {
     const char* const expected_uri;
   } tests[] = {
       {
-          "PROXY foo:bar@foopy:10",
-          "foo:bar@foopy:10",
+          "SOCKS5 foo:bar@foopy:10",
+          "socks5://foo:bar@foopy:10",
       },
   };
 

--- a/chromium_src/net/base/proxy_string_util.cc
+++ b/chromium_src/net/base/proxy_string_util.cc
@@ -91,9 +91,9 @@ namespace net {
 
 std::string ProxyServerToProxyUri(const ProxyServer& proxy_server) {
   std::string proxy_uri = ProxyServerToProxyUri_ChromiumImpl(proxy_server);
-  // Doesn't make sense to add the auth information to HostPortPair if the proxy
-  // doesn't have the concept of a host.
-  if (proxy_server.scheme() == ProxyServer::SCHEME_DIRECT)
+
+  // We only inject AUTH information for SOCKS5 proxies (Tor-only).
+  if (proxy_server.scheme() != ProxyServer::SCHEME_SOCKS5)
     return proxy_uri;
 
   std::string scheme_prefix;
@@ -113,9 +113,8 @@ std::string ProxyServerToPacResultElement(const ProxyServer& proxy_server) {
   std::string proxy_pac =
       ProxyServerToPacResultElement_ChromiumImpl(proxy_server);
 
-  // Doesn't make sense to add the auth information to HostPortPair if the proxy
-  // doesn't have the concept of a host.
-  if (proxy_server.scheme() == ProxyServer::SCHEME_DIRECT)
+  // We only inject AUTH information for SOCKS5 proxies (Tor-only).
+  if (proxy_server.scheme() != ProxyServer::SCHEME_SOCKS5)
     return proxy_pac;
 
   std::string scheme_prefix;

--- a/chromium_src/net/base/proxy_string_util.cc
+++ b/chromium_src/net/base/proxy_string_util.cc
@@ -90,8 +90,13 @@ std::string GetProxyServerAuthString(const ProxyServer& proxy_server) {
 namespace net {
 
 std::string ProxyServerToProxyUri(const ProxyServer& proxy_server) {
-  std::string scheme_prefix;
   std::string proxy_uri = ProxyServerToProxyUri_ChromiumImpl(proxy_server);
+  // Doesn't make sense to add the auth information to HostPortPair if the proxy
+  // doesn't have the concept of a host.
+  if (proxy_server.scheme() == ProxyServer::SCHEME_DIRECT)
+    return proxy_uri;
+
+  std::string scheme_prefix;
   size_t colon = proxy_uri.find(':');
   if (colon != std::string::npos && proxy_uri.size() - colon >= 3 &&
       proxy_uri[colon + 1] == '/' && proxy_uri[colon + 2] == '/') {
@@ -105,9 +110,15 @@ std::string ProxyServerToProxyUri(const ProxyServer& proxy_server) {
 }
 
 std::string ProxyServerToPacResultElement(const ProxyServer& proxy_server) {
-  std::string scheme_prefix;
   std::string proxy_pac =
       ProxyServerToPacResultElement_ChromiumImpl(proxy_server);
+
+  // Doesn't make sense to add the auth information to HostPortPair if the proxy
+  // doesn't have the concept of a host.
+  if (proxy_server.scheme() == ProxyServer::SCHEME_DIRECT)
+    return proxy_pac;
+
+  std::string scheme_prefix;
   size_t space = proxy_pac.find(' ');
   if (space != std::string::npos && proxy_pac.size() - space >= 1) {
     scheme_prefix = proxy_pac.substr(0, space + 1);


### PR DESCRIPTION
If either ProxyServerToProxyUri() or ProxyServerToPacResultElement()
are called for a ProxyServer using a direct:// scheme, we shouldn't be
trying to add any AUTH information since such schemes don't have the
concept of a host, which would cause a CRASH on DCHECK-enabled builds
as ProxyServer::host_port_pair() assumes it won't ever be called for
tha type of scheme.

Resolves https://github.com/brave/brave-browser/issues/19527

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A