### PR TITLE
Passed Active Origin to Allow Spend Panel (uplift to 1.33.x)

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -71,6 +71,7 @@ import {
 export type confirmPanelTabs = 'transaction' | 'details'
 
 export interface Props {
+  siteURL: string
   accounts: WalletAccountType[]
   visibleTokens: ERCToken[]
   fullTokenList: ERCToken[]
@@ -92,6 +93,7 @@ export interface Props {
 
 function ConfirmTransactionPanel (props: Props) {
   const {
+    siteURL,
     accounts,
     selectedNetwork,
     transactionInfo,
@@ -125,10 +127,6 @@ function ConfirmTransactionPanel (props: Props) {
   const [isEditing, setIsEditing] = React.useState<boolean>(false)
   const [currentTokenAllowance, setCurrentTokenAllowance] = React.useState<string>('')
   const [isEditingAllowance, setIsEditingAllowance] = React.useState<boolean>(false)
-
-  // Will remove this hardcoded value once we know
-  // where the site info will be coming from.
-  const siteURL = 'https://app.compound.finance'
 
   const findSpotPrice = usePricing(transactionSpotPrices)
   const parseTransaction = useTransactionParser(selectedNetwork, accounts, transactionSpotPrices, visibleTokens, fullTokenList)

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -484,16 +484,16 @@ function Container (props: Props) {
 
   if (selectedPendingTransaction && selectedPanel === 'connectHardwareWallet') {
     return (
-        <PanelWrapper isLonger={false}>
-          <StyledExtensionWrapper>
-            <ConnectHardwareWalletPanel
-                onCancel={onCancelConnectHardwareWallet}
-                walletName={selectedAccount.name}
-                hardwareWalletError={props.panel.hardwareWalletError}
-                retryCallable={onConfirmTransaction}
-            />
-          </StyledExtensionWrapper>
-        </PanelWrapper>
+      <PanelWrapper isLonger={false}>
+        <StyledExtensionWrapper>
+          <ConnectHardwareWalletPanel
+            onCancel={onCancelConnectHardwareWallet}
+            walletName={selectedAccount.name}
+            hardwareWalletError={props.panel.hardwareWalletError}
+            retryCallable={onConfirmTransaction}
+          />
+        </StyledExtensionWrapper>
+      </PanelWrapper>
     )
   }
 
@@ -502,6 +502,7 @@ function Container (props: Props) {
       <PanelWrapper isLonger={true}>
         <LongWrapper>
           <ConfirmTransactionPanel
+            siteURL={activeOrigin}
             onConfirm={onConfirmTransaction}
             onReject={onRejectTransaction}
             onRejectAllTransactions={onRejectAllTransactions}

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -171,6 +171,7 @@ export const _ConfirmTransaction = () => {
   return (
     <StyledExtensionWrapperLonger>
       <ConfirmTransactionPanel
+        siteURL='https://app.uniswap.org'
         selectedNetwork={mockNetworks[0]}
         onQueueNextTransction={onQueueNextTransction}
         onRejectAllTransactions={onRejectAllTransactions}


### PR DESCRIPTION
Uplift of #11132
Resolves https://github.com/brave/brave-browser/issues/19534

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.