### PR TITLE
Fixes an incorrect zh-CN l10n. (uplift to 1.34.x)

### DIFF
--- a/components/resources/strings/brave_components_resources_zh-CN.xtb
+++ b/components/resources/strings/brave_components_resources_zh-CN.xtb
@@ -769,7 +769,7 @@
 <translation id="1036635552229153800">数据已成功上传，但未移动到 brave-import 目录。您可以在导入设置页面上手动执行此操作。</translation>
 <translation id="3793279629218362523">管理对等端 ID 和 IPNS 密钥</translation>
 <translation id="572392919096807438">记住我的决定</translation>
-<translation id="7978789143098237970">知道我关闭这个站点</translation>
+<translation id="7978789143098237970">直到我关闭这个站点</translation>
 <translation id="3523195733429162409">24 小时</translation>
 <translation id="2373264732659722940">1 周</translation>
 <translation id="6318437367327684789">始终</translation>


### PR DESCRIPTION
Fixes brave/brave-browser#18094
Uplift of #11742

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.