### PR TITLE
Tweak behavior of #brave-adblock-cookie-list-default flag

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -76,6 +76,7 @@ const char kRegionalAdBlockComponentTest64PublicKey[] =
 
 using brave_shields::features::kBraveAdblockCnameUncloaking;
 using brave_shields::features::kBraveAdblockCollapseBlockedElements;
+using brave_shields::features::kBraveAdblockCookieListDefault;
 using brave_shields::features::kBraveAdblockCosmeticFiltering;
 using brave_shields::features::kBraveAdblockDefault1pBlocking;
 
@@ -2209,4 +2210,68 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringIframeScriptlet) {
       browser()->tab_strip_model()->GetActiveWebContents();
 
   ASSERT_EQ(true, EvalJs(contents, "show_ad"));
+}
+
+class DefaultCookieListFlagEnabledTest : public AdBlockServiceTest {
+ public:
+  DefaultCookieListFlagEnabledTest() {
+    feature_list_.InitAndEnableFeature(kBraveAdblockCookieListDefault);
+  }
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+};
+
+// Test that the `brave-adblock-default-1p-blocking` flag forces the Cookie
+// List UUID to be enabled, until manually enabled and then disabled again.
+IN_PROC_BROWSER_TEST_F(DefaultCookieListFlagEnabledTest,
+                       CosmeticFilteringIframeScriptlet) {
+  std::vector<adblock::FilterList> regional_catalog =
+      std::vector<adblock::FilterList>();
+  regional_catalog.push_back(adblock::FilterList(
+      brave_shields::kCookieListUuid,
+      "https://easylist-downloads.adblockplus.org/liste_fr.txt",
+      "EasyList Liste FR", {"fr"}, "https://forums.lanik.us/viewforum.php?f=91",
+      "emaecjinaegfkoklcdafkiocjhoeilao",
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbqIWuMS7r2OPXCsIPbbLG1H"
+      "/"
+      "d3NM9uzCMscw7R9ZV3TwhygvMOpZrNp4Y4hImy2H+HE0OniCqzuOAaq7+"
+      "SHXcdHwItvLK"
+      "tnRmeWgdqxgEdzJ8rZMWnfi+dODTbA4QvxI6itU5of8trDFbLzFqgnEOBk8ZxtjM/"
+      "M5v3"
+      "UeYh+EYHSEyHnDSJKbKevlXC931xlbdca0q0Ps3Ln6w/pJFByGbOh212mD/"
+      "PvwS6jIH3L"
+      "YjrMVUMefKC/ywn/AAdnwM5mGirm1NflQCJQOpTjIhbRIXBlACfV/"
+      "hwI1lqfKbFnyr4aP"
+      "Odg3JcOZZVoyi+ko3rKG3vH9JPWEy24Ys9A3SYpTwIDAQAB",
+      "Removes advertisements from French websites"));
+  g_brave_browser_process->ad_block_regional_service_manager()
+      ->SetRegionalCatalog(regional_catalog);
+
+  {
+    const auto lists =
+        g_brave_browser_process->ad_block_regional_service_manager()
+            ->GetRegionalLists();
+    // Although never explicitly enabled, it should be presented as enabled by
+    // default at first.
+    ASSERT_EQ(1UL, lists->GetList().size());
+    EXPECT_EQ(true, lists->GetList()[0].FindKey("enabled")->GetBool());
+  }
+
+  // Enable the filter list, and then disable it again.
+  g_brave_browser_process->ad_block_regional_service_manager()
+      ->EnableFilterList(brave_shields::kCookieListUuid, true);
+  g_brave_browser_process->ad_block_regional_service_manager()
+      ->EnableFilterList(brave_shields::kCookieListUuid, false);
+
+  WaitForBraveExtensionShieldsDataReady();
+
+  {
+    const auto lists =
+        g_brave_browser_process->ad_block_regional_service_manager()
+            ->GetRegionalLists();
+    // It should be actually disabled now.
+    ASSERT_EQ(1UL, lists->GetList().size());
+    EXPECT_EQ(false, lists->GetList()[0].FindKey("enabled")->GetBool());
+  }
 }

