### PR TITLE
fix(wallet): reduce scope of address checks in useTransactionParser hook

### DIFF
--- a/components/brave_wallet_ui/common/constants/mocks.ts
+++ b/components/brave_wallet_ui/common/constants/mocks.ts
@@ -4,7 +4,11 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import {
-  TransactionInfo
+  ERCToken,
+  EthereumChain,
+  TransactionInfo,
+  TransactionStatus,
+  TransactionType
 } from '../../constants/types'
 
 export const getMockedTransactionInfo = (): TransactionInfo => {
@@ -25,12 +29,36 @@ export const getMockedTransactionInfo = (): TransactionInfo => {
       maxPriorityFeePerGas: '',
       maxFeePerGas: ''
     },
-    txStatus: 1,
-    txType: 5,
+    txStatus: TransactionStatus.Approved,
+    txType: TransactionType.Other,
     txParams: [],
     txArgs: [],
     createdTime: { microseconds: 0 },
     submittedTime: { microseconds: 0 },
     confirmedTime: { microseconds: 0 }
   }
+}
+
+export const mockNetwork: EthereumChain = {
+  chainId: '0x1',
+  chainName: 'Ethereum Main Net',
+  rpcUrls: ['https://mainnet.infura.io/v3/'],
+  blockExplorerUrls: ['https://etherscan.io/'],
+  symbol: 'ETH',
+  symbolName: 'Ethereum',
+  decimals: 18,
+  iconUrls: [],
+  isEip1559: true
+}
+
+export const mockERC20Token: ERCToken = {
+  contractAddress: 'mockContractAddress',
+  name: 'Dog Coin',
+  symbol: 'DOG',
+  logo: '',
+  isErc20: true,
+  isErc721: false,
+  decimals: 18,
+  visible: true,
+  tokenId: ''
 }

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
@@ -1,0 +1,207 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { TransactionType } from '../../constants/types'
+import {
+  getMockedTransactionInfo,
+  mockERC20Token,
+  mockNetwork
+} from '../constants/mocks'
+import { SwapExchangeProxy } from './address-labels'
+import { useTransactionParser } from './transaction-parser'
+
+describe('useTransactionParser hook', () => {
+  describe('check for sameAddressError field', () => {
+    describe.each([
+      ['ERC20Transfer', TransactionType.ERC20Transfer, 'recipient'],
+      ['ERC20Approve', TransactionType.ERC20Approve, 'approval target']
+    ])('%s', (_, txType, toLabel) => {
+      it(`should be defined when sender and ${toLabel} are same`, () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [], []
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          fromAddress: '0xdeadbeef',
+          txArgs: ['0xdeadbeef', 'foo']
+        })
+
+        expect(parsedTransaction.sameAddressError).toBeDefined()
+      })
+
+      it(`should be undefined when sender and ${toLabel} are different`, () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [], []
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          fromAddress: '0xdeadbeef',
+          txArgs: ['0xbadcafe', 'foo']
+        })
+
+        expect(parsedTransaction.sameAddressError).toBeUndefined()
+      })
+    })
+
+    describe.each([
+      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom]
+    ])('%s', (_, txType) => {
+      it('should be undefined when sender and recipient are same', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [], []
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          fromAddress: '0xdeadbeef',
+          txArgs: ['mockOwner', '0xdeadbeef', 'mockTokenID']
+        })
+
+        expect(parsedTransaction.sameAddressError).toBeUndefined()
+      })
+
+      it('should be defined when owner and recipient are same', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [], []
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          fromAddress: 'mockFromAddress',
+          txArgs: ['0xdeadbeef', '0xdeadbeef', 'mockTokenID']
+        })
+
+        expect(parsedTransaction.sameAddressError).toBeDefined()
+      })
+
+      it('should be undefined when owner and recipient are different', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [], []
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          fromAddress: 'mockFromAddress',
+          txArgs: ['mockOwner', 'mockToAddress', 'mockTokenID']
+        })
+
+        expect(parsedTransaction.sameAddressError).toBeUndefined()
+      })
+    })
+
+    describe.each([
+      // ETHSend can have same sender and recipient in case of cancel transactions
+      ['ETHSend', TransactionType.ETHSend],
+      ['Other', TransactionType.Other],
+      ['0x Swap', TransactionType.Other]
+    ])('%s', (name, txType) => {
+      it('should always be undefined', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [], []
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          fromAddress: '0xdeadbeef',
+          txData: {
+            ...mockTransactionInfo.txData,
+            baseData: {
+              ...mockTransactionInfo.txData.baseData,
+              to: name === '0x Swap' ? SwapExchangeProxy : '0xdeadbeef'
+            }
+          }
+        })
+
+        expect(parsedTransaction.sameAddressError).toBeUndefined()
+      })
+    })
+  })
+
+  describe('check for contractAddressError', () => {
+    describe.each([
+      ['ERC20Approve', TransactionType.ERC20Approve],
+      ['ETHSend', TransactionType.ETHSend],
+      ['Other', TransactionType.Other],
+      ['0x Swap', TransactionType.Other]
+    ])('%s', (name, txType) => {
+      it('should always be undefined', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [],
+          [{ ...mockERC20Token, contractAddress: '0xdeadbeef' }]
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txArgs: txType === TransactionType.ETHSend ? [] : ['mockArg1', 'mockArg2'],
+          txType,
+          txData: {
+            ...mockTransactionInfo.txData,
+            baseData: {
+              ...mockTransactionInfo.txData.baseData,
+              to: name === '0x Swap' ? SwapExchangeProxy : '0xdeadbeef'
+            }
+          }
+        })
+
+        expect(parsedTransaction.contractAddressError).toBeUndefined()
+      })
+    })
+
+    describe.each([
+      ['ERC20Transfer', TransactionType.ERC20Transfer],
+      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom]
+    ])('%s', (_, txType) => {
+      it('should be defined when recipient is a known contract address', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [],
+          [{ ...mockERC20Token, contractAddress: '0xdeadbeef' }]
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txArgs: txType === TransactionType.ERC20Transfer
+            ? ['0xdeadbeef', 'mockAmount']
+            : ['mockOwner', '0xdeadbeef', 'mockTokenID'],
+          txType
+        })
+
+        expect(parsedTransaction.contractAddressError).toBeDefined()
+      })
+
+      it('should be undefined when recipient is an unknown contract address', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [], [], [],
+          [{ ...mockERC20Token, contractAddress: '0xdeadbeef' }]
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txArgs: txType === TransactionType.ERC20Transfer
+            ? ['0xbadcafe', 'mockAmount']
+            : ['mockOwner', '0xbadcafe', 'mockTokenID'],
+          txType
+        })
+
+        expect(parsedTransaction.contractAddressError).toBeUndefined()
+      })
+    })
+  })
+})

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -54,6 +54,7 @@ interface ParsedTransaction extends ParsedTransactionFees {
   decimals: number
   insufficientFundsError: boolean
   contractAddressError?: string
+  sameAddressError?: string
   erc721ERCToken?: ERCToken
   erc721TokenId?: string
   isSwap?: boolean
@@ -100,15 +101,51 @@ export function useTransactionParser (
     return visibleTokens.find((token) => token.contractAddress.toLowerCase() === contractAddress.toLowerCase())
   }, [visibleTokens])
 
