### PR TITLE
Fix rust cargo audit (Uplift to 1.35.x)

### DIFF
--- a/ios/browser/brave_wallet/eth_tx_controller_factory.cc
+++ b/ios/browser/brave_wallet/eth_tx_controller_factory.cc
@@ -22,8 +22,7 @@ namespace brave_wallet {
 
 // static
 mojo::PendingRemote<mojom::EthTxController>
-EthTxControllerFactory::GetForBrowserState(
-    ChromeBrowserState* browser_state) {
+EthTxControllerFactory::GetForBrowserState(ChromeBrowserState* browser_state) {
   return static_cast<EthTxController*>(
              GetInstance()->GetServiceForBrowserState(browser_state, true))
       ->MakeRemote();

--- a/script/audit_deps.py
+++ b/script/audit_deps.py
@@ -25,6 +25,11 @@ NPM_EXCLUDE_PATHS = [
 # Tag @sec-team before adding any advisory to this list
 # Ignore these rust advisories
 IGNORED_CARGO_ADVISORIES = [
+    # Remove when:
+    # https://github.com/chronotope/chrono/issues/602 is resolved
+    # Tracking issue: https://github.com/brave/brave-browser/issues/18838
+    'RUSTSEC-2020-0071',
+    'RUSTSEC-2020-0159'
 ]
 
 # Use only these (sub)paths for cargo audit.


### PR DESCRIPTION
Manual uplift of https://github.com/brave/brave-core/pull/11890

Fixes cargo advisories brought in by the SKU portion of https://github.com/brave/brave-core/pull/11985

NO TICKET