### PR TITLE
Show seed words in red when they are not selected in order

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
@@ -19,7 +19,8 @@ import { getLocale } from '../../../../../common/locale'
 
 export interface Props {
   onSubmit: () => void
-  recoveryPhrase: RecoveryObject[]
+  shuffledPhrase: RecoveryObject[]
+  recoveryPhrase: string[]
   sortedPhrase: RecoveryObject[]
   selectWord: (word: RecoveryObject) => void
   unSelectWord: (word: RecoveryObject) => void
@@ -27,8 +28,8 @@ export interface Props {
 }
 
 function OnboardingVerify (props: Props) {
-  const { onSubmit, recoveryPhrase, selectWord, unSelectWord, sortedPhrase, hasVerifyError } = props
-
+  const { onSubmit, shuffledPhrase, selectWord, unSelectWord, sortedPhrase, hasVerifyError, recoveryPhrase } = props
+  console.log(shuffledPhrase, recoveryPhrase)
   const addWord = (word: RecoveryObject) => () => {
     selectWord(word)
   }
@@ -38,13 +39,13 @@ function OnboardingVerify (props: Props) {
   }
 
   const isDisabled = React.useMemo((): boolean => {
-    return sortedPhrase.length !== recoveryPhrase.length
-  }, [sortedPhrase, recoveryPhrase])
+    return sortedPhrase.length !== shuffledPhrase.length
+  }, [sortedPhrase, shuffledPhrase])
 
   const numberOfWordRows = React.useMemo((): number => {
     const numberOfWordColumns = 4
-    return Math.ceil(recoveryPhrase.length / numberOfWordColumns)
-  }, [recoveryPhrase])
+    return Math.ceil(shuffledPhrase.length / numberOfWordColumns)
+  }, [shuffledPhrase])
 
   return (
     <StyledWrapper>
@@ -56,7 +57,11 @@ function OnboardingVerify (props: Props) {
             key={word.id}
             onClick={removeWord(word)}
           >
-            <SelectedBubbleText>{index + 1}. {word.value}</SelectedBubbleText>
+            <SelectedBubbleText
+              isInCorrectPosition={recoveryPhrase[index] === word.value}
+            >
+              {index + 1}. {word.value}
+            </SelectedBubbleText>
           </SelectedBubble>
         )}
         {hasVerifyError &&
@@ -66,7 +71,7 @@ function OnboardingVerify (props: Props) {
         }
       </SelectedPhraseContainer>
       <RecoveryPhraseContainer>
-        {recoveryPhrase.map((word) =>
+        {shuffledPhrase.map((word) =>
           <RecoveryBubble
             key={word.id}
             onClick={addWord(word)}

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/index.tsx
@@ -29,7 +29,7 @@ export interface Props {
 
 function OnboardingVerify (props: Props) {
   const { onSubmit, shuffledPhrase, selectWord, unSelectWord, sortedPhrase, hasVerifyError, recoveryPhrase } = props
-  console.log(shuffledPhrase, recoveryPhrase)
+
   const addWord = (word: RecoveryObject) => () => {
     selectWord(word)
   }

--- a/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-onboarding/verify/style.ts
@@ -5,6 +5,7 @@ interface StyleProps {
   isSelected: boolean
   error: boolean
   numberOfRows: number
+  isInCorrectPosition: boolean
 }
 
 const selectedBubbleHeight = 34
@@ -111,12 +112,12 @@ export const SelectedBubble = styled(WalletButton)`
   border-radius: 4px;
 `
 
-export const SelectedBubbleText = styled.span`
+export const SelectedBubbleText = styled.span<Partial<StyleProps>>`
   font-family: Poppins;
   font-size: 14px;
   line-height: 22px;
   font-weight: 600;
-  color: ${(p) => p.theme.color.text01};
+  color: ${(p) => p.isInCorrectPosition ? p.theme.color.text01 : p.theme.color.errorText};
 `
 
 export const ErrorContainer = styled.div`

--- a/components/brave_wallet_ui/stories/screens/backup-wallet.tsx
+++ b/components/brave_wallet_ui/stories/screens/backup-wallet.tsx
@@ -131,7 +131,8 @@ function BackupWallet (props: Props) {
       {backupStep === 2 &&
         <OnboardingVerify
           onSubmit={checkPhrase}
-          recoveryPhrase={shuffledPhrase}
+          shuffledPhrase={shuffledPhrase}
+          recoveryPhrase={recoveryPhrase}
           sortedPhrase={sortedPhrase}
           selectWord={selectWord}
           unSelectWord={unSelectWord}


### PR DESCRIPTION
This PR adds functionality to show seeds word selected by a user during recovery in red if they are in an incorrect position. This provides a better UX to users.

Resolves https://github.com/brave/brave-browser/issues/19736

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

https://user-images.githubusercontent.com/48117473/150353963-a36759c6-c346-4715-8145-4e2840faca7d.mov
