### PR TITLE
Make signing methods more compatible with MetaMask

### DIFF
--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -296,6 +296,8 @@ bool ParsePersonalSignParams(const std::string& json,
   *address = *address_str;
   if (IsValidHexString(*message_str)) {
     *message = *message_str;
+  } else if (IsValidHexString("0x" + *message_str)) {
+    *message = "0x" + *message_str;
   } else {
     *message = ToHex(*message_str);
   }

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -297,6 +297,13 @@ TEST(EthResponseHelperUnitTest, ParsePersonalSignParams) {
           "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83"
         ]
       })");
+  const std::string json_missing_0x_prefix(
+      R"({
+        "params": [
+          "deadbeef",
+          "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83"
+        ]
+      })");
   const std::string json_extra_entry(
       R"({
         "params": [
@@ -317,6 +324,11 @@ TEST(EthResponseHelperUnitTest, ParsePersonalSignParams) {
   std::string address;
   std::string message;
   EXPECT_TRUE(ParsePersonalSignParams(json, &address, &message));
+  EXPECT_EQ(address, "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83");
+  EXPECT_EQ(message, "0xdeadbeef");
+
+  EXPECT_TRUE(
+      ParsePersonalSignParams(json_missing_0x_prefix, &address, &message));
   EXPECT_EQ(address, "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83");
   EXPECT_EQ(message, "0xdeadbeef");
 

--- a/components/brave_wallet/common/eth_sign_typed_data_helper.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.cc
@@ -242,8 +242,16 @@ absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeField(
       return absl::nullopt;
 
     absl::optional<double> value_double = value.GetIfDouble();
-    if (!value_double)
-      return absl::nullopt;
+    if (!value_double) {
+      const std::string* value_str = value.GetIfString();
+      if (!value_str)
+        return absl::nullopt;
+      double val;
+      if (!base::StringToDouble(*value_str, &val))
+        return absl::nullopt;
+      value_double = val;
+    }
+
     // check if value excceeds type bound
     switch (type_check) {
       case 8:
@@ -274,8 +282,16 @@ absl::optional<std::vector<uint8_t>> EthSignTypedDataHelper::EncodeField(
         type_check > 256)
       return absl::nullopt;
     absl::optional<double> value_double = value.GetIfDouble();
-    if (!value_double)
-      return absl::nullopt;
+    if (!value_double) {
+      const std::string* value_str = value.GetIfString();
+      if (!value_str)
+        return absl::nullopt;
+      double val;
+      if (!base::StringToDouble(*value_str, &val))
+        return absl::nullopt;
+      value_double = val;
+    }
+
     // check if value excceeds type bound
     switch (type_check) {
       case 8:

--- a/components/brave_wallet/common/eth_sign_typed_data_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper_unittest.cc
@@ -387,6 +387,25 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
         "0000000000000000000000000000000000000000000000000000000000010000");
   }
 
+  {
+    // Encode string values for uint types
+    auto encoded_field = helper->EncodeField("uint8", base::Value("255"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "00000000000000000000000000000000000000000000000000000000000000ff");
+    encoded_field = helper->EncodeField("uint32", base::Value("4096"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000001000");
+    encoded_field = helper->EncodeField("uint256", base::Value("65536"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000010000");
+  }
+
   // uint8 - uint256
   EXPECT_FALSE(helper->EncodeField("intA", base::Value(1)));
   EXPECT_FALSE(helper->EncodeField("int1", base::Value(1)));
@@ -409,6 +428,25 @@ TEST(EthSignedTypedDataHelperUnitTest, EncodeField) {
         base::ToLowerASCII(base::HexEncode(*encoded_field)),
         "0000000000000000000000000000000000000000000000000000000000001000");
     encoded_field = helper->EncodeField("int256", base::Value(65536));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000010000");
+  }
+
+  {
+    // Encode string values for int types
+    auto encoded_field = helper->EncodeField("int8", base::Value("127"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "000000000000000000000000000000000000000000000000000000000000007f");
+    encoded_field = helper->EncodeField("int32", base::Value("4096"));
+    ASSERT_TRUE(encoded_field);
+    EXPECT_EQ(
+        base::ToLowerASCII(base::HexEncode(*encoded_field)),
+        "0000000000000000000000000000000000000000000000000000000000001000");
+    encoded_field = helper->EncodeField("int256", base::Value("65536"));
     ASSERT_TRUE(encoded_field);
     EXPECT_EQ(
         base::ToLowerASCII(base::HexEncode(*encoded_field)),


### PR DESCRIPTION
2 different fixes for signing data:

1. MM allows for typed data with `uint*` and `int*` types to have string values. 

Snapshot a dapp for governance and voting on proposals does this. Instead of on chain it just signs data for voting.
https://snapshot.org/#/bbondy.eth/proposal/0xe8d6d011fd1ced4f7b9ef5de19dcd47ac728d9a3553fa60dcb73ecf6ad768b61 

---

2. After signing in on the Dapp https://studio.manifold.xyz/ it tries to sign data with personal sign without 0x prefix for the hex data.

See the implementation of personal_sign here:
https://github.com/ethereum/go-ethereum/pull/2940/files#diff-d0d5842eca210323f32aeb8c0710124e1bfd1a19f732c7ed5ee7519a318a405aR40

---

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20282
Resolves https://github.com/brave/brave-browser/issues/20283

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

