### PR TITLE
Disable pending contributions for external wallet mismatches (uplift to 1.34.x)

### DIFF
--- a/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_external_wallet.cc
+++ b/vendor/bat-native-ledger/src/bat/ledger/internal/contribution/contribution_external_wallet.cc
@@ -154,6 +154,15 @@ void ContributionExternalWallet::OnServerPublisherInfo(
 
     BLOG(1, "Publisher not verified");
 
+    // TODO(zenparsing): Adding a record to the pending contribution table at
+    // this point can lead to an (async) infinite loop if pending contributions
+    // are currently being flushed. In `unverified.cc`, the pending contribution
+    // processor processes the first available pending record and then sets a
+    // timer to process the next one. If another record is added before that
+    // timer expires, it can cause the flushing operation to continue
+    // indefinitely.
+
+    /*
     auto save_callback =
         std::bind(&ContributionExternalWallet::OnSavePendingContribution,
             this,
@@ -170,6 +179,8 @@ void ContributionExternalWallet::OnServerPublisherInfo(
     ledger_->database()->SavePendingContribution(
         std::move(list),
         save_callback);
+    */
+
     callback(type::Result::LEDGER_ERROR);
     return;
   }


### PR DESCRIPTION
Uplift of #11514
Resolves https://github.com/brave/brave-browser/issues/19996

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.