### PR TITLE
Use Contract Address for Ethereum Chain Prices

### DIFF
--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -31,6 +31,7 @@ import { NewUnapprovedTxAdded } from '../../common/constants/action_types'
 import { fetchSwapQuoteFactory } from '../../common/async/handlers'
 import { Store } from '../../common/async/types'
 import { HardwareWalletAccount } from 'components/brave_wallet_ui/common/hardware/types'
+import { GetTokenParam } from '../../utils/api-utils'
 
 const handler = new AsyncActionHandler()
 
@@ -86,10 +87,11 @@ handler.on(WalletPageActions.selectAsset.getType(), async (store: Store, payload
   const walletState = getWalletState(store)
   const defaultFiat = walletState.defaultCurrencies.fiat.toLowerCase()
   const defaultCrypto = walletState.defaultCurrencies.crypto.toLowerCase()
+  const selectedNetwork = walletState.selectedNetwork
   if (payload.asset) {
-    const selectedAssetSymbol = payload.asset.symbol.toLowerCase()
-    const defaultPrices = await assetPriceController.getPrice([selectedAssetSymbol], [defaultFiat, defaultCrypto], payload.timeFrame)
-    const priceHistory = await assetPriceController.getPriceHistory(selectedAssetSymbol, defaultFiat, payload.timeFrame)
+    const selectedAsset = payload.asset
+    const defaultPrices = await assetPriceController.getPrice([GetTokenParam(selectedNetwork, selectedAsset)], [defaultFiat, defaultCrypto], payload.timeFrame)
+    const priceHistory = await assetPriceController.getPriceHistory(GetTokenParam(selectedNetwork, selectedAsset), defaultFiat, payload.timeFrame)
     store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: priceHistory, defaultFiatPrice: defaultPrices.values[0], defaultCryptoPrice: defaultPrices.values[1], timeFrame: payload.timeFrame }))
   } else {
     store.dispatch(WalletPageActions.updatePriceInfo({ priceHistory: undefined, defaultFiatPrice: undefined, defaultCryptoPrice: undefined, timeFrame: payload.timeFrame }))

--- a/components/brave_wallet_ui/utils/api-utils.test.ts
+++ b/components/brave_wallet_ui/utils/api-utils.test.ts
@@ -1,0 +1,12 @@
+import { GetTokenParam } from './api-utils'
+import { mockNetworks } from '../stories/mock-data/mock-networks'
+import { AccountAssetOptions } from '../options/asset-options'
+
+describe('Check token param', () => {
+  test('Value should return contract address', () => {
+    expect(GetTokenParam(mockNetworks[0], AccountAssetOptions[1].asset)).toEqual('0x0D8775F648430679A709E98d2b0Cb6250d2887EF')
+  })
+  test('Value should return symbol', () => {
+    expect(GetTokenParam(mockNetworks[1], AccountAssetOptions[1].asset)).toEqual('bat')
+  })
+})

--- a/components/brave_wallet_ui/utils/api-utils.ts
+++ b/components/brave_wallet_ui/utils/api-utils.ts
@@ -1,0 +1,15 @@
+import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { EthereumChain, ERCToken } from '../constants/types'
+import { ETH } from '../options/asset-options'
+
+export const GetTokenParam = (selectedNetwork: EthereumChain, token: ERCToken): string => {
+  const isEthereumNetwork = selectedNetwork.chainId === BraveWallet.MAINNET_CHAIN_ID
+
+  if (!isEthereumNetwork) {
+    return token.symbol.toLowerCase()
+  }
+
+  return token.symbol.toLowerCase() === ETH.asset.symbol.toLowerCase()
+    ? token.symbol.toLowerCase()
+    : token.contractAddress
+}


### PR DESCRIPTION
## Description 
We now will pass a tokens `contractAddress` as a param in the `getPrice` and `getPriceHistory` methods if the `chainId` is `0x1` (Ethereum Main Net) else we will pass the tokens `symbol` since `CoinGecko` api does not support lookup by contract address for other networks.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/19574>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A
