### PR TITLE
Passed Active Origin to Allow Spend Panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -74,6 +74,7 @@ import {
 export type confirmPanelTabs = 'transaction' | 'details'
 
 export interface Props {
+  siteURL: string
   accounts: WalletAccountType[]
   visibleTokens: ERCToken[]
   fullTokenList: ERCToken[]
@@ -95,6 +96,7 @@ export interface Props {
 
 function ConfirmTransactionPanel (props: Props) {
   const {
+    siteURL,
     accounts,
     selectedNetwork,
     transactionInfo,
@@ -128,10 +130,6 @@ function ConfirmTransactionPanel (props: Props) {
   const [isEditing, setIsEditing] = React.useState<boolean>(false)
   const [currentTokenAllowance, setCurrentTokenAllowance] = React.useState<string>('')
   const [isEditingAllowance, setIsEditingAllowance] = React.useState<boolean>(false)
-
-  // Will remove this hardcoded value once we know
-  // where the site info will be coming from.
-  const siteURL = 'https://app.compound.finance'
 
   const findSpotPrice = usePricing(transactionSpotPrices)
   const parseTransaction = useTransactionParser(selectedNetwork, accounts, transactionSpotPrices, visibleTokens, fullTokenList)

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -484,16 +484,16 @@ function Container (props: Props) {
 
   if (selectedPendingTransaction && selectedPanel === 'connectHardwareWallet') {
     return (
-        <PanelWrapper isLonger={false}>
-          <StyledExtensionWrapper>
-            <ConnectHardwareWalletPanel
-                onCancel={onCancelConnectHardwareWallet}
-                walletName={selectedAccount.name}
-                hardwareWalletError={props.panel.hardwareWalletError}
-                retryCallable={onConfirmTransaction}
-            />
-          </StyledExtensionWrapper>
-        </PanelWrapper>
+      <PanelWrapper isLonger={false}>
+        <StyledExtensionWrapper>
+          <ConnectHardwareWalletPanel
+            onCancel={onCancelConnectHardwareWallet}
+            walletName={selectedAccount.name}
+            hardwareWalletError={props.panel.hardwareWalletError}
+            retryCallable={onConfirmTransaction}
+          />
+        </StyledExtensionWrapper>
+      </PanelWrapper>
     )
   }
 
@@ -502,6 +502,7 @@ function Container (props: Props) {
       <PanelWrapper isLonger={true}>
         <LongWrapper>
           <ConfirmTransactionPanel
+            siteURL={activeOrigin}
             onConfirm={onConfirmTransaction}
             onReject={onRejectTransaction}
             onRejectAllTransactions={onRejectAllTransactions}

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -170,6 +170,7 @@ export const _ConfirmTransaction = () => {
   return (
     <StyledExtensionWrapperLonger>
       <ConfirmTransactionPanel
+        siteURL='https://app.uniswap.org'
         selectedNetwork={mockNetworks[0]}
         onQueueNextTransction={onQueueNextTransction}
         onRejectAllTransactions={onRejectAllTransactions}


### PR DESCRIPTION
## Description 
The `AllowSpend` Panel had a hardcoded value of 'https://app.compound.finance' for `siteUrl`
It is now being passed the sites `activeOrigin`
 
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19534>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Before:

![Screen Shot 2021-11-17 at 9 43 14 AM](https://user-images.githubusercontent.com/40611140/142243633-3b6b579a-a7a9-4779-9e76-fd495eb5c693.png)

After:

![Screen Shot 2021-11-17 at 9 33 48 AM](https://user-images.githubusercontent.com/40611140/142243659-99246f49-bd2b-41b8-aef3-75890a1738c1.png)
