### PR TITLE
Upgrade from Chromium 96.0.4664.55 to Chromium 96.0.4664.93 (uplift to 1.33.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "96.0.4664.55",
+        "tag": "96.0.4664.93",
         "repository": {
           "url": "https://github.com/chromium/chromium"
         }

--- a/patches/chrome-VERSION.patch
+++ b/patches/chrome-VERSION.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/VERSION b/chrome/VERSION
-index f577382057389a09526d41cb7a293579fc28362f..855247cd8745ccf31b7ef52ba4209acfa5d5d356 100644
+index 79b751e02c1ede4700046d72adf2f46ab2feaab3..78eea3757e3c4ff41b86b413bf7dbba0defe202c 100644
 --- a/chrome/VERSION
 +++ b/chrome/VERSION
 @@ -1,4 +1,4 @@
  MAJOR=96
 -MINOR=0
 -BUILD=4664
--PATCH=55
+-PATCH=93
 +MINOR=1
 +BUILD=33
 +PATCH=100

--- a/patches/chrome-browser-extensions-extension_tab_util.cc.patch
+++ b/patches/chrome-browser-extensions-extension_tab_util.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/extension_tab_util.cc b/chrome/browser/extensions/extension_tab_util.cc
-index b5a21c7807a64b02563444fb38b648086409c959..67279645ff3bf11ee138e4c07a7e54ad9d5c8990 100644
+index bd054c81acf8483ceb921ad4d3c9891a90e64832..bfeb1682c4561671b088f3b2e50f0f8cb9f70294 100644
 --- a/chrome/browser/extensions/extension_tab_util.cc
 +++ b/chrome/browser/extensions/extension_tab_util.cc
 @@ -795,6 +795,7 @@ bool ExtensionTabUtil::IsKillURL(const GURL& url) {


### PR DESCRIPTION
Fixes brave/brave-browser#19950
Uplift of #11457

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.