### PR TITLE
Adds check on Activity state to show BiometricPrompt and also disables it on restore screen (uplift to 1.34.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding_fragments/UnlockWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding_fragments/UnlockWalletFragment.java
@@ -90,7 +90,12 @@ public class UnlockWalletFragment extends CryptoOnboardingFragment {
                 onNextPage.gotoRestorePage();
             }
         });
-        checkOnBiometric();
+        if (onNextPage != null && onNextPage.showBiometricPrompt()) {
+            checkOnBiometric();
+        } else if (onNextPage != null) {
+            onNextPage.showBiometricPrompt(true);
+            showPasswordRelatedControls();
+        }
     }
 
     private void checkOnBiometric() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/listeners/OnNextPage.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/listeners/OnNextPage.java
@@ -9,4 +9,6 @@ public interface OnNextPage {
     void gotoNextPage(boolean finishOnboarding);
     void gotoOnboardingPage();
     void gotoRestorePage();
+    boolean showBiometricPrompt();
+    void showBiometricPrompt(boolean show);
 }


### PR DESCRIPTION
Uplift of #11484
Resolves https://github.com/brave/brave-browser/issues/19972
Resolves https://github.com/brave/brave-browser/issues/19965

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.