### PR TITLE
chore(wallet): remove fiatBalance from Redux and use base amount units

### DIFF
--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -29,8 +29,8 @@ import {
   WalletAccountType,
   GetAllNetworksList,
   GetAllTokensReturnInfo,
-  GetNativeAssetBalancesPriceReturnInfo,
-  GetERC20TokenBalanceAndPriceReturnInfo,
+  GetNativeAssetBalancesReturnInfo,
+  GetBlockchainTokenBalanceReturnInfo,
   PortfolioTokenHistoryAndInfo,
   SendTransactionParams,
   ER20TransferParams,
@@ -39,7 +39,8 @@ import {
   ApproveERC20Params,
   WalletInfoBase,
   WalletInfo,
-  DefaultCurrencies
+  DefaultCurrencies,
+  GetPriceReturnInfo
 } from '../../constants/types'
 
 export const initialize = createAction('initialize')
@@ -71,8 +72,9 @@ export const accountsChanged = createAction('accountsChanged')
 export const selectedAccountChanged = createAction('selectedAccountChanged')
 export const setAllTokensList = createAction<GetAllTokensReturnInfo>('setAllTokensList')
 export const getAllTokensList = createAction('getAllTokensList')
-export const nativeAssetBalancesUpdated = createAction<GetNativeAssetBalancesPriceReturnInfo>('nativeAssetBalancesUpdated')
-export const tokenBalancesUpdated = createAction<GetERC20TokenBalanceAndPriceReturnInfo>('tokenBalancesUpdated')
+export const nativeAssetBalancesUpdated = createAction<GetNativeAssetBalancesReturnInfo>('nativeAssetBalancesUpdated')
+export const tokenBalancesUpdated = createAction<GetBlockchainTokenBalanceReturnInfo>('tokenBalancesUpdated')
+export const pricesUpdated = createAction<GetPriceReturnInfo>('tokenBalancesUpdated')
 export const portfolioPriceHistoryUpdated = createAction<PortfolioTokenHistoryAndInfo[][]>('portfolioPriceHistoryUpdated')
 export const selectPortfolioTimeline = createAction<BraveWallet.AssetPriceTimeframe>('selectPortfolioTimeline')
 export const portfolioTimelineUpdated = createAction<BraveWallet.AssetPriceTimeframe>('portfolioTimelineUpdated')

--- a/components/brave_wallet_ui/common/constants/mocks.ts
+++ b/components/brave_wallet_ui/common/constants/mocks.ts
@@ -64,8 +64,7 @@ export const mockAccount: WalletAccountType = {
   id: 'mockId',
   name: 'mockAccountName',
   address: 'mockAddress',
-  balance: '123.456',
-  fiatBalance: '17.34',
+  balance: '123456',
   asset: 'mockAsset', // FIXME: This is probably a useless field
   accountType: 'Primary',
   tokens: []

--- a/components/brave_wallet_ui/common/hooks/assets.test.ts
+++ b/components/brave_wallet_ui/common/hooks/assets.test.ts
@@ -1,18 +1,20 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 import {
-  mockAccount
+  mockAccount,
+  mockAssetPrices
 } from '../constants/mocks'
 import { AccountAssetOptions } from '../../options/asset-options'
 import useAssets from './assets'
+import { AccountAssetOptionType } from '../../constants/types'
 
 const mockAccounts = [
   {
     ...mockAccount,
-    tokens: [{ ...AccountAssetOptions[0], assetBalance: '0x350082652bcfb2e', fiatBalance: '100' }, AccountAssetOptions[1]]
+    tokens: [{ ...AccountAssetOptions[0], assetBalance: '238699740940532500' }, AccountAssetOptions[1]]
   },
   {
     ...mockAccount,
-    tokens: [{ ...AccountAssetOptions[0], assetBalance: '0', fiatBalance: '0' }, AccountAssetOptions[1]]
+    tokens: [{ ...AccountAssetOptions[0], assetBalance: '0' }, AccountAssetOptions[1]]
   }
 ]
 
@@ -21,7 +23,7 @@ const mockVisibleList = [
   AccountAssetOptions[1].asset
 ]
 
-const expectedResult = [{ asset: AccountAssetOptions[0].asset, assetBalance: '0.2387', fiatBalance: '100' }]
+const expectedResult = [{ asset: AccountAssetOptions[0].asset, assetBalance: '238699740940532500' }] as AccountAssetOptionType[]
 
 const getBuyAssets = async () => {
   return await mockVisibleList
@@ -29,21 +31,21 @@ const getBuyAssets = async () => {
 
 describe('useAssets hook', () => {
   it('Selected account has balances, should return expectedResult', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[0], mockVisibleList, mockVisibleList, getBuyAssets))
+    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[0], mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
     await act(async () => {
       await waitForNextUpdate()
     })
     expect(result.current.panelUserAssetList).toEqual(expectedResult)
   })
   it('Selected account has 0 balances, should return an empty array', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[1], mockVisibleList, mockVisibleList, getBuyAssets))
+    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[1], mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
     await act(async () => {
       await waitForNextUpdate()
     })
     expect(result.current.panelUserAssetList).toEqual([])
   })
   it('Selected account tokens is undefined, should return an empty array', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccount, mockVisibleList, mockVisibleList, getBuyAssets))
+    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccount, mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
     await act(async () => {
       await waitForNextUpdate()
     })

--- a/components/brave_wallet_ui/common/hooks/assets.ts
+++ b/components/brave_wallet_ui/common/hooks/assets.ts
@@ -11,15 +11,20 @@ import {
   WalletAccountType
 } from '../../constants/types'
 import { BAT, ETH } from '../../options/asset-options'