+  /**
+   * Checks if a given address is a known contract address from our token
+   * registry.
+   *
+   * @remarks
+   *
+   * This function must only be used for the following transaction types:
+   *  - ERC20Transfer
+   *  - ERC721TransferFrom
+   *  - ERC721SafeTransferFrom
+   *
+   * @param to - The address to check
+   * @returns Localized string describing the error, or undefined in case of
+   * no error.
+   */
   const checkForContractAddressError = (to: string): string | undefined => {
-    // If value is a Tokens Contract Address
     return fullTokenList?.some(token => token.contractAddress.toLowerCase() === to.toLowerCase())
       ? getLocale('braveWalletContractAddressError')
       : undefined
   }
 
+  /**
+   * Checks if a given set of sender and recipient addresses are the
+   * same.
+   *
+   * @remarks
+   *
+   * This function must only be used for the following transaction types:
+   *  - ERC20Transfer
+   *  - ERC721TransferFrom
+   *  - ERC721SafeTransferFrom
+   *  - ERC20Approve
+   *  - ETHSend
+   *
+   * @param to - The recipient address
+   * @param from - The sender address
+   */
+  const checkForSameAddressError = (to: string, from: string): string | undefined => {
+    return to.toLowerCase() === from.toLowerCase()
+      ? getLocale('braveWalletSameAddressError')
+      : undefined
+  }
+
   return React.useCallback((transactionInfo: TransactionInfo) => {
-    const { txArgs, txData, fromAddress } = transactionInfo
+    const { txArgs, txData, fromAddress, txType } = transactionInfo
     const { baseData } = txData
     const { value, to } = baseData
     const account = accounts.find((account) => account.address.toLowerCase() === fromAddress.toLowerCase())
@@ -117,7 +154,7 @@ export function useTransactionParser (
 
     switch (true) {
       // transfer(address recipient, uint256 amount) → bool
-      case transactionInfo.txType === TransactionType.ERC20Transfer: {
+      case txType === TransactionType.ERC20Transfer: {
         const [address, amount] = txArgs
         const token = findToken(to)
         const price = findSpotPrice(token?.symbol ?? '')
@@ -134,8 +171,8 @@ export function useTransactionParser (
           hash: transactionInfo.txHash,
           createdTime: transactionInfo.createdTime,
           status: transactionInfo.txStatus,
-          sender: transactionInfo.fromAddress,
-          senderLabel: getAddressLabel(transactionInfo.fromAddress),
+          sender: fromAddress,
+          senderLabel: getAddressLabel(fromAddress),
           recipient: address,
           recipientLabel: getAddressLabel(address),
           fiatValue: sendAmountFiat,
@@ -146,13 +183,19 @@ export function useTransactionParser (
           decimals: token?.decimals ?? 18,
           insufficientFundsError: insufficientNativeFunds || insufficientTokenFunds,
           contractAddressError: checkForContractAddressError(address),
+          sameAddressError: checkForSameAddressError(address, fromAddress),
           ...feeDetails
         } as ParsedTransaction
       }
 
-      case transactionInfo.txType === TransactionType.ERC721TransferFrom:
-      case transactionInfo.txType === TransactionType.ERC721SafeTransferFrom: {
-        const [fromAddress, toAddress, tokenID] = txArgs
+      // transferFrom(address owner, address to, uint256 tokenId)
+      case txType === TransactionType.ERC721TransferFrom:
+
+      // safeTransferFrom(address owner, address to, uint256 tokenId)
+      case txType === TransactionType.ERC721SafeTransferFrom: {
+        // The owner of the ERC721 must not be confused with the
+        // caller (fromAddress).
+        const [owner, toAddress, tokenID] = txArgs
         const token = findToken(to)
 
         const feeDetails = parseTransactionFees(transactionInfo)
@@ -164,8 +207,8 @@ export function useTransactionParser (
           hash: transactionInfo.txHash,
           createdTime: transactionInfo.createdTime,
           status: transactionInfo.txStatus,
-          sender: fromAddress,
-          senderLabel: getAddressLabel(transactionInfo.fromAddress),
+          sender: fromAddress, // The caller, which may not be the owner
+          senderLabel: getAddressLabel(fromAddress),
           recipient: toAddress,
           recipientLabel: getAddressLabel(toAddress),
           fiatValue: '0.00', // Display NFT values in the future
@@ -178,28 +221,29 @@ export function useTransactionParser (
           erc721ERCToken: token,
           erc721TokenId: hexToNumber(tokenID ?? ''),
           contractAddressError: checkForContractAddressError(toAddress),
+          sameAddressError: checkForSameAddressError(toAddress, owner),
           ...feeDetails
         } as ParsedTransaction
       }
 
       // approve(address spender, uint256 amount) → bool
-      case transactionInfo.txType === TransactionType.ERC20Approve: {
+      case txType === TransactionType.ERC20Approve: {
         const [address, amount] = txArgs
         const token = findToken(to)
         const feeDetails = parseTransactionFees(transactionInfo)
         const { gasFeeFiat } = feeDetails
         const totalAmountFiat = Number(gasFeeFiat).toFixed(2)
         const insufficientNativeFunds = Number(gasFeeFiat) > Number(accountsNativeFiatBalance)
-        const formatedValue = formatBalance(amount, token?.decimals ?? 18)
+        const formattedValue = formatBalance(amount, token?.decimals ?? 18)
         const userTokenBalance = usersTokenInfo?.assetBalance ?? ''
-        const allowanceValue = Number(amount) > Number(userTokenBalance) ? getLocale('braveWalletTransactionApproveUnlimited') : formatedValue
+        const allowanceValue = Number(amount) > Number(userTokenBalance) ? getLocale('braveWalletTransactionApproveUnlimited') : formattedValue
 
         return {
           hash: transactionInfo.txHash,
           createdTime: transactionInfo.createdTime,
           status: transactionInfo.txStatus,
-          sender: transactionInfo.fromAddress,
-          senderLabel: getAddressLabel(transactionInfo.fromAddress),
+          sender: fromAddress,
+          senderLabel: getAddressLabel(fromAddress),
           recipient: to,
           recipientLabel: getAddressLabel(to),
           fiatValue: (0).toFixed(2),
@@ -211,13 +255,14 @@ export function useTransactionParser (
           approvalTarget: address,
           approvalTargetLabel: getAddressLabel(address),
           insufficientFundsError: insufficientNativeFunds,
+          sameAddressError: checkForSameAddressError(address, fromAddress),
           ...feeDetails
         } as ParsedTransaction
       }
 
       // FIXME: swap needs a real parser to figure out the From and To details.
-      case transactionInfo.txData.baseData.to.toLowerCase() === SwapExchangeProxy:
-      case transactionInfo.txType === TransactionType.ETHSend:
+      case to.toLowerCase() === SwapExchangeProxy:
+      case txType === TransactionType.ETHSend:
       default: {
         const networkPrice = findSpotPrice(selectedNetwork.symbol)
         const sendAmountFiat = formatFiatBalance(value, selectedNetwork.decimals, networkPrice)
@@ -230,8 +275,8 @@ export function useTransactionParser (
           hash: transactionInfo.txHash,
           createdTime: transactionInfo.createdTime,
           status: transactionInfo.txStatus,
-          sender: transactionInfo.fromAddress,
-          senderLabel: getAddressLabel(transactionInfo.fromAddress),
+          sender: fromAddress,
+          senderLabel: getAddressLabel(fromAddress),
           recipient: to,
           recipientLabel: getAddressLabel(to),
           fiatValue: sendAmountFiat,
@@ -241,8 +286,7 @@ export function useTransactionParser (
           symbol: selectedNetwork.symbol,
           decimals: selectedNetwork?.decimals ?? 18,
           insufficientFundsError: Number(totalAmountFiat) > Number(accountsNativeFiatBalance),
-          contractAddressError: checkForContractAddressError(to),
-          isSwap: transactionInfo.txData.baseData.to.toLowerCase() === SwapExchangeProxy,
+          isSwap: to.toLowerCase() === SwapExchangeProxy,
           ...feeDetails
         } as ParsedTransaction
       }

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -221,6 +221,7 @@ function ConfirmTransactionPanel (props: Props) {
 
   const isConfirmButtonDisabled = React.useMemo(() => {
     return (
+      transactionDetails.sameAddressError ||
       transactionDetails.contractAddressError ||
       parseFloat(transactionDetails.gasFeeFiat) === 0 ? true : transactionDetails.insufficientFundsError
     )
@@ -415,6 +416,13 @@ function ConfirmTransactionPanel (props: Props) {
           {transactionDetails.contractAddressError}
         </ErrorText>
       }
+
+      {transactionDetails.sameAddressError &&
+        <ErrorText>
+          {transactionDetails.sameAddressError}
+        </ErrorText>
+      }
+
       <ButtonRow>
         <NavButton
           buttonType='reject'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5450,6 +5450,19 @@
         }
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -6113,6 +6126,15 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -14133,8 +14155,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -18498,6 +18519,15 @@
         }
       }
     },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
@@ -21895,6 +21925,14 @@
         "set-value": "^2.0.1"
       },
       "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
         "set-value": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build-storybook": "build-storybook -c .storybook -o .storybook-out",
     "storybook": "start-storybook",
     "test-unit": "jest -t",
+    "test-unit:wallet": "jest --coverage=false components/brave_wallet_ui",
     "test-python-scripts": "npm run pep8 && PYTHONPATH=./script python -m unittest discover -s ./script/test"
   },
   "repository": {
@@ -273,6 +274,7 @@
     "@storybook/addon-knobs": "6.3.1",
     "@storybook/addons": "6.3.12",
     "@storybook/react": "6.3.12",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/array-move": "2.0.0",
     "@types/bluebird": "3.5.36",
     "@types/chrome": "0.0.147",


### PR DESCRIPTION
**Summary of changes:**
- Reintroduced same address error checks (removed in https://github.com/brave/brave-core/pull/11231), and restricted its scope to exclude `ETHSend`, which is the type of cancel transactions.
- Restricted the scope of the error check for recipient addresses being known contracts, to only include `ERC20Transfer`, `ERC721TransferFrom`, and `ERC721SafeTransferFrom`. The error in the linked issue was because ETH-WETH swap didn't use the 0x exchange router but actually the WETH contract directly.
- In ERC721 transfers, sender may not be the same as the owner. The same address check is now exclusively performed between between owner and recipient. For example, we now allow an account to transfer ownership of an ERC721 to itself.
- Added an extensive test suite.

Resolves https://github.com/brave/brave-browser/issues/19745.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

### Before

https://user-images.githubusercontent.com/3684187/143542154-65119017-6513-469d-9cf3-25895ac47867.mov

### After

|WETH-ETH Swap| Cancel transaction |
-|-
|<video src="https://user-images.githubusercontent.com/3684187/143541244-8c6e6887-be29-43e8-b5bb-4ced7949f67f.mov">|<video src="https://user-images.githubusercontent.com/3684187/143541282-ffd8ec71-cd87-420f-b1ce-19ce5c073547.mov">|

## Unit tests

<img src="https://user-images.githubusercontent.com/3684187/143539481-ed2b699b-5464-43fd-af4d-b50c7c058035.png">

