### PR TITLE
Add chain validation to wallet_addEthereumChain api call

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment;
 
 import org.chromium.brave_wallet.mojom.EthereumChain;
 import org.chromium.brave_wallet.mojom.JsonRpcService;
+import org.chromium.brave_wallet.mojom.ProviderError;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.crypto_wallet.JsonRpcServiceFactory;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
@@ -282,8 +283,8 @@ public class BraveWalletAddNetworksFragment extends Fragment implements Connecti
 
     private void addEthereumChain(EthereumChain chain) {
         assert mJsonRpcService != null;
-        mJsonRpcService.addEthereumChain(chain, (chainId, accepted) -> {
-            if (!accepted) {
+        mJsonRpcService.addEthereumChain(chain, (chainId, error, errorMessage) -> {
+            if (error != ProviderError.SUCCESS) {
                 return;
             }
             Intent intent = new Intent();

--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -662,10 +662,11 @@ TEST_F(BraveWalletProviderImplUnitTest, OnAddEthereumChain) {
       base::BindLambdaForTesting([&run_loop](mojom::ProviderError error,
                                              const std::string& error_message) {
         EXPECT_EQ(error, mojom::ProviderError::kUserRejectedRequest);
-        ASSERT_FALSE(error_message.empty());
+        EXPECT_EQ(error_message, "test");
         run_loop.Quit();
       }));
-  provider()->OnAddEthereumChain("0x111", false, std::string());
+  provider()->OnAddEthereumChain(
+      "0x111", mojom::ProviderError::kUserRejectedRequest, "test");
   run_loop.Run();
 
   provider()->AddEthereumChain(
@@ -680,7 +681,8 @@ TEST_F(BraveWalletProviderImplUnitTest, OnAddEthereumChain) {
         EXPECT_EQ(error_message, "response");
         run_loop.Quit();
       }));
-  provider()->OnAddEthereumChain("0x111", false, "response");
+  provider()->OnAddEthereumChain(
+      "0x111", mojom::ProviderError::kUserRejectedRequest, "response");
 }
 
 TEST_F(BraveWalletProviderImplUnitTest,

--- a/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_provider_impl_unittest.cc
@@ -665,8 +665,22 @@ TEST_F(BraveWalletProviderImplUnitTest, OnAddEthereumChain) {
         ASSERT_FALSE(error_message.empty());
         run_loop.Quit();
       }));
-  provider()->OnAddEthereumChain("0x111", false);
+  provider()->OnAddEthereumChain("0x111", false, std::string());
   run_loop.Run();
+
+  provider()->AddEthereumChain(
+      R"({"params": [{
+        "chainId": "0x111",
+        "chainName": "Binance1 Smart Chain",
+        "rpcUrls": ["https://bsc-dataseed.binance.org/"],
+      },]})",
+      base::BindLambdaForTesting([&run_loop](mojom::ProviderError error,
+                                             const std::string& error_message) {
+        EXPECT_EQ(error, mojom::ProviderError::kUserRejectedRequest);
+        EXPECT_EQ(error_message, "response");
+        run_loop.Quit();
+      }));
+  provider()->OnAddEthereumChain("0x111", false, "response");
 }
 
 TEST_F(BraveWalletProviderImplUnitTest,

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -147,15 +147,20 @@ void BraveWalletProviderImpl::AddEthereumChain(
                      weak_factory_.GetWeakPtr()));
 }
 
