### PR TITLE
Updated color overriding on old macOS (<10.14) - uplift to 1.35.x

### DIFF
--- a/chromium_src/ui/color/mac/native_color_mixers_mac.mm
+++ b/chromium_src/ui/color/mac/native_color_mixers_mac.mm
@@ -26,27 +26,10 @@ void AddNativeUiColorMixer(ColorProvider* provider,
   // that doesn't support dark mode. We are using dark mode on old macOS but
   // some below colors are fetched from system color and they are not dark mode
   // aware. So, we should replace those colors with dark mode aware ui color.
-
-  // Cache ui colors before upstream's native color is applied and then
-  // re-apply.
-  const SkColor color_menu_item_foreground =
-      provider->GetColor(kColorMenuItemForeground);
-  const SkColor color_menu_item_foreground_disabled =
-      provider->GetColor(kColorMenuItemForegroundDisabled);
-  const SkColor color_label_selection_background =
-      provider->GetColor(kColorLabelSelectionBackground);
-  const SkColor color_textfield_selection_background =
-      provider->GetColor(kColorTextfieldSelectionBackground);
-
   AddNativeUiColorMixer_Chromium(provider, dark_window, high_contrast);
-
   ColorMixer& mixer = provider->AddMixer();
-  mixer[kColorMenuItemForeground] = {color_menu_item_foreground};
-  mixer[kColorMenuItemForegroundDisabled] = {
-      color_menu_item_foreground_disabled};
-  mixer[kColorLabelSelectionBackground] = {color_label_selection_background};
-  mixer[kColorTextfieldSelectionBackground] = {
-      color_textfield_selection_background};
+  mixer[kColorMenuItemForeground] = {kColorPrimaryForeground};
+  mixer[kColorMenuItemForegroundDisabled] = {kColorDisabledForeground};
 }
 
 }  // namespace ui


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/20351
Uplift of #11757

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.