### PR TITLE
Support external goma client and make MacOS goma-friendly (uplift to 1.35.x)

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const crypto = require('crypto')
 const l10nUtil = require('./l10nUtil')
 const Log = require('./sync/logging')
+const assert = require('assert')
 
 const runGClient = (args, options = {}) => {
   if (config.gClientVerbose) args.push('--verbose')
@@ -570,16 +571,24 @@ const util = {
     ]
 
     if (config.use_goma) {
+      const compiler_proxy_binary = path.join(config.gomaDir, util.appendExeIfWin32('compiler_proxy'))
+      assert(fs.existsSync(compiler_proxy_binary), 'compiler_proxy not found at ' + config.gomaDir)
+      options.env.GOMA_COMPILER_PROXY_BINARY = compiler_proxy_binary
       const gomaLoginInfo = util.runProcess('goma_auth', ['info'], options)
       if (gomaLoginInfo.status !== 0) {
         console.log('Login required for using Goma. This is only needed once')
         util.run('goma_auth', ['login'], options)
       }
       util.run('goma_ctl', ['ensure_start'], options)
+      util.run('goma_ctl', ['update_hook'], options)
       ninjaOpts.push('-j', config.gomaJValue)
     }
 
     util.run('autoninja', ninjaOpts, options)
+
+    if (config.isCI && config.use_goma) {
+      util.run('goma_ctl', ['stat'], options)
+    }
   },
 
   generateXcodeWorkspace: (options = config.defaultOptions) => {
@@ -746,6 +755,12 @@ const util = {
       }
     })
     return filelist
+  },
+
+  appendExeIfWin32: (input) => {
+    if (process.platform === 'win32')
+      input += '.exe'
+    return input
   }
 }
 


### PR DESCRIPTION
Uplift of #11838
Resolves https://github.com/brave/brave-browser/issues/20347

We don't have `isBraveReleaseBuild()` flag in `1.35.x` so I use `!shouldSign()` to disable dSYMs in this branch (PR builds are unsigned). True `Release` builds are signed, in this case dSYMs will be active as intended.

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.