### PR TITLE
fix(wallet): prevent flicker in hardware wallet connect screen

### DIFF
--- a/components/brave_wallet_ui/common/async/hardware.ts
+++ b/components/brave_wallet_ui/common/async/hardware.ts
@@ -10,15 +10,22 @@ import WalletApiProxy from '../../common/wallet_api_proxy'
 import LedgerBridgeKeyring from '../../common/ledgerjs/eth_ledger_bridge_keyring'
 import TrezorBridgeKeyring from '../../common/trezor/trezor_bridge_keyring'
 import { TrezorErrorsCodes } from '../trezor/trezor-messages'
-import { HardwareWalletErrorType } from 'components/brave_wallet_ui/constants/types'
+import { HardwareWalletResponseCodeType } from 'components/brave_wallet_ui/constants/types'
+import { StatusCodes as LedgerStatusCodes } from '@ledgerhq/errors'
 
-export function dialogErrorFromLedgerErrorCode (code: string | number): HardwareWalletErrorType {
+export function dialogErrorFromLedgerErrorCode (code: string | number): HardwareWalletResponseCodeType {
   if (code === 'TransportOpenUserCancelled') {
     return 'deviceNotConnected'
   }
+
   if (code === 'TransportLocked') {
     return 'deviceBusy'
   }
+
+  if (code === LedgerStatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED) {
+    return 'transactionRejected'
+  }
+
   return 'openEthereumApp'
 }
 

--- a/components/brave_wallet_ui/common/hardware_operations.ts
+++ b/components/brave_wallet_ui/common/hardware_operations.ts
@@ -1,11 +1,11 @@
 import { EthereumSignedTx } from 'trezor-connect/lib/typescript'
 import { HardwareWalletAccount } from '../components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/types'
-import { HardwareWalletErrorType } from '../constants/types'
+import { HardwareWalletResponseCodeType } from '../constants/types'
 
 export interface SignHardwareTransactionType {
   success: boolean
   error?: string
-  deviceError?: HardwareWalletErrorType
+  deviceError?: HardwareWalletResponseCodeType
 }
 export interface SignatureVRS {
   v: number

--- a/components/brave_wallet_ui/common/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -86,7 +86,6 @@ export default class LedgerBridgeKeyring extends EventEmitter {
       const signed = await eth.signTransaction(path, rawTxHex)
       return { success: true, payload: signed }
     } catch (e) {
-      console.log(e)
       return { success: false, error: e.message, code: e.statusCode || e.id || e.name }
     }
   }

--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -12,13 +12,13 @@ import {
 } from './style'
 import { NavButton } from '..'
 import { getLocale } from '../../../../common/locale'
-import { HardwareWalletErrorType } from '../../../constants/types'
+import { HardwareWalletResponseCodeType } from '../../../constants/types'
 import useInterval from '../../../common/hooks/interval'
 
 export interface Props {
   onCancel: () => void
   walletName: string
-  hardwareWalletError?: HardwareWalletErrorType
+  hardwareWalletCode?: HardwareWalletResponseCodeType
   retryCallable: () => void
 }
 
@@ -26,20 +26,24 @@ function ConnectHardwareWalletPanel (props: Props) {
   const {
     onCancel,
     walletName,
-    hardwareWalletError,
+    hardwareWalletCode,
     retryCallable
   } = props
 
-  const isConnected = hardwareWalletError !== undefined && hardwareWalletError !== 'deviceNotConnected'
-  const getTitle = () => {
-    if (hardwareWalletError === 'deviceBusy') {
+  const isConnected = hardwareWalletCode !== undefined && hardwareWalletCode !== 'deviceNotConnected'
+
+  const title = React.useMemo(() => {
+    if (hardwareWalletCode === 'deviceBusy') {
       return getLocale('braveWalletConnectHardwarePanelConfirmation').replace('$1', walletName)
     }
-    if (hardwareWalletError === 'openEthereumApp') {
+
+    if (hardwareWalletCode === 'openEthereumApp') {
       return getLocale('braveWalletConnectHardwarePanelOpenApp').replace('$1', walletName)
     }
+
     return getLocale('braveWalletConnectHardwarePanelConnect').replace('$1', walletName)
-  }
+  }, [hardwareWalletCode])
+
   const onClickInstructions = () => {
     window.open('https://support.brave.com/hc/en-us/articles/4409309138701', '_blank')
   }
@@ -58,14 +62,18 @@ function ConnectHardwareWalletPanel (props: Props) {
           }
         </Description>
       </ConnectionRow>
-      <Title>
-        {getTitle()}
-      </Title>
+      <Title>{title}</Title>
       <InstructionsButton onClick={onClickInstructions}>{getLocale('braveWalletConnectHardwarePanelInstructions')}</InstructionsButton>
       <PageIcon />
-      <ButtonWrapper>
-        <NavButton buttonType='secondary' text={getLocale('braveWalletBackupButtonCancel')} onSubmit={onCancel} />
-      </ButtonWrapper>
+
+      {
+        hardwareWalletCode !== 'deviceBusy' && (
+          <ButtonWrapper>
+            <NavButton buttonType='secondary' text={getLocale('braveWalletBackupButtonCancel')} onSubmit={onCancel} />
+          </ButtonWrapper>
+        )
+      }
+
     </StyledWrapper>
   )
 }

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -134,10 +134,11 @@ export type ChartTimelineType =
   | '1Year'
   | 'AllTime'
 
-export type HardwareWalletErrorType =
+export type HardwareWalletResponseCodeType =
   | 'deviceNotConnected'
   | 'deviceBusy'
   | 'openEthereumApp'
+  | 'transactionRejected'
 
 export interface BuySendSwapObjectType {
   name: string
@@ -218,7 +219,7 @@ export interface PanelState {
   swapError?: SwapErrorResponse
   signMessageData: BraveWallet.SignMessageRequest[]
   switchChainRequest: BraveWallet.SwitchChainRequest
-  hardwareWalletError?: HardwareWalletErrorType
+  hardwareWalletCode?: HardwareWalletResponseCodeType
 }
 
 export interface PageState {

--- a/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
+++ b/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
@@ -19,7 +19,7 @@ import {
   SwapResponse,
   SignMessageRequest,
   SwitchChainRequest,
-  HardwareWalletErrorType
+  HardwareWalletResponseCodeType
 } from '../../constants/types'
 import { SwapParamsPayloadType } from '../../common/constants/action_types'
 import { TransactionInfo } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
@@ -49,5 +49,5 @@ export const signMessageProcessed = createAction<SignMessageProcessedPayload>('s
 export const signMessageHardware = createAction<SignMessageRequest>('signMessageHardware')
 export const signMessageHardwareProcessed = createAction<SignMessageHardwareProcessedPayload>('signMessageHardwareProcessed')
 export const approveHardwareTransaction = createAction<TransactionInfo>('approveHardwareTransaction')
-export const setHardwareWalletInteractionError = createAction<HardwareWalletErrorType | undefined>('setHardwareWalletInteractionError')
+export const setHardwareWalletInteractionError = createAction<HardwareWalletResponseCodeType | undefined>('setHardwareWalletInteractionError')
 export const cancelConnectHardwareWallet = createAction<TransactionInfo>('cancelConnectHardwareWallet')

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -491,7 +491,7 @@ function Container (props: Props) {
           <ConnectHardwareWalletPanel
             onCancel={onCancelConnectHardwareWallet}
             walletName={selectedAccount.name}
-            hardwareWalletError={props.panel.hardwareWalletError}
+            hardwareWalletCode={props.panel.hardwareWalletCode}
             retryCallable={onConfirmTransaction}
           />
         </StyledExtensionWrapper>

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -5,7 +5,7 @@
 
 import { createReducer } from 'redux-act'
 import {
-  HardwareWalletErrorType,
+  HardwareWalletResponseCodeType,
   PanelState,
   SwapErrorResponse,
   SwapResponse,
@@ -50,7 +50,7 @@ const defaultState: PanelState = {
     },
     chainId: ''
   },
-  hardwareWalletError: undefined
+  hardwareWalletCode: undefined
 }
 
 const reducer = createReducer<PanelState>({}, defaultState)
@@ -110,10 +110,10 @@ reducer.on(PanelActions.signMessage, (state: any, payload: SignMessagePayload[])
   }
 })
 
-reducer.on(PanelActions.setHardwareWalletInteractionError, (state: any, payload?: HardwareWalletErrorType) => {
+reducer.on(PanelActions.setHardwareWalletInteractionError, (state: any, payload?: HardwareWalletResponseCodeType) => {
   return {
     ...state,
-    hardwareWalletError: payload
+    hardwareWalletCode: payload
   }
 })
 


### PR DESCRIPTION
**What's new:**
1. The flicker issue after opening the Ethereum app of Ledger, has been resolved.
2. Removed "Cancel" button from the connect screen when transaction is being confirmed on the device. The only two permissible actions are Accept/Reject on the hardware wallet. This fixes https://github.com/brave/brave-browser/issues/19485 which has been already marked as closed, although I'm not sure it was fixed.

Continuation of https://github.com/brave/brave-core/pull/11152 (hence, uplifts to release and/or beta must also match).

Resolves https://github.com/brave/brave-browser/issues/19480.
Resolves https://github.com/brave/brave-browser/issues/19485.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

https://user-images.githubusercontent.com/3684187/143373489-637eb10e-bb67-4707-8566-b7dfa5fadf5c.mov



