### PR TITLE
F/U for ms-edge protocol impls

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -520,8 +520,8 @@ source_set("ui") {
 
   if (is_win) {
     sources += [
-      "webui/new_tab_page/ms_edge_protocol_message_handler.cc",
-      "webui/new_tab_page/ms_edge_protocol_message_handler.h",
+      "webui/settings/ms_edge_protocol_message_handler.cc",
+      "webui/settings/ms_edge_protocol_message_handler.h",
     ]
   }
 

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -48,7 +48,7 @@
 #endif
 
 #if defined(OS_WIN)
-#include "brave/browser/ui/webui/new_tab_page/ms_edge_protocol_message_handler.h"
+#include "brave/browser/ui/webui/settings/ms_edge_protocol_message_handler.h"
 #endif
 
 using ntp_background_images::ViewCounterServiceFactory;

--- a/browser/ui/webui/settings/ms_edge_protocol_message_handler.cc
+++ b/browser/ui/webui/settings/ms_edge_protocol_message_handler.cc
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "brave/browser/ui/webui/new_tab_page/ms_edge_protocol_message_handler.h"
+#include "brave/browser/ui/webui/settings/ms_edge_protocol_message_handler.h"
 
 #include "base/bind.h"
 #include "base/command_line.h"

--- a/browser/ui/webui/settings/ms_edge_protocol_message_handler.cc
+++ b/browser/ui/webui/settings/ms_edge_protocol_message_handler.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/webui/settings/ms_edge_protocol_message_handler.h"
 
+#include <shlobj.h>
+
 #include "base/bind.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
@@ -126,6 +128,8 @@ void MSEdgeProtocolMessageHandler::OnSetDefaultProtocolHandler(bool success) {
     FireWebUIListener("notify-ms-edge-protocol-default-handler-status",
                       base::Value(success));
   }
+
+  ::SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
 }
 
 void MSEdgeProtocolMessageHandler::LaunchSystemDialog() {

--- a/browser/ui/webui/settings/ms_edge_protocol_message_handler.h
+++ b/browser/ui/webui/settings/ms_edge_protocol_message_handler.h
@@ -3,8 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifndef BRAVE_BROWSER_UI_WEBUI_NEW_TAB_PAGE_MS_EDGE_PROTOCOL_MESSAGE_HANDLER_H_
-#define BRAVE_BROWSER_UI_WEBUI_NEW_TAB_PAGE_MS_EDGE_PROTOCOL_MESSAGE_HANDLER_H_
+#ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_MS_EDGE_PROTOCOL_MESSAGE_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_SETTINGS_MS_EDGE_PROTOCOL_MESSAGE_HANDLER_H_
 
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
@@ -43,4 +43,4 @@ class MSEdgeProtocolMessageHandler : public content::WebUIMessageHandler {
   base::WeakPtrFactory<MSEdgeProtocolMessageHandler> weak_factory_{this};
 };
 
-#endif  // BRAVE_BROWSER_UI_WEBUI_NEW_TAB_PAGE_MS_EDGE_PROTOCOL_MESSAGE_HANDLER_H_
+#endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_MS_EDGE_PROTOCOL_MESSAGE_HANDLER_H_

--- a/patches/chrome-browser-shell_integration.h.patch
+++ b/patches/chrome-browser-shell_integration.h.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/shell_integration.h b/chrome/browser/shell_integration.h
-index 29e98f5b2839a44a488d6baec756b660935302dd..b761dea9fbb8f0009976997a41d9a10b2aaf3df1 100644
+index 29e98f5b2839a44a488d6baec756b660935302dd..d642af75e8a79972a2b2a07cdd60cc97451176d7 100644
 --- a/chrome/browser/shell_integration.h
 +++ b/chrome/browser/shell_integration.h
-@@ -235,6 +235,7 @@ class DefaultBrowserWorker : public DefaultWebClientWorker {
+@@ -232,6 +232,7 @@ class DefaultBrowserWorker : public DefaultWebClientWorker {
+   DefaultBrowserWorker(const DefaultBrowserWorker&) = delete;
+   DefaultBrowserWorker& operator=(const DefaultBrowserWorker&) = delete;
+ 
++  BRAVE_DEFAULT_BROWSER_WORKER_H
   protected:
    ~DefaultBrowserWorker() override;
  
-+  BRAVE_DEFAULT_BROWSER_WORKER_H
-  private:
-   // Check if Chrome is the default browser.
-   DefaultWebClientState CheckIsDefaultImpl() override;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/19922

* Updated patch file BRAVE_DEFAULT_BROWSER_WORKER_H should be in public section.
* Moved ms_edge_protocol_message_handler.cc to browser/ui/webui/settings (don't need QA)
* Notified default protocol change to system - W/o notifying, control panel is not refreshed whe when it's already opened
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open control panel and go to ms-edge protocol option
2. Launch browser and set this as a default app for ms-edge protocol
3. Check control panel is refreshed