### PR TITLE
Fallback to FullTokenList in TransactionParser

### DIFF
--- a/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
@@ -502,4 +502,85 @@ describe('useTransactionParser hook', () => {
       })
     })
   })
+  describe('check for token symbol', () => {
+    describe.each([
+      ['ERC20Approve', TransactionType.ERC20Approve],
+      ['ERC20Transfer', TransactionType.ERC20Transfer],
+      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom]
+    ])('%s', (_, txType) => {
+      it('should be empty', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [mockAccount], [], [mockERC20Token]
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          txData: {
+            ...mockTransactionInfo.txData,
+            baseData: {
+              ...mockTransactionInfo.txData.baseData,
+              to: 'test'
+            }
+          },
+          txArgs: [
+            'mockRecipient',
+            '0xde0b6b3a7640000'
+          ]
+        })
+
+        expect(parsedTransaction.symbol).toEqual('')
+      })
+      it('Gets token symbol from visibleList, should be DOG', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [mockAccount], [], [mockERC20Token]
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          txData: {
+            ...mockTransactionInfo.txData,
+            baseData: {
+              ...mockTransactionInfo.txData.baseData,
+              to: 'mockContractAddress'
+            }
+          },
+          txArgs: [
+            'mockRecipient',
+            '0xde0b6b3a7640000'
+          ]
+        })
+
+        expect(parsedTransaction.symbol).toEqual('DOG')
+      })
+      it('Gets token symbol from fallback fullTokenList, should be DOG', () => {
+        const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
+          mockNetwork, [mockAccount], [], [], [mockERC20Token]
+        ))
+
+        const mockTransactionInfo = getMockedTransactionInfo()
+        const parsedTransaction = transactionParser({
+          ...mockTransactionInfo,
+          txType,
+          txData: {
+            ...mockTransactionInfo.txData,
+            baseData: {
+              ...mockTransactionInfo.txData.baseData,
+              to: 'mockContractAddress'
+            }
+          },
+          txArgs: [
+            'mockRecipient',
+            '0xde0b6b3a7640000'
+          ]
+        })
+
+        expect(parsedTransaction.symbol).toEqual('DOG')
+      })
+    })
+  })
 })

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -98,8 +98,9 @@ export function useTransactionParser (
   const parseTransactionFees = useTransactionFeesParser(selectedNetwork, findSpotPrice(selectedNetwork.symbol))
 
   const findToken = React.useCallback((contractAddress: string) => {
-    return visibleTokens.find((token) => token.contractAddress.toLowerCase() === contractAddress.toLowerCase())
-  }, [visibleTokens])
+    const checkVisibleList = visibleTokens.find((token) => token.contractAddress.toLowerCase() === contractAddress.toLowerCase())
+    return checkVisibleList ?? (fullTokenList?.find((token) => token.contractAddress.toLowerCase() === contractAddress.toLowerCase()))
+  }, [visibleTokens, fullTokenList])
 
   /**
    * Checks if a given address is a known contract address from our token


### PR DESCRIPTION
## Description 
Fallback to FullTokenList in TransactionParser

Before the `findToken` method in the `TransactionParser` hook would only do a find from the users `visibleTokens` causing a bug where a tokens `symbol` would not appear in the `Approve Spend` panel if `Approving Token` was not added by the user.

It will now fallback to the `fullTokenList` if no token is found.

note: (This is not a full fix for this issue, for if the token also does not exist in our `ercTokenRegistry` the same bug will occur. Once we have an API ready to get token information from `etherscan` we will be able to make this more full proof.)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19556>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/144145657-8ebf0688-14e3-499a-b3c9-75feb62cfa36.mov
