### PR TITLE
Use active webcontents instead of tab_id for connect to site requests

### DIFF
--- a/browser/brave_wallet/brave_wallet_tab_helper.cc
+++ b/browser/brave_wallet/brave_wallet_tab_helper.cc
@@ -14,7 +14,6 @@
 #include "components/permissions/permission_request.h"
 #include "components/permissions/permission_request_manager.h"
 #include "components/permissions/request_type.h"
-#include "components/sessions/content/session_tab_helper.h"
 #include "content/public/browser/web_contents.h"
 
 #if !defined(OS_ANDROID) && !defined(OS_IOS)
@@ -113,9 +112,8 @@ GURL BraveWalletTabHelper::GetBubbleURL() {
   }
   DCHECK(!accounts.empty());
 
-  int32_t tab_id = sessions::SessionTabHelper::IdForTab(web_contents_).id();
-  webui_url = brave_wallet::GetConnectWithSiteWebUIURL(
-      webui_url, tab_id, accounts, requesting_origin);
+  webui_url = brave_wallet::GetConnectWithSiteWebUIURL(webui_url, accounts,
+                                                       requesting_origin);
   DCHECK(webui_url.is_valid());
 
   return webui_url;

--- a/browser/ui/wallet_bubble_manager_delegate_impl.cc
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.cc
@@ -13,25 +13,12 @@
 #include "brave/browser/ui/webui/brave_wallet/wallet_common_ui.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
-#include "chrome/browser/ui/browser_list.h"
-#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "components/grit/brave_components_strings.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
 #include "url/gurl.h"
