### PR TITLE
Do not mark a publisher as verified if their wallet address is empty

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.cc
@@ -68,33 +68,30 @@ void GetPublisherStatusFromMessage(
   info->status = ledger::type::PublisherStatus::CONNECTED;
   for (const auto& wallet : response.wallets()) {
     if (wallet.has_uphold_wallet()) {
-      switch (wallet.uphold_wallet().wallet_state()) {
-        case publishers_pb::UPHOLD_ACCOUNT_KYC:
-          info->status = ledger::type::PublisherStatus::UPHOLD_VERIFIED;
-          info->address = wallet.uphold_wallet().address();
-          return;
-        default:
-          break;
+      auto& uphold = wallet.uphold_wallet();
+      if (uphold.wallet_state() == publishers_pb::UPHOLD_ACCOUNT_KYC &&
+          !uphold.address().empty()) {
+        info->status = ledger::type::PublisherStatus::UPHOLD_VERIFIED;
+        info->address = uphold.address();
+        return;
       }
     }
     if (wallet.has_bitflyer_wallet()) {
-      switch (wallet.bitflyer_wallet().wallet_state()) {
-        case publishers_pb::BITFLYER_ACCOUNT_KYC:
-          info->status = ledger::type::PublisherStatus::BITFLYER_VERIFIED;
-          info->address = wallet.bitflyer_wallet().address();
-          return;
-        default:
-          break;
+      auto& bitflyer = wallet.bitflyer_wallet();
+      if (bitflyer.wallet_state() == publishers_pb::BITFLYER_ACCOUNT_KYC &&
+          !bitflyer.address().empty()) {
+        info->status = ledger::type::PublisherStatus::BITFLYER_VERIFIED;
+        info->address = bitflyer.address();
+        return;
       }
     }
     if (wallet.has_gemini_wallet()) {
-      switch (wallet.gemini_wallet().wallet_state()) {
-        case publishers_pb::GEMINI_ACCOUNT_KYC:
-          info->status = ledger::type::PublisherStatus::GEMINI_VERIFIED;
-          info->address = wallet.gemini_wallet().address();
-          return;
-        default:
-          break;
+      auto& gemini = wallet.gemini_wallet();
+      if (gemini.wallet_state() == publishers_pb::GEMINI_ACCOUNT_KYC &&
+          !gemini.address().empty()) {
+        info->status = ledger::type::PublisherStatus::GEMINI_VERIFIED;
+        info->address = gemini.address();
+        return;
       }
     }
   }

--- a/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher_unittest.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher_unittest.cc
@@ -3,65 +3,127 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <memory>
 #include <string>
-#include <vector>
+#include <utility>
 
-#include "base/test/task_environment.h"
-#include "bat/ledger/internal/ledger_client_mock.h"
-#include "bat/ledger/internal/ledger_impl_mock.h"
+#include "base/big_endian.h"
+#include "bat/ledger/internal/core/bat_ledger_test.h"
 #include "bat/ledger/internal/endpoint/private_cdn/get_publisher/get_publisher.h"
-#include "bat/ledger/ledger.h"
+#include "bat/ledger/internal/endpoint/private_cdn/private_cdn_util.h"
+#include "bat/ledger/internal/publisher/protos/channel_response.pb.h"
 #include "net/http/http_status_code.h"
-#include "testing/gtest/include/gtest/gtest.h"
 
 // npm run test -- brave_unit_tests --filter=GetPublisherTest.*
-
-using ::testing::_;
-using ::testing::Invoke;
 
 namespace ledger {
 namespace endpoint {
 namespace private_cdn {
 
-class GetPublisherTest : public testing::Test {
- private:
-  base::test::TaskEnvironment scoped_task_environment_;
-
+class GetPublisherTest : public BATLedgerTest {
  protected:
-  std::unique_ptr<ledger::MockLedgerClient> mock_ledger_client_;
-  std::unique_ptr<ledger::MockLedgerImpl> mock_ledger_impl_;
-  std::unique_ptr<GetPublisher> publisher_;
+  mojom::Result Request(const std::string& id,
+                        const std::string& prefix,
+                        mojom::ServerPublisherInfoPtr* info) {
+    DCHECK(info);
+    base::RunLoop run_loop;
+    mojom::Result result;
 
-  GetPublisherTest() {
-    mock_ledger_client_ = std::make_unique<ledger::MockLedgerClient>();
-    mock_ledger_impl_ =
-        std::make_unique<ledger::MockLedgerImpl>(mock_ledger_client_.get());
-    publisher_ = std::make_unique<GetPublisher>(mock_ledger_impl_.get());
+    GetPublisher(GetLedgerImpl())
+        .Request(id, prefix,
+                 [&run_loop, &result, info](
+                     mojom::Result request_result,
+                     mojom::ServerPublisherInfoPtr request_info) {
+                   result = request_result;
+                   *info = std::move(request_info);
+                   run_loop.Quit();
+                 });
+
+    run_loop.Run();
+    return result;
+  }
+
+  std::string StringifyChannelResponse(
+      const publishers_pb::ChannelResponseList& message) {
+    std::string out;
+    message.SerializeToString(&out);
+
+    // Add padding header
+    uint32_t length = out.length();
+    out.insert(0, 4, ' ');
+    base::WriteBigEndian(&out[0], length);
+
+    return out;
   }
 };
 
 TEST_F(GetPublisherTest, ServerError404) {
-  ON_CALL(*mock_ledger_client_, LoadURL(_, _))
-      .WillByDefault(
-          Invoke([](
-              type::UrlRequestPtr request,
-              client::LoadURLCallback callback) {
-            type::UrlResponse response;
-            response.status_code = 404;
-            response.url = request->url;
-            response.body = "";
-            callback(response);
-          }));
+  auto response = mojom::UrlResponse::New();
+  response->status_code = net::HTTP_NOT_FOUND;
+  AddNetworkResultForTesting(GetServerUrl("/publishers/prefixes/ce55"),
+                             mojom::UrlMethod::GET, std::move(response));
 
-  publisher_->Request(
-      "brave.com",
-      "ce55",
-      [](const type::Result result, type::ServerPublisherInfoPtr info) {
-    EXPECT_EQ(result, type::Result::LEDGER_OK);
-    EXPECT_EQ(info->publisher_key, "brave.com");
-    EXPECT_EQ(info->status, type::PublisherStatus::NOT_VERIFIED);
-  });
+  mojom::Result result;
+  mojom::ServerPublisherInfoPtr info;
+
+  result = Request("brave.com", "ce55", &info);
+  EXPECT_EQ(result, mojom::Result::LEDGER_OK);
+  ASSERT_TRUE(info);
+  EXPECT_EQ(info->publisher_key, "brave.com");
+  EXPECT_EQ(info->status, type::PublisherStatus::NOT_VERIFIED);
+}
+
+TEST_F(GetPublisherTest, UpholdVerified) {
+  publishers_pb::ChannelResponseList message;
+  auto* channel = message.add_channel_responses();
+  channel->set_channel_identifier("brave.com");
+
+  auto* uphold_wallet = channel->add_wallets()->mutable_uphold_wallet();
+  uphold_wallet->set_wallet_state(publishers_pb::UPHOLD_ACCOUNT_KYC);
+  uphold_wallet->set_address("abcd");
+
+  auto response = mojom::UrlResponse::New();
+  response->status_code = net::HTTP_OK;
+  response->body = StringifyChannelResponse(message);
+
+  AddNetworkResultForTesting(GetServerUrl("/publishers/prefixes/ce55"),
+                             mojom::UrlMethod::GET, std::move(response));
+
+  mojom::Result result;
+  mojom::ServerPublisherInfoPtr info;
+
+  result = Request("brave.com", "ce55", &info);
+  EXPECT_EQ(result, mojom::Result::LEDGER_OK);
+  ASSERT_TRUE(info);
+  EXPECT_EQ(info->publisher_key, "brave.com");
+  EXPECT_EQ(info->status, type::PublisherStatus::UPHOLD_VERIFIED);
+  EXPECT_EQ(info->address, "abcd");
+}
+
+TEST_F(GetPublisherTest, EmptyWalletAddress) {
+  publishers_pb::ChannelResponseList message;
+  auto* channel = message.add_channel_responses();
+  channel->set_channel_identifier("brave.com");
+
+  auto* uphold_wallet = channel->add_wallets()->mutable_uphold_wallet();
+  uphold_wallet->set_wallet_state(publishers_pb::UPHOLD_ACCOUNT_KYC);
+  uphold_wallet->set_address("");
+
+  auto response = mojom::UrlResponse::New();
+  response->status_code = net::HTTP_OK;
+  response->body = StringifyChannelResponse(message);
+
+  AddNetworkResultForTesting(GetServerUrl("/publishers/prefixes/ce55"),
+                             mojom::UrlMethod::GET, std::move(response));
+
+  mojom::Result result;
+  mojom::ServerPublisherInfoPtr info;
+
+  result = Request("brave.com", "ce55", &info);
+  EXPECT_EQ(result, mojom::Result::LEDGER_OK);
+  ASSERT_TRUE(info);
+  EXPECT_EQ(info->publisher_key, "brave.com");
+  EXPECT_EQ(info->status, type::PublisherStatus::CONNECTED);
+  EXPECT_EQ(info->address, "");
 }
 
 }  // namespace private_cdn


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19458

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Given that the user is verified and connected Uphold
- When the user visits a publisher that is Uphold-verified but does not have an uphold wallet address (e.g. `https://getusppe.org/` in a production rewards environment)
- And opens the tipping dialog
- Then the tipping dialog should display a "publisher cannot receive tips" message
- And tips should be stored in the pending tip list.