### PR TITLE
Fixes Brave Ads unblinded tokens are not always refilled - 1.35.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/account/account.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/account/account.cc
@@ -240,13 +240,12 @@ void Account::OnDidGetIssuers(const IssuersInfo& issuers) {
     return;
   }
 
-  if (!HasIssuersChanged(issuers)) {
-    return;
+  if (HasIssuersChanged(issuers)) {
+    BLOG(1, "Updated issuers");
+    SetIssuers(issuers);
+  } else {
+    BLOG(1, "Issuers already up to date");
   }
-
-  BLOG(1, "Updated issuers");
-
-  SetIssuers(issuers);
 
   TopUpUnblindedTokens();
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/11842
Resolves https://github.com/brave/brave-browser/issues/20487

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
