### PR TITLE
Implement provider methods: wallet_getPermissions, wallet_requestPermissions

### DIFF
--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
@@ -40,7 +40,8 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate,
   GURL GetOrigin() const override;
   void RequestEthereumPermissions(
       RequestEthereumPermissionsCallback callback) override;
-  void GetAllowedAccounts(GetAllowedAccountsCallback callback) override;
+  void GetAllowedAccounts(bool include_accounts_when_locked,
+                          GetAllowedAccountsCallback callback) override;
 
  private:
   void ContinueRequestEthereumPermissions(

--- a/components/brave_wallet/browser/brave_wallet_provider_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_delegate.h
@@ -36,7 +36,8 @@ class BraveWalletProviderDelegate {
   virtual GURL GetOrigin() const = 0;
   virtual void RequestEthereumPermissions(
       RequestEthereumPermissionsCallback callback) = 0;
-  virtual void GetAllowedAccounts(GetAllowedAccountsCallback callback) = 0;
+  virtual void GetAllowedAccounts(bool include_accounts_when_locked,
+                                  GetAllowedAccountsCallback callback) = 0;
 };
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -210,6 +210,7 @@ void BraveWalletProviderImpl::AddAndApproveTransaction(
   }
 
   GetAllowedAccounts(
+      false,
       base::BindOnce(&BraveWalletProviderImpl::ContinueAddAndApproveTransaction,
                      weak_factory_.GetWeakPtr(), std::move(callback),
                      std::move(tx_data), from));
@@ -275,6 +276,7 @@ void BraveWalletProviderImpl::AddAndApprove1559Transaction(
         from));
   } else {
     GetAllowedAccounts(
+        false,
         base::BindOnce(&BraveWalletProviderImpl::
                            ContinueAddAndApprove1559TransactionWithAccounts,
                        weak_factory_.GetWeakPtr(), std::move(callback),
@@ -289,6 +291,7 @@ void BraveWalletProviderImpl::ContinueAddAndApprove1559Transaction(
     const std::string& chain_id) {
   tx_data->chain_id = chain_id;
   GetAllowedAccounts(
+      false,
       base::BindOnce(&BraveWalletProviderImpl::
                          ContinueAddAndApprove1559TransactionWithAccounts,
                      weak_factory_.GetWeakPtr(), std::move(callback),
@@ -359,10 +362,12 @@ void BraveWalletProviderImpl::SignMessage(const std::string& address,
 
   // Convert to checksum address
   auto checksum_address = EthAddress::FromHex(address);
-  GetAllowedAccounts(base::BindOnce(
-      &BraveWalletProviderImpl::ContinueSignMessage, weak_factory_.GetWeakPtr(),
-      checksum_address.ToChecksumAddress(), message_str,
-      std::move(message_bytes), std::move(callback), false));
+  GetAllowedAccounts(
+      false,
+      base::BindOnce(&BraveWalletProviderImpl::ContinueSignMessage,
+                     weak_factory_.GetWeakPtr(),
+                     checksum_address.ToChecksumAddress(), message_str,
+                     std::move(message_bytes), std::move(callback), false));
 }
 
 void BraveWalletProviderImpl::SignTypedMessage(
@@ -397,10 +402,11 @@ void BraveWalletProviderImpl::SignTypedMessage(
 
   // Convert to checksum address
   auto checksum_address = EthAddress::FromHex(address);
-  GetAllowedAccounts(base::BindOnce(
-      &BraveWalletProviderImpl::ContinueSignMessage, weak_factory_.GetWeakPtr(),
-      checksum_address.ToChecksumAddress(), message, std::move(eip712_hash),
-      std::move(callback), true));
+  GetAllowedAccounts(
+      false, base::BindOnce(&BraveWalletProviderImpl::ContinueSignMessage,
+                            weak_factory_.GetWeakPtr(),
+                            checksum_address.ToChecksumAddress(), message,
+                            std::move(eip712_hash), std::move(callback), true));
 }
 
 void BraveWalletProviderImpl::ContinueSignMessage(
@@ -563,9 +569,11 @@ void BraveWalletProviderImpl::OnRequestEthereumPermissions(
 }
 
 void BraveWalletProviderImpl::GetAllowedAccounts(
+    bool include_accounts_when_locked,
     GetAllowedAccountsCallback callback) {
   DCHECK(delegate_);
   delegate_->GetAllowedAccounts(
+      include_accounts_when_locked,
       base::BindOnce(&BraveWalletProviderImpl::OnGetAllowedAccounts,
                      weak_factory_.GetWeakPtr(), std::move(callback)));
 }
@@ -580,8 +588,8 @@ void BraveWalletProviderImpl::OnGetAllowedAccounts(
 
 void BraveWalletProviderImpl::UpdateKnownAccounts() {
   GetAllowedAccounts(
-      base::BindOnce(&BraveWalletProviderImpl::OnUpdateKnownAccounts,
-                     weak_factory_.GetWeakPtr()));
+      false, base::BindOnce(&BraveWalletProviderImpl::OnUpdateKnownAccounts,
+                            weak_factory_.GetWeakPtr()));
 }
 
 void BraveWalletProviderImpl::OnUpdateKnownAccounts(

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -58,7 +58,8 @@ class BraveWalletProviderImpl final
                                     mojom::ProviderError error,
                                     const std::string& error_message);
   void GetChainId(GetChainIdCallback callback) override;
-  void GetAllowedAccounts(GetAllowedAccountsCallback callback) override;
+  void GetAllowedAccounts(bool include_accounts_when_locked,
+                          GetAllowedAccountsCallback callback) override;
   void AddEthereumChain(const std::string& json_payload,
                         AddEthereumChainCallback callback) override;
   void SwitchEthereumChain(const std::string& chain_id,

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -82,7 +82,7 @@ interface BraveWalletProvider {
                                         KeyringInfo keyring_info);
 
   // Used for eth_accounts method requests and as part of RequestEthereumPermissions
-  GetAllowedAccounts() => (array<string> accounts, ProviderError error, string message);
+  GetAllowedAccounts(bool include_accounts_when_locked) => (array<string> accounts, ProviderError error, string message);
 
   // Determines if the keyring is locked.
   IsLocked() => (bool isLocked);

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -486,7 +486,26 @@ bool ParseWalletWatchAssetParams(const std::string& json,
   *token =
       mojom::ERCToken::New(eth_addr.ToChecksumAddress(), *symbol /* name */,
                            logo, true, false, *symbol, decimals, true, "");
+  return true;
+}
 
+// Parses param request objects from
+// https://eips.ethereum.org/EIPS/eip-2255
+bool ParseRequestPermissionsParams(
+    const std::string& json,
+    std::vector<std::string>* restricted_methods) {
+  // [{
+  //   "eth_accounts": {}
+  // }]
+  if (!restricted_methods)
+    return false;
+  restricted_methods->clear();
+  auto param_obj = GetObjectFromParamsList(json);
+  if (!param_obj)
+    return false;
+  for (auto prop : param_obj->DictItems()) {
+    restricted_methods->push_back(prop.first);
+  }
   return true;
 }
 

--- a/components/brave_wallet/common/eth_request_helper.h
+++ b/components/brave_wallet/common/eth_request_helper.h
@@ -51,6 +51,9 @@ bool ParseSwitchEthereumChainParams(const std::string& json,
 bool ParseWalletWatchAssetParams(const std::string& json,
                                  mojom::ERCTokenPtr* token,
                                  std::string* error_message);
+bool ParseRequestPermissionsParams(
+    const std::string& json,
+    std::vector<std::string>* restricted_methods);
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -834,4 +834,50 @@ TEST(EthRequestHelperUnitTest, ParseWalletWatchAssetParams) {
   EXPECT_TRUE(error_message.empty());
 }
 
+TEST(EthResponseHelperUnitTest, ParseRequestPermissionsParams) {
+  std::vector<std::string> restricted_methods;
+
+  std::string json =
+      R"({
+        "method": "wallet_requestPermissions",
+        "params": [{
+          "eth_accounts": {},
+        }]
+      })";
+  EXPECT_TRUE(ParseRequestPermissionsParams(json, &restricted_methods));
+  EXPECT_EQ(restricted_methods, (std::vector<std::string>{"eth_accounts"}));
+
+  json =
+      R"({
+        "method": "wallet_requestPermissions",
+        "params": [{
+          "eth_accounts": {},
+          "eth_someFutureMethod": {}
+        }]
+      })";
+  EXPECT_TRUE(ParseRequestPermissionsParams(json, &restricted_methods));
+  EXPECT_EQ(restricted_methods,
+            (std::vector<std::string>{"eth_accounts", "eth_someFutureMethod"}));
+
+  json =
+      R"({
+        "method": "wallet_requestPermissions",
+        "params": [{}]
+      })";
+  EXPECT_TRUE(ParseRequestPermissionsParams(json, &restricted_methods));
+  EXPECT_EQ(restricted_methods, (std::vector<std::string>()));
+
+  EXPECT_FALSE(ParseRequestPermissionsParams(json, nullptr));
+  EXPECT_FALSE(ParseRequestPermissionsParams("", &restricted_methods));
+  EXPECT_FALSE(ParseRequestPermissionsParams("\"42\"", &restricted_methods));
+  EXPECT_FALSE(ParseRequestPermissionsParams("{}", &restricted_methods));
+  EXPECT_FALSE(ParseRequestPermissionsParams("[]", &restricted_methods));
+  EXPECT_FALSE(
+      ParseRequestPermissionsParams("{ params: 5 }", &restricted_methods));
+  EXPECT_FALSE(
+      ParseRequestPermissionsParams("{ params: [5] }", &restricted_methods));
+  EXPECT_FALSE(
+      ParseRequestPermissionsParams("{ params: [] }", &restricted_methods));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/value_conversion_utils.h
+++ b/components/brave_wallet/common/value_conversion_utils.h
@@ -6,15 +6,22 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_VALUE_CONVERSION_UTILS_H_
 #define BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_VALUE_CONVERSION_UTILS_H_
 
+#include <string>
+#include <vector>
+
 #include "base/values.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
+#include "url/origin.h"
 
 namespace brave_wallet {
 
 base::Value EthereumChainToValue(const mojom::EthereumChainPtr& chain);
 absl::optional<mojom::EthereumChain> ValueToEthereumChain(
     const base::Value& value);
+base::ListValue PermissionRequestResponseToValue(
+    const url::Origin& origin,
+    const std::vector<std::string> accounts);
 
 mojom::ERCTokenPtr ValueToERCToken(const base::Value& value);
 

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -34,6 +34,8 @@ constexpr char kMethod[] = "method";
 constexpr char kParams[] = "params";
 constexpr char kAddEthereumChainMethod[] = "wallet_addEthereumChain";
 constexpr char kSwitchEthereumChainMethod[] = "wallet_switchEthereumChain";
+constexpr char kRequestPermissionsMethod[] = "wallet_requestPermissions";
+constexpr char kGetPermissionsMethod[] = "wallet_getPermissions";
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -681,11 +681,12 @@ bool BraveWalletJSHandler::CommonRequestOrSendAsync(
     return false;
 
   if (method == kEthAccounts) {
-    brave_wallet_provider_->GetAllowedAccounts(base::BindOnce(
-        &BraveWalletJSHandler::OnGetAllowedAccounts,
-        weak_ptr_factory_.GetWeakPtr(), std::move(id),
-        std::move(global_context), std::move(global_callback),
-        std::move(promise_resolver), isolate, force_json_response));
+    brave_wallet_provider_->GetAllowedAccounts(
+        false, base::BindOnce(
+                   &BraveWalletJSHandler::OnGetAllowedAccounts,
+                   weak_ptr_factory_.GetWeakPtr(), std::move(id),
+                   std::move(global_context), std::move(global_callback),
+                   std::move(promise_resolver), isolate, force_json_response));
   } else if (method == kEthRequestAccounts) {
     brave_wallet_provider_->RequestEthereumPermissions(base::BindOnce(
         &BraveWalletJSHandler::OnEthereumPermissionRequested,
@@ -788,11 +789,12 @@ bool BraveWalletJSHandler::CommonRequestOrSendAsync(
         std::move(global_context), std::move(global_callback),
         std::move(promise_resolver), isolate, force_json_response));
   } else if (method == kGetPermissionsMethod) {
-    brave_wallet_provider_->GetAllowedAccounts(base::BindOnce(
-        &BraveWalletJSHandler::OnGetGetPermissionsAccountsRequested,
-        weak_ptr_factory_.GetWeakPtr(), std::move(id),
-        std::move(global_context), std::move(global_callback),
-        std::move(promise_resolver), isolate, force_json_response));
+    brave_wallet_provider_->GetAllowedAccounts(
+        true, base::BindOnce(
+                  &BraveWalletJSHandler::OnGetGetPermissionsAccountsRequested,
+                  weak_ptr_factory_.GetWeakPtr(), std::move(id),
+                  std::move(global_context), std::move(global_callback),
+                  std::move(promise_resolver), isolate, force_json_response));
   } else {
     brave_wallet_provider_->Request(
         normalized_json_request, true,

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.cc
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.cc
@@ -15,6 +15,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_wallet/common/eth_request_helper.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
+#include "brave/components/brave_wallet/common/value_conversion_utils.h"
 #include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "brave/components/brave_wallet/renderer/brave_wallet_response_helpers.h"
 #include "brave/components/brave_wallet/resources/grit/brave_wallet_script_generated.h"
@@ -118,6 +119,47 @@ std::unique_ptr<base::Value> GetJsonRpcRequest(
 
 namespace brave_wallet {
 
+void BraveWalletJSHandler::OnRequestPermissionsAccountsRequested(
+    base::Value id,
+    v8::Global<v8::Context> global_context,
+    std::unique_ptr<v8::Global<v8::Function>> global_callback,
+    v8::Global<v8::Promise::Resolver> promise_resolver,
+    v8::Isolate* isolate,
+    bool force_json_response,
+    const std::vector<std::string>& accounts,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  v8::HandleScope handle_scope(isolate);
+  v8::MicrotasksScope microtasks(isolate,
+                                 v8::MicrotasksScope::kDoNotRunMicrotasks);
+  first_allowed_account_.clear();
+  if (accounts.size() > 0)
+    first_allowed_account_ = accounts[0];
+  // Note that we'll update this from `AccountsChangedEvent` as well, but we
+  // need to update it earlier here before we give a response in case the JS
+  // page has a handler that checks window.ethereum.selectedAddress
+  UpdateAndBindJSProperties();
+  std::unique_ptr<base::Value> formed_response;
+  bool success = error == mojom::ProviderError::kSuccess;
+  if (success && accounts.empty()) {
+    formed_response =
+        GetProviderErrorDictionary(mojom::ProviderError::kUserRejectedRequest,
+                                   "User rejected the request.");
+  } else if (!success) {
+    formed_response = GetProviderErrorDictionary(error, error_message);
+  } else {
+    formed_response =
+        base::Value::ToUniquePtrValue(PermissionRequestResponseToValue(
+            url::Origin(render_frame_->GetWebFrame()->GetSecurityOrigin()),
+            accounts));
+  }
+
+  SendResponse(std::move(id), std::move(global_context),
+               std::move(global_callback), std::move(promise_resolver), isolate,
+               force_json_response, std::move(formed_response),
+               success && !accounts.empty());
+}
+
 void BraveWalletJSHandler::OnEthereumPermissionRequested(
     base::Value id,
     v8::Global<v8::Context> global_context,
@@ -197,6 +239,42 @@ void BraveWalletJSHandler::OnGetAllowedAccounts(
     for (size_t i = 0; i < accounts.size(); i++) {
       formed_response->Append(base::Value(accounts[i]));
     }
+  }
+
+  SendResponse(std::move(id), std::move(global_context),
+               std::move(global_callback), std::move(promise_resolver), isolate,
+               force_json_response, std::move(formed_response),
+               error == mojom::ProviderError::kSuccess);
+}
+
+void BraveWalletJSHandler::OnGetGetPermissionsAccountsRequested(
+    base::Value id,
+    v8::Global<v8::Context> global_context,
+    std::unique_ptr<v8::Global<v8::Function>> global_callback,
+    v8::Global<v8::Promise::Resolver> promise_resolver,
+    v8::Isolate* isolate,
+    bool force_json_response,
+    const std::vector<std::string>& accounts,
+    mojom::ProviderError error,
+    const std::string& error_message) {
+  v8::HandleScope handle_scope(isolate);
+  v8::MicrotasksScope microtasks(isolate,
+                                 v8::MicrotasksScope::kDoNotRunMicrotasks);
+  first_allowed_account_.clear();
+  if (accounts.size() > 0)
+    first_allowed_account_ = accounts[0];
+  // Note that we'll update this from `AccountsChangedEvent` as well, but we
+  // need to update it earlier here before we give a response in case the JS
+  // page has a handler that checks window.ethereum.selectedAddress
+  UpdateAndBindJSProperties();
+  std::unique_ptr<base::Value> formed_response;
+  if (error == mojom::ProviderError::kSuccess) {
+    formed_response =
+        base::Value::ToUniquePtrValue(PermissionRequestResponseToValue(
+            url::Origin(render_frame_->GetWebFrame()->GetSecurityOrigin()),
+            accounts));
+  } else {
+    formed_response = GetProviderErrorDictionary(error, error_message);
   }
 
   SendResponse(std::move(id), std::move(global_context),
@@ -696,6 +774,25 @@ bool BraveWalletJSHandler::CommonRequestOrSendAsync(
                        std::move(global_context), std::move(global_callback),
                        std::move(promise_resolver), isolate,
                        force_json_response));
+  } else if (method == kRequestPermissionsMethod) {
+    std::vector<std::string> restricted_methods;
+    if (!ParseRequestPermissionsParams(normalized_json_request,
+                                       &restricted_methods))
+      return false;
+    if (std::find(restricted_methods.begin(), restricted_methods.end(),
+                  "eth_accounts") == restricted_methods.end())
+      return false;
+    brave_wallet_provider_->RequestEthereumPermissions(base::BindOnce(
+        &BraveWalletJSHandler::OnRequestPermissionsAccountsRequested,
+        weak_ptr_factory_.GetWeakPtr(), std::move(id),
+        std::move(global_context), std::move(global_callback),
+        std::move(promise_resolver), isolate, force_json_response));
+  } else if (method == kGetPermissionsMethod) {
+    brave_wallet_provider_->GetAllowedAccounts(base::BindOnce(
+        &BraveWalletJSHandler::OnGetGetPermissionsAccountsRequested,
+        weak_ptr_factory_.GetWeakPtr(), std::move(id),
+        std::move(global_context), std::move(global_callback),
+        std::move(promise_resolver), isolate, force_json_response));
   } else {
     brave_wallet_provider_->Request(
         normalized_json_request, true,

--- a/components/brave_wallet/renderer/brave_wallet_js_handler.h
+++ b/components/brave_wallet/renderer/brave_wallet_js_handler.h
@@ -108,6 +108,27 @@ class BraveWalletJSHandler : public mojom::EventsListener {
       const std::vector<std::string>& accounts,
       mojom::ProviderError error,
       const std::string& error_message);
+  void OnRequestPermissionsAccountsRequested(
+      base::Value id,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> callback,
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate,
+      bool force_json_response,
+      const std::vector<std::string>& accounts,
+      mojom::ProviderError error,
+      const std::string& error_message);
+  void OnGetGetPermissionsAccountsRequested(
+      base::Value id,
+      v8::Global<v8::Context> global_context,
+      std::unique_ptr<v8::Global<v8::Function>> callback,
+      v8::Global<v8::Promise::Resolver> promise_resolver,
+      v8::Isolate* isolate,
+      bool force_json_response,
+      const std::vector<std::string>& accounts,
+      mojom::ProviderError error,
+      const std::string& error_message);
+
   void OnIsUnlocked(v8::Global<v8::Context> global_context,
                     v8::Global<v8::Promise::Resolver> promise_resolver,
                     v8::Isolate* isolate,
@@ -121,6 +142,15 @@ class BraveWalletJSHandler : public mojom::EventsListener {
                             const std::vector<std::string>& accounts,
                             mojom::ProviderError error,
                             const std::string& error_message);
+  void OnGetPermissions(base::Value id,
+                        v8::Global<v8::Context> global_context,
+                        std::unique_ptr<v8::Global<v8::Function>> callback,
+                        v8::Global<v8::Promise::Resolver> promise_resolver,
+                        v8::Isolate* isolate,
+                        bool force_json_response,
+                        const std::vector<std::string>& accounts,
+                        mojom::ProviderError error,
+                        const std::string& error_message);
   void OnAddOrSwitchEthereumChain(
       base::Value id,
       v8::Global<v8::Context> global_context,


### PR DESCRIPTION
The first commit implements the functionality which also fixes support for sites like ImmutableX.

Note that `wallet_getPermissions` returns the accounts list even if the keyring is locked unlike `eth_accounts`. The 2nd commit fixes that.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19274

This implements https://eips.ethereum.org/EIPS/eip-2255

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

