### PR TITLE
Remove un-needed cookie exceptions

### DIFF
--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -36,7 +36,7 @@ bool BraveIsAllowedThirdParty(const GURL& url,
           {{ContentSettingsPattern::FromString(kWp),
             ContentSettingsPattern::FromString(kWordpress)},
            {ContentSettingsPattern::FromString(kWordpress),
-            ContentSettingsPattern::FromString(kWp)}});,
+            ContentSettingsPattern::FromString(kWp)}});
 
   if (net::registry_controlled_domains::GetDomainAndRegistry(
           url, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES) ==

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -32,11 +32,10 @@ bool BraveIsAllowedThirdParty(const GURL& url,
   static const base::NoDestructor<
       // url -> first_party_url allow map
       std::vector<std::pair<ContentSettingsPattern, ContentSettingsPattern>>>
-      entity_list(
-          {{ContentSettingsPattern::FromString(kWp),
-            ContentSettingsPattern::FromString(kWordpress)},
-           {ContentSettingsPattern::FromString(kWordpress),
-            ContentSettingsPattern::FromString(kWp)}});
+      entity_list({{ContentSettingsPattern::FromString(kWp),
+                    ContentSettingsPattern::FromString(kWordpress)},
+                   {ContentSettingsPattern::FromString(kWordpress),
+                    ContentSettingsPattern::FromString(kWp)}});
 
   if (net::registry_controlled_domains::GetDomainAndRegistry(
           url, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES) ==

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -25,14 +25,6 @@ namespace {
 
 constexpr char kWp[] = "https://[*.]wp.com/*";
 constexpr char kWordpress[] = "https://[*.]wordpress.com/*";
-constexpr char kPlaystation[] = "https://[*.]playstation.com/*";
-constexpr char kSonyentertainmentnetwork[] =
-    "https://[*.]sonyentertainmentnetwork.com/*";
-constexpr char kSony[] = "https://[*.]sony.com/*";
-constexpr char kGoogle[] = "https://[*.]google.com/*";
-constexpr char kGoogleusercontent[] = "https://[*.]googleusercontent.com/*";
-constexpr char kFacebook[] = "https://[*.]facebook.com/*";
-constexpr char kInstagram[] = "https://[*.]instagram.com/*";
 
 bool BraveIsAllowedThirdParty(const GURL& url,
                               const GURL& first_party_url,
@@ -44,23 +36,7 @@ bool BraveIsAllowedThirdParty(const GURL& url,
           {{ContentSettingsPattern::FromString(kWp),
             ContentSettingsPattern::FromString(kWordpress)},
            {ContentSettingsPattern::FromString(kWordpress),
-            ContentSettingsPattern::FromString(kWp)},
-           {ContentSettingsPattern::FromString(kGoogle),
-            ContentSettingsPattern::FromString(kGoogleusercontent)},
-           {ContentSettingsPattern::FromString(kGoogleusercontent),
-            ContentSettingsPattern::FromString(kGoogle)},
-           {ContentSettingsPattern::FromString(kInstagram),
-            ContentSettingsPattern::FromString(kFacebook)},
-           {ContentSettingsPattern::FromString(kFacebook),
-            ContentSettingsPattern::FromString(kInstagram)},
-           {ContentSettingsPattern::FromString(kPlaystation),
-            ContentSettingsPattern::FromString(kSonyentertainmentnetwork)},
-           {ContentSettingsPattern::FromString(kSonyentertainmentnetwork),
-            ContentSettingsPattern::FromString(kPlaystation)},
-           {ContentSettingsPattern::FromString(kSony),
-            ContentSettingsPattern::FromString(kPlaystation)},
-           {ContentSettingsPattern::FromString(kPlaystation),
-            ContentSettingsPattern::FromString(kSony)}});
+            ContentSettingsPattern::FromString(kWp)}});,
 
   if (net::registry_controlled_domains::GetDomainAndRegistry(
           url, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES) ==


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Removing unused cookie exceptions.  Using a jenkins build with these commented out.  Leaving only Wordpress exceptions, which I cannot confirm if needed

Checked `playstation.com`  (login works, and a purchasing game). Original issue: https://github.com/brave/brave-core/pull/5857

Checked `gmail.com` (Signature works fine). Original issue: https://github.com/brave/brave-core/pull/5953

Checked `instagram.com` (Login works, 2FA and Facebook button works). Original issue: https://github.com/brave/brave-core/pull/8069

