### PR TITLE
fix(wallet): do not hardcode default gas price on adding unapproved txn

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -19,7 +19,6 @@ namespace brave_wallet {
 extern const char kAssetRatioBaseURL[];
 
 constexpr uint256_t kDefaultSendEthGasLimit = 21000;
-constexpr uint256_t kDefaultSendEthGasPrice = 150000000000ULL;  // 150 Gwei
 constexpr uint256_t kDefaultERC20TransferGasLimit = 300000;
 constexpr uint256_t kDefaultERC721TransferGasLimit = 800000;
 constexpr uint256_t kDefaultERC20ApproveGasLimit = 300000;


### PR DESCRIPTION
We should not have any concept of fixed default gas price, because it can be very volatile and the value depends on the network. Since the constant of `150 Gwei` was set with Ethereum in mind, users are forced to overpay fees by orders of magnitude on other low-fee EVM networks like Polygon and BSC.

This PR ensures gas price is always fetched using the `eth_gasPrice` RPC command while creating unapproved transactions, if not already specified. This fix also applies to cancel and speedup transactions. Additionally, adapted the unit-tests to work with the changes + some misc readability fixes.

Resolves https://github.com/brave/brave-browser/issues/19706.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

https://user-images.githubusercontent.com/3684187/143410579-f99c5135-abfa-4603-ab59-dcb6ca1b09b1.mov

## Test plan

This PR only impacts Type-0 transactions (i.e., having legacy gas pricing fields). Testing should include the following:
- Polygon network (expected gas price = 30 Gwei)
- BSC network  (expected gas price = 5 GWei)
- Ethereum network using Trezor keyring  (expected gas price = check etherscan)