### PR TITLE
Sync seed additional checks

### DIFF
--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -115,12 +115,16 @@ group("constants") {
 source_set("unit_tests") {
   testonly = true
   sources = [
+    "//brave/components/brave_sync/brave_sync_prefs_unittest.cc",
     "//brave/components/brave_sync/qr_code_data_unittest.cc",
     "//brave/components/brave_sync/qr_code_validator_unittest.cc",
   ]
 
   deps = [
+    ":prefs",
     ":qr_code_data",
     "//base/test:test_support",
+    "//components/os_crypt:test_support",
+    "//components/prefs:test_support",
   ]
 }

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -102,7 +102,9 @@ std::string Prefs::GetSeedPath() {
   return kSyncV2Seed;
 }
 
-std::string Prefs::GetSeed() const {
+std::string Prefs::GetSeed(bool* failed_to_decrypt) const {
+  if (failed_to_decrypt)
+    *failed_to_decrypt = false;
   const std::string encoded_seed = pref_service_->GetString(kSyncV2Seed);
   std::string encrypted_seed;
   if (!base::Base64Decode(encoded_seed, &encrypted_seed)) {
@@ -112,6 +114,8 @@ std::string Prefs::GetSeed() const {
   std::string seed;
   if (!OSCrypt::DecryptString(encrypted_seed, &seed)) {
     LOG(ERROR) << "Decrypt sync seed failure";
+    if (failed_to_decrypt)
+      *failed_to_decrypt = true;
     return std::string();
   }
   return seed;

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -104,20 +104,29 @@ std::string Prefs::GetSeedPath() {
 
 std::string Prefs::GetSeed(bool* failed_to_decrypt) const {
   if (failed_to_decrypt)
-    *failed_to_decrypt = false;
+    *failed_to_decrypt = true;
+
   const std::string encoded_seed = pref_service_->GetString(kSyncV2Seed);
+  if (encoded_seed.empty()) {
+    if (failed_to_decrypt)
+      *failed_to_decrypt = false;
+    return std::string();
+  }
+
   std::string encrypted_seed;
   if (!base::Base64Decode(encoded_seed, &encrypted_seed)) {
     LOG(ERROR) << "base64 decode sync seed failure";
     return std::string();
   }
+
   std::string seed;
   if (!OSCrypt::DecryptString(encrypted_seed, &seed)) {
     LOG(ERROR) << "Decrypt sync seed failure";
-    if (failed_to_decrypt)
-      *failed_to_decrypt = true;
     return std::string();
   }
+
+  if (failed_to_decrypt)
+    *failed_to_decrypt = false;
   return seed;
 }
 

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -103,13 +103,12 @@ std::string Prefs::GetSeedPath() {
 }
 
 std::string Prefs::GetSeed(bool* failed_to_decrypt) const {
-  if (failed_to_decrypt)
-    *failed_to_decrypt = true;
+  CHECK(failed_to_decrypt);
+  *failed_to_decrypt = true;
 
   const std::string encoded_seed = pref_service_->GetString(kSyncV2Seed);
   if (encoded_seed.empty()) {
-    if (failed_to_decrypt)
-      *failed_to_decrypt = false;
+    *failed_to_decrypt = false;
     return std::string();
   }
 
@@ -125,8 +124,7 @@ std::string Prefs::GetSeed(bool* failed_to_decrypt) const {
     return std::string();
   }
 
-  if (failed_to_decrypt)
-    *failed_to_decrypt = false;
+  *failed_to_decrypt = false;
   return seed;
 }
 

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -32,7 +32,7 @@ class Prefs {
 
   static std::string GetSeedPath();
 
-  std::string GetSeed() const;
+  std::string GetSeed(bool* failed_to_decrypt) const;
   bool SetSeed(const std::string& seed);
 
   bool IsSyncV1Migrated() const;

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -9,6 +9,7 @@
 
 #include "base/base64.h"
 #include "base/logging.h"
+#include "base/test/gtest_util.h"
 #include "base/test/task_environment.h"
 #include "components/os_crypt/os_crypt_mocker.h"
 #include "components/prefs/testing_pref_service.h"
@@ -94,6 +95,11 @@ TEST_F(BraveSyncPrefsTest, FailedToDecryptBraveSeedValue) {
   EXPECT_TRUE(failed_to_decrypt);
 
   OSCryptMocker::TearDown();
+}
+
+using BraveSyncPrefsDeathTest = BraveSyncPrefsTest;
+TEST_F(BraveSyncPrefsDeathTest, GetSeedOutNullptrCHECK) {
+  EXPECT_CHECK_DEATH(brave_sync_prefs()->GetSeed(nullptr));
 }
 
 }  // namespace brave_sync

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -1,0 +1,99 @@
+/* Copyright 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_sync/brave_sync_prefs.h"
+
+#include <memory>
+
+#include "base/base64.h"
+#include "base/logging.h"
+#include "base/test/task_environment.h"
+#include "components/os_crypt/os_crypt_mocker.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_sync {
+
+namespace {
+
+const char kValidSyncCode[] =
+    "fringe digital begin feed equal output proof cheap "
+    "exotic ill sure question trial squirrel glove celery "
+    "awkward push jelly logic broccoli almost grocery drift";
+
+}  // namespace
+
+class BraveSyncPrefsTest : public testing::Test {
+ protected:
+  BraveSyncPrefsTest() {
+    brave_sync::Prefs::RegisterProfilePrefs(pref_service_.registry());
+    brave_sync_prefs_ = std::make_unique<brave_sync::Prefs>(&pref_service_);
+  }
+
+  brave_sync::Prefs* brave_sync_prefs() { return brave_sync_prefs_.get(); }
+
+  PrefService* pref_service() { return &pref_service_; }
+
+  base::test::SingleThreadTaskEnvironment task_environment_;
+  TestingPrefServiceSimple pref_service_;
+  std::unique_ptr<brave_sync::Prefs> brave_sync_prefs_;
+};
+
+#if defined(OS_APPLE)
+
+// On macOS expected to see decryption failure when reading seed on
+// locked keyring
+TEST_F(BraveSyncPrefsTest, ValidPassphraseKeyringLocked) {
+  OSCryptMocker::SetUp();
+
+  brave_sync_prefs()->SetSeed(kValidSyncCode);
+
+  bool failed_to_decrypt = false;
+  OSCryptMocker::SetBackendLocked(true);
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
+  EXPECT_TRUE(failed_to_decrypt);
+
+  OSCryptMocker::TearDown();
+}
+
+#endif  // defined(OS_APPLE)
+
+TEST_F(BraveSyncPrefsTest, FailedToDecryptBraveSeedValue) {
+  OSCryptMocker::SetUp();
+
+  // Empty seed is expected as valid when sync is not turned on
+  bool failed_to_decrypt = false;
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
+  EXPECT_FALSE(failed_to_decrypt);
+
+  // Valid code does not set failed_to_decrypt
+  brave_sync_prefs()->SetSeed(kValidSyncCode);
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), kValidSyncCode);
+  EXPECT_FALSE(failed_to_decrypt);
+
+  // Wrong base64-encoded seed must set failed_to_decrypt to true
+  const char kWrongBase64String[] = "AA%BB";
+  std::string base64_decoded;
+  EXPECT_FALSE(base::Base64Decode(kWrongBase64String, &base64_decoded));
+  pref_service()->SetString(brave_sync::Prefs::GetSeedPath(),
+                            kWrongBase64String);
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
+  EXPECT_TRUE(failed_to_decrypt);
+
+  // Valid base64 string but not valid encrypted string must set
+  // failed_to_decrypt to true. Note: "v10" prefix is important to make
+  // DecryptString fail. Also the remaining string must be 12 or more bytes.
+  std::string valid_base64_string;
+  base::Base64Encode("v10_AABBCCDDEEFF", &valid_base64_string);
+  pref_service()->SetString(brave_sync::Prefs::GetSeedPath(),
+                            valid_base64_string);
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
+  EXPECT_TRUE(failed_to_decrypt);
+
+  OSCryptMocker::TearDown();
+}
+
+}  // namespace brave_sync

--- a/components/sync/driver/BUILD.gn
+++ b/components/sync/driver/BUILD.gn
@@ -24,6 +24,7 @@ source_set("unit_tests") {
     "//brave/components/brave_sync:crypto",
     "//brave/components/brave_sync:network_time_helper",
     "//brave/components/brave_sync:prefs",
+    "//components/os_crypt:os_crypt",
     "//components/os_crypt:test_support",
     "//components/prefs:prefs",
     "//components/signin/public/identity_manager:test_support",

--- a/components/sync/driver/brave_sync_service_impl.cc
+++ b/components/sync/driver/brave_sync_service_impl.cc
@@ -59,6 +59,11 @@ bool BraveSyncServiceImpl::IsSetupInProgress() const {
          !user_settings_->IsFirstSetupComplete();
 }
 
+void BraveSyncServiceImpl::StopAndClear() {
+  SyncServiceImpl::StopAndClear();
+  brave_sync_prefs_.Clear();
+}
+
 std::string BraveSyncServiceImpl::GetOrCreateSyncCode() {
   bool failed_to_decrypt = false;
   std::string sync_code = brave_sync_prefs_.GetSeed(&failed_to_decrypt);
@@ -97,8 +102,6 @@ void BraveSyncServiceImpl::OnSelfDeviceInfoDeleted(base::OnceClosure cb) {
   // This function will follow normal reset process and set SyncRequested to
   // false
   StopAndClear();
-  brave_sync_prefs_.Clear();
-  // Sync prefs will be clear in SyncServiceImpl::StopImpl
   std::move(cb).Run();
 }
 

--- a/components/sync/driver/brave_sync_service_impl.h
+++ b/components/sync/driver/brave_sync_service_impl.h
@@ -30,6 +30,7 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
 
   // SyncServiceImpl implementation
   bool IsSetupInProgress() const override;
+  void StopAndClear() override;
 
   std::string GetOrCreateSyncCode();
   bool SetSyncCode(const std::string& sync_code);

--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -204,4 +204,22 @@ TEST_F(BraveSyncServiceImplTest, DISABLED_EmulateGetOrCreateSyncCodeCHECK) {
   OSCryptMocker::TearDown();
 }
 
+TEST_F(BraveSyncServiceImplTest, StopAndClearForBraveSeed) {
+  OSCryptMocker::SetUp();
+
+  CreateSyncService(SyncServiceImpl::MANUAL_START);
+
+  brave_sync_service_impl()->Initialize();
+  EXPECT_FALSE(engine());
+
+  bool set_code_result = brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
+  EXPECT_TRUE(set_code_result);
+
+  brave_sync_service_impl()->StopAndClear();
+
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(nullptr), "");
+
+  OSCryptMocker::TearDown();
+}
+
 }  // namespace syncer

--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -7,6 +7,7 @@
 
 #include "base/base64.h"
 #include "base/logging.h"
+#include "base/test/gtest_util.h"
 #include "base/test/task_environment.h"
 #include "brave/components/sync/driver/brave_sync_service_impl.h"
 #include "brave/components/sync/driver/sync_service_impl_delegate.h"
@@ -186,8 +187,18 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphraseKeyringLocked) {
 
 #endif  // defined(OS_APPLE)
 
-TEST_F(BraveSyncServiceImplTest, DISABLED_EmulateGetOrCreateSyncCodeCHECK) {
+// Google test doc strongly recommends to use ``*DeathTest` naming
+// for test suite
+using BraveSyncServiceImplDeathTest = BraveSyncServiceImplTest;
+
+TEST_F(BraveSyncServiceImplDeathTest, EmulateGetOrCreateSyncCodeCHECK) {
   OSCryptMocker::SetUp();
+
+  CreateSyncService(SyncServiceImpl::MANUAL_START);
+
+  brave_sync_service_impl()->Initialize();
+  EXPECT_FALSE(engine());
+
   std::string wrong_seed = "123";
   std::string encrypted_wrong_seed;
   EXPECT_TRUE(OSCrypt::EncryptString(wrong_seed, &encrypted_wrong_seed));
@@ -197,9 +208,7 @@ TEST_F(BraveSyncServiceImplTest, DISABLED_EmulateGetOrCreateSyncCodeCHECK) {
   pref_service()->SetString(brave_sync::Prefs::GetSeedPath(),
                             encoded_wrong_seed);
 
-  CreateSyncService(SyncServiceImpl::MANUAL_START);
-
-  std::string seed = brave_sync_service_impl()->GetOrCreateSyncCode();
+  EXPECT_CHECK_DEATH(brave_sync_service_impl()->GetOrCreateSyncCode());
 
   OSCryptMocker::TearDown();
 }

--- a/components/sync/driver/brave_sync_service_impl_unittest.cc
+++ b/components/sync/driver/brave_sync_service_impl_unittest.cc
@@ -164,29 +164,6 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphraseLeadingTrailingWhitespace) {
   OSCryptMocker::TearDown();
 }
 
-#if defined(OS_APPLE)
-
-TEST_F(BraveSyncServiceImplTest, ValidPassphraseKeyringLocked) {
-  OSCryptMocker::SetUp();
-
-  CreateSyncService(SyncServiceImpl::MANUAL_START);
-
-  brave_sync_service_impl()->Initialize();
-  EXPECT_FALSE(engine());
-
-  bool set_code_result = brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
-  EXPECT_TRUE(set_code_result);
-
-  bool failed_to_decrypt = false;
-  OSCryptMocker::SetBackendLocked(true);
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_TRUE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
-}
-
-#endif  // defined(OS_APPLE)
-
 // Google test doc strongly recommends to use ``*DeathTest` naming
 // for test suite
 using BraveSyncServiceImplDeathTest = BraveSyncServiceImplTest;
@@ -226,7 +203,9 @@ TEST_F(BraveSyncServiceImplTest, StopAndClearForBraveSeed) {
 
   brave_sync_service_impl()->StopAndClear();
 
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(nullptr), "");
+  bool failed_to_decrypt = false;
+  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
+  EXPECT_FALSE(failed_to_decrypt);
 
   OSCryptMocker::TearDown();
 }

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -303,7 +303,7 @@ void BraveSyncWorker::OnStateChanged(syncer::SyncService* service) {
   }
 
   brave_sync::Prefs brave_sync_prefs(browser_state_->GetPrefs());
-  std::string sync_code = brave_sync_prefs.GetSeed();
+  std::string sync_code = brave_sync_prefs.GetSeed(nullptr);
   DCHECK_NE(sync_code.size(), 0u);
 
   if (service->GetUserSettings()->IsPassphraseRequired()) {

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -303,8 +303,10 @@ void BraveSyncWorker::OnStateChanged(syncer::SyncService* service) {
   }
 
   brave_sync::Prefs brave_sync_prefs(browser_state_->GetPrefs());
-  std::string sync_code = brave_sync_prefs.GetSeed(nullptr);
+  bool failed_to_decrypt = false;
+  std::string sync_code = brave_sync_prefs.GetSeed(&failed_to_decrypt);
   DCHECK_NE(sync_code.size(), 0u);
+  DCHECK(!failed_to_decrypt);
 
   if (service->GetUserSettings()->IsPassphraseRequired()) {
     SetDecryptionPassphrase(service);


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20303

This PR does following things:
- prevents `BraveSyncServiceImpl::GetOrCreateSyncCode` from creating new sync code when `OSCrypt::DecryptString` failed;
- splits the case when CHECK happens to distinguish cases of empty seed string and the case of wrong words;
- introduces the disabled unit test `DISABLED_EmulateGetOrCreateSyncCodeCHECK` which shows one of the way how the mentioned CHECK may happened;
- improves the work of `Disable Sync (Clear Data)` button from sync-internals page to clean out Brave sync prefs also.


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Just ensure that regular create/connect to the sync chain works:
1. Create new chain, ensure you see all green statuses on brave://sync-internals.com .
2. Copy sync words, leave the chain.
3. Join the chain by codewords, ensure you see all green statuses on brave://sync-internals.com .