-import { formatBalance } from '../../utils/format-balances'
+
+// Hooks
+import usePricing from './pricing'
 
 export default function useAssets (
   accounts: WalletAccountType[],
   selectedAccount: WalletAccountType,
   fullTokenList: BraveWallet.BlockchainToken[],
   userVisibleTokensInfo: BraveWallet.BlockchainToken[],
+  spotPrices: BraveWallet.AssetPrice[],
   getBuyAssets: () => Promise<BraveWallet.BlockchainToken[]>
 ) {
+  const { computeFiatAmount } = usePricing(spotPrices)
+
   const tokenOptions: BraveWallet.BlockchainToken[] = React.useMemo(
     () =>
       fullTokenList.map((token) => ({
@@ -43,8 +48,7 @@ export default function useAssets (
       userVisibleTokenOptions
         .map((token) => ({
           asset: token,
-          assetBalance: '0',
-          fiatBalance: '0'
+          assetBalance: '0'
         })),
     [userVisibleTokenOptions]
   )
@@ -53,8 +57,7 @@ export default function useAssets (
     const assets = tokenOptions
       .map((token) => ({
         asset: token,
-        assetBalance: '0',
-        fiatBalance: '0'
+        assetBalance: '0'
       }))
 
     return [
@@ -80,25 +83,25 @@ export default function useAssets (
           ...token,
           logo: `chrome://erc-token-images/${token.logo}`
         },
-        assetBalance: '0',
-        fiatBalance: '0'
+        assetBalance: '0'
       }) as AccountAssetOptionType))
     }).catch(e => console.error(e))
   }, [])
 
   const panelUserAssetList = React.useMemo((): AccountAssetOptionType[] => {
     // selectedAccount.tokens can be undefined
-    if (selectedAccount?.tokens) {
-      const formatedList = selectedAccount?.tokens?.map((asset) => ({
-        asset: asset.asset,
-        assetBalance: formatBalance(asset.assetBalance, asset.asset.decimals),
-        fiatBalance: asset.fiatBalance
-      })).sort(function (a, b) { return Number(b.fiatBalance) - Number(a.fiatBalance) }) // Sorting by Fiat Value
-
-      // Do not show an asset unless the selectedAccount has a balance
-      return formatedList.filter((token) => parseFloat(token.assetBalance) !== 0)
+    if (!selectedAccount?.tokens) {
+      return []
     }
-    return []
+
+    const formattedList = selectedAccount?.tokens?.sort(function (a, b) {
+      const bFiatBalance = computeFiatAmount(b.assetBalance, b.asset.symbol, b.asset.decimals)
+      const aFiatBalance = computeFiatAmount(a.assetBalance, a.asset.symbol, a.asset.decimals)
+      return Number(bFiatBalance) - Number(aFiatBalance)
+    }) // Sorting by Fiat Value
+
+    // Do not show an asset unless the selectedAccount has a balance
+    return formattedList.filter((token) => parseFloat(token.assetBalance) !== 0)
     // Using accounts as a dependency here to trigger balance changes
   }, [selectedAccount, accounts])
 

--- a/components/brave_wallet_ui/common/hooks/balance.ts
+++ b/components/brave_wallet_ui/common/hooks/balance.ts
@@ -5,28 +5,30 @@
 
 import * as React from 'react'
 
-import { AccountAssetOptionType, WalletAccountType } from '../../constants/types'
-import { formatBalance } from '../../utils/format-balances'
+import { BraveWallet, WalletAccountType } from '../../constants/types'
 
-export default function useBalance (selectedAccount: WalletAccountType) {
-  return React.useCallback((asset: AccountAssetOptionType) => {
-    let assetBalance = ''
-    let fiatBalance = ''
-
-    if (!selectedAccount || !selectedAccount.tokens) {
-      return { assetBalance, fiatBalance }
+export default function useBalance (network: BraveWallet.EthereumChain) {
+  return React.useCallback((account?: WalletAccountType, token?: BraveWallet.BlockchainToken) => {
+    if (!account) {
+      return ''
     }
 
-    const token = selectedAccount.tokens.find(
-      (token) => token.asset.symbol === asset?.asset.symbol
+    // Return native asset balance
+    if (!token || token.symbol.toLowerCase() === network.symbol.toLowerCase()) {
+      return account.balance
+    }
+
+    if (!account.tokens) {
+      return ''
+    }
+
+    const loadedToken = account.tokens.find(
+      (each) => each.asset.contractAddress.toLowerCase() === token.contractAddress.toLowerCase()
     )
-    if (!token) {
-      return { assetBalance, fiatBalance }
+    if (!loadedToken) {
+      return ''
     }
 
-    return {
-      assetBalance: formatBalance(token.assetBalance, token.asset.decimals),
-      fiatBalance: token.fiatBalance
-    }
-  }, [selectedAccount])
+    return loadedToken.assetBalance
+  }, [network])
 }

--- a/components/brave_wallet_ui/common/hooks/pricing.test.ts
+++ b/components/brave_wallet_ui/common/hooks/pricing.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import {
+  mockAssetPrices
+} from '../constants/mocks'
+import usePricing from './pricing'
+
+describe('usePricing hook', () => {
+    it('should return asset price of DOG token', () => {
+      const { result } = renderHook(() => usePricing(mockAssetPrices))
+      expect(result.current.findAssetPrice('DOG')).toEqual('100')
+    })
+
+    it('should return empty asset price of unknown token', () => {
+      const { result } = renderHook(() => usePricing(mockAssetPrices))
+      expect(result.current.findAssetPrice('CAT')).toEqual('')
+    })
+
+    it('should compute fiat amount for DOG token', () => {
+      const { result } = renderHook(() => usePricing(mockAssetPrices))
+      expect(result.current.computeFiatAmount('7', 'DOG', 1)).toEqual('70.00')
+    })
+
+    it('should return empty fiat value for unknown token', () => {
+      const { result } = renderHook(() => usePricing(mockAssetPrices))
+      expect(result.current.computeFiatAmount('7', 'CAT', 0)).toEqual('')
+    })
+
+    it('should return empty fiat value for empty amount', () => {
+      const { result } = renderHook(() => usePricing(mockAssetPrices))
+      expect(result.current.computeFiatAmount('', 'DOG', 0)).toEqual('')
+    })
+})

--- a/components/brave_wallet_ui/common/hooks/pricing.ts
+++ b/components/brave_wallet_ui/common/hooks/pricing.ts
@@ -6,11 +6,24 @@
 import * as React from 'react'
 
 import { BraveWallet } from '../../constants/types'
+import { formatFiatBalance } from '../../utils/format-balances'
 
 export default function usePricing (spotPrices: BraveWallet.AssetPrice[]) {
-  return React.useCallback((symbol: string) => {
+  const findAssetPrice = React.useCallback((symbol: string) => {
     return spotPrices.find(
       (token) => token.fromAsset.toLowerCase() === symbol.toLowerCase()
-    )?.price ?? '0'
+    )?.price ?? ''
   }, [spotPrices])
+
+  const computeFiatAmount = React.useCallback((value: string, symbol: string, decimals: number) => {
+    const price = findAssetPrice(symbol)
+
+    if (!price || !value) {
+      return ''
+    }
+
+    return formatFiatBalance(value, decimals, price)
+  }, [findAssetPrice])
+
+  return { computeFiatAmount, findAssetPrice }
 }

--- a/components/brave_wallet_ui/common/hooks/select-preset.test.ts
+++ b/components/brave_wallet_ui/common/hooks/select-preset.test.ts
@@ -20,19 +20,16 @@ describe('usePreset hook', () => {
         ...mockAccount,
         tokens: [{
           asset: mockERC20Token,
-          assetBalance: balance,
-          fiatBalance: '0'
+          assetBalance: balance
         }]
       },
       {
         asset: mockERC20Token,
-        assetBalance: 'mockBalance',
-        fiatBalance: 'mockBalance'
+        assetBalance: 'mockBalance'
       },
       {
         asset: mockERC20Token,
-        assetBalance: 'mockBalance',
-        fiatBalance: 'mockBalance'
+        assetBalance: 'mockBalance'
       },
       mockFunc,
       jest.fn()

--- a/components/brave_wallet_ui/common/hooks/token.test.ts
+++ b/components/brave_wallet_ui/common/hooks/token.test.ts
@@ -3,11 +3,11 @@ import {
   mockERC20Token,
   mockNetwork
 } from '../constants/mocks'
-import { FindBlockchainTokenInfoReturnInfo } from '../../constants/types'
+import { GetBlockchainTokenInfoReturnInfo } from '../../constants/types'
 import useTokenInfo from './token'
 
 const findBlockchainTokenInfo = async (address: string) => {
-  return await { token: null } as FindBlockchainTokenInfoReturnInfo
+  return { token: null } as GetBlockchainTokenInfoReturnInfo
 }
 
 describe('useTokenInfo hook', () => {

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
@@ -232,11 +232,10 @@ describe('useTransactionParser hook', () => {
             ...mockAccount,
             tokens: [{
               asset: mockERC20Token,
-              assetBalance: '0x0', // 0 DOG
-              fiatBalance: '0'
+              assetBalance: '0' // 0 DOG
             }],
             address: '0xdeadbeef',
-            balance: '0x38d7ea4c68000' // 0.001 ETH
+            balance: '1000000000000000' // 0.001 ETH
           }],
           mockAssetPrices, [], []
         ))
@@ -281,7 +280,7 @@ describe('useTransactionParser hook', () => {
           [{
             ...mockAccount,
             address: '0xdeadbeef',
-            balance: '0xde0b6b3a7640000' // 1 ETH
+            balance: '1000000000000000000' // 1 ETH
           }],
           mockAssetPrices, [], []
         ))
@@ -330,7 +329,7 @@ describe('useTransactionParser hook', () => {
           [{
             ...mockAccount,
             address: '0xdeadbeef',
-            balance: '0x38d7ea4c68000' // 0.001 ETH
+            balance: '1000000000000000' // 0.001 ETH
           }],
           mockAssetPrices, [], []
         ))
@@ -371,7 +370,7 @@ describe('useTransactionParser hook', () => {
           [{
             ...mockAccount,
             address: '0xdeadbeef',
-            balance: '0xdebe79c2e6ee000' // 1.00315 ETH
+            balance: '1003150000000000000' // 1.00315 ETH
           }],
           mockAssetPrices, [], []
         ))
@@ -416,11 +415,10 @@ describe('useTransactionParser hook', () => {
             ...mockAccount,
             tokens: [{
               asset: mockERC20Token,
-              assetBalance: '0x38d7ea4c68000', // 0.001 DOG
-              fiatBalance: '0'
+              assetBalance: '1000000000000000' // 0.001 DOG
             }],
             address: '0xdeadbeef',
-            balance: '0xb30e8870ae000' // 0.00315 ETH
+            balance: '3150000000000000' // 0.00315 ETH
           }],
           mockAssetPrices, [], []
         ))
@@ -468,13 +466,14 @@ describe('useTransactionParser hook', () => {
             ...mockAccount,
             tokens: [{
               asset: mockERC20Token,
-              assetBalance: '0xde0b6b3a7640000', // 1 DOG
-              fiatBalance: '0'
+              assetBalance: '1000000000000000000' // 1 DOG
             }],
             address: '0xdeadbeef',
-            balance: '0xb30e8870ae000' // 0.00315 ETH
+            balance: '3150000000000000' // 0.00315 ETH
           }],
-          mockAssetPrices, [], []
+          mockAssetPrices,
+          [],
+          [mockERC20Token]
         ))
 
         const mockTransactionInfo = getMockedTransactionInfo()

--- a/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
+++ b/components/brave_wallet_ui/common/reducers/wallet_reducer.ts
@@ -10,15 +10,16 @@ import {
   BraveWallet,
   GetAllNetworksList,
   GetAllTokensReturnInfo,
-  GetERC20TokenBalanceAndPriceReturnInfo,
-  GetNativeAssetBalancesPriceReturnInfo,
+  GetBlockchainTokenBalanceReturnInfo,
+  GetNativeAssetBalancesReturnInfo,
   GetPriceHistoryReturnInfo,
   PortfolioTokenHistoryAndInfo,
   WalletAccountType,
   WalletState,
   WalletInfoBase,
   WalletInfo,
-  DefaultCurrencies
+  DefaultCurrencies,
+  GetPriceReturnInfo
 } from '../../constants/types'
 import {
   ActiveOriginChanged,
@@ -32,6 +33,7 @@ import { mojoTimeDeltaToJSDate } from '../../utils/datetime-utils'
 import * as WalletActions from '../actions/wallet_actions'
 import { formatFiatBalance } from '../../utils/format-balances'
 import { sortTransactionByDate } from '../../utils/tx-utils'
+import { normalizeNumericValue } from '../../utils/bn-utils'
 
 const defaultState: WalletState = {
   hasInitialized: false,
@@ -92,7 +94,6 @@ reducer.on(WalletActions.initialized, (state: any, payload: WalletInfo) => {
       name: info.name,
       address: info.address,
       balance: '',
-      fiatBalance: '',
       asset: 'eth',
       accountType: getAccountType(info),
       deviceId: info.hardware ? info.hardware.deviceId : '',
@@ -157,15 +158,12 @@ reducer.on(WalletActions.setAllTokensList, (state: any, payload: GetAllTokensRet
   }
 })
 
-reducer.on(WalletActions.nativeAssetBalancesUpdated, (state: any, payload: GetNativeAssetBalancesPriceReturnInfo) => {
+reducer.on(WalletActions.nativeAssetBalancesUpdated, (state: any, payload: GetNativeAssetBalancesReturnInfo) => {
   let accounts: WalletAccountType[] = [...state.accounts]
 
   accounts.forEach((account, index) => {
     if (payload.balances[index].error === BraveWallet.ProviderError.kSuccess) {
-      accounts[index].balance = payload.balances[index].balance
-      accounts[index].fiatBalance = payload.fiatPrice !== ''
-        ? formatFiatBalance(payload.balances[index].balance, state.selectedNetwork.decimals, payload.fiatPrice).toString()
-        : ''
+      accounts[index].balance = normalizeNumericValue(payload.balances[index].balance)
     }
   })
   return {
@@ -174,7 +172,7 @@ reducer.on(WalletActions.nativeAssetBalancesUpdated, (state: any, payload: GetNa
   }
 })
 
-reducer.on(WalletActions.tokenBalancesUpdated, (state: any, payload: GetERC20TokenBalanceAndPriceReturnInfo) => {
+reducer.on(WalletActions.tokenBalancesUpdated, (state: any, payload: GetBlockchainTokenBalanceReturnInfo) => {
   const userTokens: BraveWallet.BlockchainToken[] = state.userVisibleTokensInfo
   const userVisibleTokensInfo = userTokens.map((token) => {
     return {
@@ -182,47 +180,37 @@ reducer.on(WalletActions.tokenBalancesUpdated, (state: any, payload: GetERC20Tok
       logo: `chrome://erc-token-images/${token.logo}`
     }
   })
-  const prices = payload.prices
-  const findTokenPrice = (symbol: string) => {
-    if (prices.success) {
-      return prices.values.find((value) => value.fromAsset === symbol.toLowerCase())?.price ?? ''
-    } else {
-      return ''
-    }
-  }
+
   let accounts: WalletAccountType[] = [...state.accounts]
   accounts.forEach((account, accountIndex) => {
     payload.balances[accountIndex].forEach((info, tokenIndex) => {
       let assetBalance = ''
-      let fiatBalance = ''
 
       if (userVisibleTokensInfo[tokenIndex].contractAddress === '') {
         assetBalance = account.balance
-        fiatBalance = account.fiatBalance
       } else if (info.error === BraveWallet.ProviderError.kSuccess && userVisibleTokensInfo[tokenIndex].isErc721) {
         assetBalance = info.balance
-        fiatBalance = '' // TODO: support estimated market value.
       } else if (info.error === BraveWallet.ProviderError.kSuccess) {
-        const tokenPrice = findTokenPrice(userVisibleTokensInfo[tokenIndex].symbol)
         assetBalance = info.balance
-        fiatBalance = tokenPrice !== ''
-          ? formatFiatBalance(info.balance, userVisibleTokensInfo[tokenIndex].decimals, findTokenPrice(userVisibleTokensInfo[tokenIndex].symbol))
-          : ''
       } else if (account.tokens[tokenIndex]) {
         assetBalance = account.tokens[tokenIndex].assetBalance
-        fiatBalance = account.tokens[tokenIndex].fiatBalance
       }
       account.tokens.splice(tokenIndex, 1, {
         asset: userVisibleTokensInfo[tokenIndex],
-        assetBalance,
-        fiatBalance
+        assetBalance: normalizeNumericValue(assetBalance)
       })
     })
   })
   return {
     ...state,
-    transactionSpotPrices: prices.values,
     accounts
+  }
+})
+
+reducer.on(WalletActions.pricesUpdated, (state: WalletState, payload: GetPriceReturnInfo) => {
+  return {
+    ...state,
+    transactionSpotPrices: payload.success ? payload.values : state.transactionSpotPrices
   }
 })
 

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
@@ -16,7 +16,7 @@ import { formatWithCommasAndDecimals } from '../../../utils/format-prices'
 import { getLocale } from '../../../../common/locale'
 import { reduceAddress } from '../../../utils/reduce-address'
 import { withPlaceholderIcon } from '../../shared'
-import { hexToNumber } from '../../../utils/format-balances'
+import { formatBalance, hexToNumber } from '../../../utils/format-balances'
 
 // Styled Components
 import {
@@ -218,8 +218,10 @@ function SwapInputComponent (props: Props) {
     return withPlaceholderIcon(AssetIcon, { size: 'small', marginLeft: 4, marginRight: 8 })
   }, [])
 
-  const formatedAssetBalance = selectedAssetBalance
-    ? getLocale('braveWalletBalance') + ': ' + formatWithCommasAndDecimals(selectedAssetBalance?.toString() ?? '')
+  const formattedAssetBalance = selectedAssetBalance
+    ? getLocale('braveWalletBalance') + ': ' + formatWithCommasAndDecimals(
+        formatBalance(selectedAssetBalance, selectedAsset?.asset.decimals ?? 18)
+      )
     : ''
 
   return (
@@ -236,7 +238,7 @@ function SwapInputComponent (props: Props) {
             */}
 
               {componentType !== 'exchange' && componentType !== 'toAddress' && componentType !== 'buyAmount' &&
-                <FromBalanceText>{formatedAssetBalance}</FromBalanceText>
+                <FromBalanceText>{formattedAssetBalance}</FromBalanceText>
               }
               {componentType === 'toAddress' &&
                 <PasteButton onClick={onPaste}>

--- a/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { create } from 'ethereum-blockies'
 
 // Hooks
-import { useExplorer } from '../../../common/hooks'
+import { useExplorer, usePricing } from '../../../common/hooks'
 
 // Utils
 import { reduceAddress } from '../../../utils/reduce-address'
@@ -11,11 +11,13 @@ import {
   formatFiatAmountWithCommasAndDecimals,
   formatTokenAmountWithCommasAndDecimals
 } from '../../../utils/format-prices'
+import { formatBalance } from '../../../utils/format-balances'
 
 import { Tooltip } from '../../shared'
 import { getLocale } from '../../../../common/locale'
 import { BraveWallet, DefaultCurrencies } from '../../../constants/types'
 import { TransactionPopup } from '../'
+
 // Styled Components
 import {
   StyledWrapper,
@@ -34,11 +36,12 @@ import {
 import { TransactionPopupItem } from '../transaction-popup'
 
 export interface Props {
+  spotPrices: BraveWallet.AssetPrice[]
   defaultCurrencies: DefaultCurrencies
   address: string
-  fiatBalance: string
   assetBalance: string
   assetTicker: string
+  assetDecimals: number
   selectedNetwork: BraveWallet.EthereumChain
   name: string
 }
@@ -48,10 +51,11 @@ const PortfolioAccountItem = (props: Props) => {
     address,
     name,
     assetBalance,
-    fiatBalance,
     assetTicker,
+    assetDecimals,
     selectedNetwork,
-    defaultCurrencies
+    defaultCurrencies,
+    spotPrices
   } = props
   const [showAccountPopup, setShowAccountPopup] = React.useState<boolean>(false)
   const onCopyToClipboard = async () => {
@@ -63,6 +67,13 @@ const PortfolioAccountItem = (props: Props) => {
   }, [address])
 
   const onClickViewOnBlockExplorer = useExplorer(selectedNetwork)
+
+  const formattedAssetBalance = formatBalance(assetBalance, assetDecimals)
+
+  const { computeFiatAmount } = usePricing(spotPrices)
+  const fiatBalance = React.useMemo(() => {
+    return computeFiatAmount(assetBalance, assetTicker, assetDecimals)
+  }, [computeFiatAmount, assetDecimals, assetBalance, assetTicker])
 
   const onShowTransactionPopup = () => {
     setShowAccountPopup(true)
@@ -88,7 +99,7 @@ const PortfolioAccountItem = (props: Props) => {
       <RightSide>
         <BalanceColumn>
           <FiatBalanceText>{formatFiatAmountWithCommasAndDecimals(fiatBalance, defaultCurrencies.fiat)}</FiatBalanceText>
-          <AssetBalanceText>{formatTokenAmountWithCommasAndDecimals(assetBalance, assetTicker)}</AssetBalanceText>
+          <AssetBalanceText>{formatTokenAmountWithCommasAndDecimals(formattedAssetBalance, assetTicker)}</AssetBalanceText>
         </BalanceColumn>
         <MoreButton onClick={onShowTransactionPopup}>
           <MoreIcon />

--- a/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-transaction-item/index.tsx
@@ -11,7 +11,11 @@ import {
 // Utils
 import { toProperCase } from '../../../utils/string-utils'
 import { mojoTimeDeltaToJSDate, formatDateAsRelative } from '../../../utils/datetime-utils'
-import { formatFiatAmountWithCommasAndDecimals } from '../../../utils/format-prices'
+import {
+  formatFiatAmountWithCommasAndDecimals,
+  formatTokenAmountWithCommasAndDecimals
+} from '../../../utils/format-prices'
+import { formatBalance } from '../../../utils/format-balances'
 
 // Hooks
 import { useExplorer, useTransactionParser } from '../../../common/hooks'
@@ -305,13 +309,13 @@ const PortfolioTransactionItem = (props: Props) => {
       <DetailRow>
         <BalanceColumn>
           <DetailTextDark>{/* We need to return a Transaction Time Stamp to calculate Fiat value here */}{formatFiatAmountWithCommasAndDecimals(transactionDetails.fiatValue, defaultCurrencies.fiat)}</DetailTextDark>
-          <DetailTextLight>{transactionDetails.nativeCurrencyTotal} {selectedNetwork.symbol}</DetailTextLight>
+          <DetailTextLight>{formatTokenAmountWithCommasAndDecimals(transactionDetails.nativeCurrencyTotal, selectedNetwork.symbol)}</DetailTextLight>
         </BalanceColumn>
         <TransactionFeesTooltip
           text={
             <>
               <TransactionFeeTooltipTitle>{getLocale('braveWalletAllowSpendTransactionFee')}</TransactionFeeTooltipTitle>
-              <TransactionFeeTooltipBody>{transactionDetails.gasFee} {selectedNetwork.symbol}</TransactionFeeTooltipBody>
+              <TransactionFeeTooltipBody>{formatTokenAmountWithCommasAndDecimals(formatBalance(transactionDetails.gasFee, selectedNetwork.decimals), selectedNetwork.symbol)}</TransactionFeeTooltipBody>
               <TransactionFeeTooltipBody>{formatFiatAmountWithCommasAndDecimals(transactionDetails.gasFeeFiat, defaultCurrencies.fiat)}</TransactionFeeTooltipBody>
             </>
           }

--- a/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
@@ -12,7 +12,6 @@ import { reduceAddress } from '../../../../utils/reduce-address'
 import { copyToClipboard } from '../../../../utils/copy-to-clipboard'
 import { create } from 'ethereum-blockies'
 import { getLocale } from '../../../../../common/locale'
-import { formatBalance } from '../../../../utils/format-balances'
 import { sortTransactionByDate } from '../../../../utils/tx-utils'
 
 // Styled Components
@@ -261,10 +260,10 @@ function Accounts (props: Props) {
           <SubDivider />
           {selectedAccount.tokens.filter((token) => !token.asset.isErc721).map((item) =>
             <PortfolioAssetItem
+              spotPrices={transactionSpotPrices}
               defaultCurrencies={defaultCurrencies}
               key={item.asset.contractAddress}
-              assetBalance={formatBalance(item.assetBalance, item.asset.decimals)}
-              fiatBalance={item.fiatBalance}
+              assetBalance={item.assetBalance}
               token={item.asset}
             />
           )}
@@ -275,10 +274,10 @@ function Accounts (props: Props) {
               <SubDivider />
               {erc271Tokens?.map((item) =>
                 <PortfolioAssetItem
+                  spotPrices={transactionSpotPrices}
                   defaultCurrencies={defaultCurrencies}
                   key={item.asset.contractAddress}
-                  assetBalance={formatBalance(item.assetBalance, item.asset.decimals)}
-                  fiatBalance={item.fiatBalance}
+                  assetBalance={item.assetBalance}
                   token={item.asset}
                 />
               )}

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -10,13 +10,22 @@ import {
   UpdateUnapprovedTransactionGasFieldsType,
   UpdateUnapprovedTransactionSpendAllowanceType
 } from '../../../common/constants/action_types'
+
+// Utils
 import { reduceAddress } from '../../../utils/reduce-address'
 import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 import { reduceAccountDisplayName } from '../../../utils/reduce-account-name'
 import { formatBalance, toWeiHex } from '../../../utils/format-balances'
-import { formatWithCommasAndDecimals, formatFiatAmountWithCommasAndDecimals } from '../../../utils/format-prices'
-import { getLocale } from '../../../../common/locale'
+import {
+  formatWithCommasAndDecimals,
+  formatFiatAmountWithCommasAndDecimals,
+  formatTokenAmountWithCommasAndDecimals
+} from '../../../utils/format-prices'
+
+// Hooks
 import { usePricing, useTransactionParser, useTokenInfo } from '../../../common/hooks'
+
+import { getLocale } from '../../../../common/locale'
 import { withPlaceholderIcon } from '../../shared'
 
 import { NavButton, PanelTab, TransactionDetailBox } from '../'
@@ -33,7 +42,7 @@ import {
   AccountNameText,
   TopRow,
   NetworkText,
-  TransactionAmmountBig,
+  TransactionAmountBig,
   TransactionFiatAmountBig,
   GrandTotalText,
   MessageBox,
@@ -83,7 +92,7 @@ export interface Props {
   transactionsQueueLength: number
   transactionQueueNumber: number
   defaultCurrencies: DefaultCurrencies
-  onQueueNextTransction: () => void
+  onQueueNextTransaction: () => void
   onConfirm: () => void
   onReject: () => void
   onRejectAllTransactions: () => void
@@ -106,7 +115,7 @@ function ConfirmTransactionPanel (props: Props) {
     transactionQueueNumber,
     fullTokenList,
     defaultCurrencies,
-    onQueueNextTransction,
+    onQueueNextTransaction,
     onConfirm,
     onReject,
     onRejectAllTransactions,
@@ -131,7 +140,7 @@ function ConfirmTransactionPanel (props: Props) {
   const [currentTokenAllowance, setCurrentTokenAllowance] = React.useState<string>('')
   const [isEditingAllowance, setIsEditingAllowance] = React.useState<boolean>(false)
 
-  const findSpotPrice = usePricing(transactionSpotPrices)
+  const { findAssetPrice } = usePricing(transactionSpotPrices)
   const parseTransaction = useTransactionParser(selectedNetwork, accounts, transactionSpotPrices, visibleTokens, fullTokenList)
   const transactionDetails = parseTransaction(transactionInfo)
 
@@ -243,7 +252,7 @@ function ConfirmTransactionPanel (props: Props) {
       <EditGas
         transactionInfo={transactionInfo}
         onCancel={onToggleEditGas}
-        networkSpotPrice={findSpotPrice(selectedNetwork.symbol)}
+        networkSpotPrice={findAssetPrice(selectedNetwork.symbol)}
         selectedNetwork={selectedNetwork}
         baseFeePerGas={baseFeePerGas}
         suggestedMaxPriorityFeeChoices={suggestedMaxPriorityFeeChoices}
@@ -282,7 +291,7 @@ function ConfirmTransactionPanel (props: Props) {
           <QueueStepRow>
             <QueueStepText>{transactionQueueNumber} {getLocale('braveWalletQueueOf')} {transactionsQueueLength}</QueueStepText>
             <QueueStepButton
-              onClick={onQueueNextTransction}
+              onClick={onQueueNextTransaction}
             >
               {transactionQueueNumber === transactionsQueueLength
                 ? getLocale('braveWalletQueueFirst')
@@ -316,13 +325,13 @@ function ConfirmTransactionPanel (props: Props) {
             transactionInfo.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom) &&
             <AssetIconWithPlaceholder selectedAsset={transactionDetails.erc721BlockchainToken} />
           }
-          <TransactionAmmountBig>
+          <TransactionAmountBig>
             {transactionInfo.txType === BraveWallet.TransactionType.ERC721TransferFrom ||
               transactionInfo.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom
               ? transactionDetails.erc721BlockchainToken?.name + ' ' + transactionDetails.erc721TokenId
-              : formatWithCommasAndDecimals(transactionDetails.value) + ' ' + transactionDetails.symbol
+              : formatTokenAmountWithCommasAndDecimals(transactionDetails.value, transactionDetails.symbol)
             }
-          </TransactionAmmountBig>
+          </TransactionAmountBig>
           {transactionInfo.txType !== BraveWallet.TransactionType.ERC721TransferFrom &&
             transactionInfo.txType !== BraveWallet.TransactionType.ERC721SafeTransferFrom &&
             <TransactionFiatAmountBig>{formatFiatAmountWithCommasAndDecimals(transactionDetails.fiatValue, defaultCurrencies.fiat)}</TransactionFiatAmountBig>
@@ -350,7 +359,7 @@ function ConfirmTransactionPanel (props: Props) {
                   <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
                   <SectionRow>
                     <TransactionTitle>{getLocale('braveWalletAllowSpendTransactionFee')}</TransactionTitle>
-                    <TransactionTypeText>{formatWithCommasAndDecimals(transactionDetails.gasFee)} {selectedNetwork.symbol}</TransactionTypeText>
+                    <TransactionTypeText>{formatWithCommasAndDecimals(formatBalance(transactionDetails.gasFee, selectedNetwork.decimals))} {selectedNetwork.symbol}</TransactionTypeText>
                   </SectionRow>
                   <TransactionText
                     hasError={transactionDetails.insufficientFundsError}
@@ -371,7 +380,7 @@ function ConfirmTransactionPanel (props: Props) {
                 <SectionRow>
                   <TransactionTitle>{getLocale('braveWalletAllowSpendProposedAllowance')}</TransactionTitle>
                   <SectionRightColumn>
-                    <TransactionTypeText>{transactionDetails.value} {transactionDetails.symbol}</TransactionTypeText>
+                    <TransactionTypeText>{formatTokenAmountWithCommasAndDecimals(transactionDetails.value, transactionDetails.symbol)}</TransactionTypeText>
                     <TransactionText />
                   </SectionRightColumn>
                 </SectionRow>
@@ -383,7 +392,7 @@ function ConfirmTransactionPanel (props: Props) {
                   <TransactionTitle>{getLocale('braveWalletConfirmTransactionGasFee')}</TransactionTitle>
                   <SectionRightColumn>
                     <EditButton onClick={onToggleEditGas}>{getLocale('braveWalletAllowSpendEditButton')}</EditButton>
-                    <TransactionTypeText>{formatWithCommasAndDecimals(transactionDetails.gasFee)} {selectedNetwork.symbol}</TransactionTypeText>
+                    <TransactionTypeText>{formatWithCommasAndDecimals(formatBalance(transactionDetails.gasFee, selectedNetwork.decimals))} {selectedNetwork.symbol}</TransactionTypeText>
                     <TransactionText>{formatFiatAmountWithCommasAndDecimals(transactionDetails.gasFeeFiat, defaultCurrencies.fiat)}</TransactionText>
                   </SectionRightColumn>
                 </SectionRow>
@@ -397,7 +406,7 @@ function ConfirmTransactionPanel (props: Props) {
                         transactionInfo.txType !== BraveWallet.TransactionType.ERC721TransferFrom)
                         ? formatWithCommasAndDecimals(transactionDetails.value)
                         : transactionDetails.value
-                      } {transactionDetails.symbol} + {transactionDetails.gasFee} {selectedNetwork.symbol}</GrandTotalText>
+                      } {transactionDetails.symbol} + {formatBalance(transactionDetails.gasFee, selectedNetwork.decimals)} {selectedNetwork.symbol}</GrandTotalText>
                   </SingleRow>
                   <TransactionText
                     hasError={transactionDetails.insufficientFundsError}

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -74,7 +74,7 @@ export const NetworkText = styled.span`
   color: ${(p) => p.theme.color.text03};
 `
 
-export const TransactionAmmountBig = styled.span`
+export const TransactionAmountBig = styled.span`
   font-family: Poppins;
   font-size: 18px;
   line-height: 22px;

--- a/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
@@ -41,7 +41,7 @@ import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 import { copyToClipboard } from '../../../utils/copy-to-clipboard'
 
 // Hooks
-import { useExplorer } from '../../../common/hooks'
+import { useExplorer, usePricing } from '../../../common/hooks'
 
 import {
   WalletAccountType,
@@ -58,6 +58,7 @@ import { create, background } from 'ethereum-blockies'
 import { getLocale } from '../../../../common/locale'
 
 export interface Props {
+  spotPrices: BraveWallet.AssetPrice[]
   selectedAccount: WalletAccountType
   selectedNetwork: BraveWallet.EthereumChain
   isConnected: boolean
@@ -71,6 +72,7 @@ export interface Props {
 
 const ConnectedPanel = (props: Props) => {
   const {
+    spotPrices,
     onLockWallet,
     onOpenSettings,
     isConnected,
@@ -140,11 +142,17 @@ const ConnectedPanel = (props: Props) => {
     return !SwapSupportedChains.includes(selectedNetwork.chainId)
   }, [SwapSupportedChains, selectedNetwork])
 
-  const formatedAssetBalance = formatBalance(selectedAccount.balance, selectedNetwork.decimals)
+  const formattedAssetBalance = formatBalance(selectedAccount.balance, selectedNetwork.decimals)
 
-  const formatedAssetBalanceWithDecimals = selectedAccount.balance
-    ? formatTokenAmountWithCommasAndDecimals(formatedAssetBalance, selectedNetwork.symbol)
+  const formattedAssetBalanceWithDecimals = selectedAccount.balance
+    ? formatTokenAmountWithCommasAndDecimals(formattedAssetBalance, selectedNetwork.symbol)
     : ''
+
+  const { computeFiatAmount } = usePricing(spotPrices)
+
+  const selectedAccountFiatBalance = React.useMemo(() => computeFiatAmount(
+    selectedAccount.balance, selectedNetwork.symbol, selectedNetwork.decimals
+  ), [computeFiatAmount, selectedNetwork, selectedAccount])
 
   const onClickViewOnBlockExplorer = useExplorer(selectedNetwork)
 
@@ -194,18 +202,18 @@ const ConnectedPanel = (props: Props) => {
             </Tooltip>
           </BalanceColumn>
           <BalanceColumn>
-            <AssetBalanceText>{formatedAssetBalanceWithDecimals}</AssetBalanceText>
-            <FiatBalanceText>{formatFiatAmountWithCommasAndDecimals(selectedAccount.fiatBalance, defaultCurrencies.fiat)}</FiatBalanceText>
+            <AssetBalanceText>{formattedAssetBalanceWithDecimals}</AssetBalanceText>
+            <FiatBalanceText>{formatFiatAmountWithCommasAndDecimals(selectedAccountFiatBalance, defaultCurrencies.fiat)}</FiatBalanceText>
           </BalanceColumn>
         </CenterColumn>
         <AssetContainer isScrolled={isScrolled}>
           {userAssetList?.map((asset) =>
             <PortfolioAssetItem
+              spotPrices={spotPrices}
               defaultCurrencies={defaultCurrencies}
               action={onClickAsset(asset.asset.symbol)}
               key={asset.asset.contractAddress}
               assetBalance={asset.assetBalance}
-              fiatBalance={asset.fiatBalance}
               token={asset.asset}
               isPanel={true}
             />

--- a/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
+++ b/components/brave_wallet_ui/components/extension/edit-gas/index.tsx
@@ -6,9 +6,10 @@ import { BraveWallet } from '../../../constants/types'
 import { UpdateUnapprovedTransactionGasFieldsType } from '../../../common/constants/action_types'
 
 import { NavButton, Panel } from '../'
+
+// Utils
 import {
   formatFiatGasFee,
-  toWei,
   toGWei,
   addCurrencies,
   formatGasFee,
@@ -16,6 +17,9 @@ import {
   gWeiToWeiHex,
   toWeiHex
 } from '../../../utils/format-balances'
+import { addNumericValues } from '../../../utils/bn-utils'
+
+// Hooks
 import { useTransactionFeesParser } from '../../../common/hooks'
 
 // Styled Components
@@ -76,10 +80,10 @@ const EditGas = (props: Props) => {
   const { isEIP1559Transaction } = transactionFees
 
   const [suggestedMaxPriorityFee, setSuggestedMaxPriorityFee] = React.useState<string>(suggestedMaxPriorityFeeChoices[1])
-  const [gasLimit, setGasLimit] = React.useState<string>(toWei(transactionFees.gasLimit, 0))
-  const [gasPrice, setGasPrice] = React.useState<string>(toGWei(transactionFees.gasPrice, selectedNetwork.decimals))
-  const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = React.useState<string>(toGWei(transactionFees.maxPriorityFeePerGas, selectedNetwork.decimals))
-  const [maxFeePerGas, setMaxFeePerGas] = React.useState<string>(toGWei(transactionFees.maxFeePerGas, selectedNetwork.decimals))
+  const [gasLimit, setGasLimit] = React.useState<string>(transactionFees.gasLimit)
+  const [gasPrice, setGasPrice] = React.useState<string>(toGWei(transactionFees.gasPrice))
+  const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = React.useState<string>(toGWei(transactionFees.maxPriorityFeePerGas))
+  const [maxFeePerGas, setMaxFeePerGas] = React.useState<string>(toGWei(transactionFees.maxFeePerGas))
 
   const handleGasPriceInputChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setGasPrice(event.target.value)
@@ -93,11 +97,8 @@ const EditGas = (props: Props) => {
     const value = event.target.value
     setMaxPriorityFeePerGas(value)
 
-    const computedMaxFeePerGasWeiHex = addCurrencies(baseFeePerGas, gWeiToWei(value))
-    const computedMaxFeePerGasGWei = toGWei(
-      computedMaxFeePerGasWeiHex,
-      selectedNetwork.decimals
-    )
+    const computedMaxFeePerGasWei = addNumericValues(baseFeePerGas, gWeiToWei(value))
+    const computedMaxFeePerGasGWei = toGWei(computedMaxFeePerGasWei)
     setMaxFeePerGas(computedMaxFeePerGasGWei)
   }
 
@@ -227,7 +228,7 @@ const EditGas = (props: Props) => {
             <CurrentBaseRow>
               <CurrentBaseText>{getLocale('braveWalletEditGasBaseFee')}</CurrentBaseText>
               <CurrentBaseText>
-                {`${toGWei(baseFeePerGas, selectedNetwork.decimals)} ${getLocale('braveWalletEditGasGwei')}`}
+                {`${toGWei(baseFeePerGas)} ${getLocale('braveWalletEditGasGwei')}`}
               </CurrentBaseText>
             </CurrentBaseRow>
 

--- a/components/brave_wallet_ui/components/extension/transaction-detail-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/transaction-detail-panel/index.tsx
@@ -9,7 +9,10 @@ import { reduceAddress } from '../../../utils/reduce-address'
 import { getTransactionStatusString } from '../../../utils/tx-utils'
 import { toProperCase } from '../../../utils/string-utils'
 import { mojoTimeDeltaToJSDate } from '../../../utils/datetime-utils'
-import { formatFiatAmountWithCommasAndDecimals, formatWithCommasAndDecimals } from '../../../utils/format-prices'
+import {
+  formatFiatAmountWithCommasAndDecimals,
+  formatTokenAmountWithCommasAndDecimals
+} from '../../../utils/format-prices'
 
 import { getLocale } from '../../../../common/locale'
 import {
@@ -121,7 +124,7 @@ const TransactionDetailPanel = (props: Props) => {
       transaction.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom) {
       return transactionDetails.erc721BlockchainToken?.name + ' ' + transactionDetails.erc721TokenId
     }
-    return formatWithCommasAndDecimals(transactionDetails.value) + ' ' + transactionDetails.symbol
+    return formatTokenAmountWithCommasAndDecimals(transactionDetails.value, transactionDetails.symbol)
   }, [transactionDetails, transaction])
 
   const transactionFiatValue = React.useMemo((): string => {

--- a/components/brave_wallet_ui/components/extension/transaction-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/extension/transaction-list-item/index.tsx
@@ -12,7 +12,10 @@ import {
 import { toProperCase } from '../../../utils/string-utils'
 import { getTransactionStatusString } from '../../../utils/tx-utils'
 import { mojoTimeDeltaToJSDate, formatDateAsRelative } from '../../../utils/datetime-utils'
-import { formatFiatAmountWithCommasAndDecimals } from '../../../utils/format-prices'
+import {
+  formatFiatAmountWithCommasAndDecimals,
+  formatTokenAmountWithCommasAndDecimals
+} from '../../../utils/format-prices'
 
 // Hooks
 import { useTransactionParser } from '../../../common/hooks'
@@ -191,7 +194,7 @@ const TransactionsListItem = (props: Props) => {
       <DetailRow>
         <BalanceColumn>
           <DetailTextDark>{formatFiatAmountWithCommasAndDecimals(transactionDetails.fiatValue, defaultCurrencies.fiat)}</DetailTextDark>
-          <DetailTextLight>{transactionDetails.nativeCurrencyTotal} {selectedNetwork.symbol}</DetailTextLight>
+          <DetailTextLight>{formatTokenAmountWithCommasAndDecimals(transactionDetails.nativeCurrencyTotal, selectedNetwork.symbol)}</DetailTextLight>
           <StatusRow>
             <StatusBubble status={transactionDetails.status} />
             <DetailTextDarkBold>

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -11,13 +11,13 @@ import { HardwareWalletResponseCodeType } from '../common/hardware/types'
 // path of generated mojom files.
 export { BraveWallet }
 export { Url } from 'gen/url/mojom/url.mojom.m.js'
+export { TimeDelta }
 
 export interface WalletAccountType {
   id: string
   name: string
   address: string
   balance: string
-  fiatBalance: string
   asset: string
   accountType: 'Primary' | 'Secondary' | 'Ledger' | 'Trezor'
   tokens: AccountAssetOptionType[]
@@ -40,19 +40,16 @@ export interface AssetOptionType {
 export interface UserAssetOptionType {
   asset: AssetOptionType
   assetBalance: number
-  fiatBalance: number
 }
 
 export interface AccountAssetOptionType {
   asset: BraveWallet.BlockchainToken
   assetBalance: string
-  fiatBalance: string
 }
 
 export interface UserWalletObject {
   name: string
   address: string
-  fiatBalance: string
   assetBalance: number
 }
 
@@ -320,18 +317,12 @@ export interface GetAllTokensReturnInfo {
   tokens: BraveWallet.BlockchainToken[]
 }
 
-export type GetBalanceReturnInfo = BraveWallet.JsonRpcService_GetBalance_ResponseParams
-
-export interface GetNativeAssetBalancesPriceReturnInfo {
-  fiatPrice: string
-  balances: GetBalanceReturnInfo[]
+export interface GetNativeAssetBalancesReturnInfo {
+  balances: BraveWallet.JsonRpcService_GetBalance_ResponseParams[]
 }
 
-export type GetBlockchainTokenBalanceReturnInfo = BraveWallet.JsonRpcService_GetERC20TokenBalance_ResponseParams
-
-export interface GetERC20TokenBalanceAndPriceReturnInfo {
-  balances: GetBlockchainTokenBalanceReturnInfo[][]
-  prices: GetPriceReturnInfo
+export interface GetBlockchainTokenBalanceReturnInfo {
+  balances: BraveWallet.JsonRpcService_GetERC20TokenBalance_ResponseParams[][]
 }
 
 export interface GetFlattenedAccountBalancesReturnInfo {

--- a/components/brave_wallet_ui/options/asset-options.ts
+++ b/components/brave_wallet_ui/options/asset-options.ts
@@ -20,8 +20,7 @@ export const ETH: AccountAssetOptionType = {
     visible: true,
     tokenId: ''
   },
-  assetBalance: '0',
-  fiatBalance: '0'
+  assetBalance: '0'
 }
 
 export const BAT: AccountAssetOptionType = {
@@ -36,8 +35,7 @@ export const BAT: AccountAssetOptionType = {
     visible: false,
     tokenId: ''
   },
-  assetBalance: '0',
-  fiatBalance: '0'
+  assetBalance: '0'
 }
 
 export const RopstenSwapAssetOptions: AccountAssetOptionType[] = [
@@ -54,8 +52,7 @@ export const RopstenSwapAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   },
   {
     asset: {
@@ -69,8 +66,7 @@ export const RopstenSwapAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   }
 ]
 
@@ -159,8 +155,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   },
   {
     asset: {
@@ -174,8 +169,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   },
   {
     asset: {
@@ -189,8 +183,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   },
   {
     asset: {
@@ -204,8 +197,7 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   },
   {
     asset: {
@@ -219,7 +211,6 @@ export const AccountAssetOptions: AccountAssetOptionType[] = [
       visible: true,
       tokenId: ''
     },
-    assetBalance: '0',
-    fiatBalance: '0'
+    assetBalance: '0'
   }
 ]

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import { Switch, Route, useHistory, useLocation } from 'react-router-dom'
+
 import * as WalletPageActions from './actions/wallet_page_actions'
 import * as WalletActions from '../common/actions/wallet_actions'
 import store from './store'
@@ -39,9 +40,13 @@ import {
 import BuySendSwap from '../stories/screens/buy-send-swap'
 import Onboarding from '../stories/screens/onboarding'
 import BackupWallet from '../stories/screens/backup-wallet'
+
+// Utils
 import { formatWithCommasAndDecimals } from '../utils/format-prices'
 import { GetBuyOrFaucetUrl } from '../utils/buy-asset-url'
 import { mojoTimeDeltaToJSDate } from '../utils/datetime-utils'
+import { stripERC20TokenImageURL } from '../utils/string-utils'
+import { addNumericValues } from '../utils/bn-utils'
 
 import {
   findENSAddress,
@@ -55,16 +60,16 @@ import {
   getBuyAssets
 } from '../common/async/lib'
 
-import { formatBalance } from '../utils/format-balances'
+// Hooks
 import {
   useSwap,
   useAssets,
   useBalance,
   useSend,
   usePreset,
-  useTokenInfo
+  useTokenInfo,
+  usePricing
 } from '../common/hooks'
-import { stripERC20TokenImageURL } from '../utils/string-utils'
 
 type Props = {
   wallet: WalletState
@@ -135,6 +140,7 @@ function Container (props: Props) {
     selectedAccount,
     props.wallet.fullTokenList,
     props.wallet.userVisibleTokensInfo,
+    transactionSpotPrices,
     getBuyAssets
   )
 
@@ -202,10 +208,11 @@ function Container (props: Props) {
     props.wallet.fullTokenList
   )
 
-  const getSelectedAccountBalance = useBalance(selectedAccount)
-  const { assetBalance: sendAssetBalance } = getSelectedAccountBalance(selectedSendAsset)
-  const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
-  const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
+  const { computeFiatAmount } = usePricing(transactionSpotPrices)
+  const getAccountBalance = useBalance(selectedNetwork)
+  const sendAssetBalance = getAccountBalance(selectedAccount, selectedSendAsset?.asset)
+  const fromAssetBalance = getAccountBalance(selectedAccount, fromAsset?.asset)
+  const toAssetBalance = getAccountBalance(selectedAccount, toAsset?.asset)
 
   const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, selectedSendAsset, onSetFromAmount, onSetSendAmount)
 
@@ -287,46 +294,25 @@ function Container (props: Props) {
     return (mnemonic || '').split(' ')
   }, [mnemonic])
 
-  // This will scrape all of the user's accounts and combine the asset balances for a single asset
-  const fullAssetBalance = (asset: BraveWallet.BlockchainToken): number | string => {
-    const amounts = accounts.map((account) => {
-      let balance
-      const found = account.tokens.find((token) => token.asset.contractAddress === asset.contractAddress)
-      if (found) {
-        balance = Number(formatBalance(found.assetBalance, found.asset.decimals))
-      }
-      return balance
-    })
-    const grandTotal = amounts.reduce(function (a, b) {
-      return a !== undefined && b !== undefined ? a + b : undefined
-    })
-    return grandTotal ?? ''
-  }
+  // This will scrape all the user's accounts and combine the asset balances for a single asset
+  const fullAssetBalance = React.useCallback((asset: BraveWallet.BlockchainToken) => {
+    const amounts = accounts.map((account) =>
+      getAccountBalance(account, asset))
 
-  // This will scrape all of the user's accounts and combine the fiat value for a single asset
-  const fullAssetFiatBalance = (asset: BraveWallet.BlockchainToken): number | string => {
-    const amounts = accounts.map((account) => {
-      let fiatBalance
-      const found = account.tokens.find((token) => token.asset.contractAddress === asset.contractAddress)
-      if (found && found.fiatBalance !== '') {
-        fiatBalance = Number(found.fiatBalance)
-      }
-      return fiatBalance
+    return amounts.reduce(function (a, b) {
+      return a !== '' && b !== ''
+        ? addNumericValues(a, b)
+        : ''
     })
-    const grandTotal = amounts.reduce(function (a, b) {
-      return a !== undefined && b !== undefined ? a + b : undefined
-    })
-    return grandTotal ?? ''
-  }
+  }, [accounts, getAccountBalance])
 
   // This looks at the users asset list and returns the full balance for each asset
   const userAssetList = React.useMemo(() => {
     return userVisibleTokenOptions.map((asset) => ({
       asset: asset,
-      assetBalance: fullAssetBalance(asset)?.toString(),
-      fiatBalance: fullAssetFiatBalance(asset)?.toString()
-    }))
-  }, [userVisibleTokenOptions, accounts])
+      assetBalance: fullAssetBalance(asset)
+    }) as AccountAssetOptionType)
+  }, [userVisibleTokenOptions, fullAssetBalance])
 
   const onSelectAsset = (asset: BraveWallet.BlockchainToken) => {
     props.walletPageActions.selectAsset({ asset: asset, timeFrame: selectedTimeline })
@@ -334,18 +320,25 @@ function Container (props: Props) {
 
   // This will scrape all of the user's accounts and combine the fiat value for every asset
   const fullPortfolioBalance = React.useMemo(() => {
-    const filteredList = userAssetList.filter((token) => token.asset.visible && !token.asset.isErc721)
-    const amountList = filteredList.map((item) => {
-      return fullAssetFiatBalance(item.asset) !== '' ? fullAssetFiatBalance(item.asset) : undefined
-    })
-    if (amountList.length === 0) {
+    const visibleAssetOptions = userAssetList
+      .filter((token) => token.asset.visible && !token.asset.isErc721)
+
+    if (visibleAssetOptions.length === 0) {
       return ''
     }
-    const grandTotal = amountList.reduce(function (a, b) {
-      return a !== undefined && b !== undefined ? Number(a) + Number(b) : undefined
+
+    const visibleAssetFiatBalances = visibleAssetOptions
+      .map((item) => {
+        return computeFiatAmount(item.assetBalance, item.asset.symbol, item.asset.decimals)
+      })
+
+    const grandTotal = visibleAssetFiatBalances.reduce(function (a, b) {
+      return a !== '' && b !== ''
+        ? addNumericValues(a, b)
+        : ''
     })
-    return grandTotal !== undefined ? formatWithCommasAndDecimals(grandTotal?.toString()) : ''
-  }, [userAssetList])
+    return formatWithCommasAndDecimals(grandTotal)
+  }, [userAssetList, fullAssetBalance, computeFiatAmount])
 
   const onChangeTimeline = (timeline: BraveWallet.AssetPriceTimeframe) => {
     if (selectedAsset) {
@@ -355,14 +348,14 @@ function Container (props: Props) {
     }
   }
 
-  const formatedPriceHistory = React.useMemo(() => {
-    const formated = selectedAssetPriceHistory.map((obj) => {
+  const formattedPriceHistory = React.useMemo(() => {
+    const formatted = selectedAssetPriceHistory.map((obj) => {
       return {
         date: mojoTimeDeltaToJSDate(obj.date),
         close: Number(obj.price)
       }
     })
-    return formated
+    return formatted
   }, [selectedAssetPriceHistory])
 
   const onShowAddModal = () => {
@@ -619,7 +612,7 @@ function Container (props: Props) {
                 selectedAsset={selectedAsset}
                 selectedAssetFiatPrice={selectedAssetFiatPrice}
                 selectedAssetCryptoPrice={selectedAssetCryptoPrice}
-                selectedAssetPriceHistory={formatedPriceHistory}
+                selectedAssetPriceHistory={formattedPriceHistory}
                 portfolioPriceHistory={portfolioPriceHistory}
                 selectedTimeline={selectedTimeline}
                 selectedPortfolioTimeline={selectedPortfolioTimeline}

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -143,6 +143,7 @@ function Container (props: Props) {
     selectedAccount,
     props.wallet.fullTokenList,
     props.wallet.userVisibleTokensInfo,
+    transactionSpotPrices,
     getBuyAssets
   )
 
@@ -213,10 +214,10 @@ function Container (props: Props) {
     setSelectedAccounts([selectedAccount])
   }, [selectedAccount])
 
-  const getSelectedAccountBalance = useBalance(selectedAccount)
-  const { assetBalance: sendAssetBalance } = getSelectedAccountBalance(selectedSendAsset)
-  const { assetBalance: fromAssetBalance } = getSelectedAccountBalance(fromAsset)
-  const { assetBalance: toAssetBalance } = getSelectedAccountBalance(toAsset)
+  const getSelectedAccountBalance = useBalance(selectedNetwork)
+  const sendAssetBalance = getSelectedAccountBalance(selectedAccount, selectedSendAsset?.asset)
+  const fromAssetBalance = getSelectedAccountBalance(selectedAccount, fromAsset?.asset)
+  const toAssetBalance = getSelectedAccountBalance(selectedAccount, toAsset?.asset)
 
   const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, selectedSendAsset, onSetFromAmount, onSetSendAmount)
 
@@ -431,7 +432,7 @@ function Container (props: Props) {
     props.walletActions.rejectAllTransactions()
   }
 
-  const onQueueNextTransction = () => {
+  const onQueueNextTransaction = () => {
     props.walletActions.queueNextTransaction()
   }
   const retryHardwareOperation = () => {
@@ -603,7 +604,7 @@ function Container (props: Props) {
             onConfirm={onConfirmTransaction}
             onReject={onRejectTransaction}
             onRejectAllTransactions={onRejectAllTransactions}
-            onQueueNextTransction={onQueueNextTransction}
+            onQueueNextTransaction={onQueueNextTransaction}
             transactionQueueNumber={pendingTransactions.findIndex(tx => tx.id === selectedPendingTransaction.id) + 1}
             transactionsQueueLength={pendingTransactions.length}
             accounts={accounts}
@@ -973,6 +974,7 @@ function Container (props: Props) {
     <PanelWrapper isLonger={false}>
       <ConnectedPanel
         defaultCurrencies={defaultCurrencies}
+        spotPrices={transactionSpotPrices}
         selectedAccount={selectedAccount}
         selectedNetwork={GetNetworkInfo(selectedNetwork.chainId, networkList)}
         isConnected={isConnectedToSite}

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -350,14 +350,6 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     return account.assets.find((a) => a.symbol === selectedAsset?.symbol)
   }
 
-  // This calculates the fiat value of a single accounts asset balance
-  const singleAccountFiatBalance = (account: RPCResponseType) => {
-    const asset = assetInfo(account)
-    const data = CurrentPriceMockData.find((coin) => coin.symbol === asset?.symbol)
-    const value = data ? asset ? Number(asset.balance) * Number(data.usd) : 0 : 0
-    return formatWithCommasAndDecimals(value.toString())
-  }
-
   // This returns the balance of a single accounts asset
   const singleAccountBalance = (account: RPCResponseType) => {
     const balance = assetInfo(account)?.balance
@@ -382,7 +374,6 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
         name: name,
         address: wallet.address,
         balance: singleAccountBalance(wallet),
-        fiatBalance: singleAccountFiatBalance(wallet),
         asset: selectedAsset ? selectedAsset.symbol : '',
         accountType: 'Primary',
         tokens: []
@@ -418,8 +409,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     return newList.map((asset) => {
       return {
         asset: asset,
-        assetBalance: scrapedFullAssetBalance(asset).toString(),
-        fiatBalance: scrapedFullAssetFiatBalance(asset).toString()
+        assetBalance: scrapedFullAssetBalance(asset).toString()
       }
     })
   }, [mockUserWalletPreferences.viewableAssets])

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -66,7 +66,6 @@ const accounts: WalletAccountType[] = [
     address: '0x7d66c9ddAED3115d93Bd1790332f3Cd06Cf52B14',
     balance: '0.31178',
     asset: 'eth',
-    fiatBalance: '0',
     accountType: 'Primary',
     tokens: []
   },
@@ -76,7 +75,6 @@ const accounts: WalletAccountType[] = [
     address: '0x73A29A1da97149722eB09c526E4eAd698895bDCf',
     balance: '0.31178',
     asset: 'eth',
-    fiatBalance: '0',
     accountType: 'Primary',
     tokens: []
   },
@@ -86,7 +84,6 @@ const accounts: WalletAccountType[] = [
     address: '0x3f29A1da97149722eB09c526E4eAd698895b426',
     balance: '0.31178',
     asset: 'eth',
-    fiatBalance: '0',
     accountType: 'Primary',
     tokens: []
   }
@@ -136,7 +133,7 @@ export const _ConfirmTransaction = () => {
   const onRejectAllTransactions = () => {
     alert('Rejected All Transaction')
   }
-  const onQueueNextTransction = () => {
+  const onQueueNextTransaction = () => {
     alert('Will queue next transaction in line')
   }
 
@@ -177,7 +174,7 @@ export const _ConfirmTransaction = () => {
         defaultCurrencies={mockDefaultCurrencies}
         siteURL='https://app.uniswap.org'
         selectedNetwork={mockNetworks[0]}
-        onQueueNextTransction={onQueueNextTransction}
+        onQueueNextTransaction={onQueueNextTransaction}
         onRejectAllTransactions={onRejectAllTransactions}
         transactionQueueNumber={0}
         transactionsQueueLength={0}
@@ -327,7 +324,6 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
       address: '1',
       balance: '0.31178',
       asset: 'eth',
-      fiatBalance: '0',
       accountType: 'Primary',
       tokens: []
     }
@@ -534,6 +530,7 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
         <>
           {selectedPanel === 'main' ? (
             <ConnectedPanel
+              spotPrices={[]}
               defaultCurrencies={mockDefaultCurrencies}
               selectedNetwork={selectedNetwork}
               selectedAccount={selectedAccount}

--- a/components/brave_wallet_ui/utils/bn-utils.test.ts
+++ b/components/brave_wallet_ui/utils/bn-utils.test.ts
@@ -1,0 +1,28 @@
+import {
+  addNumericValues,
+  multiplyNumericValues,
+  normalizeNumericValue,
+  isNumericValueGreaterThan
+} from './bn-utils'
+
+describe('bn-utils', () => {
+  it('should add two numeric values', () => {
+    expect(addNumericValues('0x1', '0x2')).toEqual('3')
+    expect(addNumericValues('1', '2')).toEqual('3')
+  })
+
+  it('should multiply two numeric values', () => {
+    expect(multiplyNumericValues('0x2', '0x3')).toEqual('6')
+    expect(multiplyNumericValues('2', '3')).toEqual('6')
+  })
+
+  it('should normalize a hex numeric value', () => {
+    expect(normalizeNumericValue('0x2')).toEqual('2')
+  })
+
+  it('should compare two numeric values', () => {
+    expect(isNumericValueGreaterThan('0x2', '0x3')).toEqual(false)
+    expect(isNumericValueGreaterThan('2', '3')).toEqual(false)
+    expect(isNumericValueGreaterThan('3', '2')).toEqual(true)
+  })
+})

--- a/components/brave_wallet_ui/utils/bn-utils.ts
+++ b/components/brave_wallet_ui/utils/bn-utils.ts
@@ -1,0 +1,50 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BigNumber from 'bignumber.js'
+
+/**
+ * Returns the result of adding two numeric string amounts.
+ *
+ * The return value is always exact and unrounded. Do NOT use this
+ * function with floating-point numeric values.
+ *
+ * @param a First numeric value.
+ * @param b Second numeric value.
+ */
+export function addNumericValues (a: string, b: string): string {
+  return new BigNumber(a).plus(b).toFixed(0)
+}
+
+/**
+ * Returns the result of multiplying two numeric string amounts.
+ *
+ * The return value is always exact and unrounded. Do NOT use this
+ * function with floating-point numeric values.
+ *
+ * @param a First numeric value.
+ * @param b Second numeric value.
+ */
+export function multiplyNumericValues (a: string, b: string): string {
+   return new BigNumber(a).times(b).toFixed(0)
+}
+
+/**
+ * Returns the normalized string of the given numeric value.
+ *
+ * This function is typically used for converting a hex value to
+ * numeric value.
+ *
+ * @param value Numeric value to normalize.
+ */
+export function normalizeNumericValue (value: string): string {
+  return value === ''
+    ? ''
+    : new BigNumber(value).toFixed(0)
+}
+
+export function isNumericValueGreaterThan (a: string, b: string): boolean {
+  return new BigNumber(a).isGreaterThan(b)
+}

--- a/components/brave_wallet_ui/utils/format-balances.ts
+++ b/components/brave_wallet_ui/utils/format-balances.ts
@@ -26,6 +26,10 @@ export const formatInputValue = (value: string, decimals: number, round = true) 
 }
 
 export const formatBalance = (balance: string, decimals: number) => {
+  if (!balance) {
+    return ''
+  }
+
   if (decimals === 0) {
     const result = new BigNumber(balance)
     return (result.isNaN()) ? '0' : result.toFixed(0)
@@ -51,6 +55,10 @@ export const formatGasFeeFromFiat = (gasFee: string, price: string) => {
 }
 
 export const formatFiatBalance = (balance: string, decimals: number, price: string) => {
+  if (!price) {
+    return ''
+  }
+
   const formattedBalance = formatBalance(balance, decimals)
   const result = new BigNumber(formattedBalance).multipliedBy(price)
   return (result.isNaN()) ? '0.00' : result.toFixed(2, BigNumber.ROUND_UP)
@@ -78,8 +86,8 @@ export const toWeiHex = (value: string, decimals: number) => {
   return (result.isNaN()) ? '0x0' : '0x' + result.toString(16)
 }
 
-export const toGWei = (value: string, decimals: number) => {
-  const result = new BigNumber(value).dividedBy(10 ** decimals).multipliedBy(10 ** 9)
+export const toGWei = (value: string) => {
+  const result = new BigNumber(value).dividedBy(10 ** 9)
   return result.isNaN() ? '0' : result.toFixed(2).replace(/\.00$/, '')
 }
 
@@ -96,4 +104,9 @@ export const gWeiToWeiHex = (value: string) => {
 export const addCurrencies = (first: string, second: string) => {
   const result = new BigNumber(first).plus(new BigNumber(second))
   return `0x${result.toString(16)}`
+}
+
+export const formatHexStrToNumber = (value: string): string => {
+  const result = new BigNumber(value)
+  return result.isNaN() ? '0' : result.toFixed(0)
 }


### PR DESCRIPTION
**Summary of changes:**
- Add native asset price to `transactionSpotPrices` field, and remove `fiatPrice`.
- Do not update balances when refreshing prices, and vice-versa.
- Do not store computed `fiatBalance` in Redux, and instead compute it from `assetBalance` and `transactionSpotPrices` using the `usePricing` custom hook.
- Do not perform amount-based computations on floating point numbers. Always use `BigNumber` for addition, multiplication, etc.
- Always represent amounts/balances in Redux using base units (ex, wei for Ethereum).

Related to https://github.com/brave/brave-browser/issues/20264.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

TBA