### PR TITLE
add title to speedreader documents

### DIFF
--- a/components/speedreader/BUILD.gn
+++ b/components/speedreader/BUILD.gn
@@ -52,6 +52,7 @@ static_library("speedreader") {
     "//components/prefs:prefs",
     "//components/sessions:sessions",
     "//content/public/browser",
+    "//crypto",
     "//services/network/public/cpp",
     "//services/network/public/mojom",
     "//third_party/blink/public/common",

--- a/components/speedreader/DEPS
+++ b/components/speedreader/DEPS
@@ -3,6 +3,7 @@ include_rules = [
   "+components/prefs",
   "+components/sessions/content",
   "+content/public/browser",
+  "+crypto",
   "+services/network/public",
   "+services/network/public/cpp",
   "+services/network/public/mojom",

--- a/components/speedreader/rust/lib/src/readability/src/extractor.rs
+++ b/components/speedreader/rust/lib/src/readability/src/extractor.rs
@@ -254,6 +254,10 @@ pub fn extract_dom<S: ::std::hash::BuildHasher>(
         let charset_blob = format!("<meta charset=\"{}\"/>", charset);
         content = charset_blob + &content;
     }
+    if !meta.title.is_empty() {
+        let title_blob = format!("<title>{}</title>", &meta.title);
+        content = title_blob + &content;
+    }
     Ok(Product { meta, content })
 }
 

--- a/components/speedreader/speedreader_rewriter_service.cc
+++ b/components/speedreader/speedreader_rewriter_service.cc
@@ -13,7 +13,6 @@
 #include "base/feature_list.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"
-#include "base/strings/string_piece.h"
 #include "base/strings/string_util.h"
 #include "base/task/post_task.h"
 #include "base/task/thread_pool.h"
@@ -41,12 +40,12 @@ std::string GetDistilledPageStylesheet(const base::FilePath& stylesheet_path) {
   }
 
   const std::string style_hash = crypto::SHA256HashString(stylesheet);
-  const std::string style_hash_b64 = base::Base64Encode(base::as_bytes(
-    base::make_span(style_hash)));
+  const std::string style_hash_b64 =
+      base::Base64Encode(base::as_bytes(base::make_span(style_hash)));
 
   return "<meta http-equiv=\"Content-Security-Policy\" content=\""
-            "script-src 'none'; style-src 'sha256-" + style_hash_b64 + "'\">\n"
-         "<style id=\"brave_speedreader_style\">" + stylesheet + "</style>";
+      "script-src 'none'; style-src 'sha256-" + style_hash_b64 + "'\">\n"
+      "<style id=\"brave_speedreader_style\">" + stylesheet + "</style>";
 }
 
 }  // namespace

--- a/components/speedreader/speedreader_rewriter_service.cc
+++ b/components/speedreader/speedreader_rewriter_service.cc
@@ -29,14 +29,17 @@ namespace speedreader {
 
 namespace {
 
-std::string WrapStylesheetWithCSP(const std::string &stylesheet) {
+std::string WrapStylesheetWithCSP(const std::string& stylesheet) {
   const std::string style_hash = crypto::SHA256HashString(stylesheet);
   const std::string style_hash_b64 =
       base::Base64Encode(base::as_bytes(base::make_span(style_hash)));
 
   return "<meta http-equiv=\"Content-Security-Policy\" content=\""
-      "script-src 'none'; style-src 'sha256-" + style_hash_b64 + "'\">\n"
-      "<style id=\"brave_speedreader_style\">" + stylesheet + "</style>";
+         "script-src 'none'; style-src 'sha256-" +
+         style_hash_b64 +
+         "'\">\n"
+         "<style id=\"brave_speedreader_style\">" +
+         stylesheet + "</style>";
 }
 
 std::string GetDistilledPageStylesheet(const base::FilePath& stylesheet_path) {


### PR DESCRIPTION
This is a very hacky, but i think correct, way of adding a title element to speedreader documents.  It does so through JS injection, which sidesteps all the tricky speedreader bits 

fixes brave/brave-browser#19182