### PR TITLE
(uplift to 1.33.x) Retry signMessage for ConnectHardwareView (#11301)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/permission_bubble/chooser_bubble_ui.cc
+++ b/chromium_src/chrome/browser/ui/views/permission_bubble/chooser_bubble_ui.cc
@@ -43,6 +43,9 @@ class BraveBubbleDialogDelegateView : public views::BubbleDialogDelegateView {
       return;
     content::WebContents* active =
         browser->tab_strip_model()->GetActiveWebContents();
+    if (!active) {
+      return;
+    }
     auto* tab_helper =
         brave_wallet::BraveWalletTabHelper::FromWebContents(active);
     if (tab_helper)

--- a/components/brave_wallet_ui/common/async/hardware.ts
+++ b/components/brave_wallet_ui/common/async/hardware.ts
@@ -29,6 +29,13 @@ export function dialogErrorFromLedgerErrorCode (code: string | number): Hardware
   return 'openEthereumApp'
 }
 
+export function dialogErrorFromTrezorErrorCode (code: TrezorErrorsCodes): HardwareWalletResponseCodeType {
+  if (code === TrezorErrorsCodes.CommandInProgress) {
+    return 'deviceBusy'
+  }
+  return 'openEthereumApp'
+}
+
 export async function signTrezorTransaction (apiProxy: WalletApiProxy, path: string, txInfo: BraveWallet.TransactionInfo): Promise<SignHardwareTransactionType> {
   const chainId = await apiProxy.ethJsonRpcController.getChainId()
   const nonce = await apiProxy.ethTxController.getNonceForHardwareTransaction(txInfo.id)

--- a/components/brave_wallet_ui/common/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -105,7 +105,7 @@ export default class LedgerBridgeKeyring extends EventEmitter {
       }
       return { success: true, payload: signature }
     } catch (e) {
-      return { success: false, error: e.message, code: e.id }
+      return { success: false, error: e.message, code: e.statusCode || e.id || e.name }
     }
   }
 

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -2,7 +2,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import {
   TransactionInfo,
   SignMessageRequest,
@@ -39,7 +38,8 @@ import {
   signLedgerTransaction,
   signMessageWithHardwareKeyring,
   cancelHardwareOperation,
-  dialogErrorFromLedgerErrorCode
+  dialogErrorFromLedgerErrorCode,
+  dialogErrorFromTrezorErrorCode
 } from '../../common/async/hardware'
 
 import { fetchSwapQuoteFactory } from '../../common/async/handlers'
@@ -48,7 +48,6 @@ import { getLocale } from '../../../common/locale'
 
 import getWalletPanelApiProxy from '../wallet_panel_api_proxy'
 import { TrezorErrorsCodes } from '../../common/trezor/trezor-messages'
-import { LedgerErrorsCodes } from '../../common/ledgerjs/eth_ledger_bridge_keyring'
 
 const handler = new AsyncActionHandler()
 
@@ -343,16 +342,21 @@ handler.on(PanelActions.signMessageHardware.getType(), async (store, messageData
   await navigateToConnectHardwareWallet(store)
   const info = hardwareAccount.hardware
   const signed = await signMessageWithHardwareKeyring(apiProxy, info.vendor, info.path, messageData.message)
-  if (!signed.success &&
-      (signed.code === TrezorErrorsCodes.CommandInProgress ||
-       signed.code === LedgerErrorsCodes.TransportLocked)) {
-    // do nothing as the operation is already in progress
-    return
+  if (!signed.success) {
+    if (signed.code) {
+      const deviceError = (info.vendor === TREZOR_HARDWARE_VENDOR)
+        ? dialogErrorFromTrezorErrorCode(signed.code as TrezorErrorsCodes) : dialogErrorFromLedgerErrorCode(signed.code)
+      if (deviceError !== 'transactionRejected') {
+        await store.dispatch(PanelActions.setHardwareWalletInteractionError(deviceError))
+        return
+      }
+    }
   }
   const payload: SignMessageHardwareProcessedPayload =
     signed.success ? { success: signed.success, id: messageData.id, signature: signed.payload }
                    : { success: signed.success, id: messageData.id, error: signed.error }
   store.dispatch(PanelActions.signMessageHardwareProcessed(payload))
+  await store.dispatch(PanelActions.navigateToMain())
   apiProxy.panelHandler.closeUI()
 })
 

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -415,15 +415,7 @@ function Container (props: Props) {
   const onQueueNextTransction = () => {
     props.walletActions.queueNextTransaction()
   }
-  const retryHardwareOperation = () => {
-    // signMessageData by default initialized as [{ id: -1, address: '', message: '' }]
-    if (signMessageData && signMessageData.length && signMessageData[0].id !== -1) {
-      onSignData()
-    }
-    if (selectedPendingTransaction) {
-      onConfirmTransaction()
-    }
-  }
+
   const onConfirmTransaction = () => {
     if (!selectedPendingTransaction) {
       return
@@ -434,7 +426,15 @@ function Container (props: Props) {
       props.walletActions.approveTransaction(selectedPendingTransaction)
     }
   }
-
+  const retryHardwareOperation = () => {
+    // signMessageData by default initialized as [{ id: -1, address: '', message: '' }]
+    if (signMessageData && signMessageData.length && signMessageData[0].id !== -1) {
+      onSignData()
+    }
+    if (selectedPendingTransaction) {
+      onConfirmTransaction()
+    }
+  }
   const onOpenSettings = () => {
     props.walletPanelActions.openWalletSettings()
   }

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -415,6 +415,14 @@ function Container (props: Props) {
   const onQueueNextTransction = () => {
     props.walletActions.queueNextTransaction()
   }
+  const retryHardwareOperation = () => {
+    if (signMessageData) {
+      onSignData()
+    }
+    if (selectedPendingTransaction) {
+      onConfirmTransaction()
+    }
+  }
   const onConfirmTransaction = () => {
     if (!selectedPendingTransaction) {
       return
@@ -492,7 +500,7 @@ function Container (props: Props) {
             onCancel={onCancelConnectHardwareWallet}
             walletName={selectedAccount.name}
             hardwareWalletCode={props.panel.hardwareWalletCode}
-            retryCallable={onConfirmTransaction}
+            retryCallable={retryHardwareOperation}
           />
         </StyledExtensionWrapper>
       </PanelWrapper>

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -416,7 +416,8 @@ function Container (props: Props) {
     props.walletActions.queueNextTransaction()
   }
   const retryHardwareOperation = () => {
-    if (signMessageData) {
+    // signMessageData by default initialized as [{ id: -1, address: '', message: '' }]
+    if (signMessageData && signMessageData.length && signMessageData[0].id !== -1) {
       onSignData()
     }
     if (selectedPendingTransaction) {

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -277,7 +277,7 @@
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_DISCONNECTED" desc="Connect Hardware panel disconnected status"><ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph> disconnected</message>
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_INSTRUCTIONS" desc="Connect Hardware panel instructions button">Instructions</message>
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_CONNECT" desc="Connect Hardware panel title">Connect your <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
-  <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_CONFIRMATION" desc="Connect Hardware panel confirmation description">Hardware wallet requires transaction confirmation. <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
+  <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_CONFIRMATION" desc="Connect Hardware panel confirmation description">Hardware wallet requires confirmation on device. <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
   <message name="IDS_BRAVE_WALLET_CONNECT_HARDWARE_PANEL_OPEN_APP" desc="Connect Hardware panel open app text">Hardware wallet requires Ethereum App opened on <ph name="DEVICE_NAME"><ex>Ledger</ex>$1</ph></message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_SENT" desc="Transaction sent label">sent</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_RECEIVED" desc="Transaction received label">received</message>


### PR DESCRIPTION
Uplift of #11301 #11332
Resolves https://github.com/brave/brave-browser/issues/19757
Resolves https://github.com/brave/brave-browser/issues/19824
Resolves https://github.com/brave/brave-browser/issues/19823

Should be merged to 1.33.x after https://github.com/brave/brave-core/pull/11317

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.