### PR TITLE
Enable EIP1559 for trezor keyring

### DIFF
--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -163,9 +163,10 @@ bool ShouldCreate1559Tx(brave_wallet::mojom::TxData1559Ptr tx_data_1559,
                                        account->address, address);
                                  });
 
-  // Only ledger hardware keyring supports EIP-1559 at the moment.
+  // Only ledger and trezor hardware keyrings support EIP-1559 at the moment.
   if (account_it != account_infos.end() && (*account_it)->hardware &&
-      (*account_it)->hardware->vendor != mojom::kLedgerHardwareVendor) {
+      ((*account_it)->hardware->vendor != mojom::kLedgerHardwareVendor &&
+       (*account_it)->hardware->vendor != mojom::kTrezorHardwareVendor)) {
     keyring_supports_eip1559 = false;
   }
 

--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -302,10 +302,8 @@ handler.on(WalletActions.sendTransaction.getType(), async (store: Store, payload
         case 'Primary':
         case 'Secondary':
         case 'Ledger':
-          keyringSupportsEIP1559 = true
-          break
         case 'Trezor':
-          keyringSupportsEIP1559 = false
+          keyringSupportsEIP1559 = true
           break
         default:
           keyringSupportsEIP1559 = false


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20116

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Auto test for eth_sendTransaction part: `npm test brave_unit_tests -- --filter=EthResponseHelperUnitTest.ShouldCreate1559Tx`

Manual test plan specified in the linked issue.
