### PR TITLE
Fix linking errors on Windows for npm run unit_tests

### DIFF
--- a/patches/chrome-installer-setup-BUILD.gn.patch
+++ b/patches/chrome-installer-setup-BUILD.gn.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/installer/setup/BUILD.gn b/chrome/installer/setup/BUILD.gn
-index f3964983b8a917184453fffcb5a8537f29f11eea..d939db0d317d22266cc3016c1572247e973afb00 100644
+index f3964983b8a917184453fffcb5a8537f29f11eea..7f25d8d587985fe9eb6d962fa150bb187d455620 100644
 --- a/chrome/installer/setup/BUILD.gn
 +++ b/chrome/installer/setup/BUILD.gn
-@@ -51,6 +51,7 @@ if (is_win) {
-     ]
- 
-     libs = [ "netapi32.lib" ]
-+    import("//brave/chromium_src/chrome/installer/setup/sources.gni") deps += brave_chromium_src_chrome_installer_setup_deps sources+= brave_chromium_src_chrome_installer_setup_sources
+@@ -128,6 +128,7 @@ if (is_win) {
+         "channel_override_work_item.h",
+       ]
+     }
++    import("//brave/chromium_src/chrome/installer/setup/sources.gni") deps += brave_chromium_src_chrome_installer_setup_deps sources += brave_chromium_src_chrome_installer_setup_sources
    }
  
-   static_library("lib") {
+   process_version_rc_template("setup_exe_version") {


### PR DESCRIPTION
channel_override_work_item.{h,cc} are only included if is_chrome_branded
is set in the //chrome/installer/setup:lib target, which is a dependency
of the unit_tets target, causing a link issue due to our chromium_src
override in chromium_src/chrome/installer/setup/install_worker.cc, which
requires ChannelOverrideWorkItem to be enabled.

This is not a problem for Brave at the moment since we have a patch for
the //chrome/installer/setup:setup target that makes sure to add those
sources, but since that does not work for building the unit_tests target
as it references //chrome/installer/setup:lib instead.

The solution is to move the patch in //chrome/installer/setup/BUILD.gn
to add the sources in //chrome/installer/setup:lib, instead of doing it
in  //chrome/installer/setup:setup (which depends on :lib anyway).

Resolves https://github.com/brave/brave-browser/issues/20105

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A