### PR TITLE
[Android] force return to top activity after wallet reset (uplift to 1.33.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveWalletResetPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveWalletResetPreference.java
@@ -27,6 +27,8 @@ import org.chromium.base.ApiCompatibilityUtils;
 import org.chromium.base.Log;
 import org.chromium.brave_wallet.mojom.KeyringController;
 import org.chromium.chrome.R;
+import org.chromium.chrome.browser.ChromeTabbedActivity;
+import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.crypto_wallet.KeyringControllerFactory;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
@@ -103,6 +105,9 @@ public class BraveWalletResetPreference
                             Utils.setCryptoOnboarding(true);
                         }
                         mKeyringController.close();
+
+                        // Force clear activity stack
+                        launchBraveTabbedActivity();
                     } else {
                         Log.w(TAG, "mKeyringController is null");
                     }
@@ -161,5 +166,12 @@ public class BraveWalletResetPreference
         }
 
         mKeyringController = KeyringControllerFactory.getInstance().getKeyringController(this);
+    }
+
+    private void launchBraveTabbedActivity() {
+        Intent intent =
+                new Intent(BraveActivity.getChromeTabbedActivity(), ChromeTabbedActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        BraveActivity.getChromeTabbedActivity().startActivity(intent);
     }
 }


### PR DESCRIPTION
Uplift of #11291
Resolves brave/brave-browser/issues/19734

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.