### PR TITLE
Fix statement wrong time calculation on linux.

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/time_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/time_util.cc
@@ -11,6 +11,84 @@
 
 namespace ads {
 
+namespace {
+
+bool g_from_local_exploded_failed = false;
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+base::Time CalculateBeginningOfMonth(const base::Time& time) {
+  base::Time::Exploded exploded;
+  time.LocalExplode(&exploded);
+  DCHECK(exploded.HasValidValues());
+
+  base::Time adjusted_time =
+      GetLocalMidnight(time - base::Days(exploded.day_of_month - 1), exploded);
+  return adjusted_time;
+}
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+base::Time CalculateEndOfPreviousMonth(const base::Time& time) {
+  base::Time::Exploded exploded;
+  time.LocalExplode(&exploded);
+  DCHECK(exploded.HasValidValues());
+
+  base::Time adjusted_time =
+      GetLocalMidnight(time - base::Days(exploded.day_of_month - 1), exploded);
+  adjusted_time -= base::Milliseconds(1);
+  return adjusted_time;
+}
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+base::Time CalculateBeginningOfPreviousMonth(const base::Time& time) {
+  base::Time end_prev_month = CalculateEndOfPreviousMonth(time);
+  return CalculateBeginningOfMonth(end_prev_month);
+}
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+base::Time CalculateEndOfMonth(const base::Time& time) {
+  base::Time::Exploded exploded;
+  time.LocalExplode(&exploded);
+  DCHECK(exploded.HasValidValues());
+
+  const base::Time next_month_first_day =
+      time + base::Days(GetLastDayOfMonth(exploded.year, exploded.month) -
+                        exploded.day_of_month + 1);
+  base::Time adjusted_time = GetLocalMidnight(next_month_first_day, exploded);
+  adjusted_time -= base::Milliseconds(1);
+
+  return adjusted_time;
+}
+
+}  // namespace
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+base::Time GetLocalMidnight(const base::Time& time,
+                            const base::Time::Exploded& exploded) {
+  base::Time midnight =
+      time - base::Hours(exploded.hour) - base::Minutes(exploded.minute) -
+      base::Seconds(exploded.second) - base::Milliseconds(exploded.millisecond);
+
+  // Check for errors due to daylight saving time change.
+  base::Time::Exploded midnight_exploded;
+  midnight.LocalExplode(&midnight_exploded);
+  DCHECK(midnight_exploded.HasValidValues());
+
+  if (midnight_exploded.hour != 0) {
+    if (midnight_exploded.day_of_month == exploded.day_of_month) {
+      midnight -= base::Hours(1);
+    } else {
+      midnight += base::Hours(1);
+    }
+  }
+
+  return midnight;
+}
+
 int GetLocalTimeAsMinutes(const base::Time& time) {
   base::Time::Exploded exploded;
   time.LocalExplode(&exploded);
@@ -42,7 +120,9 @@ base::Time AdjustTimeToBeginningOfPreviousMonth(const base::Time& time) {
 
   base::Time adjusted_time;
   const bool success = base::Time::FromLocalExploded(exploded, &adjusted_time);
-  DCHECK(success);
+  if (!success || g_from_local_exploded_failed) {
+    return CalculateBeginningOfPreviousMonth(time);
+  }
 
   return adjusted_time;
 }
@@ -70,7 +150,9 @@ base::Time AdjustTimeToEndOfPreviousMonth(const base::Time& time) {
 
   base::Time adjusted_time;
   const bool success = base::Time::FromLocalExploded(exploded, &adjusted_time);
-  DCHECK(success);
+  if (!success || g_from_local_exploded_failed) {
+    return CalculateEndOfPreviousMonth(time);
+  }
 
   return adjusted_time;
 }
@@ -92,7 +174,9 @@ base::Time AdjustTimeToBeginningOfMonth(const base::Time& time) {
 
   base::Time adjusted_time;
   const bool success = base::Time::FromLocalExploded(exploded, &adjusted_time);
-  DCHECK(success);
+  if (!success || g_from_local_exploded_failed) {
+    return CalculateBeginningOfMonth(time);
+  }
 
   return adjusted_time;
 }
@@ -114,7 +198,9 @@ base::Time AdjustTimeToEndOfMonth(const base::Time& time) {
 
   base::Time adjusted_time;
   const bool success = base::Time::FromLocalExploded(exploded, &adjusted_time);
-  DCHECK(success);
+  if (!success || g_from_local_exploded_failed) {
+    return CalculateEndOfMonth(time);
+  }
 
   return adjusted_time;
 }
@@ -137,6 +223,10 @@ base::Time GetTimeAtBeginningOfThisMonth() {
 base::Time GetTimeAtEndOfThisMonth() {
   const base::Time& now = base::Time::Now();
   return AdjustTimeToEndOfMonth(now);
+}
+
+void SetFromLocalExplodedFailedForTesting(bool set_failed) {
+  g_from_local_exploded_failed = set_failed;
 }
 
 }  // namespace ads

--- a/vendor/bat-native-ads/src/bat/ads/internal/time_util.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/time_util.h
@@ -6,9 +6,7 @@
 #ifndef BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_TIME_UTIL_H_
 #define BRAVE_VENDOR_BAT_NATIVE_ADS_SRC_BAT_ADS_INTERNAL_TIME_UTIL_H_
 
-namespace base {
-class Time;
-}  // namespace base
+#include "base/time/time.h"
 
 namespace ads {
 
@@ -23,6 +21,15 @@ base::Time GetTimeAtBeginningOfLastMonth();
 base::Time GetTimeAtEndOfLastMonth();
 base::Time GetTimeAtBeginningOfThisMonth();
 base::Time GetTimeAtEndOfThisMonth();
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+base::Time GetLocalMidnight(const base::Time& time,
+                            const base::Time::Exploded& exploded);
+
+// TODO(https://github.com/brave/brave-browser/issues/20169): Remove this
+// function when base::Time::FromLocalExploded for linux sandbox will be fixed.
+void SetFromLocalExplodedFailedForTesting(bool set_failed);
 
 }  // namespace ads
 


### PR DESCRIPTION
The reason of DCHECK was in `base::Time::FromLocalExpolode` function which doesn't work from Linux sandbox. See for more details: https://github.com/brave/brave-browser/issues/20169
This PR bypasses this problem by using base::Time::LocalExpolode function, which works correctly (because libc `localtime_r` function is intercepted by main browser process).

<!-- Add brave-browser issue bellow that this PR will resolve -->
fix https://github.com/brave/brave-browser/issues/20104 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

