### PR TITLE
Check NTP SI component update when NTP opens

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/ntp_background_images_service.h
@@ -70,6 +70,7 @@ class NTPBackgroundImagesService {
   std::string GetSuperReferralCode() const;
 
   std::vector<std::string> GetTopSitesFaviconList() const;
+  void CheckNTPSIComponentUpdateIfNeeded();
 
  private:
   friend class TestNTPBackgroundImagesService;
@@ -144,7 +145,9 @@ class NTPBackgroundImagesService {
   virtual void UnRegisterSuperReferralComponent();
   virtual void MarkThisInstallIsNotSuperReferralForever();
 
+  base::Time last_update_check_time_;
   base::RepeatingTimer si_update_check_timer_;
+  base::RepeatingClosure si_update_check_callback_;
   std::vector<std::string> top_site_favicon_list_;
   bool test_data_used_ = false;
   component_updater::ComponentUpdateService* component_update_service_;

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -255,6 +255,7 @@ void ViewCounterService::RegisterPageView() {
   new_tab_count_state_->AddDelta(1);
   UpdateP3AValues();
   // This will be no-op when component is not ready.
+  service_->CheckNTPSIComponentUpdateIfNeeded();
   model_.RegisterPageView();
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/19581

We priodically check component update every 15 mins in background.
But, sometimes this check could be missed when app is in suspended mode.
To overcome this limitation, browser will try to check update when NTP
is opened if backgroud update check is missed.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

