### PR TITLE
Enables wallet on Android by default, disables Dapps(uplift to 1.33.x)

### DIFF
--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -88,10 +88,14 @@ void BraveRendererUpdater::UpdateRenderer(
       brave_wallet_web3_provider_.GetValue());
 
   bool brave_use_native_wallet =
+#if defined(OS_ANDROID)
+      false;
+#else
       (default_wallet ==
            brave_wallet::mojom::DefaultWallet::BraveWalletPreferExtension ||
        default_wallet == brave_wallet::mojom::DefaultWallet::BraveWallet) &&
       is_wallet_allowed_for_context_;
+#endif
 
   bool allow_overwrite_window_ethereum =
       default_wallet ==

--- a/components/brave_wallet/common/features.cc
+++ b/components/brave_wallet/common/features.cc
@@ -10,14 +10,8 @@
 namespace brave_wallet {
 namespace features {
 
-const base::Feature kNativeBraveWalletFeature{
-  "NativeBraveWallet",
-#if !defined(OS_ANDROID)
-      base::FEATURE_ENABLED_BY_DEFAULT
-#else
-      base::FEATURE_DISABLED_BY_DEFAULT
-#endif
-};
+const base::Feature kNativeBraveWalletFeature{"NativeBraveWallet",
+                                              base::FEATURE_ENABLED_BY_DEFAULT};
 
 }  // namespace features
 }  // namespace brave_wallet


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/19702
Uplift of https://github.com/brave/brave-core/pull/11263