### PR TITLE
Disable pending contributions for external wallet mismatches

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_external_wallet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_external_wallet.cc
@@ -154,6 +154,15 @@ void ContributionExternalWallet::OnServerPublisherInfo(
 
     BLOG(1, "Publisher not verified");
 
+    // TODO(zenparsing): Adding a record to the pending contribution table at
+    // this point can lead to an (async) infinite loop if pending contributions
+    // are currently being flushed. In `unverified.cc`, the pending contribution
+    // processor processes the first available pending record and then sets a
+    // timer to process the next one. If another record is added before that
+    // timer expires, it can cause the flushing operation to continue
+    // indefinitely.
+
+    /*
     auto save_callback =
         std::bind(&ContributionExternalWallet::OnSavePendingContribution,
             this,
@@ -170,6 +179,8 @@ void ContributionExternalWallet::OnServerPublisherInfo(
     ledger_->database()->SavePendingContribution(
         std::move(list),
         save_callback);
+    */
+
     callback(type::Result::LEDGER_ERROR);
     return;
   }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19996

This change temporarily disables pending tips for the "cross-custodial" wallet case, where the creator is verified with a different wallet provider from the user.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Given that the user is verified with wallet provider A
- When the user sends a one-time tip to a creator that is verified with provider B
- Then the "pending tips" list should be empty.

The pending tips list can be viewed at `brave://rewards` by clicking the "See all" link in the rewards summary. If there are no pending tips, then this link will not be available.

Note that pending tips should still work when the creator is not verified.