### PR TITLE
[Android] Cleaned up java warnings

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java
@@ -114,7 +114,7 @@ public class BuySendSwapActivity extends AsyncInitializationActivity
     private boolean mInitialLayoutInflationComplete;
 
     private TextView mSlippageToleranceText;
-    private int radioSlippageToleranceCheckedId = 0;
+    private int radioSlippageToleranceCheckedId;
 
     public enum ActivityType {
         BUY(0),

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -1855,6 +1855,7 @@ public class BraveNewTabPageLayout
                 BraveNewsControllerFactory.getInstance().getBraveNewsController(this);
     }
 
+    @Override
     public void onCryptoWidgetBottomSheetDialogDismiss() {
         startTimer();
     }

--- a/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
+++ b/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java
@@ -746,7 +746,7 @@ public class BraveRewardsPanel
         mPopupWindow.showAsDropDown(mAnchorView, 0, 0);
 
         checkForRewardsOnboarding();
-        mBraveRewardsNativeWorker.getInstance().StartProcess();
+        BraveRewardsNativeWorker.getInstance().StartProcess();
     }
 
     private void checkForRewardsOnboarding() {


### PR DESCRIPTION
These warnings are fixed:

../../brave/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BuySendSwapActivity.java:117: warning: [NoRedundantFieldInit] Do not explicitly initialize a non-final field with a default value
    private int radioSlippageToleranceCheckedId = 0;
                ^
    (see https://issuetracker.google.com/issues/37124982)
  Did you mean 'private int radioSlippageToleranceCheckedId;'?
../../brave/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java:1858: warning: [MissingOverride] onCryptoWidgetBottomSheetDialogDismiss implements method in CryptoWidgetBottomSheetDialogDismissListener; expected @Override
    public void onCryptoWidgetBottomSheetDialogDismiss() {
                ^
    (see https://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override public void onCryptoWidgetBottomSheetDialogDismiss() {'?
../../brave/android/java/org/chromium/chrome/browser/rewards/BraveRewardsPanel.java:745: warning: [StaticQualifiedUsingExpression] Static method getInstance should not be accessed from an object instance; instead use BraveRewardsNativeWorker.getInstance
        mBraveRewardsNativeWorker.getInstance().StartProcess();
                                 ^
    (see https://errorprone.info/bugpattern/StaticQualifiedUsingExpression)
  Did you mean 'BraveRewardsNativeWorker.getInstance().StartProcess();'?
3 warnings

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20188

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

