### PR TITLE
Updated widevine permission bubble

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -214,8 +214,9 @@
       <message name="IDS_SETTINGS_IMPORT_PAYMENTS_CHECKBOX" desc="Checkbox for importing payments info">
         Payment methods
       </message>
+      <!-- Widevine -->
       <message name="IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT" desc="Text fragment for Widevine permission request. 'Widevine' is the name of a plugin and should not be translated.">
-          Install and run Widevine
+          Install and run Google Widevine
       </message>
       <message name="IDS_WIDEVINE_DONT_ASK_AGAIN_CHECKBOX" desc="Checkbox for prevent showing widevine install prompt">
         Don't ask again
@@ -237,16 +238,27 @@
       </message>
       <if expr="is_linux">
         <message name="IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_INSTALL" desc="Text fragment for Widevine permission request. 'Widevine' is the name of a plugin and should not be translated.">
-          Install Widevine
+          Install Google Widevine
         </message>
         <message name="IDS_WIDEVINE_PERMISSION_REQUEST_TEXT_FRAGMENT_RESTART_BROWSER" desc="Text fragment for Widevine permission request. 'Widevine' is the name of a plugin and should not be translated.">
-          Restart browser to enable Widevine
+          Restart browser to enable Google Widevine
         </message>
       </if>
       <message name="IDS_WIDEVINE_INSTALL_MESSAGE" desc="Bubble info text when Widevine is not installed. 'Widevine' is the name of a plugin and should not be translated.">
-        Google Widevine is a piece of Digital Rights Management (DRM) code that we at Brave Software do not own and cannot inspect. The Google Widevine code is loaded from Google servers, not from our servers. It is loaded only when you enable this option. We discourage the use of DRM, but we respect user choice and acknowledge that some Brave users would like to use services that require it.
-
-By installing this extension, you are agreeing to the Google Widevine Terms of Use. You agree that Brave is not responsible for any damages or losses in connection with your use of Google Widevine.
+        Widevine is sometimes needed to play media on a webpage. It's a Google extension loaded from Google servers, which Brave cannot inspect. By installing, you'll agree to Google's terms of use. 
+      </message>
+      <message name="IDS_WIDEVINE_PERMISSIONS_BUBBLE_FOOTNOTE_TEXT" desc="Message shown on the bottom of the widevine permissions bubble.">
+        <ph name="LEARN_MORE_ABOUT_WIDEVINE">$1<ex>Learn more about Widevine</ex></ph>.
+Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/extensions</ex></ph>.
+      </message>
+      <message name="IDS_WIDEVINE_PERMISSIONS_BUBBLE_LEARN_MORE" desc="Message shown on the bottom of the widevine permissions bubble.">
+        Learn more about Widevine
+      </message>
+      <message name="IDS_PERMISSIONS_BUBBLE_SETTINGS_EXTENSIONS_LINK" desc="Settings extenions link in the widevine permission bubble footnote description." translateable="false">
+        brave://settings/extensions
+      </message>
+      <message name="IDS_BRAVE_PERMISSIONS_BUBBLE_PROMPT" desc="The label that is used to introduce permission request details to the user in a popup.">
+        <ph name="SITE_NAME">$1<ex>google.com</ex></ph> is asking you to
       </message>
       <!-- Autoplay -->
       <message name="IDS_SETTINGS_SITE_SETTINGS_AUTOPLAY" desc="Label for autoplay site settings.">

--- a/chromium_src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc
@@ -8,8 +8,10 @@
 #include "base/feature_list.h"
 #include "brave/common/url_constants.h"
 #include "brave/components/permissions/permission_lifetime_utils.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/common/webui_url_constants.h"
+#include "chrome/grit/generated_resources.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/permissions/features.h"
 #include "components/permissions/permission_prompt.h"
@@ -25,7 +27,7 @@
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
 #include "brave/browser/widevine/widevine_permission_request.h"
