### PR TITLE
Disable flaky speedreader test on macos

### DIFF
--- a/browser/ui/speedreader/speedreader_bubble_browsertest.cc
+++ b/browser/ui/speedreader/speedreader_bubble_browsertest.cc
@@ -55,15 +55,18 @@ IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
   ShowAndVerifyUi();
 }
 
-#if defined(OS_MAC)
-// Disable this test for intermittent crashes.
+// Disable this test for intermittent crashes on macOS.
 // See https://github.com/brave/brave-browser/issues/20082
-IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
-                       DISABLED_InvokeUi_speedreader_mode_bubble_basic) {
+#if defined(OS_MAC)
+#define MAYBE_InvokeUi_speedreader_mode_bubble_basic \
+  DISABLED_InvokeUi_speedreader_mode_bubble_basic
 #else
-IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
-                       InvokeUi_speedreader_mode_bubble_basic) {
+#define MAYBE_InvokeUi_speedreader_mode_bubble_basic \
+  InvokeUi_speedreader_mode_bubble_basic
 #endif
+
+IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
+                       MAYBE_InvokeUi_speedreader_mode_bubble_basic) {
   speedreader_bubble_ = true;
   // We need to navigate somewhere so the host is non-empty. For tests the new
   // tab page is fine.

--- a/browser/ui/speedreader/speedreader_bubble_browsertest.cc
+++ b/browser/ui/speedreader/speedreader_bubble_browsertest.cc
@@ -60,7 +60,7 @@ IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
   speedreader_bubble_ = true;
   // We need to navigate somewhere so the host is non-empty. For tests the new
   // tab page is fine.
-  NavigateToNewTab();
+  EXPECT_TRUE(NavigateToNewTab());
   const GURL active_url = ActiveWebContents()->GetLastCommittedURL();
   EXPECT_FALSE(active_url.host().empty());
   ShowAndVerifyUi();

--- a/browser/ui/speedreader/speedreader_bubble_browsertest.cc
+++ b/browser/ui/speedreader/speedreader_bubble_browsertest.cc
@@ -55,8 +55,15 @@ IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
   ShowAndVerifyUi();
 }
 
+#if defined(OS_MAC)
+// Disable this test for intermittent crashes.
+// See https://github.com/brave/brave-browser/issues/20082
+IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
+                       DISABLED_InvokeUi_speedreader_mode_bubble_basic) {
+#else
 IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
                        InvokeUi_speedreader_mode_bubble_basic) {
+#endif
   speedreader_bubble_ = true;
   // We need to navigate somewhere so the host is non-empty. For tests the new
   // tab page is fine.


### PR DESCRIPTION
Avoid blocking green ci runs until we can track this down. I'm assuming from the reports that the crash is at least more common on macOS, so we can maintain some coverage by only disabling it there.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Works around brave/brave-browser#20082

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Verify `SpeedreaderBubbleBrowserTest.InvokeUi_speedreader_mode_bubble_basic` doesn't run on macOS ci jobs, but does run on linux and windows.