### PR TITLE
Fix generation of Windows delta update files

### DIFF
--- a/chromium_src/courgette/third_party/bsdiff/paged_array.h
+++ b/chromium_src/courgette/third_party/bsdiff/paged_array.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COURGETTE_THIRD_PARTY_BSDIFF_PAGED_ARRAY_H_
+#define BRAVE_CHROMIUM_SRC_COURGETTE_THIRD_PARTY_BSDIFF_PAGED_ARRAY_H_
+
+#define PagedArray PagedArray_ChromiumImpl
+#define kPagedArrayDefaultPageLogSize kPagedArrayDefaultPageLogSize_ChromiumImpl
+
+#include "src/courgette/third_party/bsdiff/paged_array.h"
+
+#undef kPagedArrayDefaultPageLogSize
+#undef PagedArray
+
+namespace courgette {
+
+// Chromium's courgette.exe runs into memory allocation errors when called on
+// Brave's binaries. Reducing the log page size from 18 (=1 MB) to 14
+// (=1/16th MB) fixes this. This makes it seem likely that the errors are
+// caused by address space fragmentation. Unfortunately, we have not yet been
+// able to find the root cause for this. So we use this workaround.
+constexpr int kPagedArrayDefaultPageLogSize = 14;
+
+template <typename T, int LOG_PAGE_SIZE = kPagedArrayDefaultPageLogSize>
+using PagedArray = PagedArray_ChromiumImpl<T, LOG_PAGE_SIZE>;
+
+}  // namespace courgette
+
+#endif  // BRAVE_CHROMIUM_SRC_COURGETTE_THIRD_PARTY_BSDIFF_PAGED_ARRAY_H_


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/18696.

The change should not have any visible effect on the browser. What it should do is fix the broken delta update generation in CI builds. And it should let users update the browser on Windows with delta files, which are significantly smaller than the full binary. One way of checking this is to go to brave://settings/help and seeing how long it takes to download an update.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Windows delta update generation is currently disabled in CI because the associated functionality is broken. This PR fixes this. Once everything is merged it could be tested whether the delta update files are being used when updating to a new version. See eg. #11096, and https://github.com/google/omaha/commit/c5a0282dd013b648386cfea40c3df7c3080af806h for inspecting logs files.