### PR TITLE
Fix inexact amounts in transction confirmation screen

### DIFF
--- a/components/brave_wallet_ui/common/hooks/transaction-parser.ts
+++ b/components/brave_wallet_ui/common/hooks/transaction-parser.ts
@@ -56,6 +56,7 @@ interface ParsedTransaction extends ParsedTransactionFees {
   fiatTotal: string
   nativeCurrencyTotal: string
   value: string
+  valueExact: string
   symbol: string
   decimals: number
   insufficientFundsError: boolean
@@ -193,6 +194,7 @@ export function useTransactionParser (
           fiatTotal: totalAmountFiat,
           nativeCurrencyTotal: sendAmountFiat && formatGasFeeFromFiat(sendAmountFiat, networkSpotPrice),
           value: formatBalance(amount, token?.decimals ?? 18),
+          valueExact: formatBalance(amount, token?.decimals ?? 18, false),
           symbol: token?.symbol ?? '',
           decimals: token?.decimals ?? 18,
           insufficientFundsError: insufficientNativeFunds || insufficientTokenFunds,
@@ -230,6 +232,7 @@ export function useTransactionParser (
           fiatTotal: totalAmountFiat,
           nativeCurrencyTotal: totalAmountFiat && formatGasFeeFromFiat(totalAmountFiat, networkSpotPrice),
           value: '1', // Can only send 1 erc721 at a time
+          valueExact: '1',
           symbol: token?.symbol ?? '',
           decimals: 0,
           insufficientFundsError: insufficientNativeFunds,
@@ -252,6 +255,10 @@ export function useTransactionParser (
           ? getLocale('braveWalletTransactionApproveUnlimited')
           : formatBalance(amount, token?.decimals ?? 18)
 
+        const formattedAllowanceValueExact = isNumericValueGreaterThan(amount, accountTokenBalance)
+          ? getLocale('braveWalletTransactionApproveUnlimited')
+          : formatBalance(amount, token?.decimals ?? 18, false)
+
         return {
           hash: transactionInfo.txHash,
           nonce,
@@ -265,6 +272,7 @@ export function useTransactionParser (
           fiatTotal: totalAmountFiat,
           nativeCurrencyTotal: (0).toFixed(2),
           value: formattedAllowanceValue,
+          valueExact: formattedAllowanceValueExact,
           symbol: token?.symbol ?? '',
           decimals: token?.decimals ?? 18,
           approvalTarget: address,
@@ -299,6 +307,7 @@ export function useTransactionParser (
           fiatTotal: totalAmountFiat,
           nativeCurrencyTotal: sendAmountFiat && formatGasFeeFromFiat(sendAmountFiat, networkSpotPrice),
           value: formatBalance(value, selectedNetwork.decimals),
+          valueExact: formatBalance(value, selectedNetwork.decimals, false),
           symbol: selectedNetwork.symbol,
           decimals: selectedNetwork?.decimals ?? 18,
           insufficientFundsError: isNumericValueGreaterThan(addNumericValues(gasFee, value), accountNativeBalance),

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/index.tsx
@@ -350,7 +350,7 @@ function ConfirmTransactionPanel (props: Props) {
             {transactionInfo.txType === BraveWallet.TransactionType.ERC721TransferFrom ||
               transactionInfo.txType === BraveWallet.TransactionType.ERC721SafeTransferFrom
               ? transactionDetails.erc721BlockchainToken?.name + ' ' + transactionDetails.erc721TokenId
-              : formatTokenAmountWithCommasAndDecimals(transactionDetails.value, transactionDetails.symbol)
+              : formatTokenAmountWithCommasAndDecimals(transactionDetails.valueExact, transactionDetails.symbol)
             }
           </TransactionAmountBig>
           {transactionInfo.txType !== BraveWallet.TransactionType.ERC721TransferFrom &&
@@ -405,7 +405,7 @@ function ConfirmTransactionPanel (props: Props) {
                 <SectionRow>
                   <TransactionTitle>{getLocale('braveWalletAllowSpendProposedAllowance')}</TransactionTitle>
                   <SectionRightColumn>
-                    <TransactionTypeText>{formatTokenAmountWithCommasAndDecimals(transactionDetails.value, transactionDetails.symbol)}</TransactionTypeText>
+                    <TransactionTypeText>{formatTokenAmountWithCommasAndDecimals(transactionDetails.valueExact, transactionDetails.symbol)}</TransactionTypeText>
                     <TransactionText />
                   </SectionRightColumn>
                 </SectionRow>
@@ -429,8 +429,8 @@ function ConfirmTransactionPanel (props: Props) {
                     <GrandTotalText>
                       {(transactionInfo.txType !== BraveWallet.TransactionType.ERC721SafeTransferFrom &&
                         transactionInfo.txType !== BraveWallet.TransactionType.ERC721TransferFrom)
-                        ? formatWithCommasAndDecimals(transactionDetails.value)
-                        : transactionDetails.value
+                        ? formatWithCommasAndDecimals(transactionDetails.valueExact)
+                        : transactionDetails.valueExact
                       } {transactionDetails.symbol} + {formatBalance(transactionDetails.gasFee, selectedNetwork.decimals)} {selectedNetwork.symbol}</GrandTotalText>
                   </SingleRow>
                   <TransactionText

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/style.ts
@@ -187,6 +187,7 @@ export const SingleRow = styled.div`
   justify-content: space-between;
   flex-direction: row;
   width: 100%;
+  gap: 5px;
 `
 
 export const SectionRightColumn = styled.div`

--- a/components/brave_wallet_ui/utils/format-balances.ts
+++ b/components/brave_wallet_ui/utils/format-balances.ts
@@ -25,7 +25,7 @@ export const formatInputValue = (value: string, decimals: number, round = true) 
   return formattedValue.replace(/\.0*$|(\.\d*[1-9])0+$/, '$1')
 }
 
-export const formatBalance = (balance: string, decimals: number) => {
+export const formatBalance = (balance: string, decimals: number, round: boolean = true) => {
   if (!balance) {
     return ''
   }
@@ -36,7 +36,13 @@ export const formatBalance = (balance: string, decimals: number) => {
   }
 
   const result = new BigNumber(balance).dividedBy(10 ** decimals)
-  return (result.isNaN()) ? '0.0000' : result.toFixed(4, BigNumber.ROUND_UP)
+  if (result.isNaN()) {
+    return '0.0000'
+  }
+
+  return round
+    ? result.toFixed(4, BigNumber.ROUND_UP)
+    : result.toFormat()
 }
 
 export const formatGasFee = (gasPrice: string, gasLimit: string, decimals: number) => {

--- a/components/brave_wallet_ui/utils/format-prices.test.ts
+++ b/components/brave_wallet_ui/utils/format-prices.test.ts
@@ -4,50 +4,47 @@ import {
   formatTokenAmountWithCommasAndDecimals
 } from './format-prices'
 
-describe('Check Formating with Commas and Decimals', () => {
-  test('Value was empty, should return an empty string', () => {
+describe('Check Formatting with Commas and Decimals', () => {
+  it('should return an empty string if value is empty', () => {
     const value = ''
     expect(formatWithCommasAndDecimals(value)).toEqual('')
   })
 
-  test('Value is 0 should return 0.00', () => {
-    const value = '0'
-    expect(formatWithCommasAndDecimals(value)).toEqual('0.00')
-  })
-
-  test('Value is Unlimited should return Unlimited', () => {
-    const value = 'Unlimited'
-    expect(formatWithCommasAndDecimals(value)).toEqual('Unlimited')
+  it.each([
+    ['0.00', '0'],
+    ['Unlimited', 'Unlimited']
+  ])('should return %s if value is %s', (expected, value) => {
+    expect(formatWithCommasAndDecimals(value)).toEqual(expected)
   })
 })
 
-describe('Check Formating with Commas and Decimals for Fiat', () => {
-  test('Value was empty, should return an empty string', () => {
+describe('Check Formatting with Commas and Decimals for Fiat', () => {
+  it('should return an empty string if value is empty', () => {
     const value = ''
     expect(formatFiatAmountWithCommasAndDecimals(value, 'USD')).toEqual('')
   })
 
-  test('USD Value is 0 should return $0.00', () => {
-    const value = '0'
-    expect(formatFiatAmountWithCommasAndDecimals(value, 'USD')).toEqual('$0.00')
-  })
-
-  test('RUB Value is 0 should return $0.00', () => {
-    const value = '0'
-    expect(formatFiatAmountWithCommasAndDecimals(value, 'RUB')).toEqual('₽0.00')
+  it.each([
+    ['$0.00', '0', 'USD'],
+    ['₽0.00', '0', 'RUB'],
+    ['₽0.10', '0.1', 'RUB'],
+    ['₽0.001', '0.001', 'RUB']
+  ])('should return %s if value is %s %s', (expected, value, currency) => {
+    expect(formatFiatAmountWithCommasAndDecimals(value, currency)).toEqual(expected)
   })
 })
 
-describe('Check Formating with Commas and Decimals for Tokens', () => {
-  test('Value was empty, should return an empty string', () => {
+describe('Check Formatting with Commas and Decimals for Tokens', () => {
+  it('should return an empty string if value is empty', () => {
     const value = ''
     const symbol = ''
     expect(formatTokenAmountWithCommasAndDecimals(value, symbol)).toEqual('')
   })
 
-  test('Value is 0 should return 0.00 ETH', () => {
-    const value = '0'
-    const symbol = 'ETH'
-    expect(formatTokenAmountWithCommasAndDecimals(value, symbol)).toEqual('0.00 ETH')
+  it.each([
+    ['0.00 ETH', '0', 'ETH'],
+    ['0.000000000000000001 ETH', '0.000000000000000001', 'ETH']
+  ])('should return %s if value is %s %s', (expected, value, symbol) => {
+    expect(formatTokenAmountWithCommasAndDecimals(value, symbol)).toEqual(expected)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "brave-core",
-      "version": "1.36.55",
+      "version": "1.36.56",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
@@ -18,7 +18,7 @@
         "@types/react-router-dom": "^5.1.9",
         "@types/webtorrent": "^0.109.0",
         "array-move": "^2.2.1",
-        "bignumber.js": "^7.2.1",
+        "bignumber.js": "^9.0.2",
         "bluebird": "^3.5.1",
         "core-js": "^3.9.1",
         "date-fns": "^2.15.0",
@@ -3420,14 +3420,6 @@
         "ethers": "^5.5.2"
       }
     },
-    "node_modules/@ledgerhq/hw-app-eth/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@ledgerhq/hw-transport": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.20.0.tgz",
@@ -6092,15 +6084,6 @@
         "ws": "^7.4.0"
       }
     },
-    "node_modules/@trezor/blockchain-link/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@trezor/connect-common": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.0.2.tgz",
@@ -8675,9 +8658,9 @@
       "dev": true
     },
     "node_modules/bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
       "engines": {
         "node": "*"
       }
@@ -15313,15 +15296,6 @@
         "bignumber.js": "^9.0.1",
         "queue": "^6.0.2",
         "socket.io-client": "^4.1.2"
-      }
-    },
-    "node_modules/hd-wallet/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/he": {
@@ -22263,24 +22237,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "node_modules/ripple-lib-transactionparser/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ripple-lib/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/rlp": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
@@ -24959,15 +24915,6 @@
         "tiny-worker": "^2.3.0",
         "trezor-link": "1.7.3",
         "whatwg-fetch": "^3.5.0"
-      }
-    },
-    "node_modules/trezor-connect/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/trezor-link": {
@@ -30426,13 +30373,6 @@
         "axios": "^0.24.0",
         "bignumber.js": "^9.0.2",
         "ethers": "^5.5.2"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-        }
       }
     },
     "@ledgerhq/hw-transport": {
@@ -32279,14 +32219,6 @@
         "ripple-lib": "1.10.0",
         "tiny-worker": "^2.3.0",
         "ws": "^7.4.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-          "dev": true
-        }
       }
     },
     "@trezor/connect-common": {
@@ -34436,9 +34368,9 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -39601,14 +39533,6 @@
         "bignumber.js": "^9.0.1",
         "queue": "^6.0.2",
         "socket.io-client": "^4.1.2"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-          "dev": true
-        }
       }
     },
     "he": {
@@ -45017,14 +44941,6 @@
         "ripple-keypairs": "^1.0.3",
         "ripple-lib-transactionparser": "0.8.2",
         "ws": "^7.2.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-          "dev": true
-        }
       }
     },
     "ripple-lib-transactionparser": {
@@ -45035,14 +44951,6 @@
       "requires": {
         "bignumber.js": "^9.0.0",
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-          "dev": true
-        }
       }
     },
     "rlp": {
@@ -47101,14 +47009,6 @@
         "tiny-worker": "^2.3.0",
         "trezor-link": "1.7.3",
         "whatwg-fetch": "^3.5.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-          "dev": true
-        }
       }
     },
     "trezor-link": {

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "@types/webtorrent": "^0.109.0",
     "@noble/bls12-381": "1.0.1",
     "array-move": "^2.2.1",
-    "bignumber.js": "^7.2.1",
+    "bignumber.js": "^9.0.2",
     "bluebird": "^3.5.1",
     "core-js": "^3.9.1",
     "date-fns": "^2.15.0",

--- a/third_party/npm_bignumber.js/README.chromium
+++ b/third_party/npm_bignumber.js/README.chromium
@@ -1,4 +1,4 @@
 Name: bignumber.js
 URL: https://github.com/MikeMcl/bignumber.js
 License: MIT
-License File: /brave/node_modules/bignumber.js/LICENCE
+License File: /brave/node_modules/bignumber.js/LICENCE.md


### PR DESCRIPTION
**Motivation:** We want users to sign **exactly** what they enter in amount fields. For this to happen, we must display unaltered amounts in the transaction confirmation screen (panel).

**Summary of changes:**
- Refactored utils in `format-prices.ts` to use `bignumber.js`. Fiat values are always formatted to two places of decimals, unless less than `0.01`. Crypto values are no longer formatted using the log stuff - my reasoning is that `formatWithCommasAndDecimals` is always passed values that are pre-formatted using utils in `format-balances.ts`, so we don't need another level of formatter. I still keep most of the logic as-is.
- Added a `valueExact` field to transaction parser response, to be used in the transaction confirmation screen.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20432.
Resolves https://github.com/brave/brave-browser/issues/19521.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

Here are the transaction screens after creation a transaction with value `0.037314235731347379 ETH`.

|Before|After|
-|-
|<img src="https://user-images.githubusercontent.com/3684187/150423328-8b8fe3b1-f804-4e3f-8f7f-fcb27d7f1f0f.png">|<img src="https://user-images.githubusercontent.com/3684187/150423096-133ba3fa-1fe1-4119-9096-0673e7ebcdf4.png">|
