### PR TITLE
feat(wallet): Display Custom Chain and Token Icons

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -293,6 +293,7 @@ constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletWatchListAdvanced", IDS_BRAVE_WALLET_WATCH_LIST_ADVANCED},
     {"braveWalletWatchListCoingeckoId",
      IDS_BRAVE_WALLET_WATCH_LIST_COINGECKO_ID},
+    {"braveWalletIconURL", IDS_BRAVE_WALLET_ICON_URL},
     {"braveWalletAccountSettingsDisclaimer",
      IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_DISCLAIMER},
     {"braveWalletAccountSettingsShowKey",

--- a/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/edit-visible-assets-modal/index.tsx
@@ -76,6 +76,7 @@ const EditVisibleAssetsModal = (props: Props) => {
   const [tokenContractAddress, setTokenContractAddress] = React.useState<string>('')
   const [tokenDecimals, setTokenDecimals] = React.useState<string>('')
   const [coingeckoID, setCoingeckoID] = React.useState<string>('')
+  const [iconURL, setIconURL] = React.useState<string>('')
 
   // If a user removes all of their assets from the userVisibleTokenInfo list,
   // there is a check in the async/lib.ts folder that will still return the networks
@@ -140,6 +141,13 @@ const EditVisibleAssetsModal = (props: Props) => {
       setHasError(false)
     }
     setCoingeckoID(event.target.value)
+  }
+
+  const handleIconURLChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (hasError) {
+      setHasError(false)
+    }
+    setIconURL(event.target.value)
   }
 
   const nativeAsset = {
@@ -210,12 +218,14 @@ const EditVisibleAssetsModal = (props: Props) => {
       if (foundTokenInfoByContractAddress.isErc721) {
         let token = foundTokenInfoByContractAddress
         token.tokenId = tokenID ? toHex(tokenID) : ''
+        token.logo = iconURL
         setIsLoading(true)
         onAddCustomAsset(token)
         return
       }
       let foundToken = foundTokenInfoByContractAddress
       foundToken.coingeckoId = coingeckoID !== '' ? coingeckoID : foundTokenInfoByContractAddress.coingeckoId
+      foundToken.logo = iconURL
       onAddCustomAsset(foundToken)
     } else {
       const newToken: BraveWallet.BlockchainToken = {
@@ -226,7 +236,7 @@ const EditVisibleAssetsModal = (props: Props) => {
         name: tokenName,
         symbol: tokenSymbol,
         tokenId: tokenID ? toHex(tokenID) : '',
-        logo: '',
+        logo: iconURL,
         visible: true,
         coingeckoId: coingeckoID
       }
@@ -319,6 +329,7 @@ const EditVisibleAssetsModal = (props: Props) => {
       setTokenDecimals('')
       setTokenID('')
       setCoingeckoID('')
+      setIconURL('')
       return
     }
     onFindTokenInfoByContractAddress(tokenContractAddress)
@@ -402,6 +413,11 @@ const EditVisibleAssetsModal = (props: Props) => {
                 <SubDivider />
                 {showAdvancedFields &&
                   <>
+                    <InputLabel>{getLocale('braveWalletIconURL')}</InputLabel>
+                    <Input
+                      value={iconURL}
+                      onChange={handleIconURLChanged}
+                    />
                     <InputLabel>{getLocale('braveWalletWatchListCoingeckoId')}</InputLabel>
                     <Input
                       value={coingeckoID}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -229,6 +229,7 @@ provideStrings({
   braveWalletWatchListTokenIdError: 'Token ID is required',
   braveWalletWatchListAdvanced: 'Advanced',
   braveWalletWatchListCoingeckoId: 'Coingecko ID',
+  braveWalletIconURL: 'Icon URL',
 
   // AmountPresets
   braveWalletPreset25: '25%',

--- a/components/brave_wallet_ui/utils/string-utils.test.ts
+++ b/components/brave_wallet_ui/utils/string-utils.test.ts
@@ -1,4 +1,4 @@
-import { isRemoteImageURL } from './string-utils'
+import { isRemoteImageURL, isValidIconExtension } from './string-utils'
 
 describe('Checking URL is remote image or not', () => {
   test('HTTP URL should return true', () => {
@@ -19,5 +19,27 @@ describe('Checking URL is remote image or not', () => {
 
   test('undefined input should return undefined', () => {
     expect(isRemoteImageURL(undefined)).toEqual(undefined)
+  })
+})
+
+describe('Checking URL ends with a valid icon extension', () => {
+  test('Ends with .png should return true', () => {
+    expect(isValidIconExtension('http://test.com/test.png')).toEqual(true)
+  })
+
+  test('Ends with .svg should return true', () => {
+    expect(isValidIconExtension('https://test.com/test.svg')).toEqual(true)
+  })
+
+  test('Ends with .jpg should return true', () => {
+    expect(isValidIconExtension('https://test.com/test.jpg')).toEqual(true)
+  })
+
+  test('Ends with .jpeg should return true', () => {
+    expect(isValidIconExtension('https://test.com/test.jpeg')).toEqual(true)
+  })
+
+  test('Ends with .com should return false', () => {
+    expect(isValidIconExtension('https://test.com/')).toEqual(false)
   })
 })

--- a/components/brave_wallet_ui/utils/string-utils.ts
+++ b/components/brave_wallet_ui/utils/string-utils.ts
@@ -7,3 +7,6 @@ export const toProperCase = (value: string) =>
 
 export const isRemoteImageURL = (url?: string) =>
   url?.startsWith('http://') || url?.startsWith('https://') || url?.startsWith('data:image/')
+
+export const isValidIconExtension = (url?: string) =>
+  url?.endsWith('.jpg') || url?.endsWith('.jpeg') || url?.endsWith('.png') || url?.endsWith('.svg')

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -196,6 +196,7 @@
   <message name="IDS_BRAVE_WALLET_WATCH_LIST_TOKEN_ID_ERROR" desc="Visible assets modal tokenId error">Token ID is required</message>
   <message name="IDS_BRAVE_WALLET_WATCH_LIST_ADVANCED" desc="Visible assets modal advanced fields">Advanced</message>
   <message name="IDS_BRAVE_WALLET_WATCH_LIST_COINGECKO_ID" desc="Visible assets modal Coingecko ID label">Coingecko ID</message>
+  <message name="IDS_BRAVE_WALLET_ICON_URL" desc="Visible assets modal Icon URL label">Icon URL</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_DISCLAIMER" desc="Account settings modal warning">WARNING: Never share your recovery phrase. Anyone with this phrase can take your assets forever.</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_SHOW_KEY" desc="Account settings modal show key button">Show key</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SETTINGS_HIDE_KEY" desc="Account settings modal hide key button">Hide key</message>


### PR DESCRIPTION
## Description 
Display Custom Chain and Token Icons in Wallet UI

1. Adding a `Icon URL` to a custom network will now display that icon for the base asset.
2. There is now a `Icon URL` field in the `EditVisibleAssets` modal under the `Advanced` section.
3. Added an additional safety check to make sure that the `URL` ends with a valid icon extension (.png, .jpg, etc..)

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/20687>
Resolves https://github.com/brave/brave-browser/issues/20000

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

Custom Network Icon Demo:

https://user-images.githubusercontent.com/40611140/151205989-fa94e836-4ce3-4be1-b300-b427109c5ce7.mov

Custom Token Icon Demo:

https://user-images.githubusercontent.com/40611140/151206034-b8a5c61a-9fcc-41cb-90d3-d6a3bfc63a8d.mov

Adding a Custom Token from Coingecko:

https://user-images.githubusercontent.com/40611140/151247794-83a25355-4732-4695-82b4-41bb586fc802.mov
