### PR TITLE
Corrects wallet creation on Android and let user go to the next page only after the wallet has been fully created (uplift to 1.34.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding_fragments/SecurePasswordFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding_fragments/SecurePasswordFragment.java
@@ -132,14 +132,12 @@ public class SecurePasswordFragment extends CryptoOnboardingFragment {
     private void goToTheNextPage(String passwordInput) {
         KeyringController keyringController = getKeyringController();
         if (keyringController != null) {
-            keyringController.createWallet(passwordInput,
-                    recoveryPhrases
-                    -> {
-                            // Do nothing with recovery phrase for now
-                    });
+            keyringController.createWallet(passwordInput, recoveryPhrases -> {
+                // Go to the next page after wallet creation is done
+                Utils.setCryptoOnboarding(false);
+                onNextPage.gotoNextPage(false);
+            });
         }
-        Utils.setCryptoOnboarding(false);
-        onNextPage.gotoNextPage(false);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.P)


### PR DESCRIPTION
Uplift of #11563
Resolves https://github.com/brave/brave-browser/issues/20039

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.