### PR TITLE
Support custom notification changes on Android 12.

### DIFF
--- a/browser/notifications/android/java/src/org/chromium/chrome/browser/notifications/BraveAdsNotificationBuilder.java
+++ b/browser/notifications/android/java/src/org/chromium/chrome/browser/notifications/BraveAdsNotificationBuilder.java
@@ -20,6 +20,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Process;
 import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.RemoteViews;
 
@@ -61,6 +62,11 @@ public class BraveAdsNotificationBuilder extends NotificationBuilderBase {
      * down towards 0.
      */
     private static final int MAX_SCALABLE_PADDING_DP = 3;
+
+    /**
+     * The notification body height in compact view mode for Android S.
+     */
+    private static final int COMPACT_BODY_CONTAINER_HEIGHT_S = 40;
 
     /**
      * The amount of padding at the start of the button, either before an icon or before the text.
@@ -138,6 +144,18 @@ public class BraveAdsNotificationBuilder extends NotificationBuilderBase {
             } else {
                 view.setImageViewResource(smallIconId, mSmallIconId);
             }
+        }
+
+        // Support following custom notification changes on Android 12:
+        // - custom notification already contains icon
+        // - the dimensions become less than before.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            compactView.setViewPadding(R.id.title, 0, 0, 0, 0);
+            compactView.setViewPadding(R.id.body_container, 0, 0, 0, 0);
+            compactView.setViewLayoutHeight(R.id.body_container, COMPACT_BODY_CONTAINER_HEIGHT_S,
+                    TypedValue.COMPLEX_UNIT_DIP);
+            compactView.setViewVisibility(R.id.icon_frame, View.GONE);
+            bigView.setViewVisibility(R.id.icon_frame, View.GONE);
         }
 
         // Note: under the hood this is not a NotificationCompat builder so be mindful of the


### PR DESCRIPTION
Support following custom notification changes on Android 12:
- custom notification already contains icon
- the dimensions become less than before.

See: https://developer.android.com/about/versions/12/behavior-changes-12

Notifications appearance on Android 12:
![image](https://user-images.githubusercontent.com/86598290/149736406-08c73a76-5b4e-4411-b053-6b3ed361b148.png)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/19145

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

