### PR TITLE
Dump the test's full output to the xUnit output xml file

### DIFF
--- a/chromium_src/base/test/launcher/test_results_tracker.cc
+++ b/chromium_src/base/test/launcher/test_results_tracker.cc
@@ -6,18 +6,12 @@
 // Upstream deliberately avoids including the failure's details and stack trace
 // in the result XML for the xUnit format, so we need to add it explicitly to be
 // able to visualize the data directly from Jenkins for each failed test.
-#define TEST_RESULTS_TRACKER_ADD_FAILURE_DETAILS                             \
-  std::string failure_data;                                                  \
-  for (const TestResultPart& result_part : result.test_result_parts) {       \
-    failure_data += StringPrintf(                                            \
-        "Failure at %s (line %d):\n\n%s\n\n", result_part.file_name.c_str(), \
-        result_part.line_number, result_part.message.c_str());               \
-  }                                                                          \
-  fprintf(out_,                                                              \
-          "      <failure message=\"[  FAILED  ] %s.%s\" "                   \
-          "type=\"\"><![CDATA[%s]]></failure>\n",                            \
-          testsuite_name.c_str(), result.GetTestName().c_str(),              \
-          failure_data.c_str());
+#define TEST_RESULTS_TRACKER_ADD_FAILURE_DETAILS                \
+  fprintf(out_,                                                 \
+          "      <failure message=\"[  FAILED  ] %s.%s\" "      \
+          "type=\"\"><![CDATA[%s]]></failure>\n",               \
+          testsuite_name.c_str(), result.GetTestName().c_str(), \
+          result.output_snippet.c_str());
 
 #include "src/base/test/launcher/test_results_tracker.cc"
 


### PR DESCRIPTION
Selectively picking up the affected file name, line number and error
message for each part of a tests' results means we won't be dumping
other bits into the output XML that are present on the standard output
when running the tests from the console, resulting in information loss.

More specifically, this becomes an bigger annoyance when a new failure
is detected by `npm run network-audit`, since the requests causing that
suite to fail will only be printed as a part of the test's full output
message (instead of being tied to each TestResultPart object), forcing
developers to check the full log in Jenkins to figure out what failed.

Therefore, let's stop iterating over the |test_result_parts| vector
from TestResults, and dump the contents of its |output_snippet| instead
to make sure we don't lose any bit of information that could be useful
to diagnose a test failure.

Resolves https://github.com/brave/brave-browser/issues/20111

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A