### PR TITLE
Fixes Brave Ads dislike icon should be shown based upon the advertiser ID - 1.35.x

### DIFF
--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_history/ads_history.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_history/ads_history.cc
@@ -58,7 +58,7 @@ AdsHistoryInfo Get(const AdsHistoryFilterType filter_type,
 
 void AddAdNotification(const AdNotificationInfo& ad,
                        const ConfirmationType& confirmation_type) {
-  const AdHistoryInfo ad_history =
+  const AdHistoryInfo& ad_history =
       BuildAdHistory(ad, confirmation_type, ad.title, ad.body);
 
   Client::Get()->AppendAdHistory(ad_history);
@@ -66,7 +66,7 @@ void AddAdNotification(const AdNotificationInfo& ad,
 
 void AddNewTabPageAd(const NewTabPageAdInfo& ad,
                      const ConfirmationType& confirmation_type) {
-  const AdHistoryInfo ad_history =
+  const AdHistoryInfo& ad_history =
       BuildAdHistory(ad, confirmation_type, ad.company_name, ad.alt);
 
   Client::Get()->AppendAdHistory(ad_history);
@@ -74,7 +74,7 @@ void AddNewTabPageAd(const NewTabPageAdInfo& ad,
 
 void AddPromotedContentAd(const PromotedContentAdInfo& ad,
                           const ConfirmationType& confirmation_type) {
-  const AdHistoryInfo ad_history =
+  const AdHistoryInfo& ad_history =
       BuildAdHistory(ad, confirmation_type, ad.title, ad.description);
 
   Client::Get()->AppendAdHistory(ad_history);
@@ -82,7 +82,7 @@ void AddPromotedContentAd(const PromotedContentAdInfo& ad,
 
 void AddInlineContentAd(const InlineContentAdInfo& ad,
                         const ConfirmationType& confirmation_type) {
-  const AdHistoryInfo ad_history =
+  const AdHistoryInfo& ad_history =
       BuildAdHistory(ad, confirmation_type, ad.title, ad.description);
 
   Client::Get()->AppendAdHistory(ad_history);

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_history/ads_history_util.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_history/ads_history_util.cc
@@ -33,7 +33,7 @@ AdHistoryInfo BuildAdHistory(const AdInfo& ad,
   ad_history.ad_content.brand_display_url = GetHostFromUrl(ad.target_url);
   ad_history.ad_content.brand_url = ad.target_url;
   ad_history.ad_content.like_action_type =
-      Client::Get()->GetAdContentLikeActionTypeForSegment(ad.segment);
+      Client::Get()->GetAdContentLikeActionTypeForAdvertiser(ad.advertiser_id);
   ad_history.ad_content.confirmation_type = confirmation_type;
   ad_history.category_content.opt_action_type =
       Client::Get()->GetCategoryContentOptActionTypeForSegment(ad.segment);

--- a/vendor/bat-native-ads/src/bat/ads/internal/ads_history/ads_history_util_unittest.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/ads_history/ads_history_util_unittest.cc
@@ -39,7 +39,7 @@ TEST_F(BatAdsAdsHistoryUtilTest, BuildAd) {
   ad.target_url = "https://brave.com";
 
   // Act
-  const AdHistoryInfo ad_history =
+  const AdHistoryInfo& ad_history =
       BuildAdHistory(ad, ConfirmationType::kViewed, "title", "description");
 
   // Assert

--- a/vendor/bat-native-ads/src/bat/ads/internal/client/client.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client/client.cc
@@ -238,10 +238,10 @@ AdContentLikeActionType Client::ToggleAdThumbDown(
   return like_action_type;
 }
 
-AdContentLikeActionType Client::GetAdContentLikeActionTypeForSegment(
-    const std::string& segment) {
+AdContentLikeActionType Client::GetAdContentLikeActionTypeForAdvertiser(
+    const std::string& advertiser_id) {
   for (const auto& element : client_->ads_shown_history) {
-    if (element.category_content.category == segment) {
+    if (element.ad_content.advertiser_id == advertiser_id) {
       return element.ad_content.like_action_type;
     }
   }

--- a/vendor/bat-native-ads/src/bat/ads/internal/client/client.h
+++ b/vendor/bat-native-ads/src/bat/ads/internal/client/client.h
@@ -64,8 +64,8 @@ class Client final {
 
   AdContentLikeActionType ToggleAdThumbUp(const AdContentInfo& ad_content);
   AdContentLikeActionType ToggleAdThumbDown(const AdContentInfo& ad_content);
-  AdContentLikeActionType GetAdContentLikeActionTypeForSegment(
-      const std::string& segment);
+  AdContentLikeActionType GetAdContentLikeActionTypeForAdvertiser(
+      const std::string& advertiser_id);
 
   CategoryContentOptActionType ToggleAdOptIn(
       const std::string& category,

--- a/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/dislike_frequency_cap.cc
+++ b/vendor/bat-native-ads/src/bat/ads/internal/frequency_capping/exclusion_rules/dislike_frequency_cap.cc
@@ -37,7 +37,7 @@ std::string DislikeFrequencyCap::GetLastMessage() const {
 }
 
 bool DislikeFrequencyCap::DoesRespectCap(const CreativeAdInfo& creative_ad) {
-  const FilteredAdvertiserList filtered_advertisers =
+  const FilteredAdvertiserList& filtered_advertisers =
       Client::Get()->GetFilteredAdvertisers();
   if (filtered_advertisers.empty()) {
     return true;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/11855
Resolves https://github.com/brave/brave-browser/issues/20512

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
