### PR TITLE
[network-audit] Gracefully ignore requests with invalid URLs

### DIFF
--- a/browser/net/brave_network_audit_browsertest.cc
+++ b/browser/net/brave_network_audit_browsertest.cc
@@ -112,7 +112,11 @@ bool PerformNetworkAuditProcess(base::Value* events) {
     EXPECT_TRUE(url_str);
 
     GURL url(*url_str);
-    EXPECT_TRUE(url.is_valid());
+    if (!url.is_valid()) {
+      // Network requests to invalid URLs don't pose a threat and can happen in
+      // dev-only environments (e.g. building with brave_stats_updater_url="").
+      return true;
+    }
 
     if (RE2::FullMatch(url.host(), "[a-z]+")) {
       // Chromium sometimes sends requests to random non-resolvable hosts.


### PR DESCRIPTION
Sometimes the audit can encounter requests to invalid (e.g. empty) URLs
when verifying results (e.g. building with brave_stats_updater_url=""
in dev-only environments), which will make the audit fail with a not
very helpful error message "NETWORK AUDIT FAIL:" (i.e. empty URL).

Since this type of network requests to invalid URLs don't pose a
security threat (i.e. not real requests), let's relax a  bit the
EXPECT_TRUE(url.is_valid()) expectations and simply ignore invalid
URLs early in the verification process, so that we won't fail the
audit due to incompletely configured builds, which are perfectly
fine in any case for dev-only environments.

Resolves https://github.com/brave/brave-browser/issues/19588

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A