### PR TITLE
Use Chromium's upstream git repository instead of the GitHub mirror

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -624,6 +624,15 @@ const util = {
     const targetSHA = util.runGit(config.srcDir, ['rev-parse', chromiumRef], true)
     const needsUpdate = ((targetSHA !== headSHA) || (!headSHA && !targetSHA))
     if (needsUpdate) {
+      const gitChromiumRemoteUrl = util.runGit(config.srcDir, ['remote', 'get-url', 'origin'], true)
+      if (config.chromiumRepo != gitChromiumRemoteUrl) {
+        console.log(`Chromium repo's URL ${chalk.blue.bold('needs update')}. Current URL is ${chalk.italic(gitChromiumRemoteUrl)} but it should be ${chalk.italic(config.chromiumRepo)}`)
+        util.runGit(config.srcDir, ['remote', 'set-url', 'origin', config.chromiumRepo], true)
+        // We need to make sure the URL is also updated in the .gclient file to
+        // prevent gclient sync from auto-fixing the URL in .git/config again.
+        util.buildGClientConfig()
+      }
+
       const currentRef = util.getGitReadableLocalRef(config.srcDir)
       console.log(`Chromium repo ${chalk.blue.bold('needs update')}. Target is ${chalk.italic(chromiumRef)} at commit ${targetSHA || '[missing]'} but current commit is ${chalk.italic(currentRef || '[unknown]')} at commit ${chalk.inverse(headSHA || '[missing]')}.`)
     } else {

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
         "dir": "src",
         "tag": "96.0.4664.45",
         "repository": {
-          "url": "https://github.com/chromium/chromium"
+          "url": "https://chromium.googlesource.com/chromium/src.git"
         }
       }
     }


### PR DESCRIPTION
The GitHub mirrow has been temporarily out-of-sync since past Wednesday
November 17th which, even though they run a couple of manual syncs in
the past days, is causing trouble for us to work on rebases because we
can't fetch the right tags from the mirror.

This change changes the URL in package.json to point to the upstream
repository and makes the necessary changes to npm run sync so that
the gclient and git configurations get updated to it.

According to the upstream bug at https://crbug.com/1272797, this
situation should be fixed soon as it's been treated as high prio,
but we can't depend on that to be able to update to newer tags, so
we'd better make this change now, and then maybe return to using the
GitHub mirror later on when the situation is fixed, if needed.

Resolves https://github.com/brave/brave-browser/issues/19720

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A