### PR TITLE
feat(wallet): disable EIP-1559 on Polygon and Avalanche

### DIFF
--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -362,6 +362,19 @@ void JsonRpcService::UpdateIsEip1559(const std::string& chain_id,
   if (error != mojom::ProviderError::kSuccess)
     return;
 
+  // Disable EIP-1559 on selected networks, by overwriting is_eip1559 to
+  // false.
+  //
+  // This list needs to be updated until we have a generic EIP-1559 gas
+  // oracle. See: https://github.com/brave/brave-browser/issues/20469.
+  if (chain_id == "0x13881" ||  // Polygon Mumbai Testnet
+      chain_id == "0x89" ||     // Polygon Mainnet
+      chain_id == "0xa86a" ||   // Avalanche Mainnet
+      chain_id == "0xa869"      // Avalanche Fuji Testnet
+  ) {
+    is_eip1559 = false;
+  }
+
   bool changed = false;
   if (chain_id == brave_wallet::mojom::kLocalhostChainId) {
     changed = prefs_->GetBoolean(kSupportEip1559OnLocalhostChain) != is_eip1559;

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1457,6 +1457,41 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559CustomChain) {
   EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
 }
 
+TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559DisablePolygon) {
+  std::vector<base::Value> values;
+
+  // Define EthereumChain for Polygon network with is_eip1559 set to true.
+  brave_wallet::mojom::EthereumChain polygon(
+      "0x89", "Polygon Mainnet", {"https://url.com"}, {"https://url.com"},
+      {"https://url.com"}, "Polygon Matic", "MATIC", 18, true);
+  auto polygon_ptr = polygon.Clone();
+  values.push_back(brave_wallet::EthereumChainToValue(polygon_ptr));
+
+  UpdateCustomNetworks(prefs(), &values);
+
+  // Expected is_eip1559 should always be false for Polygon.
+  TestJsonRpcServiceObserver observer(polygon.chain_id, false);
+  json_rpc_service_->AddObserver(observer.GetReceiver());
+
+  // Switching to Polygon should update is_eip1559 to false, even if it
+  // was previously set to true.
+  EXPECT_TRUE(GetIsEip1559FromPrefs(polygon.chain_id));
+  SetIsEip1559Interceptor(true);
+  SetNetwork(polygon.chain_id);
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_TRUE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(polygon.chain_id));
+
+  // Switching to Polygon again should not call observer methods for change
+  // in is_eip1559.
+  observer.Reset(polygon.chain_id, false);
+  SetIsEip1559Interceptor(true);
+  SetNetwork(polygon.chain_id);
+  EXPECT_TRUE(observer.chain_changed_called());
+  EXPECT_FALSE(observer.is_eip1559_changed_called());
+  EXPECT_FALSE(GetIsEip1559FromPrefs(polygon.chain_id));
+}
+
 TEST_F(JsonRpcServiceUnitTest, GetEthAddrInvalidDomain) {
   const std::vector<std::string> invalid_domains = {"", ".eth", "-brave.eth",
                                                     "brave-.eth", "b.eth"};


### PR DESCRIPTION
Our current EIP-1559 gas oracle queries the Etherscan API, which only
supports Ethereum mainnet. As a result, priority fee estimations on
custom networks use results for Ethereum mainnet, which can either
result in transactions being stuck in the mempool forever, or in
over-payment of gas fees.

This commit will be reverted in brave/brave-browser#20469.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20652.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Demo

|Before|After|
-|-
|<video src="https://user-images.githubusercontent.com/3684187/150785691-13554dce-5219-4ad9-9c6d-ff30ae36bf9c.mov">|<video src="https://user-images.githubusercontent.com/3684187/150785370-03681605-e5d3-4ac3-81f2-5ba326400269.mov">|