### PR TITLE
Fix crash with popup windows requesting Ethereum permission

### DIFF
--- a/browser/ui/DEPS
+++ b/browser/ui/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+chrome/browser/ui/views/bubble/webui_bubble_manager.h",
+  "+chrome/browser/ui/views/frame/top_container_view.h",
 ]

--- a/browser/ui/wallet_bubble_manager_delegate_impl.cc
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.cc
@@ -15,6 +15,7 @@
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "components/grit/brave_components_strings.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/views/view.h"
@@ -145,10 +146,15 @@ WalletBubbleManagerDelegateImpl::WalletBubbleManagerDelegateImpl(
   Browser* browser = chrome::FindBrowserWithWebContents(web_contents_);
   DCHECK(browser);
 
-  views::View* anchor_view = static_cast<BraveBrowserView*>(browser->window())
-                                 ->GetWalletButtonAnchorView();
-  DCHECK(anchor_view);
+  views::View* anchor_view;
+  if (browser->is_type_normal()) {
+    anchor_view = static_cast<BraveBrowserView*>(browser->window())
+                      ->GetWalletButtonAnchorView();
+  } else {
+    anchor_view = static_cast<BrowserView*>(browser->window())->top_container();
+  }
 
+  DCHECK(anchor_view);
   webui_bubble_manager_ =
       std::make_unique<BraveWebUIBubbleManagerT<WalletPanelUI>>(
           anchor_view, browser, webui_url_, IDS_ACCNAME_BRAVE_WALLET_BUTTON,


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19566

I wasn't able to get a test case working quickly but I posted this issue to look at it again. I just want to get the fix in and uplifted for the next hotfix first. https://github.com/brave/brave-browser/issues/19567

Looks like this:

<img width="346" alt="Screen Shot 2021-11-18 at 1 47 39 PM" src="https://user-images.githubusercontent.com/831718/142477906-5945a240-da94-470b-9e8e-a019d307dcfc.png">



## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested]
(https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

