### PR TITLE
Remove amount from Rewards "payment arrived" message (uplift to 1.35.x)

### DIFF
--- a/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
+++ b/components/brave_rewards/resources/extension/brave_rewards/_locales/en_US/messages.json
@@ -140,14 +140,11 @@
     "description": ""
   },
   "rewardsPaymentCompleted": {
-    "message": "Congrats! Your $amount$ $month$ rewards have arrived!",
+    "message": "Congrats! Your $month$ rewards have arrived!",
     "description": "",
     "placeholders": {
-      "amount": {
-        "content": "$1"
-      },
       "month": {
-        "content": "$2"
+        "content": "$1"
       }
     }
   },

--- a/components/brave_rewards/resources/shared/components/newtab/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/shared/components/newtab/stories/locale_strings.ts
@@ -17,7 +17,7 @@ export const localeStrings = {
   rewardsOptInTerms: 'By proceeding, you agree to the $1Terms of Service$2 and $3Privacy Policy$4.',
   rewardsOptInText: 'Earn tokens by viewing Brave Private Ads and support content creators automatically.',
   rewardsPaymentCheckStatus: 'Check status',
-  rewardsPaymentCompleted: 'Congrats! Your $1 $2 rewards have arrived!',
+  rewardsPaymentCompleted: 'Congrats! Your $1 rewards have arrived!',
   rewardsPaymentPending: 'Your $1 $2 rewards will arrive in $3',
   rewardsPaymentProcessing: 'Your $1 $2 rewards are on the way. Keep an eye out!',
   rewardsProgress: 'Progress',

--- a/components/brave_rewards/resources/shared/components/payment_status_view.tsx
+++ b/components/brave_rewards/resources/shared/components/payment_status_view.tsx
@@ -133,7 +133,6 @@ export function PaymentStatusView (props: Props) {
         <div>
           {
             formatMessage(getString('rewardsPaymentCompleted'), [
-              <RewardAmount key='amount' amount={props.earningsLastMonth} />,
               getPaymentMonth()
             ])
           }

--- a/components/brave_rewards/resources/shared/components/wallet_card/stories/locale_strings.ts
+++ b/components/brave_rewards/resources/shared/components/wallet_card/stories/locale_strings.ts
@@ -1,6 +1,6 @@
 export const localeStrings = {
   rewardsPaymentCheckStatus: 'Check status',
-  rewardsPaymentCompleted: 'Congrats! Your $1 $2 rewards have arrived!',
+  rewardsPaymentCompleted: 'Congrats! Your $1 rewards have arrived!',
   rewardsPaymentPending: 'Your $1 $2 rewards will arrive in $3',
   rewardsPaymentProcessing: 'Your $1 $2 rewards are on the way. Keep an eye out!',
   walletAccountLink: 'Go to your $1 account',

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -4,7 +4,7 @@
     Check status
   </message>
   <message name="IDS_REWARDS_PAYMENT_COMPLETED" desc="">
-    Congrats! Your <ph name="AMOUNT">$1<ex>+1.5 BAT</ex></ph> <ph name="MONTH">$2<ex>October</ex></ph> rewards have arrived!
+    Congrats! Your <ph name="MONTH">$1<ex>October</ex></ph> rewards have arrived!
   </message>
   <message name="IDS_REWARDS_PAYMENT_PENDING" desc="">
     Your <ph name="AMOUNT">$1<ex>+1.5 BAT</ex></ph> <ph name="MONTH">$2<ex>October</ex></ph> rewards will arrive in <ph name="DAYS">$3<ex>4 days</ex></ph>


### PR DESCRIPTION
Uplift of #11931
Resolves https://github.com/brave/brave-browser/issues/20597

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.