### PR TITLE
Enable ServiceWorkerTerminationOnNoControllee by default

### DIFF
--- a/chromium_src/content/public/common/content_features.cc
+++ b/chromium_src/content/public/common/content_features.cc
@@ -19,6 +19,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kWebNfc, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
     {kWebOTP, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kServiceWorkerTerminationOnNoControllee, base::FEATURE_ENABLED_BY_DEFAULT},
 }});
 
 }  // namespace features

--- a/patches/content-browser-service_worker-service_worker_version.cc.patch
+++ b/patches/content-browser-service_worker-service_worker_version.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/content/browser/service_worker/service_worker_version.cc b/content/browser/service_worker/service_worker_version.cc
+index 26cdf768f189f054855f351ebfbb427aec049c01..b102140e0501335983d110bbf8080efc48baedd6 100644
+--- a/content/browser/service_worker/service_worker_version.cc
++++ b/content/browser/service_worker/service_worker_version.cc
+@@ -74,7 +74,7 @@ const base::FeatureParam<int> kUpdateDelayParam{
+ // timeout.
+ const base::FeatureParam<int> kTerminationDelayParam{
+     &features::kServiceWorkerTerminationOnNoControllee,
+-    "termination_delay_in_ms", std::numeric_limits<int>::max()};
++    "termination_delay_in_ms", 30000};
+ 
+ const char kClaimClientsStateErrorMesage[] =
+     "Only the active worker can claim clients.";


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/18980

Enabled a feature to terminate a service worker when it doesn't control any clients.
The timeout is 30sec.

Chromium has `content\browser\service_worker\service_worker_version_unittest.cc` but they don't care about the default feature/parameter state.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

