### PR TITLE
Add API to set nonce and add ability to reset nonce information

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -995,13 +995,25 @@ Are you sure you want to do this?
         '<ph name="KEY_NAME">$1<ex>MyCustomKey</ex></ph>' key export failed
       </message>
       <message name="IDS_SETTINGS_WALLET_RESET" desc="Reset wallet settings item text">
-        Reset Wallet
+        Reset Brave Wallet
+      </message>
+      <message name="IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO" desc="Reset wallet transactions">
+        Clear wallet transaction and nonce information
+      </message>
+      <message name="IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_DESC" desc="Reset wallet transactions description">
+        Clearing transactions may be useful for developers or when clearing state on a local server
       </message>
       <message name="IDS_SETTINGS_WALLET_RESET_CONFIRMATION" desc="Reset wallet settings confirmation message text">
         Are you sure you want to reset your wallet? If your wallet is not backed up, resetting will cause you to lose all account data (including any associated funds). Type "<ph name="CONFIRMATION_PHRASE">$1<ex>Yes</ex></ph>" to confirm.
       </message>
+      <message name="IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_CONFIRMATION" desc="Reset wallet settings confirmation for resetting transaction info message text">
+        Are you sure you want to reset all of your wallet transaction and nonce information? This option is mostly used by developers running a local test server. Type "<ph name="CONFIRMATION_PHRASE">$1<ex>Yes</ex></ph>" to confirm.
+      </message>
       <message name="IDS_SETTINGS_WALLET_RESET_CONFIRMED" desc="Reset wallet settings confirmed message text">
         Your wallet was reset.
+      </message>
+      <message name="IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_CONFIRMED" desc="Reset wallet settings confirmed message text">
+        Your wallet transaction information was reset.
       </message>
       <message name="IDS_SETTINGS_WALLET_RESET_CONFIRMATION_PHRASE" desc="The phrase users should type to reset wallet">
         Yes

