### PR TITLE
Added feature flags for choosing skus environment

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -24,6 +24,8 @@
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/sidebar/buildflags/buildflags.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "brave/components/skus/browser/switches.h"
 #include "brave/components/skus/common/features.h"
 #include "brave/components/speedreader/buildflags.h"
 #include "brave/components/translate/core/common/brave_translate_features.h"
@@ -188,6 +190,12 @@ constexpr char kBraveVPNDescription[] = "Experimental native VPN support";
 
 constexpr char kBraveSkusSdkName[] = "Enable experimental SKU SDK";
 constexpr char kBraveSkusSdkDescription[] = "Experimental SKU SDK support";
+constexpr char kBraveSkusEnvName[] = "Experimental SKU Environment";
+constexpr char kBraveSkusEnvDescription[] =
+    "Choose Experimental SKU Environment";
+constexpr char kBraveSkusProdEnvName[] = "production";
+constexpr char kBraveSkusStagingEnvName[] = "staging";
+constexpr char kBraveSkusDevEnvName[] = "development";
 
 constexpr char kBraveShieldsV2Name[] = "Enable Brave Shields v2";
 constexpr char kBraveShieldsV2Description[] =
@@ -296,6 +304,16 @@ constexpr char kRestrictWebSocketsPoolName[] = "Restrict WebSockets pool";
 constexpr char kRestrictWebSocketsPoolDescription[] =
     "Limits simultaneous active WebSockets connections per eTLD+1";
 
+const flags_ui::FeatureEntry::Choice kBraveSkusEnvChoices[] = {
+    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
+    {flag_descriptions::kBraveSkusProdEnvName, skus::switches::kSkusEnv,
+     skus::kEnvProduction},
+    {flag_descriptions::kBraveSkusStagingEnvName, skus::switches::kSkusEnv,
+     skus::kEnvStaging},
+    {flag_descriptions::kBraveSkusDevEnvName, skus::switches::kSkusEnv,
+     skus::kEnvDevelopment},
+};
+
 }  // namespace
 
 }  // namespace flag_descriptions
@@ -315,12 +333,17 @@ constexpr char kRestrictWebSocketsPoolDescription[] =
 #define BRAVE_VPN_FEATURE_ENTRIES
 #endif
 
-#define BRAVE_SKU_SDK_FEATURE_ENTRIES                  \
-    {"skus-sdk",                                       \
-     flag_descriptions::kBraveSkusSdkName,             \
-     flag_descriptions::kBraveSkusSdkDescription,      \
-     kOsMac | kOsWin | kOsAndroid,                     \
-     FEATURE_VALUE_TYPE(skus::features::kSkusFeature)},
+#define BRAVE_SKU_SDK_FEATURE_ENTRIES                   \
+    {"skus-sdk",                                        \
+     flag_descriptions::kBraveSkusSdkName,              \
+     flag_descriptions::kBraveSkusSdkDescription,       \
+     kOsMac | kOsWin | kOsAndroid,                      \
+     FEATURE_VALUE_TYPE(skus::features::kSkusFeature)}, \
+    {"skus-environment",                                \
+     flag_descriptions::kBraveSkusEnvName,              \
+     flag_descriptions::kBraveSkusEnvDescription,       \
+     kOsMac | kOsWin | kOsAndroid,                      \
+     MULTI_VALUE_TYPE(flag_descriptions::kBraveSkusEnvChoices)},
 
 #if BUILDFLAG(ENABLE_SIDEBAR)
 #define SIDEBAR_FEATURE_ENTRIES                     \

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -155,6 +155,7 @@ brave_chrome_browser_deps = [
   "//brave/components/p3a:buildflags",
   "//brave/components/resources",
   "//brave/components/sidebar/buildflags",
+  "//brave/components/skus/browser",
   "//brave/components/skus/common",
   "//brave/components/speedreader:buildflags",
   "//brave/components/tor/buildflags",


### PR DESCRIPTION
When one of option is selected except default, it's value is passed
via --skus-env command line switch.

fix https://github.com/brave/brave-browser/issues/20557

<img width="775" alt="Screen Shot 2022-01-19 at 4 51 40 PM" src="https://user-images.githubusercontent.com/6786187/150087313-0f605016-7b6e-4435-91a2-1ce62a3d51f0.png">

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch Brave with fresh profile and check `--skus-env` cmd line switch is not used at brave://versions
2. Choose `production` for `Experimental SKU Environment` via brave://flags and relaunch
3. Check `--skus-env=production` switch is set at brave://versions