### PR TITLE
Fix BroadcastChannelIsPartitioned test flakiness.

### DIFF
--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -325,7 +325,9 @@ void EphemeralStorageBrowserTest::CreateBroadcastChannel(
       frame,
       "self.bc = new BroadcastChannel('channel');"
       "self.bc_message = '';"
-      "self.bc.onmessage = (m) => { self.bc_message = m.data; };"));
+      "self.bc.onmessage = (m) => { self.bc_message = m.data; };"
+      "if (self.bc.name != 'channel')"
+      "  throw new Error('channel name invalid');"));
 }
 
 void EphemeralStorageBrowserTest::SendBroadcastMessage(

--- a/chromium_src/third_party/blink/renderer/modules/broadcastchannel/broadcast_channel.cc
+++ b/chromium_src/third_party/blink/renderer/modules/broadcastchannel/broadcast_channel.cc
@@ -7,16 +7,32 @@
 #include "third_party/blink/renderer/modules/storage/brave_dom_window_storage.h"
 #include "third_party/blink/renderer/platform/weborigin/security_origin_hash.h"
 
+namespace blink {
+namespace {
+
+String GetEphemeralBroadcastChannelName(LocalDOMWindow* window, String name) {
+  auto* ephemeral_storage_origin = GetEphemeralStorageOrigin(window);
+  if (!ephemeral_storage_origin) {
+    return name;
+  }
+  const auto& nonce = SecurityOriginHash::GetNonceForEphemeralStorageKeying(
+      ephemeral_storage_origin);
+  return name + String::FromUTF8(nonce.ToString());
+}
+
+}  // namespace
+}  // namespace blink
+
 // Ephemeral origin channel name altering is applied only to frame-based
 // ExecutionContexts. This is fine because any Worker-based context still
 // wouldn't be able to communicate with a frame in both directions because a
 // frame-based BroadcastChannel will use an ephemeral origin instead of the one
 // the worker is using.
-#define GetRemoteNavigationAssociatedInterfaces                          \
-  should_send_resource_timing_info_to_parent(); /* no-op */              \
-  if (auto* origin = GetEphemeralStorageOrigin(window)) {                \
-    name_ = name_ + String::Number(SecurityOriginHash::GetHash(origin)); \
-  }                                                                      \
+// The name change is applied only while connecting.
+#define GetRemoteNavigationAssociatedInterfaces                 \
+  should_send_resource_timing_info_to_parent(); /* no-op */     \
+  base::AutoReset<String> ephemeral_name_auto_reset(            \
+      &name_, GetEphemeralBroadcastChannelName(window, name_)); \
   frame->GetRemoteNavigationAssociatedInterfaces
 
 #include "src/third_party/blink/renderer/modules/broadcastchannel/broadcast_channel.cc"

--- a/chromium_src/third_party/blink/renderer/platform/weborigin/security_origin_hash.h
+++ b/chromium_src/third_party/blink/renderer/platform/weborigin/security_origin_hash.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_PLATFORM_WEBORIGIN_SECURITY_ORIGIN_HASH_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_PLATFORM_WEBORIGIN_SECURITY_ORIGIN_HASH_H_
+
+#define safe_to_compare_to_empty_or_deleted                               \
+  safe_to_compare_to_empty_or_deleted = false;                            \
+  static const base::UnguessableToken& GetNonceForEphemeralStorageKeying( \
+      const SecurityOrigin* origin) {                                     \
+    CHECK(origin->IsOpaque());                                            \
+    return *origin->GetNonceForSerialization();                           \
+  }                                                                       \
+  static const base::UnguessableToken& GetNonceForEphemeralStorageKeying( \
+      const scoped_refptr<const SecurityOrigin>& origin) {                \
+    return GetNonceForEphemeralStorageKeying(origin.get());               \
+  }                                                                       \
+  static const bool unused
+
+#include "src/third_party/blink/renderer/platform/weborigin/security_origin_hash.h"
+
+#undef safe_to_compare_to_empty_or_deleted
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_PLATFORM_WEBORIGIN_SECURITY_ORIGIN_HASH_H_

--- a/chromium_src/third_party/blink/renderer/platform/weborigin/security_origin_hash.h
+++ b/chromium_src/third_party/blink/renderer/platform/weborigin/security_origin_hash.h
@@ -7,7 +7,7 @@
 #define BRAVE_CHROMIUM_SRC_THIRD_PARTY_BLINK_RENDERER_PLATFORM_WEBORIGIN_SECURITY_ORIGIN_HASH_H_
 
 #define safe_to_compare_to_empty_or_deleted                               \
-  safe_to_compare_to_empty_or_deleted = false;                            \
+  unused = false;                                                         \
   static const base::UnguessableToken& GetNonceForEphemeralStorageKeying( \
       const SecurityOrigin* origin) {                                     \
     CHECK(origin->IsOpaque());                                            \
@@ -17,7 +17,7 @@
       const scoped_refptr<const SecurityOrigin>& origin) {                \
     return GetNonceForEphemeralStorageKeying(origin.get());               \
   }                                                                       \
-  static const bool unused
+  static const bool safe_to_compare_to_empty_or_deleted
 
 #include "src/third_party/blink/renderer/platform/weborigin/security_origin_hash.h"
 


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Use ephemeral storage origin nonce directly as a key for BroadcastChannel partitioning.

`SecurityOriginHash::GetHash` contains a process-bound seed in `DCHECK`-enabled builds to forbid and catch cross-process hash-sharing cases.
The added `SecurityOriginHash::GetNonceForEphemeralStorageKeying` should be temporary as we must move to `blink::StorageKey` in the future and use public `nonce()` getter without introducing such vague accessors.

More info on hash with seed here: https://source.chromium.org/chromium/chromium/src/+/main:base/hash/hash.cc;l=94-114

Resolves https://github.com/brave/brave-browser/issues/20130

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

