### PR TITLE
Make sec-team the owner of the audit_deps script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 build/commands/ @bridiver
 patches/ @brave/patch-reviewers
 chromium_src/ @brave/chromium-src-reviewers
+script/audit_deps.py @brave/sec-team
 script/build-bisect.py @bsclifton
 script/uplift.py @bsclifton
 /README.md @bsclifton


### PR DESCRIPTION
There is a comment in the code to ask for a review from the sec-team, but we may as well enforce it.