### PR TITLE
Add Brave Wallet P3A telemetry for DefaultWalletSetting and KeyringCreated

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -132,6 +132,7 @@ source_set("unit_tests") {
   testonly = true
   sources = [
     "blockchain_images_source_unittest.cc",
+    "brave_wallet_p3a_unittest.cc",
     "brave_wallet_prefs_unittest.cc",
     "brave_wallet_service_unittest.cc",
     "brave_wallet_tab_helper_unittest.cc",

--- a/browser/brave_wallet/brave_wallet_p3a_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_p3a_unittest.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "base/test/metrics/histogram_tester.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/browser/brave_wallet/keyring_service_factory.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_wallet {
+
+class BraveWalletP3AUnitTest : public testing::Test {
+ public:
+  BraveWalletP3AUnitTest() {
+    histogram_tester_ = std::make_unique<base::HistogramTester>();
+  }
+
+  void SetUp() override {
+    TestingProfile::Builder builder;
+    profile_ = builder.Build();
+    keyring_service_ =
+        KeyringServiceFactory::GetServiceForContext(profile_.get());
+    wallet_service_ =
+        brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
+            profile_.get());
+  }
+  void WaitForResponse() { task_environment_.RunUntilIdle(); }
+
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<TestingProfile> profile_;
+  std::unique_ptr<base::HistogramTester> histogram_tester_;
+  KeyringService* keyring_service_;
+  BraveWalletService* wallet_service_;
+};
+
+TEST_F(BraveWalletP3AUnitTest, DefaultWalletSetting) {
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::BraveWalletPreferExtension), 1);
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::None), 0);
+  wallet_service_->SetDefaultWallet(mojom::DefaultWallet::None);
+  WaitForResponse();
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::None), 1);
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::CryptoWallets), 0);
+  wallet_service_->SetDefaultWallet(mojom::DefaultWallet::CryptoWallets);
+  WaitForResponse();
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::CryptoWallets), 1);
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::BraveWallet), 0);
+  wallet_service_->SetDefaultWallet(mojom::DefaultWallet::BraveWallet);
+  WaitForResponse();
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::BraveWallet), 1);
+  wallet_service_->SetDefaultWallet(
+      mojom::DefaultWallet::BraveWalletPreferExtension);
+  WaitForResponse();
+  histogram_tester_->ExpectBucketCount(
+      "Brave.Wallet.DefaultWalletSetting",
+      static_cast<int>(mojom::DefaultWallet::BraveWalletPreferExtension), 2);
+}
+
+TEST_F(BraveWalletP3AUnitTest, KeyringCreated) {
+  histogram_tester_->ExpectBucketCount("Brave.Wallet.KeyringCreated", 0, 1);
+  keyring_service_->CreateWallet("testing123", base::DoNothing());
+  WaitForResponse();
+  histogram_tester_->ExpectBucketCount("Brave.Wallet.KeyringCreated", 1, 1);
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -16,6 +16,8 @@ static_library("browser") {
     "blockchain_registry.h",
     "brave_wallet_constants.cc",
     "brave_wallet_constants.h",
+    "brave_wallet_p3a.cc",
+    "brave_wallet_p3a.h",
     "brave_wallet_prefs.cc",
     "brave_wallet_prefs.h",
     "brave_wallet_provider_delegate.h",

--- a/components/brave_wallet/browser/brave_wallet_p3a.cc
+++ b/components/brave_wallet/browser/brave_wallet_p3a.cc
@@ -1,0 +1,68 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_wallet/browser/brave_wallet_p3a.h"
+
+#include "base/metrics/histogram_macros.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/browser/keyring_service.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_wallet {
+
+// Has the Wallet keyring been created?
+// i) No, ii) Yes
+void RecordKeyringCreated(mojom::KeyringInfoPtr keyring_info) {
+  UMA_HISTOGRAM_BOOLEAN(
+      "Brave.Wallet.KeyringCreated",
+      static_cast<int>(keyring_info->is_default_keyring_created));
+}
+
+// What is the DefaultWalletSetting?
+// i) AskDeprecated, ii) None, ii) CryptoWallets,
+// iv) BraveWalletPreferExtension, v) BraveWallet
+void RecordDefaultWalletSetting(PrefService* pref_service) {
+  const int max_bucket =
+      static_cast<int>(brave_wallet::mojom::DefaultWallet::kMaxValue);
+  auto default_wallet = pref_service->GetInteger(kDefaultWallet2);
+  UMA_HISTOGRAM_EXACT_LINEAR("Brave.Wallet.DefaultWalletSetting",
+                             default_wallet, max_bucket);
+}
+
+BraveWalletP3A::BraveWalletP3A(BraveWalletService* wallet_service,
+                               KeyringService* keyring_service,
+                               PrefService* pref_service)
+    : wallet_service_(wallet_service),
+      keyring_service_(keyring_service),
+      pref_service_(pref_service) {
+  RecordInitialBraveWalletP3AState();
+  wallet_service_->AddObserver(
+      wallet_service_observer_receiver_.BindNewPipeAndPassRemote());
+  keyring_service_->AddObserver(
+      keyring_service_observer_receiver_.BindNewPipeAndPassRemote());
+}
+
+BraveWalletP3A::~BraveWalletP3A() = default;
+
+void BraveWalletP3A::RecordInitialBraveWalletP3AState() {
+  keyring_service_->GetKeyringInfo(mojom::kDefaultKeyringId,
+                                   base::BindOnce(&RecordKeyringCreated));
+  RecordDefaultWalletSetting(pref_service_);
+}
+
+// KeyringServiceObserver
+void BraveWalletP3A::KeyringCreated() {
+  keyring_service_->GetKeyringInfo(mojom::kDefaultKeyringId,
+                                   base::BindOnce(&RecordKeyringCreated));
+}
+
+// BraveWalletServiceObserver
+void BraveWalletP3A::OnDefaultWalletChanged(
+    brave_wallet::mojom::DefaultWallet default_wallet) {
+  RecordDefaultWalletSetting(pref_service_);
+}
+
+}  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_p3a.h
+++ b/components/brave_wallet/browser/brave_wallet_p3a.h
@@ -1,0 +1,68 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_P3A_H_
+#define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_P3A_H_
+
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+
+class PrefService;
+
+namespace brave_wallet {
+
+class BraveWalletService;
+class KeyringService;
+
+// Reports BraveWallet related P3A data
+class BraveWalletP3A : public mojom::BraveWalletServiceObserver,
+                       public mojom::KeyringServiceObserver {
+ public:
+  BraveWalletP3A(BraveWalletService* wallet_service,
+                 KeyringService* keyring_service,
+                 PrefService* pref_service);
+
+  ~BraveWalletP3A() override;
+  BraveWalletP3A(const BraveWalletP3A&) = delete;
+  BraveWalletP3A& operator=(BraveWalletP3A&) = delete;
+
+  // KeyringServiceObserver
+  void KeyringCreated() override;
+  void KeyringRestored() override {}
+  void KeyringReset() override {}
+  void Locked() override {}
+  void Unlocked() override {}
+  void BackedUp() override {}
+  void AccountsChanged() override {}
+  void AutoLockMinutesChanged() override {}
+  void SelectedAccountChanged() override {}
+
+  // BraveWalletServiceObserver
+  void OnActiveOriginChanged(const std::string& origin) override {}
+  void OnDefaultWalletChanged(
+      brave_wallet::mojom::DefaultWallet wallet) override;
+  void OnDefaultBaseCurrencyChanged(const std::string& currency) override {}
+  void OnDefaultBaseCryptocurrencyChanged(
+      const std::string& cryptocurrency) override {}
+  void OnNetworkListChanged() override {}
+
+ private:
+  void RecordInitialBraveWalletP3AState();
+  raw_ptr<BraveWalletService> wallet_service_;
+  raw_ptr<KeyringService> keyring_service_;
+  raw_ptr<PrefService> pref_service_;
+
+  mojo::Receiver<brave_wallet::mojom::BraveWalletServiceObserver>
+      wallet_service_observer_receiver_{this};
+  mojo::Receiver<brave_wallet::mojom::KeyringServiceObserver>
+      keyring_service_observer_receiver_{this};
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_P3A_H_

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -120,6 +120,7 @@ BraveWalletService::BraveWalletService(
       json_rpc_service_(json_rpc_service),
       eth_tx_service_(eth_tx_service),
       prefs_(prefs),
+      brave_wallet_p3a_(this, keyring_service, prefs),
       weak_ptr_factory_(this) {
   if (delegate_)
     delegate_->AddObserver(this);

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -15,6 +15,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_p3a.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -191,6 +192,7 @@ class BraveWalletService : public KeyedService,
   raw_ptr<JsonRpcService> json_rpc_service_ = nullptr;
   raw_ptr<EthTxService> eth_tx_service_ = nullptr;
   raw_ptr<PrefService> prefs_ = nullptr;
+  BraveWalletP3A brave_wallet_p3a_;
   mojo::ReceiverSet<mojom::BraveWalletService> receivers_;
   PrefChangeRegistrar pref_change_registrar_;
   base::RepeatingTimer p3a_periodic_timer_;

--- a/components/p3a/brave_p3a_service.cc
+++ b/components/p3a/brave_p3a_service.cc
@@ -100,6 +100,8 @@ constexpr const char* kCollectedHistograms[] = {
     "Brave.Sync.Status.2",
     "Brave.Sync.ProgressTokenEverReset",
     "Brave.Uptime.BrowserOpenMinutes",
+    "Brave.Wallet.DefaultWalletSetting",
+    "Brave.Wallet.KeyringCreated",
     "Brave.Wallet.UsageDaily",
     "Brave.Wallet.UsageWeekly",
     "Brave.Wallet.UsageMonthly",


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/20383. Supersedes https://github.com/brave/brave-core/pull/11899.
Security / privacy review: https://github.com/brave/security/issues/723.

Implements two new P3A histograms for the Brave Wallet, loosely modeled after the IpfsP3A implementation.

* Brave.Wallet.DefaultWalletSetting
* Brave.Wallet.KeyringCreated

The pull request adds a `BraveWalletP3A` class that implements the `BraveWalletServiceObserver` for detecting when the `DefaultWalletSetting` has changed and the `KeyringServerObserver` for detecting when a Keyring is created.

`BraveWalletP3A::RecordInitialBraveWalletP3AState` is called in the `BraveWalletP3A` constructor, which fetches the current value of DefaultWalletSetting and KeyringCreated from the prefs service and keyring service respectively, and adds them to the histograms. When `OnDefaultWalletSetting` and `KeyringCreated` are called on the service observers, `BraveWalletP3A` fetches the updated values from the same place.

Todo
~~- [ ] Move existing wallet p3a code in BraveWalletService to BraveWalletP3A (edit: may leave this for a follow up pull request)~~ out of scope
- [x] Complete privacy review in #p3a
- [x] Add tests
- [x] Write test plan

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create new profile, verify that  Brave.Wallet.DefaultWalletSetting and Brave.Wallet.KeyringCreated are not present in brave://histograms
1. Create a wallet, refresh brave://histograms and verify Brave.Wallet.KeyringCreated and Brave.Wallet.DefaultWalletSetting are set appropriately.
1. In brave://settings, change the default wallet and verify that the Brave.Wallet.DefaultWalletSetting in brave://histograms reflects the updated setting
