### PR TITLE
Correct month-end date for rewards NTP widget (uplift to 1.33.x)

### DIFF
--- a/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
+++ b/components/brave_rewards/resources/shared/components/newtab/rewards_card.tsx
@@ -35,7 +35,13 @@ const monthDayFormatter = new Intl.DateTimeFormat(undefined, {
 function renderDateRange () {
   const now = new Date()
   const start = new Date(now.getFullYear(), now.getMonth(), 1)
-  const end = new Date(start.getFullYear(), start.getMonth() + 1, -1)
+
+  // To get the last day of the month, we can create a date for the next month,
+  // (months greater than 11 wrap around) with the day part set to 0 (one before
+  // the first day of the month). The Date constructor will perform the offset
+  // for us.
+  const end = new Date(start.getFullYear(), start.getMonth() + 1, 0)
+
   return (
     <>{monthDayFormatter.format(start)} - {monthDayFormatter.format(end)}</>
   )


### PR DESCRIPTION
Uplift of #11252
Resolves https://github.com/brave/brave-browser/issues/19691

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.