### PR TITLE
Fixes 2 crashes on Android wallet: a crash on clicking an asset from Accounts and a crash on clicking percent on Send screen (uplift to 1.33.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AccountDetailActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/AccountDetailActivity.java
@@ -176,6 +176,7 @@ public class AccountDetailActivity extends AsyncInitializationActivity
                                 cryptoBalanceString);
 
                 walletListItemModel.setIconPath("file://" + tokensPath + "/" + userAsset.logo);
+                walletListItemModel.setErcToken(userAsset);
                 walletListItemModelList.add(walletListItemModel);
             }
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -357,7 +357,8 @@ public class BuySendSwapActivity extends AsyncInitializationActivity
             if (mActivityType == ActivityType.SWAP) {
                 updateBalance(mCustomAccountAdapter.getTitleAtPosition(position), false);
             }
-        } else if (parent.getId() == R.id.slippage_tolerance_spinner) {
+        } else if (parent.getId() == R.id.slippage_tolerance_spinner
+                && mActivityType == ActivityType.SWAP) {
             getSendSwapQuota(true, false);
         }
     }
@@ -874,7 +875,9 @@ public class BuySendSwapActivity extends AsyncInitializationActivity
                 EditText fromValueText = findViewById(R.id.from_value_text);
                 fromValueText.setText(String.format(Locale.getDefault(), "%f", amountToGet));
                 radioPerPercent.clearCheck();
-                getSendSwapQuota(true, false);
+                if (mActivityType == ActivityType.SWAP) {
+                    getSendSwapQuota(true, false);
+                }
             }
         });
     }


### PR DESCRIPTION
Uplift of #11259
Resolves https://github.com/brave/brave-browser/issues/19697

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.