### PR TITLE
Reduce build verbosity on macOS

### DIFF
--- a/build/commands/lib/build.js
+++ b/build/commands/lib/build.js
@@ -132,7 +132,11 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
   if (config.xcode_gen_target) {
     util.generateXcodeWorkspace()
   } else {
-    util.buildTarget()
+    util.buildTarget().catch(err => {
+      console.error(err)
+      if (!options.continueOnFail)
+        process.exit(1)
+    })
   }
 }
 

--- a/build/commands/lib/createDist.js
+++ b/build/commands/lib/createDist.js
@@ -26,7 +26,11 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
     }
   }
   config.buildTarget = 'create_dist'
-  util.buildTarget()
+  util.buildTarget().catch(err => {
+    console.error(err)
+    if (!options.continueOnFail)
+      process.exit(1)
+  })
 }
 
 module.exports = createDist

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -649,7 +649,7 @@ const util = {
     }
   },
 
-  buildTarget: (options = config.defaultOptions) => {
+  buildTarget: async (options = config.defaultOptions) => {
     console.log('building ' + config.buildTarget + '...')
 
     if (process.platform === 'win32') {
@@ -678,11 +678,17 @@ const util = {
       ninjaOpts.push('-j', config.gomaJValue)
     }
 
-    // The warnings silenced by the regular expressions below occupy many tens of thousands of lines.
-    const headerRegex = options.verbose ? /.^/ : /in compilation unit/
-    const bodyRegex = options.verbose ? /.^/ : /the DIE at offset 0x[0-9a-f]+ has a DW_AT_specification attribute referring to the DIE at offset 0x[0-9a-f]+, which was not marked as a declaration/
+    if (process.stdout.isTTY || options.verbose)
+      util.run('autoninja', ninjaOpts, options)
+    else {
+      // Silence tens of thousands of unnecessary warnings.
+      const headerRegex = options.verbose ? /.^/ : /in compilation unit/
+      const bodyRegex = options.verbose ? /.^/ : /the DIE at offset 0x[0-9a-f]+ has a DW_AT_specification attribute referring to the DIE at offset 0x[0-9a-f]+, which was not marked as a declaration/
 
-    return util.runFiltered('autoninja', ninjaOpts, options, headerRegex, bodyRegex)
+      return util.runFiltered('autoninja', ninjaOpts, options, headerRegex, bodyRegex)
+    }
+
+
   },
 
   generateXcodeWorkspace: (options = config.defaultOptions) => {

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -678,14 +678,9 @@ const util = {
       ninjaOpts.push('-j', config.gomaJValue)
     }
 
-    if (options.verbose) {
-      const headerRegex = /.^/
-      const bodyRegex = /.^/
-    } else {
-      // The warnings below account for many tens of thousands of lines of build output.
-      const headerRegex = /in compilation unit/
-      const bodyRegex = /the DIE at offset 0x[0-9a-f]+ has a DW_AT_specification attribute referring to the DIE at offset 0x[0-9a-f]+, which was not marked as a declaration/
-    }
+    // The warnings silenced by the regular expressions below occupy many tens of thousands of lines.
+    const headerRegex = options.verbose ? /.^/ : /in compilation unit/
+    const bodyRegex = options.verbose ? /.^/ : /the DIE at offset 0x[0-9a-f]+ has a DW_AT_specification attribute referring to the DIE at offset 0x[0-9a-f]+, which was not marked as a declaration/
 
     return util.runFiltered('autoninja', ninjaOpts, options, headerRegex, bodyRegex)
   },

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -95,7 +95,7 @@ const util = {
   runFiltered: (cmd, args=[], options = {}, header=/.^/, body=/.^/) => {
     Log.command(options.cwd, cmd, args)
     return new Promise((resolve, reject) => {
-      const prog = spawn(cmd, args);
+      const prog = spawn(cmd, args, options.cmdOptions);
       const out = new util.FilteredStream(
         header, body, data => process.stdout.write(data)
       )

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -705,10 +705,10 @@ const util = {
       ninjaOpts.push('-j', config.gomaJValue)
     }
 
-    if (process.stdout.isTTY || options.verbose)
+    if (process.platform !== 'darwin' || process.stdout.isTTY || options.verbose)
       util.run('autoninja', ninjaOpts, options)
     else {
-      // Silence tens of thousands of unnecessary warnings.
+      // Silence tens of thousands of unnecessary warnings on macOS.
       const headerRegex = options.verbose ? /.^/ : /in compilation unit/
       const bodyRegex = options.verbose ? /.^/ : /the DIE at offset 0x[0-9a-f]+ has a DW_AT_specification attribute referring to the DIE at offset 0x[0-9a-f]+, which was not marked as a declaration/
 

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -112,7 +112,7 @@ const util = {
         if (code === 0)
           resolve(code)
         else {
-          const err = new Error(`${cmd} ${args} failed with code ${code}.`)
+          const err = new Error(`${cmd} ${args.join(' ')} failed with code ${code}.`)
           reject(err)
         }
       });
@@ -156,7 +156,7 @@ const util = {
           }
         }
         if (hasFailed) {
-          const err = new Error(`${cmd} ${args} failed with code ${statusCode}.`)
+          const err = new Error(`${cmd} ${args.join(' ')} failed with code ${statusCode}.`)
           err.stderr = stderr
           err.stdout = stdout
           reject(err)

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -93,9 +93,11 @@ const util = {
    * header and headers that are not followed by a body line are not silenced.
    */
   runFiltered: (cmd, args=[], options = {}, header=/.^/, body=/.^/) => {
-    Log.command(options.cwd, cmd, args)
+    const cmdOptions = Object.assign({}, options)
+    cmdOptions.stdio = 'pipe'
+    Log.command(cmdOptions.cwd, cmd, args)
     return new Promise((resolve, reject) => {
-      const prog = spawn(cmd, args, options.cmdOptions);
+      const prog = spawn(cmd, args, cmdOptions);
       const out = new util.FilteredStream(
         header, body, data => process.stdout.write(data)
       )


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/16417.

Silences build log output of the form

```
[2022-01-17T20:51:31.389Z] Brave Browser Nightly Helper (GPU).dSYM/Contents/Resources/DWARF/Brave Browser Nightly Helper (GPU): in compilation unit '../../sandbox/mac/sandbox_logging.cc' (offset 0xbe2b0):
[2022-01-17T20:51:31.389Z] Brave Browser Nightly Helper (GPU).dSYM/Contents/Resources/DWARF/Brave Browser Nightly Helper (GPU): the DIE at offset 0xc2866 has a DW_AT_specification attribute referring to the DIE at offset 0xbe7db, which was not marked as a declaration
[2022-01-17T20:51:31.389Z] Brave Browser Nightly Helper (GPU).dSYM/Contents/Resources/DWARF/Brave Browser Nightly Helper (GPU): the DIE at offset 0xc2884 has a DW_AT_specification attribute referring to the DIE at offset 0xbe7db, which was not marked as a declaration
[2022-01-17T20:51:31.390Z] Brave Browser Nightly Helper (GPU).dSYM/Contents/Resources/DWARF/Brave Browser Nightly Helper (GPU): the DIE at offset 0xc28c1 has a DW_AT_specification attribute referring to the DIE at offset 0xbe84e, which was not marked as a declaration
...
```

This reduces the build output on macOS from 171k lines to 77k. On other platforms, the output does not appear.

I'm adding quite a bit of code so would be especially interested in reviewers' opinions. Also, I did not see an existing place to put unit tests for my changes to the build script. I have included them as a comment.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Only the build process is affected.