### PR TITLE
Add feature flag to enable Easylist-Cookie List by default

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -52,6 +52,7 @@
 
 using brave_shields::features::kBraveAdblockCnameUncloaking;
 using brave_shields::features::kBraveAdblockCollapseBlockedElements;
+using brave_shields::features::kBraveAdblockCookieListDefault;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockCspRules;
 using brave_shields::features::kBraveAdblockDefault1pBlocking;
@@ -79,6 +80,12 @@ constexpr char kBraveAdblockCollapseBlockedElementsName[] =
 constexpr char kBraveAdblockCollapseBlockedElementsDescription[] =
     "Cause iframe and img elements to be collapsed if the URL of their src "
     "attribute is blocked";
+
+constexpr char kBraveAdblockCookieListDefaultName[] =
+    "Treat 'Easylist-Cookie List' as a default list source";
+constexpr char kBraveAdblockCookieListDefaultDescription[] =
+    "Enables the 'Easylist-Cookie List' regional list regardless of its "
+    "toggle setting in brave://adblock";
 
 constexpr char kBraveAdblockCosmeticFilteringName[] =
     "Enable cosmetic filtering";
@@ -371,6 +378,10 @@ constexpr char kFileSystemAccessAPIDescription[] =
      flag_descriptions::kBraveAdblockCollapseBlockedElementsName,           \
      flag_descriptions::kBraveAdblockCollapseBlockedElementsDescription,    \
      kOsAll, FEATURE_VALUE_TYPE(kBraveAdblockCollapseBlockedElements)},     \
+    {"brave-adblock-cookie-list-default",                                   \
+     flag_descriptions::kBraveAdblockCookieListDefaultName,                 \
+     flag_descriptions::kBraveAdblockCookieListDefaultDescription,          \
+     kOsAll, FEATURE_VALUE_TYPE(kBraveAdblockCookieListDefault)},           \
     {"brave-adblock-cosmetic-filtering",                                    \
      flag_descriptions::kBraveAdblockCosmeticFilteringName,                 \
      flag_descriptions::kBraveAdblockCosmeticFilteringDescription, kOsAll,  \

--- a/components/brave_shields/common/features.cc
+++ b/components/brave_shields/common/features.cc
@@ -25,6 +25,10 @@ const base::Feature kBraveAdblockCnameUncloaking{
 // iframes that initiate a blocked network request.
 const base::Feature kBraveAdblockCollapseBlockedElements{
     "BraveAdblockCollapseBlockedElements", base::FEATURE_ENABLED_BY_DEFAULT};
+// When enabled, Brave will treat "Easylist-Cookie List" as a default,
+// always-on list, overriding any locally set preference.
+const base::Feature kBraveAdblockCookieListDefault{
+    "BraveAdblockCookieListDefault", base::FEATURE_DISABLED_BY_DEFAULT};
 const base::Feature kBraveAdblockCosmeticFiltering{
     "BraveAdblockCosmeticFiltering",
     base::FEATURE_ENABLED_BY_DEFAULT};

--- a/components/brave_shields/common/features.h
+++ b/components/brave_shields/common/features.h
@@ -15,6 +15,7 @@ namespace features {
 extern const base::Feature kBraveAdblockDefault1pBlocking;
 extern const base::Feature kBraveAdblockCnameUncloaking;
 extern const base::Feature kBraveAdblockCollapseBlockedElements;
+extern const base::Feature kBraveAdblockCookieListDefault;
 extern const base::Feature kBraveAdblockCosmeticFiltering;
 extern const base::Feature kBraveAdblockCspRules;
 extern const base::Feature kBraveDomainBlock;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19689

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit https://digikey.com and confirm that a cookie banner popup is shown at the bottom of the screen.
2. Visit brave://flags and enable the `#brave-adblock-cookie-list-default` flag, then restart the browser.
3. Visit https://digikey.com and confirm that no cookie banner popup is shown.
4. Visit brave://adblock and confirm that there is no entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` under `Additional filters`.
5. Return to brave://flags and set `#brave-adblock-cookie-list-default` back to either `Default` or `Disabled`, and restart the browser.
6. Visit https://digikey.com and confirm that the cookie banner popup is shown again.
7. Visit brave://adblock and confirm that the entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` has appeared and is unchecked.
8. Enable the `Easylist-Cookie List - Filter Obtrusive Cookie Notices` entry, then repeat steps 2-5.
9. Visit brave://adblock and confirm that the entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` is checked.