### PR TITLE
Remove ifdef guards to restore net log events.

### DIFF
--- a/chromium_src/net/log/net_log_event_type_list.h
+++ b/chromium_src/net/log/net_log_event_type_list.h
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef BRAVE_CHROMIUM_SRC_NET_LOG_NET_LOG_EVENT_TYPE_LIST_H_
-#define BRAVE_CHROMIUM_SRC_NET_LOG_NET_LOG_EVENT_TYPE_LIST_H_
+// NOTE: No header guards are used, since this file is intended to be expanded
+// directly into net_log.h. DO NOT include this file anywhere else.
+// The following line silences a presubmit warning that would otherwise be
+// triggered by this:
+// no-include-guard-because-multiply-included
+// NOLINT(build/header_guard)
 
 #include "src/net/log/net_log_event_type_list.h"
 
@@ -12,5 +16,3 @@ EVENT_TYPE(SOCKS5_AUTH_WRITE)
 
 // The time spent waiting for the authentication response from the SOCKS server
 EVENT_TYPE(SOCKS5_AUTH_READ)
-
-#endif  // BRAVE_CHROMIUM_SRC_NET_LOG_NET_LOG_EVENT_TYPE_LIST_H_


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Fix net log errors DCHECK caused by fixing lint errors in https://github.com/brave/brave-core/pull/11126/commits/84dc6e9fafc959fc41174dbd7ddd022d89c12159
The header shouldn't have `#ifdef` guards, I've copied a comment with `NOLINT` pragmas from the original file to not trigger linter.

```
Received fatal exception EXCEPTION_BREAKPOINT
Backtrace:
        base::debug::BreakDebuggerAsyncSafe [0x00007FFA2AF20F8D+13] (D:\brave\1\src\base\debug\debugger_win.cc:21)
        logging::LogMessage::~LogMessage [0x00007FFA2AE187C4+1028] (D:\brave\1\src\base\logging.cc:885)
        logging::LogMessage::~LogMessage [0x00007FFA2AE197A0+16] (D:\brave\1\src\base\logging.cc:580)
        net::NetLog::GetEventTypesAsValue [0x00007FFA1EE970C9+169] (D:\brave\1\src\net\log\net_log.cc:201)
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

