### PR TITLE
Populate AC dropdown when Ads/Rewards is enabled (uplift to 1.33.x)

### DIFF
--- a/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
+++ b/browser/resources/settings/brave_rewards_page/brave_rewards_page.js
@@ -150,7 +150,6 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
     this.openRewardsPanel_ = () => {
       chrome.braveRewards.openBrowserActionUI('brave_rewards_panel.html')
       this.isAutoContributeSupported_()
-      this.populateAutoContributeAmountDropdown_()
     }
     this.browserProxy_.getLocale().then((locale) => {
       this.shouldAllowAdsSubdivisionTargeting_ = locale === 'en-US'
@@ -158,8 +157,14 @@ class SettingsBraveRewardsPage extends SettingsBraveRewardsPageBase {
     this.browserProxy_.getRewardsEnabled().then((enabled) => {
       if (enabled) {
         this.isAutoContributeSupported_()
-        this.populateAutoContributeAmountDropdown_()
       }
+    })
+    chrome.braveRewards.onAdsEnabled.addListener(() => {
+      // Populate the auto contribute amount dropdown when Ads/Rewards is
+      // enabled (we don't have a Rewards-specific listener, but this works for
+      // our purposes as we just want to ensure the dropdown is populated the
+      // first time we enable)
+      this.populateAutoContributeAmountDropdown_()
     })
   }
 


### PR DESCRIPTION
Uplift of #11175
Resolves https://github.com/brave/brave-browser/issues/19587

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.