### PR TITLE
Disable Chromium's DeviceInfoSyncBridge::ExpireOldEntries

### DIFF
--- a/chromium_src/components/sync/model/metadata_batch.cc
+++ b/chromium_src/components/sync/model/metadata_batch.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "src/components/sync/model/metadata_batch.cc"
+
+namespace syncer {
+
+void MetadataBatch::ClearProgressToken() {
+  state_.mutable_progress_marker()->clear_token();
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/model/metadata_batch.h
+++ b/chromium_src/components/sync/model/metadata_batch.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_MODEL_METADATA_BATCH_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_MODEL_METADATA_BATCH_H_
+
+#define SetModelTypeState \
+  ClearProgressToken();   \
+  void SetModelTypeState
+
+#include "src/components/sync/model/metadata_batch.h"
+
+#undef SetModelTypeState
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_MODEL_METADATA_BATCH_H_

--- a/chromium_src/components/sync_device_info/device_info_prefs.cc
+++ b/chromium_src/components/sync_device_info/device_info_prefs.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/sync_device_info/device_info_prefs.h"
+
+#define RegisterProfilePrefs RegisterProfilePrefs_ChromiumImpl
+
+#include "src/components/sync_device_info/device_info_prefs.cc"
+
+#undef RegisterProfilePrefs
+
+namespace syncer {
+namespace {
+
+// Preference name for storing the time when reset of progress token for devices
+// was done. This happens when we need to re-fetch the devices which were
+// expired and are hidden on the client but still present on the server.
+const char kResetDevicesProgressTokenTime[] =
+    "brave_sync_v2.reset_devices_progress_token_time";
+
+}  // namespace
+
+bool DeviceInfoPrefs::IsResetDevicesProgressTokenDone() {
+  base::Time time = pref_service_->GetTime(kResetDevicesProgressTokenTime);
+  return !time.is_null();
+}
+
+void DeviceInfoPrefs::SetResetDevicesProgressTokenDone() {
+  pref_service_->SetTime(kResetDevicesProgressTokenTime, base::Time::Now());
+}
+
+void DeviceInfoPrefs::RegisterProfilePrefs(PrefRegistrySimple* registry) {
+  registry->RegisterTimePref(kResetDevicesProgressTokenTime, base::Time());
+  RegisterProfilePrefs_ChromiumImpl(registry);
+}
+
+}  // namespace syncer

--- a/chromium_src/components/sync_device_info/device_info_prefs.h
+++ b/chromium_src/components/sync_device_info/device_info_prefs.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_PREFS_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_PREFS_H_
+
+#define RegisterProfilePrefs                                       \
+  RegisterProfilePrefs_ChromiumImpl(PrefRegistrySimple* registry); \
+  void SetResetDevicesProgressTokenDone();                         \
+  bool IsResetDevicesProgressTokenDone();                          \
+  static void RegisterProfilePrefs
+
+#include "src/components/sync_device_info/device_info_prefs.h"
+
+#undef RegisterProfilePrefs
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_PREFS_H_

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
@@ -18,8 +18,11 @@
 // breaks the ability to remove other device in sync chain for Brave
 #define BRAVE_DEVICE_INFO_SYNC_BRIDGE_APPLY_SYNC_CHANGES_SKIP_NEXT_IF if (false)
 
+#define BRAVE_SKIP_EXPIRE_OLD_ENTRIES return;
+
 #include "src/components/sync_device_info/device_info_sync_bridge.cc"
 
+#undef BRAVE_SKIP_EXPIRE_OLD_ENTRIES
 #undef BRAVE_DEVICE_INFO_SYNC_BRIDGE_APPLY_SYNC_CHANGES_SKIP_NEXT_IF
 #undef RefreshLocalDeviceInfoIfNeeded
 #undef BRAVE_MAKE_LOCAL_DEVICE_SPECIFICS

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
@@ -20,8 +20,15 @@
 
 #define BRAVE_SKIP_EXPIRE_OLD_ENTRIES return;
 
+#define BRAVE_ON_READ_ALL_METADATA_CLEAR_PROGRESS_TOKEN         \
+  if (!device_info_prefs_->IsResetDevicesProgressTokenDone()) { \
+    metadata_batch->ClearProgressToken();                       \
+    device_info_prefs_->SetResetDevicesProgressTokenDone();     \
+  }
+
 #include "src/components/sync_device_info/device_info_sync_bridge.cc"
 
+#undef BRAVE_ON_READ_ALL_METADATA_CLEAR_PROGRESS_TOKEN
 #undef BRAVE_SKIP_EXPIRE_OLD_ENTRIES
 #undef BRAVE_DEVICE_INFO_SYNC_BRIDGE_APPLY_SYNC_CHANGES_SKIP_NEXT_IF
 #undef RefreshLocalDeviceInfoIfNeeded

--- a/patches/components-sync_device_info-device_info_sync_bridge.cc.patch
+++ b/patches/components-sync_device_info-device_info_sync_bridge.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/sync_device_info/device_info_sync_bridge.cc b/components/sync_device_info/device_info_sync_bridge.cc
-index 8472cd21a14cf7ea67a19abf0f0a569d0a4f18cb..70519f5865ca9258d82e7da100da9912b83dc1d8 100644
+index 8472cd21a14cf7ea67a19abf0f0a569d0a4f18cb..acd8bf5728a919bb858ef59cadb649f50c5f07b0 100644
 --- a/components/sync_device_info/device_info_sync_bridge.cc
 +++ b/components/sync_device_info/device_info_sync_bridge.cc
 @@ -261,6 +261,7 @@ std::unique_ptr<DeviceInfoSpecifics> MakeLocalDeviceSpecifics(
@@ -27,7 +27,15 @@ index 8472cd21a14cf7ea67a19abf0f0a569d0a4f18cb..70519f5865ca9258d82e7da100da9912
      }
  
      if (change->type() == EntityChange::ACTION_DELETE) {
-@@ -893,6 +895,7 @@ DeviceInfoSyncBridge::CountActiveDevicesByType() const {
+@@ -685,6 +687,7 @@ void DeviceInfoSyncBridge::OnReadAllMetadata(
+     return;
+   }
+ 
++  BRAVE_ON_READ_ALL_METADATA_CLEAR_PROGRESS_TOKEN
+   // In the regular case for sync being disabled, wait for MergeSyncData()
+   // before initializing the LocalDeviceInfoProvider.
+   if (!metadata_batch->GetModelTypeState().initial_sync_done() &&
+@@ -893,6 +896,7 @@ DeviceInfoSyncBridge::CountActiveDevicesByType() const {
  }
  
  void DeviceInfoSyncBridge::ExpireOldEntries() {

--- a/patches/components-sync_device_info-device_info_sync_bridge.cc.patch
+++ b/patches/components-sync_device_info-device_info_sync_bridge.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/sync_device_info/device_info_sync_bridge.cc b/components/sync_device_info/device_info_sync_bridge.cc
-index 8472cd21a14cf7ea67a19abf0f0a569d0a4f18cb..1c3d2da86782a5154dbfcfcd764f22a87e7b93de 100644
+index 8472cd21a14cf7ea67a19abf0f0a569d0a4f18cb..70519f5865ca9258d82e7da100da9912b83dc1d8 100644
 --- a/components/sync_device_info/device_info_sync_bridge.cc
 +++ b/components/sync_device_info/device_info_sync_bridge.cc
 @@ -261,6 +261,7 @@ std::unique_ptr<DeviceInfoSpecifics> MakeLocalDeviceSpecifics(
@@ -27,3 +27,11 @@ index 8472cd21a14cf7ea67a19abf0f0a569d0a4f18cb..1c3d2da86782a5154dbfcfcd764f22a8
      }
  
      if (change->type() == EntityChange::ACTION_DELETE) {
+@@ -893,6 +895,7 @@ DeviceInfoSyncBridge::CountActiveDevicesByType() const {
+ }
+ 
+ void DeviceInfoSyncBridge::ExpireOldEntries() {
++  BRAVE_SKIP_EXPIRE_OLD_ENTRIES
+   const base::Time expiration_threshold =
+       base::Time::Now() - kExpirationThreshold;
+   std::unordered_set<std::string> cache_guids_to_expire;


### PR DESCRIPTION
<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/20937

This PR disables Chromium's feature of expiring old devices in the sync chain.
Chromium removes the devices from the local sync db which are older than 56 days but these devices are still stored on ser server.
This PR disables `DeviceInfoSyncBridge::ExpireOldEntries` to prevent expiring of the devices. Also, for the existing browsers with enabled sync it once resets the progress token at `DeviceInfoSyncBridge::OnReadAllMetadata` to reset.


## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Test plan

I. Test plan for QA. You will need to have a sync chain where are present devices which were unused for more than 56 days.
1. Connect to the chain with build which contains this PR. Expected to see old devices.
2. Restart browser. Expected still to see old devices.
3. Take the Android phone, install the version containing this PR, connect to the sync chain with expired devices via QR. Expected to see old devices.
4. Restart browser app on the phone, it's also expected to see the old devices.

II. Test plan when it is possible to make own builds, but still require to have a sync chain with expired devices. Useless for QA team
1. Disable code at `DeviceInfoSyncBridge::OnReadAllMetadata` of metadata_batch->ClearProgressToken()
2. Disable code at `#define BRAVE_SKIP_EXPIRE_OLD_ENTRIES return;`
3. Connect to the chain with with old devices
4. Restart brower, ensure there are no old devices 
5. Enable Brave code at `DeviceInfoSyncBridge::OnReadAllMetadata`
   Enable Brave code at BRAVE_SKIP_EXPIRE_OLD_ENTRIES
   remove pref of `brave_sync_v2.reset_devices_progress_token_time`
6. Run browser again, ensure expired devices appeared again
