### PR TITLE
Use provider name in wallet disconnect string

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -170,8 +170,13 @@
     "description": ""
   },
   "walletDisconnectLink": {
-    "message": "Disconnect from Brave Rewards",
-    "description": ""
+    "message": "Disconnect from $provider$",
+    "description": "",
+    "placeholders": {
+      "provider": {
+        "content": "$1"
+      }
+    }
   },
   "walletEstimatedEarnings": {
     "message": "Estimated Earnings",

--- a/components/brave_rewards/resources/shared/components/wallet_card/external_wallet_bubble.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/external_wallet_bubble.tsx
@@ -107,7 +107,7 @@ export function ExternalWalletBubble (props: Props) {
           <style.link>
             <style.linkMarker />
             <button onClick={actionHandler('disconnect')}>
-              {getString('walletDisconnectLink')}
+              {formatMessage(getString('walletDisconnectLink'), [providerName])}
             </button>
           </style.link>
         </style.links>

--- a/components/brave_rewards/resources/shared/components/wallet_card/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/shared/components/wallet_card/stories/locale_strings.ts
@@ -5,7 +5,7 @@ export const localeStrings = {
   walletCompleteVerificationLink: 'Go to $1 to complete verification',
   walletCompleteVerificationText: 'Please complete identity verification in order to start receiving rewards.',
   walletDisconnected: 'Disconnected',
-  walletDisconnectLink: 'Disconnect from Brave Rewards',
+  walletDisconnectLink: 'Disconnect from $1',
   walletEstimatedEarnings: 'Estimated Earnings',
   walletLogIntoYourAccount: 'Log into your $1 account',
   walletMonthlyTips: 'Monthly Tips',

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -19,7 +19,7 @@
     Disconnected
   </message>
   <message name="IDS_REWARDS_WALLET_DISCONNECT_LINK" desc="">
-    Disconnect from Brave Rewards
+    Disconnect from <ph name="PROVIDER">$1<ex>Uphold</ex></ph>
   </message>
   <message name="IDS_REWARDS_WALLET_ESTIMATED_EARNINGS" desc="">
     Estimated Earnings


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19626

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Clean profile
- Enable Rewards
- Verify with Uphold
- Verify that "My Wallet" dropdown in wallet panel has entry that says "Disconnect from Uphold"
- Verify same thing in Rewards panel