-void BraveWalletProviderImpl::OnAddEthereumChain(const std::string& chain_id,
-                                                 bool accepted) {
+void BraveWalletProviderImpl::OnAddEthereumChain(
+    const std::string& chain_id,
+    bool accepted,
+    const std::string& error_message) {
   DCHECK(delegate_);
   if (!chain_callbacks_.contains(chain_id))
     return;
   if (!accepted) {
+    auto message =
+        error_message.empty()
+            ? l10n_util::GetStringUTF8(IDS_WALLET_ALREADY_IN_PROGRESS_ERROR)
+            : error_message;
     std::move(chain_callbacks_[chain_id])
-        .Run(mojom::ProviderError::kUserRejectedRequest,
-             l10n_util::GetStringUTF8(IDS_WALLET_ALREADY_IN_PROGRESS_ERROR));
+        .Run(mojom::ProviderError::kUserRejectedRequest, message);
 
     chain_callbacks_.erase(chain_id);
     return;

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.cc
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.cc
@@ -149,19 +149,13 @@ void BraveWalletProviderImpl::AddEthereumChain(
 
 void BraveWalletProviderImpl::OnAddEthereumChain(
     const std::string& chain_id,
-    bool accepted,
+    mojom::ProviderError error,
     const std::string& error_message) {
   DCHECK(delegate_);
   if (!chain_callbacks_.contains(chain_id))
     return;
-  if (!accepted) {
-    auto message =
-        error_message.empty()
-            ? l10n_util::GetStringUTF8(IDS_WALLET_ALREADY_IN_PROGRESS_ERROR)
-            : error_message;
-    std::move(chain_callbacks_[chain_id])
-        .Run(mojom::ProviderError::kUserRejectedRequest, message);
-
+  if (error != mojom::ProviderError::kSuccess) {
+    std::move(chain_callbacks_[chain_id]).Run(error, error_message);
     chain_callbacks_.erase(chain_id);
     return;
   }

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -121,7 +121,9 @@ class BraveWalletProviderImpl final
   void OnUnapprovedTxUpdated(mojom::TransactionInfoPtr tx_info) override {}
   void OnTransactionStatusChanged(mojom::TransactionInfoPtr tx_info) override;
 
-  void OnAddEthereumChain(const std::string& chain_id, bool accepted);
+  void OnAddEthereumChain(const std::string& chain_id,
+                          bool accepted,
+                          const std::string& error_message);
 
   void OnChainApprovalResult(const std::string& chain_id,
                              const std::string& error);

--- a/components/brave_wallet/browser/brave_wallet_provider_impl.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_impl.h
@@ -122,7 +122,7 @@ class BraveWalletProviderImpl final
   void OnTransactionStatusChanged(mojom::TransactionInfoPtr tx_info) override;
 
   void OnAddEthereumChain(const std::string& chain_id,
-                          bool accepted,
+                          mojom::ProviderError error,
                           const std::string& error_message);
 
   void OnChainApprovalResult(const std::string& chain_id,

--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -34,6 +34,10 @@ std::string net_peerCount() {
   return GetJsonRpcNoParams("net_peerCount");
 }
 
+std::string eth_chainId() {
+  return GetJsonRpcNoParams("eth_chainId");
+}
+
 std::string eth_protocolVersion() {
   return GetJsonRpcNoParams("eth_protocolVersion");
 }

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -23,6 +23,8 @@ std::string net_version();
 std::string net_listening();
 // Returns number of peers currently connected to the client.
 std::string net_peerCount();
+// Request chainId for a network.
+std::string eth_chainId();
 // Returns the current ethereum protocol version.
 std::string eth_protocolVersion();
 // Returns an object with data about the sync status or false.

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -206,7 +206,13 @@ void JsonRpcService::OnEthChainIdValidated(
     const std::string& response,
     const base::flat_map<std::string, std::string>& headers) {
   std::string result;
-  ParseSingleStringResult(response, &result);
+  if (!ParseSingleStringResult(response, &result)) {
+    std::move(callback).Run(
+        chain->chain_id, false,
+        l10n_util::GetStringFUTF8(IDS_BRAVE_WALLET_ETH_CHAIN_ID_FAILED,
+                                  base::ASCIIToUTF16(chain->rpc_urls.front())));
+    return;
+  }
   if (result != chain->chain_id) {
     std::move(callback).Run(
         chain->chain_id, false,

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -9,6 +9,7 @@
 
 #include "base/bind.h"
 #include "base/environment.h"
+#include "base/json/json_writer.h"
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
@@ -182,18 +183,41 @@ void JsonRpcService::AddEthereumChain(mojom::EthereumChainPtr chain,
 void JsonRpcService::AddEthereumChainForOrigin(
     mojom::EthereumChainPtr chain,
     const GURL& origin,
-    AddEthereumChainCallback callback) {
+    AddEthereumChainForOriginCallback callback) {
   DCHECK_EQ(origin, url::Origin::Create(origin).GetURL());
   if (!origin.is_valid() ||
       add_chain_pending_requests_.contains(chain->chain_id) ||
       HasRequestFromOrigin(origin)) {
-    std::move(callback).Run(chain->chain_id, false);
+    std::move(callback).Run(chain->chain_id, false, std::string());
+    return;
+  }
+  RequestInternal(
+      eth::eth_chainId(), true, GURL(chain->rpc_urls.front()),
+      base::BindOnce(&JsonRpcService::OnEthChainIdValidated,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(chain), origin,
+                     std::move(callback)));
+}
+
+void JsonRpcService::OnEthChainIdValidated(
+    mojom::EthereumChainPtr chain,
+    const GURL& origin,
+    AddEthereumChainForOriginCallback callback,
+    const int http_code,
+    const std::string& response,
+    const base::flat_map<std::string, std::string>& headers) {
+  std::string result;
+  ParseSingleStringResult(response, &result);
+  if (result != chain->chain_id) {
+    std::move(callback).Run(
+        chain->chain_id, false,
+        l10n_util::GetStringFUTF8(IDS_BRAVE_WALLET_ETH_CHAIN_ID_FAILED,
+                                  base::ASCIIToUTF16(chain->rpc_urls.front())));
     return;
   }
   auto chain_id = chain->chain_id;
   add_chain_pending_requests_[chain_id] =
       EthereumChainRequest(origin, std::move(*chain));
-  std::move(callback).Run(chain_id, true);
+  std::move(callback).Run(chain_id, true, std::string());
 }
 
 void JsonRpcService::AddEthereumChainRequestCompleted(
@@ -205,6 +229,7 @@ void JsonRpcService::AddEthereumChainRequestCompleted(
     AddCustomNetwork(prefs_,
                      add_chain_pending_requests_.at(chain_id).request.Clone());
   }
+
   std::string error =
       approved ? std::string()
                : l10n_util::GetStringUTF8(IDS_WALLET_USER_REJECTED_REQUEST);
@@ -410,7 +435,6 @@ void JsonRpcService::OnFilGetBalance(
     const int status,
     const std::string& body,
     const base::flat_map<std::string, std::string>& headers) {
-  DLOG(ERROR) << "status:" << status << " body:" << body;
   if (status < 200 || status > 299) {
     std::move(callback).Run(
         "", mojom::ProviderError::kInternalError,

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -129,9 +129,10 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
   void GetNetwork(GetNetworkCallback callback) override;
   void AddEthereumChain(mojom::EthereumChainPtr chain,
                         AddEthereumChainCallback callback) override;
-  void AddEthereumChainForOrigin(mojom::EthereumChainPtr chain,
-                                 const GURL& origin,
-                                 AddEthereumChainCallback callback) override;
+  void AddEthereumChainForOrigin(
+      mojom::EthereumChainPtr chain,
+      const GURL& origin,
+      AddEthereumChainForOriginCallback callback) override;
   void AddEthereumChainRequestCompleted(const std::string& chain_id,
                                         bool approved) override;
   void RemoveEthereumChain(const std::string& chain_id,
@@ -341,6 +342,13 @@ class JsonRpcService : public KeyedService, public mojom::JsonRpcService {
                        bool auto_retry_on_network_change,
                        const GURL& network_url,
                        RequestCallback callback);
+  void OnEthChainIdValidated(
+      mojom::EthereumChainPtr chain,
+      const GURL& origin,
+      AddEthereumChainForOriginCallback callback,
+      const int http_code,
+      const std::string& response,
+      const base::flat_map<std::string, std::string>& headers);
 
   FRIEND_TEST_ALL_PREFIXES(JsonRpcServiceUnitTest, IsValidDomain);
   FRIEND_TEST_ALL_PREFIXES(JsonRpcServiceUnitTest, Reset);

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -591,8 +591,8 @@ struct SwitchChainRequest {
 // network.
 interface JsonRpcService {
   // Checks the chain ID for an ethereum chain that should be added
-  AddEthereumChain(EthereumChain chain) => (string chain_id, bool accepted);
-  AddEthereumChainForOrigin(EthereumChain chain, url.mojom.Url origin) => (string chain_id, bool accepted, string error_message);
+  AddEthereumChain(EthereumChain chain) => (string chain_id, ProviderError error, string error_message);
+  AddEthereumChainForOrigin(EthereumChain chain, url.mojom.Url origin) => (string chain_id, ProviderError error, string error_message);
   AddEthereumChainRequestCompleted(string chain_id, bool approved);
   RemoveEthereumChain(string chain_id) => (bool success);
   GetPendingChainRequests() => (array<EthereumChain> networks);

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -592,7 +592,7 @@ struct SwitchChainRequest {
 interface JsonRpcService {
   // Checks the chain ID for an ethereum chain that should be added
   AddEthereumChain(EthereumChain chain) => (string chain_id, bool accepted);
-  AddEthereumChainForOrigin(EthereumChain chain, url.mojom.Url origin) => (string chain_id, bool accepted);
+  AddEthereumChainForOrigin(EthereumChain chain, url.mojom.Url origin) => (string chain_id, bool accepted, string error_message);
   AddEthereumChainRequestCompleted(string chain_id, bool approved);
   RemoveEthereumChain(string chain_id) => (bool success);
   GetPendingChainRequests() => (array<EthereumChain> networks);

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -396,4 +396,5 @@
   <message name="IDS_BRAVE_WALLET_NFT_DETAIL_BLOCKCHAIN" desc="NFT detail screen blockchain category">Blockchain</message>
   <message name="IDS_BRAVE_WALLET_NFT_DETAIL_TOKEN_STANDARD" desc="NFT detail screen token standard category">Token standard</message>
   <message name="IDS_BRAVE_WALLET_NFT_DETAIL_TOKEN_ID" desc="NFT detail screen token id category">Token ID</message>
+  <message name="IDS_BRAVE_WALLET_ETH_CHAIN_ID_FAILED" desc="The error message when request for method 'eth_chainId' on custom network url failed">Request for method 'eth_chainId' on <ph name="URL">$1<ex>https://some.network/rpc/</ex></ph> failed</message>
 </grit-part>

--- a/test/data/brave-wallet/brave_wallet_ethereum_chain.html
+++ b/test/data/brave-wallet/brave_wallet_ethereum_chain.html
@@ -6,7 +6,7 @@
   var chain_added_result = false;
   const url = new URL(window.location.href)
   const id = url.searchParams.get('id');
-
+  const rpc = url.searchParams.get('rpc');
   const data = [{
                      chainId: id ? id : '0x38',
                      chainName: 'Binance1 Smart Chain',
@@ -15,17 +15,19 @@
                          symbol: 'BNB',
                          decimals: 18
                      },
-                     rpcUrls: ['https://bsc-dataseed.binance.org/'],
+                     rpcUrls: [rpc ? decodeURIComponent(rpc) : 'https://bsc-dataseed.binance.org/'],
                      iconUrls: [],
                      blockExplorerUrls: ['https://bscscan.com/'],
                  }]
   window.ethereum.request(
       { method: 'wallet_addEthereumChain', params:data }).then(result => {
+        console.log(result)
         request_finished = true;
         chain_added_result = result === null
       }).catch(error => {
+        console.log(error)
         request_finished = true;
-        chain_added_result = result.code != 4001
+        chain_added_result = error.code != 4001
       })
 </script></head>
 <body></body>


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/17640

When a page does a call to add a new network we call eh_chainId and compare it with the first rpc url in the list because this url will be used for this network by default. If it respond same chain id we add this network, otherwise return error to a page.
Same was as it mentioned in spec https://eips.ethereum.org/EIPS/eip-3085
```
The wallet SHOULD compare the specified chainId value with the eth_chainId return value from the endpoint
```

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- call wallet_addEthereumChain with chainId that is not used in rpc network