### PR TITLE
Do not update action visibility if previous popup owner is null (uplift to 1.34.x)

### DIFF
--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -449,13 +449,11 @@ void BraveActionsContainer::SetPopupOwner(
     DCHECK(!popup_owner_);
     popup_owner_ = popup_owner;
     UpdateActionVisibility(popup_owner->GetId());
-    return;
+  } else if (popup_owner_) {
+    auto* previous_owner = popup_owner_;
+    popup_owner_ = nullptr;
+    UpdateActionVisibility(previous_owner->GetId());
   }
-
-  auto* previous_owner = popup_owner_;
-  DCHECK(previous_owner);
-  popup_owner_ = nullptr;
-  UpdateActionVisibility(previous_owner->GetId());
 }
 
 void BraveActionsContainer::HideActivePopup() {


### PR DESCRIPTION
Uplift of #11462
Resolves https://github.com/brave/brave-browser/issues/19958

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.