### PR TITLE
Generate concrete classes for mojo generated interfaces for testing

### DIFF
--- a/build/ios/mojom/mojom_wrappers.gni
+++ b/build/ios/mojom/mojom_wrappers.gni
@@ -55,6 +55,8 @@ template("mojom_wrappers") {
       "//brave/build/ios/mojom/objc_templates/module+private.h.tmpl",
       "//brave/build/ios/mojom/objc_templates/module.mm.tmpl",
       "//brave/build/ios/mojom/objc_templates/struct_declaration.tmpl",
+      "//brave/build/ios/mojom/objc_templates/test_interface_declaration.tmpl",
+      "//brave/build/ios/mojom/objc_templates/test_interface_implementation.tmpl",
       "//brave/build/ios/mojom/objc_templates/private_interface_bridge_declaration.tmpl",
       "//brave/build/ios/mojom/objc_templates/private_interface_bridge_implementation.tmpl",
       "//brave/build/ios/mojom/objc_templates/private_interface_declaration.tmpl",

--- a/build/ios/mojom/objc_templates/interface_macros.tmpl
+++ b/build/ios/mojom/objc_templates/interface_macros.tmpl
@@ -1,5 +1,4 @@
-{%- macro objc_methods(interface) -%}
-{%-  for method in interface.methods %}
+{%- macro objc_method(method) -%}
 {%-   set name = method|objc_method_name_formatter %}
 - (void){{name}}
 {%- if method.parameters or method.response_parameters %}:{%- endif -%}
@@ -23,7 +22,11 @@
 {%- endfor -%}
 ))completion
 {%- endif -%}
-;
+{%- endmacro -%}
+
+{%- macro objc_methods(interface) -%}
+{%-  for method in interface.methods -%}
+{{ objc_method(method) }};
 {%- endfor -%}
 {%- endmacro -%}
 

--- a/build/ios/mojom/objc_templates/module.h.tmpl
+++ b/build/ios/mojom/objc_templates/module.h.tmpl
@@ -47,6 +47,10 @@ NS_SWIFT_NAME({{class_prefix}})
 {%    include "interface_declaration.tmpl" %}
 {%- endfor %}
 
+{% for interface in interfaces %}
+{%    include "test_interface_declaration.tmpl" %}
+{%- endfor %}
+
 NS_ASSUME_NONNULL_END
 
 #endif  // {{header_guard}}

--- a/build/ios/mojom/objc_templates/module.mm.tmpl
+++ b/build/ios/mojom/objc_templates/module.mm.tmpl
@@ -37,3 +37,7 @@
 {%- for interface in interface_bridges %}
 {%    include "private_interface_bridge_implementation.tmpl" %}
 {%- endfor %}
+
+{% for interface in interfaces %}
+{%    include "test_interface_implementation.tmpl" %}
+{%- endfor %}

--- a/build/ios/mojom/objc_templates/test_interface_declaration.tmpl
+++ b/build/ios/mojom/objc_templates/test_interface_declaration.tmpl
@@ -1,0 +1,27 @@
+
+OBJC_EXPORT
+NS_SWIFT_NAME({{class_prefix}}.Test{{interface.name}})
+@interface {{class_prefix}}Test{{interface.name}} : NSObject <{{class_prefix}}{{interface.name}}>
+{%- for method in interface.methods -%}
+{%-   set args = method.parameters %}
+@property(nonatomic, nullable, copy) void (^_{{method|objc_method_name_formatter}})(
+{%-   for param in method.parameters -%}
+{%-     set nullable = param.kind|objc_argument_modifiers(inside_callback=True) -%}
+{%-     set type = "%s%s"|format(param.kind|objc_wrapper_type, " " + nullable if nullable) -%}
+{{type}} {{param.name|under_to_lower_camel}}
+{%-     if not loop.last -%},{{" "}}{%- endif -%}
+{%-   endfor -%}
+{%-   if method.response_parameters -%}
+{%-   if method.parameters -%},{{" "}}{%- endif -%}
+void (^completion)(
+{%- for param in method.response_parameters -%}
+{%-   set nullable = param.kind|objc_argument_modifiers(inside_callback=True) -%}
+{%-   set type = "%s%s"|format(param.kind|objc_wrapper_type, " " + nullable if nullable) -%}
+{{type}} {{param.name|under_to_lower_camel}}
+{%- if not loop.last -%},{{" "}}{%- endif -%}
+{%- endfor -%}
+)
+{%- endif -%}
+);
+{%- endfor %}
+@end

