### PR TITLE
chore(wallet): decouple token balances from asset options list

### DIFF
--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -453,8 +453,8 @@ export const fetchSwapQuoteFactory = (
     takerAddress: accountAddress,
     sellAmount: fromAssetAmount || '',
     buyAmount: toAssetAmount || '',
-    buyToken: toAsset.asset.contractAddress || toAsset.asset.symbol,
-    sellToken: fromAsset.asset.contractAddress || fromAsset.asset.symbol,
+    buyToken: toAsset.contractAddress || toAsset.symbol,
+    sellToken: fromAsset.contractAddress || fromAsset.symbol,
     slippagePercentage: slippageTolerance.slippage / 100,
     gasPrice: ''
   }

--- a/components/brave_wallet_ui/common/constants/action_types.ts
+++ b/components/brave_wallet_ui/common/constants/action_types.ts
@@ -5,7 +5,6 @@
 
 import {
   BraveWallet,
-  AccountAssetOptionType,
   SlippagePresetObjectType,
   WalletAccountType
 } from '../../constants/types'
@@ -52,8 +51,8 @@ export type SetUserAssetVisiblePayloadType = {
 }
 
 export type SwapParamsPayloadType = {
-  fromAsset: AccountAssetOptionType
-  toAsset: AccountAssetOptionType
+  fromAsset: BraveWallet.BlockchainToken
+  toAsset: BraveWallet.BlockchainToken
   fromAssetAmount?: string
   toAssetAmount?: string
   slippageTolerance: SlippagePresetObjectType

--- a/components/brave_wallet_ui/common/constants/mocks.ts
+++ b/components/brave_wallet_ui/common/constants/mocks.ts
@@ -65,9 +65,8 @@ export const mockAccount: WalletAccountType = {
   name: 'mockAccountName',
   address: 'mockAddress',
   balance: '123456',
-  asset: 'mockAsset', // FIXME: This is probably a useless field
   accountType: 'Primary',
-  tokens: []
+  tokenBalanceRegistry: {}
 }
 
 export const mockAssetPrices: BraveWallet.AssetPrice[] = [

--- a/components/brave_wallet_ui/common/hooks/assets.test.ts
+++ b/components/brave_wallet_ui/common/hooks/assets.test.ts
@@ -1,29 +1,37 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 import {
   mockAccount,
-  mockAssetPrices
+  mockAssetPrices,
+  mockNetwork
 } from '../constants/mocks'
 import { AccountAssetOptions } from '../../options/asset-options'
 import useAssets from './assets'
-import { AccountAssetOptionType } from '../../constants/types'
+import { WalletAccountType } from '../../constants/types'
 
 const mockAccounts = [
   {
     ...mockAccount,
-    tokens: [{ ...AccountAssetOptions[0], assetBalance: '238699740940532500' }, AccountAssetOptions[1]]
-  },
+    tokenBalanceRegistry: {
+      [AccountAssetOptions[0].contractAddress.toLowerCase()]: '238699740940532500',
+      [AccountAssetOptions[1].contractAddress.toLowerCase()]: '0'
+    }
+  } as WalletAccountType,
   {
     ...mockAccount,
-    tokens: [{ ...AccountAssetOptions[0], assetBalance: '0' }, AccountAssetOptions[1]]
-  }
+    balance: '',
+    tokenBalanceRegistry: {
+      [AccountAssetOptions[0].contractAddress.toLowerCase()]: '0',
+      [AccountAssetOptions[1].contractAddress.toLowerCase()]: '0'
+    }
+  } as WalletAccountType
 ]
 
 const mockVisibleList = [
-  AccountAssetOptions[0].asset,
-  AccountAssetOptions[1].asset
+  AccountAssetOptions[0],
+  AccountAssetOptions[1]
 ]
 
-const expectedResult = [{ asset: AccountAssetOptions[0].asset, assetBalance: '238699740940532500' }] as AccountAssetOptionType[]
+const expectedResult = [AccountAssetOptions[0]]
 
 const getBuyAssets = async () => {
   return await mockVisibleList
@@ -31,21 +39,23 @@ const getBuyAssets = async () => {
 
 describe('useAssets hook', () => {
   it('Selected account has balances, should return expectedResult', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[0], mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
+    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[0], mockNetwork, mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
     await act(async () => {
       await waitForNextUpdate()
     })
     expect(result.current.panelUserAssetList).toEqual(expectedResult)
   })
+
   it('Selected account has 0 balances, should return an empty array', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[1], mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
+    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccounts[1], mockNetwork, mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
     await act(async () => {
       await waitForNextUpdate()
     })
     expect(result.current.panelUserAssetList).toEqual([])
   })
-  it('Selected account tokens is undefined, should return an empty array', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccount, mockVisibleList, mockVisibleList, mockAssetPrices, getBuyAssets))
+
+  it('should return empty array for panelUserAssetList if visible assets is empty', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useAssets(mockAccounts, mockAccount, mockNetwork, mockVisibleList, [], mockAssetPrices, getBuyAssets))
     await act(async () => {
       await waitForNextUpdate()
     })

--- a/components/brave_wallet_ui/common/hooks/assets.ts
+++ b/components/brave_wallet_ui/common/hooks/assets.ts
@@ -6,7 +6,6 @@
 import * as React from 'react'
 
 import {
-  AccountAssetOptionType,
   BraveWallet,
   WalletAccountType
 } from '../../constants/types'
@@ -14,102 +13,74 @@ import { BAT, ETH } from '../../options/asset-options'
 
 // Hooks
 import usePricing from './pricing'
+import useBalance from './balance'
 
 export default function useAssets (
   accounts: WalletAccountType[],
   selectedAccount: WalletAccountType,
+  selectedNetwork: BraveWallet.EthereumChain,
   fullTokenList: BraveWallet.BlockchainToken[],
   userVisibleTokensInfo: BraveWallet.BlockchainToken[],
   spotPrices: BraveWallet.AssetPrice[],
   getBuyAssets: () => Promise<BraveWallet.BlockchainToken[]>
 ) {
   const { computeFiatAmount } = usePricing(spotPrices)
+  const getBalance = useBalance(selectedNetwork)
 
-  const tokenOptions: BraveWallet.BlockchainToken[] = React.useMemo(
-    () =>
-      fullTokenList.map((token) => ({
-        ...token,
-        logo: `chrome://erc-token-images/${token.logo}`
-      })),
-    [fullTokenList]
-  )
-
-  const userVisibleTokenOptions: BraveWallet.BlockchainToken[] = React.useMemo(
-    () =>
-      userVisibleTokensInfo.map((token) => ({
-        ...token,
-        logo: `chrome://erc-token-images/${token.logo}`
-      })),
-    [userVisibleTokensInfo]
-  )
-
-  const sendAssetOptions: AccountAssetOptionType[] = React.useMemo(
-    () =>
-      userVisibleTokenOptions
-        .map((token) => ({
-          asset: token,
-          assetBalance: '0'
-        })),
-    [userVisibleTokenOptions]
-  )
-
-  const assetOptions: AccountAssetOptionType[] = React.useMemo(() => {
-    const assets = tokenOptions
-      .map((token) => ({
-        asset: token,
-        assetBalance: '0'
-      }))
-
+  const assetOptions: BraveWallet.BlockchainToken[] = React.useMemo(() => {
     return [
       ETH,
 
-      ...assets.filter((asset) => asset.asset.symbol === 'BAT'),
+      ...fullTokenList.filter((asset) => asset.symbol === 'BAT'),
 
-      ...sendAssetOptions
-        .filter(asset => !['BAT', 'ETH'].includes(asset.asset.symbol)),
+      ...userVisibleTokensInfo
+        .filter(asset => !['BAT', 'ETH'].includes(asset.symbol)),
 
-      ...assets
-        .filter(asset => !['BAT', 'ETH'].includes(asset.asset.symbol))
-        .filter(asset => !sendAssetOptions.some(token => token.asset.symbol === asset.asset.symbol))
+      ...fullTokenList
+        .filter(asset => !['BAT', 'ETH'].includes(asset.symbol))
+        .filter(asset => !userVisibleTokensInfo.some(token => token.symbol === asset.symbol))
     ]
-  }, [tokenOptions, sendAssetOptions])
+  }, [fullTokenList, userVisibleTokensInfo])
 
-  const [buyAssetOptions, setBuyAssetOptions] = React.useState<AccountAssetOptionType[]>([BAT, ETH])
+  const [buyAssetOptions, setBuyAssetOptions] = React.useState<BraveWallet.BlockchainToken[]>([BAT, ETH])
 
   React.useEffect(() => {
     getBuyAssets().then(tokens => {
       setBuyAssetOptions(tokens.map(token => ({
-        asset: {
-          ...token,
-          logo: `chrome://erc-token-images/${token.logo}`
-        },
-        assetBalance: '0'
-      }) as AccountAssetOptionType))
+        ...token,
+        logo: `chrome://erc-token-images/${token.logo}`
+      }) as BraveWallet.BlockchainToken))
     }).catch(e => console.error(e))
   }, [])
 
