### PR TITLE
Fix gas estimation for ETHSend transactions

### DIFF
--- a/components/brave_wallet/browser/eth_tx_controller.cc
+++ b/components/brave_wallet/browser/eth_tx_controller.cc
@@ -181,10 +181,6 @@ void EthTxController::AddUnapprovedTransaction(
     return;
   }
 
-  // Use default gas limit for ETHSend if it is empty.
-  if (tx_type == mojom::TransactionType::ETHSend && !tx_ptr->gas_limit())
-    tx_ptr->set_gas_limit(kDefaultSendEthGasLimit);
-
   const std::string gas_limit = Uint256ValueToHex(tx_ptr->gas_limit());
 
   if (!tx_ptr->gas_price()) {
@@ -310,10 +306,7 @@ void EthTxController::AddUnapproved1559Transaction(
     return;
   }
 
-  // Use default gas limit for ETHSend if it is empty.
   std::string gas_limit = tx_data->base_data->gas_limit;
-  if (gas_limit.empty() && tx_type == mojom::TransactionType::ETHSend)
-    gas_limit = Uint256ValueToHex(kDefaultSendEthGasLimit);
 
   if (!tx_ptr->max_priority_fee_per_gas() || !tx_ptr->max_fee_per_gas()) {
     asset_ratio_controller_->GetGasOracle(base::BindOnce(

--- a/components/brave_wallet/browser/eth_tx_controller.cc
+++ b/components/brave_wallet/browser/eth_tx_controller.cc
@@ -170,28 +170,21 @@ void EthTxController::AddUnapprovedTransaction(
   }
 
   auto tx_ptr = std::make_unique<EthTransaction>(*tx);
-
-  mojom::TransactionType tx_type;
-  if (!GetTransactionInfoFromData(ToHex(tx_ptr->data()), &tx_type, nullptr,
-                                  nullptr)) {
-    std::move(callback).Run(
-        false, "",
-        l10n_util::GetStringUTF8(
-            IDS_WALLET_ETH_SEND_TRANSACTION_GET_TX_TYPE_FAILED));
-    return;
-  }
-
   const std::string gas_limit = Uint256ValueToHex(tx_ptr->gas_limit());
+
+  // Use empty string for data to estimate gas when data array is empty,
+  // as required by geth. This is typically the case with ETHSend.
+  const std::string data = tx_data->data.empty() ? "" : ToHex(tx_data->data);
 
   if (!tx_ptr->gas_price()) {
     rpc_controller_->GetGasPrice(base::BindOnce(
         &EthTxController::OnGetGasPrice, weak_factory_.GetWeakPtr(), from,
-        tx_data->to, tx_data->value, ToHex(tx_data->data), gas_limit,
-        std::move(tx_ptr), std::move(callback)));
+        tx_data->to, tx_data->value, data, gas_limit, std::move(tx_ptr),
+        std::move(callback)));
   } else if (!tx_ptr->gas_limit()) {
     rpc_controller_->GetEstimateGas(
         from, tx_data->to, "" /* gas */, "" /* gas_price */, tx_data->value,
-        ToHex(tx_data->data),
+        data,
         base::BindOnce(&EthTxController::ContinueAddUnapprovedTransaction,
                        weak_factory_.GetWeakPtr(), from, std::move(tx_ptr),
                        std::move(callback)));
@@ -295,29 +288,22 @@ void EthTxController::AddUnapproved1559Transaction(
   }
 
   auto tx_ptr = std::make_unique<Eip1559Transaction>(*tx);
-
-  mojom::TransactionType tx_type;
-  if (!GetTransactionInfoFromData(ToHex(tx_ptr->data()), &tx_type, nullptr,
-                                  nullptr)) {
-    std::move(callback).Run(
-        false, "",
-        l10n_util::GetStringUTF8(
-            IDS_WALLET_ETH_SEND_TRANSACTION_GET_TX_TYPE_FAILED));
-    return;
-  }
-
   std::string gas_limit = tx_data->base_data->gas_limit;
+
+  // Use empty string for data to estimate gas when data array is empty,
+  // as required by geth. This is typically the case with ETHSend.
+  const std::string data =
+      tx_data->base_data->data.empty() ? "" : ToHex(tx_data->base_data->data);
 
   if (!tx_ptr->max_priority_fee_per_gas() || !tx_ptr->max_fee_per_gas()) {
     asset_ratio_controller_->GetGasOracle(base::BindOnce(
         &EthTxController::OnGetGasOracle, weak_factory_.GetWeakPtr(), from,
-        tx_data->base_data->to, tx_data->base_data->value,
-        ToHex(tx_data->base_data->data), gas_limit, std::move(tx_ptr),
-        std::move(callback)));
+        tx_data->base_data->to, tx_data->base_data->value, data, gas_limit,
+        std::move(tx_ptr), std::move(callback)));
   } else if (gas_limit.empty()) {
     rpc_controller_->GetEstimateGas(
         from, tx_data->base_data->to, "" /* gas */, "" /* gas_price */,
-        tx_data->base_data->value, ToHex(tx_data->base_data->data),
+        tx_data->base_data->value, data,
         base::BindOnce(&EthTxController::ContinueAddUnapprovedTransaction,
                        weak_factory_.GetWeakPtr(), from, std::move(tx_ptr),
                        std::move(callback)));

--- a/components/brave_wallet/browser/eth_tx_controller_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_controller_unittest.cc
@@ -555,8 +555,8 @@ TEST_F(EthTxControllerUnitTest,
   EXPECT_TRUE(HexValueToUint256("0x17fcf18321", &gas_price_value));
   EXPECT_EQ(tx_meta->tx->gas_price(), gas_price_value);
 
-  // Default value will be used.
-  EXPECT_EQ(tx_meta->tx->gas_limit(), kDefaultSendEthGasLimit);
+  // Gas limit obtained by querying eth_estimateGas.
+  EXPECT_EQ(tx_meta->tx->gas_limit(), 38404ULL);
 }
 
 TEST_F(EthTxControllerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
@@ -581,8 +581,8 @@ TEST_F(EthTxControllerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
   EXPECT_TRUE(HexValueToUint256("0x17fcf18321", &gas_price_value));
   EXPECT_EQ(tx_meta->tx->gas_price(), gas_price_value);
 
-  // Default value will be used.
-  EXPECT_EQ(tx_meta->tx->gas_limit(), kDefaultSendEthGasLimit);
+  // Gas limit obtained by querying eth_estimateGas.
+  EXPECT_EQ(tx_meta->tx->gas_limit(), 38404ULL);
 
   // Fail if transaction is not found.
   callback_called = false;
@@ -1116,8 +1116,8 @@ TEST_F(EthTxControllerUnitTest,
   auto tx_meta = eth_tx_controller_->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
 
-  // Default gas limit value will be used.
-  EXPECT_EQ(tx_meta->tx->gas_limit(), kDefaultSendEthGasLimit);
+  // Gas limit obtained by querying eth_estimateGas.
+  EXPECT_EQ(tx_meta->tx->gas_limit(), 38404ULL);
 
   // Gas fee and estimation should be filled by gas oracle.
   auto* tx1559 = reinterpret_cast<Eip1559Transaction*>(tx_meta->tx.get());
@@ -1180,8 +1180,8 @@ TEST_F(EthTxControllerUnitTest,
   auto tx_meta = eth_tx_controller_->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
 
-  // Default gas limit value will be used.
-  EXPECT_EQ(tx_meta->tx->gas_limit(), kDefaultSendEthGasLimit);
+  // Gas limit obtained by querying eth_estimateGas.
+  EXPECT_EQ(tx_meta->tx->gas_limit(), 38404ULL);
 
   auto* tx1559 = reinterpret_cast<Eip1559Transaction*>(tx_meta->tx.get());
   EXPECT_EQ(tx1559->max_priority_fee_per_gas(), uint256_t(2) * uint256_t(1e9));


### PR DESCRIPTION
There were two main issues with gas estimation for `ETHSend`:
1. We skipped querying `eth_estimateGas` for `ETHSend` transactions, and hardcoded the value `21000`. This doesn't work for simple transfers to smart contracts which are slightly heavier in gas. We still fallback to `21000` if the call to `eth_estimateGas` fails in the RPC controller.
2. We were using `0x0` for the `data` field while querying `eth_estimateGas`, which always returned the following error response:
    ```json
    {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32602,
        "message": "invalid argument 0: json: cannot unmarshal hex string of odd length into Go struct field TransactionArgs.data of type hexutil.Bytes"
      }
    }
    ```
    We never noticed this because we had a fallback to `21000` in place in case of an error. Turns out that geth wants us to either use `"0x"` or `""` or completely omit the `data` field from the request for ETH transfers.

Resolves https://github.com/brave/brave-browser/issues/19835.

| Uplifts | `1.34.x` (TBA) | `1.33.x` (TBA) | `1.32.x` (TBA) |
-|-|-|-

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo and test plan

👉  **Attn QA:** The test plan consists of the following cases:
1. Create an ETH transfer. Verify that the gas limit is 21000.
2. Create an ETH transfer to the address `0x92cd4bd69e305634a72fc95992ecfa0699c784e7`. Verify that the gas limit is `23276`. The recipient address came from a user report (see https://github.com/brave/brave-browser/issues/19835).
3. Create an ERC-20 token transfer. Verify that the gas limit is something large (typically more than `50000`).
4. Create a swap transaction. Verify that the gas limit is something close to `200000`.
5. Create a MATIC transfer on Polygon chain. Verify that the gas limit is `21000`.
6. Create a token transfer (ex, PoS USDC) on Polygon chain. Verify that the gas limit is something greater than `21000`.

https://user-images.githubusercontent.com/3684187/144551538-ba5620fe-c9f3-43ce-ba69-53d3e4b6744e.mov
