### PR TITLE
Don't add AUTH info to HostPortPair when using direct:// schemes (uplift to 1.33.x)

### DIFF
--- a/chromium_src/net/base/BUILD.gn
+++ b/chromium_src/net/base/BUILD.gn
@@ -5,7 +5,10 @@
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "brave_proxy_string_util_unittest.cc" ]
+  sources = [
+    "brave_proxy_string_util_unittest.cc",
+    "//net/base/proxy_string_util_unittest.cc",
+  ]
 
   deps = [
     "//net",

--- a/chromium_src/net/base/BUILD.gn
+++ b/chromium_src/net/base/BUILD.gn
@@ -6,8 +6,8 @@
 source_set("unit_tests") {
   testonly = true
   sources = [
-    "brave_proxy_string_util_unittest.cc",
     "//net/base/proxy_string_util_unittest.cc",
+    "brave_proxy_string_util_unittest.cc",
   ]
 
   deps = [

--- a/chromium_src/net/base/brave_proxy_string_util_unittest.cc
+++ b/chromium_src/net/base/brave_proxy_string_util_unittest.cc
@@ -50,8 +50,8 @@ TEST(BraveProxySpecificationUtilTest, PacResultElementWithAuthToProxyServer) {
     const char* const expected_uri;
   } tests[] = {
       {
-          "PROXY foo:bar@foopy:10",
-          "foo:bar@foopy:10",
+          "SOCKS5 foo:bar@foopy:10",
+          "socks5://foo:bar@foopy:10",
       },
   };
 

--- a/chromium_src/net/base/proxy_string_util.cc
+++ b/chromium_src/net/base/proxy_string_util.cc
@@ -90,8 +90,13 @@ std::string GetProxyServerAuthString(const ProxyServer& proxy_server) {
 namespace net {
 
 std::string ProxyServerToProxyUri(const ProxyServer& proxy_server) {
-  std::string scheme_prefix;
   std::string proxy_uri = ProxyServerToProxyUri_ChromiumImpl(proxy_server);
+
+  // We only inject AUTH information for SOCKS5 proxies (Tor-only).
+  if (proxy_server.scheme() != ProxyServer::SCHEME_SOCKS5)
+    return proxy_uri;
+
+  std::string scheme_prefix;
   size_t colon = proxy_uri.find(':');
   if (colon != std::string::npos && proxy_uri.size() - colon >= 3 &&
       proxy_uri[colon + 1] == '/' && proxy_uri[colon + 2] == '/') {
@@ -105,9 +110,14 @@ std::string ProxyServerToProxyUri(const ProxyServer& proxy_server) {
 }
 
 std::string ProxyServerToPacResultElement(const ProxyServer& proxy_server) {
-  std::string scheme_prefix;
   std::string proxy_pac =
       ProxyServerToPacResultElement_ChromiumImpl(proxy_server);
+
+  // We only inject AUTH information for SOCKS5 proxies (Tor-only).
+  if (proxy_server.scheme() != ProxyServer::SCHEME_SOCKS5)
+    return proxy_pac;
+
+  std::string scheme_prefix;
   size_t space = proxy_pac.find(' ');
   if (space != std::string::npos && proxy_pac.size() - space >= 1) {
     scheme_prefix = proxy_pac.substr(0, space + 1);


### PR DESCRIPTION
Uplift of #11127
Uplift of #11151
Resolves https://github.com/brave/brave-browser/issues/19527
Resolves https://github.com/brave/brave-browser/issues/19555

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.