### PR TITLE
Check if network supports EIP1559 for eth_sendTransaction requests

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -166,6 +166,10 @@ void BraveWalletProviderImpl::SwitchEthereumChain(
     delegate_->ShowBubble();
 }
 
+void BraveWalletProviderImpl::GetNetwork(GetNetworkCallback callback) {
+  rpc_controller_->GetNetwork(std::move(callback));
+}
+
 void BraveWalletProviderImpl::AddAndApproveTransaction(
     mojom::TxDataPtr tx_data,
     const std::string& from,

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -79,6 +79,8 @@ class BraveWalletProviderImpl final
   void Init(
       mojo::PendingRemote<mojom::EventsListener> events_listener) override;
 
+  void GetNetwork(GetNetworkCallback callback) override;
+
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveWalletProviderImplUnitTest, OnAddEthereumChain);
   FRIEND_TEST_ALL_PREFIXES(BraveWalletProviderImplUnitTest,

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -202,6 +202,18 @@ mojom::EthereumChainPtr GetKnownChain(PrefService* prefs,
   return nullptr;
 }
 
+mojom::EthereumChainPtr GetChain(PrefService* prefs,
+                                 const std::string& chain_id) {
+  std::vector<mojom::EthereumChainPtr> chains;
+  GetAllChains(prefs, &chains);
+  for (const auto& chain : chains) {
+    if (chain->chain_id == chain_id)
+      return chain.Clone();
+  }
+
+  return nullptr;
+}
+
 std::string GetInfuraSubdomainForKnownChainId(const std::string& chain_id) {
   if (kInfuraSubdomains.contains(chain_id))
     return kInfuraSubdomains.at(chain_id);

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -109,6 +109,10 @@ std::string GetEnsRegistryContractAddress(const std::string& chain_id);
 // Append chain value to kBraveWalletCustomNetworks list pref.
 void AddCustomNetwork(PrefService* prefs, mojom::EthereumChainPtr chain);
 
+// Get a specific chain from all chains.
+mojom::EthereumChainPtr GetChain(PrefService* prefs,
+                                 const std::string& chain_id);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_UTILS_H_

--- a/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils_unittest.cc
@@ -860,6 +860,25 @@ TEST(BraveWalletUtilsUnitTest, GetKnownChain) {
   EXPECT_EQ(network->is_eip1559, true);
 }
 
+TEST(BraveWalletUtilsUnitTest, GetChain) {
+  TestingPrefServiceSimple prefs;
+  prefs.registry()->RegisterListPref(kBraveWalletCustomNetworks);
+  prefs.registry()->RegisterBooleanPref(kSupportEip1559OnLocalhostChain, false);
+
+  std::vector<base::Value> values;
+  brave_wallet::mojom::EthereumChain chain1(
+      "0x5566", "chain_name", {"https://url1.com"}, {"https://url1.com"},
+      {"https://url1.com"}, "symbol_name", "symbol", 11, false);
+  auto chain_ptr1 = chain1.Clone();
+  values.push_back(brave_wallet::EthereumChainToValue(chain_ptr1));
+  UpdateCustomNetworks(&prefs, &values);
+
+  EXPECT_FALSE(GetChain(&prefs, "0x123"));
+  EXPECT_EQ(GetChain(&prefs, "0x5566"), chain1.Clone());
+  EXPECT_EQ(GetChain(&prefs, "0x1"), GetKnownChain(&prefs, "0x1"));
+  EXPECT_EQ(GetChain(&prefs, "0x539"), GetKnownChain(&prefs, "0x539"));
+}
+
 TEST(BraveWalletUtilsUnitTest, GetAllKnownNetworkIds) {
   EXPECT_EQ(GetAllKnownNetworkIds(),
             std::vector<std::string>({"mainnet", "rinkeby", "ropsten", "goerli",

--- a/components/brave_wallet/browser/eth_json_rpc_controller.cc
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.cc
@@ -214,6 +214,10 @@ void EthJsonRpcController::SetNetwork(const std::string& chain_id,
     std::move(callback).Run(true);
 }
 
+void EthJsonRpcController::GetNetwork(GetNetworkCallback callback) {
+  std::move(callback).Run(GetChain(prefs_, chain_id_));
+}
+
 void EthJsonRpcController::MaybeUpdateIsEip1559(const std::string& chain_id) {
   // Only try to update is_eip1559 for localhost or custom chains.
   auto chain = GetKnownChain(prefs_, chain_id);

--- a/components/brave_wallet/browser/eth_json_rpc_controller.h
+++ b/components/brave_wallet/browser/eth_json_rpc_controller.h
@@ -115,6 +115,7 @@ class EthJsonRpcController : public KeyedService,
   bool SetNetwork(const std::string& chain_id);
   void SetNetwork(const std::string& chain_id,
                   SetNetworkCallback callback) override;
+  void GetNetwork(GetNetworkCallback callback) override;
   void AddEthereumChain(mojom::EthereumChainPtr chain,
                         const GURL& origin,
                         AddEthereumChainCallback callback) override;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -51,6 +51,9 @@ interface BraveWalletProvider {
   // Used for the connect event
   GetChainId() => (string chain_id);
 
+  // Used for getting current network information.
+  GetNetwork() => (EthereumChain network);
+
   // Used for eth_accounts method requests
   GetAllowedAccounts() => (bool success, array<string> accounts);
 };
@@ -468,6 +471,7 @@ interface EthJsonRpcController {
   GetPendingSwitchChainRequests() => (array<SwitchChainRequest> requests);
 
   SetNetwork(string chain_id) => (bool success);
+  GetNetwork() => (EthereumChain network);
   GetAllNetworks() => (array<EthereumChain> networks);
 
   // Obtains the current network's chain ID

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -135,6 +135,25 @@ mojom::TxData1559Ptr ParseEthSendTransaction1559Params(const std::string& json,
   return tx_data;
 }
 
+bool ShouldCreate1559Tx(brave_wallet::mojom::TxData1559Ptr tx_data_1559,
+                        bool network_supports_eip1559) {
+  // Network without EIP1559 support.
+  if (!network_supports_eip1559)
+    return false;
+
+  // Network with EIP1559 support and EIP1559 gas fields are specified.
+  if (tx_data_1559 && !tx_data_1559->max_priority_fee_per_gas.empty() &&
+      !tx_data_1559->max_fee_per_gas.empty())
+    return true;
+
+  // Network with EIP1559 support and legacy gas fields are specified.
+  if (tx_data_1559 && !tx_data_1559->base_data->gas_price.empty())
+    return false;
+
+  // Network with EIP1559 support and no gas fields are specified.
+  return true;
+}
+
 bool GetEthJsonRequestInfo(const std::string& json,
                            base::Value* id,
                            std::string* method,

--- a/components/brave_wallet/common/eth_request_helper.h
+++ b/components/brave_wallet/common/eth_request_helper.h
@@ -21,6 +21,9 @@ mojom::TxDataPtr ParseEthSendTransactionParams(const std::string& json,
                                                std::string* from);
 mojom::TxData1559Ptr ParseEthSendTransaction1559Params(const std::string& json,
                                                        std::string* from);
+bool ShouldCreate1559Tx(mojom::TxData1559Ptr tx_data_1559,
+                        bool network_supports_eip1559);
+
 bool NormalizeEthRequest(const std::string& input_json,
                          std::string* output_json);
 

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -147,6 +147,15 @@ class BraveWalletJSHandler : public mojom::EventsListener {
                     bool force_json_response,
                     std::unique_ptr<base::Value> formed_response,
                     bool success);
+  void ContinueEthSendTransaction(
+      const std::string& normalized_json_request,
+      base::Value id,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> global_callback,
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate,
+      bool force_json_response,
+      mojom::EthereumChainPtr chain);
 
   content::RenderFrame* render_frame_;
   bool brave_use_native_wallet_;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19536

This PR does not take keyring support into consideration as we do in https://github.com/brave/brave-core/blob/d170d9038927102d88450d965abff41e3835a3fa/components/brave_wallet_ui/common/async/handlers.ts#L267-L297, it will be added in a separate PR.
Without keyring support check, if users try to use trezor on a network that supports EIP1559, and neither EIP1559 gas fields nor the gas price field are specified, we will create EIP1559 tx, but trezor currently don't support it yet so we'll fail to process the tx.
## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Manual test plan is specified in the issue description.
Auto test coverage is added too.
