### PR TITLE
fix(wallet): fix rounding issue with 100% preset amount

### DIFF
--- a/components/brave_wallet_ui/common/hooks/index.ts
+++ b/components/brave_wallet_ui/common/hooks/index.ts
@@ -10,7 +10,7 @@ import useSend from './send'
 import { useTransactionParser, useTransactionFeesParser } from './transaction-parser'
 import useAddressLabels from './address-labels'
 import usePricing from './pricing'
-import usePreset from './selectPreset'
+import usePreset from './select-preset'
 
 export {
   useAssets,

--- a/components/brave_wallet_ui/common/hooks/select-preset.test.ts
+++ b/components/brave_wallet_ui/common/hooks/select-preset.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { mockAccount, mockERC20Token } from '../constants/mocks'
+import usePreset from './select-preset'
+
+describe('usePreset hook', () => {
+  it.each([
+    ['25% of 1 ETH', '0xde0b6b3a7640000', 0.25, '0.25'],
+    ['50% of 1 ETH', '0xde0b6b3a7640000', 0.50, '0.5'],
+    ['75% of 1 ETH', '0xde0b6b3a7640000', 0.75, '0.75'],
+    ['100% of 1 ETH', '0xde0b6b3a7640000', 1, '1'],
+    ['100% of 1.000000000000000001 ETH', '0xde0b6b3a7640001', 1, '1.000000000000000001'], // 1.000000000000000001 ---(100%)---> 1.000000000000000001
+    ['100% of 50.297939 ETH', '0x2ba062d07d5443000', 1, '50.297939'], // 50.297939 ---(100%)---> 50.297939
+    ['25% of 0.0001 ETH', '0x5af3107a4000', 0.25, '0.000025'] // 0.0001 ---(25%)---> 0.000025
+  ])('should compute %s correctly', (_, balance: string, percent, expected: string) => {
+    const mockFunc = jest.fn()
+
+    const { result: { current: calcPresetAmount } } = renderHook(() => usePreset(
+      {
+        ...mockAccount,
+        tokens: [{
+          asset: mockERC20Token,
+          assetBalance: balance,
+          fiatBalance: '0'
+        }]
+      },
+      {
+        asset: mockERC20Token,
+        assetBalance: 'mockBalance',
+        fiatBalance: 'mockBalance'
+      },
+      {
+        asset: mockERC20Token,
+        assetBalance: 'mockBalance',
+        fiatBalance: 'mockBalance'
+      },
+      mockFunc,
+      jest.fn()
+    ))
+
+    calcPresetAmount('swap')(percent)
+    expect(mockFunc.mock.calls.length).toBe(1)
+    expect(mockFunc.mock.calls[0][0]).toBe(expected)
+  })
+})

--- a/components/brave_wallet_ui/common/hooks/select-preset.ts
+++ b/components/brave_wallet_ui/common/hooks/select-preset.ts
@@ -4,7 +4,7 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import BigNumber from 'bignumber.js'
-import { formatBalance } from '../../utils/format-balances'
+import { formatInputValue } from '../../utils/format-balances'
 import { WalletAccountType, AccountAssetOptionType } from '../../constants/types'
 
 export default function usePreset (
@@ -22,8 +22,13 @@ export default function usePreset (
         token.asset.symbol === selectedAsset.asset.symbol
       )
     )
-    const amount = new BigNumber(asset?.assetBalance || '0').times(percent).toString()
-    const formattedAmount = formatBalance(amount.toString(), asset?.asset.decimals ?? 18)
+
+    const decimals = asset?.asset.decimals ?? 18
+    const amountWeiBN = new BigNumber(asset?.assetBalance || '0').times(percent)
+
+    const formattedAmount = (percent === 1)
+      ? formatInputValue(amountWeiBN.toString(), decimals, false)
+      : formatInputValue(amountWeiBN.toString(), decimals)
 
     if (sendOrSwap === 'send') {
       onSetSendAmount(formattedAmount)

--- a/components/brave_wallet_ui/common/hooks/swap.ts
+++ b/components/brave_wallet_ui/common/hooks/swap.ts
@@ -24,7 +24,7 @@ import {
 import { SlippagePresetOptions } from '../../options/slippage-preset-options'
 import { ExpirationPresetOptions } from '../../options/expiration-preset-options'
 import { ETH, RopstenSwapAssetOptions } from '../../options/asset-options'
-import { formatBalance, toWei, toWeiHex } from '../../utils/format-balances'
+import { formatInputValue, toWei, toWeiHex } from '../../utils/format-balances'
 import { debounce } from '../../../common/debounce'
 import { SwapParamsPayloadType } from '../constants/action_types'
 import useBalance from './balance'
@@ -160,8 +160,8 @@ export default function useSwap (
 
     const { buyAmount, sellAmount, price, buyTokenToEthRate, sellTokenToEthRate } = quote
 
-    setFromAmount(formatBalance(sellAmount, fromAsset.asset.decimals))
-    setToAmount(formatBalance(buyAmount, toAsset.asset.decimals))
+    setFromAmount(formatInputValue(sellAmount, fromAsset.asset.decimals))
+    setToAmount(formatInputValue(buyAmount, toAsset.asset.decimals))
 
     /**
      * Price computation block

--- a/components/brave_wallet_ui/utils/format-balances.test.ts
+++ b/components/brave_wallet_ui/utils/format-balances.test.ts
@@ -1,0 +1,18 @@
+import { formatInputValue } from './format-balances'
+
+describe('formatInputValue', () => {
+  it.each([
+    ['0x0', 18, '0'], // 0 ETH -> 0 ETH
+    ['0xde0b6b3a7640000', 18, '1'], // 1 ETH -> 1ETH
+    ['0xde0b6b3a7640001', 18, '1'], // 1.000000000000000001 ETH -> 1 ETH
+    ['0xde444324c2a8080', 18, '1.001'], // 1.001000000000000001 ETH -> 1.001 ETH
+    ['0x1', 18, '0.000000000000000001'] // 0.000000000000000001 ETH
+  ])('should format %s with %s decimals to %s', (amount: string, decimals: number, expected) => {
+    expect(formatInputValue(amount, decimals)).toBe(expected)
+  })
+
+  it('should not round if parameter is overridden', () => {
+    expect(formatInputValue('0xde0b6b3a7640001', 18)).toBe('1')
+    expect(formatInputValue('0xde0b6b3a7640001', 18, false)).toBe('1.000000000000000001')
+  })
+})

--- a/components/brave_wallet_ui/utils/format-balances.ts
+++ b/components/brave_wallet_ui/utils/format-balances.ts
@@ -1,5 +1,30 @@
 import BigNumber from 'bignumber.js'
 
+export const formatInputValue = (value: string, decimals: number, round = true) => {
+  if (decimals === 0) {
+    const result = new BigNumber(value)
+    return (result.isNaN()) ? '0' : result.toFixed(0)
+  }
+
+  const result = new BigNumber(value).dividedBy(10 ** decimals)
+  if (result.isNaN()) {
+    return '0'
+  }
+
+  // We format the number to have 6 places of decimals, unless the value
+  // is too small.
+  //
+  // For situations where the value must not be rounded, round flag may be
+  // used.
+  const formattedValue = (result.isGreaterThanOrEqualTo(0.000001) && result.decimalPlaces() > 6 && round)
+    ? result.toFixed(6)
+    : result.toFixed()
+
+  // Remove trailing zeros, including the decimal separator if necessary.
+  // Example: 1.0000000000 becomes 1.
+  return formattedValue.replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/, '$1')
+}
+
 export const formatBalance = (balance: string, decimals: number) => {
   if (decimals === 0) {
     const result = new BigNumber(balance)


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/19855.

### Overview

Please refer to the linked issue for further details. This PR only deals with amount presets (25%, 50%, ...) and better precision in swap inputs (increased to 6 places of decimal to match Metamask, and handling very small values as seen in the demo).

There's a similar issue (https://github.com/brave/brave-browser/issues/19521) that has to do with how we display the amounts in the transaction confirmation screen, which this PR doesn't impact.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

|Before|After|
-|-
|<img src="https://user-images.githubusercontent.com/3684187/144250685-6f6d95a7-e494-4764-8148-307aa9da0879.png">|<video src="https://user-images.githubusercontent.com/3684187/144250700-d8db4dcc-80ea-4bae-ab4f-c966d75cb2f4.mov">|


