### PR TITLE
Use ignore case string compare when checking keyring support

### DIFF
--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -11,6 +11,7 @@
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
 
@@ -142,13 +143,13 @@ bool ShouldCreate1559Tx(brave_wallet::mojom::TxData1559Ptr tx_data_1559,
   bool keyring_supports_eip1559 = true;
   auto account_it = std::find_if(account_infos.begin(), account_infos.end(),
                                  [&](const mojom::AccountInfoPtr& account) {
-                                   return account->address == address;
+                                   return base::EqualsCaseInsensitiveASCII(
+                                       account->address, address);
                                  });
 
   // Only ledger hardware keyring supports EIP-1559 at the moment.
-  if (account_it == account_infos.end() ||
-      ((*account_it)->hardware &&
-       (*account_it)->hardware->vendor != mojom::kLedgerHardwareVendor)) {
+  if (account_it != account_infos.end() && (*account_it)->hardware &&
+      (*account_it)->hardware->vendor != mojom::kLedgerHardwareVendor) {
     keyring_supports_eip1559 = false;
   }
 

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -152,14 +152,16 @@ TEST(EthResponseHelperUnitTest, ShouldCreate1559Tx) {
                                  account_infos, from));
   EXPECT_TRUE(
       ShouldCreate1559Tx(tx_data.Clone(), true, account_infos, ledger_address));
+  // From is not found in the account infos, can happen when keyring is locked.
+  EXPECT_TRUE(ShouldCreate1559Tx(
+      tx_data.Clone(), true /* network_supports_eip1559 */, {}, from));
   // Network don't support EIP1559
   EXPECT_FALSE(ShouldCreate1559Tx(tx_data.Clone(), false, account_infos, from));
   // Keyring don't support EIP1559
   EXPECT_FALSE(
       ShouldCreate1559Tx(tx_data.Clone(), true, account_infos, trezor_address));
-  // From is not found in the account infos, can happen when keyring is locked.
-  EXPECT_FALSE(ShouldCreate1559Tx(
-      tx_data.Clone(), true /* network_supports_eip1559 */, {}, from));
+  EXPECT_FALSE(ShouldCreate1559Tx(tx_data.Clone(), true, account_infos,
+                                  base::ToLowerASCII(trezor_address)));
 
   // Test only EIP1559 gas fee fields are specified.
   json =
@@ -217,14 +219,23 @@ TEST(EthResponseHelperUnitTest, ShouldCreate1559Tx) {
   tx_data = ParseEthSendTransaction1559Params(json, &from);
   ASSERT_TRUE(tx_data);
   EXPECT_TRUE(ShouldCreate1559Tx(tx_data.Clone(), true, account_infos, from));
+  EXPECT_TRUE(ShouldCreate1559Tx(tx_data.Clone(), true, account_infos,
+                                 base::ToLowerASCII(from)));
+  EXPECT_TRUE(
+      ShouldCreate1559Tx(tx_data.Clone(), true, account_infos, ledger_address));
+  EXPECT_TRUE(ShouldCreate1559Tx(tx_data.Clone(), true, account_infos,
+                                 base::ToLowerASCII(ledger_address)));
+  // From is not found in the account infos, can happen when keyring is locked.
+  EXPECT_TRUE(ShouldCreate1559Tx(
+      tx_data.Clone(), true /* network_supports_eip1559 */, {}, from));
+
   EXPECT_FALSE(ShouldCreate1559Tx(tx_data.Clone(), false, account_infos, from));
   EXPECT_FALSE(ShouldCreate1559Tx(tx_data.Clone(), false, account_infos, from));
   // Keyring don't support EIP1559
   EXPECT_FALSE(
       ShouldCreate1559Tx(tx_data.Clone(), true, account_infos, trezor_address));
-  // From is not found in the account infos, can happen when keyring is locked.
-  EXPECT_FALSE(ShouldCreate1559Tx(
-      tx_data.Clone(), true /* network_supports_eip1559 */, {}, from));
+  EXPECT_FALSE(ShouldCreate1559Tx(tx_data.Clone(), true, account_infos,
+                                  base::ToLowerASCII(trezor_address)));
 }
 
 TEST(EthResponseHelperUnitTest, ParseEthSignParams) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19673

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open https://app.uniswap.org/#/swap.
2. Connect an account.
3. Swap between ETH-USDC.
4. In the panel popup, click on "Edit" under gas.
5. EIP-1559 gas pricing should be displayed.

(No need to approve the transaction.)