### PR TITLE
P3A: Return metric name unhashed to json endpoint.

### DIFF
--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -318,7 +318,7 @@ BraveP3ALogStore::LogForJsonMigration BraveP3AService::Serialize(
   GenerateP3AMessage(histogram_name_hash, value, message_meta_, &message);
 
   base::Value p3a_json_value =
-      GenerateP3AMessageDict(histogram_name_hash, value, message_meta_);
+      GenerateP3AMessageDict(histogram_name, value, message_meta_);
   std::string p3a_json_message;
   const bool ok = base::JSONWriter::Write(p3a_json_value, &p3a_json_message);
   DCHECK(ok);

--- a/components/p3a/p3a_message.cc
+++ b/components/p3a/p3a_message.cc
@@ -67,7 +67,7 @@ void GenerateP3AMessage(uint64_t metric_hash,
   p3a_message->set_p3a_info(data, kDataLength);
 }
 
-base::Value GenerateP3AMessageDict(uint64_t metric_hash,
+base::Value GenerateP3AMessageDict(base::StringPiece metric_name,
                                    uint64_t metric_value,
                                    const MessageMetainfo& meta) {
   base::Value result(base::Value::Type::DICTIONARY);
@@ -92,7 +92,7 @@ base::Value GenerateP3AMessageDict(uint64_t metric_hash,
   result.SetStringKey("refcode", meta.refcode);
 
   // Set the metric
-  result.SetStringKey("metric_hash", base::NumberToString(metric_hash));
+  result.SetStringKey("metric_name", metric_name);
   result.SetIntKey("metric_value", metric_value);
 
   return result;

--- a/components/p3a/p3a_message.h
+++ b/components/p3a/p3a_message.h
@@ -40,7 +40,7 @@ void GenerateP3AMessage(uint64_t metric_hash,
                         const MessageMetainfo& meta,
                         brave_pyxis::RawP3AValue* p3a_message);
 
-base::Value GenerateP3AMessageDict(uint64_t metric_hash,
+base::Value GenerateP3AMessageDict(base::StringPiece metric_name,
                                    uint64_t metric_value,
                                    const MessageMetainfo& meta);
 


### PR DESCRIPTION
Previously we were reporting P3A metrics by the first 8 bytes of
the MD5 hash of their name to reduce bandwidth and generate a more
uniformly-sized message.

When sending reports as json, report the name unobfuscated. This
improves transparency and makes sorting and other processing steps
easier.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves brave/brave-browser#20548

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Launch Brave with a fresh profile; inspect network traffic over at least the first 5-10 minutes.

- Confirm packets to the https://p3a-json.brave.com/ endpoint have a `metric_name` key instead of a `metric_hash` key, and the the corresponding value is human readable string matching the list in the wiki.
- Confirm packets to the https://p3a.brave.com/ and https://p2a.brave.com/ endpoint have a binary hash for the metric id as before, instead of a human-readable string like the json version.