### PR TITLE
1.32.x - Uplift #11224 from brave/audit-fix-20211122

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ deps = {
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@800f9d40b7409239ff192e0be634764e747c7a75",
   "vendor/challenge_bypass_ristretto_ffi": "https://github.com/brave-intl/challenge-bypass-ristretto-ffi.git@f2eff7aca4ea04564e3647b93eb72f33ebdbf683",
   "vendor/gn-project-generators": "https://github.com/brave/gn-project-generators.git@b76e14b162aa0ce40f11920ec94bfc12da29e5d0",
-  "vendor/web-discovery-project": "https://github.com/brave/web-discovery-project@b5b8518c41c96ac4aa04c3eda7d49ad2e4bdc9dc",
+  "vendor/web-discovery-project": "https://github.com/brave/web-discovery-project@9b00978b0a4ebfc0cd7d68e7c354b7178fe184a4",
   "third_party/ethash/src": "https://github.com/chfast/ethash.git@e4a15c3d76dc09392c7efd3e30d84ee3b871e9ce",
   "third_party/bitcoin-core/src": "https://github.com/bitcoin/bitcoin.git@95ea54ba089610019a74c1176a2c7c0dba144b1c",
   "third_party/argon2/src": "https://github.com/P-H-C/phc-winner-argon2.git@62358ba2123abd17fccf2a108a301d4b52c01a7c",


### PR DESCRIPTION
Update Web Discovery Project to fix audit

Uplifts brave/brave-browser#19700 to 1.33.x