### PR TITLE
Disable flaky speedreader test on macos (uplift to 1.35.x)

### DIFF
--- a/browser/ui/speedreader/speedreader_bubble_browsertest.cc
+++ b/browser/ui/speedreader/speedreader_bubble_browsertest.cc
@@ -55,12 +55,22 @@ IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
   ShowAndVerifyUi();
 }
 
+// Disable this test for intermittent crashes on macOS.
+// See https://github.com/brave/brave-browser/issues/20082
+#if defined(OS_MAC)
+#define MAYBE_InvokeUi_speedreader_mode_bubble_basic \
+  DISABLED_InvokeUi_speedreader_mode_bubble_basic
+#else
+#define MAYBE_InvokeUi_speedreader_mode_bubble_basic \
+  InvokeUi_speedreader_mode_bubble_basic
+#endif
+
 IN_PROC_BROWSER_TEST_F(SpeedreaderBubbleBrowserTest,
-                       InvokeUi_speedreader_mode_bubble_basic) {
+                       MAYBE_InvokeUi_speedreader_mode_bubble_basic) {
   speedreader_bubble_ = true;
   // We need to navigate somewhere so the host is non-empty. For tests the new
   // tab page is fine.
-  NavigateToNewTab();
+  EXPECT_TRUE(NavigateToNewTab());
   const GURL active_url = ActiveWebContents()->GetLastCommittedURL();
   EXPECT_FALSE(active_url.host().empty());
   ShowAndVerifyUi();


### PR DESCRIPTION
Uplift of #11637

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.