### PR TITLE
Fix crash with popup windows requesting Ethereum permission (uplift to 1.33.x)

### DIFF
--- a/browser/ui/DEPS
+++ b/browser/ui/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+chrome/browser/ui/views/bubble/webui_bubble_manager.h",
+  "+chrome/browser/ui/views/frame/top_container_view.h",
 ]

--- a/browser/ui/wallet_bubble_manager_delegate_impl.cc
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.cc
@@ -15,6 +15,7 @@
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "components/grit/brave_components_strings.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/views/view.h"
@@ -145,10 +146,15 @@ WalletBubbleManagerDelegateImpl::WalletBubbleManagerDelegateImpl(
   Browser* browser = chrome::FindBrowserWithWebContents(web_contents_);
   DCHECK(browser);
 
-  views::View* anchor_view = static_cast<BraveBrowserView*>(browser->window())
-                                 ->GetWalletButtonAnchorView();
-  DCHECK(anchor_view);
+  views::View* anchor_view;
+  if (browser->is_type_normal()) {
+    anchor_view = static_cast<BraveBrowserView*>(browser->window())
+                      ->GetWalletButtonAnchorView();
+  } else {
+    anchor_view = static_cast<BrowserView*>(browser->window())->top_container();
+  }
 
+  DCHECK(anchor_view);
   webui_bubble_manager_ =
       std::make_unique<BraveWebUIBubbleManagerT<WalletPanelUI>>(
           anchor_view, browser, webui_url_, IDS_ACCNAME_BRAVE_WALLET_BUTTON,


### PR DESCRIPTION
Uplift of #11156
Resolves https://github.com/brave/brave-browser/issues/19566

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.