### PR TITLE
Add relaunch option for inline tip settings in brave://settings/rewards (uplift to 1.33.x)

### DIFF
--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.html
@@ -115,14 +115,29 @@
   <settings-toggle-button
     label="$i18n{braveRewardsInlineTipRedditLabel}"
     pref="{{prefs.brave.rewards.inline_tip.reddit}}">
+    <template is="dom-if" if="[[shouldShowRestartButtonForReddit_(prefs.brave.rewards.inline_tip.reddit.value)]]">
+      <cr-button on-click="restartBrowser_" slot="more-actions">
+        $i18n{restart}
+      </cr-button>
+    </template>
   </settings-toggle-button>
   <settings-toggle-button
     label="$i18n{braveRewardsInlineTipTwitterLabel}"
     pref="{{prefs.brave.rewards.inline_tip.twitter}}">
+    <template is="dom-if" if="[[shouldShowRestartButtonForTwitter_(prefs.brave.rewards.inline_tip.twitter.value)]]">
+      <cr-button on-click="restartBrowser_" slot="more-actions">
+        $i18n{restart}
+      </cr-button>
+    </template>
   </settings-toggle-button>
   <settings-toggle-button
     label="$i18n{braveRewardsInlineTipGithubLabel}"
     pref="{{prefs.brave.rewards.inline_tip.github}}">
+    <template is="dom-if" if="[[shouldShowRestartButtonForGithub_(prefs.brave.rewards.inline_tip.github.value)]]">
+      <cr-button on-click="restartBrowser_" slot="more-actions">
+        $i18n{restart}
+      </cr-button>
+    </template>
   </settings-toggle-button>
 </template>
 <template is="dom-if" if="[[!prefs.brave.rewards.enabled.value]]" restamp>

--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
@@ -7,13 +7,13 @@
 import {loadTimeData} from '../i18n_setup.js';
 
 import '//resources/js/cr.m.js';
-import {html, mixinBehaviors, PolymerElement} from '//resources/polymer/v3_0/polymer/polymer_bundled.min.js';
+import {html, PolymerElement} from '//resources/polymer/v3_0/polymer/polymer_bundled.min.js';
 
-import {I18nBehavior} from '//resources/js/i18n_behavior.m.js';
+import {I18nMixin} from 'chrome://resources/js/i18n_mixin.js';
+import {PrefsMixin} from '../prefs/prefs_mixin.js';
 import {BraveRewardsBrowserProxyImpl} from './brave_rewards_browser_proxy.m.js';
 
-const SettingsBraveRewardsPageBase =
-    mixinBehaviors([I18nBehavior], PolymerElement);
+const SettingsBraveRewardsPageBase = I18nMixin(PrefsMixin(PolymerElement))
 
 /**
  * 'settings-brave-rewards-page' is the settings page containing settings for
@@ -133,12 +133,28 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
 	value: []
       },
       shouldAllowAdsSubdivisionTargeting_: {
-	type: Boolean,
-	value: false
+        type: Boolean,
+        value: false
       },
       shouldShowAutoContributeSettings_: {
         type: Boolean,
         value: true
+      },
+      isRewardsEnabled_: {
+        type: Boolean,
+        value: false
+      },
+      wasInlineTippingForRedditEnabledOnStartup_: {
+        type: Boolean,
+        value: false,
+      },
+      wasInlineTippingForTwitterEnabledOnStartup_: {
+        type: Boolean,
+        value: false,
+      },
+      wasInlineTippingForGithubEnabledOnStartup_: {
+        type: Boolean,
+        value: false,
       }
     }
   }
@@ -157,6 +173,10 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
     })
     this.browserProxy_.getRewardsEnabled().then((enabled) => {
       if (enabled) {
+        this.isRewardsEnabled_ = true
+        this.wasInlineTippingForRedditEnabledOnStartup_ = this.getPref('brave.rewards.inline_tip.reddit').value
+        this.wasInlineTippingForTwitterEnabledOnStartup_ = this.getPref('brave.rewards.inline_tip.twitter').value
+        this.wasInlineTippingForGithubEnabledOnStartup_ = this.getPref('brave.rewards.inline_tip.github').value
         this.isAutoContributeSupported_()
         this.populateAutoContributeAmountDropdown_()
       }
@@ -183,6 +203,35 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
       })
       this.autoContributeMonthlyLimit_ = autoContributeChoices
     })
+  }
+
+  shouldShowRestartButtonForReddit_(enabled) {
+    if (!this.isRewardsEnabled_) {
+      return false
+    }
+
+    return enabled !== this.wasInlineTippingForRedditEnabledOnStartup_
+  }
+
+  shouldShowRestartButtonForTwitter_(enabled) {
+    if (!this.isRewardsEnabled_) {
+      return false
+    }
+
+    return enabled !== this.wasInlineTippingForTwitterEnabledOnStartup_
+  }
+
+  shouldShowRestartButtonForGithub_(enabled) {
+    if (!this.isRewardsEnabled_) {
+      return false
+    }
+
+    return enabled !== this.wasInlineTippingForGithubEnabledOnStartup_
+  }
+
+  restartBrowser_(e) {
+    e.stopPropagation();
+    window.open('chrome://restart', '_self');
   }
 }
 


### PR DESCRIPTION
Uplift of #11157
Resolves https://github.com/brave/brave-browser/issues/19564

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.