### PR TITLE
1.33.x - Uplift pull request #11285 from brave/fix-brave-news-image-crash-fix

### DIFF
--- a/components/brave_today/browser/brave_news_controller.cc
+++ b/components/brave_today/browser/brave_news_controller.cc
@@ -120,6 +120,7 @@ void BraveNewsController::GetImageData(const GURL& padded_image_url,
           // Byte padding removal failed
           absl::optional<std::vector<uint8_t>> args;
           std::move(callback).Run(std::move(args));
+          return;
         }
         // Unpadding was successful, uint8Array will be easier to move over
         // mojom


### PR DESCRIPTION
Uplifts https://github.com/brave/brave-browser/issues/19517 to 1.33.x