### PR TITLE
Allow self-transfers in panel for cancel transactions

### DIFF
--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -401,13 +401,13 @@ handler.on(WalletActions.approveERC20Allowance.getType(), async (store: Store, p
 handler.on(WalletActions.approveTransaction.getType(), async (store: Store, txInfo: TransactionInfo) => {
   const apiProxy = getAPIProxy()
   await apiProxy.ethTxController.approveTransaction(txInfo.id)
-  await refreshWalletInfo(store)
+  await store.dispatch(refreshTransactionHistory(txInfo.fromAddress))
 })
 
 handler.on(WalletActions.rejectTransaction.getType(), async (store: Store, txInfo: TransactionInfo) => {
   const apiProxy = getAPIProxy()
   await apiProxy.ethTxController.rejectTransaction(txInfo.id)
-  await refreshWalletInfo(store)
+  await store.dispatch(refreshTransactionHistory(txInfo.fromAddress))
 })
 
 handler.on(WalletActions.rejectAllTransactions.getType(), async (store) => {

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -53,7 +53,7 @@ interface ParsedTransaction extends ParsedTransactionFees {
   symbol: string
   decimals: number
   insufficientFundsError: boolean
-  addressError: string
+  contractAddressError?: string
   erc721ERCToken?: ERCToken
   erc721TokenId?: string
   isSwap?: boolean
@@ -100,16 +100,11 @@ export function useTransactionParser (
     return visibleTokens.find((token) => token.contractAddress.toLowerCase() === contractAddress.toLowerCase())
   }, [visibleTokens])
 
-  const checkForAddressError = (to: string, from: string): string => {
-    // If value is the same as the selectedAccounts Wallet Address
-    if (to.toLowerCase() === from.toLowerCase()) {
-      return getLocale('braveWalletSameAddressError')
-    }
+  const checkForContractAddressError = (to: string): string | undefined => {
     // If value is a Tokens Contract Address
-    if (fullTokenList?.some(token => token.contractAddress.toLowerCase() === to.toLowerCase())) {
-      return getLocale('braveWalletContractAddressError')
-    }
-    return ''
+    return fullTokenList?.some(token => token.contractAddress.toLowerCase() === to.toLowerCase())
+      ? getLocale('braveWalletContractAddressError')
+      : undefined
   }
 
   return React.useCallback((transactionInfo: TransactionInfo) => {
@@ -150,7 +145,7 @@ export function useTransactionParser (
           symbol: token?.symbol ?? '',
           decimals: token?.decimals ?? 18,
           insufficientFundsError: insufficientNativeFunds || insufficientTokenFunds,
-          addressError: checkForAddressError(address, transactionInfo.fromAddress),
+          contractAddressError: checkForContractAddressError(address),
           ...feeDetails
         } as ParsedTransaction
       }
@@ -182,7 +177,7 @@ export function useTransactionParser (
           insufficientFundsError: insufficientNativeFunds,
           erc721ERCToken: token,
           erc721TokenId: hexToNumber(tokenID ?? ''),
-          addressError: checkForAddressError(toAddress, fromAddress),
+          contractAddressError: checkForContractAddressError(toAddress),
           ...feeDetails
         } as ParsedTransaction
       }
@@ -246,7 +241,7 @@ export function useTransactionParser (
           symbol: selectedNetwork.symbol,
           decimals: selectedNetwork?.decimals ?? 18,
           insufficientFundsError: Number(totalAmountFiat) > Number(accountsNativeFiatBalance),
-          addressError: checkForAddressError(to, transactionInfo.fromAddress),
+          contractAddressError: checkForContractAddressError(to),
           isSwap: transactionInfo.txData.baseData.to.toLowerCase() === SwapExchangeProxy,
           ...feeDetails
         } as ParsedTransaction

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -219,6 +219,13 @@ function ConfirmTransactionPanel (props: Props) {
         : getLocale('braveWalletSend')
     , [transactionDetails])
 
+  const isConfirmButtonDisabled = React.useMemo(() => {
+    return (
+      transactionDetails.contractAddressError ||
+      parseFloat(transactionDetails.gasFeeFiat) === 0 ? true : transactionDetails.insufficientFundsError
+    )
+  }, [transactionDetails])
+
   if (isEditing) {
     return (
       <EditGas
@@ -403,9 +410,9 @@ function ConfirmTransactionPanel (props: Props) {
           {getLocale('braveWalletQueueRejectAll').replace('$1', transactionsQueueLength.toString())}
         </QueueStepButton>
       }
-      {transactionDetails.addressError &&
+      {transactionDetails.contractAddressError &&
         <ErrorText>
-          {transactionDetails.addressError}
+          {transactionDetails.contractAddressError}
         </ErrorText>
       }
       <ButtonRow>
@@ -418,7 +425,7 @@ function ConfirmTransactionPanel (props: Props) {
           buttonType='confirm'
           text={getLocale('braveWalletAllowSpendConfirmButton')}
           onSubmit={onConfirm}
-          disabled={transactionDetails.addressError || parseFloat(transactionDetails.gasFeeFiat) === 0 ? true : transactionDetails.insufficientFundsError}
+          disabled={isConfirmButtonDisabled}
         />
       </ButtonRow>
     </StyledWrapper>


### PR DESCRIPTION
This PR fixes the following issues:
- Do not refresh the entire wallet info on transaction approval/rejection.
- Allow self-transfers in the wallet panel, for cancellation transactions.

Resolves https://github.com/brave/brave-browser/issues/19642.
~~Resolves https://github.com/brave/brave-browser/issues/19536~~ As this issue already going out in 1.32.x HF

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

https://user-images.githubusercontent.com/3684187/142970228-e27c4559-66fe-4b6a-a589-c40415722457.mov