-#include "brave/grit/brave_generated_resources.h"
+#include "brave/common/webui_url_constants.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "components/permissions/request_type.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -36,6 +38,48 @@
 #endif
 
 namespace {
+
+std::unique_ptr<views::StyledLabel> CreateStyledLabelForFootnote(
+    Browser* browser,
+    const std::u16string& footnote,
+    const std::vector<std::u16string>& replacements,
+    const std::vector<GURL>& urls) {
+  // For now, only two links are added to permission bubble footnote.
+  DCHECK_EQ(2UL, replacements.size());
+  DCHECK_EQ(replacements.size(), urls.size());
+
+  std::vector<size_t> offsets;
+  std::u16string footnote_text =
+      base::ReplaceStringPlaceholders(footnote, replacements, &offsets);
+
+  auto label = std::make_unique<views::StyledLabel>();
+  label->SetText(footnote_text);
+  label->SetDefaultTextStyle(views::style::STYLE_SECONDARY);
+
+  auto add_link = [&](size_t idx, GURL url) {
+    DCHECK(idx < offsets.size());
+    DCHECK(idx < replacements.size());
+
+    gfx::Range link_range(offsets[idx],
+                          offsets[idx] + replacements[idx].length());
+
+    views::StyledLabel::RangeStyleInfo link_style =
+        views::StyledLabel::RangeStyleInfo::CreateForLink(base::BindRepeating(
+            [](Browser* browser, const GURL& url) {
+              chrome::AddSelectedTabWithURL(browser, url,
+                                            ui::PAGE_TRANSITION_LINK);
+            },
+            base::Unretained(browser), std::move(url)));
+
+    label->AddStyleRange(link_range, link_style);
+  };
+
+  for (size_t i = 0; i < urls.size(); ++i) {
+    add_link(i, urls[i]);
+  }
+
+  return label;
+}
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
 class DontAskAgainCheckbox : public views::Checkbox {
@@ -94,6 +138,22 @@ void AddAdditionalWidevineViewControlsIfNeeded(
   dialog_delegate_view->AddChildView(text);
   dialog_delegate_view->AddChildView(
       new DontAskAgainCheckbox(widevine_request));
+}
+
+void AddWidevineFootnoteView(
+    views::BubbleDialogDelegateView* dialog_delegate_view,
+    Browser* browser) {
+  const std::u16string footnote =
+      l10n_util::GetStringUTF16(IDS_WIDEVINE_PERMISSIONS_BUBBLE_FOOTNOTE_TEXT);
+  const std::vector<std::u16string> replacements{
+      l10n_util::GetStringUTF16(IDS_WIDEVINE_PERMISSIONS_BUBBLE_LEARN_MORE),
+      l10n_util::GetStringUTF16(
+          IDS_PERMISSIONS_BUBBLE_SETTINGS_EXTENSIONS_LINK)};
+  const std::vector<GURL> urls{GURL(kWidevineLearnMoreUrl),
+                               GURL(kExtensionSettingsURL)};
+
+  dialog_delegate_view->SetFootnoteView(
+      CreateStyledLabelForFootnote(browser, footnote, replacements, urls));
 }
 #else
 void AddAdditionalWidevineViewControlsIfNeeded(
@@ -173,46 +233,31 @@ views::View* AddPermissionLifetimeComboboxIfNeeded(
 
 void AddFootnoteViewIfNeeded(
     views::BubbleDialogDelegateView* dialog_delegate_view,
+    const std::vector<permissions::PermissionRequest*>& requests,
     Browser* browser) {
+#if BUILDFLAG(ENABLE_WIDEVINE)
+  // Widevine permission bubble has custom footnote.
+  if (HasWidevinePermissionRequest(requests)) {
+    AddWidevineFootnoteView(dialog_delegate_view, browser);
+    return;
+  }
+#endif
+
   if (!base::FeatureList::IsEnabled(
           permissions::features::kPermissionLifetime)) {
     return;
   }
 
-  std::vector<std::u16string> replacements{
+  const std::u16string footnote =
+      l10n_util::GetStringUTF16(IDS_PERMISSIONS_BUBBLE_FOOTNOTE_TEXT);
+  const std::vector<std::u16string> replacements{
       l10n_util::GetStringUTF16(IDS_PERMISSIONS_BUBBLE_SITE_PERMISSION_LINK),
       l10n_util::GetStringUTF16(IDS_LEARN_MORE)};
-  std::vector<size_t> offsets;
-  std::u16string footnote_text = base::ReplaceStringPlaceholders(
-      l10n_util::GetStringUTF16(IDS_PERMISSIONS_BUBBLE_FOOTNOTE_TEXT),
-      replacements, &offsets);
+  const std::vector<GURL> urls{GURL(chrome::kChromeUIContentSettingsURL),
+                               GURL(kPermissionPromptLearnMoreUrl)};
 
-  auto label = std::make_unique<views::StyledLabel>();
-  label->SetText(footnote_text);
-  label->SetDefaultTextStyle(views::style::STYLE_SECONDARY);
-
-  auto add_link = [&](size_t idx, GURL url) {
-    DCHECK(idx < offsets.size());
-    DCHECK(idx < replacements.size());
-
-    gfx::Range link_range(offsets[idx],
-                          offsets[idx] + replacements[idx].length());
-
-    views::StyledLabel::RangeStyleInfo link_style =
-        views::StyledLabel::RangeStyleInfo::CreateForLink(base::BindRepeating(
-            [](Browser* browser, const GURL& url) {
-              chrome::AddSelectedTabWithURL(browser, url,
-                                            ui::PAGE_TRANSITION_LINK);
-            },
-            base::Unretained(browser), std::move(url)));
-
-    label->AddStyleRange(link_range, link_style);
-  };
-
-  add_link(0, GURL(chrome::kChromeUIContentSettingsURL));
-  add_link(1, GURL(kPermissionPromptLearnMoreUrl));
-
-  dialog_delegate_view->SetFootnoteView(std::move(label));
+  dialog_delegate_view->SetFootnoteView(
+      CreateStyledLabelForFootnote(browser, footnote, replacements, urls));
 }
 
 }  // namespace
@@ -221,7 +266,7 @@ void AddFootnoteViewIfNeeded(
   AddAdditionalWidevineViewControlsIfNeeded(this, delegate_->Requests()); \
   auto* permission_lifetime_view =                                        \
       AddPermissionLifetimeComboboxIfNeeded(this, delegate_);             \
-  AddFootnoteViewIfNeeded(this, browser_);                                \
+  AddFootnoteViewIfNeeded(this, delegate_->Requests(), browser_);         \
   if (permission_lifetime_view) {                                         \
     set_fixed_width(                                                      \
         std::max(GetPreferredSize().width(),                              \
@@ -230,5 +275,9 @@ void AddFootnoteViewIfNeeded(
     set_should_ignore_snapping(true);                                     \
   }
 
+// undef upstream one first then define it with our one.
+#undef IDS_PERMISSIONS_BUBBLE_PROMPT
+#define IDS_PERMISSIONS_BUBBLE_PROMPT IDS_BRAVE_PERMISSIONS_BUBBLE_PROMPT
 #include "src/chrome/browser/ui/views/permission_bubble/permission_prompt_bubble_view.cc"
 #undef BRAVE_PERMISSION_PROMPT_BUBBLE_VIEW
+#undef IDS_PERMISSIONS_BUBBLE_PROMPT

--- a/common/url_constants.cc
+++ b/common/url_constants.cc
@@ -11,7 +11,6 @@ const char kMagnetScheme[] = "magnet";
 const char kBinanceScheme[] = "com.brave.binance";
 const char kGeminiScheme[] = "com.brave.gemini";
 const char kFTXScheme[] = "com.brave.ftx";
-const char kWidevineMoreInfoURL[] = "https://www.eff.org/issues/drm";
 const char kWidevineTOS[] = "https://policies.google.com/terms";
 const char kRewardsUpholdSupport[] = "https://uphold.com/en/brave/support";
 const char kP3ALearnMoreURL[] = "https://brave.com/P3A";
@@ -28,3 +27,6 @@ const char kSpeedreaderLearnMoreUrl[] =
 const char kWebDiscoveryLearnMoreUrl[] =
     "https://brave.com/browser/privacy/#web-discovery-project";
 const char kBraveSearchUrl[] = "https://search.brave.com/";
+const char kWidevineLearnMoreUrl[] =
+    "https://support.brave.com/hc/en-us/articles/"
+    "360023851591-How-do-I-view-DRM-protected-content-";

--- a/common/url_constants.h
+++ b/common/url_constants.h
@@ -13,7 +13,6 @@ extern const char kMagnetScheme[];
 extern const char kBinanceScheme[];
 extern const char kGeminiScheme[];
 extern const char kFTXScheme[];
-extern const char kWidevineMoreInfoURL[];
 extern const char kWidevineTOS[];
 extern const char kRewardsUpholdSupport[];
 extern const char kP3ALearnMoreURL[];
@@ -24,6 +23,7 @@ extern const char kPermissionPromptLearnMoreUrl[];
 extern const char kSpeedreaderLearnMoreUrl[];
 extern const char kWebDiscoveryLearnMoreUrl[];
 extern const char kBraveSearchUrl[];
+extern const char kWidevineLearnMoreUrl[];
 
 // This is introduced to replace |kDownloadChromeUrl| in
 // outdated_upgrade_bubble_view.cc"


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/9907

Permission bubble for widevine has custom footnote style.

Updated widevine permissions bubble:
<img width="339" alt="Screen Shot 2022-01-14 at 8 04 01 AM" src="https://user-images.githubusercontent.com/6786187/149422719-80721763-ac4c-471e-910d-3e7137782545.png">

Other permissions bubble for comparison:
<img width="338" alt="Screen Shot 2022-01-13 at 12 10 58 PM" src="https://user-images.githubusercontent.com/6786187/149260633-8a07658f-32b7-4edf-a085-235229d26e80.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open https://permission.site/
2. Click "Encrypted Media (EME)"
3. Check new permission pop is displayed
4. Clicking learn more link in bubble will load [learn more](https://support.brave.com/hc/en-us/articles/360023851591-How-do-I-view-DRM-protected-content-) in new tab.
