### PR TITLE
add BUILD.gn for skus rs lib to ensure rebuild on changes

### DIFF
--- a/components/skus/browser/BUILD.gn
+++ b/components/skus/browser/BUILD.gn
@@ -21,7 +21,7 @@ static_library("browser") {
     "switches.h",
   ]
 
-  public_deps = [ "rs/cxx" ]
+  public_deps = [ "rs/cxx", "rs/lib" ]
 
   deps = [
     "//base",

--- a/components/skus/browser/rs/cxx/BUILD.gn
+++ b/components/skus/browser/rs/cxx/BUILD.gn
@@ -1,7 +1,7 @@
 # Copyright 2020 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/. */
+# You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import("//brave/build/cargo.gni")
 import("//brave/build/rust/rust_cxx.gni")

--- a/components/skus/browser/rs/lib/BUILD.gn
+++ b/components/skus/browser/rs/lib/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright 2021 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import("//brave/build/cargo.gni")
+
+rust_crate("rust_lib") {
+  inputs = [
+    "Cargo.toml",
+    "src/cache.rs",
+    "src/errors.rs",
+    "src/http.rs",
+    "src/lib.rs",
+    "src/models.rs",
+    "src/sdk/credentials/fetch.rs",
+    "src/sdk/credentials/mod.rs",
+    "src/sdk/credentials/present.rs",
+    "src/sdk/mod.rs",
+    "src/sdk/orders.rs",
+    "src/storage/kv.rs",
+    "src/storage/mod.rs",
+  ]
+}


### PR DESCRIPTION
wasn't sure about the `target_name` and whether it had to be different for `lib` vs `cxx`. it seemed like we're using `rust_lib` everywhere though so I'm guessing `target_gen_dir` in `"${target_gen_dir}/${target_name}.stamp"` will ensure we don't have conflicts?