### PR TITLE
Fixes a crash that was introduced with a custom token, when you open asset screen (uplift to 1.34.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletCoinAdapter.java
@@ -163,7 +163,8 @@ public class WalletCoinAdapter extends RecyclerView.Adapter<WalletCoinAdapter.Vi
         }
 
         if (mType != AdapterType.ACCOUNTS_LIST) {
-            if (!walletListItemModel.getErcToken().logo.isEmpty()) {
+            if (walletListItemModel.getErcToken() == null
+                    || !walletListItemModel.getErcToken().logo.isEmpty()) {
                 Utils.setBitmapResource(mExecutor, mHandler, context,
                         walletListItemModel.getIconPath(), walletListItemModel.getIcon(),
                         holder.iconImg, null, true);


### PR DESCRIPTION
Uplift of #11501
Resolves https://github.com/brave/brave-browser/issues/19989

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.