--- a/components/brave_shields/browser/ad_block_service.cc
+++ b/components/brave_shields/browser/ad_block_service.cc
@@ -310,6 +310,7 @@ void AdBlockService::SetComponentIdAndBase64PublicKeyForTest(
 }
 
 void RegisterPrefsForAdBlockService(PrefRegistrySimple* registry) {
+  registry->RegisterBooleanPref(prefs::kAdBlockCookieListSettingTouched, false);
   registry->RegisterStringPref(prefs::kAdBlockCustomFilters, std::string());
   registry->RegisterDictionaryPref(prefs::kAdBlockRegionalFilters);
   registry->RegisterDictionaryPref(prefs::kAdBlockListSubscriptions);

--- a/components/brave_shields/common/brave_shield_constants.h
+++ b/components/brave_shields/common/brave_shield_constants.h
@@ -40,6 +40,8 @@ const char kObsoleteFingerprinting[] = "fingerprinting";
 const base::FilePath::CharType kCustomSubscriptionListText[] =
     FPL("list_text.txt");
 
+const char kCookieListUuid[] = "AC023D22-AE88-4060-A978-4FEEEC4221693";
+
 constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveShields", IDS_BRAVE_SHIELDS},
     {"braveShieldsEnable", IDS_BRAVE_SHIELDS_ENABLE},

--- a/components/brave_shields/common/pref_names.cc
+++ b/components/brave_shields/common/pref_names.cc
@@ -10,6 +10,8 @@ namespace prefs {
 
 const char kAdBlockCheckedDefaultRegion[] =
     "brave.ad_block.checked_default_region";
+const char kAdBlockCookieListSettingTouched[] =
+    "brave.ad_block.cookie_list_setting_touched";
 const char kAdBlockCustomFilters[] = "brave.ad_block.custom_filters";
 const char kAdBlockRegionalFilters[] = "brave.ad_block.regional_filters";
 const char kAdBlockListSubscriptions[] = "brave.ad_block.list_subscriptions";

--- a/components/brave_shields/common/pref_names.h
+++ b/components/brave_shields/common/pref_names.h
@@ -10,6 +10,7 @@ namespace brave_shields {
 namespace prefs {
 
 extern const char kAdBlockCheckedDefaultRegion[];
+extern const char kAdBlockCookieListSettingTouched[];
 extern const char kAdBlockCustomFilters[];
 extern const char kAdBlockRegionalFilters[];
 extern const char kAdBlockListSubscriptions[];


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20126

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

_Note:_ As of the time of writing, there is a filter issue preventing the space for the cookie banner from being collapsed when it appears at the top of the page. If that's still the case during testing, please consider the notice to be "not shown" so long as the text is not visible.

1. Visit https://digikey.com and confirm that a cookie notice is shown. It will appear either as a banner at the top, or as a popup along the bottom depending on window size.
2. Visit brave://flags and enable the `#brave-adblock-cookie-list-default` flag, then restart the browser.
3. Visit https://digikey.com and confirm that no cookie notice is shown.
4. Visit brave://adblock and confirm that the entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` under `Additional filters` exists and is checked.
5. Return to brave://flags and set `#brave-adblock-cookie-list-default` to `Disabled`, and restart the browser.
6. Visit https://digikey.com and confirm that the cookie notice is shown again.
7. Visit brave://adblock and confirm that the entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` is no longer checked.
8. Manually toggle the `Easylist-Cookie List - Filter Obtrusive Cookie Notices` entry to be enabled, then repeat steps 2-5.
9. Visit brave://adblock and confirm that the entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` is checked.
10. Manually toggle the `Easylist-Cookie List - Filter Obtrusive Cookie Notices` entry to be disabled.
11. Visit brave://flags and enable the `#brave-adblock-cookie-list-default` flag, then restart the browser.
12. Visit brave://adblock and confirm that the entry for `Easylist-Cookie List - Filter Obtrusive Cookie Notices` is unchecked.
13. Visit https://digikey.com and confirm that the cookie notice is shown.