### PR TITLE
Removed NTPBrandedWallpaper feature flag

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -63,7 +63,6 @@ using brave_shields::features::kBraveExtensionNetworkBlocking;
 using brave_shields::features::kCosmeticFilteringSyncLoad;
 
 using debounce::features::kBraveDebounce;
-using ntp_background_images::features::kBraveNTPBrandedWallpaper;
 using ntp_background_images::features::kBraveNTPBrandedWallpaperDemo;
 using ntp_background_images::features::kBraveNTPSuperReferralWallpaper;
 
@@ -146,11 +145,6 @@ constexpr char kCosmeticFilteringSyncLoadDescription[] =
 
 constexpr char kBraveIpfsName[] = "Enable IPFS";
 constexpr char kBraveIpfsDescription[] = "Enable native support of IPFS.";
-
-constexpr char kBraveNTPBrandedWallpaperName[] =
-    "New Tab Page Branded Wallpapers";
-constexpr char kBraveNTPBrandedWallpaperDescription[] =
-    "Allow New Tab Page Branded Wallpapers and user preference.";
 
 constexpr char kBraveNTPBrandedWallpaperDemoName[] =
     "New Tab Page Demo Branded Wallpaper";
@@ -375,10 +369,6 @@ constexpr char kFileSystemAccessAPIDescription[] =
      flag_descriptions::kUseDevUpdaterUrlName,                              \
      flag_descriptions::kUseDevUpdaterUrlDescription, kOsAll,               \
      FEATURE_VALUE_TYPE(brave_component_updater::kUseDevUpdaterUrl)},       \
-    {"brave-ntp-branded-wallpaper",                                         \
-     flag_descriptions::kBraveNTPBrandedWallpaperName,                      \
-     flag_descriptions::kBraveNTPBrandedWallpaperDescription, kOsAll,       \
-     FEATURE_VALUE_TYPE(kBraveNTPBrandedWallpaper)},                        \
     {"brave-ntp-branded-wallpaper-demo",                                    \
      flag_descriptions::kBraveNTPBrandedWallpaperDemoName,                  \
      flag_descriptions::kBraveNTPBrandedWallpaperDemoDescription, kOsAll,   \

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -31,7 +31,6 @@
 #include "brave/components/brave_sync/network_time_helper.h"
 #include "brave/components/debounce/browser/debounce_component_installer.h"
 #include "brave/components/debounce/common/features.h"
-#include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/p3a/brave_p3a_service.h"
 #include "brave/components/p3a/buildflags.h"
@@ -85,7 +84,6 @@
 
 using brave_component_updater::BraveComponent;
 using ntp_background_images::NTPBackgroundImagesService;
-using ntp_background_images::features::kBraveNTPBrandedWallpaper;
 
 namespace {
 
@@ -217,9 +215,6 @@ BraveBrowserProcessImpl::ad_block_regional_service_manager() {
 
 NTPBackgroundImagesService*
 BraveBrowserProcessImpl::ntp_background_images_service() {
-  if (!base::FeatureList::IsEnabled(kBraveNTPBrandedWallpaper))
-    return nullptr;
-
   if (!ntp_background_images_service_) {
     ntp_background_images_service_ =
         std::make_unique<NTPBackgroundImagesService>(component_updater(),

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -27,7 +27,6 @@
 #include "brave/components/brave_today/common/pref_names.h"
 #include "brave/components/crypto_dot_com/browser/buildflags/buildflags.h"
 #include "brave/components/ftx/browser/buildflags/buildflags.h"
-#include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
@@ -44,7 +43,6 @@
 #include "content/public/browser/web_ui_data_source.h"
 
 using ntp_background_images::ViewCounterServiceFactory;
-using ntp_background_images::features::kBraveNTPBrandedWallpaper;
 using ntp_background_images::prefs::kBrandedWallpaperNotificationDismissed;
 using ntp_background_images::prefs::kNewTabPageShowBackgroundImage;
 using ntp_background_images::prefs::
@@ -200,8 +198,7 @@ BraveNewTabMessageHandler* BraveNewTabMessageHandler::Create(
   }
 
   source->AddBoolean("featureFlagBraveNTPSponsoredImagesWallpaper",
-                     base::FeatureList::IsEnabled(kBraveNTPBrandedWallpaper) &&
-                         is_ads_supported_locale_);
+                     is_ads_supported_locale_);
   source->AddBoolean("braveTalkPromptAllowed",
                      BraveNewTabMessageHandler::CanPromptBraveTalk());
 

--- a/components/ntp_background_images/browser/features.cc
+++ b/components/ntp_background_images/browser/features.cc
@@ -12,9 +12,6 @@
 namespace ntp_background_images {
 namespace features {
 
-const base::Feature kBraveNTPBrandedWallpaper{
-    "BraveNTPBrandedWallpaperName",
-    base::FEATURE_ENABLED_BY_DEFAULT};
 const base::Feature kBraveNTPBrandedWallpaperDemo{
     "BraveNTPBrandedWallpaperDemoName",
     base::FEATURE_DISABLED_BY_DEFAULT};

--- a/components/ntp_background_images/browser/features.h
+++ b/components/ntp_background_images/browser/features.h
@@ -12,7 +12,6 @@ struct Feature;
 
 namespace ntp_background_images {
 namespace features {
-extern const base::Feature kBraveNTPBrandedWallpaper;
 extern const base::Feature kBraveNTPBrandedWallpaperDemo;
 extern const base::Feature kBraveNTPSuperReferralWallpaper;
 }  // namespace features


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/19754

As we customize this feature in NTP, we don't need to maintain this
feature flag. Also this makes regression when this flag is off.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch browser and check `NTPBrandedWallpaper` is not visible from brave://flags