### PR TITLE
1.34.x - Uplift #11468 - flag for tab audio icon interactivity

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -255,6 +255,12 @@ constexpr char kBraveTranslateGoDescription[] =
     "and brave translation backed. Also disables suggestions to install google "
     "translate extension.";
 
+constexpr char kTabAudioIconInteractiveName[] =
+    "Interactive Tab audio indicator";
+constexpr char kTabAudioIconInteractiveDescription[] =
+    "Enable the Tab audio indicator to also be a button which can mute and "
+    "unmute the Tab.";
+
 // A blink feature.
 constexpr char kFileSystemAccessAPIName[] = "File System Access API";
 constexpr char kFileSystemAccessAPIDescription[] =
@@ -473,6 +479,11 @@ constexpr char kFileSystemAccessAPIDescription[] =
       flag_descriptions::kFileSystemAccessAPIName,                          \
       flag_descriptions::kFileSystemAccessAPIDescription, kOsDesktop,       \
       FEATURE_VALUE_TYPE(blink::features::kFileSystemAccessAPI)},           \
+    {"tab-audio-icon-interactive",                                          \
+      flag_descriptions::kTabAudioIconInteractiveName,                      \
+      flag_descriptions::kTabAudioIconInteractiveDescription,               \
+      kOsDesktop,                                                           \
+      FEATURE_VALUE_TYPE(features::kTabAudioIconInteractive)},              \
     BRAVE_DECENTRALIZED_DNS_FEATURE_ENTRIES                                 \
     BRAVE_IPFS_FEATURE_ENTRIES                                              \
     BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                     \

--- a/browser/ui/views/tabs/brave_alert_indicator.cc
+++ b/browser/ui/views/tabs/brave_alert_indicator.cc
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+#include "base/feature_list.h"
+#include "brave/common/brave_features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/tabs/tab_types.h"
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
@@ -125,6 +127,12 @@ bool BraveAlertIndicator::OnMouseDragged(const ui::MouseEvent& event) {
 }
 
 bool BraveAlertIndicator::IsTabAudioToggleable() const {
+  // The alert indicator being interactive can be disabled entirely
+  if (!base::FeatureList::IsEnabled(features::kTabAudioIconInteractive)) {
+    return false;
+  }
+
+  // Pinned tabs are too small to select if alert indicator is a button
   if (parent_tab_->controller()->IsTabPinned(parent_tab_))
     return false;
 

--- a/common/brave_features.cc
+++ b/common/brave_features.cc
@@ -19,4 +19,7 @@ const base::Feature kBraveRewards{"BraveRewards",
 #endif
 #endif  // defined(OS_ANDROID)
 
+const base::Feature kTabAudioIconInteractive{"TabAudioIconInteractive",
+                                             base::FEATURE_ENABLED_BY_DEFAULT};
+
 }  // namespace features

--- a/common/brave_features.h
+++ b/common/brave_features.h
@@ -17,6 +17,9 @@ COMPONENT_EXPORT(CHROME_FEATURES)
 extern const base::Feature kBraveRewards;
 #endif  // defined(OS_ANDROID)
 
+COMPONENT_EXPORT(CHROME_FEATURES)
+extern const base::Feature kTabAudioIconInteractive;
+
 }  // namespace features
 
 #endif  // BRAVE_COMMON_BRAVE_FEATURES_H_

--- a/common/brave_features.h
+++ b/common/brave_features.h
@@ -17,7 +17,6 @@ COMPONENT_EXPORT(CHROME_FEATURES)
 extern const base::Feature kBraveRewards;
 #endif  // defined(OS_ANDROID)
 
-COMPONENT_EXPORT(CHROME_FEATURES)
 extern const base::Feature kTabAudioIconInteractive;
 
 }  // namespace features


### PR DESCRIPTION
Issue https://github.com/brave/brave-browser/issues/19979

Also uplifts https://github.com/brave/brave-browser/issues/20038 via https://github.com/brave/brave-core/pull/11555 to fix a windows local dev (Component) build issue introduced with #11468