### PR TITLE
Updated color overriding on old macOS (<10.14)

### DIFF
--- a/chromium_src/ui/color/mac/native_color_mixers_mac.mm
+++ b/chromium_src/ui/color/mac/native_color_mixers_mac.mm
@@ -26,27 +26,10 @@ void AddNativeUiColorMixer(ColorProvider* provider,
   // that doesn't support dark mode. We are using dark mode on old macOS but
   // some below colors are fetched from system color and they are not dark mode
   // aware. So, we should replace those colors with dark mode aware ui color.
-
-  // Cache ui colors before upstream's native color is applied and then
-  // re-apply.
-  const SkColor color_menu_item_foreground =
-      provider->GetColor(kColorMenuItemForeground);
-  const SkColor color_menu_item_foreground_disabled =
-      provider->GetColor(kColorMenuItemForegroundDisabled);
-  const SkColor color_label_selection_background =
-      provider->GetColor(kColorLabelSelectionBackground);
-  const SkColor color_textfield_selection_background =
-      provider->GetColor(kColorTextfieldSelectionBackground);
-
   AddNativeUiColorMixer_Chromium(provider, dark_window, high_contrast);
-
   ColorMixer& mixer = provider->AddMixer();
-  mixer[kColorMenuItemForeground] = {color_menu_item_foreground};
-  mixer[kColorMenuItemForegroundDisabled] = {
-      color_menu_item_foreground_disabled};
-  mixer[kColorLabelSelectionBackground] = {color_label_selection_background};
-  mixer[kColorTextfieldSelectionBackground] = {
-      color_textfield_selection_background};
+  mixer[kColorMenuItemForeground] = {kColorPrimaryForeground};
+  mixer[kColorMenuItemForegroundDisabled] = {kColorDisabledForeground};
 }
 
 }  // namespace ui


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/20351

This fixes the crash due to the de-referencing empty ColorProvider::color_map_
by calling ColorProvider::GetColor().
We can call only after GenerateColorMap() is called.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

