### PR TITLE
Disallow deletion of ethereum properties

### DIFF
--- a/browser/brave_wallet/send_transaction_browsertest.cc
+++ b/browser/brave_wallet/send_transaction_browsertest.cc
@@ -716,4 +716,16 @@ IN_PROC_BROWSER_TEST_F(SendTransactionBrowserTest,
             true);
 }
 
+IN_PROC_BROWSER_TEST_F(SendTransactionBrowserTest,
+                       EnsurePropertiesCantBeDeleted) {
+  GURL url =
+      https_server_for_files()->GetURL("a.com", "/send_transaction.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_TRUE(WaitForLoadStop(web_contents()));
+  ASSERT_EQ(EvalJs(web_contents(), "ensurePropertiesCantBeDeleted()",
+                   content::EXECUTE_SCRIPT_USE_MANUAL_REPLY)
+                .ExtractBool(),
+            true);
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/resources/brave_wallet_provider.js
+++ b/components/brave_wallet/resources/brave_wallet_provider.js
@@ -15,8 +15,24 @@
       BraveWeb3ProviderEventEmitter.removeListener
   window.ethereum.removeAllListeners =
       BraveWeb3ProviderEventEmitter.removeAllListeners
-  // For webcompat
   window.ethereum.isMetaMask = true
+  Object.defineProperty(window, 'ethereum', {
+    value: new Proxy(window.ethereum, {
+      get: (...args) => {
+        return Reflect.get(...args)
+      },
+      set: (...args) => {
+        return Reflect.set(...args)
+      },
+      deleteProperty: (target, prop) => {
+        return true
+      }
+    }),
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  })
+
   var alreadyLogged = false
   var logweb3Warning = () => {
     if (!alreadyLogged) {

--- a/test/data/brave-wallet/send_transaction.html
+++ b/test/data/brave-wallet/send_transaction.html
@@ -95,6 +95,14 @@
     window.ethereum._metamask.isUnlocked().then(result =>
       window.domAutomationController.send(result))
   }
+  function ensurePropertiesCantBeDeleted() {
+    // window.ethereum properties cannot be deleted AND they return true
+    // this is for web-compat, for example https://wallet.polygon.technology/
+    // fails otherwise as it uses a library which tries to delete
+    // window.ethereum.sendAsync and then uses it. Seriously.
+    window.domAutomationController.send(delete window.ethereum.sendAsync === true &&
+        typeof(window.ethereum.sendAsync) === 'function')
+  }
 </script>
 
 <body>


### PR DESCRIPTION
This is for webcompat with MetaMask.

The https://wallet.polygon.technology/ site does this when web3 is
defined:
```
void 0 !== n.ethereumProvider ?
  i = n.ethereumProvider :
  void 0 !== n.web3 &&
  n.web3.currentProvider &&
  (
    n.web3.currentProvider.sendAsync &&
    (n.web3.currentProvider.send = n.web3.currentProvider.sendAsync, delete n.web3.currentProvider.sendAsync),
```

key part:
```
delete n.web3.currentProvider.sendAsync
```

We used to not include web3 at all, then this code is not hit and
there's no problem.
Recently we started including a web3 shim (https://github.com/brave/brave-core/pull/11764) so that's why it's hit now.

Now that it's hit, we were failing because the Polygon site deleted
`window.ethereum.sendAsync` and then tried to use it.
We allowed this property deletion but MetaMask did not.

Instead of the fix in this commit (with the proxy method), I wanted to instead do this in `components/brave_wallet/renderer/brave_wallet_js_handler.cc`
but that won't work because it makes `delete` return false.

```
- ->Set(context, gin::StringToSymbol(isolate, "networkVersion"),
+ ->DefineOwnProperty(context, gin::StringToSymbol(isolate, "networkVersion", DontDelete),
        gin::StringToV8(isolate, std::to_string(networkVersion)))
         .Check();
```

The Polygon site won't load at all if it thinks it can't delete the
property.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20460

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

