### PR TITLE
chore(wallet): access all generated mojom types via BraveWallet

### DIFF
--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -25,23 +25,17 @@ import {
   UpdateUnapprovedTransactionSpendAllowanceType
 } from '../constants/action_types'
 import {
-  AppItem,
+  BraveWallet,
   WalletAccountType,
-  EthereumChain,
   GetAllNetworksList,
   GetAllTokensReturnInfo,
-  ERCToken,
   GetNativeAssetBalancesPriceReturnInfo,
   GetERC20TokenBalanceAndPriceReturnInfo,
   PortfolioTokenHistoryAndInfo,
-  AssetPriceTimeframe,
   SendTransactionParams,
   ER20TransferParams,
   ERC721TransferFromParams,
-  TransactionInfo,
   AccountTransactions,
-  DefaultWallet,
-  GasEstimation1559,
   ApproveERC20Params,
   WalletInfoBase,
   WalletInfo,
@@ -52,17 +46,17 @@ export const initialize = createAction('initialize')
 export const initialized = createAction<WalletInfo>('initialized')
 export const lockWallet = createAction('lockWallet')
 export const unlockWallet = createAction<UnlockWalletPayloadType>('unlockWallet')
-export const addFavoriteApp = createAction<AppItem>('addFavoriteApp')
-export const removeFavoriteApp = createAction<AppItem>('removeFavoriteApp')
+export const addFavoriteApp = createAction<BraveWallet.AppItem>('addFavoriteApp')
+export const removeFavoriteApp = createAction<BraveWallet.AppItem>('removeFavoriteApp')
 export const hasIncorrectPassword = createAction<boolean>('hasIncorrectPassword')
 export const addUserAsset = createAction<AddUserAssetPayloadType>('addUserAsset')
 export const addUserAssetError = createAction<boolean>('addUserAssetError')
 export const removeUserAsset = createAction<RemoveUserAssetPayloadType>('removeUserAsset')
 export const setUserAssetVisible = createAction<SetUserAssetVisiblePayloadType>('setUserAssetVisible')
-export const setVisibleTokensInfo = createAction<ERCToken[]>('setVisibleTokensInfo')
+export const setVisibleTokensInfo = createAction<BraveWallet.ERCToken[]>('setVisibleTokensInfo')
 export const selectAccount = createAction<WalletAccountType>('selectAccount')
-export const selectNetwork = createAction<EthereumChain>('selectNetwork')
-export const setNetwork = createAction<EthereumChain>('setNetwork')
+export const selectNetwork = createAction<BraveWallet.EthereumChain>('selectNetwork')
+export const setNetwork = createAction<BraveWallet.EthereumChain>('setNetwork')
 export const getAllNetworks = createAction('getAllNetworks')
 export const setAllNetworks = createAction<GetAllNetworksList>('getAllNetworks')
 export const chainChangedEvent = createAction<ChainChangedEventPayloadType>('chainChangedEvent')
@@ -79,8 +73,8 @@ export const getAllTokensList = createAction('getAllTokensList')
 export const nativeAssetBalancesUpdated = createAction<GetNativeAssetBalancesPriceReturnInfo>('nativeAssetBalancesUpdated')
 export const tokenBalancesUpdated = createAction<GetERC20TokenBalanceAndPriceReturnInfo>('tokenBalancesUpdated')
 export const portfolioPriceHistoryUpdated = createAction<PortfolioTokenHistoryAndInfo[][]>('portfolioPriceHistoryUpdated')
-export const selectPortfolioTimeline = createAction<AssetPriceTimeframe>('selectPortfolioTimeline')
-export const portfolioTimelineUpdated = createAction<AssetPriceTimeframe>('portfolioTimelineUpdated')
+export const selectPortfolioTimeline = createAction<BraveWallet.AssetPriceTimeframe>('selectPortfolioTimeline')
+export const portfolioTimelineUpdated = createAction<BraveWallet.AssetPriceTimeframe>('portfolioTimelineUpdated')
 export const sendTransaction = createAction<SendTransactionParams>('sendTransaction')
 export const sendERC20Transfer = createAction<ER20TransferParams>('sendERC20Transfer')
 export const sendERC721TransferFrom = createAction<ERC721TransferFromParams>('sendERC721TransferFrom')
@@ -88,15 +82,15 @@ export const approveERC20Allowance = createAction<ApproveERC20Params>('approveER
 export const newUnapprovedTxAdded = createAction<NewUnapprovedTxAdded>('newUnapprovedTxAdded')
 export const unapprovedTxUpdated = createAction<UnapprovedTxUpdated>('unapprovedTxUpdated')
 export const transactionStatusChanged = createAction<TransactionStatusChanged>('transactionStatusChanged')
-export const approveTransaction = createAction<TransactionInfo>('approveTransaction')
-export const rejectTransaction = createAction<TransactionInfo>('rejectTransaction')
+export const approveTransaction = createAction<BraveWallet.TransactionInfo>('approveTransaction')
+export const rejectTransaction = createAction<BraveWallet.TransactionInfo>('rejectTransaction')
 export const rejectAllTransactions = createAction('rejectAllTransactions')
 export const setAccountTransactions = createAction<AccountTransactions>('setAccountTransactions')
-export const defaultWalletUpdated = createAction<DefaultWallet>('defaultWalletUpdated')
+export const defaultWalletUpdated = createAction<BraveWallet.DefaultWallet>('defaultWalletUpdated')
 export const setSelectedAccount = createAction<WalletAccountType>('setSelectedAccount')
 export const activeOriginChanged = createAction<ActiveOriginChanged>('activeOriginChanged')
 export const refreshGasEstimates = createAction('refreshGasEstimates')
-export const setGasEstimates = createAction<GasEstimation1559>('setGasEstimates')
+export const setGasEstimates = createAction<BraveWallet.GasEstimation1559>('setGasEstimates')
 export const updateUnapprovedTransactionGasFields = createAction<UpdateUnapprovedTransactionGasFieldsType>('updateUnapprovedTransactionGasFields')
 export const updateUnapprovedTransactionSpendAllowance = createAction<UpdateUnapprovedTransactionSpendAllowanceType>('updateUnapprovedTransactionSpendAllowance')
 export const defaultWalletChanged = createAction<DefaultWalletChanged>('defaultWalletChanged')
@@ -110,8 +104,8 @@ export const refreshBalancesAndPrices = createAction('refreshBalancesAndPrices')
 export const setMetaMaskInstalled = createAction<boolean>('setMetaMaskInstalled')
 export const refreshAccountInfo = createAction<WalletInfoBase>('refreshAccountInfo')
 export const autoLockMinutesChanged = createAction('autoLockMinutesChanged')
-export const retryTransaction = createAction<TransactionInfo>('retryTransaction')
-export const cancelTransaction = createAction<TransactionInfo>('cancelTransaction')
-export const speedupTransaction = createAction<TransactionInfo>('speedupTransaction')
+export const retryTransaction = createAction<BraveWallet.TransactionInfo>('retryTransaction')
+export const cancelTransaction = createAction<BraveWallet.TransactionInfo>('cancelTransaction')
+export const speedupTransaction = createAction<BraveWallet.TransactionInfo>('speedupTransaction')
 export const defaultCurrenciesUpdated = createAction<DefaultCurrencies>('defaultCurrenciesUpdated')
 export const expandWalletNetworks = createAction('expandWalletNetworks')

--- a/components/brave_wallet_ui/common/api/hardware_keyrings.ts
+++ b/components/brave_wallet_ui/common/api/hardware_keyrings.ts
@@ -4,29 +4,33 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { assert } from 'chrome://resources/js/assert.m.js'
-import { TREZOR_HARDWARE_VENDOR, LEDGER_HARDWARE_VENDOR, KeyringControllerRemote } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../constants/types'
 import LedgerBridgeKeyring from '../../common/hardware/ledgerjs/eth_ledger_bridge_keyring'
 import TrezorBridgeKeyring from '../../common/hardware/trezor/trezor_bridge_keyring'
+
 export type HardwareKeyring = LedgerBridgeKeyring | TrezorBridgeKeyring
 
-const VendorTypes = [TREZOR_HARDWARE_VENDOR, LEDGER_HARDWARE_VENDOR] as const
+const VendorTypes = [
+  BraveWallet.TREZOR_HARDWARE_VENDOR,
+  BraveWallet.LEDGER_HARDWARE_VENDOR
+] as const
 export type HardwareVendor = typeof VendorTypes[number]
 
 // Lazy instances for keyrings
 let ledgerHardwareKeyring: LedgerBridgeKeyring
 let trezorHardwareKeyring: TrezorBridgeKeyring
-let keyringController: KeyringControllerRemote
+let keyringController: BraveWallet.KeyringControllerRemote
 
-export function getBraveKeyring (): KeyringControllerRemote {
+export function getBraveKeyring (): BraveWallet.KeyringControllerRemote {
   if (!keyringController) {
     /** @type {!braveWallet.mojom.KeyringControllerRemote} */
-    keyringController = new KeyringControllerRemote()
+    keyringController = new BraveWallet.KeyringControllerRemote()
   }
   return keyringController
 }
 
 export function getHardwareKeyring (type: HardwareVendor): LedgerBridgeKeyring | TrezorBridgeKeyring {
-  if (type === LEDGER_HARDWARE_VENDOR) {
+  if (type === BraveWallet.LEDGER_HARDWARE_VENDOR) {
     const ledgerKeyring = getLedgerHardwareKeyring()
     assert(type === ledgerKeyring.type())
     return ledgerKeyring

--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -21,23 +21,15 @@ import {
   TransactionStatusChanged
 } from '../constants/action_types'
 import {
-  AppItem,
+  BraveWallet,
   ApproveERC20Params,
-  AssetPriceTimeframe,
   ER20TransferParams,
   ERC721TransferFromParams,
-  EthereumChain,
-  ExternalWalletType,
   SendTransactionParams,
   SwapErrorResponse,
-  SwapResponse,
-  TransactionInfo,
-  TxData,
-  TxData1559,
   WalletAccountType,
   WalletState,
-  WalletInfo,
-  TransactionStatus
+  WalletInfo
 } from '../../constants/types'
 import { toWeiHex } from '../../utils/format-balances'
 import { hexStrToNumberArray } from '../../utils/hex-utils'
@@ -87,7 +79,7 @@ async function refreshWalletInfo (store: Store) {
 
   const mmResult =
     await braveWalletService.isExternalWalletInstalled(
-      ExternalWalletType.MetaMask)
+      BraveWallet.ExternalWalletType.MetaMask)
   store.dispatch(WalletActions.setMetaMaskInstalled(mmResult.installed))
 
   await store.dispatch(refreshTransactionHistory())
@@ -176,19 +168,19 @@ handler.on(WalletActions.unlockWallet.getType(), async (store: Store, payload: U
   store.dispatch(WalletActions.hasIncorrectPassword(!result.success))
 })
 
-handler.on(WalletActions.addFavoriteApp.getType(), async (store: Store, appItem: AppItem) => {
+handler.on(WalletActions.addFavoriteApp.getType(), async (store: Store, appItem: BraveWallet.AppItem) => {
   const walletHandler = getAPIProxy().walletHandler
   walletHandler.addFavoriteApp(appItem)
   await refreshWalletInfo(store)
 })
 
-handler.on(WalletActions.removeFavoriteApp.getType(), async (store: Store, appItem: AppItem) => {
+handler.on(WalletActions.removeFavoriteApp.getType(), async (store: Store, appItem: BraveWallet.AppItem) => {
   const walletHandler = getAPIProxy().walletHandler
   walletHandler.removeFavoriteApp(appItem)
   await refreshWalletInfo(store)
 })
 
-handler.on(WalletActions.selectNetwork.getType(), async (store: Store, payload: EthereumChain) => {
+handler.on(WalletActions.selectNetwork.getType(), async (store: Store, payload: BraveWallet.EthereumChain) => {
   const ethJsonRpcController = getAPIProxy().ethJsonRpcController
   await ethJsonRpcController.setNetwork(payload.chainId)
   await refreshWalletInfo(store)
@@ -264,7 +256,7 @@ handler.on(WalletActions.setUserAssetVisible.getType(), async (store: Store, pay
   await refreshBalancesPricesAndHistory(store)
 })
 
-handler.on(WalletActions.selectPortfolioTimeline.getType(), async (store: Store, payload: AssetPriceTimeframe) => {
+handler.on(WalletActions.selectPortfolioTimeline.getType(), async (store: Store, payload: BraveWallet.AssetPriceTimeframe) => {
   store.dispatch(WalletActions.portfolioTimelineUpdated(payload))
   await store.dispatch(refreshTokenPriceHistory(payload))
 })
@@ -315,7 +307,7 @@ handler.on(WalletActions.sendTransaction.getType(), async (store: Store, payload
   const { chainId } = await apiProxy.ethJsonRpcController.getChainId()
 
   let addResult
-  const txData: TxData = {
+  const txData: BraveWallet.TxData = {
     nonce: '',
     // Estimated by eth_tx_controller if value is '' for legacy transactions
     gasPrice: isEIP1559 ? '' : payload.gasPrice || '',
@@ -327,7 +319,7 @@ handler.on(WalletActions.sendTransaction.getType(), async (store: Store, payload
   }
 
   if (isEIP1559) {
-    const txData1559: TxData1559 = {
+    const txData1559: BraveWallet.TxData1559 = {
       baseData: txData,
       chainId,
       // Estimated by eth_tx_controller if value is ''
@@ -414,13 +406,13 @@ handler.on(WalletActions.approveERC20Allowance.getType(), async (store: Store, p
   }))
 })
 
-handler.on(WalletActions.approveTransaction.getType(), async (store: Store, txInfo: TransactionInfo) => {
+handler.on(WalletActions.approveTransaction.getType(), async (store: Store, txInfo: BraveWallet.TransactionInfo) => {
   const apiProxy = getAPIProxy()
   await apiProxy.ethTxController.approveTransaction(txInfo.id)
   await store.dispatch(refreshTransactionHistory(txInfo.fromAddress))
 })
 
-handler.on(WalletActions.rejectTransaction.getType(), async (store: Store, txInfo: TransactionInfo) => {
+handler.on(WalletActions.rejectTransaction.getType(), async (store: Store, txInfo: BraveWallet.TransactionInfo) => {
   const apiProxy = getAPIProxy()
   await apiProxy.ethTxController.rejectTransaction(txInfo.id)
   await store.dispatch(refreshTransactionHistory(txInfo.fromAddress))
@@ -438,7 +430,7 @@ handler.on(WalletActions.rejectAllTransactions.getType(), async (store) => {
 // fetchSwapQuoteFactory creates a handler function that can be used with
 // both panel and page actions.
 export const fetchSwapQuoteFactory = (
-  setSwapQuote: SimpleActionCreator<SwapResponse>,
+  setSwapQuote: SimpleActionCreator<BraveWallet.SwapResponse>,
   setSwapError: SimpleActionCreator<SwapErrorResponse | undefined>
 ) => async (store: Store, payload: SwapParamsPayloadType) => {
   const { swapController, assetRatioController } = getAPIProxy()
@@ -609,12 +601,12 @@ handler.on(WalletActions.addSitePermission.getType(), async (store: Store, paylo
 
 handler.on(WalletActions.transactionStatusChanged.getType(), async (store: Store, payload: TransactionStatusChanged) => {
   const status = payload.txInfo.txStatus
-  if (status === TransactionStatus.Confirmed || status === TransactionStatus.Error) {
+  if (status === BraveWallet.TransactionStatus.Confirmed || status === BraveWallet.TransactionStatus.Error) {
     await refreshBalancesPricesAndHistory(store)
   }
 })
 
-handler.on(WalletActions.retryTransaction.getType(), async (store: Store, payload: TransactionInfo) => {
+handler.on(WalletActions.retryTransaction.getType(), async (store: Store, payload: BraveWallet.TransactionInfo) => {
   const { ethTxController } = getAPIProxy()
   const result = await ethTxController.retryTransaction(payload.id)
   if (!result.success) {
@@ -629,7 +621,7 @@ handler.on(WalletActions.retryTransaction.getType(), async (store: Store, payloa
   }
 })
 
-handler.on(WalletActions.speedupTransaction.getType(), async (store: Store, payload: TransactionInfo) => {
+handler.on(WalletActions.speedupTransaction.getType(), async (store: Store, payload: BraveWallet.TransactionInfo) => {
   const { ethTxController } = getAPIProxy()
   const result = await ethTxController.speedupOrCancelTransaction(payload.id, false)
   if (!result.success) {
@@ -644,7 +636,7 @@ handler.on(WalletActions.speedupTransaction.getType(), async (store: Store, payl
   }
 })
 
-handler.on(WalletActions.cancelTransaction.getType(), async (store: Store, payload: TransactionInfo) => {
+handler.on(WalletActions.cancelTransaction.getType(), async (store: Store, payload: BraveWallet.TransactionInfo) => {
   const { ethTxController } = getAPIProxy()
   const result = await ethTxController.speedupOrCancelTransaction(payload.id, true)
   if (!result.success) {

--- a/components/brave_wallet_ui/common/async/hardware.test.ts
+++ b/components/brave_wallet_ui/common/async/hardware.test.ts
@@ -4,8 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { EthereumSignedTx } from 'trezor-connect/lib/typescript'
-import { TransactionInfo, LEDGER_HARDWARE_VENDOR, TREZOR_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import {
+  BraveWallet,
   GetNonceForHardwareTransactionReturnInfo,
   GetTransactionMessageToSignReturnInfo,
   ProcessHardwareSignatureReturnInfo
@@ -13,7 +13,7 @@ import {
 import {
   signTrezorTransaction,
   signLedgerTransaction
-} from '../../common/async/hardware'
+} from './hardware'
 import WalletApiProxy from '../../common/wallet_api_proxy'
 import { getLocale } from '../../../common/locale'
 import { Success, Unsuccessful } from 'trezor-connect'
@@ -30,10 +30,10 @@ window.crypto = {
   }
 }
 
-const getMockedLedgerKeyring = (expectedPath: string, expectedData: string | TransactionInfo, signed?: SignHardwareTransactionOperationResult) => {
+const getMockedLedgerKeyring = (expectedPath: string, expectedData: string | BraveWallet.TransactionInfo, signed?: SignHardwareTransactionOperationResult) => {
   return {
     type: (): HardwareVendor => {
-      return LEDGER_HARDWARE_VENDOR
+      return BraveWallet.LEDGER_HARDWARE_VENDOR
     },
     signTransaction: async (path: string, data: string): Promise<SignHardwareTransactionOperationResult> => {
       expect(path).toStrictEqual(expectedPath)
@@ -57,10 +57,10 @@ const getMockedLedgerKeyring = (expectedPath: string, expectedData: string | Tra
   }
 }
 
-const getMockedTrezorKeyring = (expectedDevicePath: string, expectedData: string | TransactionInfo, signed?: Success<EthereumSignedTx> | Unsuccessful) => {
+const getMockedTrezorKeyring = (expectedDevicePath: string, expectedData: string | BraveWallet.TransactionInfo, signed?: Success<EthereumSignedTx> | Unsuccessful) => {
   return {
     type: (): HardwareVendor => {
-      return TREZOR_HARDWARE_VENDOR
+      return BraveWallet.TREZOR_HARDWARE_VENDOR
     },
     signTransaction: async (path: string, data: string): Promise<Success<EthereumSignedTx> | Unsuccessful | undefined> => {
       expect(path).toStrictEqual(expectedDevicePath)

--- a/components/brave_wallet_ui/common/async/hardware.ts
+++ b/components/brave_wallet_ui/common/async/hardware.ts
@@ -3,7 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import {
   SignHardwareTransactionType,
   SignHardwareMessageOperationResult,
@@ -17,6 +16,7 @@ import { getHardwareKeyring, getLedgerHardwareKeyring, getTrezorHardwareKeyring,
 import { TrezorErrorsCodes } from '../hardware/trezor/trezor-messages'
 import TrezorBridgeKeyring from '../hardware/trezor/trezor_bridge_keyring'
 import LedgerBridgeKeyring from '../hardware/ledgerjs/eth_ledger_bridge_keyring'
+import { BraveWallet } from '../../constants/types'
 
 export function dialogErrorFromLedgerErrorCode (code: string | number): HardwareWalletResponseCodeType {
   if (code === 'TransportOpenUserCancelled') {

--- a/components/brave_wallet_ui/common/async/lib.ts
+++ b/components/brave_wallet_ui/common/async/lib.ts
@@ -9,9 +9,7 @@ import {
 import { formatBalance } from '../../utils/format-balances'
 import {
   AccountTransactions,
-  AssetPriceTimeframe,
-  EthereumChain,
-  ERCToken,
+  BraveWallet,
   WalletAccountType,
   AccountInfo,
   GetERCTokenInfoReturnInfo
@@ -115,7 +113,7 @@ export async function findHardwareAccountInfo (address: string): Promise<Account
   return false
 }
 
-export function refreshBalances (currentNetwork: EthereumChain) {
+export function refreshBalances (currentNetwork: BraveWallet.EthereumChain) {
   return async (dispatch: Dispatch, getState: () => State) => {
     const apiProxy = getAPIProxy()
     const { wallet: { accounts } } = getState()
@@ -125,7 +123,7 @@ export function refreshBalances (currentNetwork: EthereumChain) {
     const visibleTokensInfo = await braveWalletService.getUserAssets(currentNetwork.chainId)
 
     // Selected Network's Native Asset
-    const nativeAsset: ERCToken = {
+    const nativeAsset: BraveWallet.ERCToken = {
       contractAddress: '',
       decimals: currentNetwork.decimals,
       isErc20: false,
@@ -137,7 +135,7 @@ export function refreshBalances (currentNetwork: EthereumChain) {
       tokenId: ''
     }
 
-    const visibleTokens: ERCToken[] = visibleTokensInfo.tokens.length === 0 ? [nativeAsset] : visibleTokensInfo.tokens
+    const visibleTokens: BraveWallet.ERCToken[] = visibleTokensInfo.tokens.length === 0 ? [nativeAsset] : visibleTokensInfo.tokens
     await dispatch(WalletActions.setVisibleTokensInfo(visibleTokens))
 
     const getBalanceReturnInfos = await Promise.all(accounts.map(async (account) => {
@@ -228,7 +226,7 @@ export function refreshPrices () {
   }
 }
 
-export function refreshTokenPriceHistory (selectedPortfolioTimeline: AssetPriceTimeframe) {
+export function refreshTokenPriceHistory (selectedPortfolioTimeline: BraveWallet.AssetPriceTimeframe) {
   return async (dispatch: Dispatch, getState: () => State) => {
     const apiProxy = getAPIProxy()
     const { assetRatioController } = apiProxy

--- a/components/brave_wallet_ui/common/constants/action_types.ts
+++ b/components/brave_wallet_ui/common/constants/action_types.ts
@@ -4,9 +4,7 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import {
-  DefaultWallet,
-  TransactionInfo,
-  ERCToken,
+  BraveWallet,
   AccountAssetOptionType,
   SlippagePresetObjectType,
   WalletAccountType
@@ -26,29 +24,29 @@ export type IsEip1559Changed = {
 }
 
 export type NewUnapprovedTxAdded = {
-  txInfo: TransactionInfo
+  txInfo: BraveWallet.TransactionInfo
 }
 
 export type UnapprovedTxUpdated = {
-  txInfo: TransactionInfo
+  txInfo: BraveWallet.TransactionInfo
 }
 
 export type TransactionStatusChanged = {
-  txInfo: TransactionInfo
+  txInfo: BraveWallet.TransactionInfo
 }
 
 export type AddUserAssetPayloadType = {
-  token: ERCToken
+  token: BraveWallet.ERCToken
   chainId: string
 }
 
 export type RemoveUserAssetPayloadType = {
-  token: ERCToken
+  token: BraveWallet.ERCToken
   chainId: string
 }
 
 export type SetUserAssetVisiblePayloadType = {
-  token: ERCToken
+  token: BraveWallet.ERCToken
   chainId: string
   isVisible: boolean
 }
@@ -83,7 +81,7 @@ export type UpdateUnapprovedTransactionSpendAllowanceType = {
 }
 
 export type DefaultWalletChanged = {
-  defaultWallet: DefaultWallet
+  defaultWallet: BraveWallet.DefaultWallet
 }
 
 export type DefaultBaseCurrencyChanged = {

--- a/components/brave_wallet_ui/common/constants/mocks.ts
+++ b/components/brave_wallet_ui/common/constants/mocks.ts
@@ -4,16 +4,11 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import {
-  AssetPrice,
-  ERCToken,
-  EthereumChain,
-  TransactionInfo,
-  TransactionStatus,
-  TransactionType,
+  BraveWallet,
   WalletAccountType
 } from '../../constants/types'
 
-export const getMockedTransactionInfo = (): TransactionInfo => {
+export const getMockedTransactionInfo = (): BraveWallet.TransactionInfo => {
   return {
     id: '1',
     fromAddress: '0x8b52c24d6e2600bdb8dbb6e8da849ed38ab7e81f',
@@ -31,8 +26,8 @@ export const getMockedTransactionInfo = (): TransactionInfo => {
       maxPriorityFeePerGas: '',
       maxFeePerGas: ''
     },
-    txStatus: TransactionStatus.Approved,
-    txType: TransactionType.Other,
+    txStatus: BraveWallet.TransactionStatus.Approved,
+    txType: BraveWallet.TransactionType.Other,
     txParams: [],
     txArgs: [],
     createdTime: { microseconds: 0 },
@@ -41,7 +36,7 @@ export const getMockedTransactionInfo = (): TransactionInfo => {
   }
 }
 
-export const mockNetwork: EthereumChain = {
+export const mockNetwork: BraveWallet.EthereumChain = {
   chainId: '0x1',
   chainName: 'Ethereum Main Net',
   rpcUrls: ['https://mainnet.infura.io/v3/'],
@@ -53,7 +48,7 @@ export const mockNetwork: EthereumChain = {
   isEip1559: true
 }
 
-export const mockERC20Token: ERCToken = {
+export const mockERC20Token: BraveWallet.ERCToken = {
   contractAddress: 'mockContractAddress',
   name: 'Dog Coin',
   symbol: 'DOG',
@@ -76,7 +71,7 @@ export const mockAccount: WalletAccountType = {
   tokens: []
 }
 
-export const mockAssetPrices: AssetPrice[] = [
+export const mockAssetPrices: BraveWallet.AssetPrice[] = [
   {
     fromAsset: 'ETH',
     price: '4000',

--- a/components/brave_wallet_ui/common/hardware/hardwareKeyring.ts
+++ b/components/brave_wallet_ui/common/hardware/hardwareKeyring.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { TransactionInfo } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../constants/types'
 import { HardwareVendor } from '../api/hardware_keyrings'
 import { GetAccountsHardwareOperationResult, HardwareOperationResult, SignHardwareMessageOperationResult, SignHardwareTransactionOperationResult } from '../hardware_operations'
 
@@ -15,7 +15,7 @@ export abstract class HardwareKeyring {
 }
 
 export abstract class TrezorKeyring extends HardwareKeyring {
-  abstract signTransaction (path: string, txInfo: TransactionInfo, chainId: string): Promise<SignHardwareTransactionOperationResult>
+  abstract signTransaction (path: string, txInfo: BraveWallet.TransactionInfo, chainId: string): Promise<SignHardwareTransactionOperationResult>
   abstract signPersonalMessage (path: string, message: string): Promise<SignHardwareMessageOperationResult>
 }
 

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.test.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LEDGER_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../../constants/types'
 import LedgerBridgeKeyring from './eth_ledger_bridge_keyring'
 import { SignatureVRS } from '../../hardware_operations'
 import { LedgerDerivationPaths } from '../types'
@@ -78,7 +78,7 @@ test('Extracting accounts from legacy device', () => {
 
 test('Check ledger bridge type', () => {
   const ledgerHardwareKeyring = new LedgerBridgeKeyring()
-  return expect(ledgerHardwareKeyring.type()).toStrictEqual(LEDGER_HARDWARE_VENDOR)
+  return expect(ledgerHardwareKeyring.type()).toStrictEqual(BraveWallet.LEDGER_HARDWARE_VENDOR)
 })
 
 test('Check locks for device', () => {

--- a/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/ledgerjs/eth_ledger_bridge_keyring.ts
@@ -3,10 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LEDGER_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import { assert } from 'chrome://resources/js/assert.m.js'
 import TransportWebHID from '@ledgerhq/hw-transport-webhid'
 import Eth from '@ledgerhq/hw-app-eth'
+
+import { BraveWallet } from '../../../constants/types'
 import { getLocale } from '../../../../common/locale'
 import { hardwareDeviceIdFromAddress } from '../hardwareDeviceIdFromAddress'
 import {
@@ -14,7 +15,7 @@ import {
   SignatureVRS,
   SignHardwareMessageOperationResult,
   SignHardwareTransactionOperationResult
-} from '../../../common/hardware_operations'
+} from '../../hardware_operations'
 import { LedgerKeyring } from '../hardwareKeyring'
 import { HardwareVendor } from '../../api/hardware_keyrings'
 import { HardwareOperationResult, LedgerDerivationPaths } from '../types'
@@ -31,7 +32,7 @@ export default class LedgerBridgeKeyring extends LedgerKeyring {
   private deviceId: string
 
   type = (): HardwareVendor => {
-    return LEDGER_HARDWARE_VENDOR
+    return BraveWallet.LEDGER_HARDWARE_VENDOR
   }
 
   getAccounts = async (from: number, to: number, scheme: string): Promise<GetAccountsHardwareOperationResult> => {

--- a/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.test.ts
+++ b/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.test.ts
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 /* global window */
 
-import { TREZOR_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../../constants/types'
 import { getLocale } from '../../../../common/locale'
 import {
   kTrezorBridgeUrl,
@@ -18,7 +18,7 @@ import {
   TrezorGetAccountsResponse,
   SignTransactionResponse,
   TrezorErrorsCodes
-} from '../../../common/hardware/trezor/trezor-messages'
+} from './trezor-messages'
 import TrezorBridgeKeyring from './trezor_bridge_keyring'
 import { TrezorBridgeTransport } from './trezor-bridge-transport'
 import { TrezorCommandHandler } from './trezor-command-handler'
@@ -220,7 +220,7 @@ test('Unlock device success', () => {
 
 test('Check trezor bridge type', () => {
   const hardwareKeyring = new TrezorBridgeKeyring()
-  return expect(hardwareKeyring.type()).toStrictEqual(TREZOR_HARDWARE_VENDOR)
+  return expect(hardwareKeyring.type()).toStrictEqual(BraveWallet.TREZOR_HARDWARE_VENDOR)
 })
 
 test('Bridge not ready', () => {

--- a/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.ts
+++ b/components/brave_wallet_ui/common/hardware/trezor/trezor_bridge_keyring.ts
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { publicToAddress, toChecksumAddress, bufferToHex } from 'ethereumjs-util'
-import { TransactionInfo, TREZOR_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../../constants/types'
 import { getLocale } from '../../../../common/locale'
 import {
   TrezorCommand,
@@ -20,8 +20,8 @@ import {
   SignTransactionResponse,
   SignMessageResponse,
   TrezorGetAccountsResponse
-} from '../trezor/trezor-messages'
-import { sendTrezorCommand, closeTrezorBridge } from '../trezor/trezor-bridge-transport'
+} from './trezor-messages'
+import { sendTrezorCommand, closeTrezorBridge } from './trezor-bridge-transport'
 import { hardwareDeviceIdFromAddress } from '../hardwareDeviceIdFromAddress'
 import {
   GetAccountsHardwareOperationResult,
@@ -39,7 +39,7 @@ export default class TrezorBridgeKeyring extends TrezorKeyring {
   protected deviceId: string
 
   type = (): HardwareVendor => {
-    return TREZOR_HARDWARE_VENDOR
+    return BraveWallet.TREZOR_HARDWARE_VENDOR
   }
 
   isUnlocked = (): boolean => {
@@ -90,7 +90,7 @@ export default class TrezorBridgeKeyring extends TrezorKeyring {
     return this.getAccountsFromDevice(paths, addZeroPath)
   }
 
-  signTransaction = async (path: string, txInfo: TransactionInfo, chainId: string): Promise<SignHardwareTransactionOperationResult> => {
+  signTransaction = async (path: string, txInfo: BraveWallet.TransactionInfo, chainId: string): Promise<SignHardwareTransactionOperationResult> => {
     if (!this.isUnlocked()) {
       const unlocked = await this.unlock()
       if (!unlocked.success) {
@@ -159,7 +159,7 @@ export default class TrezorBridgeKeyring extends TrezorKeyring {
     return ''
   }
 
-  private prepareTransactionPayload = (path: string, txInfo: TransactionInfo, chainId: string): SignTransactionCommandPayload => {
+  private prepareTransactionPayload = (path: string, txInfo: BraveWallet.TransactionInfo, chainId: string): SignTransactionCommandPayload => {
     const isEIP1559Transaction = txInfo.txData.maxPriorityFeePerGas !== '' && txInfo.txData.maxFeePerGas !== ''
     if (isEIP1559Transaction) {
       return this.createEIP1559TransactionPayload(path, txInfo, chainId)
@@ -167,7 +167,7 @@ export default class TrezorBridgeKeyring extends TrezorKeyring {
     return this.createLegacyTransactionPayload(path, txInfo, chainId)
   }
 
-  private createEIP1559TransactionPayload = (path: string, txInfo: TransactionInfo, chainId: string): SignTransactionCommandPayload => {
+  private createEIP1559TransactionPayload = (path: string, txInfo: BraveWallet.TransactionInfo, chainId: string): SignTransactionCommandPayload => {
     return {
       path: path,
       transaction: {
@@ -183,7 +183,7 @@ export default class TrezorBridgeKeyring extends TrezorKeyring {
     }
   }
 
-  private createLegacyTransactionPayload = (path: string, txInfo: TransactionInfo, chainId: string): SignTransactionCommandPayload => {
+  private createLegacyTransactionPayload = (path: string, txInfo: BraveWallet.TransactionInfo, chainId: string): SignTransactionCommandPayload => {
     return {
       path: path,
       transaction: {

--- a/components/brave_wallet_ui/common/hooks/assets.ts
+++ b/components/brave_wallet_ui/common/hooks/assets.ts
@@ -7,17 +7,17 @@ import * as React from 'react'
 
 import {
   AccountAssetOptionType,
-  ERCToken,
+  BraveWallet,
   WalletAccountType
 } from '../../constants/types'
 import { ETH } from '../../options/asset-options'
 
 export default function useAssets (
   selectedAccount: WalletAccountType,
-  fullTokenList: ERCToken[],
-  userVisibleTokensInfo: ERCToken[]
+  fullTokenList: BraveWallet.ERCToken[],
+  userVisibleTokensInfo: BraveWallet.ERCToken[]
 ) {
-  const tokenOptions: ERCToken[] = React.useMemo(
+  const tokenOptions: BraveWallet.ERCToken[] = React.useMemo(
     () =>
       fullTokenList.map((token) => ({
         ...token,
@@ -26,7 +26,7 @@ export default function useAssets (
     [fullTokenList]
   )
 
-  const userVisibleTokenOptions: ERCToken[] = React.useMemo(
+  const userVisibleTokenOptions: BraveWallet.ERCToken[] = React.useMemo(
     () =>
       userVisibleTokensInfo.map((token) => ({
         ...token,

--- a/components/brave_wallet_ui/common/hooks/pricing.ts
+++ b/components/brave_wallet_ui/common/hooks/pricing.ts
@@ -5,9 +5,9 @@
 
 import * as React from 'react'
 
-import { AssetPrice } from '../../constants/types'
+import { BraveWallet } from '../../constants/types'
 
-export default function usePricing (spotPrices: AssetPrice[]) {
+export default function usePricing (spotPrices: BraveWallet.AssetPrice[]) {
   return React.useCallback((symbol: string) => {
     return spotPrices.find(
       (token) => token.fromAsset.toLowerCase() === symbol.toLowerCase()

--- a/components/brave_wallet_ui/common/hooks/send.ts
+++ b/components/brave_wallet_ui/common/hooks/send.ts
@@ -7,12 +7,12 @@ import * as React from 'react'
 import { SimpleActionCreator } from 'redux-act'
 import {
   AccountAssetOptionType,
+  BraveWallet,
   GetEthAddrReturnInfo,
   WalletAccountType,
   ER20TransferParams,
   SendTransactionParams,
   ERC721TransferFromParams,
-  ERCToken,
   GetChecksumEthAddressReturnInfo
 } from '../../constants/types'
 import { isValidAddress } from '../../utils/address-utils'
@@ -28,7 +28,7 @@ export default function useSend (
   sendERC20Transfer: SimpleActionCreator<ER20TransferParams>,
   sendTransaction: SimpleActionCreator<SendTransactionParams>,
   sendERC721TransferFrom: SimpleActionCreator<ERC721TransferFromParams>,
-  fullTokenList: ERCToken[]
+  fullTokenList: BraveWallet.ERCToken[]
 ) {
   const [selectedSendAsset, setSelectedSendAsset] = React.useState<AccountAssetOptionType>(sendAssetOptions[0])
   const [toAddressOrUrl, setToAddressOrUrl] = React.useState('')

--- a/components/brave_wallet_ui/common/hooks/swap.ts
+++ b/components/brave_wallet_ui/common/hooks/swap.ts
@@ -9,16 +9,14 @@ import BigNumber from 'bignumber.js'
 
 import {
   AccountAssetOptionType,
-  EthereumChain,
+  BraveWallet,
   ExpirationPresetObjectType,
   OrderTypes,
   SlippagePresetObjectType,
   SwapErrorResponse,
   SwapValidationErrorType,
-  SwapResponse,
   ToOrFromType,
   WalletAccountType,
-  ROPSTEN_CHAIN_ID,
   ApproveERC20Params
 } from '../../constants/types'
 import { SlippagePresetOptions } from '../../options/slippage-preset-options'
@@ -33,16 +31,16 @@ const SWAP_VALIDATION_ERROR_CODE = 100
 
 export default function useSwap (
   selectedAccount: WalletAccountType,
-  selectedNetwork: EthereumChain,
+  selectedNetwork: BraveWallet.EthereumChain,
   assetOptions: AccountAssetOptionType[],
   fetchSwapQuote: SimpleActionCreator<SwapParamsPayloadType>,
   getERC20Allowance: (contractAddress: string, ownerAddress: string, spenderAddress: string) => Promise<string>,
   approveERC20Allowance: SimpleActionCreator<ApproveERC20Params>,
-  quote?: SwapResponse,
+  quote?: BraveWallet.SwapResponse,
   rawError?: SwapErrorResponse
 ) {
   const swapAssetOptions = React.useMemo(() => {
-    if (selectedNetwork.chainId === ROPSTEN_CHAIN_ID) {
+    if (selectedNetwork.chainId === BraveWallet.ROPSTEN_CHAIN_ID) {
       return RopstenSwapAssetOptions
     }
 

--- a/components/brave_wallet_ui/common/hooks/token.ts
+++ b/components/brave_wallet_ui/common/hooks/token.ts
@@ -3,22 +3,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import * as React from 'react'
 import {
-  GetERCTokenInfoReturnInfo,
-  ERCToken,
-  EthereumChain
+  BraveWallet,
+  GetERCTokenInfoReturnInfo
 } from '../../constants/types'
 
 export default function useTokenInfo (
   getERCTokenInfo: (address: string) => Promise<GetERCTokenInfoReturnInfo>,
-  visibleTokens: ERCToken[],
-  fullTokenList: ERCToken[],
-  selectedNetwork: EthereumChain
+  visibleTokens: BraveWallet.ERCToken[],
+  fullTokenList: BraveWallet.ERCToken[],
+  selectedNetwork: BraveWallet.EthereumChain
 ) {
   const [tokenContractAddress, setTokenContractAddress] = React.useState<string>('')
-  const [foundTokenInfoByContractAddress, setFoundTokenInfoByContractAddress] = React.useState<ERCToken | undefined>()
+  const [foundTokenInfoByContractAddress, setFoundTokenInfoByContractAddress] = React.useState<BraveWallet.ERCToken | undefined>()
 
   // Instead of having this be a useCallback hook here we are using useEffect to
   // handle the asynchronous getERCTokenInfo fallback method.

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 
-import { TransactionType } from '../../constants/types'
+import { BraveWallet } from '../../constants/types'
 import {
   getMockedTransactionInfo,
   mockAccount,
@@ -14,8 +14,8 @@ import { useTransactionParser } from './transaction-parser'
 describe('useTransactionParser hook', () => {
   describe('check for sameAddressError', () => {
     describe.each([
-      ['ERC20Transfer', TransactionType.ERC20Transfer, 'recipient'],
-      ['ERC20Approve', TransactionType.ERC20Approve, 'approval target']
+      ['ERC20Transfer', BraveWallet.TransactionType.ERC20Transfer, 'recipient'],
+      ['ERC20Approve', BraveWallet.TransactionType.ERC20Approve, 'approval target']
     ])('%s', (_, txType, toLabel) => {
       it(`should be defined when sender and ${toLabel} are same`, () => {
         const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
@@ -51,8 +51,8 @@ describe('useTransactionParser hook', () => {
     })
 
     describe.each([
-      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
-      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom]
+      ['ERC721TransferFrom', BraveWallet.TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', BraveWallet.TransactionType.ERC721SafeTransferFrom]
     ])('%s', (_, txType) => {
       it('should be undefined when sender and recipient are same', () => {
         const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
@@ -105,9 +105,9 @@ describe('useTransactionParser hook', () => {
 
     describe.each([
       // ETHSend can have same sender and recipient in case of cancel transactions
-      ['ETHSend', TransactionType.ETHSend],
-      ['Other', TransactionType.Other],
-      ['0x Swap', TransactionType.Other]
+      ['ETHSend', BraveWallet.TransactionType.ETHSend],
+      ['Other', BraveWallet.TransactionType.Other],
+      ['0x Swap', BraveWallet.TransactionType.Other]
     ])('%s', (name, txType) => {
       it('should always be undefined', () => {
         const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
@@ -135,10 +135,10 @@ describe('useTransactionParser hook', () => {
 
   describe('check for contractAddressError', () => {
     describe.each([
-      ['ERC20Approve', TransactionType.ERC20Approve],
-      ['ETHSend', TransactionType.ETHSend],
-      ['Other', TransactionType.Other],
-      ['0x Swap', TransactionType.Other]
+      ['ERC20Approve', BraveWallet.TransactionType.ERC20Approve],
+      ['ETHSend', BraveWallet.TransactionType.ETHSend],
+      ['Other', BraveWallet.TransactionType.Other],
+      ['0x Swap', BraveWallet.TransactionType.Other]
     ])('%s', (name, txType) => {
       it('should always be undefined', () => {
         const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
@@ -149,7 +149,7 @@ describe('useTransactionParser hook', () => {
         const mockTransactionInfo = getMockedTransactionInfo()
         const parsedTransaction = transactionParser({
           ...mockTransactionInfo,
-          txArgs: txType === TransactionType.ETHSend ? [] : ['mockArg1', 'mockArg2'],
+          txArgs: txType === BraveWallet.TransactionType.ETHSend ? [] : ['mockArg1', 'mockArg2'],
           txType,
           txData: {
             ...mockTransactionInfo.txData,
@@ -165,9 +165,9 @@ describe('useTransactionParser hook', () => {
     })
 
     describe.each([
-      ['ERC20Transfer', TransactionType.ERC20Transfer],
-      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
-      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom]
+      ['ERC20Transfer', BraveWallet.TransactionType.ERC20Transfer],
+      ['ERC721TransferFrom', BraveWallet.TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', BraveWallet.TransactionType.ERC721SafeTransferFrom]
     ])('%s', (_, txType) => {
       it('should be defined when recipient is a known contract address', () => {
         const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(
@@ -178,7 +178,7 @@ describe('useTransactionParser hook', () => {
         const mockTransactionInfo = getMockedTransactionInfo()
         const parsedTransaction = transactionParser({
           ...mockTransactionInfo,
-          txArgs: txType === TransactionType.ERC20Transfer
+          txArgs: txType === BraveWallet.TransactionType.ERC20Transfer
             ? ['0xdeadbeef', 'mockAmount']
             : ['mockOwner', '0xdeadbeef', 'mockTokenID'],
           txType
@@ -196,7 +196,7 @@ describe('useTransactionParser hook', () => {
         const mockTransactionInfo = getMockedTransactionInfo()
         const parsedTransaction = transactionParser({
           ...mockTransactionInfo,
-          txArgs: txType === TransactionType.ERC20Transfer
+          txArgs: txType === BraveWallet.TransactionType.ERC20Transfer
             ? ['0xbadcafe', 'mockAmount']
             : ['mockOwner', '0xbadcafe', 'mockTokenID'],
           txType
@@ -209,12 +209,12 @@ describe('useTransactionParser hook', () => {
 
   describe('check for insufficientFundsError', () => {
     describe.each([
-      ['ERC20Transfer', TransactionType.ERC20Transfer],
-      ['ERC20Approve', TransactionType.ERC20Approve],
-      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
-      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom],
-      ['ETHSend', TransactionType.ETHSend],
-      ['Other', TransactionType.Other]
+      ['ERC20Transfer', BraveWallet.TransactionType.ERC20Transfer],
+      ['ERC20Approve', BraveWallet.TransactionType.ERC20Approve],
+      ['ERC721TransferFrom', BraveWallet.TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', BraveWallet.TransactionType.ERC721SafeTransferFrom],
+      ['ETHSend', BraveWallet.TransactionType.ETHSend],
+      ['Other', BraveWallet.TransactionType.Other]
     ])('%s', (_, txType) => {
       it('should be true when funds are insufficient for gas', () => {
         /**
@@ -245,7 +245,7 @@ describe('useTransactionParser hook', () => {
         const parsedTransaction = transactionParser({
           ...mockTransactionInfo,
           fromAddress: '0xdeadbeef',
-          txArgs: [TransactionType.ERC20Approve, TransactionType.ERC20Transfer].includes(txType)
+          txArgs: [BraveWallet.TransactionType.ERC20Approve, BraveWallet.TransactionType.ERC20Transfer].includes(txType)
             ? ['mockRecipient', '0x0']
             : ['mockOwner', 'mockRecipient', 'mockTokenID'],
           txType,
@@ -253,7 +253,7 @@ describe('useTransactionParser hook', () => {
             ...mockTransactionInfo.txData,
             baseData: {
               ...mockTransactionInfo.txData.baseData,
-              to: txType === TransactionType.ERC20Transfer
+              to: txType === BraveWallet.TransactionType.ERC20Transfer
                 ? mockERC20Token.contractAddress
                 : mockTransactionInfo.txData.baseData.to,
               value: '0x0', // 0 ETH
@@ -290,7 +290,7 @@ describe('useTransactionParser hook', () => {
         const parsedTransaction = transactionParser({
           ...mockTransactionInfo,
           fromAddress: '0xdeadbeef',
-          txArgs: [TransactionType.ERC20Approve, TransactionType.ERC20Transfer].includes(txType)
+          txArgs: [BraveWallet.TransactionType.ERC20Approve, BraveWallet.TransactionType.ERC20Transfer].includes(txType)
             ? ['mockRecipient', '0x0']
             : ['mockOwner', 'mockRecipient', 'mockTokenID'],
           txType,
@@ -310,8 +310,8 @@ describe('useTransactionParser hook', () => {
     })
 
     describe.each([
-      ['ETHSend', TransactionType.ETHSend],
-      ['Other', TransactionType.Other]
+      ['ETHSend', BraveWallet.TransactionType.ETHSend],
+      ['Other', BraveWallet.TransactionType.Other]
     ])('%s', (_, txType) => {
       it('should be true when funds are insufficient for send amount', () => {
         /**
@@ -433,7 +433,7 @@ describe('useTransactionParser hook', () => {
             'mockRecipient',
             '0xde0b6b3a7640000' // 1 DOG
           ],
-          txType: TransactionType.ERC20Transfer,
+          txType: BraveWallet.TransactionType.ERC20Transfer,
           txData: {
             ...mockTransactionInfo.txData,
             baseData: {
@@ -485,7 +485,7 @@ describe('useTransactionParser hook', () => {
             'mockRecipient',
             '0xde0b6b3a7640000' // 1 DOG
           ],
-          txType: TransactionType.ERC20Transfer,
+          txType: BraveWallet.TransactionType.ERC20Transfer,
           txData: {
             ...mockTransactionInfo.txData,
             baseData: {
@@ -504,10 +504,10 @@ describe('useTransactionParser hook', () => {
   })
   describe('check for token symbol', () => {
     describe.each([
-      ['ERC20Approve', TransactionType.ERC20Approve],
-      ['ERC20Transfer', TransactionType.ERC20Transfer],
-      ['ERC721TransferFrom', TransactionType.ERC721TransferFrom],
-      ['ERC721SafeTransferFrom', TransactionType.ERC721SafeTransferFrom]
+      ['ERC20Approve', BraveWallet.TransactionType.ERC20Approve],
+      ['ERC20Transfer', BraveWallet.TransactionType.ERC20Transfer],
+      ['ERC721TransferFrom', BraveWallet.TransactionType.ERC721TransferFrom],
+      ['ERC721SafeTransferFrom', BraveWallet.TransactionType.ERC721SafeTransferFrom]
     ])('%s', (_, txType) => {
       it('should be empty', () => {
         const { result: { current: transactionParser } } = renderHook(() => useTransactionParser(

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -6,12 +6,7 @@
 import * as React from 'react'
 
 import {
-  AssetPrice,
-  EthereumChain,
-  ERCToken,
-  TransactionInfo,
-  TransactionStatus,
-  TransactionType,
+  BraveWallet,
   WalletAccountType
 } from '../../constants/types'
 import {
@@ -41,7 +36,7 @@ interface ParsedTransaction extends ParsedTransactionFees {
   // Common fields
   hash: string
   createdTime: TimeDelta
-  status: TransactionStatus
+  status: BraveWallet.TransactionStatus
   sender: string
   senderLabel: string
   recipient: string
@@ -55,7 +50,7 @@ interface ParsedTransaction extends ParsedTransactionFees {
   insufficientFundsError: boolean
   contractAddressError?: string
   sameAddressError?: string
-  erc721ERCToken?: ERCToken
+  erc721ERCToken?: BraveWallet.ERCToken
   erc721TokenId?: string
   isSwap?: boolean
 
@@ -64,8 +59,8 @@ interface ParsedTransaction extends ParsedTransactionFees {
   approvalTargetLabel?: string
 }
 
-export function useTransactionFeesParser (selectedNetwork: EthereumChain, networkSpotPrice: string) {
-  return React.useCallback((transactionInfo: TransactionInfo): ParsedTransactionFees => {
+export function useTransactionFeesParser (selectedNetwork: BraveWallet.EthereumChain, networkSpotPrice: string) {
+  return React.useCallback((transactionInfo: BraveWallet.TransactionInfo): ParsedTransactionFees => {
     const { txData } = transactionInfo
     const { baseData: { gasLimit, gasPrice }, maxFeePerGas, maxPriorityFeePerGas } = txData
 
@@ -87,11 +82,11 @@ export function useTransactionFeesParser (selectedNetwork: EthereumChain, networ
 }
 
 export function useTransactionParser (
-  selectedNetwork: EthereumChain,
+  selectedNetwork: BraveWallet.EthereumChain,
   accounts: WalletAccountType[],
-  spotPrices: AssetPrice[],
-  visibleTokens: ERCToken[],
-  fullTokenList?: ERCToken[]
+  spotPrices: BraveWallet.AssetPrice[],
+  visibleTokens: BraveWallet.ERCToken[],
+  fullTokenList?: BraveWallet.ERCToken[]
 ) {
   const findSpotPrice = usePricing(spotPrices)
   const getAddressLabel = useAddressLabels(accounts)
@@ -145,7 +140,7 @@ export function useTransactionParser (
       : undefined
   }
 
-  return React.useCallback((transactionInfo: TransactionInfo) => {
+  return React.useCallback((transactionInfo: BraveWallet.TransactionInfo) => {
     const { txArgs, txData, fromAddress, txType } = transactionInfo
     const { baseData } = txData
     const { value, to } = baseData
@@ -158,7 +153,7 @@ export function useTransactionParser (
 
     switch (true) {
       // transfer(address recipient, uint256 amount) → bool
-      case txType === TransactionType.ERC20Transfer: {
+      case txType === BraveWallet.TransactionType.ERC20Transfer: {
         const [address, amount] = txArgs
         const token = findToken(to)
         const price = findSpotPrice(token?.symbol ?? '')
@@ -196,10 +191,10 @@ export function useTransactionParser (
       }
 
       // transferFrom(address owner, address to, uint256 tokenId)
-      case txType === TransactionType.ERC721TransferFrom:
+      case txType === BraveWallet.TransactionType.ERC721TransferFrom:
 
       // safeTransferFrom(address owner, address to, uint256 tokenId)
-      case txType === TransactionType.ERC721SafeTransferFrom: {
+      case txType === BraveWallet.TransactionType.ERC721SafeTransferFrom: {
         // The owner of the ERC721 must not be confused with the
         // caller (fromAddress).
         const [owner, toAddress, tokenID] = txArgs
@@ -235,7 +230,7 @@ export function useTransactionParser (
       }
 
       // approve(address spender, uint256 amount) → bool
-      case txType === TransactionType.ERC20Approve: {
+      case txType === BraveWallet.TransactionType.ERC20Approve: {
         const [address, amount] = txArgs
         const token = findToken(to)
         const feeDetails = parseTransactionFees(transactionInfo)
@@ -270,8 +265,8 @@ export function useTransactionParser (
 
       // FIXME: swap needs a real parser to figure out the From and To details.
       case to.toLowerCase() === SwapExchangeProxy:
-      case txType === TransactionType.ETHSend:
-      case txType === TransactionType.Other:
+      case txType === BraveWallet.TransactionType.ETHSend:
+      case txType === BraveWallet.TransactionType.Other:
       default: {
         const networkPrice = findSpotPrice(selectedNetwork.symbol)
         const sendAmount = formatBalance(value, selectedNetwork.decimals)

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -7,20 +7,13 @@ import { createReducer } from 'redux-act'
 import {
   AccountInfo,
   AccountTransactions,
-  AssetPriceTimeframe,
-  DefaultWallet,
-  EthereumChain,
-  GasEstimation1559,
+  BraveWallet,
   GetAllNetworksList,
   GetAllTokensReturnInfo,
   GetERC20TokenBalanceAndPriceReturnInfo,
   GetNativeAssetBalancesPriceReturnInfo,
   GetPriceHistoryReturnInfo,
-  MAINNET_CHAIN_ID,
   PortfolioTokenHistoryAndInfo,
-  ERCToken,
-  TransactionInfo,
-  TransactionStatus,
   WalletAccountType,
   WalletState,
   WalletInfoBase,
@@ -49,7 +42,7 @@ const defaultState: WalletState = {
   hasIncorrectPassword: false,
   selectedAccount: {} as WalletAccountType,
   selectedNetwork: {
-    chainId: MAINNET_CHAIN_ID,
+    chainId: BraveWallet.MAINNET_CHAIN_ID,
     chainName: 'Ethereum Mainnet',
     rpcUrls: [],
     blockExplorerUrls: [],
@@ -58,7 +51,7 @@ const defaultState: WalletState = {
     symbolName: 'Ethereum',
     decimals: 18,
     isEip1559: true
-  } as EthereumChain,
+  } as BraveWallet.EthereumChain,
   accounts: [],
   userVisibleTokensInfo: [],
   transactions: {},
@@ -68,11 +61,11 @@ const defaultState: WalletState = {
   portfolioPriceHistory: [],
   selectedPendingTransaction: undefined,
   isFetchingPortfolioPriceHistory: true,
-  selectedPortfolioTimeline: AssetPriceTimeframe.OneDay,
+  selectedPortfolioTimeline: BraveWallet.AssetPriceTimeframe.OneDay,
   networkList: [],
   transactionSpotPrices: [],
   addUserAssetError: false,
-  defaultWallet: DefaultWallet.BraveWalletPreferExtension,
+  defaultWallet: BraveWallet.DefaultWallet.BraveWalletPreferExtension,
   activeOrigin: '',
   gasEstimates: undefined,
   connectedAccounts: [],
@@ -135,7 +128,7 @@ reducer.on(WalletActions.setSelectedAccount, (state: any, payload: WalletAccount
   }
 })
 
-reducer.on(WalletActions.setNetwork, (state: any, payload: EthereumChain) => {
+reducer.on(WalletActions.setNetwork, (state: any, payload: BraveWallet.EthereumChain) => {
   return {
     ...state,
     isFetchingPortfolioPriceHistory: true,
@@ -143,7 +136,7 @@ reducer.on(WalletActions.setNetwork, (state: any, payload: EthereumChain) => {
   }
 })
 
-reducer.on(WalletActions.setVisibleTokensInfo, (state: any, payload: ERCToken[]) => {
+reducer.on(WalletActions.setVisibleTokensInfo, (state: any, payload: BraveWallet.ERCToken[]) => {
   return {
     ...state,
     userVisibleTokensInfo: payload
@@ -182,7 +175,7 @@ reducer.on(WalletActions.nativeAssetBalancesUpdated, (state: any, payload: GetNa
 })
 
 reducer.on(WalletActions.tokenBalancesUpdated, (state: any, payload: GetERC20TokenBalanceAndPriceReturnInfo) => {
-  const userTokens: ERCToken[] = state.userVisibleTokensInfo
+  const userTokens: BraveWallet.ERCToken[] = state.userVisibleTokensInfo
   const userVisibleTokensInfo = userTokens.map((token) => {
     return {
       ...token,
@@ -268,7 +261,7 @@ reducer.on(WalletActions.portfolioPriceHistoryUpdated, (state: any, payload: Por
   }
 })
 
-reducer.on(WalletActions.portfolioTimelineUpdated, (state: any, payload: AssetPriceTimeframe) => {
+reducer.on(WalletActions.portfolioTimelineUpdated, (state: any, payload: BraveWallet.AssetPriceTimeframe) => {
   return {
     ...state,
     isFetchingPortfolioPriceHistory: true,
@@ -296,7 +289,7 @@ reducer.on(WalletActions.unapprovedTxUpdated, (state: any, payload: UnapprovedTx
   const newState = { ...state }
 
   const index = state.pendingTransactions.findIndex(
-    (tx: TransactionInfo) => tx.id === payload.txInfo.id)
+    (tx: BraveWallet.TransactionInfo) => tx.id === payload.txInfo.id)
   if (index !== -1) {
     newState.pendingTransactions[index] = payload.txInfo
   }
@@ -310,8 +303,8 @@ reducer.on(WalletActions.unapprovedTxUpdated, (state: any, payload: UnapprovedTx
 
 reducer.on(WalletActions.transactionStatusChanged, (state: WalletState, payload: TransactionStatusChanged) => {
   const newPendingTransactions = state.pendingTransactions
-    .filter((tx: TransactionInfo) => tx.id !== payload.txInfo.id)
-    .concat(payload.txInfo.txStatus === TransactionStatus.Unapproved ? [payload.txInfo] : [])
+    .filter((tx: BraveWallet.TransactionInfo) => tx.id !== payload.txInfo.id)
+    .concat(payload.txInfo.txStatus === BraveWallet.TransactionStatus.Unapproved ? [payload.txInfo] : [])
 
   const sortedTransactionList = sortTransactionByDate(newPendingTransactions)
 
@@ -340,7 +333,7 @@ reducer.on(WalletActions.transactionStatusChanged, (state: WalletState, payload:
 reducer.on(WalletActions.setAccountTransactions, (state: WalletState, payload: AccountTransactions) => {
   const { selectedAccount } = state
   const newPendingTransactions = selectedAccount
-    ? payload[selectedAccount.address].filter((tx: TransactionInfo) => tx.txStatus === TransactionStatus.Unapproved) : []
+    ? payload[selectedAccount.address].filter((tx: BraveWallet.TransactionInfo) => tx.txStatus === BraveWallet.TransactionStatus.Unapproved) : []
 
   const sortedTransactionList = sortTransactionByDate(newPendingTransactions)
 
@@ -359,7 +352,7 @@ reducer.on(WalletActions.addUserAssetError, (state: any, payload: boolean) => {
   }
 })
 
-reducer.on(WalletActions.defaultWalletUpdated, (state: any, payload: DefaultWallet) => {
+reducer.on(WalletActions.defaultWalletUpdated, (state: any, payload: BraveWallet.DefaultWallet) => {
   return {
     ...state,
     defaultWallet: payload
@@ -378,7 +371,7 @@ reducer.on(WalletActions.isEip1559Changed, (state: WalletState, payload: IsEip15
     network => network.chainId === payload.chainId
   ) || state.selectedNetwork
 
-  const updatedNetwork: EthereumChain = {
+  const updatedNetwork: BraveWallet.EthereumChain = {
     ...selectedNetwork,
     isEip1559: payload.isEip1559
   }
@@ -392,7 +385,7 @@ reducer.on(WalletActions.isEip1559Changed, (state: WalletState, payload: IsEip15
   }
 })
 
-reducer.on(WalletActions.setGasEstimates, (state: any, payload: GasEstimation1559) => {
+reducer.on(WalletActions.setGasEstimates, (state: any, payload: BraveWallet.GasEstimation1559) => {
   return {
     ...state,
     gasEstimates: payload
@@ -408,7 +401,7 @@ reducer.on(WalletActions.setSitePermissions, (state: any, payload: SitePermissio
 
 reducer.on(WalletActions.queueNextTransaction, (state: any) => {
   const pendingTransactions = state.pendingTransactions
-  const index = pendingTransactions.findIndex((tx: TransactionInfo) => tx.id === state.selectedPendingTransaction.id) + 1
+  const index = pendingTransactions.findIndex((tx: BraveWallet.TransactionInfo) => tx.id === state.selectedPendingTransaction.id) + 1
   let newPendingTransaction = pendingTransactions[index]
   if (pendingTransactions.length === index) {
     newPendingTransaction = pendingTransactions[0]

--- a/components/brave_wallet_ui/common/wallet_api_proxy.ts
+++ b/components/brave_wallet_ui/common/wallet_api_proxy.ts
@@ -3,12 +3,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import * as WalletActions from '../common/actions/wallet_actions'
-import { Store } from '../common/async/types'
+import { Store } from './async/types'
 import { getBraveKeyring } from './api/hardware_keyrings'
-// Provide access to all the generated types.
-export * from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../constants/types'
 
 export default class WalletApiProxy {
   walletHandler = new BraveWallet.WalletHandlerRemote()

--- a/components/brave_wallet_ui/components/buy-send-swap/accounts-assets-networks/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/accounts-assets-networks/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {
   AccountAssetOptionType,
+  BraveWallet,
   BuySendSwapViewTypes,
-  UserAccountType,
-  EthereumChain
+  UserAccountType
 } from '../../../constants/types'
 
 import {
@@ -20,12 +20,12 @@ import {
 export interface Props {
   selectedView: BuySendSwapViewTypes
   accounts: UserAccountType[]
-  networkList: EthereumChain[]
+  networkList: BraveWallet.EthereumChain[]
   assetOptions: AccountAssetOptionType[]
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   onAddAsset: () => void
   onClickSelectAccount: (account: UserAccountType) => () => void
-  onClickSelectNetwork: (network: EthereumChain) => () => void
+  onClickSelectNetwork: (network: BraveWallet.EthereumChain) => () => void
   onSelectedAsset: (account: AccountAssetOptionType) => () => void
   goBack: () => void
   onAddNetwork: () => void

--- a/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy-send-swap-layout/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { BuySendSwapTypes, EthereumChain } from '../../../constants/types'
+import { BraveWallet, BuySendSwapTypes } from '../../../constants/types'
 import { BuySendSwapOptions } from '../../../options/buy-send-swap-options'
 import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 import Tooltip from '../buy-send-swap-tooltip'
@@ -22,7 +22,7 @@ export interface Props {
   onChangeTab: (tab: BuySendSwapTypes) => () => void
   isBuyDisabled: boolean
   isSwapDisabled: boolean
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
 }
 
 function BuySendSwapLayout (props: Props) {

--- a/components/brave_wallet_ui/components/buy-send-swap/buy/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy/index.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
 import {
   AccountAssetOptionType,
+  BraveWallet,
   BuySendSwapViewTypes,
-  EthereumChain,
   ToOrFromType,
-  MAINNET_CHAIN_ID,
   DefaultCurrencies
 } from '../../../constants/types'
 import { NavButton } from '../../extension'
@@ -20,9 +19,9 @@ import {
 
 export interface Props {
   selectedAsset: AccountAssetOptionType
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   buyAmount: string
-  networkList: EthereumChain[]
+  networkList: BraveWallet.EthereumChain[]
   defaultCurrencies: DefaultCurrencies
   onSubmit: () => void
   onInputChange: (value: string, name: string) => void
@@ -51,7 +50,7 @@ function Buy (props: Props) {
 
   return (
     <StyledWrapper>
-      {selectedNetwork.chainId === MAINNET_CHAIN_ID ? (
+      {selectedNetwork.chainId === BraveWallet.MAINNET_CHAIN_ID ? (
         <SwapInputComponent
           defaultCurrencies={defaultCurrencies}
           componentType='buyAmount'
@@ -71,7 +70,7 @@ function Buy (props: Props) {
       <NavButton
         disabled={false}
         buttonType='primary'
-        text={selectedNetwork.chainId === MAINNET_CHAIN_ID ? getLocale('braveWalletBuyWyreButton') : getLocale('braveWalletBuyFaucetButton')}
+        text={selectedNetwork.chainId === BraveWallet.MAINNET_CHAIN_ID ? getLocale('braveWalletBuyWyreButton') : getLocale('braveWalletBuyFaucetButton')}
         onSubmit={onSubmit}
       />
     </StyledWrapper>

--- a/components/brave_wallet_ui/components/buy-send-swap/header/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/header/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { UserAccountType, BuySendSwapViewTypes, EthereumChain } from '../../../constants/types'
+import { UserAccountType, BuySendSwapViewTypes, BraveWallet } from '../../../constants/types'
 import { reduceAddress } from '../../../utils/reduce-address'
 import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 import { reduceAccountDisplayName } from '../../../utils/reduce-account-name'
@@ -23,7 +23,7 @@ import {
 
 export interface Props {
   selectedAccount: UserAccountType
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   onChangeSwapView: (view: BuySendSwapViewTypes) => void
 }
 

--- a/components/brave_wallet_ui/components/buy-send-swap/select-account-with-header/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-account-with-header/index.tsx
@@ -7,7 +7,7 @@ import { getLocale } from '../../../../common/locale'
 import {
   SelectWrapper,
   SelectScrollSearchContainer
-} from '../../buy-send-swap/shared-styles'
+} from '../shared-styles'
 
 export interface Props {
   accounts: UserAccountType[]

--- a/components/brave_wallet_ui/components/buy-send-swap/select-network-with-header/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-network-with-header/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { EthereumChain } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { SelectNetwork } from '../../shared'
 import Header from '../select-header'
 import { getLocale } from '../../../../common/locale'
@@ -10,10 +10,10 @@ import {
 } from '../shared-styles'
 
 export interface Props {
-  networks: EthereumChain[]
-  selectedNetwork: EthereumChain
+  networks: BraveWallet.EthereumChain[]
+  selectedNetwork: BraveWallet.EthereumChain
   hasAddButton?: boolean
-  onSelectNetwork: (network: EthereumChain) => () => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => () => void
   onBack: () => void
   onAddNetwork?: () => void
 }

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/buy-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/buy-tab.tsx
@@ -3,7 +3,7 @@ import {
   UserAccountType,
   AccountAssetOptionType,
   BuySendSwapViewTypes,
-  EthereumChain,
+  BraveWallet,
   DefaultCurrencies
 } from '../../../constants/types'
 import {
@@ -14,15 +14,15 @@ import {
 
 export interface Props {
   accounts: UserAccountType[]
-  networkList: EthereumChain[]
-  selectedNetwork: EthereumChain
+  networkList: BraveWallet.EthereumChain[]
+  selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   assetOptions: AccountAssetOptionType[]
   buyAmount: string
   showHeader?: boolean
   defaultCurrencies: DefaultCurrencies
   onSubmit: (asset: AccountAssetOptionType) => void
-  onSelectNetwork: (network: EthereumChain) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onSetBuyAmount: (value: string) => void
   onAddNetwork: () => void
@@ -53,7 +53,7 @@ function BuyTab (props: Props) {
     setBuyView(view)
   }
 
-  const onClickSelectNetwork = (network: EthereumChain) => () => {
+  const onClickSelectNetwork = (network: BraveWallet.EthereumChain) => () => {
     onSelectNetwork(network)
     setBuyView('buy')
   }

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/send-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/send-tab.tsx
@@ -4,7 +4,7 @@ import {
   AccountAssetOptionType,
   BuySendSwapViewTypes,
   ToOrFromType,
-  EthereumChain
+  BraveWallet
 } from '../../../constants/types'
 import {
   AccountsAssetsNetworks,
@@ -15,7 +15,7 @@ import {
 export interface Props {
   accounts: UserAccountType[]
   selectedAsset: AccountAssetOptionType
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   selectedAssetAmount: string
   selectedAssetBalance: string
@@ -26,13 +26,13 @@ export interface Props {
   addressError: string
   addressWarning: string
   onSubmit: () => void
-  onSelectNetwork: (network: EthereumChain) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onSelectAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
   onSetSendAmount: (value: string) => void
   onSetToAddressOrUrl: (value: string) => void
   onSelectPresetAmount: (percent: number) => void
-  networkList: EthereumChain[]
+  networkList: BraveWallet.EthereumChain[]
   onAddNetwork: () => void
   onAddAsset: () => void
 }
@@ -68,7 +68,7 @@ function SendTab (props: Props) {
     setSendView(view)
   }
 
-  const onClickSelectNetwork = (network: EthereumChain) => () => {
+  const onClickSelectNetwork = (network: BraveWallet.EthereumChain) => () => {
     onSelectNetwork(network)
     setSendView('send')
 

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
@@ -7,7 +7,7 @@ import {
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
   ToOrFromType,
-  EthereumChain,
+  BraveWallet,
   SwapValidationErrorType
 } from '../../../constants/types'
 import {
@@ -18,11 +18,11 @@ import {
 
 export interface Props {
   accounts: UserAccountType[]
-  networkList: EthereumChain[]
+  networkList: BraveWallet.EthereumChain[]
   orderType: OrderTypes
   swapToAsset: AccountAssetOptionType
   swapFromAsset: AccountAssetOptionType
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   exchangeRate: string
   slippageTolerance: SlippagePresetObjectType
@@ -39,7 +39,7 @@ export interface Props {
   onCustomSlippageToleranceChange: (value: string) => void
   onSubmitSwap: () => void
   flipSwapAssets: () => void
-  onSelectNetwork: (network: EthereumChain) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onToggleOrderType: () => void
   onSelectSwapAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
@@ -105,7 +105,7 @@ function SwapTab (props: Props) {
     }
   }
 
-  const onClickSelectNetwork = (network: EthereumChain) => () => {
+  const onClickSelectNetwork = (network: BraveWallet.EthereumChain) => () => {
     onSelectNetwork(network)
     setSwapView('swap')
   }

--- a/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-watchlist-item/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Checkbox } from 'brave-ui'
-import { ERCToken } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { withPlaceholderIcon } from '../../shared'
 import { hexToNumber } from '../../../utils/format-balances'
 
@@ -18,11 +18,11 @@ import {
 } from './style'
 
 export interface Props {
-  onSelectAsset: (key: string, selected: boolean, token: ERCToken, isCustom: boolean) => void
-  onRemoveAsset: (token: ERCToken) => void
+  onSelectAsset: (key: string, selected: boolean, token: BraveWallet.ERCToken, isCustom: boolean) => void
+  onRemoveAsset: (token: BraveWallet.ERCToken) => void
   isCustom: boolean
   isSelected: boolean
-  token: ERCToken
+  token: BraveWallet.ERCToken
 }
 
 const AssetWatchlistItem = (props: Props) => {

--- a/components/brave_wallet_ui/components/desktop/chart-control-bar/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/chart-control-bar/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ChartTimelineObjectType, AssetPriceTimeframe } from '../../../constants/types'
+import { BraveWallet, ChartTimelineObjectType } from '../../../constants/types'
 
 // Styled Components
 import {
@@ -10,12 +10,12 @@ import {
 
 export interface Props {
   timelineOptions: ChartTimelineObjectType[]
-  selectedTimeline: AssetPriceTimeframe
-  onSubmit: (id: AssetPriceTimeframe) => void
+  selectedTimeline: BraveWallet.AssetPriceTimeframe
+  onSubmit: (id: BraveWallet.AssetPriceTimeframe) => void
 }
 
 export default class ChartControlBar extends React.PureComponent<Props, {}> {
-  onTimeSelect = (id: AssetPriceTimeframe) => () => {
+  onTimeSelect = (id: BraveWallet.AssetPriceTimeframe) => () => {
     this.props.onSubmit(id)
   }
 

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { getLocale } from '../../../../../../common/locale'
 import { NavButton } from '../../../../extension'
-import { TREZOR_HARDWARE_VENDOR, LEDGER_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../../../../constants/types'
 // Styled Components
 import { DisclaimerText, InfoIcon } from '../style'
 import {
@@ -33,7 +33,7 @@ export interface Props {
 const derivationBatch = 4
 
 export default function (props: Props) {
-  const [selectedHardwareWallet, setSelectedHardwareWallet] = React.useState<HardwareVendor>(LEDGER_HARDWARE_VENDOR)
+  const [selectedHardwareWallet, setSelectedHardwareWallet] = React.useState<HardwareVendor>(BraveWallet.LEDGER_HARDWARE_VENDOR)
   const [isConnecting, setIsConnecting] = React.useState<boolean>(false)
   const [accounts, setAccounts] = React.useState<HardwareWalletAccount[]>([])
   const [selectedDerivationPaths, setSelectedDerivationPaths] = React.useState<string[]>([])
@@ -104,19 +104,19 @@ export default function (props: Props) {
   }
 
   const onSelectLedger = () => {
-    if (selectedHardwareWallet !== LEDGER_HARDWARE_VENDOR) {
+    if (selectedHardwareWallet !== BraveWallet.LEDGER_HARDWARE_VENDOR) {
       setConnectionError(undefined)
     }
 
-    selectVendor(LEDGER_HARDWARE_VENDOR)
+    selectVendor(BraveWallet.LEDGER_HARDWARE_VENDOR)
   }
 
   const onSelectTrezor = () => {
-    if (selectedHardwareWallet !== TREZOR_HARDWARE_VENDOR) {
+    if (selectedHardwareWallet !== BraveWallet.TREZOR_HARDWARE_VENDOR) {
       setConnectionError(undefined)
     }
 
-    selectVendor(TREZOR_HARDWARE_VENDOR)
+    selectVendor(BraveWallet.TREZOR_HARDWARE_VENDOR)
   }
 
   const onSubmit = () => {
@@ -150,15 +150,15 @@ export default function (props: Props) {
       <HardwareButtonRow>
         <HardwareButton
           onClick={onSelectLedger}
-          isSelected={selectedHardwareWallet === LEDGER_HARDWARE_VENDOR}
-          disabled={isConnecting && selectedHardwareWallet !== LEDGER_HARDWARE_VENDOR}
+          isSelected={selectedHardwareWallet === BraveWallet.LEDGER_HARDWARE_VENDOR}
+          disabled={isConnecting && selectedHardwareWallet !== BraveWallet.LEDGER_HARDWARE_VENDOR}
         >
           <LedgerIcon />
         </HardwareButton>
         <HardwareButton
           onClick={onSelectTrezor}
-          isSelected={selectedHardwareWallet === TREZOR_HARDWARE_VENDOR}
-          disabled={isConnecting && selectedHardwareWallet !== TREZOR_HARDWARE_VENDOR}
+          isSelected={selectedHardwareWallet === BraveWallet.TREZOR_HARDWARE_VENDOR}
+          disabled={isConnecting && selectedHardwareWallet !== BraveWallet.TREZOR_HARDWARE_VENDOR}
         >
           <TrezorIcon />
         </HardwareButton>

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/types.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/types.ts
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { HardwareDerivationScheme, LedgerDerivationPaths, TrezorDerivationPaths } from '../../../../../common/hardware/types'
-import { LEDGER_HARDWARE_VENDOR, TREZOR_HARDWARE_VENDOR } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+import { BraveWallet } from '../../../../../constants/types'
 import { HardwareVendor } from '../../../../../common/api/hardware_keyrings'
 
 export const HardwareWalletDerivationPathLocaleMapping = {
@@ -14,8 +14,8 @@ export const HardwareWalletDerivationPathLocaleMapping = {
 }
 
 export const HardwareWalletDerivationPathsMapping = {
-  [LEDGER_HARDWARE_VENDOR]: LedgerDerivationPaths,
-  [TREZOR_HARDWARE_VENDOR]: TrezorDerivationPaths
+  [BraveWallet.LEDGER_HARDWARE_VENDOR]: LedgerDerivationPaths,
+  [BraveWallet.TREZOR_HARDWARE_VENDOR]: TrezorDerivationPaths
 }
 
 export interface HardwareWalletConnectOpts {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react'
-import {
-  ERCToken,
-  EthereumChain,
-  MAINNET_CHAIN_ID
-} from '../../../../constants/types'
+import { BraveWallet } from '../../../../constants/types'
 import {
   PopupModal,
   AssetWatchlistItem
@@ -33,15 +29,15 @@ import {
 
 export interface Props {
   onClose: () => void
-  onAddUserAsset: (token: ERCToken) => void
-  onSetUserAssetVisible: (token: ERCToken, isVisible: boolean) => void
-  onRemoveUserAsset: (token: ERCToken) => void
+  onAddUserAsset: (token: BraveWallet.ERCToken) => void
+  onSetUserAssetVisible: (token: BraveWallet.ERCToken, isVisible: boolean) => void
+  onRemoveUserAsset: (token: BraveWallet.ERCToken) => void
   addUserAssetError: boolean
-  fullAssetList: ERCToken[]
-  userVisibleTokensInfo: ERCToken[]
-  selectedNetwork: EthereumChain
+  fullAssetList: BraveWallet.ERCToken[]
+  userVisibleTokensInfo: BraveWallet.ERCToken[]
+  selectedNetwork: BraveWallet.EthereumChain
   onFindTokenInfoByContractAddress: (contractAddress: string) => void
-  foundTokenInfoByContractAddress?: ERCToken
+  foundTokenInfoByContractAddress?: BraveWallet.ERCToken
 }
 
 const EditVisibleAssetsModal = (props: Props) => {
@@ -58,7 +54,7 @@ const EditVisibleAssetsModal = (props: Props) => {
     foundTokenInfoByContractAddress
   } = props
 
-  const [filteredTokenList, setFilteredTokenList] = React.useState<ERCToken[]>([])
+  const [filteredTokenList, setFilteredTokenList] = React.useState<BraveWallet.ERCToken[]>([])
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
   const [searchValue, setSearchValue] = React.useState<string>('')
   const [showAddCustomToken, setShowAddCustomToken] = React.useState<boolean>(false)
@@ -123,7 +119,7 @@ const EditVisibleAssetsModal = (props: Props) => {
     const visibleContracts = userVisibleTokensInfo.map((token) => token.contractAddress)
     const fullList = visibleContracts.includes('') ? fullAssetList : [nativeAsset, ...fullAssetList]
     const notVisibleList = fullList.filter((token) => !visibleContracts.includes(token.contractAddress))
-    return selectedNetwork.chainId !== MAINNET_CHAIN_ID
+    return selectedNetwork.chainId !== BraveWallet.MAINNET_CHAIN_ID
       ? visibleContracts.includes('')
         ? userVisibleTokensInfo
         : [...userVisibleTokensInfo, nativeAsset]
@@ -175,7 +171,7 @@ const EditVisibleAssetsModal = (props: Props) => {
       }
       onAddUserAsset(foundTokenInfoByContractAddress)
     } else {
-      const newToken: ERCToken = {
+      const newToken: BraveWallet.ERCToken = {
         contractAddress: tokenContractAddress,
         decimals: Number(tokenDecimals),
         isErc20: !tokenID,
@@ -191,15 +187,15 @@ const EditVisibleAssetsModal = (props: Props) => {
     setIsLoading(true)
   }
 
-  const isUserToken = (token: ERCToken) => {
+  const isUserToken = (token: BraveWallet.ERCToken) => {
     return userVisibleTokensInfo.map(e => e.contractAddress.toLowerCase()).includes(token.contractAddress.toLowerCase())
   }
 
-  const isAssetSelected = (token: ERCToken): boolean => {
+  const isAssetSelected = (token: BraveWallet.ERCToken): boolean => {
     return (isUserToken(token) && token.visible) ?? false
   }
 
-  const isCustomToken = React.useCallback((token: ERCToken): boolean => {
+  const isCustomToken = React.useCallback((token: BraveWallet.ERCToken): boolean => {
     const assetListContracts = fullAssetList.map((token) => token.contractAddress)
     if (token.isErc20 || token.isErc721) {
       return !assetListContracts.includes(token.contractAddress)
@@ -208,7 +204,7 @@ const EditVisibleAssetsModal = (props: Props) => {
     }
   }, [fullAssetList])
 
-  const onCheckWatchlistItem = (key: string, selected: boolean, token: ERCToken, isCustom: boolean) => {
+  const onCheckWatchlistItem = (key: string, selected: boolean, token: BraveWallet.ERCToken, isCustom: boolean) => {
     if (isUserToken(token)) {
       if (isCustom) {
         selected ? onSetUserAssetVisible(token, true) : onSetUserAssetVisible(token, false)
@@ -241,7 +237,7 @@ const EditVisibleAssetsModal = (props: Props) => {
     toggleShowAddCustomToken()
   }
 
-  const onRemoveAsset = (token: ERCToken) => {
+  const onRemoveAsset = (token: BraveWallet.ERCToken) => {
     setIsLoading(true)
     onRemoveUserAsset(token)
   }

--- a/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
@@ -8,7 +8,7 @@ import {
 import { create } from 'ethereum-blockies'
 import { Tooltip } from '../../shared'
 import { getLocale } from '../../../../common/locale'
-import { EthereumChain, DefaultCurrencies } from '../../../constants/types'
+import { BraveWallet, DefaultCurrencies } from '../../../constants/types'
 import { TransactionPopup } from '../'
 // Styled Components
 import {
@@ -33,7 +33,7 @@ export interface Props {
   fiatBalance: string
   assetBalance: string
   assetTicker: string
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   name: string
 }
 

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 // Options
-import { ERCToken, DefaultCurrencies } from '../../../constants/types'
+import { BraveWallet, DefaultCurrencies } from '../../../constants/types'
 import { hexToNumber } from '../../../utils/format-balances'
 
 // Styled Components
@@ -24,7 +24,7 @@ export interface Props {
   action?: () => void
   assetBalance: string
   fiatBalance: string
-  token: ERCToken
+  token: BraveWallet.ERCToken
   defaultCurrencies: DefaultCurrencies
 }
 

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -3,12 +3,7 @@ import * as EthereumBlockies from 'ethereum-blockies'
 
 import { getLocale } from '../../../../common/locale'
 import {
-  AssetPrice,
-  EthereumChain,
-  ERCToken,
-  TransactionInfo,
-  TransactionStatus,
-  TransactionType,
+  BraveWallet,
   WalletAccountType,
   DefaultCurrencies
 } from '../../../constants/types'
@@ -51,19 +46,19 @@ import TransactionPopup, { TransactionPopupItem } from '../transaction-popup'
 import TransactionTimestampTooltip from '../transaction-timestamp-tooltip'
 
 export interface Props {
-  selectedNetwork: EthereumChain
-  transaction: TransactionInfo
+  selectedNetwork: BraveWallet.EthereumChain
+  transaction: BraveWallet.TransactionInfo
   account: WalletAccountType | undefined
   accounts: WalletAccountType[]
-  visibleTokens: ERCToken[]
-  transactionSpotPrices: AssetPrice[]
+  visibleTokens: BraveWallet.ERCToken[]
+  transactionSpotPrices: BraveWallet.AssetPrice[]
   displayAccountName: boolean
   defaultCurrencies: DefaultCurrencies
   onSelectAccount: (account: WalletAccountType) => void
-  onSelectAsset: (asset: ERCToken) => void
-  onRetryTransaction: (transaction: TransactionInfo) => void
-  onSpeedupTransaction: (transaction: TransactionInfo) => void
-  onCancelTransaction: (transaction: TransactionInfo) => void
+  onSelectAsset: (asset: BraveWallet.ERCToken) => void
+  onRetryTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onSpeedupTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onCancelTransaction: (transaction: BraveWallet.TransactionInfo) => void
 }
 
 const PortfolioTransactionItem = (props: Props) => {
@@ -172,7 +167,7 @@ const PortfolioTransactionItem = (props: Props) => {
 
   const transactionIntentLocale = React.useMemo(() => {
     switch (true) {
-      case transaction.txType === TransactionType.ERC20Approve: {
+      case transaction.txType === BraveWallet.TransactionType.ERC20Approve: {
         const text = getLocale('braveWalletApprovalTransactionIntent')
         return (
           <>
@@ -190,10 +185,10 @@ const PortfolioTransactionItem = (props: Props) => {
         return displayAccountName ? text.toLowerCase() : text
       }
 
-      case transaction.txType === TransactionType.ETHSend:
-      case transaction.txType === TransactionType.ERC20Transfer:
-      case transaction.txType === TransactionType.ERC721TransferFrom:
-      case transaction.txType === TransactionType.ERC721SafeTransferFrom:
+      case transaction.txType === BraveWallet.TransactionType.ETHSend:
+      case transaction.txType === BraveWallet.TransactionType.ERC20Transfer:
+      case transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom:
+      case transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom:
       default: {
         const text = getLocale('braveWalletTransactionSent')
         return (
@@ -201,11 +196,11 @@ const PortfolioTransactionItem = (props: Props) => {
             {displayAccountName ? text : toProperCase(text)}{' '}
             <AddressOrAsset
               // Disabled for ERC721 tokens until we have NFT meta data
-              disabled={transaction.txType === TransactionType.ERC721TransferFrom || transaction.txType === TransactionType.ERC721SafeTransferFrom}
+              disabled={transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom || transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom}
               onClick={onAssetClick(transactionDetails.symbol)}
             >
               {transactionDetails.symbol}
-              {transaction.txType === TransactionType.ERC721TransferFrom || transaction.txType === TransactionType.ERC721SafeTransferFrom
+              {transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom || transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom
                 ? ' ' + transactionDetails.erc721TokenId : ''}
             </AddressOrAsset>
           </>
@@ -216,7 +211,7 @@ const PortfolioTransactionItem = (props: Props) => {
 
   const transactionIntentDescription = React.useMemo(() => {
     switch (true) {
-      case transaction.txType === TransactionType.ERC20Approve: {
+      case transaction.txType === BraveWallet.TransactionType.ERC20Approve: {
         const text = getLocale('braveWalletApprovalTransactionIntent')
         return (
           <DetailRow>
@@ -233,7 +228,7 @@ const PortfolioTransactionItem = (props: Props) => {
         )
       }
 
-      // FIXME: Add as new TransactionType on the controller side.
+      // FIXME: Add as new BraveWallet.TransactionType on the controller side.
       case transaction.txData.baseData.to.toLowerCase() === SwapExchangeProxy: {
         return (
           <DetailRow>
@@ -253,10 +248,10 @@ const PortfolioTransactionItem = (props: Props) => {
         )
       }
 
-      case transaction.txType === TransactionType.ETHSend:
-      case transaction.txType === TransactionType.ERC20Transfer:
-      case transaction.txType === TransactionType.ERC721TransferFrom:
-      case transaction.txType === TransactionType.ERC721SafeTransferFrom:
+      case transaction.txType === BraveWallet.TransactionType.ETHSend:
+      case transaction.txType === BraveWallet.TransactionType.ERC20Transfer:
+      case transaction.txType === BraveWallet.TransactionType.ERC721TransferFrom:
+      case transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom:
       default: {
         return (
           <DetailRow>
@@ -313,12 +308,12 @@ const PortfolioTransactionItem = (props: Props) => {
       <StatusRow>
         <StatusBubble status={transactionDetails.status} />
         <DetailTextDarkBold>
-          {transactionDetails.status === TransactionStatus.Unapproved && getLocale('braveWalletTransactionStatusUnapproved')}
-          {transactionDetails.status === TransactionStatus.Approved && getLocale('braveWalletTransactionStatusApproved')}
-          {transactionDetails.status === TransactionStatus.Rejected && getLocale('braveWalletTransactionStatusRejected')}
-          {transactionDetails.status === TransactionStatus.Submitted && getLocale('braveWalletTransactionStatusSubmitted')}
-          {transactionDetails.status === TransactionStatus.Confirmed && getLocale('braveWalletTransactionStatusConfirmed')}
-          {transactionDetails.status === TransactionStatus.Error && getLocale('braveWalletTransactionStatusError')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Unapproved && getLocale('braveWalletTransactionStatusUnapproved')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Approved && getLocale('braveWalletTransactionStatusApproved')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Rejected && getLocale('braveWalletTransactionStatusRejected')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Submitted && getLocale('braveWalletTransactionStatusSubmitted')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Confirmed && getLocale('braveWalletTransactionStatusConfirmed')}
+          {transactionDetails.status === BraveWallet.TransactionStatus.Error && getLocale('braveWalletTransactionStatusError')}
         </DetailTextDarkBold>
       </StatusRow>
       <DetailRow>
@@ -340,7 +335,7 @@ const PortfolioTransactionItem = (props: Props) => {
           </CoinsButton>
         </TransactionFeesTooltip>
 
-        {transactionDetails.status !== TransactionStatus.Rejected ? (
+        {transactionDetails.status !== BraveWallet.TransactionStatus.Rejected ? (
           <MoreButton onClick={onShowTransactionPopup}>
             <MoreIcon />
           </MoreButton>
@@ -350,28 +345,28 @@ const PortfolioTransactionItem = (props: Props) => {
 
         {showTransactionPopup &&
           <TransactionPopup>
-            {[TransactionStatus.Approved, TransactionStatus.Submitted, TransactionStatus.Confirmed] &&
+            {[BraveWallet.TransactionStatus.Approved, BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Confirmed] &&
               <TransactionPopupItem
                 onClick={onClickViewOnBlockExplorer}
                 text={getLocale('braveWalletTransactionExplorer')}
               />
             }
 
-            {[TransactionStatus.Submitted, TransactionStatus.Approved].includes(transactionDetails.status) &&
+            {[BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Approved].includes(transactionDetails.status) &&
               <TransactionPopupItem
                 onClick={onClickSpeedupTransaction}
                 text={getLocale('braveWalletTransactionSpeedup')}
               />
             }
 
-            {[TransactionStatus.Submitted, TransactionStatus.Approved].includes(transactionDetails.status) &&
+            {[BraveWallet.TransactionStatus.Submitted, BraveWallet.TransactionStatus.Approved].includes(transactionDetails.status) &&
               <TransactionPopupItem
                 onClick={onClickCancelTransaction}
                 text={getLocale('braveWalletTransactionCancel')}
               />
             }
 
-            {[TransactionStatus.Error].includes(transactionDetails.status) &&
+            {[BraveWallet.TransactionStatus.Error].includes(transactionDetails.status) &&
               <TransactionPopupItem
                 onClick={onClickRetryTransaction}
                 text={getLocale('braveWalletTransactionRetry')}

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/style.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
-import { TransactionStatus } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { MoreVertRIcon, ArrowRightIcon } from 'brave-ui/components/icons'
 import CoinsIconSVG from '../../../assets/svg-icons/coins-icon.svg'
 import { WalletButton } from '../../shared/style'
 
 interface StyleProps {
   orb: string
-  status: TransactionStatus
+  status: BraveWallet.TransactionStatus
 }
 
 export const StyledWrapper = styled.div`

--- a/components/brave_wallet_ui/components/desktop/select-network-dropdown/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/select-network-dropdown/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { EthereumChain } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { SelectNetwork, Tooltip } from '../../shared'
 import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 // Styled Components
@@ -12,9 +12,9 @@ import {
 } from './style'
 
 export interface Props {
-  onSelectNetwork: (network: EthereumChain) => () => void
-  networkList: EthereumChain[]
-  selectedNetwork: EthereumChain
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => () => void
+  networkList: BraveWallet.EthereumChain[]
+  selectedNetwork: BraveWallet.EthereumChain
   showNetworkDropDown: boolean
   onClick: () => void
 }

--- a/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
@@ -5,10 +5,7 @@ import {
   AccountSettingsNavTypes,
   UpdateAccountNamePayloadType,
   AccountTransactions,
-  EthereumChain,
-  ERCToken,
-  AssetPrice,
-  TransactionInfo,
+  BraveWallet,
   DefaultCurrencies
 } from '../../../../constants/types'
 import { reduceAddress } from '../../../../utils/reduce-address'
@@ -61,9 +58,9 @@ export interface Props {
   accounts: WalletAccountType[]
   transactions: AccountTransactions
   privateKey: string
-  selectedNetwork: EthereumChain
-  userVisibleTokensInfo: ERCToken[]
-  transactionSpotPrices: AssetPrice[]
+  selectedNetwork: BraveWallet.EthereumChain
+  userVisibleTokensInfo: BraveWallet.ERCToken[]
+  transactionSpotPrices: BraveWallet.AssetPrice[]
   selectedAccount: WalletAccountType | undefined
   defaultCurrencies: DefaultCurrencies
   onViewPrivateKey: (address: string, isDefault: boolean) => void
@@ -74,11 +71,11 @@ export interface Props {
   onUpdateAccountName: (payload: UpdateAccountNamePayloadType) => { success: boolean }
   onRemoveAccount: (address: string, hardware: boolean) => void
   onSelectAccount: (account: WalletAccountType) => void
-  onSelectAsset: (token: ERCToken) => void
+  onSelectAsset: (token: BraveWallet.ERCToken) => void
   goBack: () => void
-  onRetryTransaction: (transaction: TransactionInfo) => void
-  onSpeedupTransaction: (transaction: TransactionInfo) => void
-  onCancelTransaction: (transaction: TransactionInfo) => void
+  onRetryTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onSpeedupTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onCancelTransaction: (transaction: BraveWallet.TransactionInfo) => void
 }
 
 function Accounts (props: Props) {

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -1,20 +1,15 @@
 import * as React from 'react'
 import { Route, useHistory, useParams } from 'react-router-dom'
-import { TransactionInfo } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import { StyledWrapper } from './style'
 import {
+  BraveWallet,
   TopTabNavTypes,
   PriceDataObjectType,
   AccountAssetOptionType,
   AccountTransactions,
-  AssetPrice,
   WalletAccountType,
-  AssetPriceTimeframe,
-  EthereumChain,
-  ERCToken,
   UpdateAccountNamePayloadType,
   WalletRoutes,
-  DefaultWallet,
   DefaultCurrencies
 } from '../../../../constants/types'
 import { TopNavOptions } from '../../../../options/top-nav-options'
@@ -34,8 +29,8 @@ interface ParamsType {
 export interface Props {
   onLockWallet: () => void
   onShowBackup: () => void
-  onChangeTimeline: (path: AssetPriceTimeframe) => void
-  onSelectAsset: (asset: ERCToken | undefined) => void
+  onChangeTimeline: (path: BraveWallet.AssetPriceTimeframe) => void
+  onSelectAsset: (asset: BraveWallet.ERCToken | undefined) => void
   onCreateAccount: (name: string) => void
   onImportAccount: (accountName: string, privateKey: string) => void
   onConnectHardwareWallet: (opts: HardwareWalletConnectOpts) => Promise<HardwareWalletAccount[]>
@@ -44,49 +39,49 @@ export interface Props {
   onUpdateAccountName: (payload: UpdateAccountNamePayloadType) => { success: boolean }
   onShowAddModal: () => void
   onHideAddModal: () => void
-  onSelectNetwork: (network: EthereumChain) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onRemoveAccount: (address: string, hardware: boolean) => void
   onViewPrivateKey: (address: string, isDefault: boolean) => void
   onDoneViewingPrivateKey: () => void
   onImportAccountFromJson: (accountName: string, password: string, json: string) => void
   onSetImportError: (error: boolean) => void
-  onAddUserAsset: (token: ERCToken) => void
-  onSetUserAssetVisible: (token: ERCToken, isVisible: boolean) => void
-  onRemoveUserAsset: (token: ERCToken) => void
+  onAddUserAsset: (token: BraveWallet.ERCToken) => void
+  onSetUserAssetVisible: (token: BraveWallet.ERCToken, isVisible: boolean) => void
+  onRemoveUserAsset: (token: BraveWallet.ERCToken) => void
   onOpenWalletSettings: () => void
   defaultCurrencies: DefaultCurrencies
   addUserAssetError: boolean
   hasImportError: boolean
-  transactionSpotPrices: AssetPrice[]
+  transactionSpotPrices: BraveWallet.AssetPrice[]
   privateKey: string
-  fullAssetList: ERCToken[]
-  userVisibleTokensInfo: ERCToken[]
+  fullAssetList: BraveWallet.ERCToken[]
+  userVisibleTokensInfo: BraveWallet.ERCToken[]
   needsBackup: boolean
   accounts: WalletAccountType[]
-  networkList: EthereumChain[]
-  selectedTimeline: AssetPriceTimeframe
-  selectedPortfolioTimeline: AssetPriceTimeframe
+  networkList: BraveWallet.EthereumChain[]
+  selectedTimeline: BraveWallet.AssetPriceTimeframe
+  selectedPortfolioTimeline: BraveWallet.AssetPriceTimeframe
   portfolioPriceHistory: PriceDataObjectType[]
   selectedAssetPriceHistory: PriceDataObjectType[]
-  selectedAssetFiatPrice: AssetPrice | undefined
-  selectedAssetCryptoPrice: AssetPrice | undefined
-  selectedAsset: ERCToken | undefined
+  selectedAssetFiatPrice: BraveWallet.AssetPrice | undefined
+  selectedAssetCryptoPrice: BraveWallet.AssetPrice | undefined
+  selectedAsset: BraveWallet.ERCToken | undefined
   portfolioBalance: string
   transactions: AccountTransactions
   userAssetList: AccountAssetOptionType[]
   isLoading: boolean
   showAddModal: boolean
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   isFetchingPortfolioPriceHistory: boolean
-  defaultWallet: DefaultWallet
+  defaultWallet: BraveWallet.DefaultWallet
   isMetaMaskInstalled: boolean
-  onRetryTransaction: (transaction: TransactionInfo) => void
-  onSpeedupTransaction: (transaction: TransactionInfo) => void
-  onCancelTransaction: (transaction: TransactionInfo) => void
+  onRetryTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onSpeedupTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onCancelTransaction: (transaction: BraveWallet.TransactionInfo) => void
   onShowVisibleAssetsModal: (showModal: boolean) => void
   showVisibleAssetsModal: boolean
   onFindTokenInfoByContractAddress: (contractAddress: string) => void
-  foundTokenInfoByContractAddress?: ERCToken
+  foundTokenInfoByContractAddress?: BraveWallet.ERCToken
 }
 
 const CryptoView = (props: Props) => {
@@ -215,7 +210,7 @@ const CryptoView = (props: Props) => {
     history.push(`${WalletRoutes.Accounts}`)
   }
 
-  const selectAsset = (asset: ERCToken | undefined) => {
+  const selectAsset = (asset: BraveWallet.ERCToken | undefined) => {
     if (asset) {
       history.push(`${WalletRoutes.Portfolio}/${asset.symbol}`)
     } else {
@@ -247,8 +242,8 @@ const CryptoView = (props: Props) => {
             hasMoreButtons={true}
             onLockWallet={onLockWallet}
           />
-          {(defaultWallet !== DefaultWallet.BraveWallet &&
-            (defaultWallet !== DefaultWallet.BraveWalletPreferExtension || (defaultWallet === DefaultWallet.BraveWalletPreferExtension && isMetaMaskInstalled))) &&
+          {(defaultWallet !== BraveWallet.DefaultWallet.BraveWallet &&
+            (defaultWallet !== BraveWallet.DefaultWallet.BraveWalletPreferExtension || (defaultWallet === BraveWallet.DefaultWallet.BraveWalletPreferExtension && isMetaMaskInstalled))) &&
             showDefaultWalletBanner &&
             <WalletBanner
               onDismiss={onDismissDefaultWalletBanner}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
@@ -4,13 +4,9 @@ import * as React from 'react'
 import {
   PriceDataObjectType,
   AccountTransactions,
-  AssetPrice,
+  BraveWallet,
   WalletAccountType,
-  AssetPriceTimeframe,
   AccountAssetOptionType,
-  ERCToken,
-  EthereumChain,
-  TransactionInfo,
   DefaultCurrencies
 } from '../../../../constants/types'
 import { getLocale } from '../../../../../common/locale'
@@ -75,41 +71,41 @@ import {
 
 export interface Props {
   toggleNav: () => void
-  onChangeTimeline: (path: AssetPriceTimeframe) => void
-  onSelectAsset: (asset: ERCToken | undefined) => void
+  onChangeTimeline: (path: BraveWallet.AssetPriceTimeframe) => void
+  onSelectAsset: (asset: BraveWallet.ERCToken | undefined) => void
   onSelectAccount: (account: WalletAccountType) => void
   onClickAddAccount: () => void
-  onSelectNetwork: (network: EthereumChain) => void
-  onAddUserAsset: (token: ERCToken) => void
-  onSetUserAssetVisible: (token: ERCToken, isVisible: boolean) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
+  onAddUserAsset: (token: BraveWallet.ERCToken) => void
+  onSetUserAssetVisible: (token: BraveWallet.ERCToken, isVisible: boolean) => void
   onShowVisibleAssetsModal: (showModal: boolean) => void
-  onRemoveUserAsset: (token: ERCToken) => void
+  onRemoveUserAsset: (token: BraveWallet.ERCToken) => void
   showVisibleAssetsModal: boolean
   defaultCurrencies: DefaultCurrencies
   addUserAssetError: boolean
-  selectedNetwork: EthereumChain
-  networkList: EthereumChain[]
+  selectedNetwork: BraveWallet.EthereumChain
+  networkList: BraveWallet.EthereumChain[]
   userAssetList: AccountAssetOptionType[]
   accounts: WalletAccountType[]
-  selectedTimeline: AssetPriceTimeframe
-  selectedPortfolioTimeline: AssetPriceTimeframe
-  selectedAsset: ERCToken | undefined
-  selectedAssetFiatPrice: AssetPrice | undefined
-  selectedAssetCryptoPrice: AssetPrice | undefined
+  selectedTimeline: BraveWallet.AssetPriceTimeframe
+  selectedPortfolioTimeline: BraveWallet.AssetPriceTimeframe
+  selectedAsset: BraveWallet.ERCToken | undefined
+  selectedAssetFiatPrice: BraveWallet.AssetPrice | undefined
+  selectedAssetCryptoPrice: BraveWallet.AssetPrice | undefined
   selectedAssetPriceHistory: PriceDataObjectType[]
   portfolioPriceHistory: PriceDataObjectType[]
   portfolioBalance: string
   transactions: AccountTransactions
   isLoading: boolean
-  fullAssetList: ERCToken[]
-  userVisibleTokensInfo: ERCToken[]
+  fullAssetList: BraveWallet.ERCToken[]
+  userVisibleTokensInfo: BraveWallet.ERCToken[]
   isFetchingPortfolioPriceHistory: boolean
-  transactionSpotPrices: AssetPrice[]
-  onRetryTransaction: (transaction: TransactionInfo) => void
-  onSpeedupTransaction: (transaction: TransactionInfo) => void
-  onCancelTransaction: (transaction: TransactionInfo) => void
+  transactionSpotPrices: BraveWallet.AssetPrice[]
+  onRetryTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onSpeedupTransaction: (transaction: BraveWallet.TransactionInfo) => void
+  onCancelTransaction: (transaction: BraveWallet.TransactionInfo) => void
   onFindTokenInfoByContractAddress: (contractAddress: string) => void
-  foundTokenInfoByContractAddress?: ERCToken
+  foundTokenInfoByContractAddress?: BraveWallet.ERCToken
 }
 
 const Portfolio = (props: Props) => {
@@ -195,7 +191,7 @@ const Portfolio = (props: Props) => {
     }
   }
 
-  const selectAsset = (asset: ERCToken) => () => {
+  const selectAsset = (asset: BraveWallet.ERCToken) => () => {
     onSelectAsset(asset)
     toggleNav()
   }
@@ -222,7 +218,7 @@ const Portfolio = (props: Props) => {
     }
   }
 
-  const onClickSelectNetwork = (network: EthereumChain) => () => {
+  const onClickSelectNetwork = (network: BraveWallet.EthereumChain) => () => {
     onSelectNetwork(network)
     toggleShowNetworkDropdown()
   }
@@ -237,12 +233,12 @@ const Portfolio = (props: Props) => {
     onShowVisibleAssetsModal(!showVisibleAssetsModal)
   }
 
-  const getFiatBalance = (account: WalletAccountType, asset: ERCToken) => {
+  const getFiatBalance = (account: WalletAccountType, asset: BraveWallet.ERCToken) => {
     const found = account.tokens.find((token) => token.asset.contractAddress === asset.contractAddress)
     return (found) ? found.fiatBalance : ''
   }
 
-  const getAssetBalance = (account: WalletAccountType, asset: ERCToken) => {
+  const getAssetBalance = (account: WalletAccountType, asset: BraveWallet.ERCToken) => {
     const found = account.tokens.find((token) => token.asset.contractAddress === asset.contractAddress)
     return (found) ? formatBalance(found.assetBalance, found.asset.decimals) : ''
   }
@@ -255,7 +251,7 @@ const Portfolio = (props: Props) => {
     }
   }, [portfolioHistory, portfolioBalance])
 
-  const selectedAssetTransactions = React.useMemo((): TransactionInfo[] => {
+  const selectedAssetTransactions = React.useMemo((): BraveWallet.TransactionInfo[] => {
     const filteredTransactions = Object.values(transactions).flatMap((txInfo) =>
       txInfo.flatMap((tx) =>
         parseTransaction(tx).symbol === selectedAsset?.symbol ? tx : []
@@ -364,7 +360,7 @@ const Portfolio = (props: Props) => {
           <SubDivider />
           {selectedAssetTransactions.length !== 0 ? (
             <>
-              {selectedAssetTransactions.map((transaction: TransactionInfo) =>
+              {selectedAssetTransactions.map((transaction: BraveWallet.TransactionInfo) =>
                 <PortfolioTransactionItem
                   defaultCurrencies={defaultCurrencies}
                   key={transaction.id}

--- a/components/brave_wallet_ui/components/extension/add-suggested-token-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/add-suggested-token-panel/index.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react'
 
-import {
-  ERCToken,
-  EthereumChain
-} from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 
 import {
   StyledWrapper,
@@ -25,8 +22,8 @@ import { reduceAddress } from '../../../utils/reduce-address'
 export interface Props {
   onCancel: () => void
   onAddToken: () => void
-  selectedNetwork: EthereumChain
-  token?: ERCToken
+  selectedNetwork: BraveWallet.EthereumChain
+  token?: BraveWallet.ERCToken
 }
 
 function AddSuggestedTokenPanel (props: Props) {

--- a/components/brave_wallet_ui/components/extension/allow-add-change-network-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/allow-add-change-network-panel/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { EthereumChain } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { getLocale } from '../../../../common/locale'
 import { NavButton, PanelTab } from '..'
 
@@ -27,7 +27,7 @@ export type tabs = 'network' | 'details'
 
 export interface Props {
   siteOrigin: string
-  networkPayload: EthereumChain
+  networkPayload: BraveWallet.EthereumChain
   panelType: 'add' | 'change'
   onCancel: () => void
   onApproveAddNetwork: () => void

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -2,13 +2,8 @@ import * as React from 'react'
 import { create } from 'ethereum-blockies'
 
 import {
+  BraveWallet,
   WalletAccountType,
-  EthereumChain,
-  TransactionInfo,
-  TransactionType,
-  AssetPrice,
-  ERCToken,
-  GasEstimation1559,
   DefaultCurrencies
 } from '../../../constants/types'
 import {
@@ -77,12 +72,12 @@ export type confirmPanelTabs = 'transaction' | 'details'
 export interface Props {
   siteURL: string
   accounts: WalletAccountType[]
-  visibleTokens: ERCToken[]
-  fullTokenList: ERCToken[]
-  transactionInfo: TransactionInfo
-  selectedNetwork: EthereumChain
-  transactionSpotPrices: AssetPrice[]
-  gasEstimates?: GasEstimation1559
+  visibleTokens: BraveWallet.ERCToken[]
+  fullTokenList: BraveWallet.ERCToken[]
+  transactionInfo: BraveWallet.TransactionInfo
+  selectedNetwork: BraveWallet.EthereumChain
+  transactionSpotPrices: BraveWallet.AssetPrice[]
+  gasEstimates?: BraveWallet.GasEstimation1559
   transactionsQueueLength: number
   transactionQueueNumber: number
   defaultCurrencies: DefaultCurrencies
@@ -161,7 +156,7 @@ function ConfirmTransactionPanel (props: Props) {
   )
 
   React.useEffect(() => {
-    if (transactionInfo.txType !== TransactionType.ERC20Approve) {
+    if (transactionInfo.txType !== BraveWallet.TransactionType.ERC20Approve) {
       return
     }
 
@@ -264,7 +259,7 @@ function ConfirmTransactionPanel (props: Props) {
     <StyledWrapper>
       <TopRow>
         <NetworkText>{reduceNetworkDisplayName(selectedNetwork.chainName)}</NetworkText>
-        {transactionInfo.txType === TransactionType.ERC20Approve &&
+        {transactionInfo.txType === BraveWallet.TransactionType.ERC20Approve &&
           <AddressAndOrb>
             <AddressText>{reduceAddress(transactionDetails.recipient)}</AddressText>
             <AccountCircle orb={toOrb} />
@@ -284,7 +279,7 @@ function ConfirmTransactionPanel (props: Props) {
           </QueueStepRow>
         }
       </TopRow>
-      {transactionInfo.txType === TransactionType.ERC20Approve ? (
+      {transactionInfo.txType === BraveWallet.TransactionType.ERC20Approve ? (
         <>
           <FavIcon src={`chrome://favicon/size/64@1x/${siteURL}`} />
           <URLText>{siteURL}</URLText>
@@ -304,19 +299,19 @@ function ConfirmTransactionPanel (props: Props) {
             <AccountNameText>{reduceAddress(transactionDetails.recipient)}</AccountNameText>
           </FromToRow>
           <TransactionTypeText>{transactionTitle}</TransactionTypeText>
-          {(transactionInfo.txType === TransactionType.ERC721TransferFrom ||
-            transactionInfo.txType === TransactionType.ERC721SafeTransferFrom) &&
+          {(transactionInfo.txType === BraveWallet.TransactionType.ERC721TransferFrom ||
+            transactionInfo.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom) &&
             <AssetIconWithPlaceholder selectedAsset={transactionDetails.erc721ERCToken} />
           }
           <TransactionAmmountBig>
-            {transactionInfo.txType === TransactionType.ERC721TransferFrom ||
-              transactionInfo.txType === TransactionType.ERC721SafeTransferFrom
+            {transactionInfo.txType === BraveWallet.TransactionType.ERC721TransferFrom ||
+              transactionInfo.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom
               ? transactionDetails.erc721ERCToken?.name + ' ' + transactionDetails.erc721TokenId
               : formatWithCommasAndDecimals(transactionDetails.value) + ' ' + transactionDetails.symbol
             }
           </TransactionAmmountBig>
-          {transactionInfo.txType !== TransactionType.ERC721TransferFrom &&
-            transactionInfo.txType !== TransactionType.ERC721SafeTransferFrom &&
+          {transactionInfo.txType !== BraveWallet.TransactionType.ERC721TransferFrom &&
+            transactionInfo.txType !== BraveWallet.TransactionType.ERC721SafeTransferFrom &&
             <TransactionFiatAmountBig>{formatFiatAmountWithCommasAndDecimals(transactionDetails.fiatValue, defaultCurrencies.fiat)}</TransactionFiatAmountBig>
           }
         </>
@@ -333,10 +328,10 @@ function ConfirmTransactionPanel (props: Props) {
           text='Details'
         />
       </TabRow>
-      <MessageBox isDetails={selectedTab === 'details'} isApprove={transactionInfo.txType === TransactionType.ERC20Approve}>
+      <MessageBox isDetails={selectedTab === 'details'} isApprove={transactionInfo.txType === BraveWallet.TransactionType.ERC20Approve}>
         {selectedTab === 'transaction' ? (
           <>
-            {transactionInfo.txType === TransactionType.ERC20Approve &&
+            {transactionInfo.txType === BraveWallet.TransactionType.ERC20Approve &&
               <>
                 <TopColumn>
                   <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
@@ -369,7 +364,7 @@ function ConfirmTransactionPanel (props: Props) {
                 </SectionRow>
               </>
             }
-            {transactionInfo.txType !== TransactionType.ERC20Approve &&
+            {transactionInfo.txType !== BraveWallet.TransactionType.ERC20Approve &&
               <>
                 <SectionRow>
                   <TransactionTitle>{getLocale('braveWalletConfirmTransactionGasFee')}</TransactionTitle>
@@ -385,8 +380,8 @@ function ConfirmTransactionPanel (props: Props) {
                   <SingleRow>
                     <TransactionTitle>{getLocale('braveWalletConfirmTransactionTotal')}</TransactionTitle>
                     <GrandTotalText>
-                      {(transactionInfo.txType !== TransactionType.ERC721SafeTransferFrom &&
-                        transactionInfo.txType !== TransactionType.ERC721TransferFrom)
+                      {(transactionInfo.txType !== BraveWallet.TransactionType.ERC721SafeTransferFrom &&
+                        transactionInfo.txType !== BraveWallet.TransactionType.ERC721TransferFrom)
                         ? formatWithCommasAndDecimals(transactionDetails.value)
                         : transactionDetails.value
                       } {transactionDetails.symbol} + {transactionDetails.gasFee} {selectedNetwork.symbol}</GrandTotalText>

--- a/components/brave_wallet_ui/components/extension/connected-bottom-nav/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-bottom-nav/index.tsx
@@ -13,13 +13,13 @@ import {
   NavOutline
 } from './style'
 
-import { PanelTypes, EthereumChain } from '../../../constants/types'
+import { BraveWallet, PanelTypes } from '../../../constants/types'
 
 export interface Props {
   onNavigate: (path: PanelTypes) => void
   isSwapDisabled: boolean
   isBuyDisabled: boolean
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
 }
 
 function ConnectedBottomNav (props: Props) {

--- a/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
@@ -38,7 +38,7 @@ import { copyToClipboard } from '../../../utils/copy-to-clipboard'
 import {
   WalletAccountType,
   PanelTypes,
-  EthereumChain,
+  BraveWallet,
   BuySupportedChains,
   SwapSupportedChains,
   WalletOrigin,
@@ -49,7 +49,7 @@ import { getLocale } from '../../../../common/locale'
 
 export interface Props {
   selectedAccount: WalletAccountType
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   isConnected: boolean
   activeOrigin: string
   defaultCurrencies: DefaultCurrencies

--- a/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
+++ b/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import BigNumber from 'bignumber.js'
 
 import { getLocale } from '../../../../common/locale'
-import { TransactionInfo, EthereumChain } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { UpdateUnapprovedTransactionGasFieldsType } from '../../../common/constants/action_types'
 import { NavButton, Panel } from '../'
 import {
@@ -44,8 +44,8 @@ export enum MaxPriorityPanels {
 export interface Props {
   onCancel: () => void
   networkSpotPrice: string
-  transactionInfo: TransactionInfo
-  selectedNetwork: EthereumChain
+  transactionInfo: BraveWallet.TransactionInfo
+  selectedNetwork: BraveWallet.EthereumChain
   baseFeePerGas: string
   suggestedMaxPriorityFeeChoices: string[]
   suggestedSliderStep: string

--- a/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { create } from 'ethereum-blockies'
-import { WalletAccountType, EthereumChain } from '../../../constants/types'
+import { BraveWallet, WalletAccountType } from '../../../constants/types'
 import { SignMessagePayload } from '../../../panel/constants/action_types'
 import { reduceAccountDisplayName } from '../../../utils/reduce-account-name'
 import { getLocale } from '../../../../common/locale'
@@ -34,7 +34,7 @@ import { TabRow } from '../shared-panel-styles'
 
 export interface Props {
   accounts: WalletAccountType[]
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   signMessageData: SignMessagePayload[]
   onSign: () => void
   onCancel: () => void

--- a/components/brave_wallet_ui/components/extension/transaction-box/index.tsx
+++ b/components/brave_wallet_ui/components/extension/transaction-box/index.tsx
@@ -2,14 +2,14 @@ import * as React from 'react'
 
 import { getLocale } from '../../../../common/locale'
 import { numberArrayToHexStr } from '../../../utils/hex-utils'
-import { TransactionInfo, TransactionType } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { CodeSnippet, CodeSnippetText, DetailRow, DetailText, TransactionText } from './style'
 
 export interface Props {
-  transactionInfo: TransactionInfo
+  transactionInfo: BraveWallet.TransactionInfo
 }
 
-const txKeys = Object.keys(TransactionType)
+const txKeys = Object.keys(BraveWallet.TransactionType)
 
 const TransactionDetailBox = (props: Props) => {
   const { transactionInfo } = props
@@ -36,7 +36,7 @@ const TransactionDetailBox = (props: Props) => {
             <TransactionText>{getLocale('braveWalletTransactionDetailBoxFunction')}:</TransactionText>
             <DetailText>{txKeys[txType]}</DetailText>
           </DetailRow>
-          {txType !== TransactionType.Other && txParams.map((param, i) =>
+          {txType !== BraveWallet.TransactionType.Other && txParams.map((param, i) =>
             <CodeSnippet key={i}>
               <code>
                 <CodeSnippetText>{param}: {txArgs[i]}</CodeSnippetText>
@@ -44,7 +44,7 @@ const TransactionDetailBox = (props: Props) => {
             </CodeSnippet>
           )}
 
-          {txType === TransactionType.Other && (
+          {txType === BraveWallet.TransactionType.Other && (
             <CodeSnippet>
               <code>
                 <CodeSnippetText>

--- a/components/brave_wallet_ui/components/shared/app-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/shared/app-list-item/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { AppItem } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 
 // Styled Components
 import {
@@ -15,7 +15,7 @@ import {
 } from './style'
 
 export interface Props {
-  appInfo: AppItem
+  appInfo: BraveWallet.AppItem
   isStared: boolean
   toggleFavorite: () => void
 }

--- a/components/brave_wallet_ui/components/shared/app-list/index.tsx
+++ b/components/brave_wallet_ui/components/shared/app-list/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { AppItem, AppsListType } from '../../../constants/types'
+import { AppsListType, BraveWallet } from '../../../constants/types'
 import { NavButton } from '../../extension/'
 import { AppListItem } from '../'
 import { getLocale } from '../../../../common/locale'
@@ -13,18 +13,18 @@ import {
 
 export interface Props {
   list: AppsListType[]
-  favApps: AppItem[]
+  favApps: BraveWallet.AppItem[]
   action: () => void
-  addToFav: (app: AppItem) => void
-  removeFromFav: (app: AppItem) => void
+  addToFav: (app: BraveWallet.AppItem) => void
+  removeFromFav: (app: BraveWallet.AppItem) => void
 }
 
 export default class AppList extends React.PureComponent<Props> {
-  checkIsSelected = (app: AppItem) => {
+  checkIsSelected = (app: BraveWallet.AppItem) => {
     return this.props.favApps.some((a) => a.name === app.name)
   }
 
-  toggleFavorite = (app: AppItem) => () => {
+  toggleFavorite = (app: BraveWallet.AppItem) => () => {
     if (this.checkIsSelected(app)) {
       this.props.removeFromFav(app)
     } else {

--- a/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
+++ b/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ERCToken } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { IconWrapper, PlaceholderText } from './style'
 import { stripERC20TokenImageURL, isRemoteImageURL } from '../../../utils/string-utils'
 import { background } from 'ethereum-blockies'
@@ -12,7 +12,7 @@ interface Config {
 }
 
 interface Props {
-  selectedAsset?: ERCToken
+  selectedAsset?: BraveWallet.ERCToken
 }
 
 function withPlaceholderIcon (WrappedComponent: React.ComponentType<any>, config: Config) {

--- a/components/brave_wallet_ui/components/shared/select-network-item/index.tsx
+++ b/components/brave_wallet_ui/components/shared/select-network-item/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { EthereumChain } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { create } from 'ethereum-blockies'
 // Styled Components
 import {
@@ -11,8 +11,8 @@ import {
 } from './style'
 
 export interface Props {
-  selectedNetwork: EthereumChain
-  network: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
+  network: BraveWallet.EthereumChain
   onSelectNetwork: () => void
 }
 

--- a/components/brave_wallet_ui/components/shared/select-network/index.tsx
+++ b/components/brave_wallet_ui/components/shared/select-network/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import SelectNetworkItem from '../select-network-item'
-import { EthereumChain } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 
 export interface Props {
-  networks: EthereumChain[]
-  selectedNetwork: EthereumChain
-  onSelectNetwork: (network: EthereumChain) => () => void
+  networks: BraveWallet.EthereumChain[]
+  selectedNetwork: BraveWallet.EthereumChain
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => () => void
 }
 
 function SelectNetwork (props: Props) {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -3,11 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import { TimeDelta } from 'gen/mojo/public/mojom/base/time.mojom.m.js'
+import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import { HardwareWalletResponseCodeType } from '../common/hardware/types'
-// Provide access to all the generated types.
-export * from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
+
+// Re-export BraveWallet for use in other modules, to avoid hard-coding the
+// path of generated mojom files.
+export { BraveWallet }
 export { Url } from 'gen/url/mojom/url.mojom.m.js'
 
 export interface WalletAccountType {

--- a/components/brave_wallet_ui/options/asset-options.ts
+++ b/components/brave_wallet_ui/options/asset-options.ts
@@ -1,4 +1,4 @@
-import { AccountAssetOptionType, ERCToken } from '../constants/types'
+import { AccountAssetOptionType, BraveWallet } from '../constants/types'
 import {
   ALGOIconUrl,
   BATIconUrl,
@@ -59,7 +59,7 @@ export const RopstenSwapAssetOptions: AccountAssetOptionType[] = [
 ]
 
 // Use only with storybook as dummy data.
-export const NewAssetOptions: ERCToken[] = [
+export const NewAssetOptions: BraveWallet.ERCToken[] = [
   {
     contractAddress: '1',
     name: 'Ethereum',

--- a/components/brave_wallet_ui/page/actions/wallet_page_actions.ts
+++ b/components/brave_wallet_ui/page/actions/wallet_page_actions.ts
@@ -21,7 +21,11 @@ import {
   ImportFromExternalWalletPayloadType,
   ImportWalletErrorPayloadType
 } from '../constants/action_types'
-import { SwapResponse, SwapErrorResponse, ERCToken, UpdateAccountNamePayloadType } from '../../constants/types'
+import {
+  BraveWallet,
+  SwapErrorResponse,
+  UpdateAccountNamePayloadType
+} from '../../constants/types'
 import { SwapParamsPayloadType } from '../../common/constants/action_types'
 import { HardwareWalletAccount } from 'components/brave_wallet_ui/common/hardware/types'
 
@@ -45,7 +49,7 @@ export const setImportAccountError = createAction<boolean>('setImportAccountErro
 export const setImportWalletError = createAction<ImportWalletErrorPayloadType>('setImportWalletError')
 export const updatePriceInfo = createAction<SelectAssetPayloadType>('updatePriceInfo')
 export const selectAsset = createAction<UpdateSelectedAssetType>('selectAsset')
-export const updateSelectedAsset = createAction<ERCToken>('updateSelectedAsset')
+export const updateSelectedAsset = createAction<BraveWallet.ERCToken>('updateSelectedAsset')
 export const setIsFetchingPriceHistory = createAction<boolean>('setIsFetchingPriceHistory')
 export const setShowIsRestoring = createAction<boolean>('setShowIsRestoring')
 export const updateAccountName = createAction<UpdateAccountNamePayloadType>('updateAccountName')
@@ -56,6 +60,6 @@ export const setCryptoWalletsInstalled = createAction<boolean>('setCryptoWallets
 export const importFromCryptoWallets = createAction<ImportFromExternalWalletPayloadType>('importFromCryptoWallets')
 export const importFromMetaMask = createAction<ImportFromExternalWalletPayloadType>('importFromMetaMask')
 export const openWalletSettings = createAction('openWalletSettings')
-export const setPageSwapQuote = createAction<SwapResponse>('setPageSwapQuote')
+export const setPageSwapQuote = createAction<BraveWallet.SwapResponse>('setPageSwapQuote')
 export const setPageSwapError = createAction<SwapErrorResponse | undefined>('setPageSwapError')
 export const fetchPageSwapQuote = createAction<SwapParamsPayloadType>('fetchPageSwapQuote')

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -8,7 +8,7 @@ import AsyncActionHandler from '../../../common/AsyncActionHandler'
 import * as WalletPageActions from '../actions/wallet_page_actions'
 import * as WalletActions from '../../common/actions/wallet_actions'
 import {
-  ExternalWalletType,
+  BraveWallet,
   UpdateAccountNamePayloadType,
   WalletState
 } from '../../constants/types'
@@ -164,10 +164,10 @@ handler.on(WalletPageActions.checkWalletsToImport.getType(), async (store) => {
   const braveWalletService = getWalletPageApiProxy().braveWalletService
   const cwResult =
     await braveWalletService.isExternalWalletInitialized(
-      ExternalWalletType.CryptoWallets)
+      BraveWallet.ExternalWalletType.CryptoWallets)
   const mmResult =
     await braveWalletService.isExternalWalletInitialized(
-      ExternalWalletType.MetaMask)
+      BraveWallet.ExternalWalletType.MetaMask)
   store.dispatch(WalletPageActions.setCryptoWalletsInstalled(cwResult.initialized))
   store.dispatch(WalletActions.setMetaMaskInstalled(mmResult.initialized))
 })
@@ -177,7 +177,7 @@ handler.on(WalletPageActions.importFromCryptoWallets.getType(), async (store: St
   const keyringController = getWalletPageApiProxy().keyringController
   const result =
     await braveWalletService.importFromExternalWallet(
-      ExternalWalletType.CryptoWallets, payload.password, payload.newPassword)
+      BraveWallet.ExternalWalletType.CryptoWallets, payload.password, payload.newPassword)
   if (result.success) {
     keyringController.notifyWalletBackupComplete()
   }
@@ -192,7 +192,7 @@ handler.on(WalletPageActions.importFromMetaMask.getType(), async (store: Store, 
   const keyringController = getWalletPageApiProxy().keyringController
   const result =
     await braveWalletService.importFromExternalWallet(
-      ExternalWalletType.MetaMask, payload.password, payload.newPassword)
+      BraveWallet.ExternalWalletType.MetaMask, payload.password, payload.newPassword)
   if (result.success) {
     keyringController.notifyWalletBackupComplete()
   }

--- a/components/brave_wallet_ui/page/constants/action_types.ts
+++ b/components/brave_wallet_ui/page/constants/action_types.ts
@@ -4,10 +4,8 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import {
-  GetPriceHistoryReturnObjectInfo,
-  ERCToken,
-  AssetPrice,
-  AssetPriceTimeframe
+  BraveWallet,
+  GetPriceHistoryReturnObjectInfo
 } from '../../constants/types'
 
 export type CreateWalletPayloadType = {
@@ -61,15 +59,15 @@ export type PrivateKeyAvailablePayloadType = {
 }
 
 export type UpdateSelectedAssetType = {
-  asset: ERCToken
-  timeFrame: AssetPriceTimeframe
+  asset: BraveWallet.ERCToken
+  timeFrame: BraveWallet.AssetPriceTimeframe
 }
 
 export type SelectAssetPayloadType = {
   priceHistory: GetPriceHistoryReturnObjectInfo | undefined
-  defaultFiatPrice: AssetPrice | undefined
-  defaultCryptoPrice: AssetPrice | undefined
-  timeFrame: AssetPriceTimeframe
+  defaultFiatPrice?: BraveWallet.AssetPrice
+  defaultCryptoPrice?: BraveWallet.AssetPrice
+  timeFrame: BraveWallet.AssetPriceTimeframe
 }
 
 export type ImportFromExternalWalletPayloadType = {

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -7,7 +7,6 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import { Switch, Route, useHistory, useLocation } from 'react-router-dom'
-import { TransactionInfo } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import * as WalletPageActions from './actions/wallet_page_actions'
 import * as WalletActions from '../common/actions/wallet_actions'
 import store from './store'
@@ -26,16 +25,13 @@ import {
   OnboardingRestore
 } from '../components/desktop'
 import {
-  // NavTypes,
+  BraveWallet,
   WalletState,
   PageState,
   WalletPageState,
-  AssetPriceTimeframe,
   AccountAssetOptionType,
   WalletAccountType,
-  ERCToken,
   UpdateAccountNamePayloadType,
-  EthereumChain,
   WalletRoutes,
   BuySendSwapTypes
 } from '../constants/types'
@@ -223,7 +219,7 @@ function Container (props: Props) {
     props.walletActions.selectAccount(account)
   }
 
-  const onSelectNetwork = (network: EthereumChain) => {
+  const onSelectNetwork = (network: BraveWallet.EthereumChain) => {
     props.walletActions.selectNetwork(network)
   }
 
@@ -286,7 +282,7 @@ function Container (props: Props) {
   }, [mnemonic])
 
   // This will scrape all of the user's accounts and combine the asset balances for a single asset
-  const fullAssetBalance = (asset: ERCToken): number | string => {
+  const fullAssetBalance = (asset: BraveWallet.ERCToken): number | string => {
     const amounts = accounts.map((account) => {
       let balance
       const found = account.tokens.find((token) => token.asset.contractAddress === asset.contractAddress)
@@ -302,7 +298,7 @@ function Container (props: Props) {
   }
 
   // This will scrape all of the user's accounts and combine the fiat value for a single asset
-  const fullAssetFiatBalance = (asset: ERCToken): number | string => {
+  const fullAssetFiatBalance = (asset: BraveWallet.ERCToken): number | string => {
     const amounts = accounts.map((account) => {
       let fiatBalance
       const found = account.tokens.find((token) => token.asset.contractAddress === asset.contractAddress)
@@ -326,7 +322,7 @@ function Container (props: Props) {
     }))
   }, [userVisibleTokenOptions, accounts])
 
-  const onSelectAsset = (asset: ERCToken) => {
+  const onSelectAsset = (asset: BraveWallet.ERCToken) => {
     props.walletPageActions.selectAsset({ asset: asset, timeFrame: selectedTimeline })
   }
 
@@ -345,7 +341,7 @@ function Container (props: Props) {
     return grandTotal !== undefined ? formatWithCommasAndDecimals(grandTotal?.toString()) : ''
   }, [userAssetList])
 
-  const onChangeTimeline = (timeline: AssetPriceTimeframe) => {
+  const onChangeTimeline = (timeline: BraveWallet.AssetPriceTimeframe) => {
     if (selectedAsset) {
       props.walletPageActions.selectAsset({ asset: selectedAsset, timeFrame: timeline })
     } else {
@@ -442,11 +438,11 @@ function Container (props: Props) {
     props.walletPageActions.checkWalletsToImport()
   }
 
-  const onSetUserAssetVisible = (token: ERCToken, isVisible: boolean) => {
+  const onSetUserAssetVisible = (token: BraveWallet.ERCToken, isVisible: boolean) => {
     props.walletActions.setUserAssetVisible({ token, chainId: selectedNetwork.chainId, isVisible })
   }
 
-  const onAddUserAsset = (token: ERCToken) => {
+  const onAddUserAsset = (token: BraveWallet.ERCToken) => {
     props.walletActions.addUserAsset({
       token: {
         ...token,
@@ -456,7 +452,7 @@ function Container (props: Props) {
     })
   }
 
-  const onRemoveUserAsset = (token: ERCToken) => {
+  const onRemoveUserAsset = (token: BraveWallet.ERCToken) => {
     props.walletActions.removeUserAsset({ token, chainId: selectedNetwork.chainId })
   }
 
@@ -464,15 +460,15 @@ function Container (props: Props) {
     props.walletPageActions.openWalletSettings()
   }
 
-  const onRetryTransaction = (transaction: TransactionInfo) => {
+  const onRetryTransaction = (transaction: BraveWallet.TransactionInfo) => {
     props.walletActions.retryTransaction(transaction)
   }
 
-  const onSpeedupTransaction = (transaction: TransactionInfo) => {
+  const onSpeedupTransaction = (transaction: BraveWallet.TransactionInfo) => {
     props.walletActions.speedupTransaction(transaction)
   }
 
-  const onCancelTransaction = (transaction: TransactionInfo) => {
+  const onCancelTransaction = (transaction: BraveWallet.TransactionInfo) => {
     props.walletActions.cancelTransaction(transaction)
   }
 

--- a/components/brave_wallet_ui/page/reducers/page_reducer.ts
+++ b/components/brave_wallet_ui/page/reducers/page_reducer.ts
@@ -6,10 +6,8 @@
 import { createReducer } from 'redux-act'
 import * as Actions from '../actions/wallet_page_actions'
 import {
+  BraveWallet,
   PageState,
-  AssetPriceTimeframe,
-  ERCToken,
-  SwapResponse,
   SwapErrorResponse,
   ImportWalletError
 } from '../../constants/types'
@@ -27,7 +25,7 @@ const defaultState: PageState = {
   invalidMnemonic: false,
   importAccountError: false,
   importWalletError: { hasError: false },
-  selectedTimeline: AssetPriceTimeframe.OneDay,
+  selectedTimeline: BraveWallet.AssetPriceTimeframe.OneDay,
   selectedAsset: undefined,
   selectedAssetFiatPrice: undefined,
   selectedAssetCryptoPrice: undefined,
@@ -103,7 +101,7 @@ reducer.on(Actions.hasMnemonicError, (state: PageState, payload: boolean) => {
   }
 })
 
-reducer.on(Actions.updateSelectedAsset, (state: PageState, payload: ERCToken) => {
+reducer.on(Actions.updateSelectedAsset, (state: PageState, payload: BraveWallet.ERCToken) => {
   return {
     ...state,
     selectedAsset: payload
@@ -164,7 +162,7 @@ reducer.on(Actions.setCryptoWalletsInstalled, (state: PageState, payload: boolea
   }
 })
 
-reducer.on(Actions.setPageSwapQuote, (state: any, payload: SwapResponse) => {
+reducer.on(Actions.setPageSwapQuote, (state: any, payload: BraveWallet.SwapResponse) => {
   return {
     ...state,
     swapQuote: payload

--- a/components/brave_wallet_ui/page/wallet_page_api_proxy.ts
+++ b/components/brave_wallet_ui/page/wallet_page_api_proxy.ts
@@ -3,7 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import WalletApiProxy, * as BraveWallet from '../common/wallet_api_proxy'
+import WalletApiProxy from '../common/wallet_api_proxy'
+import { BraveWallet } from '../constants/types'
 
 let walletPageApiProxyInstance: WalletPageApiProxy
 

--- a/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
+++ b/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
@@ -15,15 +15,8 @@ import {
   SignMessageHardwareProcessedPayload,
   SwitchEthereumChainProcessedPayload
 } from '../constants/action_types'
-import {
-  AddSuggestTokenRequest,
-  SwapErrorResponse,
-  SwapResponse,
-  SignMessageRequest,
-  SwitchChainRequest
-} from '../../constants/types'
+import { BraveWallet, SwapErrorResponse } from '../../constants/types'
 import { SwapParamsPayloadType } from '../../common/constants/action_types'
-import { TransactionInfo } from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
 import { HardwareWalletResponseCodeType } from '../../common/hardware/types'
 
 export const connectToSite = createAction<AccountPayloadType>('connectToSite')
@@ -32,7 +25,7 @@ export const visibilityChanged = createAction<boolean>('visibilityChanged')
 export const showConnectToSite = createAction<ShowConnectToSitePayload>('showConnectToSite')
 export const addEthereumChain = createAction<EthereumChainPayload>('addEthereumChain')
 export const addEthereumChainRequestCompleted = createAction<EthereumChainRequestPayload>('AddEthereumChainRequestCompleted')
-export const switchEthereumChain = createAction<SwitchChainRequest>('switchEthereumChain')
+export const switchEthereumChain = createAction<BraveWallet.SwitchChainRequest>('switchEthereumChain')
 export const switchEthereumChainProcessed = createAction<SwitchEthereumChainProcessedPayload>('switchEthereumChainProcessed')
 export const showApproveTransaction = createAction('showApproveTransaction')
 export const showUnlock = createAction('showUnlock')
@@ -45,15 +38,15 @@ export const expandWalletAccounts = createAction('expandWalletAccounts')
 export const expandWalletAddAsset = createAction('expandWalletAddAsset')
 export const navigateTo = createAction<string>('navigateTo')
 export const navigateToMain = createAction('navigateToMain')
-export const setPanelSwapQuote = createAction<SwapResponse>('setPanelSwapQuote')
+export const setPanelSwapQuote = createAction<BraveWallet.SwapResponse>('setPanelSwapQuote')
 export const setPanelSwapError = createAction<SwapErrorResponse | undefined>('setPanelSwapError')
 export const fetchPanelSwapQuote = createAction<SwapParamsPayloadType>('fetchPanelSwapQuote')
 export const signMessage = createAction<SignMessagePayload[]>('signMessage')
 export const signMessageProcessed = createAction<SignMessageProcessedPayload>('signMessageProcessed')
-export const signMessageHardware = createAction<SignMessageRequest>('signMessageHardware')
+export const signMessageHardware = createAction<BraveWallet.SignMessageRequest>('signMessageHardware')
 export const signMessageHardwareProcessed = createAction<SignMessageHardwareProcessedPayload>('signMessageHardwareProcessed')
-export const approveHardwareTransaction = createAction<TransactionInfo>('approveHardwareTransaction')
+export const approveHardwareTransaction = createAction<BraveWallet.TransactionInfo>('approveHardwareTransaction')
 export const setHardwareWalletInteractionError = createAction<HardwareWalletResponseCodeType | undefined>('setHardwareWalletInteractionError')
-export const cancelConnectHardwareWallet = createAction<TransactionInfo>('cancelConnectHardwareWallet')
-export const addSuggestToken = createAction<AddSuggestTokenRequest>('addSuggestToken')
+export const cancelConnectHardwareWallet = createAction<BraveWallet.TransactionInfo>('cancelConnectHardwareWallet')
+export const addSuggestToken = createAction<BraveWallet.AddSuggestTokenRequest>('addSuggestToken')
 export const addSuggestTokenProcessed = createAction<AddSuggestTokenProcessedPayload>('addSuggestTokenProcessed')

--- a/components/brave_wallet_ui/panel/constants/action_types.ts
+++ b/components/brave_wallet_ui/panel/constants/action_types.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import { WalletAccountType, EthereumChain, Url } from '../../constants/types'
+import { BraveWallet, Url, WalletAccountType } from '../../constants/types'
 
 export type AccountPayloadType = {
   selectedAccounts: WalletAccountType[]
@@ -21,7 +21,7 @@ export type EthereumChainRequestPayload = {
 }
 
 export type EthereumChainPayload = {
-  chain: EthereumChain
+  chain: BraveWallet.EthereumChain
 }
 
 export type SignMessagePayload = {

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -40,8 +40,8 @@ import store from './store'
 import * as WalletPanelActions from './actions/wallet_panel_actions'
 import * as WalletActions from '../common/actions/wallet_actions'
 import {
-  AppItem,
   AppsListType,
+  BraveWallet,
   WalletState,
   PanelState,
   PanelTypes,
@@ -49,7 +49,6 @@ import {
   WalletAccountType,
   BuySendSwapViewTypes,
   AccountAssetOptionType,
-  EthereumChain,
   ToOrFromType,
   WalletOrigin
 } from '../constants/types'
@@ -321,7 +320,7 @@ function Container (props: Props) {
   const onSetup = () => {
     props.walletPanelActions.setupWallet()
   }
-  const addToFavorites = (app: AppItem) => {
+  const addToFavorites = (app: BraveWallet.AppItem) => {
     props.walletActions.addFavoriteApp(app)
   }
 
@@ -337,7 +336,7 @@ function Container (props: Props) {
     props.walletPanelActions.openWalletApps()
   }
 
-  const removeFromFavorites = (app: AppItem) => {
+  const removeFromFavorites = (app: BraveWallet.AppItem) => {
     props.walletActions.removeFavoriteApp(app)
   }
 
@@ -350,7 +349,7 @@ function Container (props: Props) {
     props.walletPanelActions.navigateTo('main')
   }
 
-  const onSelectNetwork = (network: EthereumChain) => () => {
+  const onSelectNetwork = (network: BraveWallet.EthereumChain) => () => {
     props.walletActions.selectNetwork(network)
     props.walletPanelActions.navigateTo('main')
   }

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -5,11 +5,9 @@
 
 import { createReducer } from 'redux-act'
 import {
-  AddSuggestTokenRequest,
+  BraveWallet,
   PanelState,
-  SwapErrorResponse,
-  SwapResponse,
-  SwitchChainRequest
+  SwapErrorResponse
 } from '../../constants/types'
 import * as PanelActions from '../actions/wallet_panel_actions'
 import {
@@ -82,14 +80,14 @@ reducer.on(PanelActions.addEthereumChain, (state: any, networkPayload: EthereumC
   }
 })
 
-reducer.on(PanelActions.switchEthereumChain, (state: any, request: SwitchChainRequest) => {
+reducer.on(PanelActions.switchEthereumChain, (state: any, request: BraveWallet.SwitchChainRequest) => {
   return {
     ...state,
     switchChainRequest: request
   }
 })
 
-reducer.on(PanelActions.setPanelSwapQuote, (state: any, payload: SwapResponse) => {
+reducer.on(PanelActions.setPanelSwapQuote, (state: any, payload: BraveWallet.SwapResponse) => {
   return {
     ...state,
     swapQuote: payload
@@ -117,7 +115,7 @@ reducer.on(PanelActions.setHardwareWalletInteractionError, (state: any, payload?
   }
 })
 
-reducer.on(PanelActions.addSuggestToken, (state: any, payload: AddSuggestTokenRequest) => {
+reducer.on(PanelActions.addSuggestToken, (state: any, payload: BraveWallet.AddSuggestTokenRequest) => {
   return {
     ...state,
     suggestedToken: payload.token

--- a/components/brave_wallet_ui/panel/wallet_panel_api_proxy.ts
+++ b/components/brave_wallet_ui/panel/wallet_panel_api_proxy.ts
@@ -3,7 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import WalletApiProxy, * as BraveWallet from '../common/wallet_api_proxy'
+import WalletApiProxy from '../common/wallet_api_proxy'
+import { BraveWallet } from '../constants/types'
 
 class WalletPanelApiProxy extends WalletApiProxy {
   callbackRouter = new BraveWallet.PageCallbackRouter()

--- a/components/brave_wallet_ui/stories/mock-data/mock-networks.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-networks.ts
@@ -1,8 +1,8 @@
-import { EthereumChain } from '../../constants/types'
+import { BraveWallet } from '../../constants/types'
 import {
   ETHIconUrl
 } from '../../assets/asset-icons'
-export const mockNetworks: EthereumChain[] = [
+export const mockNetworks: BraveWallet.EthereumChain[] = [
   {
     chainId: '0x1',
     chainName: 'Ethereum Main Net',

--- a/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
+++ b/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
@@ -7,7 +7,7 @@ import {
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
   ToOrFromType,
-  EthereumChain,
+  BraveWallet,
   BuySupportedChains,
   SwapSupportedChains,
   SwapValidationErrorType,
@@ -22,13 +22,13 @@ import {
 
 export interface Props {
   accounts: UserAccountType[]
-  networkList: EthereumChain[]
+  networkList: BraveWallet.EthereumChain[]
   orderType: OrderTypes
   selectedSendAsset: AccountAssetOptionType
   sendAssetBalance: string
   swapToAsset: AccountAssetOptionType
   swapFromAsset: AccountAssetOptionType
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   selectedTab: BuySendSwapTypes
   exchangeRate: string
@@ -57,7 +57,7 @@ export interface Props {
   onSubmitSend: () => void
   onSubmitSwap: () => void
   flipSwapAssets: () => void
-  onSelectNetwork: (network: EthereumChain) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onToggleOrderType: () => void
   onSelectAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void

--- a/components/brave_wallet_ui/stories/screens/crypto-story-view.tsx
+++ b/components/brave_wallet_ui/stories/screens/crypto-story-view.tsx
@@ -8,16 +8,12 @@ import * as React from 'react'
 import { StyledWrapper } from '../../components/desktop/views/crypto/style'
 import {
   TopTabNavTypes,
-  AppItem,
+  BraveWallet,
   AppsListType,
   PriceDataObjectType,
   AccountAssetOptionType,
   AccountTransactions,
-  AssetPrice,
   WalletAccountType,
-  AssetPriceTimeframe,
-  EthereumChain,
-  ERCToken,
   UpdateAccountNamePayloadType,
   DefaultCurrencies
 } from '../../constants/types'
@@ -36,37 +32,37 @@ import { HardwareWalletAccount } from './../../common/hardware/types'
 export interface Props {
   defaultCurrencies: DefaultCurrencies
   isFetchingPortfolioPriceHistory: boolean
-  selectedNetwork: EthereumChain
+  selectedNetwork: BraveWallet.EthereumChain
   showAddModal: boolean
   isLoading: boolean
   userAssetList: AccountAssetOptionType[]
   transactions: AccountTransactions
   portfolioBalance: string
-  selectedAsset: ERCToken | undefined
-  selectedAssetFiatPrice: AssetPrice | undefined
-  selectedAssetCryptoPrice: AssetPrice | undefined
+  selectedAsset: BraveWallet.ERCToken | undefined
+  selectedAssetFiatPrice: BraveWallet.AssetPrice | undefined
+  selectedAssetCryptoPrice: BraveWallet.AssetPrice | undefined
   selectedAssetPriceHistory: PriceDataObjectType[]
   portfolioPriceHistory: PriceDataObjectType[]
-  selectedPortfolioTimeline: AssetPriceTimeframe
-  selectedTimeline: AssetPriceTimeframe
-  networkList: EthereumChain[]
+  selectedPortfolioTimeline: BraveWallet.AssetPriceTimeframe
+  selectedTimeline: BraveWallet.AssetPriceTimeframe
+  networkList: BraveWallet.EthereumChain[]
   accounts: WalletAccountType[]
   needsBackup: boolean
-  userVisibleTokensInfo: ERCToken[]
-  fullAssetList: ERCToken[]
+  userVisibleTokensInfo: BraveWallet.ERCToken[]
+  fullAssetList: BraveWallet.ERCToken[]
   privateKey: string
-  transactionSpotPrices: AssetPrice[]
+  transactionSpotPrices: BraveWallet.AssetPrice[]
   hasImportError: boolean
-  onAddUserAsset: (token: ERCToken) => void
-  onSetUserAssetVisible: (token: ERCToken, isVisible: boolean) => void
-  onRemoveUserAsset: (token: ERCToken) => void
+  onAddUserAsset: (token: BraveWallet.ERCToken) => void
+  onSetUserAssetVisible: (token: BraveWallet.ERCToken, isVisible: boolean) => void
+  onRemoveUserAsset: (token: BraveWallet.ERCToken) => void
   onLockWallet: () => void
   onSetImportError: (hasError: boolean) => void
   onImportAccountFromJson: (accountName: string, password: string, json: string) => void
   onDoneViewingPrivateKey: () => void
   onViewPrivateKey: (address: string, isDefault: boolean) => void
   onRemoveAccount: (address: string, hardware: boolean) => void
-  onSelectNetwork: (network: EthereumChain) => void
+  onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onToggleAddModal: () => void
   onUpdateAccountName: (payload: UpdateAccountNamePayloadType) => { success: boolean }
   getBalance: (address: string) => Promise<string>
@@ -74,13 +70,13 @@ export interface Props {
   onConnectHardwareWallet: (opts: HardwareWalletConnectOpts) => Promise<HardwareWalletAccount[]>
   onImportAccount: (accountName: string, privateKey: string) => void
   onCreateAccount: (name: string) => void
-  onSelectAsset: (asset: ERCToken | undefined) => void
-  onChangeTimeline: (path: AssetPriceTimeframe) => void
+  onSelectAsset: (asset: BraveWallet.ERCToken | undefined) => void
+  onChangeTimeline: (path: BraveWallet.AssetPriceTimeframe) => void
   onShowBackup: () => void
   onShowVisibleAssetsModal: (value: boolean) => void
   showVisibleAssetsModal: boolean
   onFindTokenInfoByContractAddress: (contractAddress: string) => void
-  foundTokenInfoByContractAddress?: ERCToken
+  foundTokenInfoByContractAddress?: BraveWallet.ERCToken
 }
 
 const CryptoStoryView = (props: Props) => {
@@ -138,7 +134,7 @@ const CryptoStoryView = (props: Props) => {
   const [selectedAccount, setSelectedAccount] = React.useState<WalletAccountType>()
   const [hideNav, setHideNav] = React.useState<boolean>(false)
   const [filteredAppsList, setFilteredAppsList] = React.useState<AppsListType[]>(AppsList())
-  const [favoriteApps, setFavoriteApps] = React.useState<AppItem[]>([
+  const [favoriteApps, setFavoriteApps] = React.useState<BraveWallet.AppItem[]>([
     AppsList()[0].appList[0]
   ])
   const [selectedTab, setSelectedTab] = React.useState<TopTabNavTypes>('portfolio')
@@ -153,11 +149,11 @@ const CryptoStoryView = (props: Props) => {
     setSelectedTab(path)
   }
 
-  const addToFavorites = (app: AppItem) => {
+  const addToFavorites = (app: BraveWallet.AppItem) => {
     const newList = [...favoriteApps, app]
     setFavoriteApps(newList)
   }
-  const removeFromFavorites = (app: AppItem) => {
+  const removeFromFavorites = (app: BraveWallet.AppItem) => {
     const newList = favoriteApps.filter(
       (fav) => fav.name !== app.name
     )

--- a/components/brave_wallet_ui/stories/wallet-components.tsx
+++ b/components/brave_wallet_ui/stories/wallet-components.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { DesktopComponentWrapper, DesktopComponentWrapperRow } from './style'
 import { SideNav, TopTabNav, ChartControlBar, WalletPageLayout, WalletSubViewLayout } from '../components/desktop'
-import { NavTypes, TopTabNavTypes, AssetPriceTimeframe } from '../constants/types'
+import { NavTypes, TopTabNavTypes, BraveWallet } from '../constants/types'
 import { NavOptions } from '../options/side-nav-options'
 import { TopNavOptions } from '../options/top-nav-options'
 import { ChartTimelineOptions } from '../options/chart-timeline-options'
@@ -64,9 +64,9 @@ _DesktopTopTabNav.story = {
 }
 
 export const _LineChartControls = () => {
-  const [selectedTimeline, setSelectedTimeline] = React.useState<AssetPriceTimeframe>(AssetPriceTimeframe.OneDay)
+  const [selectedTimeline, setSelectedTimeline] = React.useState<BraveWallet.AssetPriceTimeframe>(BraveWallet.AssetPriceTimeframe.OneDay)
 
-  const changeTimline = (path: AssetPriceTimeframe) => {
+  const changeTimline = (path: BraveWallet.AssetPriceTimeframe) => {
     setSelectedTimeline(path)
   }
   return (

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -9,18 +9,15 @@ import {
 } from '../components/desktop'
 import {
   NavTypes,
-  AssetPriceTimeframe,
+  BraveWallet,
   PriceDataObjectType,
   AccountAssetOptionType,
-  AssetPrice,
   RPCResponseType,
   OrderTypes,
   UserAccountType,
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
   ToOrFromType,
-  EthereumChain,
-  ERCToken,
   AccountTransactions,
   BuySendSwapTypes,
   WalletAccountType,
@@ -234,10 +231,10 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   const [inputValue, setInputValue] = React.useState<string>('')
   const [hasRestoreError, setHasRestoreError] = React.useState<boolean>(false)
   const [hasPasswordError, setHasPasswordError] = React.useState<boolean>(false)
-  const [selectedTimeline, setSelectedTimeline] = React.useState<AssetPriceTimeframe>(AssetPriceTimeframe.OneDay)
+  const [selectedTimeline, setSelectedTimeline] = React.useState<BraveWallet.AssetPriceTimeframe>(BraveWallet.AssetPriceTimeframe.OneDay)
   const [selectedAssetPriceHistory, setSelectedAssetPriceHistory] = React.useState<PriceDataObjectType[]>(PriceHistoryMockData.slice(15, 20))
-  const [selectedAsset, setSelectedAsset] = React.useState<ERCToken>()
-  const [selectedNetwork, setSelectedNetwork] = React.useState<EthereumChain>(mockNetworks[0])
+  const [selectedAsset, setSelectedAsset] = React.useState<BraveWallet.ERCToken>()
+  const [selectedNetwork, setSelectedNetwork] = React.useState<BraveWallet.EthereumChain>(mockNetworks[0])
   const [selectedAccount, setSelectedAccount] = React.useState<UserAccountType>(mockUserAccounts[0])
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false)
   const [fromAsset, setFromAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
@@ -257,7 +254,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   const [selectedWidgetTab, setSelectedWidgetTab] = React.useState<BuySendSwapTypes>('buy')
   const [customTolerance, setCustomTolerance] = React.useState('')
   const [showVisibleAssetsModal, setShowVisibleAssetsModal] = React.useState<boolean>(false)
-  const [foundTokenInfo, setFoundTokenInfo] = React.useState<ERCToken | undefined>()
+  const [foundTokenInfo, setFoundTokenInfo] = React.useState<BraveWallet.ERCToken | undefined>()
 
   const onToggleRestore = () => {
     setIsRestoring(!isRestoring)
@@ -324,7 +321,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
       const data = CurrentPriceMockData.find((coin) => coin.symbol === selectedAsset.symbol)
       const usdValue = data ? data.usd : '0'
       const usdTimeframeChange = data ? data.usdTimeframeChange : '0'
-      const response: AssetPrice = {
+      const response: BraveWallet.AssetPrice = {
         price: usdValue,
         assetTimeframeChange: usdTimeframeChange,
         fromAsset: '',
@@ -340,7 +337,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
       const data = CurrentPriceMockData.find((coin) => coin.symbol === selectedAsset.symbol)
       const btcValue = data ? data.btc : '0'
       const btcTimeframeChange = data ? data.btcTimeframeChange : '0'
-      const response: AssetPrice = {
+      const response: BraveWallet.AssetPrice = {
         price: btcValue,
         assetTimeframeChange: btcTimeframeChange,
         fromAsset: '',
@@ -398,7 +395,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   }, [selectedAsset, mockRPCResponse])
 
   // This will scrape all of the user's accounts and combine the balances for a single asset
-  const scrapedFullAssetBalance = (asset: ERCToken) => {
+  const scrapedFullAssetBalance = (asset: BraveWallet.ERCToken) => {
     const response = mockRPCResponse
     const amounts = response.map((account) => {
       const balance = account.assets.find((item) => item.id === asset.contractAddress)?.balance
@@ -411,7 +408,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   }
 
   // This will scrape all of the user's accounts and combine the fiat value for a single asset
-  const scrapedFullAssetFiatBalance = (asset: ERCToken) => {
+  const scrapedFullAssetFiatBalance = (asset: BraveWallet.ERCToken) => {
     const fullBallance = scrapedFullAssetBalance(asset)
     const price = Number(CurrentPriceMockData.find((coin) => coin.symbol === asset?.symbol)?.usd)
     const value = price ? price * fullBallance : 0
@@ -442,33 +439,33 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   }
 
   // This will change once we hit a real api for pricing
-  const timeline = (path: AssetPriceTimeframe) => {
+  const timeline = (path: BraveWallet.AssetPriceTimeframe) => {
     switch (path) {
-      case AssetPriceTimeframe.Live:
+      case BraveWallet.AssetPriceTimeframe.Live:
         return 17
-      case AssetPriceTimeframe.OneDay:
+      case BraveWallet.AssetPriceTimeframe.OneDay:
         return 15
-      case AssetPriceTimeframe.OneWeek:
+      case BraveWallet.AssetPriceTimeframe.OneWeek:
         return 12
-      case AssetPriceTimeframe.OneMonth:
+      case BraveWallet.AssetPriceTimeframe.OneMonth:
         return 10
-      case AssetPriceTimeframe.ThreeMonths:
+      case BraveWallet.AssetPriceTimeframe.ThreeMonths:
         return 8
-      case AssetPriceTimeframe.OneYear:
+      case BraveWallet.AssetPriceTimeframe.OneYear:
         return 4
-      case AssetPriceTimeframe.All:
+      case BraveWallet.AssetPriceTimeframe.All:
         return 0
     }
     return -1
   }
 
   // This updates the price chart timeline
-  const onChangeTimeline = (path: AssetPriceTimeframe) => {
+  const onChangeTimeline = (path: BraveWallet.AssetPriceTimeframe) => {
     setSelectedAssetPriceHistory(PriceHistoryMockData.slice(timeline(path), 20))
     setSelectedTimeline(path)
   }
 
-  const onSelectAsset = (asset: ERCToken) => {
+  const onSelectAsset = (asset: BraveWallet.ERCToken) => {
     setSelectedAsset(asset)
   }
 
@@ -488,7 +485,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     setShowAddModal(!showAddModal)
   }
 
-  const onSelectNetwork = (network: EthereumChain) => {
+  const onSelectNetwork = (network: BraveWallet.EthereumChain) => {
     setSelectedNetwork(network)
   }
 

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -22,15 +22,12 @@ import {
   SelectAccount
 } from '../components/buy-send-swap'
 import {
+  BraveWallet,
   WalletAccountType,
   PanelTypes,
-  AppItem,
   AppsListType,
   AccountAssetOptionType,
-  BuySendSwapViewTypes,
-  EthereumChain,
-  TransactionInfo,
-  TransactionType
+  BuySendSwapViewTypes
 } from '../constants/types'
 import {
   UpdateUnapprovedTransactionGasFieldsType,
@@ -100,7 +97,7 @@ const mockDefaultCurrencies = {
 }
 
 export const _ConfirmTransaction = () => {
-  const transactionInfo: TransactionInfo = {
+  const transactionInfo: BraveWallet.TransactionInfo = {
     fromAddress: '0x7d66c9ddAED3115d93Bd1790332f3Cd06Cf52B14',
     id: '465a4d6646-kjlwf665',
     txArgs: ['0x0d8775f648430679a709e98d2b0cb6250d2887ef', '0x15ddf09c97b0000'],
@@ -121,7 +118,7 @@ export const _ConfirmTransaction = () => {
     txHash: '0xab834bab0000000000000000000000007be8076f4ea4a4ad08075c2508e481d6c946d12b00000000000000000000000073a29a1da971497',
     txStatus: 0,
     txParams: ['address', 'ammount'],
-    txType: TransactionType.ERC20Transfer,
+    txType: BraveWallet.TransactionType.ERC20Transfer,
     createdTime: { microseconds: BigInt(0) },
     submittedTime: { microseconds: BigInt(0) },
     confirmedTime: { microseconds: BigInt(0) }
@@ -330,12 +327,12 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
   const [selectedAccount, setSelectedAccount] = React.useState<WalletAccountType>(
     accounts[0]
   )
-  const [favoriteApps, setFavoriteApps] = React.useState<AppItem[]>([
+  const [favoriteApps, setFavoriteApps] = React.useState<BraveWallet.AppItem[]>([
     AppsList()[0].appList[0]
   ])
   const [filteredAppsList, setFilteredAppsList] = React.useState<AppsListType[]>(AppsList())
   const [hasPasswordError, setHasPasswordError] = React.useState<boolean>(false)
-  const [selectedNetwork, setSelectedNetwork] = React.useState<EthereumChain>(mockNetworks[0])
+  const [selectedNetwork, setSelectedNetwork] = React.useState<BraveWallet.EthereumChain>(mockNetworks[0])
   const [selectedWyreAsset, setSelectedWyreAsset] = React.useState<AccountAssetOptionType>(WyreAccountAssetOptions[0])
   const [selectedAsset, setSelectedAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
   const [showSelectAsset, setShowSelectAsset] = React.useState<boolean>(false)
@@ -364,7 +361,7 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
     setSelectedPanel('main')
   }
 
-  const onSelectNetwork = (network: EthereumChain) => () => {
+  const onSelectNetwork = (network: BraveWallet.EthereumChain) => () => {
     setSelectedNetwork(network)
     setSelectedPanel('main')
   }
@@ -413,11 +410,11 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
     alert('Will expand to view more!')
   }
 
-  const addToFavorites = (app: AppItem) => {
+  const addToFavorites = (app: BraveWallet.AppItem) => {
     const newList = [...favoriteApps, app]
     setFavoriteApps(newList)
   }
-  const removeFromFavorites = (app: AppItem) => {
+  const removeFromFavorites = (app: BraveWallet.AppItem) => {
     const newList = favoriteApps.filter(
       (fav) => fav.name !== app.name
     )

--- a/components/brave_wallet_ui/utils/api-utils.ts
+++ b/components/brave_wallet_ui/utils/api-utils.ts
@@ -1,8 +1,7 @@
-import * as BraveWallet from 'gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js'
-import { EthereumChain, ERCToken } from '../constants/types'
+import { BraveWallet } from '../constants/types'
 import { ETH } from '../options/asset-options'
 
-export const GetTokenParam = (selectedNetwork: EthereumChain, token: ERCToken): string => {
+export const GetTokenParam = (selectedNetwork: BraveWallet.EthereumChain, token: BraveWallet.ERCToken): string => {
   const isEthereumNetwork = selectedNetwork.chainId === BraveWallet.MAINNET_CHAIN_ID
 
   if (!isEthereumNetwork) {

--- a/components/brave_wallet_ui/utils/buy-asset-url.ts
+++ b/components/brave_wallet_ui/utils/buy-asset-url.ts
@@ -1,26 +1,22 @@
 import {
   AccountAssetOptionType,
-  UserAccountType,
-  MAINNET_CHAIN_ID,
-  ROPSTEN_CHAIN_ID,
-  KOVAN_CHAIN_ID,
-  RINKEBY_CHAIN_ID,
-  GOERLI_CHAIN_ID
+  BraveWallet,
+  UserAccountType
 } from '../constants/types'
 
 const wyreID = 'AC_MGNVBGHPA9T'
 
 export function BuyAssetUrl (networkChainId: string, asset: AccountAssetOptionType, account: UserAccountType, buyAmount: string) {
   switch (networkChainId) {
-    case MAINNET_CHAIN_ID:
+    case BraveWallet.MAINNET_CHAIN_ID:
       return `https://pay.sendwyre.com/?dest=ethereum:${account.address}&destCurrency=${asset.asset.symbol}&amount=${buyAmount}&accountId=${wyreID}&paymentMethod=debit-card`
-    case ROPSTEN_CHAIN_ID:
+    case BraveWallet.ROPSTEN_CHAIN_ID:
       return 'https://faucet.ropsten.be/'
-    case KOVAN_CHAIN_ID:
+    case BraveWallet.KOVAN_CHAIN_ID:
       return 'https://github.com/kovan-testnet/faucet'
-    case RINKEBY_CHAIN_ID:
+    case BraveWallet.RINKEBY_CHAIN_ID:
       return 'https://www.rinkeby.io/'
-    case GOERLI_CHAIN_ID:
+    case BraveWallet.GOERLI_CHAIN_ID:
       return 'https://goerli-faucet.slock.it/'
     default:
       return ''

--- a/components/brave_wallet_ui/utils/network-utils.ts
+++ b/components/brave_wallet_ui/utils/network-utils.ts
@@ -1,6 +1,6 @@
-import { EthereumChain } from '../constants/types'
+import { BraveWallet } from '../constants/types'
 
-export const GetNetworkInfo = (chainId: string, list: EthereumChain[]) => {
+export const GetNetworkInfo = (chainId: string, list: BraveWallet.EthereumChain[]) => {
   for (let it of list) {
     if (it.chainId === chainId) {
       return it

--- a/components/brave_wallet_ui/utils/tx-utils.ts
+++ b/components/brave_wallet_ui/utils/tx-utils.ts
@@ -1,9 +1,9 @@
-import { TransactionInfo } from '../constants/types'
+import { BraveWallet } from '../constants/types'
 
 type Order = 'ascending' | 'descending'
 
-export const sortTransactionByDate = (transactions: TransactionInfo[], order: Order = 'ascending') => {
-  return [...transactions].sort(function (x: TransactionInfo, y: TransactionInfo) {
+export const sortTransactionByDate = (transactions: BraveWallet.TransactionInfo[], order: Order = 'ascending') => {
+  return [...transactions].sort(function (x: BraveWallet.TransactionInfo, y: BraveWallet.TransactionInfo) {
     return order === 'ascending'
       ? Number(x.createdTime.microseconds) - Number(y.createdTime.microseconds)
       : Number(y.createdTime.microseconds) - Number(x.createdTime.microseconds)


### PR DESCRIPTION
### Motivation

There are currently two different ways to import generated Mojom types the wallet ui codebase:
- via `gen/brave/components/brave_wallet/common/brave_wallet.mojom.m.js`.
- via `constants/types.ts`

This is often causing confusion about which method to prefer. Importing via `constants/types.ts` also gives us no way to differentiate between custom TS types vs generated mojom types.

👉 This PR introduces the following convention throughout the codebase:
**For accessing any generated mojom type, always import `BraveWallet` from `constants/types.ts` and access the required types via the `BraveWallet` object.**

Resolves https://github.com/brave/brave-browser/issues/20151.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

No functional change introduced. If the build is successful, it's good to merge.