### PR TITLE
Fix crash and wallet panel disappearing when WebHID popup opened

### DIFF
--- a/chromium_src/chrome/browser/ui/views/permission_bubble/chooser_bubble_ui.cc
+++ b/chromium_src/chrome/browser/ui/views/permission_bubble/chooser_bubble_ui.cc
@@ -43,6 +43,9 @@ class BraveBubbleDialogDelegateView : public views::BubbleDialogDelegateView {
       return;
     content::WebContents* active =
         browser->tab_strip_model()->GetActiveWebContents();
+    if (!active) {
+      return;
+    }
     auto* tab_helper =
         brave_wallet::BraveWalletTabHelper::FromWebContents(active);
     if (tab_helper)

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -416,7 +416,7 @@ function Container (props: Props) {
     props.walletActions.queueNextTransaction()
   }
   const retryHardwareOperation = () => {
-    if (signMessageData) {
+    if (signMessageData && signMessageData.length && signMessageData[0].id != -1) {
       onSignData()
     }
     if (selectedPendingTransaction) {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19824

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Add Ledger to wallet and physically disconnect it
   2. Initiate a transaction from Ledger 
   3. Wait for the connect wallet popup to show up, auto closes once WebHID popup shows up([#19823](#19823))
   4. Reconnect Ledger while the WebHID popup is shown
   5. Once you logged in to Eteherum App, click on wallet button, browser crashes