-  const panelUserAssetList = React.useMemo((): AccountAssetOptionType[] => {
-    // selectedAccount.tokens can be undefined
-    if (!selectedAccount?.tokens) {
+  const panelUserAssetList = React.useMemo(() => {
+    if (!userVisibleTokensInfo) {
       return []
     }
 
-    const formattedList = selectedAccount?.tokens?.sort(function (a, b) {
-      const bFiatBalance = computeFiatAmount(b.assetBalance, b.asset.symbol, b.asset.decimals)
-      const aFiatBalance = computeFiatAmount(a.assetBalance, a.asset.symbol, a.asset.decimals)
-      return Number(bFiatBalance) - Number(aFiatBalance)
-    }) // Sorting by Fiat Value
+    if (!selectedAccount) {
+      return []
+    }
 
-    // Do not show an asset unless the selectedAccount has a balance
-    return formattedList.filter((token) => parseFloat(token.assetBalance) !== 0)
-    // Using accounts as a dependency here to trigger balance changes
-  }, [selectedAccount, accounts])
+    const nonZeroBalanceAssets = userVisibleTokensInfo.filter(token => {
+      const balance = getBalance(selectedAccount, token)
+      return balance !== '' && parseInt(balance) > 0
+    })
+
+    return nonZeroBalanceAssets.sort(function (a, b) {
+      const aBalance = getBalance(selectedAccount, a)
+      const bBalance = getBalance(selectedAccount, b)
+
+      const bFiatBalance = computeFiatAmount(bBalance, b.symbol, b.decimals)
+      const aFiatBalance = computeFiatAmount(aBalance, a.symbol, a.decimals)
+
+      return Number(bFiatBalance) - Number(aFiatBalance)
+    })
+  }, [selectedAccount, userVisibleTokensInfo, getBalance, computeFiatAmount])
 
   return {
-    tokenOptions,
     assetOptions,
-    userVisibleTokenOptions,
-    sendAssetOptions,
+    sendAssetOptions: userVisibleTokensInfo,
     buyAssetOptions,
     panelUserAssetList
   }

--- a/components/brave_wallet_ui/common/hooks/balance.ts
+++ b/components/brave_wallet_ui/common/hooks/balance.ts
@@ -18,17 +18,10 @@ export default function useBalance (network: BraveWallet.EthereumChain) {
       return account.balance
     }
 
-    if (!account.tokens) {
+    if (!account.tokenBalanceRegistry) {
       return ''
     }
 
-    const loadedToken = account.tokens.find(
-      (each) => each.asset.contractAddress.toLowerCase() === token.contractAddress.toLowerCase()
-    )
-    if (!loadedToken) {
-      return ''
-    }
-
-    return loadedToken.assetBalance
+    return (account.tokenBalanceRegistry || {})[token.contractAddress.toLowerCase()] || ''
   }, [network])
 }

--- a/components/brave_wallet_ui/common/hooks/select-preset.test.ts
+++ b/components/brave_wallet_ui/common/hooks/select-preset.test.ts
@@ -1,36 +1,30 @@
 import { renderHook } from '@testing-library/react-hooks'
 
