### PR TITLE
Replace duplicate text when password does not match criteria

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/import-meta-mask-or-legacy/index.tsx
@@ -119,24 +119,27 @@ function OnboardingImportMetaMaskOrLegacy (props: Props) {
         </CheckboxRow>
       }
       {!useSamePasswordVerified &&
-        <InputColumn>
-          <PasswordInput
-            placeholder={getLocale('braveWalletCreatePasswordInput')}
-            value={password}
-            onChange={onPasswordChanged}
-            onKeyDown={handleKeyDown}
-            error={getLocale('braveWalletCreatePasswordError')}
-            hasError={hasPasswordError}
-          />
-          <PasswordInput
-            placeholder={getLocale('braveWalletConfirmPasswordInput')}
-            value={confirmedPassword}
-            onChange={onConfirmPasswordChanged}
-            onKeyDown={handleKeyDown}
-            error={getLocale('braveWalletConfirmPasswordError')}
-            hasError={hasConfirmPasswordError}
-          />
-        </InputColumn>
+        <>
+          <Description>{getLocale('braveWalletCreatePasswordDescription')}</Description>
+          <InputColumn>
+            <PasswordInput
+              placeholder={getLocale('braveWalletCreatePasswordInput')}
+              value={password}
+              onChange={onPasswordChanged}
+              onKeyDown={handleKeyDown}
+              error={getLocale('braveWalletCreatePasswordError')}
+              hasError={hasPasswordError}
+            />
+            <PasswordInput
+              placeholder={getLocale('braveWalletConfirmPasswordInput')}
+              value={confirmedPassword}
+              onChange={onConfirmPasswordChanged}
+              onKeyDown={handleKeyDown}
+              error={getLocale('braveWalletConfirmPasswordError')}
+              hasError={hasConfirmPasswordError}
+            />
+          </InputColumn>
+        </>
       }
       <NavButton buttonType='primary' text={getLocale('braveWalletAddAccountImport')} onSubmit={onSubmit} disabled={disabled} />
       {!isMetaMask &&

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/index.tsx
@@ -150,6 +150,7 @@ function OnboardingRestore (props: Props) {
             </Checkbox>
           </CheckboxRow>
           <FormText>{getLocale('braveWalletRestoreFormText')}</FormText>
+          <Description textAlign='left'>{getLocale('braveWalletCreatePasswordDescription')}</Description>
           <InputColumn>
             <PasswordInput
               placeholder={getLocale('braveWalletCreatePasswordInput')}

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/restore/style.ts
@@ -1,5 +1,9 @@
 import styled from 'styled-components'
 
+interface StyleProps {
+  textAlign?: 'left' | 'right' | 'center' | 'justify'
+}
+
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -18,7 +22,7 @@ export const Title = styled.span`
   margin-bottom: 8px;
 `
 
-export const Description = styled.span`
+export const Description = styled.span<StyleProps>`
   display: flex;
   align-items: center;
   font-family: Poppins;
@@ -26,7 +30,7 @@ export const Description = styled.span`
   font-weight: 300;
   color: ${(p) => p.theme.color.text02};
   max-width: 520px;
-  text-align: center;
+  text-align: ${(p) => p.textAlign ? p.textAlign : 'center'};
   margin-bottom: 25px;
 `
 

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -118,7 +118,7 @@ provideStrings({
   braveWalletCreatePasswordDescription: 'Passwords must be at least 7 characters, and contain at least one number and one special character.',
   braveWalletCreatePasswordInput: 'Password',
   braveWalletConfirmPasswordInput: 'Confirm password',
-  braveWalletCreatePasswordError: 'Passwords must be at least 7 characters, and contain at least one number and one special character.',
+  braveWalletCreatePasswordError: 'Password criteria doesn\'t match.',
   braveWalletConfirmPasswordError: 'Passwords do not match',
 
   // Lock Screen

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -110,7 +110,7 @@
   <message name="IDS_BRAVE_WALLET_CREATE_PASSWORD_DESCRIPTION" desc="Create Password screen description">Passwords must be at least 7 characters, and contain at least one number and one special character.</message>
   <message name="IDS_BRAVE_WALLET_CREATE_PASSWORD_INPUT" desc="Create Password screen password input">Password</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_PASSWORD_INPUT" desc="Create Password screen confirm password input">Confirm password</message>
-  <message name="IDS_BRAVE_WALLET_CREATE_PASSWORD_ERROR" desc="Create Password screen password input error">Passwords must be at least 7 characters, and contain at least one number and one special character.</message>
+  <message name="IDS_BRAVE_WALLET_CREATE_PASSWORD_ERROR" desc="Create Password screen password input error">Password criteria doesn't match.</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_PASSWORD_ERROR" desc="Create Password screen confirm password input error">Passwords do not match</message>
   <message name="IDS_BRAVE_WALLET_LOCK_SCREEN_TITLE" desc="Lock screen title">Enter password to unlock wallet</message>
   <message name="IDS_BRAVE_WALLET_LOCK_SCREEN_BUTTON" desc="Lock screen unlock button">Unlock</message>


### PR DESCRIPTION
This PR resolves duplicate text when password does not match criteria by changing the error message to `https://github.com/brave/brave-browser/issues/18715` and adding a the description `Passwords must be at least 7 characters, and contain at least one number and one special character.` in places where it was missing.

Resolves https://github.com/brave/brave-browser/issues/18715

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x
<img width="517" alt="Screenshot 2022-01-20 at 10 41 16" src="https://user-images.githubusercontent.com/48117473/150297077-d69052c2-bd63-48d2-b8e2-52155312a028.png">
<img width="750" alt="Screenshot 2022-01-20 at 10 54 43" src="https://user-images.githubusercontent.com/48117473/150297108-c894ce0d-aa4b-47f3-b92f-15108aeaf7e0.png">
] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

