### PR TITLE
Check for null headers in subscription list downloads (uplift to 1.34.x)

### DIFF
--- a/components/brave_shields/browser/ad_block_subscription_download_client.cc
+++ b/components/brave_shields/browser/ad_block_subscription_download_client.cc
@@ -83,6 +83,11 @@ void AdBlockSubscriptionDownloadClient::OnDownloadSucceeded(
   if (!download_manager)
     return;
 
+  if (!completion_info.response_headers) {
+    download_manager->OnDownloadFailed(guid);
+    return;
+  }
+
   std::string mimetype;
   if (!completion_info.response_headers->GetMimeType(&mimetype)) {
     download_manager->OnDownloadFailed(guid);


### PR DESCRIPTION
Uplift of #11556
Resolves https://github.com/brave/brave-browser/issues/20032

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.