### PR TITLE
Fix #19069 - IsWebstoreUpdateUrl should return true for kChromeWebstoreUpdateURL even when component-updater switch is set (uplift to 1.32.x)

### DIFF
--- a/chromium_src/extensions/common/extension_urls.cc
+++ b/chromium_src/extensions/common/extension_urls.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "extensions/common/extension_urls.h"
+
+#define IsWebstoreUpdateUrl IsWebstoreUpdateUrl_ChromiumImpl
+#include "../../../../extensions/common/extension_urls.cc"
+#undef IsWebstoreUpdateUrl
+
+namespace extension_urls {
+
+namespace {
+
+bool IsDefaultWebstoreUpdateUrl(const GURL& update_url) {
+  GURL store_url = GetDefaultWebstoreUpdateUrl();
+  return (update_url.host_piece() == store_url.host_piece() &&
+          update_url.path_piece() == store_url.path_piece());
+}
+
+}  // namespace
+
+bool IsWebstoreUpdateUrl(const GURL& update_url) {
+  return IsDefaultWebstoreUpdateUrl(update_url) ||
+         IsWebstoreUpdateUrl_ChromiumImpl(update_url);
+}
+
+}  // namespace extension_urls

--- a/chromium_src/extensions/common/extension_urls_browsertest.cc
+++ b/chromium_src/extensions/common/extension_urls_browsertest.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/command_line.h"
+#include "chrome/test/base/chrome_test_utils.h"
+#include "components/component_updater/component_updater_switches.h"
+#include "content/public/test/browser_test.h"
+#include "extensions/common/extension_urls.h"
+
+using ExtensionUrlsBrowserTest = PlatformBrowserTest;
+
+IN_PROC_BROWSER_TEST_F(ExtensionUrlsBrowserTest, IsWebstoreUpdateUrl) {
+  GURL url = GURL(extension_urls::kChromeWebstoreUpdateURL);
+  EXPECT_TRUE(extension_urls::IsWebstoreUpdateUrl(url));
+
+  url = GURL(UPDATER_PROD_ENDPOINT);
+  EXPECT_TRUE(base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kComponentUpdater));
+  EXPECT_TRUE(extension_urls::IsWebstoreUpdateUrl(url));
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -662,6 +662,7 @@ if (!is_android) {
       "//brave/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view_browsertest.cc",
       "//brave/chromium_src/components/content_settings/core/browser/brave_content_settings_registry_browsertest.cc",
       "//brave/chromium_src/components/favicon/core/favicon_database_browsertest.cc",
+      "//brave/chromium_src/extensions/common/extension_urls_browsertest.cc",
       "//brave/chromium_src/third_party/blink/public/platform/disable_client_hints_browsertest.cc",
       "//brave/chromium_src/third_party/blink/renderer/core/frame/reporting_observer_browsertest.cc",
       "//brave/common/brave_channel_info_browsertest.cc",


### PR DESCRIPTION
Manual uplift of https://github.com/brave/brave-core/pull/10781
Fixes https://github.com/brave/brave-browser/issues/19069

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.