### PR TITLE
Support external goma client and make MacOS goma-friendly 

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -304,6 +304,16 @@ Config.prototype.buildArgs = function () {
 
   if (!this.isBraveReleaseBuild()) {
     args.chrome_pgo_phase = 0
+
+    if (process.platform === 'darwin' && this.targetOS != 'ios' && args.is_official_build) {
+      // Currently we're using is_official_build mode in PR builds on CI. This enables dSYMs
+      // by default, which slows down link phase, but also disables relocatable compilation
+      // on MacOS (aka 'zero goma cachehits' style).
+      //
+      // Don't create dSYMs in non-public Release builds.
+      // See //build/config/apple/symbols.gni for additional details.
+      args.enable_dsyms = false
+    }
   }
 
   if (this.shouldSign()) {

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -152,6 +152,7 @@ const Config = function () {
   this.gomaServerHost = getNPMConfig(['goma_server_host'])
   // os.cpus().length is number of threads not physical cores
   this.gomaJValue = Math.min(40, os.cpus().length * 2)
+  this.isCI = process.env.BUILD_ID !== undefined
   this.braveStatsApiKey = getNPMConfig(['brave_stats_api_key']) || ''
   this.braveStatsUpdaterUrl = getNPMConfig(['brave_stats_updater_url']) || ''
   this.ignore_compile_failure = false

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -631,6 +631,16 @@ Config.prototype.update = function (options) {
 
   if (options.use_goma) {
     this.use_goma = true
+    if (process.env.GOMA_DIR !== undefined) {
+      this.gomaDir = process.env.GOMA_DIR
+    } else {
+      const build_goma_dir = path.join(this.srcDir, 'build', 'goma')
+      if (fs.existsSync(build_goma_dir)) {
+        this.gomaDir = build_goma_dir
+      } else {
+        this.gomaDir = path.join(this.depotToolsDir, '.cipd_bin')
+      }
+    }
   } else {
     this.use_goma = false
   }
@@ -891,7 +901,7 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
     }
 
     if (this.use_goma && this.gomaServerHost) {
-      env.CC_WRAPPER = path.join(this.depotToolsDir, '.cipd_bin', 'gomacc')
+      env.CC_WRAPPER = path.join(this.gomaDir, 'gomacc')
       env.GOMA_SERVER_HOST = this.gomaServerHost
       // env.NINJA_REMOTE_NUM_JOBS = this.gomaJValue
       // console.log('ninja remote jobs number is ' + env.NINJA_REMOTE_NUM_JOBS)

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const crypto = require('crypto')
 const l10nUtil = require('./l10nUtil')
 const Log = require('./sync/logging')
+const assert = require('assert')
 
 const runGClient = (args, options = {}) => {
   if (config.gClientVerbose) args.push('--verbose')
@@ -578,12 +579,16 @@ const util = {
     ]
 
     if (config.use_goma) {
+      const compiler_proxy_binary = path.join(config.gomaDir, util.appendExeIfWin32('compiler_proxy'))
+      assert(fs.existsSync(compiler_proxy_binary), 'compiler_proxy not found at ' + config.gomaDir)
+      options.env.GOMA_COMPILER_PROXY_BINARY = compiler_proxy_binary
       const gomaLoginInfo = util.runProcess('goma_auth', ['info'], options)
       if (gomaLoginInfo.status !== 0) {
         console.log('Login required for using Goma. This is only needed once')
         util.run('goma_auth', ['login'], options)
       }
       util.run('goma_ctl', ['ensure_start'], options)
+      util.run('goma_ctl', ['update_hook'], options)
       ninjaOpts.push('-j', config.gomaJValue)
     }
 
@@ -754,6 +759,12 @@ const util = {
       }
     })
     return filelist
+  },
+
+  appendExeIfWin32: (input) => {
+    if (process.platform === 'win32')
+      input += '.exe'
+    return input
   }
 }
 

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -593,6 +593,10 @@ const util = {
     }
 
     util.run('autoninja', ninjaOpts, options)
+
+    if (config.isCI && config.use_goma) {
+      util.run('goma_ctl', ['stat'], options)
+    }
   },
 
   generateXcodeWorkspace: (options = config.defaultOptions) => {


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
We've [modified the upstream goma client](https://github.com/brave-experiments/goma-client/tree/main/patches) to fix underlying issues with MacOS framework search logic and now CI will use it during MacOS builds.
This PR adds support for a custom goma client lookup during `npm run build` steps. The search order is:
 1. environment var `GOMA_DIR`
 2. `src/build/goma` dir (this dir is `.gitignore`d in upstream)
 3. `depot_tools/.cipd_bin` dir (the default location)

Also this PR changes the way MacOS non-official Release configuration is built to support relocatable compilation.

Resolves https://github.com/brave/brave-browser/issues/20347

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