-
-namespace {
-
-content::WebContents* GetActiveWebContents() {
-  return BrowserList::GetInstance()
-      ->GetLastActive()
-      ->tab_strip_model()
-      ->GetActiveWebContents();
-}
-
-}  // namespace
 
 namespace brave_wallet {
 

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
@@ -13,11 +13,11 @@
 WalletPanelHandler::WalletPanelHandler(
     mojo::PendingReceiver<brave_wallet::mojom::PanelHandler> receiver,
     ui::MojoBubbleWebUIController* webui_controller,
-    GetWebContentsForTabCallback get_web_contents_for_tab,
+    GetActiveWebContentsCallback get_active_web_contents,
     PanelCloseOnDeactivationCallback close_on_deactivation)
     : receiver_(this, std::move(receiver)),
       webui_controller_(webui_controller),
-      get_web_contents_for_tab_(std::move(get_web_contents_for_tab)),
+      get_active_web_contents_(std::move(get_active_web_contents)),
       close_on_deactivation_(std::move(close_on_deactivation)) {}
 
 WalletPanelHandler::~WalletPanelHandler() {}
@@ -37,9 +37,8 @@ void WalletPanelHandler::CloseUI() {
 }
 
 void WalletPanelHandler::ConnectToSite(const std::vector<std::string>& accounts,
-                                       const std::string& origin,
-                                       int32_t tab_id) {
-  content::WebContents* contents = get_web_contents_for_tab_.Run(tab_id);
+                                       const std::string& origin) {
+  content::WebContents* contents = get_active_web_contents_.Run();
   if (!contents)
     return;
 
@@ -47,9 +46,8 @@ void WalletPanelHandler::ConnectToSite(const std::vector<std::string>& accounts,
                                                               contents);
 }
 
-void WalletPanelHandler::CancelConnectToSite(const std::string& origin,
-                                             int32_t tab_id) {
-  content::WebContents* contents = get_web_contents_for_tab_.Run(tab_id);
+void WalletPanelHandler::CancelConnectToSite(const std::string& origin) {
+  content::WebContents* contents = get_active_web_contents_.Run();
   if (!contents)
     return;
 

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.h
@@ -20,13 +20,13 @@ class WebUI;
 
 class WalletPanelHandler : public brave_wallet::mojom::PanelHandler {
  public:
-  using GetWebContentsForTabCallback =
-      base::RepeatingCallback<content::WebContents*(int32_t)>;
+  using GetActiveWebContentsCallback =
+      base::RepeatingCallback<content::WebContents*()>;
   using PanelCloseOnDeactivationCallback = base::RepeatingCallback<void(bool)>;
   WalletPanelHandler(
       mojo::PendingReceiver<brave_wallet::mojom::PanelHandler> receiver,
       ui::MojoBubbleWebUIController* webui_controller,
-      GetWebContentsForTabCallback get_web_contents_for_tab,
+      GetActiveWebContentsCallback get_active_web_contents,
       PanelCloseOnDeactivationCallback close_on_deactivation);
 
   WalletPanelHandler(const WalletPanelHandler&) = delete;
@@ -38,14 +38,13 @@ class WalletPanelHandler : public brave_wallet::mojom::PanelHandler {
   void CloseUI() override;
   void SetCloseOnDeactivate(bool close) override;
   void ConnectToSite(const std::vector<std::string>& accounts,
-                     const std::string& origin,
-                     int32_t tab_id) override;
-  void CancelConnectToSite(const std::string& origin, int32_t tab_id) override;
+                     const std::string& origin) override;
+  void CancelConnectToSite(const std::string& origin) override;
 
  private:
   mojo::Receiver<brave_wallet::mojom::PanelHandler> receiver_;
   ui::MojoBubbleWebUIController* const webui_controller_;
-  const GetWebContentsForTabCallback get_web_contents_for_tab_;
+  const GetActiveWebContentsCallback get_active_web_contents_;
   const PanelCloseOnDeactivationCallback close_on_deactivation_;
 };
 

--- a/browser/ui/webui/brave_wallet/wallet_common_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_common_ui.cc
@@ -58,4 +58,11 @@ content::WebContents* GetWebContentsFromTabId(Browser** browser,
   return nullptr;
 }
 
+content::WebContents* GetActiveWebContents() {
+  return BrowserList::GetInstance()
+      ->GetLastActive()
+      ->tab_strip_model()
+      ->GetActiveWebContents();
+}
+
 }  // namespace brave_wallet

--- a/browser/ui/webui/brave_wallet/wallet_common_ui.h
+++ b/browser/ui/webui/brave_wallet/wallet_common_ui.h
@@ -27,6 +27,7 @@ bool IsBraveWalletOrigin(const url::Origin& origin);
 
 content::WebContents* GetWebContentsFromTabId(Browser** browser,
                                               int32_t tab_id);
+content::WebContents* GetActiveWebContents();
 
 }  // namespace brave_wallet
 

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
@@ -100,7 +100,7 @@ void WalletPanelUI::CreatePanelHandler(
 
   panel_handler_ = std::make_unique<WalletPanelHandler>(
       std::move(panel_receiver), this,
-      base::BindRepeating(&brave_wallet::GetWebContentsFromTabId, nullptr),
+      base::BindRepeating(&brave_wallet::GetActiveWebContents),
       std::move(deactivation_callback_));
   wallet_handler_ =
       std::make_unique<WalletHandler>(std::move(wallet_receiver), profile);

--- a/components/brave_wallet/browser/ethereum_permission_utils.cc
+++ b/components/brave_wallet/browser/ethereum_permission_utils.cc
@@ -135,17 +135,14 @@ bool GetSubRequestOrigin(const GURL& old_origin,
 }
 
 GURL GetConnectWithSiteWebUIURL(const GURL& webui_base_url,
-                                int32_t tab_id,
                                 const std::vector<std::string>& accounts,
                                 const std::string& origin) {
-  DCHECK(webui_base_url.is_valid() && tab_id > 0 && !accounts.empty() &&
-         !origin.empty());
+  DCHECK(webui_base_url.is_valid() && !accounts.empty() && !origin.empty());
 
   std::vector<std::string> query_parts;
   for (const auto& account : accounts) {
     query_parts.push_back(base::StringPrintf("addr=%s", account.c_str()));
   }
-  query_parts.push_back(base::StringPrintf("tabId=%d", tab_id));
   query_parts.push_back(base::StringPrintf("origin=%s", origin.c_str()));
   std::string query_str = base::JoinString(query_parts, "&");
   url::Replacements<char> replacements;

--- a/components/brave_wallet/browser/ethereum_permission_utils.h
+++ b/components/brave_wallet/browser/ethereum_permission_utils.h
@@ -58,13 +58,12 @@ bool GetSubRequestOrigin(const GURL& old_origin,
                          GURL* new_origin);
 
 /**
- * Given tab ID, accounts, and origin, return the WebUI URL for connecting
- * with site (ethereum permission) request.
+ * Given accounts, and origin, return the WebUI URL for connecting with site
+ * (ethereum permission) request.
  * Example output:
- *   chrome://wallet-panel.top-chrome/?addr=0x123&addr=0x456&tabId=1&origin=https://test.com
+ *   chrome://wallet-panel.top-chrome/?addr=0x123&addr=0x456&origin=https://test.com
  */
 GURL GetConnectWithSiteWebUIURL(const GURL& webui_base_url,
-                                int32_t tab_id,
                                 const std::vector<std::string>& accounts,
                                 const std::string& origin);
 

--- a/components/brave_wallet/browser/ethereum_permission_utils_unittest.cc
+++ b/components/brave_wallet/browser/ethereum_permission_utils_unittest.cc
@@ -147,11 +147,11 @@ TEST(EthereumPermissionUtilsUnitTest, GetConnectWithSiteWebUIURL) {
       "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8A",
       "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8B"};
   std::string origin = "https://test.com:123";
-  GURL url_out = GetConnectWithSiteWebUIURL(base_url, 1, addrs, origin);
+  GURL url_out = GetConnectWithSiteWebUIURL(base_url, addrs, origin);
   EXPECT_EQ(url_out.spec(),
             "chrome://wallet-panel.top-chrome/"
             "?addr=0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8A&addr="
-            "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8B&tabId=1&origin=https://"
+            "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8B&origin=https://"
             "test.com:123#connectWithSite");
 }
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -108,8 +108,8 @@ interface PanelHandler {
   // Notify the backend that the dialog should be closed.
   CloseUI();
 
-  ConnectToSite(array<string> accounts, string origin, int32 tab_id);
-  CancelConnectToSite(string origin, int32 tab_id);
+  ConnectToSite(array<string> accounts, string origin);
+  CancelConnectToSite(string origin);
   SetCloseOnDeactivate(bool close);
 };
 

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -211,7 +211,6 @@ export interface PanelState {
   connectToSiteOrigin: string
   selectedPanel: PanelTypes
   panelTitle: string
-  tabId: number
   connectingAccounts: string[]
   networkPayload: BraveWallet.EthereumChain
   swapQuote?: BraveWallet.SwapResponse

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -130,10 +130,9 @@ handler.on(WalletActions.initialize.getType(), async (store) => {
   // TODO(jocelyn): Extract ConnectToSite UI pieces out from panel UI.
   const url = new URL(window.location.href)
   if (url.hash === '#connectWithSite') {
-    const tabId = Number(url.searchParams.get('tabId')) || -1
     const accounts = url.searchParams.getAll('addr') || []
     const origin = url.searchParams.get('origin') || ''
-    store.dispatch(PanelActions.showConnectToSite({ tabId, accounts, origin }))
+    store.dispatch(PanelActions.showConnectToSite({ accounts, origin }))
     return
   } else {
     const chain = await getPendingChainRequest()
@@ -164,9 +163,8 @@ handler.on(WalletActions.initialize.getType(), async (store) => {
 })
 
 handler.on(PanelActions.cancelConnectToSite.getType(), async (store: Store, payload: AccountPayloadType) => {
-  const state = getPanelState(store)
   const apiProxy = getWalletPanelApiProxy()
-  apiProxy.panelHandler.cancelConnectToSite(payload.siteToConnectTo, state.tabId)
+  apiProxy.panelHandler.cancelConnectToSite(payload.siteToConnectTo)
   apiProxy.panelHandler.closeUI()
 })
 
@@ -228,11 +226,10 @@ handler.on(PanelActions.approveHardwareTransaction.getType(), async (store: Stor
 })
 
 handler.on(PanelActions.connectToSite.getType(), async (store: Store, payload: AccountPayloadType) => {
-  const state = getPanelState(store)
   const apiProxy = getWalletPanelApiProxy()
   let accounts: string[] = []
   payload.selectedAccounts.forEach((account) => { accounts.push(account.address) })
-  apiProxy.panelHandler.connectToSite(accounts, payload.siteToConnectTo, state.tabId)
+  apiProxy.panelHandler.connectToSite(accounts, payload.siteToConnectTo)
   apiProxy.panelHandler.closeUI()
 })
 

--- a/components/brave_wallet_ui/panel/constants/action_types.ts
+++ b/components/brave_wallet_ui/panel/constants/action_types.ts
@@ -11,7 +11,6 @@ export type AccountPayloadType = {
 }
 
 export type ShowConnectToSitePayload = {
-  tabId: number
   accounts: string[]
   origin: string
 }

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -24,7 +24,6 @@ const defaultState: PanelState = {
   connectToSiteOrigin: '',
   selectedPanel: 'main',
   panelTitle: '',
-  tabId: -1,
   connectingAccounts: [],
   networkPayload: {
     chainId: '0x1',
@@ -69,7 +68,6 @@ reducer.on(PanelActions.navigateTo, (state: any, selectedPanel: string) => {
 reducer.on(PanelActions.showConnectToSite, (state: any, payload: ShowConnectToSitePayload) => {
   return {
     ...state,
-    tabId: payload.tabId,
     connectToSiteOrigin: payload.origin,
     connectingAccounts: payload.accounts
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17273

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1.  Setup wallet & unlock it if needed
2. Visit any website and open dev tool
3. Call `window.ethereum.enable()` in dev tool should show the prompt, origin displayed in the prompt should be the website's origin.
4. Create another tab and visit another website (different origin from step 2) and call `window.ethereum.enable()` in dev tool
5. Check the origin in the prompt and accept the request from the prompt with account address 1.
6. Go back to tab opened in step 2 and click on wallet icon in the toolbar should re-display the prompt with a correct origin.
7. Accept the request with account address 2.
8. Visit brave://settings/content/ethereum and double check the allow entries are website1's origin + account address2 and website2's origin + account address1.