### PR TITLE
Fix support not opening in connect hardware wallet panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -20,6 +20,7 @@ export interface Props {
   walletName: string
   hardwareWalletCode?: HardwareWalletResponseCodeType
   retryCallable: () => void
+  onClickInstructions: () => void
 }
 
 function ConnectHardwareWalletPanel (props: Props) {
@@ -27,7 +28,8 @@ function ConnectHardwareWalletPanel (props: Props) {
     onCancel,
     walletName,
     hardwareWalletCode,
-    retryCallable
+    retryCallable,
+    onClickInstructions
   } = props
 
   const isConnected = hardwareWalletCode !== undefined && hardwareWalletCode !== 'deviceNotConnected'
@@ -43,10 +45,6 @@ function ConnectHardwareWalletPanel (props: Props) {
 
     return getLocale('braveWalletConnectHardwarePanelConnect').replace('$1', walletName)
   }, [hardwareWalletCode])
-
-  const onClickInstructions = () => {
-    window.open('https://support.brave.com/hc/en-us/articles/4409309138701', '_blank')
-  }
 
   useInterval(retryCallable, 3000)
 

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -494,6 +494,16 @@ function Container (props: Props) {
     props.walletActions.expandWalletNetworks()
   }
 
+  const onClickInstructions = () => {
+    const url = 'https://support.brave.com/hc/en-us/articles/4409309138701'
+
+    chrome.tabs.create({ url }, () => {
+      if (chrome.runtime.lastError) {
+        console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
+      }
+    })
+  }
+
   const isConnectedToSite = React.useMemo((): boolean => {
     if (activeOrigin === WalletOrigin) {
       return true
@@ -542,6 +552,7 @@ function Container (props: Props) {
             walletName={selectedAccount.name}
             hardwareWalletCode={props.panel.hardwareWalletCode}
             retryCallable={retryHardwareOperation}
+            onClickInstructions={onClickInstructions}
           />
         </StyledExtensionWrapper>
       </PanelWrapper>

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -646,12 +646,18 @@ export const _ConnectHardwareWallet = () => {
     // Doesn't do anything in storybook
   }
 
+  const onClickInstructions = () => {
+    // Open support link in new tab
+    window.open('https://support.brave.com/hc/en-us/articles/4409309138701', '_blank')
+  }
+
   return (
     <StyledExtensionWrapper>
       <ConnectHardwareWalletPanel
         walletName='Ledger 1'
         onCancel={onCancel}
         retryCallable={onConfirmTransaction}
+        onClickInstructions={onClickInstructions}
       />
     </StyledExtensionWrapper>
   )


### PR DESCRIPTION
This PR fixes support tab not opening when a user clicks on `Instructions` button. The issue is caused by `window.open` method which does not work in the panel. To fix the issue, I have used `chrome.tabs.create` method which works correctly in the panel.

Resolves https://github.com/brave/brave-browser/issues/19890

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

