### PR TITLE
Make verify sorted box bigger for different lengths of recovery phrase

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/backup/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/backup/index.tsx
@@ -18,16 +18,17 @@ export interface Props {
   isOnboarding: boolean
   onSubmitTerms: (key: string, selected: boolean) => void
   onCancel: () => void
+  recoveryPhraseLength: number
 }
 
 function OnboardingRecovery (props: Props) {
-  const { onSubmit, isBackupTermsAccepted, isOnboarding, onSubmitTerms, onCancel } = props
+  const { onSubmit, isBackupTermsAccepted, isOnboarding, onSubmitTerms, onCancel, recoveryPhraseLength } = props
 
   return (
     <StyledWrapper>
       <PageIcon />
       <Title>{getLocale('braveWalletBackupIntroTitle')}</Title>
-      <Description>{getLocale('braveWalletBackupIntroDescription')}</Description>
+      <Description>{getLocale('braveWalletBackupIntroDescription').replace('$1', recoveryPhraseLength.toString())}</Description>
       <TermsRow>
         <Checkbox value={{ backupTerms: isBackupTermsAccepted }} onChange={onSubmitTerms}>
           <div data-key='backupTerms'>{getLocale('braveWalletBackupIntroTerms')}</div>

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
@@ -41,11 +41,16 @@ function OnboardingVerify (props: Props) {
     return sortedPhrase.length !== recoveryPhrase.length
   }, [sortedPhrase, recoveryPhrase])
 
+  const numberOfWordRows = React.useMemo((): number => {
+    const numberOfWordColumns = 4
+    return Math.ceil(recoveryPhrase.length / numberOfWordColumns)
+  }, [recoveryPhrase])
+
   return (
     <StyledWrapper>
       <Title>{getLocale('braveWalletVerifyRecoveryTitle')}</Title>
       <Description>{getLocale('braveWalletVerifyRecoveryDescription')}</Description>
-      <SelectedPhraseContainer error={hasVerifyError}>
+      <SelectedPhraseContainer error={hasVerifyError} numberOfRows={numberOfWordRows}>
         {sortedPhrase.map((word, index) =>
           <SelectedBubble
             key={word.id}

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
@@ -4,7 +4,10 @@ import { WalletButton } from '../../../shared/style'
 interface StyleProps {
   isSelected: boolean
   error: boolean
+  numberOfRows: number
 }
+
+const selectedBubbleHeight = 34
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -47,7 +50,7 @@ export const SelectedPhraseContainer = styled.div<Partial<StyleProps>>`
   flex-direction: row;
   flex-wrap: wrap;
   width: 466px;
-  min-height: 112px;
+  min-height: ${(p) => p.numberOfRows ? `${(p.numberOfRows * selectedBubbleHeight) + 10}px` : '112px'};
   margin-bottom: 40px;
   border: ${(p) => `1px solid ${p.theme.color.divider01}`};
   box-sizing: border-box;

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -94,7 +94,7 @@ provideStrings({
 
   // Backup Wallet Intro
   braveWalletBackupIntroTitle: 'Back up your crypto wallet',
-  braveWalletBackupIntroDescription: 'In the next step you’ll see a 12-word recovery phrase, which you can use to recover your primary crypto accounts. Save it someplace safe. Your recovery phrase is the only way to regain account access in case of forgotten password, lost or stolen device, or you want to switch wallets.',
+  braveWalletBackupIntroDescription: 'In the next step you’ll see a $1-word recovery phrase, which you can use to recover your primary crypto accounts. Save it someplace safe. Your recovery phrase is the only way to regain account access in case of forgotten password, lost or stolen device, or you want to switch wallets.',
   braveWalletBackupIntroTerms: 'I understand that if I lose my recovery words, I will not be able to access my crypto wallet.',
   braveWalletBackupButtonSkip: 'Skip',
   braveWalletBackupButtonCancel: 'Cancel',

--- a/components/brave_wallet_ui/stories/mock-data/user-accounts.ts
+++ b/components/brave_wallet_ui/stories/mock-data/user-accounts.ts
@@ -30,5 +30,8 @@ export const recoveryPhrase = [
   'parent',
   'stop',
   'bowl',
-  'exercise'
+  'exercise',
+  'order',
+  'glasses',
+  'sound'
 ]

--- a/components/brave_wallet_ui/stories/screens/backup-wallet.tsx
+++ b/components/brave_wallet_ui/stories/screens/backup-wallet.tsx
@@ -115,6 +115,7 @@ function BackupWallet (props: Props) {
           onCancel={onCancel}
           isBackupTermsAccepted={backupTerms}
           isOnboarding={isOnboarding}
+          recoveryPhraseLength={recoveryPhrase.length}
         />
       }
       {backupStep === 1 &&

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -91,7 +91,7 @@
   <message name="IDS_BRAVE_WALLET_WELCOME_BUTTON" desc="Onboarding get started button">Get Started</message>
   <message name="IDS_BRAVE_WALLET_WELCOME_RESTORE_BUTTON" desc="Restore screen button">Restore</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_INTRO_TITLE" desc="Backup screen title">Back up your crypto wallet</message>
-  <message name="IDS_BRAVE_WALLET_BACKUP_INTRO_DESCRIPTION" desc="Backup screen description">In the next step you’ll see a 12-word recovery phrase, which you can use to recover your primary crypto accounts. Save it someplace safe. Your recovery phrase is the only way to regain account access in case of forgotten password, lost or stolen device, or you want to switch wallets.</message>
+  <message name="IDS_BRAVE_WALLET_BACKUP_INTRO_DESCRIPTION" desc="Backup screen description">In the next step you’ll see a <ph name="RECOVERY_PHRASE_LENGTH">$1</ph>-word recovery phrase, which you can use to recover your primary crypto accounts. Save it someplace safe. Your recovery phrase is the only way to regain account access in case of forgotten password, lost or stolen device, or you want to switch wallets.</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_INTRO_TERMS" desc="Backup screen terms check box">I understand that if I lose my recovery words, I will not be able to access my crypto wallet.</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_BUTTON_SKIP" desc="Backup screen skip button">Skip</message>
   <message name="IDS_BRAVE_WALLET_BACKUP_BUTTON_CANCEL" desc="Backup screen cancel button">Cancel</message>


### PR DESCRIPTION
Recovery phrases can have varying lengths(12, 15, 18, 21, or 24). This PR adds the functionality to make selected recovery box adjust height based on the number of recovery phrase words.

Additionally, the PR changes the text in the first backup step to say the exact number of words in recovery phrase.

Resolves https://github.com/brave/brave-browser/issues/20125

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan

## 15 word recovery phrase
<img width="531" alt="Screenshot 2021-12-17 at 14 57 42" src="https://user-images.githubusercontent.com/48117473/146550424-28215cf9-f63c-4993-a8bd-97079a8f0699.png">

## Updated welcome message
<img width="531" alt="Screenshot 2021-12-17 at 14 56 43" src="https://user-images.githubusercontent.com/48117473/146550687-6578e594-51e5-4f1f-aae7-00277f3d2234.png">


