### PR TITLE
Added site data observer to shields panel v2

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -95,6 +95,8 @@ source_set("ui") {
       "toolbar/brave_recent_tabs_sub_menu_model.h",
       "webui/brave_settings_ui.cc",
       "webui/brave_settings_ui.h",
+      "webui/brave_shields/shields_data_handler.cc",
+      "webui/brave_shields/shields_data_handler.h",
       "webui/brave_shields/shields_panel_handler.cc",
       "webui/brave_shields/shields_panel_handler.h",
       "webui/brave_shields/shields_panel_ui.cc",

--- a/browser/ui/brave_shields_data_controller.cc
+++ b/browser/ui/brave_shields_data_controller.cc
@@ -25,6 +25,9 @@ void BraveShieldsDataController::ClearAllResourcesList() {
   resource_list_http_redirects_.clear();
   resource_list_blocked_js_.clear();
   resource_list_blocked_fingerprints_.clear();
+
+  for (Observer& obs : observer_list_)
+    obs.OnResourcesChanged();
 }
 
 void BraveShieldsDataController::AddObserver(Observer* obs) {
@@ -49,7 +52,11 @@ int BraveShieldsDataController::GetTotalBlockedCount() {
 bool BraveShieldsDataController::GetIsBraveShieldsEnabled() {
   auto* map = HostContentSettingsMapFactory::GetForProfile(
       web_contents()->GetBrowserContext());
-  return brave_shields::GetBraveShieldsEnabled(map, web_contents()->GetURL());
+  return brave_shields::GetBraveShieldsEnabled(map, GetCurrentSiteURL());
+}
+
+GURL BraveShieldsDataController::GetCurrentSiteURL() {
+  return web_contents()->GetURL();
 }
 
 void BraveShieldsDataController::HandleItemBlocked(
@@ -68,7 +75,7 @@ void BraveShieldsDataController::HandleItemBlocked(
   }
 
   for (Observer& obs : observer_list_)
-    obs.OnResourcesCountChange(GetTotalBlockedCount());
+    obs.OnResourcesChanged();
 }
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(BraveShieldsDataController);

--- a/browser/ui/brave_shields_data_controller.h
+++ b/browser/ui/brave_shields_data_controller.h
@@ -30,7 +30,7 @@ class BraveShieldsDataController
 
   class Observer : public base::CheckedObserver {
    public:
-    virtual void OnResourcesCountChange(const int count) = 0;
+    virtual void OnResourcesChanged() = 0;
   };
 
   void HandleItemBlocked(const std::string& block_type,
@@ -38,6 +38,7 @@ class BraveShieldsDataController
   void ClearAllResourcesList();
   int GetTotalBlockedCount();
   bool GetIsBraveShieldsEnabled();
+  GURL GetCurrentSiteURL();
 
   void AddObserver(Observer* obs);
   void RemoveObserver(Observer* obs);

--- a/browser/ui/views/brave_actions/brave_shields_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.cc
@@ -171,7 +171,7 @@ void BraveShieldsActionView::Update() {
   UpdateIconState();
 }
 
-void BraveShieldsActionView::OnResourcesCountChange(const int count) {
+void BraveShieldsActionView::OnResourcesChanged() {
   UpdateIconState();
 }
 

--- a/browser/ui/views/brave_actions/brave_shields_action_view.h
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.h
@@ -33,13 +33,6 @@ class BraveShieldsActionView
   // views::LabelButton:
   std::unique_ptr<views::LabelButtonBorder> CreateDefaultBorder()
       const override;
-  // brave_shields::BraveShieldsDataController
-  void OnResourcesCountChange(const int count) override;
-  // TabStripModelObserver
-  void OnTabStripModelChanged(
-      TabStripModel* tab_strip_model,
-      const TabStripModelChange& change,
-      const TabStripSelectionChange& selection) override;
   SkPath GetHighlightPath() const;
 
  private:
@@ -47,6 +40,13 @@ class BraveShieldsActionView
   void UpdateIconState();
   gfx::ImageSkia GetIconImage(bool is_enabled);
   std::unique_ptr<IconWithBadgeImageSource> GetImageSource();
+  // brave_shields::BraveShieldsDataController
+  void OnResourcesChanged() override;
+  // TabStripModelObserver
+  void OnTabStripModelChanged(
+      TabStripModel* tab_strip_model,
+      const TabStripModelChange& change,
+      const TabStripSelectionChange& selection) override;
 
   std::unique_ptr<WebUIBubbleManagerT<ShieldsPanelUI>> webui_bubble_manager_;
   Profile* profile_ = nullptr;

--- a/browser/ui/webui/brave_shields/shields_data_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_data_handler.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <utility>
+
+#include "brave/browser/ui/webui/brave_shields/shields_data_handler.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "ui/webui/mojo_bubble_web_ui_controller.h"
+
+ShieldsDataHandler::ShieldsDataHandler(
+    mojo::PendingReceiver<brave_shields_panel::mojom::DataHandler>
+        data_handler_receiver,
+    ui::MojoBubbleWebUIController* webui_controller)
+    : data_handler_receiver_(this, std::move(data_handler_receiver)),
+      webui_controller_(webui_controller) {
+  auto* profile = Profile::FromWebUI(webui_controller_->web_ui());
+  DCHECK(profile);
+  Browser* browser = chrome::FindLastActiveWithProfile(profile);
+  browser->tab_strip_model()->AddObserver(this);
+  auto* shields_data_ctrlr = GetActiveShieldsDataController();
+  if (!shields_data_ctrlr)
+    return;
+  UpdateSiteBlockInfo();
+  shields_data_ctrlr->AddObserver(this);
+}
+
+ShieldsDataHandler::~ShieldsDataHandler() {
+  /* The lifecycle of this class is similar to ShieldsPanelUI and
+   * ShieldsPanelUI's cache gets destryed after ~300ms of being idle.
+   */
+  auto* shields_data_ctrlr = GetActiveShieldsDataController();
+  if (!shields_data_ctrlr)
+    return;
+  shields_data_ctrlr->RemoveObserver(this);
+}
+
+void ShieldsDataHandler::RegisterUIHandler(
+    mojo::PendingRemote<brave_shields_panel::mojom::UIHandler>
+        ui_handler_receiver) {
+  ui_handler_remote_.Bind(std::move(ui_handler_receiver));
+  UpdateSiteBlockInfo();
+}
+
+void ShieldsDataHandler::GetSiteBlockInfo(GetSiteBlockInfoCallback callback) {
+  std::move(callback).Run(site_block_info_.Clone());
+}
+
+BraveShieldsDataController*
+ShieldsDataHandler::GetActiveShieldsDataController() {
+  auto* profile = Profile::FromWebUI(webui_controller_->web_ui());
+  DCHECK(profile);
+
+  Browser* browser = chrome::FindLastActiveWithProfile(profile);
+  auto* web_contents = browser->tab_strip_model()->GetActiveWebContents();
+
+  if (web_contents) {
+    return BraveShieldsDataController::FromWebContents(web_contents);
+  }
+
+  return nullptr;
+}
+
+void ShieldsDataHandler::UpdateSiteBlockInfo() {
+  auto* shields_data_ctrlr = GetActiveShieldsDataController();
+  if (!shields_data_ctrlr)
+    return;
+
+  site_block_info_.host = shields_data_ctrlr->GetCurrentSiteURL().host();
+  site_block_info_.total_blocked_resources =
+      shields_data_ctrlr->GetTotalBlockedCount();
+
+  // Notify remote that data changed
+  if (ui_handler_remote_) {
+    ui_handler_remote_.get()->OnSiteBlockInfoChanged(site_block_info_.Clone());
+  }
+}
+
+void ShieldsDataHandler::OnResourcesChanged() {
+  UpdateSiteBlockInfo();
+}
+
+void ShieldsDataHandler::OnTabStripModelChanged(
+    TabStripModel* tab_strip_model,
+    const TabStripModelChange& change,
+    const TabStripSelectionChange& selection) {
+  if (selection.active_tab_changed()) {
+    // OnResourcesChanged doesnt get triggered instantly on active tab change so
+    // trigger this explicitly
+    UpdateSiteBlockInfo();
+
+    if (selection.new_contents) {
+      BraveShieldsDataController::FromWebContents(selection.new_contents)
+          ->AddObserver(this);
+    }
+
+    if (selection.old_contents) {
+      BraveShieldsDataController::FromWebContents(selection.old_contents)
+          ->RemoveObserver(this);
+    }
+  }
+}

--- a/browser/ui/webui/brave_shields/shields_data_handler.h
+++ b/browser/ui/webui/brave_shields/shields_data_handler.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_BRAVE_SHIELDS_SHIELDS_DATA_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_BRAVE_SHIELDS_SHIELDS_DATA_HANDLER_H_
+
+#include "brave/browser/ui/brave_shields_data_controller.h"
+#include "brave/components/brave_shields/common/brave_shields_panel.mojom.h"
+#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
+
+namespace ui {
+class MojoBubbleWebUIController;
+}  // namespace ui
+
+using brave_shields::BraveShieldsDataController;
+using brave_shields_panel::mojom::SiteBlockInfo;
+
+class ShieldsDataHandler : public brave_shields_panel::mojom::DataHandler,
+                           public BraveShieldsDataController::Observer,
+                           public TabStripModelObserver {
+ public:
+  ShieldsDataHandler(
+      mojo::PendingReceiver<brave_shields_panel::mojom::DataHandler>
+          data_handler_receiver,
+      ui::MojoBubbleWebUIController* webui_controller);
+
+  ShieldsDataHandler(const ShieldsDataHandler&) = delete;
+  ShieldsDataHandler& operator=(const ShieldsDataHandler&) = delete;
+  ~ShieldsDataHandler() override;
+
+  // mojom::DataHandler
+  void RegisterUIHandler(
+      mojo::PendingRemote<brave_shields_panel::mojom::UIHandler>
+          ui_handler_receiver) override;
+  void GetSiteBlockInfo(GetSiteBlockInfoCallback callback) override;
+
+ private:
+  BraveShieldsDataController* GetActiveShieldsDataController();
+  void UpdateSiteBlockInfo();
+
+  // brave_shields::BraveShieldsDataController
+  void OnResourcesChanged() override;
+  // TabStripModelObserver
+  void OnTabStripModelChanged(
+      TabStripModel* tab_strip_model,
+      const TabStripModelChange& change,
+      const TabStripSelectionChange& selection) override;
+
+  mojo::Receiver<brave_shields_panel::mojom::DataHandler>
+      data_handler_receiver_;
+  mojo::Remote<brave_shields_panel::mojom::UIHandler> ui_handler_remote_;
+  ui::MojoBubbleWebUIController* const webui_controller_;
+  SiteBlockInfo site_block_info_;
+};
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_BRAVE_SHIELDS_SHIELDS_DATA_HANDLER_H_

--- a/browser/ui/webui/brave_shields/shields_panel_ui.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_ui.cc
@@ -46,13 +46,16 @@ void ShieldsPanelUI::BindInterface(
 }
 
 void ShieldsPanelUI::CreatePanelHandler(
-    mojo::PendingRemote<brave_shields_panel::mojom::Page> page,
     mojo::PendingReceiver<brave_shields_panel::mojom::PanelHandler>
-        panel_receiver) {
-  DCHECK(page);
+        panel_receiver,
+    mojo::PendingReceiver<brave_shields_panel::mojom::DataHandler>
+        data_handler_receiver) {
   auto* profile = Profile::FromWebUI(web_ui());
   DCHECK(profile);
 
   panel_handler_ =
       std::make_unique<ShieldsPanelHandler>(std::move(panel_receiver), this);
+
+  data_handler_ = std::make_unique<ShieldsDataHandler>(
+      std::move(data_handler_receiver), this);
 }

--- a/browser/ui/webui/brave_shields/shields_panel_ui.h
+++ b/browser/ui/webui/brave_shields/shields_panel_ui.h
@@ -8,10 +8,10 @@
 
 #include <memory>
 
+#include "brave/browser/ui/webui/brave_shields/shields_data_handler.h"
 #include "brave/browser/ui/webui/brave_shields/shields_panel_handler.h"
 #include "brave/components/brave_shields/common/brave_shields_panel.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
-#include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "ui/webui/mojo_bubble_web_ui_controller.h"
 
@@ -31,11 +31,13 @@ class ShieldsPanelUI : public ui::MojoBubbleWebUIController,
 
  private:
   void CreatePanelHandler(
-      mojo::PendingRemote<brave_shields_panel::mojom::Page> page,
       mojo::PendingReceiver<brave_shields_panel::mojom::PanelHandler>
-          panel_receiver) override;
+          panel_receiver,
+      mojo::PendingReceiver<brave_shields_panel::mojom::DataHandler>
+          data_handler_receiver) override;
 
   std::unique_ptr<ShieldsPanelHandler> panel_handler_;
+  std::unique_ptr<ShieldsDataHandler> data_handler_;
 
   mojo::Receiver<brave_shields_panel::mojom::PanelHandlerFactory>
       panel_factory_receiver_{this};

--- a/components/brave_shields/common/brave_shields_panel.mojom
+++ b/components/brave_shields/common/brave_shields_panel.mojom
@@ -10,8 +10,8 @@ import "url/mojom/url.mojom";
 // Used by the WebUI page to bootstrap bidirectional communication.
 interface PanelHandlerFactory {
   // The WebUI calls this method when the page is first initialized.
-  CreatePanelHandler(pending_remote<Page> page,
-    pending_receiver<PanelHandler> panel_handler);
+  CreatePanelHandler(pending_receiver<PanelHandler> panel_handler,
+    pending_receiver<DataHandler> data_handler);
 };
 
 // Browser-side handler for requests from WebUI page.
@@ -26,5 +26,16 @@ interface PanelHandler {
 };
 
 // WebUI-side handler for requests from the browser.
-interface Page {
+interface UIHandler {
+  OnSiteBlockInfoChanged(SiteBlockInfo site_block_info);
+};
+
+interface DataHandler {
+  RegisterUIHandler(pending_remote<UIHandler> ui_handler);
+  GetSiteBlockInfo() => (SiteBlockInfo site_block_info);
+};
+
+struct SiteBlockInfo {
+  string host;
+  int32 total_blocked_resources;
 };

--- a/components/brave_shields/resources/panel/api/panel_browser_api.ts
+++ b/components/brave_shields/resources/panel/api/panel_browser_api.ts
@@ -8,20 +8,20 @@ import * as BraveShields from 'gen/brave/components/brave_shields/common/brave_s
 export * from 'gen/brave/components/brave_shields/common/brave_shields_panel.mojom.m.js'
 
 interface API {
-  pageCallbackRouter: BraveShields.PageCallbackRouter
   panelHandler: BraveShields.PanelHandlerRemote
+  dataHandler: BraveShields.DataHandlerRemote
 }
 
 let panelBrowserAPIInstance: API
 class PanelBrowserAPI implements API {
-  pageCallbackRouter = new BraveShields.PageCallbackRouter()
   panelHandler = new BraveShields.PanelHandlerRemote()
+  dataHandler = new BraveShields.DataHandlerRemote()
 
   constructor () {
     const factory = BraveShields.PanelHandlerFactory.getRemote()
     factory.createPanelHandler(
-      this.pageCallbackRouter.$.bindNewPipeAndPassRemote(),
-      this.panelHandler.$.bindNewPipeAndPassReceiver()
+      this.panelHandler.$.bindNewPipeAndPassReceiver(),
+      this.dataHandler.$.bindNewPipeAndPassReceiver()
     )
   }
 }

--- a/components/brave_shields/resources/panel/components/main-panel/hooks.ts
+++ b/components/brave_shields/resources/panel/components/main-panel/hooks.ts
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import getPanelBrowserAPI, { UIHandlerReceiver, SiteBlockInfo } from '../../api/panel_browser_api'
+
+export function useGetShieldsData () {
+  const [siteBlockInfo, setSiteBlockInfo] = React.useState<SiteBlockInfo>()
+
+  React.useEffect(() => {
+    const uiHandlerReceiver = new UIHandlerReceiver({
+      onSiteBlockInfoChanged: (siteBlockInfo) => {
+        setSiteBlockInfo(siteBlockInfo)
+      }
+    })
+
+    getPanelBrowserAPI().dataHandler.registerUIHandler(
+      uiHandlerReceiver.$.bindNewPipeAndPassRemote())
+  }, [])
+
+  return { siteBlockInfo }
+}

--- a/components/brave_shields/resources/panel/components/main-panel/index.tsx
+++ b/components/brave_shields/resources/panel/components/main-panel/index.tsx
@@ -4,16 +4,18 @@ import * as S from './style'
 import { FabulouslyLargeToggle } from '../../../../../web-components/toggle'
 import AdvancedControlsContent from '../advanced-controls-content'
 import { getLocale, splitStringForTag } from '../../../../../common/locale'
+import { useGetShieldsData } from './hooks'
 
 function MainPanel () {
   const [isExpanded, setIsExpanded] = React.useState(false)
   const braveShieldsUp = splitStringForTag(getLocale('braveShieldsUp'))
   const braveShieldsBlockedNote = splitStringForTag(getLocale('braveShieldsBlockedNote'))
+  const { siteBlockInfo } = useGetShieldsData()
 
   return (
     <S.Box>
       <S.PanelHeader>
-        <S.SiteTitle>brave.com</S.SiteTitle>
+        <S.SiteTitle>{siteBlockInfo?.host}</S.SiteTitle>
       </S.PanelHeader>
       <S.ToggleBox>
         <FabulouslyLargeToggle
@@ -26,7 +28,7 @@ function MainPanel () {
           {braveShieldsUp.afterTag}
         </S.StatusText>
         <S.BlockCountBox>
-          <S.BlockCount>21</S.BlockCount>
+          <S.BlockCount>{siteBlockInfo?.totalBlockedResources}</S.BlockCount>
           <S.BlockNote>
             {braveShieldsBlockedNote.beforeTag}
             <a href="#">{braveShieldsBlockedNote.duringTag}</a>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20425

This PR creates a data handler which is a proxy to the shields data controller instance. The lifecycle of data handler is similar to ShieldsPanelUI class. Currently, it notifies location url and total count of blocked resources only. The change happens on various cases:

1. on active tab changes
2. on active tab's web content changes
3. on a new tab's web content
4. on active tab's web content that doesn't have new resources (ReadyToCommitNavigation)

![image](https://user-images.githubusercontent.com/8665427/148821411-1a914ad4-5d53-4e6e-ac47-edd169c45ec1.png)


## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

