### PR TITLE
Change sidebar's builtin shortcut behavior

### DIFF
--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -41,6 +41,8 @@ class SidebarController : public SidebarService::Observer {
   void AddItemWithCurrentTab();
   // If current browser doesn't have a tab for |url|, active tab will load
   // |url|. Otherwise, existing tab will be activated.
+  // ShowSingletonTab() has similar functionality but it loads url in the
+  // new tab.
   void LoadAtTab(const GURL& url);
 
   bool IsActiveIndex(int index) const;
@@ -57,6 +59,10 @@ class SidebarController : public SidebarService::Observer {
  private:
   void OnPreferenceChanged(const std::string& pref_name);
   void UpdateSidebarVisibility();
+
+  // Iterate tabs by host (if tabs with host of URL exist).
+  // Otherwise, load URL in the active tab.
+  void IterateOrLoadAtActiveTab(const GURL& url);
 
   BraveBrowser* browser_ = nullptr;
   // Interface to view.

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -29,10 +29,10 @@ SidebarItem GetBuiltInItemForType(SidebarItem::BuiltInItemType type) {
   switch (type) {
     case SidebarItem::BuiltInItemType::kBraveTalk:
       return SidebarItem::Create(
-          GURL("https://talk.brave.com/"),
+          GURL("https://talk.brave.com/widget"),
           l10n_util::GetStringUTF16(IDS_SIDEBAR_BRAVE_TALK_ITEM_TITLE),
           SidebarItem::Type::kTypeBuiltIn,
-          SidebarItem::BuiltInItemType::kBraveTalk, true);
+          SidebarItem::BuiltInItemType::kBraveTalk, false);
     case SidebarItem::BuiltInItemType::kWallet:
       return SidebarItem::Create(
           GURL("chrome://wallet/"),

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -175,7 +175,7 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Check service has updated built-in item. Previously url was deprecated.xxx.
   EXPECT_EQ(1UL, service_->items().size());
-  EXPECT_EQ("https://talk.brave.com/", service_->items()[0].url);
+  EXPECT_EQ("https://talk.brave.com/widget", service_->items()[0].url);
 
   // Simulate re-launch and check service has still updated items.
   service_->RemoveObserver(this);
@@ -185,7 +185,7 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Check service has updated built-in item. Previously url was deprecated.xxx.
   EXPECT_EQ(1UL, service_->items().size());
-  EXPECT_EQ("https://talk.brave.com/", service_->items()[0].url);
+  EXPECT_EQ("https://talk.brave.com/widget", service_->items()[0].url);
 }
 
 TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithoutBuiltInItemTypeKey) {


### PR DESCRIPTION
fix brave/brave-browser#20645

If there is no opened tab that loaded same host with shortcut's,
clicking loads at current active tab.
Otherwise, iterate all opened tab whenever user clicks.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves 

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`npm run test brave_browser_tests -- --filter=SidebarBrowserTest.IterateBuiltInWebTypeTest`

1. Lauch browser and enable sidebar feature from brave://flags and re-launch
2. Open many NTP tabs and loading https://talk.brave.com/ on some existing tabs
3. Check currently opened talk tabs are iterated whenever clicks sidebar's talk icon 