### PR TITLE
Fix#16420 - Omnibox autocomplete disabled for Tor Windows

### DIFF
--- a/browser/tor/tor_profile_manager.cc
+++ b/browser/tor/tor_profile_manager.cc
@@ -131,4 +131,9 @@ void TorProfileManager::InitTorProfileUserPrefs(Profile* profile) {
     BUILDFLAG(ENABLE_BRAVE_TRANSLATE_GO)
   pref_service->SetBoolean(translate::prefs::kOfferTranslateEnabled, false);
 #endif
+
+  // Disable autocomplete prefs
+  pref_service->SetBoolean(kAutocompleteEnabled, false);
+  pref_service->SetBoolean(kTopSiteSuggestionsEnabled, false);
+  pref_service->SetBoolean(kBraveSuggestedSiteSuggestionsEnabled, false);
 }

--- a/browser/tor/tor_profile_manager_unittest.cc
+++ b/browser/tor/tor_profile_manager_unittest.cc
@@ -82,4 +82,10 @@ TEST_F(TorProfileManagerUnitTest, InitTorProfileUserPrefs) {
   EXPECT_FALSE(tor_profile->GetPrefs()->GetBoolean(
       translate::prefs::kOfferTranslateEnabled));
 #endif
+
+  // Check autocomplete prefs
+  EXPECT_FALSE(tor_profile->GetPrefs()->GetBoolean(kAutocompleteEnabled));
+  EXPECT_FALSE(tor_profile->GetPrefs()->GetBoolean(kTopSiteSuggestionsEnabled));
+  EXPECT_FALSE(tor_profile->GetPrefs()->GetBoolean(
+      kBraveSuggestedSiteSuggestionsEnabled));
 }


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#16420.

Normal window with autocomplete enabled.

![image](https://user-images.githubusercontent.com/28645536/147511435-3ac01f5c-c974-4c92-b778-5c0044b7df75.png)
![image](https://user-images.githubusercontent.com/28645536/147511505-73aa67ed-b9a0-4646-b4f8-5bdef9819c16.png)

Tor window
![image](https://user-images.githubusercontent.com/28645536/147511537-25310a20-bb3a-4685-a50b-c0a06b19d398.png)


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

cc @diracdeltas 