### PR TITLE
Add support for Xcode 13.1 and 13.2 when building arm64 sim slices

### DIFF
--- a/patches/build-config-ios-BUILD.gn.patch
+++ b/patches/build-config-ios-BUILD.gn.patch
@@ -1,0 +1,14 @@
+diff --git a/build/config/ios/BUILD.gn b/build/config/ios/BUILD.gn
+index 83fb0a535279981832b5dcae00b0e931d1df48ba..758e22f3b1a5ea465f784c9f34f2f9a798e7c8fb 100644
+--- a/build/config/ios/BUILD.gn
++++ b/build/config/ios/BUILD.gn
+@@ -128,7 +128,8 @@ config("runtime_library") {
+   # libclang_rt.iossim.a for arm64 simulator builds. This can be
+   # removed when an arm64 slice is added to upstream Clang.
+   if (target_environment == "simulator" && current_cpu == "arm64") {
+-    assert(xcode_version_int == 1300)
++    assert(xcode_version_int == 1300 || xcode_version_int == 1310 ||
++           xcode_version_int == 1320)
+     ldflags += [
+       "-lSystem",
+       rebase_path("$ios_toolchains_path/usr/lib/clang/13.0.0/" +


### PR DESCRIPTION
Adds a patch to `build/config/ios/BUILD.gn` which patches the assertion to accept Xcode 13.1 and 13.2 as well. I have verified that both these Xcodes have the same folders (`/usr/local/clang/13.0.0/`) and is likely the actual upstream change that will come as it is done the same way below for the catalyst builds: https://source.chromium.org/chromium/chromium/src/+/main:build/config/ios/BUILD.gn;l=144

`CI/skip` added because PR CI does not build arm64 slice, will verify with @mihaiplesa that the branch builds an arm64 slice (tested locally and it does work)

Resolves https://github.com/brave/brave-browser/issues/19942

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

