### PR TITLE
Add API to get checksum'ed address

### DIFF
--- a/components/brave_wallet/browser/keyring_controller.cc
+++ b/components/brave_wallet/browser/keyring_controller.cc
@@ -22,6 +22,7 @@
 #include "brave/components/brave_wallet/browser/hd_key.h"
 #include "brave/components/brave_wallet/browser/hd_keyring.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/common/eth_address.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
@@ -1363,6 +1364,12 @@ void KeyringController::IsStrongPassword(const std::string& password,
   }
 
   std::move(callback).Run(true);
+}
+
+void KeyringController::GetChecksumEthAddress(
+    const std::string& address,
+    GetChecksumEthAddressCallback callback) {
+  std::move(callback).Run(EthAddress::FromHex(address).ToChecksumAddress());
 }
 
 void KeyringController::HasPendingUnlockRequest(

--- a/components/brave_wallet/browser/keyring_controller.h
+++ b/components/brave_wallet/browser/keyring_controller.h
@@ -185,6 +185,8 @@ class KeyringController : public KeyedService, public mojom::KeyringController {
                           SetAutoLockMinutesCallback callback) override;
   void IsStrongPassword(const std::string& password,
                         IsStrongPasswordCallback callback) override;
+  void GetChecksumEthAddress(const std::string& address,
+                             GetChecksumEthAddressCallback callback) override;
   void HasPendingUnlockRequest(
       HasPendingUnlockRequestCallback callback) override;
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -411,6 +411,9 @@ interface KeyringController {
   // - At least one non-alphanumeric character
   IsStrongPassword(string password) => (bool result);
 
+  // Get the checksume'd EthAddress for the specified address
+  GetChecksumEthAddress(string address) => (string checksum_address);
+
   // Obtains if there's a pending unlock request
   // Note that there is no need for an API to notify unlocked
   // because the KeyringControllerObserver Unlocked event can be used for that.


### PR DESCRIPTION
In Ethereum there is a checksum that is built into an address' checksum.
This task is to provide an API to get a checkum'ed address from an address.
It will be used by the desktop, Android and iOS front ends in future tasks to give a warning or error in different conditions.

For now I put this in `KeyringController`, in the future we might refactor this out into a `Utils` mojo file. 

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20061

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

