### PR TITLE
feat(wallet): Token Balances in Wallet Panel

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -383,6 +383,8 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletSitePermissionsNewAccount",
      IDS_BRAVE_WALLET_SITE_PERMISSIONS_NEW_ACCOUNT},
     {"braveWalletPanelNotConnected", IDS_BRAVE_WALLET_PANEL_NOT_CONNECTED},
+    {"braveWalletPanelScrollForMoreAssets",
+     IDS_BRAVE_WALLET_PANEL_SCROLL_FOR_MORE_ASSETS},
     {"braveWalletTransactionDetailBoxFunction",
      IDS_BRAVE_WALLET_TRANSACTION_DETAIL_BOX_FUNCTION},
     {"braveWalletTransactionDetailBoxHex",

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -26,6 +26,7 @@ export interface Props {
   fiatBalance: string
   token: BraveWallet.ERCToken
   defaultCurrencies: DefaultCurrencies
+  isPanel?: boolean
 }
 
 const PortfolioAssetItem = (props: Props) => {
@@ -34,7 +35,8 @@ const PortfolioAssetItem = (props: Props) => {
     fiatBalance,
     action,
     token,
-    defaultCurrencies
+    defaultCurrencies,
+    isPanel
   } = props
 
   const AssetIconWithPlaceholder = React.useMemo(() => {
@@ -50,13 +52,13 @@ const PortfolioAssetItem = (props: Props) => {
         <StyledWrapper disabled={token.isErc721} onClick={action}>
           <NameAndIcon>
             <AssetIconWithPlaceholder selectedAsset={token} />
-            <AssetName>{token.name} {token.isErc721 ? hexToNumber(token.tokenId ?? '') : ''}</AssetName>
+            <AssetName isPanel={isPanel}>{token.name} {token.isErc721 ? hexToNumber(token.tokenId ?? '') : ''}</AssetName>
           </NameAndIcon>
           <BalanceColumn>
             {!token.isErc721 &&
-              <FiatBalanceText>{formatFiatAmountWithCommasAndDecimals(fiatBalance, defaultCurrencies.fiat)}</FiatBalanceText>
+              <FiatBalanceText isPanel={isPanel}>{formatFiatAmountWithCommasAndDecimals(fiatBalance, defaultCurrencies.fiat)}</FiatBalanceText>
             }
-            <AssetBalanceText>{formatedAssetBalance}</AssetBalanceText>
+            <AssetBalanceText isPanel={isPanel}>{formatedAssetBalance}</AssetBalanceText>
           </BalanceColumn>
         </StyledWrapper>
       }

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
@@ -3,9 +3,10 @@ import { AssetIconProps, AssetIconFactory, WalletButton } from '../../shared/sty
 
 interface StyleProps {
   disabled: boolean
+  isPanel: boolean
 }
 
-export const StyledWrapper = styled(WalletButton) <StyleProps>`
+export const StyledWrapper = styled(WalletButton) <Partial<StyleProps>>`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -25,12 +26,12 @@ export const NameAndIcon = styled.div`
   flex-direction: row;
 `
 
-export const AssetName = styled.span`
+export const AssetName = styled.span<Partial<StyleProps>>`
   font-family: Poppins;
   font-size: 13px;
   line-height: 20px;
   letter-spacing: 0.01em;
-  color: ${(p) => p.theme.color.text01};
+  color: ${(p) => p.isPanel ? p.theme.palette.white : p.theme.color.text01};
 `
 
 export const BalanceColumn = styled.div`
@@ -40,20 +41,20 @@ export const BalanceColumn = styled.div`
   flex-direction: column;
 `
 
-export const FiatBalanceText = styled.span`
+export const FiatBalanceText = styled.span<Partial<StyleProps>>`
   font-family: Poppins;
   font-size: 13px;
   line-height: 20px;
   letter-spacing: 0.01em;
-  color: ${(p) => p.theme.color.text01};
+  color: ${(p) => p.isPanel ? p.theme.palette.white : p.theme.color.text01};
 `
 
-export const AssetBalanceText = styled.span`
+export const AssetBalanceText = styled.span<Partial<StyleProps>>`
   font-family: Poppins;
   font-size: 12px;
   line-height: 18px;
   letter-spacing: 0.01em;
-  color: ${(p) => p.theme.color.text03};
+  color: ${(p) => p.isPanel ? p.theme.palette.white : p.theme.color.text03};
 `
 
 // Construct styled-component using JS object instead of string, for editor

--- a/components/brave_wallet_ui/components/extension/connected-bottom-nav/style.ts
+++ b/components/brave_wallet_ui/components/extension/connected-bottom-nav/style.ts
@@ -13,6 +13,8 @@ export const StyledWrapper = styled.div`
   align-items: center;
   justify-content: center;
   padding: 0px 12px;
+  position: absolute;
+  bottom: 0px;
 `
 
 export const NavOutline = styled.div`

--- a/components/brave_wallet_ui/components/extension/connected-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/connected-panel/style.ts
@@ -7,6 +7,7 @@ import { WalletButton } from '../../shared/style'
 interface StyleProps {
   panelBackground: string
   orb: string
+  isScrolled: boolean
 }
 
 export const StyledWrapper = styled.div<Partial<StyleProps>>`
@@ -15,19 +16,48 @@ export const StyledWrapper = styled.div<Partial<StyleProps>>`
   width: 100%;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   background: ${(p) => p.panelBackground};
+  position: relative;
 `
 
-export const CenterColumn = styled.div`
-  flex: 1;
+export const ScrollContainer = styled.div`
   display: flex;
   width: 100%;
   flex-direction: column;
   align-items: center;
+  justify-content: flex-start;
+  height: 292px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  position: relative;
+  box-sizing: border-box;
+`
+
+export const CenterColumn = styled.div`
+  display: flex;
+  width: 100%;
+  min-height: 230px;
+  flex-direction: column;
+  align-items: center;
   justify-content: space-between;
-  padding: 12px 0px 28px;
+  padding: 12px 0px 20px;
   max-width: 300px;
+`
+
+export const AssetContainer = styled.div<Partial<StyleProps>>`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  max-width: 300px;
+  padding-top: 30px;
+  color: ${(p) => p.theme.palette.white};
+  opacity: ${(p) => p.isScrolled ? 1 : 0};
+  transition-duration: 0.4s;
+  transition-timing-function: ease-out;
+  transition-delay: 0s;
 `
 
 export const AccountCircle = styled(WalletButton) <Partial<StyleProps>>`
@@ -160,4 +190,18 @@ export const SwitchIcon = styled.div`
   left: 0px;
   bottom: 0px;
   z-index: 10;
+`
+
+export const MoreAssetsText = styled.span<Partial<StyleProps>>`
+  font-family: Poppins;
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: 0.01em;
+  color: ${(p) => p.theme.palette.white};
+  opacity: ${(p) => p.isScrolled ? 0 : 0.8};
+  transition-duration: 0.4s;
+  transition-timing-function: ease-out;
+  transition-delay: 0s;
+  position: absolute;
+  bottom: 60px;
 `

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -67,6 +67,7 @@ import {
 } from '../common/async/lib'
 import { isHardwareAccount } from '../utils/address-utils'
 import { useAssets, useBalance, useSwap, useSend, usePreset } from '../common/hooks'
+import { formatBalance } from '../utils/format-balances'
 
 type Props = {
   panel: PanelState
@@ -536,6 +537,22 @@ function Container (props: Props) {
     }
   }, [connectedAccounts, selectedAccount, activeOrigin])
 
+  const userAssetList = React.useMemo(() => {
+    // selectedAccount.tokens can be undefined
+    if (selectedAccount.tokens) {
+      const formatedList = selectedAccount?.tokens?.map((asset) => ({
+        asset: asset.asset,
+        assetBalance: formatBalance(asset.assetBalance, asset.asset.decimals),
+        fiatBalance: asset.fiatBalance
+      })).sort(function (a, b) { return Number(b.fiatBalance) - Number(a.fiatBalance) }) // Sorting by Fiat Value
+
+      // Do not show an asset unless the selectedAccount has a balance
+      return formatedList.filter((token) => parseFloat(token.assetBalance) !== 0)
+    }
+    return []
+    // Using accounts as a dependency here to trigger balance changes
+  }, [selectedAccount, accounts])
+
   if (!hasInitialized || !accounts) {
     return null
   }
@@ -970,6 +987,7 @@ function Container (props: Props) {
         onLockWallet={onLockWallet}
         onOpenSettings={onOpenSettings}
         activeOrigin={activeOrigin}
+        userAssetList={userAssetList}
       />
     </PanelWrapper>
   )

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -305,6 +305,7 @@ provideStrings({
   braveWalletPanelTitle: 'Brave Wallet',
   braveWalletPanelConnected: 'Connected',
   braveWalletPanelNotConnected: 'Not connected',
+  braveWalletPanelScrollForMoreAssets: 'Scroll for more assets',
 
   // Site Permissions Panel
   braveWalletSitePermissionsTitle: 'Site permissions',

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -547,6 +547,7 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
               onLockWallet={onLockWallet}
               onOpenSettings={onOpenSettings}
               activeOrigin=''
+              userAssetList={AccountAssetOptions}
             />
           ) : (
             <>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -257,6 +257,7 @@
   <message name="IDS_BRAVE_WALLET_SITE_PERMISSIONS_SWITCH" desc="Site Permissions panel switch account for connected site">Switch</message>
   <message name="IDS_BRAVE_WALLET_SITE_PERMISSIONS_NEW_ACCOUNT" desc="Site Permissions panel add a new account">New account</message>
   <message name="IDS_BRAVE_WALLET_PANEL_NOT_CONNECTED" desc="Brave Wallet panel disconnected status">Not connected</message>
+  <message name="IDS_BRAVE_WALLET_PANEL_SCROLL_FOR_MORE_ASSETS" desc="Brave Wallet panel scroll to view more assets">Scroll for more assets</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_DETAIL_BOX_FUNCTION" desc="Transaction detail box function label">FUNCTION TYPE</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_DETAIL_BOX_HEX" desc="Transaction detail box hex data label">HEX DATA</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_DETAIL_BOX_BYTES" desc="Transaction detail box bytes label">BYTES</message>


### PR DESCRIPTION
## Description 
Introducing Token Balances in the Brave Wallet Panel

1) You can now see your `VisibleAssets` in the `Wallet Panel` by scrolling down on the main view.
2) The value for each `Asset`  is filtered by the `SelectedAccount` balances.
3) If the `SelectedAccount` has a `0` balance for an `Asset` it will not show that `Asset`.
4) The `Asset` list is sorted by `Fait` holdings value.
5) Clicking on an `Asset` will route you to the `AssetDetail` page.
6) Clicking a NFT (ERC721) token is disabled until we have a details page built out.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/20179>

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

https://user-images.githubusercontent.com/40611140/147006884-cbba26ad-e8fc-4266-87b7-1eb81fd08c3c.mov