-import { mockAccount, mockERC20Token } from '../constants/mocks'
+import { mockAccount, mockERC20Token, mockNetwork } from '../constants/mocks'
 import usePreset from './select-preset'
 
 describe('usePreset hook', () => {
   it.each([
-    ['25% of 1 ETH', '0xde0b6b3a7640000', 0.25, '0.25'],
-    ['50% of 1 ETH', '0xde0b6b3a7640000', 0.50, '0.5'],
-    ['75% of 1 ETH', '0xde0b6b3a7640000', 0.75, '0.75'],
-    ['100% of 1 ETH', '0xde0b6b3a7640000', 1, '1'],
-    ['100% of 1.000000000000000001 ETH', '0xde0b6b3a7640001', 1, '1.000000000000000001'], // 1.000000000000000001 ---(100%)---> 1.000000000000000001
-    ['100% of 50.297939 ETH', '0x2ba062d07d5443000', 1, '50.297939'], // 50.297939 ---(100%)---> 50.297939
-    ['25% of 0.0001 ETH', '0x5af3107a4000', 0.25, '0.000025'] // 0.0001 ---(25%)---> 0.000025
+    ['25% of 1 ETH', '1000000000000000000', 0.25, '0.25'],
+    ['50% of 1 ETH', '1000000000000000000', 0.50, '0.5'],
+    ['75% of 1 ETH', '1000000000000000000', 0.75, '0.75'],
+    ['100% of 1 ETH', '1000000000000000000', 1, '1'],
+    ['100% of 1.000000000000000001 ETH', '1000000000000000001', 1, '1.000000000000000001'], // 1.000000000000000001 ---(100%)---> 1.000000000000000001
+    ['100% of 50.297939 ETH', '50297939000000000000', 1, '50.297939'], // 50.297939 ---(100%)---> 50.297939
+    ['25% of 0.0001 ETH', '100000000000000', 0.25, '0.000025'] // 0.0001 ---(25%)---> 0.000025
   ])('should compute %s correctly', (_, balance: string, percent, expected: string) => {
     const mockFunc = jest.fn()
 
     const { result: { current: calcPresetAmount } } = renderHook(() => usePreset(
       {
         ...mockAccount,
-        tokens: [{
-          asset: mockERC20Token,
-          assetBalance: balance
-        }]
+        tokenBalanceRegistry: {
+          [mockERC20Token.contractAddress.toLowerCase()]: balance
+        }
       },
-      {
-        asset: mockERC20Token,
-        assetBalance: 'mockBalance'
-      },
-      {
-        asset: mockERC20Token,
-        assetBalance: 'mockBalance'
-      },
+      mockNetwork,
+      mockERC20Token,
+      mockERC20Token,
       mockFunc,
       jest.fn()
     ))

--- a/components/brave_wallet_ui/common/hooks/send.ts
+++ b/components/brave_wallet_ui/common/hooks/send.ts
@@ -6,7 +6,6 @@
 import * as React from 'react'
 import { SimpleActionCreator } from 'redux-act'
 import {
-  AccountAssetOptionType,
   BraveWallet,
   GetEthAddrReturnInfo,
   WalletAccountType,
@@ -23,14 +22,14 @@ export default function useSend (
   findENSAddress: (address: string) => Promise<GetEthAddrReturnInfo>,
   findUnstoppableDomainAddress: (address: string) => Promise<GetEthAddrReturnInfo>,
   getChecksumEthAddress: (address: string) => Promise<GetChecksumEthAddressReturnInfo>,
-  sendAssetOptions: AccountAssetOptionType[],
+  sendAssetOptions: BraveWallet.BlockchainToken[],
   selectedAccount: WalletAccountType,
   sendERC20Transfer: SimpleActionCreator<ER20TransferParams>,
   sendTransaction: SimpleActionCreator<SendTransactionParams>,
   sendERC721TransferFrom: SimpleActionCreator<ERC721TransferFromParams>,
   fullTokenList: BraveWallet.BlockchainToken[]
 ) {
-  const [selectedSendAsset, setSelectedSendAsset] = React.useState<AccountAssetOptionType>(sendAssetOptions[0])
+  const [selectedSendAsset, setSelectedSendAsset] = React.useState<BraveWallet.BlockchainToken>(sendAssetOptions[0])
   const [toAddressOrUrl, setToAddressOrUrl] = React.useState('')
   const [toAddress, setToAddress] = React.useState('')
   const [addressError, setAddressError] = React.useState('')
@@ -41,8 +40,8 @@ export default function useSend (
     setSelectedSendAsset(sendAssetOptions[0])
   }, [sendAssetOptions])
 
-  const onSelectSendAsset = (asset: AccountAssetOptionType) => {
-    if (asset.asset.isErc721) {
+  const onSelectSendAsset = (asset: BraveWallet.BlockchainToken) => {
+    if (asset.isErc721) {
       setSendAmount('1')
     } else {
       setSendAmount('')
@@ -164,25 +163,25 @@ export default function useSend (
   }, [toAddressOrUrl, selectedAccount])
 
   const onSubmitSend = () => {
-    selectedSendAsset.asset.isErc20 && sendERC20Transfer({
+    selectedSendAsset.isErc20 && sendERC20Transfer({
       from: selectedAccount.address,
       to: toAddress,
-      value: toWeiHex(sendAmount, selectedSendAsset.asset.decimals),
-      contractAddress: selectedSendAsset.asset.contractAddress
+      value: toWeiHex(sendAmount, selectedSendAsset.decimals),
+      contractAddress: selectedSendAsset.contractAddress
     })
 
-    selectedSendAsset.asset.isErc721 && sendERC721TransferFrom({
+    selectedSendAsset.isErc721 && sendERC721TransferFrom({
       from: selectedAccount.address,
       to: toAddress,
       value: '',
-      contractAddress: selectedSendAsset.asset.contractAddress,
-      tokenId: selectedSendAsset.asset.tokenId ?? ''
+      contractAddress: selectedSendAsset.contractAddress,
+      tokenId: selectedSendAsset.tokenId ?? ''
     })
 
-    !selectedSendAsset.asset.isErc721 && !selectedSendAsset.asset.isErc20 && sendTransaction({
+    !selectedSendAsset.isErc721 && !selectedSendAsset.isErc20 && sendTransaction({
       from: selectedAccount.address,
       to: toAddress,
-      value: toWeiHex(sendAmount, selectedSendAsset.asset.decimals)
+      value: toWeiHex(sendAmount, selectedSendAsset.decimals)
     })
 
     setToAddressOrUrl('')

--- a/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.test.ts
@@ -230,10 +230,9 @@ describe('useTransactionParser hook', () => {
           mockNetwork,
           [{
             ...mockAccount,
-            tokens: [{
-              asset: mockERC20Token,
-              assetBalance: '0' // 0 DOG
-            }],
+            tokenBalanceRegistry: {
+              [mockERC20Token.contractAddress.toLowerCase()]: '0'
+            },
             address: '0xdeadbeef',
             balance: '1000000000000000' // 0.001 ETH
           }],
@@ -413,10 +412,9 @@ describe('useTransactionParser hook', () => {
           mockNetwork,
           [{
             ...mockAccount,
-            tokens: [{
-              asset: mockERC20Token,
-              assetBalance: '1000000000000000' // 0.001 DOG
-            }],
+            tokenBalanceRegistry: {
+              [mockERC20Token.contractAddress.toLowerCase()]: '1000000000000000' // 0.001 DOG
+            },
             address: '0xdeadbeef',
             balance: '3150000000000000' // 0.00315 ETH
           }],
@@ -464,10 +462,9 @@ describe('useTransactionParser hook', () => {
           mockNetwork,
           [{
             ...mockAccount,
-            tokens: [{
-              asset: mockERC20Token,
-              assetBalance: '1000000000000000000' // 1 DOG
-            }],
+            tokenBalanceRegistry: {
+              [mockERC20Token.contractAddress.toLowerCase()]: '1000000000000000000' // 1 DOG
+            },
             address: '0xdeadbeef',
             balance: '3150000000000000' // 0.00315 ETH
           }],

--- a/components/brave_wallet_ui/components/buy-send-swap/accounts-assets-networks/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/accounts-assets-networks/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {
-  AccountAssetOptionType,
   BraveWallet,
   BuySendSwapViewTypes,
   UserAccountType
@@ -21,12 +20,12 @@ export interface Props {
   selectedView: BuySendSwapViewTypes
   accounts: UserAccountType[]
   networkList: BraveWallet.EthereumChain[]
-  assetOptions: AccountAssetOptionType[]
+  assetOptions: BraveWallet.BlockchainToken[]
   selectedNetwork: BraveWallet.EthereumChain
   onAddAsset: () => void
   onClickSelectAccount: (account: UserAccountType) => () => void
   onClickSelectNetwork: (network: BraveWallet.EthereumChain) => () => void
-  onSelectedAsset: (account: AccountAssetOptionType) => () => void
+  onSelectedAsset: (account: BraveWallet.BlockchainToken) => () => void
   goBack: () => void
   onAddNetwork: () => void
 }

--- a/components/brave_wallet_ui/components/buy-send-swap/buy/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/buy/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {
-  AccountAssetOptionType,
   BraveWallet,
   BuySendSwapViewTypes,
   ToOrFromType,
@@ -18,7 +17,7 @@ import {
 } from './style'
 
 export interface Props {
-  selectedAsset: AccountAssetOptionType
+  selectedAsset: BraveWallet.BlockchainToken
   selectedNetwork: BraveWallet.EthereumChain
   buyAmount: string
   networkList: BraveWallet.EthereumChain[]

--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset-item/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { AccountAssetOptionType } from '../../../constants/types'
+
+import { BraveWallet } from '../../../constants/types'
 import { withPlaceholderIcon } from '../../shared'
 import { hexToNumber } from '../../../utils/format-balances'
 
@@ -13,7 +14,7 @@ import {
 } from './style'
 
 export interface Props {
-  asset: AccountAssetOptionType
+  asset: BraveWallet.BlockchainToken
   onSelectAsset: () => void
 }
 
@@ -26,10 +27,10 @@ function SelectAssetItem (props: Props) {
 
   return (
     <StyledWrapper onClick={onSelectAsset}>
-      <AssetIconWithPlaceholder selectedAsset={asset.asset} />
+      <AssetIconWithPlaceholder selectedAsset={asset} />
       <AssetAndBalance>
-        <AssetName>{asset.asset.name} {asset.asset.isErc721 ? hexToNumber(asset.asset.tokenId ?? '') : ''}</AssetName>
-        <AssetBalance>{asset.asset.symbol}</AssetBalance>
+        <AssetName>{asset.name} {asset.isErc721 ? hexToNumber(asset.tokenId ?? '') : ''}</AssetName>
+        <AssetBalance>{asset.symbol}</AssetBalance>
       </AssetAndBalance>
     </StyledWrapper>
   )

--- a/components/brave_wallet_ui/components/buy-send-swap/select-asset/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/select-asset/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import Fuse from 'fuse.js'
 
 import SelectAssetItem from '../select-asset-item'
-import { AccountAssetOptionType } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { SearchBar } from '../../shared'
 import Header from '../select-header'
 import { getLocale } from '../../../../common/locale'
@@ -15,9 +15,9 @@ import {
 } from '../shared-styles'
 
 export interface Props {
-  assets: AccountAssetOptionType[]
+  assets: BraveWallet.BlockchainToken[]
   onAddAsset: () => void
-  onSelectAsset: (asset: AccountAssetOptionType) => () => void
+  onSelectAsset: (asset: BraveWallet.BlockchainToken) => () => void
   onBack: () => void
 }
 
@@ -41,19 +41,19 @@ function SelectAsset (props: Props) {
     ]
   }), [assets])
 
-  const [filteredAssetList, setFilteredAssetList] = React.useState<AccountAssetOptionType[]>(assets)
+  const [filteredAssetList, setFilteredAssetList] = React.useState<BraveWallet.BlockchainToken[]>(assets)
 
   const filterAssetList = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const search = event.target.value
     if (search === '') {
       setFilteredAssetList(assets)
     } else {
-      const filteredList = fuse.search(search).map((result: Fuse.FuseResult<AccountAssetOptionType>) => result.item)
+      const filteredList = fuse.search(search).map((result: Fuse.FuseResult<BraveWallet.BlockchainToken>) => result.item)
       setFilteredAssetList(filteredList)
     }
   }, [fuse, assets])
 
-  const erc271Tokens = React.useMemo(() => filteredAssetList.filter((token) => token.asset.isErc721), [filteredAssetList])
+  const erc271Tokens = React.useMemo(() => filteredAssetList.filter((token) => token.isErc721), [filteredAssetList])
 
   return (
     <SelectWrapper>
@@ -67,9 +67,9 @@ function SelectAsset (props: Props) {
       <SelectScrollSearchContainer>
         {
           // Temp filtering out erc721 tokens, sending will be handled in a different PR
-          filteredAssetList.filter((token) => !token.asset.isErc721).map((asset: AccountAssetOptionType) =>
+          filteredAssetList.filter((token) => !token.isErc721).map((asset: BraveWallet.BlockchainToken) =>
             <SelectAssetItem
-              key={asset.asset.contractAddress}
+              key={asset.contractAddress}
               asset={asset}
               onSelectAsset={onSelectAsset(asset)}
             />
@@ -80,9 +80,9 @@ function SelectAsset (props: Props) {
             <DivderTextWrapper>
               <DividerText>{getLocale('braveWalletTopNavNFTS')}</DividerText>
             </DivderTextWrapper>
-            {erc271Tokens.map((asset: AccountAssetOptionType) =>
+            {erc271Tokens.map((asset: BraveWallet.BlockchainToken) =>
               <SelectAssetItem
-                key={asset.asset.contractAddress}
+                key={asset.contractAddress}
                 asset={asset}
                 onSelectAsset={onSelectAsset(asset)}
               />

--- a/components/brave_wallet_ui/components/buy-send-swap/send/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/send/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {
-  AccountAssetOptionType,
+  BraveWallet,
   BuySendSwapViewTypes,
   ToOrFromType
 } from '../../../constants/types'
@@ -14,7 +14,7 @@ import {
 } from './style'
 
 export interface Props {
-  selectedAsset: AccountAssetOptionType
+  selectedAsset: BraveWallet.BlockchainToken
   selectedAssetAmount: string
   selectedAssetBalance: string
   toAddressOrUrl: string

--- a/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap-input-component/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {
-  AccountAssetOptionType,
+  BraveWallet,
   OrderTypes,
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
@@ -55,7 +55,7 @@ export interface Props {
   autoFocus?: boolean
   componentType: BuySendSwapInputType
   selectedAssetBalance?: string
-  selectedAsset?: AccountAssetOptionType
+  selectedAsset?: BraveWallet.BlockchainToken
   selectedAssetInputAmount?: string
   addressError?: string
   addressWarning?: string
@@ -157,9 +157,9 @@ function SwapInputComponent (props: Props) {
         return getLocale('braveWalletBuy')
       case 'exchange':
         if (orderType === 'market') {
-          return `${getLocale('braveWalletSwapMarket')} ${getLocale('braveWalletSwapPriceIn')} ${selectedAsset?.asset.symbol}`
+          return `${getLocale('braveWalletSwapMarket')} ${getLocale('braveWalletSwapPriceIn')} ${selectedAsset?.symbol}`
         } else {
-          return `${getLocale('braveWalletSwapPriceIn')} ${selectedAsset?.asset.symbol}`
+          return `${getLocale('braveWalletSwapPriceIn')} ${selectedAsset?.symbol}`
         }
       case 'selector':
         if (orderType === 'market') {
@@ -220,7 +220,7 @@ function SwapInputComponent (props: Props) {
 
   const formattedAssetBalance = selectedAssetBalance
     ? getLocale('braveWalletBalance') + ': ' + formatWithCommasAndDecimals(
-        formatBalance(selectedAssetBalance, selectedAsset?.asset.decimals ?? 18)
+        formatBalance(selectedAssetBalance, selectedAsset?.decimals ?? 18)
       )
     : ''
 
@@ -228,7 +228,7 @@ function SwapInputComponent (props: Props) {
     <BubbleContainer>
       {componentType !== 'selector' &&
         <>
-          {!selectedAsset?.asset.isErc721 &&
+          {!selectedAsset?.isErc721 &&
             <Row>
               <FromBalanceText componentType={componentType}>{getTitle()}</FromBalanceText>
 
@@ -251,7 +251,7 @@ function SwapInputComponent (props: Props) {
             {componentType === 'buyAmount' &&
               <AssetTicker>{CurrencySymbols[defaultCurrencies?.fiat ?? 'USD']}</AssetTicker>
             }
-            {!selectedAsset?.asset.isErc721 &&
+            {!selectedAsset?.isErc721 &&
               <Input
                 componentType={componentType}
                 type={componentType === 'toAddress' ? 'text' : 'number'}
@@ -274,16 +274,16 @@ function SwapInputComponent (props: Props) {
               </RefreshButton>
             }
             {componentType !== 'exchange' && componentType !== 'toAddress' &&
-              <AssetButton isERC721={selectedAsset?.asset.isErc721} onClick={onShowSelection}>
+              <AssetButton isERC721={selectedAsset?.isErc721} onClick={onShowSelection}>
                 <ButtonLeftSide>
-                  <AssetIconWithPlaceholder selectedAsset={selectedAsset?.asset} />
-                  <AssetTicker>{selectedAsset?.asset.symbol} {selectedAsset?.asset.isErc721 ? hexToNumber(selectedAsset?.asset.tokenId ?? '') : ''}</AssetTicker>
+                  <AssetIconWithPlaceholder selectedAsset={selectedAsset} />
+                  <AssetTicker>{selectedAsset?.symbol} {selectedAsset?.isErc721 ? hexToNumber(selectedAsset?.tokenId ?? '') : ''}</AssetTicker>
                 </ButtonLeftSide>
                 <CaratDownIcon />
               </AssetButton>
             }
           </Row>
-          {componentType === 'fromAmount' && !selectedAsset?.asset.isErc721 &&
+          {componentType === 'fromAmount' && !selectedAsset?.isErc721 &&
             <PresetRow>
               {AmountPresetOptions().map((preset, idx) =>
                 <PresetButton

--- a/components/brave_wallet_ui/components/buy-send-swap/swap/index.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/swap/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { getLocale, splitStringForTag } from '../../../../common/locale'
 import {
-  AccountAssetOptionType,
+  BraveWallet,
   OrderTypes,
   BuySendSwapViewTypes,
   SlippagePresetObjectType,
@@ -31,8 +31,8 @@ import {
 import { LoaderIcon } from 'brave-ui/components/icons'
 
 export interface Props {
-  toAsset: AccountAssetOptionType
-  fromAsset: AccountAssetOptionType
+  toAsset: BraveWallet.BlockchainToken
+  fromAsset: BraveWallet.BlockchainToken
   fromAmount: string
   toAmount: string
   exchangeRate: string
@@ -54,7 +54,7 @@ export interface Props {
   onSelectPresetAmount: (percent: number) => void
   onSelectExpiration: (expiration: ExpirationPresetObjectType) => void
   onSelectSlippageTolerance: (slippage: SlippagePresetObjectType) => void
-  onFilterAssetList: (asset: AccountAssetOptionType) => void
+  onFilterAssetList: (asset: BraveWallet.BlockchainToken) => void
   onQuoteRefresh: () => void
 }
 
@@ -108,7 +108,7 @@ function Swap (props: Props) {
 
     if (validationError === 'insufficientAllowance') {
       return getLocale('braveWalletSwapInsufficientAllowance')
-        .replace('$1', fromAsset.asset.symbol)
+        .replace('$1', fromAsset.symbol)
     }
 
     if (validationError === 'insufficientLiquidity') {

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/buy-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/buy-tab.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {
   UserAccountType,
-  AccountAssetOptionType,
   BuySendSwapViewTypes,
   BraveWallet,
   DefaultCurrencies
@@ -17,11 +16,11 @@ export interface Props {
   networkList: BraveWallet.EthereumChain[]
   selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
-  assetOptions: AccountAssetOptionType[]
+  assetOptions: BraveWallet.BlockchainToken[]
   buyAmount: string
   showHeader?: boolean
   defaultCurrencies: DefaultCurrencies
-  onSubmit: (asset: AccountAssetOptionType) => void
+  onSubmit: (asset: BraveWallet.BlockchainToken) => void
   onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onSetBuyAmount: (value: string) => void
@@ -47,7 +46,7 @@ function BuyTab (props: Props) {
     onAddNetwork
   } = props
   const [buyView, setBuyView] = React.useState<BuySendSwapViewTypes>('buy')
-  const [selectedAsset, setSelectedAsset] = React.useState<AccountAssetOptionType>(assetOptions[0])
+  const [selectedAsset, setSelectedAsset] = React.useState<BraveWallet.BlockchainToken>(assetOptions[0])
 
   const onChangeBuyView = (view: BuySendSwapViewTypes) => {
     setBuyView(view)
@@ -63,7 +62,7 @@ function BuyTab (props: Props) {
     setBuyView('buy')
   }
 
-  const onSelectedAsset = (asset: AccountAssetOptionType) => () => {
+  const onSelectedAsset = (asset: BraveWallet.BlockchainToken) => () => {
     setSelectedAsset(asset)
     setBuyView('buy')
   }

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/send-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/send-tab.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {
   UserAccountType,
-  AccountAssetOptionType,
   BuySendSwapViewTypes,
   ToOrFromType,
   BraveWallet
@@ -14,12 +13,12 @@ import {
 
 export interface Props {
   accounts: UserAccountType[]
-  selectedAsset: AccountAssetOptionType
+  selectedAsset: BraveWallet.BlockchainToken
   selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   selectedAssetAmount: string
   selectedAssetBalance: string
-  assetOptions: AccountAssetOptionType[]
+  assetOptions: BraveWallet.BlockchainToken[]
   toAddressOrUrl: string
   toAddress: string
   showHeader?: boolean
@@ -28,7 +27,7 @@ export interface Props {
   onSubmit: () => void
   onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
-  onSelectAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
+  onSelectAsset: (asset: BraveWallet.BlockchainToken, toOrFrom: ToOrFromType) => void
   onSetSendAmount: (value: string) => void
   onSetToAddressOrUrl: (value: string) => void
   onSelectPresetAmount: (percent: number) => void
@@ -81,7 +80,7 @@ function SendTab (props: Props) {
     setSendView('send')
   }
 
-  const onSelectedAsset = (asset: AccountAssetOptionType) => () => {
+  const onSelectedAsset = (asset: BraveWallet.BlockchainToken) => () => {
     onSelectAsset(asset, 'from')
     setSendView('send')
   }

--- a/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
+++ b/components/brave_wallet_ui/components/buy-send-swap/tabs/swap-tab.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {
   UserAccountType,
-  AccountAssetOptionType,
   OrderTypes,
   BuySendSwapViewTypes,
   SlippagePresetObjectType,
@@ -20,8 +19,8 @@ export interface Props {
   accounts: UserAccountType[]
   networkList: BraveWallet.EthereumChain[]
   orderType: OrderTypes
-  swapToAsset: AccountAssetOptionType
-  swapFromAsset: AccountAssetOptionType
+  swapToAsset: BraveWallet.BlockchainToken
+  swapFromAsset: BraveWallet.BlockchainToken
   selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   exchangeRate: string
@@ -31,7 +30,7 @@ export interface Props {
   toAmount: string
   fromAssetBalance: string
   toAssetBalance: string
-  assetOptions: AccountAssetOptionType[]
+  assetOptions: BraveWallet.BlockchainToken[]
   isFetchingQuote: boolean
   isSubmitDisabled: boolean
   validationError?: SwapValidationErrorType
@@ -42,7 +41,7 @@ export interface Props {
   onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onToggleOrderType: () => void
-  onSelectSwapAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
+  onSelectSwapAsset: (asset: BraveWallet.BlockchainToken, toOrFrom: ToOrFromType) => void
   onSelectSlippageTolerance: (slippage: SlippagePresetObjectType) => void
   onSelectExpiration: (expiration: ExpirationPresetObjectType) => void
   onSetExchangeRate: (value: string) => void
@@ -94,7 +93,7 @@ function SwapTab (props: Props) {
   } = props
   const [swapView, setSwapView] = React.useState<BuySendSwapViewTypes>('swap')
   const [isSelectingAsset, setIsSelectingAsset] = React.useState<ToOrFromType>('from')
-  const [filteredAssetList, setFilteredAssetList] = React.useState<AccountAssetOptionType[]>(assetOptions)
+  const [filteredAssetList, setFilteredAssetList] = React.useState<BraveWallet.BlockchainToken[]>(assetOptions)
 
   const onChangeSwapView = (view: BuySendSwapViewTypes, option?: ToOrFromType) => {
     if (option) {
@@ -115,12 +114,12 @@ function SwapTab (props: Props) {
     setSwapView('swap')
   }
 
-  const onSelectAsset = (asset: AccountAssetOptionType) => () => {
+  const onSelectAsset = (asset: BraveWallet.BlockchainToken) => () => {
     onSelectSwapAsset(asset, isSelectingAsset)
     setSwapView('swap')
   }
 
-  const onFilterAssetList = (asset: AccountAssetOptionType) => {
+  const onFilterAssetList = (asset: BraveWallet.BlockchainToken) => {
     const newList = assetOptions.filter((assets) => assets !== asset)
     setFilteredAssetList(newList)
   }

--- a/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/index.tsx
@@ -53,6 +53,9 @@ import {
   PortfolioTransactionItem
 } from '../../'
 
+// Hooks
+import { useBalance } from '../../../../common/hooks'
+
 export interface Props {
   accounts: WalletAccountType[]
   transactions: AccountTransactions
@@ -99,6 +102,8 @@ function Accounts (props: Props) {
     onSpeedupTransaction,
     onCancelTransaction
   } = props
+
+  const getBalance = useBalance(selectedNetwork)
 
   const groupById = (accounts: WalletAccountType[], key: string) => {
     return accounts.reduce((result, obj) => {
@@ -175,7 +180,10 @@ function Accounts (props: Props) {
     }
   }, [selectedAccount, transactions])
 
-  const erc271Tokens = React.useMemo(() => selectedAccount?.tokens.filter((token) => token.asset.isErc721), [selectedAccount])
+  const erc271Tokens = React.useMemo(() =>
+    userVisibleTokensInfo.filter((token) => token.isErc721),
+    [userVisibleTokensInfo]
+  )
 
   return (
     <StyledWrapper>
@@ -275,13 +283,13 @@ function Accounts (props: Props) {
           </WalletInfoRow>
           <SubviewSectionTitle>{getLocale('braveWalletAccountsAssets')}</SubviewSectionTitle>
           <SubDivider />
-          {selectedAccount.tokens.filter((token) => !token.asset.isErc721).map((item) =>
+          {userVisibleTokensInfo.filter((token) => !token.isErc721).map((item) =>
             <PortfolioAssetItem
               spotPrices={transactionSpotPrices}
               defaultCurrencies={defaultCurrencies}
-              key={item.asset.contractAddress}
-              assetBalance={item.assetBalance}
-              token={item.asset}
+              key={item.contractAddress}
+              assetBalance={getBalance(selectedAccount, item)}
+              token={item}
             />
           )}
           {erc271Tokens?.length !== 0 &&
@@ -293,9 +301,9 @@ function Accounts (props: Props) {
                 <PortfolioAssetItem
                   spotPrices={transactionSpotPrices}
                   defaultCurrencies={defaultCurrencies}
-                  key={item.asset.contractAddress}
-                  assetBalance={item.assetBalance}
-                  token={item.asset}
+                  key={item.contractAddress}
+                  assetBalance={getBalance(selectedAccount, item)}
+                  token={item}
                 />
               )}
               <Spacer />

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -5,7 +5,7 @@ import {
   BraveWallet,
   TopTabNavTypes,
   PriceDataObjectType,
-  AccountAssetOptionType,
+  UserAssetInfoType,
   AccountTransactions,
   WalletAccountType,
   UpdateAccountNamePayloadType,
@@ -69,7 +69,7 @@ export interface Props {
   selectedAsset: BraveWallet.BlockchainToken | undefined
   portfolioBalance: string
   transactions: AccountTransactions
-  userAssetList: AccountAssetOptionType[]
+  userAssetList: UserAssetInfoType[]
   isLoading: boolean
   showAddModal: boolean
   selectedNetwork: BraveWallet.EthereumChain

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/index.tsx
@@ -6,7 +6,7 @@ import {
   AccountTransactions,
   BraveWallet,
   WalletAccountType,
-  AccountAssetOptionType,
+  UserAssetInfoType,
   DefaultCurrencies,
   AddAccountNavTypes
 } from '../../../../constants/types'
@@ -85,7 +85,7 @@ export interface Props {
   addUserAssetError: boolean
   selectedNetwork: BraveWallet.EthereumChain
   networkList: BraveWallet.EthereumChain[]
-  userAssetList: AccountAssetOptionType[]
+  userAssetList: UserAssetInfoType[]
   accounts: WalletAccountType[]
   selectedTimeline: BraveWallet.AssetPriceTimeframe
   selectedPortfolioTimeline: BraveWallet.AssetPriceTimeframe
@@ -148,14 +148,14 @@ const Portfolio = (props: Props) => {
     foundTokenInfoByContractAddress
   } = props
 
-  const [filteredAssetList, setfilteredAssetList] = React.useState<AccountAssetOptionType[]>(userAssetList)
+  const [filteredAssetList, setfilteredAssetList] = React.useState<UserAssetInfoType[]>(userAssetList)
   const [fullPortfolioFiatBalance, setFullPortfolioFiatBalance] = React.useState<string>(portfolioBalance)
   const [hoverBalance, setHoverBalance] = React.useState<string>()
   const [hoverPrice, setHoverPrice] = React.useState<string>()
   const [showNetworkDropdown, setShowNetworkDropdown] = React.useState<boolean>(false)
   const parseTransaction = useTransactionParser(selectedNetwork, accounts, transactionSpotPrices, userVisibleTokensInfo)
 
-  const getAccountBalance = useBalance(selectedNetwork)
+  const getBalance = useBalance(selectedNetwork)
 
   const toggleShowNetworkDropdown = () => {
     setShowNetworkDropdown(!showNetworkDropdown)
@@ -350,7 +350,7 @@ const Portfolio = (props: Props) => {
               assetDecimals={selectedAsset.decimals}
               name={account.name}
               address={account.address}
-              assetBalance={getAccountBalance(account, selectedAsset)}
+              assetBalance={getBalance(account, selectedAsset)}
               selectedNetwork={selectedNetwork}
             />
           )}

--- a/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connected-panel/index.tsx
@@ -41,7 +41,7 @@ import { reduceNetworkDisplayName } from '../../../utils/network-utils'
 import { copyToClipboard } from '../../../utils/copy-to-clipboard'
 
 // Hooks
-import { useExplorer, usePricing } from '../../../common/hooks'
+import { useBalance, useExplorer, usePricing } from '../../../common/hooks'
 
 import {
   WalletAccountType,
@@ -51,8 +51,7 @@ import {
   SwapSupportedChains,
   WalletOrigin,
   DefaultCurrencies,
-  WalletRoutes,
-  AccountAssetOptionType
+  WalletRoutes
 } from '../../../constants/types'
 import { create, background } from 'ethereum-blockies'
 import { getLocale } from '../../../../common/locale'
@@ -64,7 +63,7 @@ export interface Props {
   isConnected: boolean
   activeOrigin: string
   defaultCurrencies: DefaultCurrencies
-  userAssetList: AccountAssetOptionType[]
+  userAssetList: BraveWallet.BlockchainToken[]
   navAction: (path: PanelTypes) => void
   onLockWallet: () => void
   onOpenSettings: () => void
@@ -85,6 +84,8 @@ const ConnectedPanel = (props: Props) => {
   } = props
   const [showMore, setShowMore] = React.useState<boolean>(false)
   const [isScrolled, setIsScrolled] = React.useState<boolean>(false)
+
+  const getBalance = useBalance(selectedNetwork)
 
   let scrollRef = React.useRef<HTMLDivElement | null>(null)
 
@@ -215,10 +216,10 @@ const ConnectedPanel = (props: Props) => {
             <PortfolioAssetItem
               spotPrices={spotPrices}
               defaultCurrencies={defaultCurrencies}
-              action={onClickAsset(asset.asset.symbol)}
-              key={asset.asset.contractAddress}
-              assetBalance={asset.assetBalance}
-              token={asset.asset}
+              action={onClickAsset(asset.symbol)}
+              key={asset.contractAddress}
+              assetBalance={getBalance(selectedAccount, asset)}
+              token={asset}
               isPanel={true}
             />
           )}

--- a/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
+++ b/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx
@@ -57,7 +57,7 @@ function withPlaceholderIcon (WrappedComponent: React.ComponentType<any>, config
         marginLeft={marginLeft ?? 0}
         marginRight={marginRight ?? 0}
       >
-        <WrappedComponent icon={selectedAsset?.symbol === 'ETH' ? ETH.asset.logo : selectedAsset?.logo} />
+        <WrappedComponent icon={selectedAsset?.symbol === 'ETH' ? ETH.logo : selectedAsset?.logo} />
       </IconWrapper>
     )
   }

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -13,14 +13,17 @@ export { BraveWallet }
 export { Url } from 'gen/url/mojom/url.mojom.m.js'
 export { TimeDelta }
 
+interface TokenBalanceRegistry {
+  [contractAddress: string]: string
+}
+
 export interface WalletAccountType {
   id: string
   name: string
   address: string
+  tokenBalanceRegistry: TokenBalanceRegistry
   balance: string
-  asset: string
   accountType: 'Primary' | 'Secondary' | 'Ledger' | 'Trezor'
-  tokens: AccountAssetOptionType[]
   deviceId?: string
 }
 
@@ -37,12 +40,7 @@ export interface AssetOptionType {
   logo: string
 }
 
-export interface UserAssetOptionType {
-  asset: AssetOptionType
-  assetBalance: number
-}
-
-export interface AccountAssetOptionType {
+export interface UserAssetInfoType {
   asset: BraveWallet.BlockchainToken
   assetBalance: string
 }
@@ -332,7 +330,8 @@ export interface GetFlattenedAccountBalancesReturnInfo {
 
 export interface PortfolioTokenHistoryAndInfo {
   history: GetPriceHistoryReturnObjectInfo
-  token: AccountAssetOptionType
+  token: BraveWallet.BlockchainToken
+  balance: string
 }
 
 interface BaseTransactionParams {

--- a/components/brave_wallet_ui/options/asset-options.ts
+++ b/components/brave_wallet_ui/options/asset-options.ts
@@ -1,4 +1,9 @@
-import { AccountAssetOptionType, BraveWallet } from '../constants/types'
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { BraveWallet } from '../constants/types'
 import {
   ALGOIconUrl,
   BATIconUrl,
@@ -8,65 +13,53 @@ import {
   ZRXIconUrl
 } from '../assets/asset-icons'
 
-export const ETH: AccountAssetOptionType = {
-  asset: {
-    contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    name: 'Ethereum',
-    symbol: 'ETH',
-    logo: ETHIconUrl,
-    isErc20: false,
+export const ETH = {
+  contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+  name: 'Ethereum',
+  symbol: 'ETH',
+  logo: ETHIconUrl,
+  isErc20: false,
+  isErc721: false,
+  decimals: 18,
+  visible: true,
+  tokenId: ''
+} as BraveWallet.BlockchainToken
+
+export const BAT = {
+  contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
+  name: 'Basic Attention Token',
+  symbol: 'BAT',
+  logo: 'chrome://erc-token-images/bat.png',
+  isErc20: true,
+  isErc721: false,
+  decimals: 18,
+  visible: false,
+  tokenId: ''
+} as BraveWallet.BlockchainToken
+
+export const RopstenSwapAssetOptions: BraveWallet.BlockchainToken[] = [
+  ETH,
+  {
+    contractAddress: '0xad6d458402f60fd3bd25163575031acdce07538d',
+    name: 'DAI Stablecoin',
+    symbol: 'DAI',
+    logo: 'chrome://erc-token-images/dai.png',
+    isErc20: true,
     isErc721: false,
     decimals: 18,
     visible: true,
     tokenId: ''
   },
-  assetBalance: '0'
-}
-
-export const BAT: AccountAssetOptionType = {
-  asset: {
-    contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
-    name: 'Basic Attention Token',
-    symbol: 'BAT',
-    logo: 'chrome://erc-token-images/bat.png',
+  {
+    contractAddress: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
+    name: 'USD Coin',
+    symbol: 'USDC',
+    logo: 'chrome://erc-token-images/usdc.png',
     isErc20: true,
     isErc721: false,
-    decimals: 18,
-    visible: false,
+    decimals: 6,
+    visible: true,
     tokenId: ''
-  },
-  assetBalance: '0'
-}
-
-export const RopstenSwapAssetOptions: AccountAssetOptionType[] = [
-  ETH,
-  {
-    asset: {
-      contractAddress: '0xad6d458402f60fd3bd25163575031acdce07538d',
-      name: 'DAI Stablecoin',
-      symbol: 'DAI',
-      logo: 'chrome://erc-token-images/dai.png',
-      isErc20: true,
-      isErc721: false,
-      decimals: 18,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
-  },
-  {
-    asset: {
-      contractAddress: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
-      name: 'USD Coin',
-      symbol: 'USDC',
-      logo: 'chrome://erc-token-images/usdc.png',
-      isErc20: true,
-      isErc721: false,
-      decimals: 6,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
   }
 ]
 
@@ -141,76 +134,61 @@ export const NewAssetOptions: BraveWallet.BlockchainToken[] = [
 ]
 
 // Use only with storybook as dummy data.
-export const AccountAssetOptions: AccountAssetOptionType[] = [
+export const AccountAssetOptions: BraveWallet.BlockchainToken[] = [
   ETH,
   {
-    asset: {
-      contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
-      name: 'Basic Attention Token',
-      symbol: 'BAT',
-      logo: BATIconUrl,
-      isErc20: true,
-      isErc721: false,
-      decimals: 18,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
+    contractAddress: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
+    name: 'Basic Attention Token',
+    symbol: 'BAT',
+    logo: BATIconUrl,
+    isErc20: true,
+    isErc721: false,
+    decimals: 18,
+    visible: true,
+    tokenId: ''
   },
   {
-    asset: {
-      contractAddress: '3',
-      name: 'Binance Coin',
-      symbol: 'BNB',
-      logo: BNBIconUrl,
-      isErc20: true,
-      isErc721: false,
-      decimals: 8,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
+    contractAddress: '3',
+    name: 'Binance Coin',
+    symbol: 'BNB',
+    logo: BNBIconUrl,
+    isErc20: true,
+    isErc721: false,
+    decimals: 8,
+    visible: true,
+    tokenId: ''
   },
   {
-    asset: {
-      contractAddress: '4',
-      name: 'Bitcoin',
-      symbol: 'BTC',
-      logo: BTCIconUrl,
-      isErc20: true,
-      isErc721: false,
-      decimals: 8,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
+    contractAddress: '4',
+    name: 'Bitcoin',
+    symbol: 'BTC',
+    logo: BTCIconUrl,
+    isErc20: true,
+    isErc721: false,
+    decimals: 8,
+    visible: true,
+    tokenId: ''
   },
   {
-    asset: {
-      contractAddress: '5',
-      name: 'Algorand',
-      symbol: 'ALGO',
-      logo: ALGOIconUrl,
-      isErc20: true,
-      isErc721: false,
-      decimals: 8,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
+    contractAddress: '5',
+    name: 'Algorand',
+    symbol: 'ALGO',
+    logo: ALGOIconUrl,
+    isErc20: true,
+    isErc721: false,
+    decimals: 8,
+    visible: true,
+    tokenId: ''
   },
   {
-    asset: {
-      contractAddress: '0xE41d2489571d322189246DaFA5ebDe1F4699F498',
-      name: '0x',
-      symbol: 'ZRX',
-      logo: ZRXIconUrl,
-      isErc20: true,
-      isErc721: false,
-      decimals: 18,
-      visible: true,
-      tokenId: ''
-    },
-    assetBalance: '0'
+    contractAddress: '0xE41d2489571d322189246DaFA5ebDe1F4699F498',
+    name: '0x',
+    symbol: 'ZRX',
+    logo: ZRXIconUrl,
+    isErc20: true,
+    isErc721: false,
+    decimals: 18,
+    visible: true,
+    tokenId: ''
   }
 ]

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -50,7 +50,6 @@ import {
   WalletPanelState,
   WalletAccountType,
   BuySendSwapViewTypes,
-  AccountAssetOptionType,
   ToOrFromType,
   WalletOrigin
 } from '../constants/types'
@@ -107,7 +106,8 @@ function Container (props: Props) {
     activeOrigin,
     pendingTransactions,
     defaultCurrencies,
-    transactions
+    transactions,
+    userVisibleTokensInfo
   } = props.wallet
 
   const {
@@ -134,20 +134,20 @@ function Container (props: Props) {
 
   const {
     assetOptions,
-    userVisibleTokenOptions,
     sendAssetOptions,
     buyAssetOptions,
     panelUserAssetList
   } = useAssets(
     accounts,
     selectedAccount,
+    selectedNetwork,
     props.wallet.fullTokenList,
-    props.wallet.userVisibleTokensInfo,
+    userVisibleTokensInfo,
     transactionSpotPrices,
     getBuyAssets
   )
 
-  const [selectedWyreAsset, setSelectedWyreAsset] = React.useState<AccountAssetOptionType>(buyAssetOptions[0])
+  const [selectedWyreAsset, setSelectedWyreAsset] = React.useState<BraveWallet.BlockchainToken>(buyAssetOptions[0])
 
   const {
     exchangeRate,
@@ -215,11 +215,11 @@ function Container (props: Props) {
   }, [selectedAccount])
 
   const getSelectedAccountBalance = useBalance(selectedNetwork)
-  const sendAssetBalance = getSelectedAccountBalance(selectedAccount, selectedSendAsset?.asset)
-  const fromAssetBalance = getSelectedAccountBalance(selectedAccount, fromAsset?.asset)
-  const toAssetBalance = getSelectedAccountBalance(selectedAccount, toAsset?.asset)
+  const sendAssetBalance = getSelectedAccountBalance(selectedAccount, selectedSendAsset)
+  const fromAssetBalance = getSelectedAccountBalance(selectedAccount, fromAsset)
+  const toAssetBalance = getSelectedAccountBalance(selectedAccount, toAsset)
 
-  const onSelectPresetAmountFactory = usePreset(selectedAccount, fromAsset, selectedSendAsset, onSetFromAmount, onSetSendAmount)
+  const onSelectPresetAmountFactory = usePreset(selectedAccount, selectedNetwork, fromAsset, selectedSendAsset, onSetFromAmount, onSetSendAmount)
 
   const onSetBuyAmount = (value: string) => {
     setBuyAmount(value)
@@ -257,7 +257,7 @@ function Container (props: Props) {
     setShowSelectAsset(false)
   }
 
-  const onSelectAsset = (asset: AccountAssetOptionType) => () => {
+  const onSelectAsset = (asset: BraveWallet.BlockchainToken) => () => {
     if (selectedPanel === 'buy') {
       setSelectedWyreAsset(asset)
     } else if (selectedPanel === 'swap') {
@@ -611,7 +611,7 @@ function Container (props: Props) {
             selectedNetwork={GetNetworkInfo(selectedNetwork.chainId, networkList)}
             transactionInfo={selectedPendingTransaction}
             transactionSpotPrices={transactionSpotPrices}
-            visibleTokens={userVisibleTokenOptions}
+            visibleTokens={userVisibleTokensInfo}
             refreshGasEstimates={props.walletActions.refreshGasEstimates}
             getERC20Allowance={getERC20Allowance}
             updateUnapprovedTransactionGasFields={props.walletActions.updateUnapprovedTransactionGasFields}
@@ -694,7 +694,7 @@ function Container (props: Props) {
   }
 
   if (showSelectAsset) {
-    let assets: AccountAssetOptionType[]
+    let assets: BraveWallet.BlockchainToken[]
     if (selectedPanel === 'buy') {
       assets = buyAssetOptions
     } else if (selectedPanel === 'send') {
@@ -911,7 +911,7 @@ function Container (props: Props) {
             selectedNetwork={selectedNetwork}
             transaction={selectedTransaction}
             transactionSpotPrices={transactionSpotPrices}
-            visibleTokens={userVisibleTokenOptions}
+            visibleTokens={userVisibleTokensInfo}
           />
         </SelectContainer>
       </PanelWrapper>
@@ -934,7 +934,7 @@ function Container (props: Props) {
                 onSelectTransaction={onSelectTransaction}
                 selectedNetwork={selectedNetwork}
                 selectedAccount={selectedAccount}
-                visibleTokens={userVisibleTokenOptions}
+                visibleTokens={userVisibleTokensInfo}
                 transactionSpotPrices={transactionSpotPrices}
                 transactions={transactions}
               />

--- a/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
+++ b/components/brave_wallet_ui/stories/screens/buy-send-swap.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import {
   BuySendSwapTypes,
   UserAccountType,
-  AccountAssetOptionType,
   OrderTypes,
   SlippagePresetObjectType,
   ExpirationPresetObjectType,
@@ -24,10 +23,10 @@ export interface Props {
   accounts: UserAccountType[]
   networkList: BraveWallet.EthereumChain[]
   orderType: OrderTypes
-  selectedSendAsset: AccountAssetOptionType
+  selectedSendAsset: BraveWallet.BlockchainToken
   sendAssetBalance: string
-  swapToAsset: AccountAssetOptionType
-  swapFromAsset: AccountAssetOptionType
+  swapToAsset: BraveWallet.BlockchainToken
+  swapFromAsset: BraveWallet.BlockchainToken
   selectedNetwork: BraveWallet.EthereumChain
   selectedAccount: UserAccountType
   selectedTab: BuySendSwapTypes
@@ -45,22 +44,22 @@ export interface Props {
   toAddress: string
   addressError: string
   addressWarning: string
-  buyAssetOptions: AccountAssetOptionType[]
-  sendAssetOptions: AccountAssetOptionType[]
-  swapAssetOptions: AccountAssetOptionType[]
+  buyAssetOptions: BraveWallet.BlockchainToken[]
+  sendAssetOptions: BraveWallet.BlockchainToken[]
+  swapAssetOptions: BraveWallet.BlockchainToken[]
   isFetchingSwapQuote: boolean
   isSwapSubmitDisabled: boolean
   customSlippageTolerance: string
   defaultCurrencies: DefaultCurrencies
   onCustomSlippageToleranceChange: (value: string) => void
-  onSubmitBuy: (asset: AccountAssetOptionType) => void
+  onSubmitBuy: (asset: BraveWallet.BlockchainToken) => void
   onSubmitSend: () => void
   onSubmitSwap: () => void
   flipSwapAssets: () => void
   onSelectNetwork: (network: BraveWallet.EthereumChain) => void
   onSelectAccount: (account: UserAccountType) => void
   onToggleOrderType: () => void
-  onSelectAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
+  onSelectAsset: (asset: BraveWallet.BlockchainToken, toOrFrom: ToOrFromType) => void
   onSelectSlippageTolerance: (slippage: SlippagePresetObjectType) => void
   onSelectExpiration: (expiration: ExpirationPresetObjectType) => void
   onSetExchangeRate: (value: string) => void
@@ -73,7 +72,7 @@ export interface Props {
   onSelectPresetSendAmount: (percent: number) => void
   onSelectTab: (tab: BuySendSwapTypes) => void
   onSwapQuoteRefresh: () => void
-  onSelectSendAsset: (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => void
+  onSelectSendAsset: (asset: BraveWallet.BlockchainToken, toOrFrom: ToOrFromType) => void
   onAddNetwork: () => void
   onAddAsset: (value: boolean) => void
 }

--- a/components/brave_wallet_ui/stories/screens/crypto-story-view.tsx
+++ b/components/brave_wallet_ui/stories/screens/crypto-story-view.tsx
@@ -11,7 +11,7 @@ import {
   BraveWallet,
   AppsListType,
   PriceDataObjectType,
-  AccountAssetOptionType,
+  UserAssetInfoType,
   AccountTransactions,
   WalletAccountType,
   UpdateAccountNamePayloadType,
@@ -35,7 +35,7 @@ export interface Props {
   selectedNetwork: BraveWallet.EthereumChain
   showAddModal: boolean
   isLoading: boolean
-  userAssetList: AccountAssetOptionType[]
+  userAssetList: UserAssetInfoType[]
   transactions: AccountTransactions
   portfolioBalance: string
   selectedAsset: BraveWallet.BlockchainToken | undefined

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -11,7 +11,6 @@ import {
   NavTypes,
   BraveWallet,
   PriceDataObjectType,
-  AccountAssetOptionType,
   RPCResponseType,
   OrderTypes,
   UserAccountType,
@@ -234,8 +233,8 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
   const [selectedNetwork, setSelectedNetwork] = React.useState<BraveWallet.EthereumChain>(mockNetworks[0])
   const [selectedAccount, setSelectedAccount] = React.useState<UserAccountType>(mockUserAccounts[0])
   const [showAddModal, setShowAddModal] = React.useState<boolean>(false)
-  const [fromAsset, setFromAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
-  const [toAsset, setToAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[1])
+  const [fromAsset, setFromAsset] = React.useState<BraveWallet.BlockchainToken>(AccountAssetOptions[0])
+  const [toAsset, setToAsset] = React.useState<BraveWallet.BlockchainToken>(AccountAssetOptions[1])
   const [orderType, setOrderType] = React.useState<OrderTypes>('market')
   const [exchangeRate, setExchangeRate] = React.useState('0.0027533')
   const [slippageTolerance, setSlippageTolerance] = React.useState<SlippagePresetObjectType>(SlippagePresetOptions[0])
@@ -376,7 +375,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
         balance: singleAccountBalance(wallet),
         asset: selectedAsset ? selectedAsset.symbol : '',
         accountType: 'Primary',
-        tokens: []
+        tokenBalanceRegistry: {}
       } as WalletAccountType
     })
     return newList
@@ -483,7 +482,7 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     alert('Will make a custom asset visible')
   }
 
-  const onSelectTransactAsset = (asset: AccountAssetOptionType, toOrFrom: ToOrFromType) => {
+  const onSelectTransactAsset = (asset: BraveWallet.BlockchainToken, toOrFrom: ToOrFromType) => {
     if (toOrFrom === 'from') {
       setFromAsset(asset)
     } else {
@@ -496,8 +495,8 @@ export const _DesktopWalletConcept = (args: { onboarding: boolean, locked: boole
     setToAsset(fromAsset)
   }
 
-  const onSubmitBuy = (asset: AccountAssetOptionType) => {
-    alert(`Buy ${asset.asset.symbol} asset`)
+  const onSubmitBuy = (asset: BraveWallet.BlockchainToken) => {
+    alert(`Buy ${asset.symbol} asset`)
   }
 
   const onSwapQuoteRefresh = () => {

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -28,7 +28,6 @@ import {
   WalletAccountType,
   PanelTypes,
   AppsListType,
-  AccountAssetOptionType,
   BuySendSwapViewTypes
 } from '../constants/types'
 import {
@@ -64,28 +63,25 @@ const accounts: WalletAccountType[] = [
     id: '1',
     name: 'Account 1',
     address: '0x7d66c9ddAED3115d93Bd1790332f3Cd06Cf52B14',
-    balance: '0.31178',
-    asset: 'eth',
+    balance: '311780000000000000',
     accountType: 'Primary',
-    tokens: []
+    tokenBalanceRegistry: {}
   },
   {
     id: '2',
     name: 'Account 2',
     address: '0x73A29A1da97149722eB09c526E4eAd698895bDCf',
-    balance: '0.31178',
-    asset: 'eth',
+    balance: '311780000000000000',
     accountType: 'Primary',
-    tokens: []
+    tokenBalanceRegistry: {}
   },
   {
     id: '3',
     name: 'Account 3',
     address: '0x3f29A1da97149722eB09c526E4eAd698895b426',
-    balance: '0.31178',
-    asset: 'eth',
+    balance: '311780000000000000',
     accountType: 'Primary',
-    tokens: []
+    tokenBalanceRegistry: {}
   }
 ]
 
@@ -323,9 +319,8 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
       name: 'Account 1',
       address: '1',
       balance: '0.31178',
-      asset: 'eth',
       accountType: 'Primary',
-      tokens: []
+      tokenBalanceRegistry: {}
     }
   ]
   const transactionList = {
@@ -345,8 +340,8 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
   const [filteredAppsList, setFilteredAppsList] = React.useState<AppsListType[]>(AppsList())
   const [hasPasswordError, setHasPasswordError] = React.useState<boolean>(false)
   const [selectedNetwork, setSelectedNetwork] = React.useState<BraveWallet.EthereumChain>(mockNetworks[0])
-  const [selectedWyreAsset, setSelectedWyreAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
-  const [selectedAsset, setSelectedAsset] = React.useState<AccountAssetOptionType>(AccountAssetOptions[0])
+  const [selectedWyreAsset, setSelectedWyreAsset] = React.useState<BraveWallet.BlockchainToken>(AccountAssetOptions[0])
+  const [selectedAsset, setSelectedAsset] = React.useState<BraveWallet.BlockchainToken>(AccountAssetOptions[0])
   const [showSelectAsset, setShowSelectAsset] = React.useState<boolean>(false)
   const [toAddress, setToAddress] = React.useState('')
   const [fromAmount, setFromAmount] = React.useState('')
@@ -358,7 +353,7 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
   }
 
   const onSubmitBuy = () => {
-    alert(`Buy ${selectedWyreAsset.asset.symbol} asset`)
+    alert(`Buy ${selectedWyreAsset.symbol} asset`)
   }
 
   const onChangeSendView = (view: BuySendSwapViewTypes) => {
@@ -389,7 +384,7 @@ export const _ConnectedPanel = (args: { locked: boolean }) => {
     setShowSelectAsset(false)
   }
 
-  const onSelectAsset = (asset: AccountAssetOptionType) => () => {
+  const onSelectAsset = (asset: BraveWallet.BlockchainToken) => () => {
     if (selectedPanel === 'buy') {
       setSelectedWyreAsset(asset)
     } else {

--- a/components/brave_wallet_ui/utils/api-utils.test.ts
+++ b/components/brave_wallet_ui/utils/api-utils.test.ts
@@ -5,40 +5,50 @@ import { mockAccount } from '../common/constants/mocks'
 
 describe('Check token param', () => {
   test('Value should return contract address', () => {
-    expect(GetTokenParam(mockNetworks[0], AccountAssetOptions[1].asset)).toEqual('0x0D8775F648430679A709E98d2b0Cb6250d2887EF')
+    expect(GetTokenParam(mockNetworks[0], AccountAssetOptions[1])).toEqual('0x0D8775F648430679A709E98d2b0Cb6250d2887EF')
   })
   test('Value should return symbol', () => {
-    expect(GetTokenParam(mockNetworks[1], AccountAssetOptions[1].asset)).toEqual('bat')
+    expect(GetTokenParam(mockNetworks[1], AccountAssetOptions[1])).toEqual('bat')
   })
 })
 
+const mockUserVisibleTokenOptions = [
+  AccountAssetOptions[0],
+  AccountAssetOptions[1]
+]
 const mockAccounts = [
   {
     ...mockAccount,
-    tokens: [{ ...AccountAssetOptions[0], assetBalance: '0x350082652bcfb2e' }, AccountAssetOptions[1]]
+    tokenBalanceRegistry: {
+      [AccountAssetOptions[0].contractAddress.toLowerCase()]: '238699740940532526',
+      [AccountAssetOptions[1].contractAddress.toLowerCase()]: '0'
+    }
   },
   {
     ...mockAccount,
-    tokens: [{ ...AccountAssetOptions[0], assetBalance: '0x11e40b7737cd000' }, AccountAssetOptions[1]]
+    tokenBalanceRegistry: {
+      [AccountAssetOptions[0].contractAddress.toLowerCase()]: '80573000000000000',
+      [AccountAssetOptions[1].contractAddress.toLowerCase()]: '0'
+    }
   }
 ]
 
 const expectedResult = [
   {
-    balance: 0.31930000000000003,
-    token: AccountAssetOptions[0].asset
+    balance: 319272740940532500,
+    token: AccountAssetOptions[0]
   },
   {
     balance: 0,
-    token: AccountAssetOptions[1].asset
+    token: AccountAssetOptions[1]
   }
 ]
 
 describe('Check Flattened Account Balances', () => {
   test('Value should return an Empty Array', () => {
-    expect(GetFlattenedAccountBalances([])).toEqual([])
+    expect(GetFlattenedAccountBalances([], mockUserVisibleTokenOptions)).toEqual([])
   })
   test('Value should return a Flattened Account Balance List', () => {
-    expect(GetFlattenedAccountBalances(mockAccounts)).toEqual(expectedResult)
+    expect(GetFlattenedAccountBalances(mockAccounts, mockUserVisibleTokenOptions)).toEqual(expectedResult)
   })
 })

--- a/components/brave_wallet_ui/utils/buy-asset-url.ts
+++ b/components/brave_wallet_ui/utils/buy-asset-url.ts
@@ -1,16 +1,15 @@
 import {
-  AccountAssetOptionType,
   BraveWallet,
   UserAccountType
 } from '../constants/types'
 
 import { getBuyAssetUrl } from '../common/async/lib'
 
-export function GetBuyOrFaucetUrl (networkChainId: string, asset: AccountAssetOptionType, account: UserAccountType, buyAmount: string): Promise<string> {
+export function GetBuyOrFaucetUrl (networkChainId: string, asset: BraveWallet.BlockchainToken, account: UserAccountType, buyAmount: string): Promise<string> {
   return new Promise(async (resolve, reject) => {
     switch (networkChainId) {
       case BraveWallet.MAINNET_CHAIN_ID:
-        getBuyAssetUrl(account.address, asset.asset.symbol, buyAmount)
+        getBuyAssetUrl(account.address, asset.symbol, buyAmount)
           .then(resolve)
           .catch(reject)
         break


### PR DESCRIPTION
### Background

This PR retires the `AccountAssetOptionType` in favour of `BraveWallet.BlockchainToken`. The refactoring is to remove logical inconsistencies that existed with the old model.

`AccountAssetOptionType.assetBalance` in isolation doesn't make much sense because balance is a function of network, account, and the asset info. In most cases, the balances held in the assets list is `0` anyway, and we always need to loop through all `accounts` and subsequently `account.tokens`, to query a token balance.

In the new design, we have maintain a token balance registry for each account, that can be easily queried. The `useBalance` hook has been updated to work with this new mechanism.

**Other cleanups/enhancements:**
* 🗑️ Removed `tokens` field from `WalletAccountType`, since it's always a copy of `userVisibleTokensInfo`.
* 🗑️ Removed `asset` field from `WalletAccountType` which was unused.
* 🔄 Ensure updates to token balances are always reflected in `selectedAccount`.
* ⚡ Make balance queries `O(1)` instead of `O(n)`, `n` being the size of the visible assets list.

Resolves https://github.com/brave/brave-browser/issues/20441.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

No functional changes have been done in this PR. Pay attention to the following things during QA:
* Portfolio loads fine.
* Icons in visible assets, send assets, swap assets, etc, are not broken.
* Balances in portfolio, account/asset view, etc., are correctly displayed.
* Switching the network refreshes the balances in visible assets list, and the portfolio total correctly.
* Prices are displayed correctly.
* Preset buttons (25%, 50%, 75%, 100%) are functioning correctly.
* Able to create and submit an ETH and ERC20 transaction.
* Able to create and submit a swap transaction.