--- a/browser/brave_wallet/brave_wallet_reset.cc
+++ b/browser/brave_wallet/brave_wallet_reset.cc
@@ -15,11 +15,14 @@
 
 namespace brave_wallet {
 
-void ResetWallet(content::BrowserContext* context) {
+void ResetTransactionInfo(content::BrowserContext* context) {
   auto* eth_tx_controller =
       brave_wallet::EthTxControllerFactory::GetControllerForContext(context);
   eth_tx_controller->Reset();
+}
 
+void ResetWallet(content::BrowserContext* context) {
+  ResetTransactionInfo(context);
   auto* rpc_controller =
       brave_wallet::RpcControllerFactory::GetControllerForContext(context);
   rpc_controller->Reset();

--- a/browser/brave_wallet/brave_wallet_reset.h
+++ b/browser/brave_wallet/brave_wallet_reset.h
@@ -14,6 +14,7 @@ class BrowserContext;
 
 namespace brave_wallet {
 
+void ResetTransactionInfo(content::BrowserContext* context);
 void ResetWallet(content::BrowserContext* context);
 
 }  // namespace brave_wallet

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_browser_proxy.js
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_browser_proxy.js
@@ -18,6 +18,7 @@ export class BraveWalletBrowserProxy {
    removeEthereumChain (chainId) {}
    addEthereumChain (value) {}
    setActiveNetwork (chainId) {}
+   resetTransactionInfo () {}
 }
 
 /**
@@ -27,6 +28,10 @@ export class BraveWalletBrowserProxyImpl {
   /** @override */
   resetWallet () {
     chrome.send('resetWallet', [])
+  }
+  /** @override */
+  resetTransactionInfo() {
+    chrome.send('resetTransactionInfo', [])
   }
   /** @override */
   setBraveWalletEnabled (value) {

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -17,6 +17,9 @@
       cursor: pointer;
       color: red;
     }
+    .reset-transaction-info {
+      cursor: pointer;
+    }
     settings-dropdown-menu.wide-drop-down {
       --md-select-width: 225px;
     }    
@@ -91,6 +94,12 @@
   </template>
 </settings-animated-pages>
 <template is="dom-if" if="[[!isNetworkEditor_]]">
+  <div class="settings-box " on-click="onResetTransactionInfo_">
+    <div class="flex cr-padded-text reset-transaction-info">
+      <div>$i18n{resetTransactionInfo}</div>
+      <div class="secondary">$i18n{resetTransactionInfoDesc}</div>
+    </div>
+  </div>
   <div class="settings-box " on-click="onResetWallet_">
     <div class="flex cr-padded-text reset-wallet">
       <div>$i18n{resetWallet}</div>

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.js
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.js
@@ -156,6 +156,14 @@ class SettingsBraveWalletPage extends SettingsBraveWalletPageBase {
     this.browserProxy_.resetWallet()
     window.alert(this.i18n('walletResetConfirmed'))
   }
+
+  onResetTransactionInfo_() {
+    var message = this.i18n('walletResetTransactionInfoConfirmation')
+    if (window.prompt(message) !== this.i18n('walletResetConfirmationPhrase'))
+      return
+    this.browserProxy_.resetTransactionInfo()
+    window.alert(this.i18n('walletResetTransactionInfoConfirmed'))
+  }
 }
 
 customElements.define(

--- a/browser/ui/webui/settings/brave_default_extensions_handler.cc
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.cc
@@ -107,6 +107,10 @@ void BraveDefaultExtensionsHandler::RegisterMessages() {
       "resetWallet",
       base::BindRepeating(&BraveDefaultExtensionsHandler::ResetWallet,
                           base::Unretained(this)));
+  web_ui()->RegisterMessageCallback(
+      "resetTransactionInfo",
+      base::BindRepeating(&BraveDefaultExtensionsHandler::ResetTransactionInfo,
+                          base::Unretained(this)));
 
   web_ui()->RegisterMessageCallback(
       "setWebTorrentEnabled",
@@ -207,6 +211,11 @@ void BraveDefaultExtensionsHandler::GetRestartNeeded(
 void BraveDefaultExtensionsHandler::ResetWallet(
     base::Value::ConstListView args) {
   brave_wallet::ResetWallet(profile_);
+}
+
+void BraveDefaultExtensionsHandler::ResetTransactionInfo(
+    base::Value::ConstListView args) {
+  brave_wallet::ResetTransactionInfo(profile_);
 }
 
 void BraveDefaultExtensionsHandler::SetWebTorrentEnabled(

--- a/browser/ui/webui/settings/brave_default_extensions_handler.h
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.h
@@ -68,6 +68,7 @@ class BraveDefaultExtensionsHandler : public settings::SettingsPageUIHandler
                        const std::string& error,
                        extensions::webstore_install::Result result);
   void ResetWallet(base::Value::ConstListView args);
+  void ResetTransactionInfo(base::Value::ConstListView args);
   void OnRestartNeededChanged();
   bool IsRestartNeeded();
 

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
@@ -407,8 +407,15 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
     {"ipfsKeyRemove", IDS_SETTINGS_IPNS_KEY_REMOVE_ITEM},
     {"ipfsKeyExportError", IDS_SETTINGS_IPNS_KEYS_EXPORT_ERROR},
     {"resetWallet", IDS_SETTINGS_WALLET_RESET},
+    {"resetTransactionInfo", IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO},
+    {"resetTransactionInfoDesc",
+     IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_DESC},
     {"walletResetConfirmation", IDS_SETTINGS_WALLET_RESET_CONFIRMATION},
+    {"walletResetTransactionInfoConfirmation",
+     IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_CONFIRMATION},
     {"walletResetConfirmed", IDS_SETTINGS_WALLET_RESET_CONFIRMED},
+    {"walletResetTransactionInfoConfirmed",
+     IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_CONFIRMED},
     {"walletNetworksLinkTitle", IDS_SETTINGS_WALLET_NETWORKS_ITEM},
     {"walletAddNetworkDialogTitle", IDS_SETTINGS_WALLET_ADD_NETWORK_TITLE},
     {"walletAddNetworkInvalidURLInput",
@@ -469,6 +476,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
   auto confirmation_text = l10n_util::GetStringFUTF16(
       IDS_SETTINGS_WALLET_RESET_CONFIRMATION, confirmation_phrase);
   html_source->AddString("walletResetConfirmation", confirmation_text);
+  auto reset_tx_confirmation_text = l10n_util::GetStringFUTF16(
+      IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO_CONFIRMATION,
+      confirmation_phrase);
+  html_source->AddString("walletResetTransactionInfoConfirmation",
+                         reset_tx_confirmation_text);
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   html_source->AddString("webDiscoveryLearnMoreURL", kWebDiscoveryLearnMoreUrl);
 #endif

--- a/components/brave_wallet/browser/eth_tx_controller.h
+++ b/components/brave_wallet/browser/eth_tx_controller.h
@@ -98,6 +98,10 @@ class EthTxController : public KeyedService,
       const std::string& tx_meta_id,
       const std::vector<uint8_t>& data,
       SetDataForUnapprovedTransactionCallback callback) override;
+  void SetNonceForUnapprovedTransaction(
+      const std::string& tx_meta_id,
+      const std::string& nonce,
+      SetNonceForUnapprovedTransactionCallback) override;
   void GetNonceForHardwareTransaction(
       const std::string& tx_meta_id,
       GetNonceForHardwareTransactionCallback callback) override;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -676,6 +676,7 @@ interface EthTxController {
   SetGasPriceAndLimitForUnapprovedTransaction(string tx_meta_id, string gas_price, string gas_limit) => (bool success);
   SetGasFeeAndLimitForUnapprovedTransaction(string tx_meta_id, string max_priority_fee_per_gas, string max_fee_per_gas, string gas_limit) => (bool success);
   SetDataForUnapprovedTransaction(string tx_meta_id, array<uint8> data) => (bool success);
+  SetNonceForUnapprovedTransaction(string tx_meta_id, string nonce) => (bool success);
 
   // Used for creating transaction data
   MakeERC20TransferData(string to_address, string amount) => (bool success, array<uint8> data);


### PR DESCRIPTION
- Adds an API for setting a custom nonce on a transaction
- Adds a way to reset transactions and nonce info. Note that I acknowledge it would be more useful to do it per network, but for now it is only clearing everything. We can do per network later possibly based on demand.


<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19760
Resolves https://github.com/brave/brave-browser/issues/20286

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