--- a/build/ios/mojom/objc_templates/test_interface_implementation.tmpl
+++ b/build/ios/mojom/objc_templates/test_interface_implementation.tmpl
@@ -1,0 +1,24 @@
+{%- import "interface_macros.tmpl" as interface_macros %}
+
+@implementation {{class_prefix}}Test{{interface.name}}
+{% for method in interface.methods -%}
+{%- set name = "_%s"|format(method|objc_method_name_formatter) %}
+{{ interface_macros.objc_method(method) }} {
+  if (self.{{name}} != nil) {
+    self.{{name}}(
+{%-  for param in method.parameters -%}
+    {{param.name|under_to_lower_camel}}
+{%-  if not loop.last -%},{{" "}}{%- endif -%}
+{%-  endfor %}
+{%-  if method.response_parameters -%}
+{%-  if method.parameters -%},{{" "}}{%- endif -%}
+completion
+{%-  endif -%}
+);
+  } else {
+    [NSException raise:NSInvalidArgumentException
+                format:@"{{name}} is not implemented"];
+  }
+}
+{%- endfor %}
+@end


### PR DESCRIPTION
This will create special test classes which conform to each mojo interface. Each class will contain properties for each method to override that particular calls functionality. For instance for wallet, you can create a `TestKeyringService` and setup only the `createWallet` method override to test all flows of creating a wallet without having to write multiple conforming classes.

Example:

The current `SwapService` mojo interface is generated as such:

```objc
OBJC_EXPORT
@protocol BraveWalletSwapService
@required
- (void)priceQuote:(BraveWalletSwapParams*)params completion:(void (^)(bool success, BraveWalletSwapResponse* _Nullable response, NSString* _Nullable errorResponse))completion;
- (void)transactionPayload:(BraveWalletSwapParams*)params completion:(void (^)(bool success, BraveWalletSwapResponse* _Nullable response, NSString* _Nullable errorResponse))completion;
@end
```

This PR now also generates:

```objc
OBJC_EXPORT
NS_SWIFT_NAME(BraveWallet.TestSwapService)
@interface BraveWalletTestSwapService : NSObject <BraveWalletSwapService>
@property(nonatomic, nullable, copy) void (^_priceQuote)(BraveWalletSwapParams* params, void (^completion)(bool success, BraveWalletSwapResponse* _Nullable response, NSString* _Nullable errorResponse));
@property(nonatomic, nullable, copy) void (^_transactionPayload)(BraveWalletSwapParams* params, void (^completion)(bool success, BraveWalletSwapResponse* _Nullable response, NSString* _Nullable errorResponse));
@end
```

and 

```objc
@implementation BraveWalletTestSwapService
- (void)priceQuote:(BraveWalletSwapParams*)params completion:(void (^)(bool success, BraveWalletSwapResponse* _Nullable response, NSString* _Nullable errorResponse))completion {
  if (self._priceQuote != nil) {
    self._priceQuote(params, completion);
  } else {
    [NSException raise:NSInvalidArgumentException
                format:@"_priceQuote is not implemented"];
  }
}

- (void)transactionPayload:(BraveWalletSwapParams*)params completion:(void (^)(bool success, BraveWalletSwapResponse* _Nullable response, NSString* _Nullable errorResponse))completion {
  if (self._transactionPayload != nil) {
    self._transactionPayload(params, completion);
  } else {
    [NSException raise:NSInvalidArgumentException
                format:@"_transactionPayload is not implemented"];
  }
}
@end
```

Which allows us to create a `BraveWalletTestSwapService` and implement the individual functions that will be called when you execute the actual method on the interface. For example, the `_priceQuote` block would be called when calling `priceQuote` on the class.

By default, no functions are implemented and calls to the methods on that class will result in an exception being thrown since these are only supposed to be used within testing environments

Resolves https://github.com/brave/brave-browser/issues/20388

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

