### PR TITLE
Retry signMessage for ConnectHardwareView

### DIFF
--- a/components/brave_wallet_ui/common/async/hardware.ts
+++ b/components/brave_wallet_ui/common/async/hardware.ts
@@ -29,6 +29,13 @@ export function dialogErrorFromLedgerErrorCode (code: string | number): Hardware
   return 'openEthereumApp'
 }
 
+export function dialogErrorFromTrezorErrorCode (code: TrezorErrorsCodes): HardwareWalletResponseCodeType {
+  if (code === TrezorErrorsCodes.CommandInProgress) {
+    return 'deviceBusy'
+  }
+  return 'openEthereumApp'
+}
+
 export async function signTrezorTransaction (apiProxy: WalletApiProxy, path: string, txInfo: BraveWallet.TransactionInfo): Promise<SignHardwareTransactionType> {
   const chainId = await apiProxy.ethJsonRpcController.getChainId()
   const nonce = await apiProxy.ethTxController.getNonceForHardwareTransaction(txInfo.id)

--- a/components/brave_wallet_ui/common/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -104,7 +104,7 @@ export default class LedgerBridgeKeyring extends EventEmitter {
       }
       return { success: true, payload: signature }
     } catch (e) {
-      return { success: false, error: e.message, code: e.id }
+      return { success: false, error: e.message, code: e.statusCode || e.id || e.name }
     }
   }
 

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -2,7 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
-
+import { StatusCodes as LedgerStatusCodes } from '@ledgerhq/errors'
 import {
   TransactionInfo,
   SignMessageRequest,
@@ -48,7 +48,6 @@ import { getLocale } from '../../../common/locale'
 
 import getWalletPanelApiProxy from '../wallet_panel_api_proxy'
 import { TrezorErrorsCodes } from '../../common/trezor/trezor-messages'
-import { LedgerErrorsCodes } from '../../common/ledgerjs/eth_ledger_bridge_keyring'
 
 const handler = new AsyncActionHandler()
 
@@ -340,16 +339,19 @@ handler.on(PanelActions.signMessageHardware.getType(), async (store, messageData
   await navigateToConnectHardwareWallet(store)
   const info = hardwareAccount.hardware
   const signed = await signMessageWithHardwareKeyring(apiProxy, info.vendor, info.path, messageData.message)
-  if (!signed.success &&
-      (signed.code === TrezorErrorsCodes.CommandInProgress ||
-       signed.code === LedgerErrorsCodes.TransportLocked)) {
-      // do nothing as the operation is already in progress
+  if (!signed.success) {
+    if (signed.code && (signed.code !== LedgerStatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED ||
+                        signed.code === TrezorErrorsCodes.CommandInProgress)) {
+      const deviceError = dialogErrorFromLedgerErrorCode(signed.code)
+      await store.dispatch(PanelActions.setHardwareWalletInteractionError(deviceError))
       return
+    }
   }
   const payload: SignMessageHardwareProcessedPayload =
     signed.success ? { success: signed.success, id: messageData.id, signature: signed.payload }
                    : { success: signed.success, id: messageData.id, error: signed.error }
   store.dispatch(PanelActions.signMessageHardwareProcessed(payload))
+  await store.dispatch(PanelActions.navigateToMain())
   apiProxy.panelHandler.closeUI()
 })
 

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -415,6 +415,14 @@ function Container (props: Props) {
   const onQueueNextTransction = () => {
     props.walletActions.queueNextTransaction()
   }
+  const retryHardwareOperation = () => {
+    if (signMessageData) {
+      onSignData()
+    }
+    if (selectedPendingTransaction) {
+      onConfirmTransaction()
+    }
+  }
   const onConfirmTransaction = () => {
     if (!selectedPendingTransaction) {
       return
@@ -492,7 +500,7 @@ function Container (props: Props) {
             onCancel={onCancelConnectHardwareWallet}
             walletName={selectedAccount.name}
             hardwareWalletCode={props.panel.hardwareWalletCode}
-            retryCallable={onConfirmTransaction}
+            retryCallable={retryHardwareOperation}
           />
         </StyledExtensionWrapper>
       </PanelWrapper>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -277,7 +277,7 @@
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_DISCONNECTED" desc="Connect Hardware panel disconnected status"><ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph> disconnected</message>
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_INSTRUCTIONS" desc="Connect Hardware panel instructions button">Instructions</message>
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_CONNECT" desc="Connect Hardware panel title">Connect your <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
-  <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_CONFIRMATION" desc="Connect Hardware panel confirmation description">Hardware wallet requires transaction confirmation. <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
+  <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_CONFIRMATION" desc="Connect Hardware panel confirmation description">Hardware wallet requires confirmation on device. <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_OPEN_APP" desc="Connect Hardware panel open app text">Hardware wallet requires Ethereum App opened on <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_SENT" desc="Transaction sent label">sent</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_RECEIVED" desc="Transaction received label">received</message>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19757

- Changed message because it is used for both signing transactions and messages
- Added sign messages handler for retries to ConnectHardwareView

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Connect Hardware device
   2. Initiate a sign transaction for ledger wallet
   3. Hardware connect popup shows up but shows disconnected
